### PR TITLE
pass with-openssl argument through in maximus test

### DIFF
--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -111,7 +111,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \
 	--enable-ssl-crtd \
-	--with-openssl \
+	--with-openssl=${with_openssl:-yes} \
 	"
 
 # Fix the distclean testing.


### PR DESCRIPTION
Compiling on Mac with homebrew requires passing through a custom location of openssl libraries (MacOS has deprecated the openssl compatibility layer).
Add the ability to the maximus test to pass through a nonstandard openssl location.
This is not needed in any other test.

In order to successfully pass test-builds on MacOS + homebrew, the needed command line is:
CXXFLAGS=-Wno-deprecated-declarations with_openssl=/usr/local/opt/openssl/ ./test-builds.sh
