### PR TITLE
Do not output extra new lines at the end of debugs() lines.

### DIFF
--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -117,7 +117,7 @@ file_close(int fd)
 
     close(fd);
 
-    debugs(6, F->flags.close_request ? 2 : 5, "file_close: FD " << fd << " really closing\n");
+    debugs(6, F->flags.close_request ? 2 : 5, "file_close: FD " << fd << " really closing");
 
     fd_close(fd);
 

--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -177,7 +177,7 @@ IcmpPinger::Recv(void)
 
     if (0 == n) {
         /* EOF indicator */
-        debugs(42, DBG_CRITICAL, HERE << "EOF encountered. Pinger exiting.\n");
+        debugs(42, DBG_CRITICAL, "EOF encountered. Pinger exiting.");
         errno = 0;
         Close();
         exit(EXIT_FAILURE);

--- a/src/main.cc
+++ b/src/main.cc
@@ -1626,7 +1626,7 @@ SquidMain(int argc, char **argv)
         return 0;
     }
 
-    debugs(1,2, HERE << "Doing post-config initialization\n");
+    debugs(1,2, "Doing post-config initialization");
     leave_suid();
     RunRegisteredHere(RegisteredRunner::finalizeConfig);
 

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -364,7 +364,7 @@ get_session_cb(SSL *, unsigned char *sessionID, int len, int *copy)
     }
 
     if (!session)
-        debugs(83, 5, "Failed to retrieve SSL_SESSION from cache\n");
+        debugs(83, 5, "Failed to retrieve SSL_SESSION from cache");
 
     // With the parameter copy the callback can require the SSL engine
     // to increment the reference count of the SSL_SESSION object, Normally

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -1006,7 +1006,7 @@ Ssl::setClientSNI(SSL *ssl, const char *fqdn)
     }
     return true;
 #else
-    debugs(83, 7,  "no support for TLS servername extension (SNI)\n");
+    debugs(83, 7,  "no support for TLS servername extension (SNI)");
     return false;
 #endif
 }
@@ -1215,7 +1215,7 @@ completeIssuers(X509_STORE_CTX *ctx, STACK_OF(X509) *untrustedCerts)
 static int
 untrustedToStoreCtx_cb(X509_STORE_CTX *ctx,void *data)
 {
-    debugs(83, 4,  "Try to use pre-downloaded intermediate certificates\n");
+    debugs(83, 4,  "Try to use pre-downloaded intermediate certificates");
 
     SSL *ssl = static_cast<SSL *>(X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
     STACK_OF(X509) *sslUntrustedStack = static_cast <STACK_OF(X509) *>(SSL_get_ex_data(ssl, ssl_ex_index_ssl_untrusted_chain));


### PR DESCRIPTION
Debugs() adds a new line automatically. Extra new lines complicate
parsing and viewing cache logs.

These changes are untested.