### PR TITLE
Automatically revive hopeless kids on reconfigure and after a timeout

### DIFF
--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -96,6 +96,7 @@ public:
     time_t positiveDnsTtl;
     time_t shutdownLifetime;
     time_t backgroundPingRate;
+    time_t hopelessKidRevivalDelay; ///< hopeless_kid_revival_delay
 
     struct {
         time_t read;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -473,6 +473,26 @@ DOC_START
 	CAP_IPC_LOCK capability, or equivalent.
 DOC_END
 
+NAME: hopeless_kid_revival_delay
+COMMENT: time-units
+TYPE: time_t
+LOC: Config.hopelessKidRevivalDelay
+DEFAULT: 1 hour
+DOC_START
+	Normally, when a kid process dies, Squid immediately restarts the
+	kid. A kid experiencing frequent deaths is marked as "hopeless" for
+	the duration specified by this directive. Hopeless kids are not
+	automatically restarted.
+
+	Currently, zero values are not supported because they result in
+	misconfigured SMP Squid instances running forever, endlessly
+	restarting each dying kid. To effectively disable hopeless kids
+	revival, set the delay to a huge value (e.g., 1 year).
+
+	Reconfiguration also clears all hopeless kids designations, allowing
+	for manual revival of hopeless kids.
+DOC_END
+
 COMMENT_START
  OPTIONS FOR AUTHENTICATION
  -----------------------------------------------------------------------------

--- a/src/ipc/Kid.h
+++ b/src/ipc/Kid.h
@@ -47,6 +47,12 @@ public:
     /// whether the failures are "repeated and frequent"
     bool hopeless() const;
 
+    /// forgets all past failures, ensuring that we are not hopeless()
+    void forgetFailures() { badFailures = 0; }
+
+    /// \returns the time since process termination
+    time_t deathDuration() const;
+
     /// returns true if the process terminated normally
     bool calledExit() const;
 
@@ -72,6 +78,8 @@ public:
     const String& name() const;
 
 private:
+    void reportStopped() const;
+
     // Information preserved across restarts
     String theName; ///< process name
     int badFailures; ///< number of "repeated frequent" failures
@@ -79,6 +87,7 @@ private:
     // Information specific to a running or stopped kid
     pid_t  pid; ///< current (for a running kid) or last (for stopped kid) PID
     time_t startTime; ///< last start time
+    time_t stopTime = 0; ///< last termination time
     bool   isRunning; ///< whether the kid is assumed to be alive
     PidStatus status; ///< exit status of a stopped kid
 };

--- a/src/ipc/Kids.cc
+++ b/src/ipc/Kids.cc
@@ -82,6 +82,35 @@ bool Kids::allHopeless() const
     return true;
 }
 
+void
+Kids::forgetAllFailures()
+{
+    for (auto &kid: storage)
+        kid.forgetFailures();
+}
+
+time_t
+Kids::forgetOldFailures()
+{
+    time_t nextCheckDelay = 0;
+    for (auto &kid: storage) {
+        if (!kid.hopeless())
+            continue;
+
+        const auto deathDuration = kid.deathDuration(); // protect from time changes
+        if (Config.hopelessKidRevivalDelay <= deathDuration) {
+            kid.forgetFailures(); // this kid will be revived now
+            continue;
+        }
+
+        const auto remainingDeathTime = Config.hopelessKidRevivalDelay - deathDuration;
+        assert(remainingDeathTime > 0);
+        if (remainingDeathTime < nextCheckDelay || !nextCheckDelay)
+            nextCheckDelay = remainingDeathTime;
+    }
+    return nextCheckDelay; // still zero if there were no still-hopeless kids
+}
+
 /// whether all kids called exited happy
 bool Kids::allExitedHappy() const
 {

--- a/src/ipc/Kids.h
+++ b/src/ipc/Kids.h
@@ -36,6 +36,13 @@ public:
     /// whether all kids are hopeless
     bool allHopeless() const;
 
+    /// forgets all failures in all kids
+    void forgetAllFailures();
+
+    /// forgets all failures in hopeless kids that were dead for a long time
+    /// \returns seconds till the next check (zero if there are no hopeless kids left)
+    time_t forgetOldFailures();
+
     /// whether all kids called exited happy
     bool allExitedHappy() const;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -153,12 +153,14 @@ static int malloc_debug_level = 0;
 static volatile int do_reconfigure = 0;
 static volatile int do_rotate = 0;
 static volatile int do_shutdown = 0;
+static volatile int do_revive_kids = 0;
 static volatile int shutdown_status = EXIT_SUCCESS;
 static volatile int do_handle_stopped_child = 0;
 
 static int RotateSignal = -1;
 static int ReconfigureSignal = -1;
 static int ShutdownSignal = -1;
+static int ReviveKidsSignal = -1;
 
 static void mainRotate(void);
 static void mainReconfigureStart(void);
@@ -731,6 +733,19 @@ reconfigure(int sig)
 #if !HAVE_SIGACTION
 
     signal(sig, reconfigure);
+#endif
+#endif
+}
+
+void
+master_revive_kids(int sig)
+{
+    ReviveKidsSignal = sig;
+    do_revive_kids = true;
+
+#if !_SQUID_WINDOWS_
+#if !HAVE_SIGACTION
+    signal(sig, master_revive_kids);
 #endif
 #endif
 }
@@ -1774,32 +1789,87 @@ mainStartScript(const char *prog)
     }
 }
 
-#endif /* _SQUID_WINDOWS_ */
+/// Initiates shutdown sequence. Shutdown ends when the last running kids stops.
+static void
+masterShutdownStart()
+{
+    if (AvoidSignalAction("shutdown", do_shutdown))
+        return;
+    debugs(1, 2, "received shutdown command");
+    shutting_down = 1;
+}
 
-#if !_SQUID_WINDOWS_
+/// Initiates reconfiguration sequence. See also: masterReconfigureFinish().
+static void
+masterReconfigureStart()
+{
+    if (AvoidSignalAction("reconfiguration", do_reconfigure))
+        return;
+    debugs(1, 2, "received reconfiguration command");
+    reconfiguring = 1;
+    TheKids.forgetAllFailures();
+    // TODO: hot-reconfiguration of the number of kids, kids revival delay,
+    // PID file location, etc.
+}
+
+/// Ends reconfiguration sequence started by masterReconfigureStart().
+static void
+masterReconfigureFinish()
+{
+    reconfiguring = 0;
+}
+
+/// Reacts to the kid revival alarm.
+static void
+masterReviveKids()
+{
+    if (AvoidSignalAction("kids revival", do_revive_kids))
+        return;
+    debugs(1, 2, "woke up after ~" << Config.hopelessKidRevivalDelay << "s");
+    // nothing to do here -- actual revival happens elsewhere in the main loop
+    // the alarm was needed just to wake us up so that we do a loop iteration
+}
+
 static void
 masterCheckAndBroadcastSignals()
 {
-    // if (do_reconfigure)
-    //     TODO: hot-reconfiguration of the number of kids and PID file location
-
     if (do_shutdown)
-        shutting_down = 1;
+        masterShutdownStart();
+    if (do_reconfigure)
+        masterReconfigureStart();
+    if (do_revive_kids)
+        masterReviveKids();
+
+    // emulate multi-step reconfiguration assumed by AvoidSignalAction()
+    if (reconfiguring)
+        masterReconfigureFinish();
 
     BroadcastSignalIfAny(DebugSignal);
     BroadcastSignalIfAny(RotateSignal);
     BroadcastSignalIfAny(ReconfigureSignal);
     BroadcastSignalIfAny(ShutdownSignal);
+    ReviveKidsSignal = -1; // alarms are not broadcasted
 }
-#endif
+
+/// Maintains the following invariant: An alarm should be scheduled when and
+/// only when there are hopeless kid(s) that cannot be immediately revived.
+static void
+masterMaintainKidRevivalSchedule()
+{
+    const auto nextCheckDelay = TheKids.forgetOldFailures();
+    assert(nextCheckDelay >= 0);
+    (void)alarm(static_cast<unsigned int>(nextCheckDelay)); // resets or cancels
+    if (nextCheckDelay)
+        debugs(1, 2, "will recheck hopeless kids in " << nextCheckDelay << " seconds");
+}
 
 static inline bool
 masterSignaled()
 {
-    return (DebugSignal > 0 || RotateSignal > 0 || ReconfigureSignal > 0 || ShutdownSignal > 0);
+    return (DebugSignal > 0 || RotateSignal > 0 || ReconfigureSignal > 0 ||
+            ShutdownSignal > 0 || ReviveKidsSignal > 0);
 }
 
-#if !_SQUID_WINDOWS_
 /// makes the caller a daemon process running in the background
 static void
 GoIntoBackground()
@@ -1815,6 +1885,23 @@ GoIntoBackground()
     }
     // child, running as a background daemon (or a failed-to-fork parent)
 }
+
+static void
+masterExit()
+{
+    if (TheKids.someSignaled(SIGINT) || TheKids.someSignaled(SIGTERM)) {
+        syslog(LOG_ALERT, "Exiting due to unexpected forced shutdown");
+        exit(EXIT_FAILURE);
+    }
+
+    if (TheKids.allHopeless()) {
+        syslog(LOG_ALERT, "Exiting due to repeated, frequent failures");
+        exit(EXIT_FAILURE);
+    }
+
+    exit(EXIT_SUCCESS);
+}
+
 #endif /* !_SQUID_WINDOWS_ */
 
 static void
@@ -1829,6 +1916,12 @@ watch_child(char *argv[])
 #endif
 
     int nullfd;
+
+    // TODO: zero values are not supported because they result in
+    // misconfigured SMP Squid instances running forever, endlessly
+    // restarting each dying kid.
+    if (Config.hopelessKidRevivalDelay <= 0)
+        throw TexcHere("hopeless_kid_revival_delay must be positive");
 
     enter_suid();
 
@@ -1892,6 +1985,7 @@ watch_child(char *argv[])
     squid_signal(SIGHUP, reconfigure, 0);
 
     squid_signal(SIGTERM, master_shutdown, 0);
+    squid_signal(SIGALRM, master_revive_kids, 0);
     squid_signal(SIGINT, master_shutdown, 0);
 #ifdef SIGTTIN
     squid_signal(SIGTTIN, master_shutdown, 0);
@@ -1903,6 +1997,8 @@ watch_child(char *argv[])
         // but we keep going in hope that user knows best
     }
     TheKids.init();
+
+    configured_once = 1;
 
     syslog(LOG_NOTICE, "Squid Parent: will start %d kids", (int)TheKids.count());
 
@@ -1951,33 +2047,16 @@ watch_child(char *argv[])
             waitFlag = WNOHANG;
         PidStatus status;
         pid = WaitForAnyPid(status, waitFlag);
+        getCurrentTime();
 
         // check for a stopped kid
-        Kid* kid = pid > 0 ? TheKids.find(pid) : NULL;
-        if (kid) {
+        if (Kid *kid = pid > 0 ? TheKids.find(pid) : nullptr)
             kid->stop(status);
-            if (kid->calledExit()) {
-                syslog(LOG_NOTICE,
-                       "Squid Parent: %s process %d exited with status %d",
-                       kid->name().termedBuf(),
-                       kid->getPid(), kid->exitStatus());
-            } else if (kid->signaled()) {
-                syslog(LOG_NOTICE,
-                       "Squid Parent: %s process %d exited due to signal %d with status %d",
-                       kid->name().termedBuf(),
-                       kid->getPid(), kid->termSignal(), kid->exitStatus());
-            } else {
-                syslog(LOG_NOTICE, "Squid Parent: %s process %d exited",
-                       kid->name().termedBuf(), kid->getPid());
-            }
-            if (kid->hopeless()) {
-                syslog(LOG_NOTICE, "Squid Parent: %s process %d will not"
-                       " be restarted due to repeated, frequent failures",
-                       kid->name().termedBuf(), kid->getPid());
-            }
-        } else if (pid > 0) {
+        else if (pid > 0)
             syslog(LOG_NOTICE, "Squid Parent: unknown child process %d exited", pid);
-        }
+
+        masterCheckAndBroadcastSignals();
+        masterMaintainKidRevivalSchedule();
 
         if (!TheKids.someRunning() && !TheKids.shouldRestartSome()) {
             leave_suid();
@@ -1985,21 +2064,8 @@ watch_child(char *argv[])
             // RegisteredRunner::startShutdown which promises a loop iteration.
             RunRegisteredHere(RegisteredRunner::finishShutdown);
             enter_suid();
-
-            if (TheKids.someSignaled(SIGINT) || TheKids.someSignaled(SIGTERM)) {
-                syslog(LOG_ALERT, "Exiting due to unexpected forced shutdown");
-                exit(EXIT_FAILURE);
-            }
-
-            if (TheKids.allHopeless()) {
-                syslog(LOG_ALERT, "Exiting due to repeated, frequent failures");
-                exit(EXIT_FAILURE);
-            }
-
-            exit(EXIT_SUCCESS);
+            masterExit();
         }
-
-        masterCheckAndBroadcastSignals();
     }
 
     /* NOTREACHED */

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -365,8 +365,9 @@ BroadcastSignalIfAny(int& sig)
     if (sig > 0) {
         if (IamMasterProcess()) {
             for (int i = TheKids.count() - 1; i >= 0; --i) {
-                Kid& kid = TheKids.get(i);
-                kill(kid.getPid(), sig);
+                const auto &kid = TheKids.get(i);
+                if (kid.running())
+                    kill(kid.getPid(), sig);
             }
         }
         sig = -1;


### PR DESCRIPTION
Squid declares kids with "repeated, frequent failures" as hopeless.
Hopeless kids were not automatically restarted. In the absence of
automated recovery, admins were forced to restart the whole Squid
instance (after fixing the underlying problem that led to those kid
failures). Squid instance restarts hurt users.

In many cases, the underlying kid-killing problem is temporary, and
Squid can eventually fully recover without any admin involvement.

Squid now automatically restarts a hopeless kid after a configurable
downtime (a new hopeless_kid_revival_delay directive with a 60 minute
default value).

We also now restart all hopeless kids upon receiving a reconfiguration
signal.

Also: do not send signals to non-running kids.