### PR TITLE
Do not die silently when dying early.

### DIFF
--- a/src/Debug.h
+++ b/src/Debug.h
@@ -99,7 +99,17 @@ private:
     static Context *Current; ///< deepest active context; nil outside debugs()
 };
 
-extern FILE *debug_log;
+/// cache.log FILE or, as the last resort, stderr stream;
+/// may be nil during static initialization and destruction!
+FILE *DebugStream();
+/// change-avoidance macro; new code should call DebugStream() instead
+#define debug_log DebugStream()
+
+/// start logging to stderr (instead of cache.log, if any)
+void StopUsingDebugLog();
+
+/// a hack for low-level file descriptor manipulations in ipcCreate()
+void ResyncDebugLog(FILE *newDestination);
 
 size_t BuildPrefixInit();
 const char * SkipBuildPrefix(const char* path);

--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -416,7 +416,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     execvp(prog, (char *const *) args);
     xerrno = errno;
 
-    debug_log = fdopen(2, "a+");
+    ResyncDebugLog(fdopen(2, "a+"));
 
     debugs(54, DBG_CRITICAL, "ipcCreate: " << prog << ": " << xstrerr(xerrno));
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1471,7 +1471,6 @@ SquidMain(int argc, char **argv)
     ConfigureCurrentKid(argv[0]);
 
     Debug::parseOptions(NULL);
-    debug_log = stderr;
 
 #if defined(SQUID_MAXFD_LIMIT)
 
@@ -1731,7 +1730,7 @@ SquidMain(int argc, char **argv)
 static void
 sendSignal(void)
 {
-    debug_log = stderr;
+    StopUsingDebugLog();
 
 #if USE_WIN32_SERVICE
     // WIN32_sendSignal() does not need the PID value to signal,

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -16,7 +16,8 @@
 #include "squid.h"
 #include "Debug.h"
 
-FILE *debug_log = NULL;
+#define STUB_API "debug.cc"
+#include "tests/STUB.h"
 
 char *Debug::debugOptions;
 char *Debug::cache_log= NULL;
@@ -25,6 +26,15 @@ int Debug::Levels[MAX_DEBUG_SECTIONS];
 int Debug::override_X = 0;
 int Debug::log_stderr = 1;
 bool Debug::log_syslog = false;
+
+void StopUsingDebugLog() STUB
+void ResyncDebugLog(FILE *) STUB
+
+FILE *
+DebugStream()
+{
+    return stderr;
+}
 
 Ctx
 ctx_enter(const char *)


### PR DESCRIPTION
Report (to stderr) various problems (e.g., unhandled exceptions) that
may occur very early in Squid lifetime, before stderr-logging is forced
by SquidMain() and way before proper logging is configured by the first
_db_init() call.

To enable such early reporting, we started with a trivial change:
  -FILE *debug_log = NULL;
  +FILE *debug_log = stderr;
... but realized that debug_log may not be assigned early enough! The
resulting (larger) changes ensure that we can log (to stderr if
necessary) as soon as stderr itself is initialized. They also polish
related logging code, including localization of stderr checks and
elimination of double-closure during log rotation on Windows.

These reporting changes do not bypass or eliminate any failures.