### PR TITLE
Bug 4748: r15240 broke IP-based URLs, twice.

### DIFF
--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -947,7 +947,8 @@ Dns::CachedIps::seekNewGood(const char *name)
 void
 Dns::CachedIps::reset(const Ip::Address &ip)
 {
-    ips.resize(1, Dns::CachedIp(ip));
+    ips.clear();
+    ips.emplace_back(ip);
     goodPosition = 0;
     // Assume that the given IP is good because CachedIps are designed to never
     // run out of good IPs.
@@ -978,10 +979,12 @@ Dns::CachedIps::have(const Ip::Address &ip, size_t *positionOrNil) const
         if (cachedIp.ip == ip) {
             if (auto position = positionOrNil)
                 *position = pos;
+            debugs(14, 7, ip << " at " << pos << " in " << *this);
             return true;
         }
     }
     // no such address; leave *position as is
+    debugs(14, 7, " no " << ip << " in " << *this);
     return false;
 }
 


### PR DESCRIPTION
r15240 (a.k.a. fd9c47d) broke ipcacheCheckNumeric() because that
function's static storage was no longer reset properly between calls.
This bug is very different from bug 4741, but their symptoms (e.g.,
false "Host header forgery" SECURITY ALERTs) can be the same.

I did not realize that std::vector::resize(n, x) ignores x when the
vector size is already at least n. It is not a reset()-like method. My
tests did not have enough different IP-based URLs to expose this bug.