### PR TITLE
Made Ip::Address::fromHost() handle nil pointers after fd9c47d.

### DIFF
--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -917,7 +917,10 @@ Ip::Address::fromHost(const char *host)
 {
     setEmpty();
 
-    if (!host || host[0] != '[')
+    if (!host)
+        return false;
+
+    if (host[0] != '[')
         return lookupHostIP(host, true); // no brackets
 
     /* unwrap a bracketed [presumably IPv6] address, presumably without port */


### PR DESCRIPTION
No functionality changes expected. Nobody was passing nil pointers to
this code before or after fd9c47d AFAICT, but now that this code is
exposed as a public method, it must handle nil pointers.

Detected by Coverity Scan. Issue 1415049 (FORWARD_NULL).