### PR TITLE
Remove HERE.

### DIFF
--- a/src/BodyPipe.cc
+++ b/src/BodyPipe.cc
@@ -133,12 +133,12 @@ BodyPipe::BodyPipe(Producer *aProducer): theBodySize(-1),
     // TODO: teach MemBuf to start with zero minSize
     // TODO: limit maxSize by theBodySize, when known?
     theBuf.init(2*1024, MaxCapacity);
-    debugs(91,7, HERE << "created BodyPipe" << status());
+    debugs(91,7, "created BodyPipe" << status());
 }
 
 BodyPipe::~BodyPipe()
 {
-    debugs(91,7, HERE << "destroying BodyPipe" << status());
+    debugs(91,7, "destroying BodyPipe" << status());
     assert(!theProducer);
     assert(!theConsumer);
     theBuf.clean();
@@ -155,7 +155,7 @@ void BodyPipe::setBodySize(uint64_t aBodySize)
     assert(!theConsumer);
 
     theBodySize = aBodySize;
-    debugs(91,7, HERE << "set body size" << status());
+    debugs(91,7, "set body size" << status());
 }
 
 uint64_t BodyPipe::bodySize() const
@@ -194,13 +194,13 @@ void
 BodyPipe::clearProducer(bool atEof)
 {
     if (theProducer.set()) {
-        debugs(91,7, HERE << "clearing BodyPipe producer" << status());
+        debugs(91,7, "clearing BodyPipe producer" << status());
         theProducer.clear();
         if (atEof) {
             if (!bodySizeKnown())
                 theBodySize = thePutSize;
             else if (bodySize() != thePutSize)
-                debugs(91,3, HERE << "aborting on premature eof" << status());
+                debugs(91,3, "aborting on premature eof" << status());
         } else {
             // asserta that we can detect the abort if the consumer joins later
             assert(!bodySizeKnown() || bodySize() != thePutSize);
@@ -241,7 +241,7 @@ BodyPipe::setConsumerIfNotLate(const Consumer::Pointer &aConsumer)
     Must(!abortedConsumption); // did not promise to never consume
 
     theConsumer = aConsumer;
-    debugs(91,7, HERE << "set consumer" << status());
+    debugs(91,7, "set consumer" << status());
     if (theBuf.hasContent())
         scheduleBodyDataNotification();
     if (!theProducer)
@@ -254,7 +254,7 @@ void
 BodyPipe::clearConsumer()
 {
     if (theConsumer.set()) {
-        debugs(91,7, HERE << "clearing consumer" << status());
+        debugs(91,7, "clearing consumer" << status());
         theConsumer.clear();
         // do not abort if we have not consumed so that HTTP or ICAP can retry
         // benign xaction failures due to persistent connection race conditions
@@ -319,7 +319,7 @@ void
 BodyPipe::enableAutoConsumption()
 {
     mustAutoConsume = true;
-    debugs(91,5, HERE << "enabled auto consumption" << status());
+    debugs(91,5, "enabled auto consumption" << status());
     if (!theConsumer && theBuf.hasContent())
         startAutoConsumption();
 }
@@ -331,7 +331,7 @@ BodyPipe::startAutoConsumption()
     Must(mustAutoConsume);
     Must(!theConsumer);
     theConsumer = new BodySink(this);
-    debugs(91,7, HERE << "starting auto consumption" << status());
+    debugs(91,7, "starting auto consumption" << status());
     scheduleBodyDataNotification();
 }
 
@@ -376,7 +376,7 @@ BodyPipe::postConsume(size_t size)
 {
     assert(!isCheckedOut);
     theGetSize += size;
-    debugs(91,7, HERE << "consumed " << size << " bytes" << status());
+    debugs(91,7, "consumed " << size << " bytes" << status());
     if (mayNeedMoreData()) {
         AsyncCall::Pointer call=  asyncCall(91, 7,
                                             "BodyProducer::noteMoreBodySpaceAvailable",
@@ -391,7 +391,7 @@ BodyPipe::postAppend(size_t size)
 {
     assert(!isCheckedOut);
     thePutSize += size;
-    debugs(91,7, HERE << "added " << size << " bytes" << status());
+    debugs(91,7, "added " << size << " bytes" << status());
 
     if (mustAutoConsume && !theConsumer && size > 0)
         startAutoConsumption();
@@ -486,7 +486,7 @@ BodyPipeCheckout::~BodyPipeCheckout()
         // Do not pipe.undoCheckOut(*this) because it asserts or throws
         // TODO: consider implementing the long-term solution discussed at
         // http://www.mail-archive.com/squid-dev@squid-cache.org/msg07910.html
-        debugs(91,2, HERE << "Warning: cannot undo BodyPipeCheckout");
+        debugs(91,2, "Warning: cannot undo BodyPipeCheckout");
         thePipe.checkIn(*this);
     }
 }

--- a/src/CommCalls.cc
+++ b/src/CommCalls.cc
@@ -75,7 +75,7 @@ CommConnectCbParams::syncWithComm()
     // drop the call if the call was scheduled before comm_close but
     // is being fired after comm_close
     if (fd >= 0 && fd_table[fd].closing()) {
-        debugs(5, 3, HERE << "dropping late connect call: FD " << fd);
+        debugs(5, 3, "dropping late connect call: FD " << fd);
         return false;
     }
     return true; // now we are in sync and can handle the call
@@ -94,7 +94,7 @@ CommIoCbParams::syncWithComm()
     // change parameters if the call was scheduled before comm_close but
     // is being fired after comm_close
     if ((conn->fd < 0 || fd_table[conn->fd].closing()) && flag != Comm::ERR_CLOSING) {
-        debugs(5, 3, HERE << "converting late call to Comm::ERR_CLOSING: " << conn);
+        debugs(5, 3, "converting late call to Comm::ERR_CLOSING: " << conn);
         flag = Comm::ERR_CLOSING;
     }
     return true; // now we are in sync and can handle the call

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -129,7 +129,7 @@ const char * SkipBuildPrefix(const char* path);
  *
  * Its purpose is to inactivate calls made following previous debugs()
  * guidelines such as
- * debugs(1,2, HERE << "some message");
+ * debugs(1,2, "some message");
  *
  * His former objective is now absorbed in the debugs call itself
  */

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -124,23 +124,9 @@ const char * SkipBuildPrefix(const char* path);
         } \
    } while (/*CONSTCOND*/ 0)
 
-/** stream manipulator which does nothing.
- * \deprecated Do not add to new code, and remove when editing old code
- *
- * Its purpose is to inactivate calls made following previous debugs()
- * guidelines such as
- * debugs(1,2, "some message");
- *
- * His former objective is now absorbed in the debugs call itself
- */
-inline std::ostream&
-HERE(std::ostream& s)
-{
-    return s;
-}
-
 /*
- * MYNAME is for use at debug levels 0 and 1 where HERE is too messy.
+ * MYNAME can force-feed level-0/1 debugs() with an approximate source code
+ * location. Caution: Most level 0/1 debugs() should not report their location!
  *
  * debugs(1,1, MYNAME << "WARNING: some message");
  */

--- a/src/DelayUser.cc
+++ b/src/DelayUser.cc
@@ -131,7 +131,7 @@ DelayUser::id(CompositePoolNode::CompositeSelectionDetails &details)
     if (!details.user || !details.user->user() || !details.user->user()->username())
         return new NullDelayId;
 
-    debugs(77, 3, HERE << "Adding a slow-down for User '" << details.user->user()->username() << "'");
+    debugs(77, 3, "Adding a slow-down for User '" << details.user->user()->username() << "'");
     return new Id(this, details.user->user());
 }
 

--- a/src/DiskIO/AIO/AIODiskFile.cc
+++ b/src/DiskIO/AIO/AIODiskFile.cc
@@ -64,12 +64,12 @@ AIODiskFile::open(int flags, mode_t, RefCount<IORequestor> callback)
     ioRequestor = callback;
 
     if (fd < 0) {
-        debugs(79, 3, HERE << ": got failure (" << errno << ")");
+        debugs(79, 3, "got failure (" << errno << ")");
         error(true);
     } else {
         closed = false;
         ++store_open_disk_fd;
-        debugs(79, 3, HERE << ": opened FD " << fd);
+        debugs(79, 3, "opened FD " << fd);
     }
 
     callback->ioCompletedNotification();

--- a/src/DiskIO/Blocking/BlockingFile.cc
+++ b/src/DiskIO/Blocking/BlockingFile.cc
@@ -110,7 +110,7 @@ BlockingFile::read(ReadRequest *aRequest)
     assert (fd > -1);
     assert (ioRequestor.getRaw());
     readRequest = aRequest;
-    debugs(79, 3, HERE << aRequest->len << " for FD " << fd << " at " << aRequest->offset);
+    debugs(79, 3, aRequest->len << " for FD " << fd << " at " << aRequest->offset);
     file_read(fd, aRequest->buf, aRequest->len, aRequest->offset, ReadDone, this);
 }
 
@@ -125,7 +125,7 @@ BlockingFile::ReadDone(int fd, const char *buf, int len, int errflag, void *my_d
 void
 BlockingFile::write(WriteRequest *aRequest)
 {
-    debugs(79, 3, HERE << aRequest->len << " for FD " << fd << " at " << aRequest->offset);
+    debugs(79, 3, aRequest->len << " for FD " << fd << " at " << aRequest->offset);
     writeRequest = aRequest;
     file_write(fd,
                aRequest->offset,
@@ -181,7 +181,7 @@ void
 BlockingFile::writeDone(int rvfd, int errflag, size_t len)
 {
     assert (rvfd == fd);
-    debugs(79, 3, HERE << "FD " << fd << ", len " << len);
+    debugs(79, 3, "FD " << fd << ", len " << len);
 
     WriteRequest::Pointer result = writeRequest;
     writeRequest = NULL;

--- a/src/DiskIO/DiskDaemon/DiskdAction.cc
+++ b/src/DiskIO/DiskDaemon/DiskdAction.cc
@@ -65,13 +65,13 @@ DiskdAction::Create(const Mgr::CommandPointer &aCmd)
 DiskdAction::DiskdAction(const Mgr::CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(79, 5, HERE);
+    debugs(79, 5, "");
 }
 
 void
 DiskdAction::add(const Action& action)
 {
-    debugs(79, 5, HERE);
+    debugs(79, 5, "");
     data += dynamic_cast<const DiskdAction&>(action).data;
 }
 
@@ -114,7 +114,7 @@ DiskdAction::collect()
 void
 DiskdAction::dump(StoreEntry* entry)
 {
-    debugs(79, 5, HERE);
+    debugs(79, 5, "");
     Must(entry != NULL);
     storeAppendPrintf(entry, "sent_count: %.0f\n", data.sent_count);
     storeAppendPrintf(entry, "recv_count: %.0f\n", data.recv_count);

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
@@ -189,7 +189,7 @@ DiskThreadsDiskFile::close()
         ioRequestor->closeCompleted();
         return;
     } else {
-        debugs(79, DBG_CRITICAL, HERE << "DiskThreadsDiskFile::close: " <<
+        debugs(79, DBG_CRITICAL, "DiskThreadsDiskFile::close: " <<
                "did NOT close because ioInProgress() is true.  now what?");
     }
 }

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -209,7 +209,7 @@ IpcIoFile::error() const
 void
 IpcIoFile::read(ReadRequest *readRequest)
 {
-    debugs(79,3, HERE << "(disker" << diskId << ", " << readRequest->len << ", " <<
+    debugs(79,3, "(disker" << diskId << ", " << readRequest->len << ", " <<
            readRequest->offset << ")");
 
     assert(ioRequestor != NULL);
@@ -230,7 +230,7 @@ IpcIoFile::readCompleted(ReadRequest *readRequest,
 {
     bool ioError = false;
     if (!response) {
-        debugs(79, 3, HERE << "error: timeout");
+        debugs(79, 3, "error: timeout");
         ioError = true; // I/O timeout does not warrant setting error_?
     } else {
         if (response->xerrno) {
@@ -257,7 +257,7 @@ IpcIoFile::readCompleted(ReadRequest *readRequest,
 void
 IpcIoFile::write(WriteRequest *writeRequest)
 {
-    debugs(79,3, HERE << "(disker" << diskId << ", " << writeRequest->len << ", " <<
+    debugs(79,3, "(disker" << diskId << ", " << writeRequest->len << ", " <<
            writeRequest->offset << ")");
 
     assert(ioRequestor != NULL);
@@ -299,7 +299,7 @@ IpcIoFile::writeCompleted(WriteRequest *writeRequest,
         (writeRequest->free_func)(const_cast<char*>(writeRequest->buf)); // broken API?
 
     if (!ioError) {
-        debugs(79,5, HERE << "wrote " << writeRequest->len << " to disker" <<
+        debugs(79,5, "wrote " << writeRequest->len << " to disker" <<
                diskId << " at " << writeRequest->offset);
     }
 
@@ -333,7 +333,7 @@ IpcIoFile::push(IpcIoPendingRequest *const pending)
     // warning: this call may result in indirect push() recursion
     HandleResponses("before push");
 
-    debugs(47, 7, HERE);
+    debugs(47, 7, "");
     Must(diskId >= 0);
     Must(pending);
     Must(pending->readRequest || pending->writeRequest);
@@ -361,7 +361,7 @@ IpcIoFile::push(IpcIoPendingRequest *const pending)
             memcpy(buf, pending->writeRequest->buf, ipcIo.len); // optimize away
         }
 
-        debugs(47, 7, HERE << "pushing " << SipcIo(KidIdentifier, ipcIo, diskId));
+        debugs(47, 7, "pushing " << SipcIo(KidIdentifier, ipcIo, diskId));
 
         if (queue->push(diskId, ipcIo))
             Notify(diskId); // must notify disker
@@ -411,7 +411,7 @@ IpcIoFile::canWait() const
             static_cast<time_msec_t>(expectedWait) < config.ioTimeout)
         return true; // expected wait time is acceptible
 
-    debugs(47,2, HERE << "cannot wait: " << expectedWait <<
+    debugs(47,2, "cannot wait: " << expectedWait <<
            " oldest: " << SipcIo(KidIdentifier, oldestIo, diskId));
     return false; // do not want to wait that long
 }
@@ -420,7 +420,7 @@ IpcIoFile::canWait() const
 void
 IpcIoFile::HandleOpenResponse(const Ipc::StrandSearchResponse &response)
 {
-    debugs(47, 7, HERE << "coordinator response to open request");
+    debugs(47, 7, "coordinator response to open request");
     for (IpcIoFileList::iterator i = WaitingForOpen.begin();
             i != WaitingForOpen.end(); ++i) {
         if (response.strand.tag == (*i)->dbName) {
@@ -430,7 +430,7 @@ IpcIoFile::HandleOpenResponse(const Ipc::StrandSearchResponse &response)
         }
     }
 
-    debugs(47, 4, HERE << "LATE disker response to open for " <<
+    debugs(47, 4, "LATE disker response to open for " <<
            response.strand.tag);
     // nothing we can do about it; completeIo() has been called already
 }
@@ -438,7 +438,7 @@ IpcIoFile::HandleOpenResponse(const Ipc::StrandSearchResponse &response)
 void
 IpcIoFile::HandleResponses(const char *const when)
 {
-    debugs(47, 4, HERE << "popping all " << when);
+    debugs(47, 4, "popping all " << when);
     IpcIoMsg ipcIo;
     // get all responses we can: since we are not pushing, this will stop
     int diskId;
@@ -453,7 +453,7 @@ void
 IpcIoFile::handleResponse(IpcIoMsg &ipcIo)
 {
     const int requestId = ipcIo.requestId;
-    debugs(47, 7, HERE << "popped disker response: " <<
+    debugs(47, 7, "popped disker response: " <<
            SipcIo(KidIdentifier, ipcIo, diskId));
 
     Must(requestId);
@@ -461,7 +461,7 @@ IpcIoFile::handleResponse(IpcIoMsg &ipcIo)
         pending->completeIo(&ipcIo);
         delete pending; // XXX: leaking if throwing
     } else {
-        debugs(47, 4, HERE << "LATE disker response to " << ipcIo.command <<
+        debugs(47, 4, "LATE disker response to " << ipcIo.command <<
                "; ipcIo" << KidIdentifier << '.' << requestId);
         // nothing we can do about it; completeIo() has been called already
     }
@@ -471,7 +471,7 @@ void
 IpcIoFile::Notify(const int peerId)
 {
     // TODO: Count and report the total number of notifications, pops, pushes.
-    debugs(47, 7, HERE << "kid" << peerId);
+    debugs(47, 7, "kid" << peerId);
     Ipc::TypedMsgHdr msg;
     msg.setType(Ipc::mtIpcIoNotification); // TODO: add proper message type?
     msg.putInt(KidIdentifier);
@@ -483,7 +483,7 @@ void
 IpcIoFile::HandleNotification(const Ipc::TypedMsgHdr &msg)
 {
     const int from = msg.getInt();
-    debugs(47, 7, HERE << "from " << from);
+    debugs(47, 7, "from " << from);
     queue->clearReaderSignal(from);
     if (IamDiskProcess())
         DiskerHandleRequests();
@@ -515,7 +515,7 @@ IpcIoFile::CheckTimeouts(void *const param)
 {
     Must(param);
     const int diskId = reinterpret_cast<uintptr_t>(param);
-    debugs(47, 7, HERE << "diskId=" << diskId);
+    debugs(47, 7, "diskId=" << diskId);
     const IpcIoFilesMap::const_iterator i = IpcIoFiles.find(diskId);
     if (i != IpcIoFiles.end())
         i->second->checkTimeouts();
@@ -551,7 +551,7 @@ IpcIoFile::checkTimeouts()
         IpcIoPendingRequest *const pending = i->second;
 
         const unsigned int requestId = i->first;
-        debugs(47, 7, HERE << "disker timeout; ipcIo" <<
+        debugs(47, 7, "disker timeout; ipcIo" <<
                KidIdentifier << '.' << requestId);
 
         pending->completeIo(NULL); // no response
@@ -649,7 +649,7 @@ diskerRead(IpcIoMsg &ipcIo)
 {
     if (!Ipc::Mem::GetPage(Ipc::Mem::PageId::ioPage, ipcIo.page)) {
         ipcIo.len = 0;
-        debugs(47,2, HERE << "run out of shared memory pages for IPC I/O");
+        debugs(47,2, "run out of shared memory pages for IPC I/O");
         return;
     }
 
@@ -661,13 +661,13 @@ diskerRead(IpcIoMsg &ipcIo)
     if (read >= 0) {
         ipcIo.xerrno = 0;
         const size_t len = static_cast<size_t>(read); // safe because read > 0
-        debugs(47,8, HERE << "disker" << KidIdentifier << " read " <<
+        debugs(47,8, "disker" << KidIdentifier << " read " <<
                (len == ipcIo.len ? "all " : "just ") << read);
         ipcIo.len = len;
     } else {
         ipcIo.xerrno = errno;
         ipcIo.len = 0;
-        debugs(47,5, HERE << "disker" << KidIdentifier << " read error: " <<
+        debugs(47,5, "disker" << KidIdentifier << " read error: " <<
                ipcIo.xerrno);
     }
 }
@@ -740,7 +740,7 @@ diskerWrite(IpcIoMsg &ipcIo)
 void
 IpcIoFile::DiskerHandleMoreRequests(void *source)
 {
-    debugs(47, 7, HERE << "resuming handling requests after " <<
+    debugs(47, 7, "resuming handling requests after " <<
            static_cast<const char *>(source));
     DiskerHandleMoreRequestsScheduled = false;
     IpcIoFile::DiskerHandleRequests();
@@ -778,7 +778,7 @@ IpcIoFile::WaitBeforePop()
     Ipc::QueueReader::Balance &balance = queue->localBalance();
     balance += static_cast<int64_t>(credit - debit);
 
-    debugs(47, 7, HERE << "rate limiting balance: " << balance << " after +" << credit << " -" << debit);
+    debugs(47, 7, "rate limiting balance: " << balance << " after +" << credit << " -" << debit);
 
     if (ipcIo.command == IpcIo::cmdWrite && balance > maxImbalance) {
         // if the next request is (likely) write and we accumulated
@@ -791,7 +791,7 @@ IpcIoFile::WaitBeforePop()
                    "I/O requests for " << (toSpend/1e3) << " seconds " <<
                    "to obey " << ioRate << "/sec rate limit");
 
-        debugs(47, 3, HERE << "rate limiting by " << toSpend << " ms to get" <<
+        debugs(47, 3, "rate limiting by " << toSpend << " ms to get" <<
                (1e3*maxRate) << "/sec rate");
         eventAdd("IpcIoFile::DiskerHandleMoreRequests",
                  &IpcIoFile::DiskerHandleMoreRequests,
@@ -837,7 +837,7 @@ IpcIoFile::DiskerHandleRequests()
                          minBreakSecs, 0, false);
                 DiskerHandleMoreRequestsScheduled = true;
             }
-            debugs(47, 3, HERE << "pausing after " << popped << " I/Os in " <<
+            debugs(47, 3, "pausing after " << popped << " I/Os in " <<
                    elapsedMsec << "ms; " << (elapsedMsec/popped) << "ms per I/O");
             break;
         }
@@ -860,7 +860,7 @@ IpcIoFile::DiskerHandleRequest(const int workerId, IpcIoMsg &ipcIo)
         return;
     }
 
-    debugs(47,5, HERE << "disker" << KidIdentifier <<
+    debugs(47,5, "disker" << KidIdentifier <<
            (ipcIo.command == IpcIo::cmdRead ? " reads " : " writes ") <<
            ipcIo.len << " at " << ipcIo.offset <<
            " ipcIo" << workerId << '.' << ipcIo.requestId);
@@ -870,7 +870,7 @@ IpcIoFile::DiskerHandleRequest(const int workerId, IpcIoMsg &ipcIo)
     else // ipcIo.command == IpcIo::cmdWrite
         diskerWrite(ipcIo);
 
-    debugs(47, 7, HERE << "pushing " << SipcIo(workerId, ipcIo, KidIdentifier));
+    debugs(47, 7, "pushing " << SipcIo(workerId, ipcIo, KidIdentifier));
 
     try {
         if (queue->push(workerId, ipcIo))
@@ -913,7 +913,7 @@ DiskerClose(const SBuf &path)
 {
     if (TheFile >= 0) {
         file_close(TheFile);
-        debugs(79,3, HERE << "rock db closed " << path << ": FD " << TheFile);
+        debugs(79,3, "rock db closed " << path << ": FD " << TheFile);
         TheFile = -1;
         --store_open_disk_fd;
     }

--- a/src/DiskIO/Mmapped/MmappedFile.cc
+++ b/src/DiskIO/Mmapped/MmappedFile.cc
@@ -58,7 +58,7 @@ MmappedFile::MmappedFile(char const *aPath): fd(-1),
 {
     assert(aPath);
     path_ = xstrdup(aPath);
-    debugs(79,5, HERE << this << ' ' << path_);
+    debugs(79,5, this << ' ' << path_);
 }
 
 MmappedFile::~MmappedFile()
@@ -117,7 +117,7 @@ void MmappedFile::doClose()
 void
 MmappedFile::close()
 {
-    debugs(79, 3, HERE << this << " closing for " << ioRequestor);
+    debugs(79, 3, this << " closing for " << ioRequestor);
     doClose();
     assert(ioRequestor != NULL);
     ioRequestor->closeCompleted();
@@ -144,7 +144,7 @@ MmappedFile::error() const
 void
 MmappedFile::read(ReadRequest *aRequest)
 {
-    debugs(79,3, HERE << "(FD " << fd << ", " << aRequest->len << ", " <<
+    debugs(79,3, "(FD " << fd << ", " << aRequest->len << ", " <<
            aRequest->offset << ")");
 
     assert(fd >= 0);
@@ -174,7 +174,7 @@ MmappedFile::read(ReadRequest *aRequest)
 void
 MmappedFile::write(WriteRequest *aRequest)
 {
-    debugs(79,3, HERE << "(FD " << fd << ", " << aRequest->len << ", " <<
+    debugs(79,3, "(FD " << fd << ", " << aRequest->len << ", " <<
            aRequest->offset << ")");
 
     assert(fd >= 0);
@@ -189,10 +189,10 @@ MmappedFile::write(WriteRequest *aRequest)
     const ssize_t written =
         pwrite(fd, aRequest->buf, aRequest->len, aRequest->offset);
     if (written < 0) {
-        debugs(79, DBG_IMPORTANT, HERE << "error: " << xstrerr(errno));
+        debugs(79, DBG_IMPORTANT, "error: " << xstrerr(errno));
         error_ = true;
     } else if (static_cast<size_t>(written) != aRequest->len) {
-        debugs(79, DBG_IMPORTANT, HERE << "problem: " << written << " < " << aRequest->len);
+        debugs(79, DBG_IMPORTANT, "problem: " << written << " < " << aRequest->len);
         error_ = true;
     }
 
@@ -200,7 +200,7 @@ MmappedFile::write(WriteRequest *aRequest)
         (aRequest->free_func)(const_cast<char*>(aRequest->buf)); // broken API?
 
     if (!error_) {
-        debugs(79,5, HERE << "wrote " << aRequest->len << " to FD " << fd << " at " << aRequest->offset);
+        debugs(79,5, "wrote " << aRequest->len << " to FD " << fd << " at " << aRequest->offset);
     } else {
         doClose();
     }
@@ -240,7 +240,7 @@ Mmapping::map()
 
     if (buf == MAP_FAILED) {
         const int errNo = errno;
-        debugs(79,3, HERE << "error FD " << fd << "mmap(" << length << '+' <<
+        debugs(79,3, "error FD " << fd << "mmap(" << length << '+' <<
                delta << ", " << offset << '-' << delta << "): " << xstrerr(errNo));
         buf = NULL;
         return NULL;
@@ -252,7 +252,7 @@ Mmapping::map()
 bool
 Mmapping::unmap()
 {
-    debugs(79,9, HERE << "FD " << fd <<
+    debugs(79,9, "FD " << fd <<
            " munmap(" << buf << ", " << length << '+' << delta << ')');
 
     if (!buf) // forgot or failed to map
@@ -261,7 +261,7 @@ Mmapping::unmap()
     const bool error = munmap(buf, length + delta) != 0;
     if (error) {
         const int errNo = errno;
-        debugs(79,3, HERE << "error FD " << fd <<
+        debugs(79,3, "error FD " << fd <<
                " munmap(" << buf << ", " << length << '+' << delta << "): " <<
                "): " << xstrerr(errNo));
     }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -109,7 +109,7 @@ FwdState::abort(void* d)
     if (Comm::IsConnOpen(fwd->serverConnection())) {
         fwd->closeServerConnection("store entry aborted");
     } else {
-        debugs(17, 7, HERE << "store entry aborted; no connection to close");
+        debugs(17, 7, "store entry aborted; no connection to close");
     }
     fwd->serverDestinations.clear();
     fwd->stopAndDestroy("store entry aborted");
@@ -225,7 +225,7 @@ FwdState::selectPeerForIntercepted()
     p->remote = clientConn->local;
     getOutgoingAddress(request, p);
 
-    debugs(17, 3, HERE << "using client original destination: " << *p);
+    debugs(17, 3, "using client original destination: " << *p);
     serverDestinations.push_back(p);
 }
 #endif
@@ -234,7 +234,7 @@ void
 FwdState::completed()
 {
     if (flags.forward_completed) {
-        debugs(17, DBG_IMPORTANT, HERE << "FwdState::completed called on a completed request! Bad!");
+        debugs(17, DBG_IMPORTANT, "FwdState::completed called on a completed request! Bad!");
         return;
     }
 
@@ -243,7 +243,7 @@ FwdState::completed()
     request->hier.stopPeerClock(false);
 
     if (EBIT_TEST(entry->flags, ENTRY_ABORTED)) {
-        debugs(17, 3, HERE << "entry aborted");
+        debugs(17, 3, "entry aborted");
         return ;
     }
 
@@ -345,7 +345,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         }
     }
 
-    debugs(17, 3, HERE << "'" << entry->url() << "'");
+    debugs(17, 3, "'" << entry->url() << "'");
     /*
      * This seems like an odd place to bind mem_obj and request.
      * Might want to assert that request is NULL at this point
@@ -422,7 +422,7 @@ FwdState::EnoughTimeToReForward(const time_t fwdStart)
 void
 FwdState::startConnectionOrFail()
 {
-    debugs(17, 3, HERE << entry->url());
+    debugs(17, 3, entry->url());
 
     if (serverDestinations.size() > 0) {
         // Ditch error page if it was created before.
@@ -444,7 +444,7 @@ FwdState::startConnectionOrFail()
             return; // expect a noteDestination*() call
         }
 
-        debugs(17, 3, HERE << "Connection failed: " << entry->url());
+        debugs(17, 3, "Connection failed: " << entry->url());
         if (!err) {
             ErrorState *anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request);
             fail(anErr);
@@ -469,7 +469,7 @@ FwdState::fail(ErrorState * errorState)
         return;
 
     if (pconnRace == racePossible) {
-        debugs(17, 5, HERE << "pconn race happened");
+        debugs(17, 5, "pconn race happened");
         pconnRace = raceHappened;
     }
 
@@ -486,7 +486,7 @@ FwdState::fail(ErrorState * errorState)
 void
 FwdState::unregister(Comm::ConnectionPointer &conn)
 {
-    debugs(17, 3, HERE << entry->url() );
+    debugs(17, 3, entry->url() );
     assert(serverConnection() == conn);
     assert(Comm::IsConnOpen(conn));
     comm_remove_close_handler(conn->fd, closeHandler);
@@ -498,7 +498,7 @@ FwdState::unregister(Comm::ConnectionPointer &conn)
 void
 FwdState::unregister(int fd)
 {
-    debugs(17, 3, HERE << entry->url() );
+    debugs(17, 3, entry->url() );
     assert(fd == serverConnection()->fd);
     unregister(serverConn);
 }
@@ -512,7 +512,7 @@ FwdState::unregister(int fd)
 void
 FwdState::complete()
 {
-    debugs(17, 3, HERE << entry->url() << "\n\tstatus " << entry->getReply()->sline.status());
+    debugs(17, 3, entry->url() << "\n\tstatus " << entry->getReply()->sline.status());
 #if URL_CHECKSUM_DEBUG
 
     entry->mem_obj->checkUrlChecksum();
@@ -521,7 +521,7 @@ FwdState::complete()
     logReplyStatus(n_tries, entry->getReply()->sline.status());
 
     if (reforward()) {
-        debugs(17, 3, HERE << "re-forwarding " << entry->getReply()->sline.status() << " " << entry->url());
+        debugs(17, 3, "re-forwarding " << entry->getReply()->sline.status() << " " << entry->url());
 
         if (Comm::IsConnOpen(serverConn))
             unregister(serverConn);
@@ -535,9 +535,9 @@ FwdState::complete()
 
     } else {
         if (Comm::IsConnOpen(serverConn))
-            debugs(17, 3, HERE << "server FD " << serverConnection()->fd << " not re-forwarding status " << entry->getReply()->sline.status());
+            debugs(17, 3, "server FD " << serverConnection()->fd << " not re-forwarding status " << entry->getReply()->sline.status());
         else
-            debugs(17, 3, HERE << "server (FD closed) not re-forwarding status " << entry->getReply()->sline.status());
+            debugs(17, 3, "server (FD closed) not re-forwarding status " << entry->getReply()->sline.status());
         EBIT_CLR(entry->flags, ENTRY_FWD_HDR_WAIT);
         entry->complete();
 
@@ -615,7 +615,7 @@ FwdState::checkRetry()
         return false;
 
     if (!self) { // we have aborted before the server called us back
-        debugs(17, 5, HERE << "not retrying because of earlier abort");
+        debugs(17, 5, "not retrying because of earlier abort");
         // we will be destroyed when the server clears its Pointer to us
         return false;
     }
@@ -677,10 +677,10 @@ void
 FwdState::retryOrBail()
 {
     if (checkRetry()) {
-        debugs(17, 3, HERE << "re-forwarding (" << n_tries << " tries, " << (squid_curtime - start_t) << " secs)");
+        debugs(17, 3, "re-forwarding (" << n_tries << " tries, " << (squid_curtime - start_t) << " secs)");
         // we should retry the same destination if it failed due to pconn race
         if (pconnRace == raceHappened)
-            debugs(17, 4, HERE << "retrying the same destination");
+            debugs(17, 4, "retrying the same destination");
         else
             serverDestinations.erase(serverDestinations.begin()); // last one failed. try another.
         startConnectionOrFail();
@@ -714,7 +714,7 @@ FwdState::doneWithRetries()
 void
 FwdState::handleUnregisteredServerEnd()
 {
-    debugs(17, 2, HERE << "self=" << self << " err=" << err << ' ' << entry->url());
+    debugs(17, 2, "self=" << self << " err=" << err << ' ' << entry->url());
     assert(!Comm::IsConnOpen(serverConn));
     retryOrBail();
 }
@@ -739,7 +739,7 @@ FwdState::connectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, in
     }
 
     serverConn = conn;
-    debugs(17, 3, HERE << serverConnection() << ": '" << entry->url() << "'" );
+    debugs(17, 3, serverConnection() << ": '" << entry->url() << "'" );
 
     closeHandler = comm_add_close_handler(serverConnection()->fd, fwdServerClosedWrapper, this);
 
@@ -906,7 +906,7 @@ FwdState::connectStart()
         }
 
         // Pinned connection failure.
-        debugs(17,2,HERE << "Pinned connection failed: " << pinned_connection);
+        debugs(17,2,"Pinned connection failed: " << pinned_connection);
         ErrorState *anErr = new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, request);
         fail(anErr);
         stopAndDestroy("pinned connection failure");
@@ -932,7 +932,7 @@ FwdState::connectStart()
     if (openedPconn) {
         serverConn = temp;
         flags.connected_okay = true;
-        debugs(17, 3, HERE << "reusing pconn " << serverConnection());
+        debugs(17, 3, "reusing pconn " << serverConnection());
         ++n_tries;
 
         closeHandler = comm_add_close_handler(serverConnection()->fd,  fwdServerClosedWrapper, this);
@@ -1093,7 +1093,7 @@ FwdState::reforward()
     StoreEntry *e = entry;
 
     if (EBIT_TEST(e->flags, ENTRY_ABORTED)) {
-        debugs(17, 3, HERE << "entry aborted");
+        debugs(17, 3, "entry aborted");
         return 0;
     }
 
@@ -1104,10 +1104,10 @@ FwdState::reforward()
     e->mem_obj->checkUrlChecksum();
 #endif
 
-    debugs(17, 3, HERE << e->url() << "?" );
+    debugs(17, 3, e->url() << "?" );
 
     if (!EBIT_TEST(e->flags, ENTRY_FWD_HDR_WAIT)) {
-        debugs(17, 3, HERE << "No, ENTRY_FWD_HDR_WAIT isn't set");
+        debugs(17, 3, "No, ENTRY_FWD_HDR_WAIT isn't set");
         return 0;
     }
 
@@ -1119,12 +1119,12 @@ FwdState::reforward()
 
     if (serverDestinations.size() <= 1 && !PeerSelectionInitiator::subscribed) {
         // NP: <= 1 since total count includes the recently failed one.
-        debugs(17, 3, HERE << "No alternative forwarding paths left");
+        debugs(17, 3, "No alternative forwarding paths left");
         return 0;
     }
 
     const Http::StatusCode s = e->getReply()->sline.status();
-    debugs(17, 3, HERE << "status " << s);
+    debugs(17, 3, "status " << s);
     return reforwardableStatus(s);
 }
 

--- a/src/HttpHeaderTools.cc
+++ b/src/HttpHeaderTools.cc
@@ -169,7 +169,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
     const char *end, *pos;
     val->clean();
     if (*start != '"') {
-        debugs(66, 2, HERE << "failed to parse a quoted-string header field near '" << start << "'");
+        debugs(66, 2, "failed to parse a quoted-string header field near '" << start << "'");
         return 0;
     }
     pos = start + 1;
@@ -179,7 +179,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         if (*pos =='\r') {
             ++pos;
             if ((pos-start) > len || *pos != '\n') {
-                debugs(66, 2, HERE << "failed to parse a quoted-string header field with '\\r' octet " << (start-pos)
+                debugs(66, 2, "failed to parse a quoted-string header field with '\\r' octet " << (start-pos)
                        << " bytes into '" << start << "'");
                 val->clean();
                 return 0;
@@ -189,14 +189,14 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         if (*pos == '\n') {
             ++pos;
             if ( (pos-start) > len || (*pos != ' ' && *pos != '\t')) {
-                debugs(66, 2, HERE << "failed to parse multiline quoted-string header field '" << start << "'");
+                debugs(66, 2, "failed to parse multiline quoted-string header field '" << start << "'");
                 val->clean();
                 return 0;
             }
             // TODO: replace the entire LWS with a space
             val->append(" ");
             ++pos;
-            debugs(66, 2, HERE << "len < pos-start => " << len << " < " << (pos-start));
+            debugs(66, 2, "len < pos-start => " << len << " < " << (pos-start));
             continue;
         }
 
@@ -204,7 +204,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         if (quoted) {
             ++pos;
             if (!*pos || (pos-start) > len) {
-                debugs(66, 2, HERE << "failed to parse a quoted-string header field near '" << start << "'");
+                debugs(66, 2, "failed to parse a quoted-string header field near '" << start << "'");
                 val->clean();
                 return 0;
             }
@@ -213,7 +213,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         while (end < (start+len) && *end != '\\' && *end != '\"' && (unsigned char)*end > 0x1F && *end != 0x7F)
             ++end;
         if (((unsigned char)*end <= 0x1F && *end != '\r' && *end != '\n') || *end == 0x7F) {
-            debugs(66, 2, HERE << "failed to parse a quoted-string header field with CTL octet " << (start-pos)
+            debugs(66, 2, "failed to parse a quoted-string header field with CTL octet " << (start-pos)
                    << " bytes into '" << start << "'");
             val->clean();
             return 0;
@@ -223,7 +223,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
     }
 
     if (*pos != '\"') {
-        debugs(66, 2, HERE << "failed to parse a quoted-string header field which did not end with \" ");
+        debugs(66, 2, "failed to parse a quoted-string header field which did not end with \" ");
         val->clean();
         return 0;
     }

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -474,7 +474,7 @@ bool
 HttpReply::receivedBodyTooLarge(HttpRequest& request, int64_t receivedSize)
 {
     calcMaxBodySize(request);
-    debugs(58, 3, HERE << receivedSize << " >? " << bodySizeMax);
+    debugs(58, 3, receivedSize << " >? " << bodySizeMax);
     return bodySizeMax >= 0 && receivedSize > bodySizeMax;
 }
 
@@ -482,7 +482,7 @@ bool
 HttpReply::expectedBodyTooLarge(HttpRequest& request)
 {
     calcMaxBodySize(request);
-    debugs(58, 7, HERE << "bodySizeMax=" << bodySizeMax);
+    debugs(58, 7, "bodySizeMax=" << bodySizeMax);
 
     if (bodySizeMax < 0) // no body size limit
         return false;
@@ -491,7 +491,7 @@ HttpReply::expectedBodyTooLarge(HttpRequest& request)
     if (!expectingBody(request.method, expectedSize))
         return false;
 
-    debugs(58, 6, HERE << expectedSize << " >? " << bodySizeMax);
+    debugs(58, 6, expectedSize << " >? " << bodySizeMax);
 
     if (expectedSize < 0) // expecting body of an unknown length
         return false;
@@ -518,7 +518,7 @@ HttpReply::calcMaxBodySize(HttpRequest& request) const
     for (AclSizeLimit *l = Config.ReplyBodySize; l; l = l -> next) {
         /* if there is no ACL list or if the ACLs listed match use this size value */
         if (!l->aclList || ch.fastCheck(l->aclList).allowed()) {
-            debugs(58, 4, HERE << "bodySizeMax=" << bodySizeMax);
+            debugs(58, 4, "bodySizeMax=" << bodySizeMax);
             bodySizeMax = l->size; // may be -1
             break;
         }

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -53,7 +53,7 @@ HttpRequest::HttpRequest(const HttpRequestMethod& aMethod, AnyP::ProtocolType aP
 {
     assert(mx);
     static unsigned int id = 1;
-    debugs(93,7, HERE << "constructed, this=" << this << " id=" << ++id);
+    debugs(93,7, "constructed, this=" << this << " id=" << ++id);
     init();
     initHTTP(aMethod, aProtocol, aSchemeImg, aUrlpath);
 }
@@ -61,7 +61,7 @@ HttpRequest::HttpRequest(const HttpRequestMethod& aMethod, AnyP::ProtocolType aP
 HttpRequest::~HttpRequest()
 {
     clean();
-    debugs(93,7, HERE << "destructed, this=" << this);
+    debugs(93,7, "destructed, this=" << this);
 }
 
 void
@@ -274,7 +274,7 @@ HttpRequest::sanityCheckStartLine(const char *buf, const size_t hdr_len, Http::S
     if (hdr_len < 2) {
         // this is ony a real error if the headers apparently complete.
         if (hdr_len > 0) {
-            debugs(58, 3, HERE << "Too large request header (" << hdr_len << " bytes)");
+            debugs(58, 3, "Too large request header (" << hdr_len << " bytes)");
             *error = Http::scInvalidHeader;
         }
         return false;
@@ -401,7 +401,7 @@ HttpRequest::icapHistory() const
     if (!icapHistory_) {
         if (Log::TheConfig.hasIcapToken || IcapLogfileStatus == LOG_ENABLE) {
             icapHistory_ = new Adaptation::Icap::History();
-            debugs(93,4, HERE << "made " << icapHistory_ << " for " << this);
+            debugs(93,4, "made " << icapHistory_ << " for " << this);
         }
     }
 
@@ -415,7 +415,7 @@ HttpRequest::adaptHistory(bool createIfNone) const
 {
     if (!adaptHistory_ && createIfNone) {
         adaptHistory_ = new Adaptation::History();
-        debugs(93,4, HERE << "made " << adaptHistory_ << " for " << this);
+        debugs(93,4, "made " << adaptHistory_ << " for " << this);
     }
 
     return adaptHistory_;
@@ -456,8 +456,8 @@ void
 HttpRequest::detailError(err_type aType, int aDetail)
 {
     if (errType || errDetail)
-        debugs(11, 5, HERE << "old error details: " << errType << '/' << errDetail);
-    debugs(11, 5, HERE << "current error details: " << aType << '/' << aDetail);
+        debugs(11, 5, "old error details: " << errType << '/' << errDetail);
+    debugs(11, 5, "current error details: " << aType << '/' << aDetail);
     // checking type and detail separately may cause inconsistency, but
     // may result in more details available if they only become available later
     if (!errType)
@@ -469,7 +469,7 @@ HttpRequest::detailError(err_type aType, int aDetail)
 void
 HttpRequest::clearError()
 {
-    debugs(11, 7, HERE << "old error details: " << errType << '/' << errDetail);
+    debugs(11, 7, "old error details: " << errType << '/' << errDetail);
     errType = ERR_NONE;
     errDetail = ERR_DETAIL_NONE;
 }
@@ -615,7 +615,7 @@ HttpRequest::getRangeOffsetLimit()
     for (AclSizeLimit *l = Config.rangeOffsetLimit; l; l = l -> next) {
         /* if there is no ACL list or if the ACLs listed match use this limit value */
         if (!l->aclList || ch.fastCheck(l->aclList).allowed()) {
-            debugs(58, 4, HERE << "rangeOffsetLimit=" << rangeOffsetLimit);
+            debugs(58, 4, "rangeOffsetLimit=" << rangeOffsetLimit);
             rangeOffsetLimit = l->size; // may be -1
             break;
         }

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -334,7 +334,7 @@ MemStore::get(const cache_key *key)
         return e;
     }
 
-    debugs(20, 3, HERE << "mem-loading failed; freeing " << index);
+    debugs(20, 3, "mem-loading failed; freeing " << index);
     map->freeEntry(index); // do not let others into the same trap
     return NULL;
 }
@@ -612,7 +612,7 @@ MemStore::shouldCache(StoreEntry &e) const
     }
 
     if (!e.memoryCachable()) {
-        debugs(20, 7, HERE << "Not memory cachable: " << e);
+        debugs(20, 7, "Not memory cachable: " << e);
         return false; // will not cache due to entry state or properties
     }
 
@@ -628,7 +628,7 @@ MemStore::shouldCache(StoreEntry &e) const
     const int64_t loadedSize = e.mem_obj->endOffset();
     const int64_t ramSize = max(loadedSize, expectedSize);
     if (ramSize > maxObjectSize()) {
-        debugs(20, 5, HERE << "Too big max(" <<
+        debugs(20, 5, "Too big max(" <<
                loadedSize << ", " << expectedSize << "): " << e);
         return false; // will not cache due to cachable entry size limits
     }
@@ -639,7 +639,7 @@ MemStore::shouldCache(StoreEntry &e) const
     }
 
     if (!map) {
-        debugs(20, 5, HERE << "No map to mem-cache " << e);
+        debugs(20, 5, "No map to mem-cache " << e);
         return false;
     }
 
@@ -658,7 +658,7 @@ MemStore::startCaching(StoreEntry &e)
     sfileno index = 0;
     Ipc::StoreMapAnchor *slot = map->openForWriting(reinterpret_cast<const cache_key *>(e.key), index);
     if (!slot) {
-        debugs(20, 5, HERE << "No room in mem-cache map to index " << e);
+        debugs(20, 5, "No room in mem-cache map to index " << e);
         return false;
     }
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -60,14 +60,14 @@ ACLChecklist::markFinished(const allow_t &finalAnswer, const char *reason)
     assert (!finished() && !asyncInProgress());
     finished_ = true;
     allow_ = finalAnswer;
-    debugs(28, 3, HERE << this << " answer " << allow_ << " for " << reason);
+    debugs(28, 3, this << " answer " << allow_ << " for " << reason);
 }
 
 /// Called first (and once) by all checks to initialize their state
 void
 ACLChecklist::preCheck(const char *what)
 {
-    debugs(28, 3, HERE << this << " checking " << what);
+    debugs(28, 3, this << " checking " << what);
 
     // concurrent checks using the same Checklist are not supported
     assert(!occupied_);
@@ -379,7 +379,7 @@ ACLChecklist::calcImplicitAnswer()
         implicitRuleAnswer = ACCESS_DENIED;
     // else we saw no rules and will respond with ACCESS_DUNNO
 
-    debugs(28, 3, HERE << this << " NO match found, last action " <<
+    debugs(28, 3, this << " NO match found, last action " <<
            lastAction << " so returning " << implicitRuleAnswer);
     markFinished(implicitRuleAnswer, "implicit rule won");
 }

--- a/src/acl/DomainData.cc
+++ b/src/acl/DomainData.cc
@@ -80,7 +80,7 @@ aclDomainCompare(T const &a, T const &b)
             bool d3big = (strlen(d3) > strlen(d4)); // Always suggest removing the longer one.
             debugs(28, DBG_IMPORTANT, "WARNING: '" << (d3big?d3:d4) << "' is a subdomain of '" << (d3big?d4:d3) << "'");
             debugs(28, DBG_IMPORTANT, "WARNING: You should remove '" << (d3big?d3:d4) << "' from the ACL named '" << AclMatchedName << "'");
-            debugs(28, 2, HERE << "Ignore '" << d3 << "' to keep splay tree searching predictable");
+            debugs(28, 2, "Ignore '" << d3 << "' to keep splay tree searching predictable");
         }
     } else if (ret == 0) {
         // It may be an exact duplicate. No problem. Just drop.

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -64,7 +64,7 @@ ACLFilledChecklist::~ACLFilledChecklist()
     cbdataReferenceDone(sslErrors);
 #endif
 
-    debugs(28, 4, HERE << "ACLFilledChecklist destroyed " << this);
+    debugs(28, 4, "ACLFilledChecklist destroyed " << this);
 }
 
 static void

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -46,19 +46,19 @@ aclGetDenyInfoPage(AclDenyInfoList ** head, const char *name, int redirect_allow
 
     AclDenyInfoList *A = NULL;
 
-    debugs(28, 8, HERE << "got called for " << name);
+    debugs(28, 8, "got called for " << name);
 
     for (A = *head; A; A = A->next) {
         AclNameList *L = NULL;
 
         if (!redirect_allowed && strchr(A->err_page_name, ':') ) {
-            debugs(28, 8, HERE << "Skip '" << A->err_page_name << "' 30x redirects not allowed as response here.");
+            debugs(28, 8, "Skip '" << A->err_page_name << "' 30x redirects not allowed as response here.");
             continue;
         }
 
         for (L = A->acl_list; L; L = L->next) {
             if (!strcmp(name, L->name)) {
-                debugs(28, 8, HERE << "match on " << name);
+                debugs(28, 8, "match on " << name);
                 return A->err_page_id;
             }
 

--- a/src/acl/Ip.cc
+++ b/src/acl/Ip.cc
@@ -464,7 +464,7 @@ acl_ip_data::FactoryParse(const char *t)
     if (changed)
         debugs(28, DBG_CRITICAL, "aclIpParseIpData: WARNING: Netmask masks away part of the specified IP in '" << t << "'");
 
-    debugs(28,9, HERE << "Parsed: " << q->addr1 << "-" << q->addr2 << "/" << q->mask << "(/" << q->mask.cidr() <<")");
+    debugs(28,9, "Parsed: " << q->addr1 << "-" << q->addr2 << "/" << q->mask << "(/" << q->mask.cidr() <<")");
 
     /* 1.2.3.4/255.255.255.0  --> 1.2.3.0 */
     /* Same as IPv6 (not so trivial to depict) */

--- a/src/adaptation/AccessCheck.cc
+++ b/src/adaptation/AccessCheck.cc
@@ -39,7 +39,7 @@ Adaptation::AccessCheck::Start(Method method, VectPoint vp,
         return true;
     }
 
-    debugs(83, 3, HERE << "adaptation off, skipping");
+    debugs(83, 3, "adaptation off, skipping");
     return false;
 }
 
@@ -55,7 +55,7 @@ Adaptation::AccessCheck::AccessCheck(const ServiceFilter &aFilter,
         h->start("ACL");
 #endif
 
-    debugs(93, 5, HERE << "AccessCheck constructed for " <<
+    debugs(93, 5, "AccessCheck constructed for " <<
            methodStr(filter.method) << " " << vectPointStr(filter.point));
 }
 
@@ -87,11 +87,11 @@ Adaptation::AccessCheck::usedDynamicRules()
 
     DynamicGroupCfg services;
     if (!ah->extractFutureServices(services)) { // clears history
-        debugs(85,9, HERE << "no service-proposed rules stored");
+        debugs(85,9, "no service-proposed rules stored");
         return false; // earlier service did not plan for the future
     }
 
-    debugs(85,3, HERE << "using stored service-proposed rules: " << services);
+    debugs(85,3, "using stored service-proposed rules: " << services);
 
     ServiceGroupPointer g = new DynamicServiceChain(services, filter);
     callBack(g);
@@ -103,13 +103,13 @@ Adaptation::AccessCheck::usedDynamicRules()
 void
 Adaptation::AccessCheck::check()
 {
-    debugs(93, 4, HERE << "start checking");
+    debugs(93, 4, "start checking");
 
     typedef AccessRules::iterator ARI;
     for (ARI i = AllRules().begin(); i != AllRules().end(); ++i) {
         AccessRule *r = *i;
         if (isCandidate(*r)) {
-            debugs(93, 5, HERE << "check: rule '" << r->id << "' is a candidate");
+            debugs(93, 5, "check: rule '" << r->id << "' is a candidate");
             candidates.push_back(r->id);
         }
     }
@@ -125,7 +125,7 @@ Adaptation::AccessCheck::check()
 void
 Adaptation::AccessCheck::checkCandidates()
 {
-    debugs(93, 4, HERE << "has " << candidates.size() << " rules");
+    debugs(93, 4, "has " << candidates.size() << " rules");
 
     while (!candidates.empty()) {
         if (AccessRule *r = FindRule(topCandidate())) {
@@ -142,7 +142,7 @@ Adaptation::AccessCheck::checkCandidates()
         candidates.erase(candidates.begin()); // the rule apparently went away (reconfigure)
     }
 
-    debugs(93, 4, HERE << "NO candidates left");
+    debugs(93, 4, "NO candidates left");
     callBack(NULL);
     Must(done());
 }
@@ -150,7 +150,7 @@ Adaptation::AccessCheck::checkCandidates()
 void
 Adaptation::AccessCheck::AccessCheckCallbackWrapper(allow_t answer, void *data)
 {
-    debugs(93, 8, HERE << "callback answer=" << answer);
+    debugs(93, 8, "callback answer=" << answer);
     AccessCheck *ac = (AccessCheck*)data;
 
     /** \todo AYJ 2008-06-12: If answer == ACCESS_AUTH_REQUIRED
@@ -172,7 +172,7 @@ void
 Adaptation::AccessCheck::noteAnswer(allow_t answer)
 {
     Must(!candidates.empty()); // the candidate we were checking must be there
-    debugs(93,5, HERE << topCandidate() << " answer=" << answer);
+    debugs(93,5, topCandidate() << " answer=" << answer);
 
     if (answer.allowed()) { // the rule matched
         ServiceGroupPointer g = topGroup();
@@ -193,7 +193,7 @@ Adaptation::AccessCheck::noteAnswer(allow_t answer)
 void
 Adaptation::AccessCheck::callBack(const ServiceGroupPointer &g)
 {
-    debugs(93,3, HERE << g);
+    debugs(93,3, g);
     CallJobHere1(93, 5, theInitiator, Adaptation::Initiator,
                  noteAdaptationAclCheckDone, g);
     mustStop("done"); // called back or will never be able to call back
@@ -206,12 +206,12 @@ Adaptation::AccessCheck::topGroup() const
     if (candidates.size()) {
         if (AccessRule *r = FindRule(topCandidate())) {
             g = FindGroup(r->groupId);
-            debugs(93,5, HERE << "top group for " << r->id << " is " << g);
+            debugs(93,5, "top group for " << r->id << " is " << g);
         } else {
-            debugs(93,5, HERE << "no rule for " << topCandidate());
+            debugs(93,5, "no rule for " << topCandidate());
         }
     } else {
-        debugs(93,5, HERE << "no candidates"); // should not happen
+        debugs(93,5, "no candidates"); // should not happen
     }
 
     return g;
@@ -222,18 +222,18 @@ Adaptation::AccessCheck::topGroup() const
 bool
 Adaptation::AccessCheck::isCandidate(AccessRule &r)
 {
-    debugs(93,7,HERE << "checking candidacy of " << r.id << ", group " <<
+    debugs(93,7,"checking candidacy of " << r.id << ", group " <<
            r.groupId);
 
     ServiceGroupPointer g = FindGroup(r.groupId);
 
     if (!g) {
-        debugs(93,7,HERE << "lost " << r.groupId << " group in rule" << r.id);
+        debugs(93,7,"lost " << r.groupId << " group in rule" << r.id);
         return false;
     }
 
     const bool wants = g->wants(filter);
-    debugs(93,7,HERE << r.groupId << (wants ? " wants" : " ignores"));
+    debugs(93,7,r.groupId << (wants ? " wants" : " ignores"));
     return wants;
 }
 

--- a/src/adaptation/AccessRule.cc
+++ b/src/adaptation/AccessRule.cc
@@ -36,7 +36,7 @@ void
 Adaptation::AccessRule::finalize()
 {
     if (!group()) { // no explicit group
-        debugs(93,7, HERE << "no service group: " << groupId);
+        debugs(93,7, "no service group: " << groupId);
         // try to add a one-service group
         if (FindService(groupId) != NULL) {
             ServiceGroupPointer g = new SingleService(groupId);

--- a/src/adaptation/Answer.cc
+++ b/src/adaptation/Answer.cc
@@ -18,7 +18,7 @@ Adaptation::Answer::Error(bool final)
 {
     Answer answer(akError);
     answer.final = final;
-    debugs(93, 4, HERE << "error: " << final);
+    debugs(93, 4, "error: " << final);
     return answer;
 }
 
@@ -27,7 +27,7 @@ Adaptation::Answer::Forward(Http::Message *aMsg)
 {
     Answer answer(akForward);
     answer.message = aMsg;
-    debugs(93, 4, HERE << "forwarding: " << (void*)aMsg);
+    debugs(93, 4, "forwarding: " << (void*)aMsg);
     return answer;
 }
 
@@ -36,7 +36,7 @@ Adaptation::Answer::Block(const String &aRule)
 {
     Answer answer(akBlock);
     answer.ruleId = aRule;
-    debugs(93, 4, HERE << "blocking rule: " << aRule);
+    debugs(93, 4, "blocking rule: " << aRule);
     return answer;
 }
 

--- a/src/adaptation/Config.cc
+++ b/src/adaptation/Config.cc
@@ -118,14 +118,14 @@ Adaptation::Config::removeRule(const String& id)
 void
 Adaptation::Config::clear()
 {
-    debugs(93, 3, HERE << "rules: " << AllRules().size() << ", groups: " <<
+    debugs(93, 3, "rules: " << AllRules().size() << ", groups: " <<
            AllGroups().size() << ", services: " << serviceConfigs.size());
     typedef ServiceConfigs::const_iterator SCI;
     const ServiceConfigs& configs = serviceConfigs;
     for (SCI cfg = configs.begin(); cfg != configs.end(); ++cfg)
         removeService((*cfg)->key);
     serviceConfigs.clear();
-    debugs(93, 3, HERE << "rules: " << AllRules().size() << ", groups: " <<
+    debugs(93, 3, "rules: " << AllRules().size() << ", groups: " <<
            AllGroups().size() << ", services: " << serviceConfigs.size());
 }
 
@@ -205,7 +205,7 @@ Adaptation::Config::finalize()
         }
     }
 
-    debugs(93,3, HERE << "Created " << created << " adaptation services");
+    debugs(93,3, "Created " << created << " adaptation services");
 
     // services remember their configs; we do not have to
     serviceConfigs.clear();
@@ -221,7 +221,7 @@ FinalizeEach(Collection &collection, const char *label)
     for (CI i = collection.begin(); i != collection.end(); ++i)
         (*i)->finalize();
 
-    debugs(93,2, HERE << "Initialized " << collection.size() << ' ' << label);
+    debugs(93,2, "Initialized " << collection.size() << ' ' << label);
 }
 
 void

--- a/src/adaptation/History.cc
+++ b/src/adaptation/History.cc
@@ -120,8 +120,8 @@ bool Adaptation::History::getXxRecord(String &name, String &value) const
 void Adaptation::History::updateNextServices(const String &services)
 {
     if (theNextServices != TheNullServices)
-        debugs(93,3, HERE << "old services: " << theNextServices);
-    debugs(93,3, HERE << "new services: " << services);
+        debugs(93,3, "old services: " << theNextServices);
+    debugs(93,3, "new services: " << services);
     Must(services != TheNullServices);
     theNextServices = services;
 }
@@ -155,8 +155,8 @@ void
 Adaptation::History::setFutureServices(const DynamicGroupCfg &services)
 {
     if (!theFutureServices.empty())
-        debugs(93,3, HERE << "old future services: " << theFutureServices);
-    debugs(93,3, HERE << "new future services: " << services);
+        debugs(93,3, "old future services: " << theFutureServices);
+    debugs(93,3, "new future services: " << services);
     theFutureServices = services; // may be empty
 }
 

--- a/src/adaptation/Initiate.cc
+++ b/src/adaptation/Initiate.cc
@@ -61,14 +61,14 @@ Adaptation::Initiate::initiator(const CbcPointer<Initiator> &i)
 // internal cleanup
 void Adaptation::Initiate::swanSong()
 {
-    debugs(93, 5, HERE << "swan sings" << status());
+    debugs(93, 5, "swan sings" << status());
 
     if (theInitiator.set()) {
-        debugs(93, 3, HERE << "fatal failure; sending abort notification");
+        debugs(93, 3, "fatal failure; sending abort notification");
         tellQueryAborted(true); // final by default
     }
 
-    debugs(93, 5, HERE << "swan sang" << status());
+    debugs(93, 5, "swan sang" << status());
 }
 
 void Adaptation::Initiate::clearInitiator()

--- a/src/adaptation/Iterator.cc
+++ b/src/adaptation/Iterator.cc
@@ -71,7 +71,7 @@ void Adaptation::Iterator::start()
 void Adaptation::Iterator::step()
 {
     ++iterations;
-    debugs(93,5, HERE << '#' << iterations << " plan: " << thePlan);
+    debugs(93,5, '#' << iterations << " plan: " << thePlan);
 
     Must(!theLauncher);
 
@@ -97,7 +97,7 @@ void Adaptation::Iterator::step()
 
     ServicePointer service = thePlan.current();
     Must(service != NULL);
-    debugs(93,5, HERE << "using adaptation service: " << service->cfg().key);
+    debugs(93,5, "using adaptation service: " << service->cfg().key);
 
     if (Adaptation::Config::needHistory) {
         Adaptation::History::Pointer ah = request->adaptHistory(true);
@@ -139,7 +139,7 @@ Adaptation::Iterator::handleAdaptedHeader(Http::Message *aMsg)
                 // definately sent request, now use it as the cause
                 theCause = cause; // moving the lock
                 theMsg = 0;
-                debugs(93,3, HERE << "in request satisfaction mode");
+                debugs(93,3, "in request satisfaction mode");
             }
         }
     }
@@ -165,7 +165,7 @@ void Adaptation::Iterator::noteInitiatorAborted()
 
 void Adaptation::Iterator::handleAdaptationBlock(const Answer &answer)
 {
-    debugs(93,5, HERE << "blocked by " << answer);
+    debugs(93,5, "blocked by " << answer);
     clearAdaptation(theLauncher);
     updatePlan(false);
     sendAnswer(answer);
@@ -174,7 +174,7 @@ void Adaptation::Iterator::handleAdaptationBlock(const Answer &answer)
 
 void Adaptation::Iterator::handleAdaptationError(bool final)
 {
-    debugs(93,5, HERE << "final: " << final << " plan: " << thePlan);
+    debugs(93,5, "final: " << final << " plan: " << thePlan);
     clearAdaptation(theLauncher);
     updatePlan(false);
 
@@ -184,18 +184,18 @@ void Adaptation::Iterator::handleAdaptationError(bool final)
     // can we ignore the failure (compute while thePlan is not exhausted)?
     Must(!thePlan.exhausted());
     const bool canIgnore = thePlan.current()->cfg().bypass;
-    debugs(85,5, HERE << "flags: " << srcIntact << canIgnore << adapted);
+    debugs(85,5, "flags: " << srcIntact << canIgnore << adapted);
 
     if (srcIntact) {
         if (thePlan.replacement(filter()) != NULL) {
-            debugs(93,3, HERE << "trying a replacement service");
+            debugs(93,3, "trying a replacement service");
             step();
             return;
         }
     }
 
     if (canIgnore && srcIntact && adapted) {
-        debugs(85,3, HERE << "responding with older adapted msg");
+        debugs(85,3, "responding with older adapted msg");
         sendAnswer(Answer::Forward(theMsg));
         mustStop("sent older adapted msg");
         return;
@@ -230,22 +230,22 @@ bool Adaptation::Iterator::updatePlan(bool adopt)
 
     Adaptation::History::Pointer ah = r->adaptHistory();
     if (!ah) {
-        debugs(85,9, HERE << "no history to store a service-proposed plan");
+        debugs(85,9, "no history to store a service-proposed plan");
         return false; // the feature is not enabled or is not triggered
     }
 
     String services;
     if (!ah->extractNextServices(services)) { // clears history
-        debugs(85,9, HERE << "no service-proposed plan received");
+        debugs(85,9, "no service-proposed plan received");
         return false; // the service did not provide a new plan
     }
 
     if (!adopt) {
-        debugs(85,3, HERE << "rejecting service-proposed plan");
+        debugs(85,3, "rejecting service-proposed plan");
         return false;
     }
 
-    debugs(85,3, HERE << "retiring old plan: " << thePlan);
+    debugs(85,3, "retiring old plan: " << thePlan);
 
     Adaptation::ServiceFilter f = this->filter();
     DynamicGroupCfg current, future;
@@ -253,13 +253,13 @@ bool Adaptation::Iterator::updatePlan(bool adopt)
 
     if (!future.empty()) {
         ah->setFutureServices(future);
-        debugs(85,3, HERE << "noted future service-proposed plan: " << future);
+        debugs(85,3, "noted future service-proposed plan: " << future);
     }
 
     // use the current config even if it is empty; we must replace the old plan
     theGroup = new DynamicServiceChain(current, f); // refcounted
     thePlan = ServicePlan(theGroup, f);
-    debugs(85,3, HERE << "adopted service-proposed plan: " << thePlan);
+    debugs(85,3, "adopted service-proposed plan: " << thePlan);
     return true;
 }
 

--- a/src/adaptation/Service.cc
+++ b/src/adaptation/Service.cc
@@ -16,7 +16,7 @@
 Adaptation::Service::Service(const ServiceConfigPointer &aConfig): theConfig(aConfig)
 {
     Must(theConfig != NULL);
-    debugs(93,3, HERE << "creating adaptation service " << cfg().key);
+    debugs(93,3, "creating adaptation service " << cfg().key);
 }
 
 Adaptation::Service::~Service()

--- a/src/adaptation/ServiceConfig.cc
+++ b/src/adaptation/ServiceConfig.cc
@@ -192,7 +192,7 @@ Adaptation::ServiceConfig::grokUri(const char *value)
     // AYJ: most of this is duplicate of URL::parse() in src/url.cc
 
     if (!value || !*value) {
-        debugs(3, DBG_CRITICAL, HERE << cfg_filename << ':' << config_lineno << ": " <<
+        debugs(3, DBG_CRITICAL, cfg_filename << ':' << config_lineno << ": " <<
                "empty adaptation service URI");
         return false;
     }
@@ -205,7 +205,7 @@ Adaptation::ServiceConfig::grokUri(const char *value)
     if (schemeEnd != String::npos)
         protocol=uri.substr(0,schemeEnd);
 
-    debugs(3, 5, HERE << cfg_filename << ':' << config_lineno << ": " <<
+    debugs(3, 5, cfg_filename << ':' << config_lineno << ": " <<
            "service protocol is " << protocol);
 
     if (protocol.size() == 0)
@@ -281,7 +281,7 @@ Adaptation::ServiceConfig::grokUri(const char *value)
     len = e - s;
 
     if (len > 1024) {
-        debugs(3, DBG_CRITICAL, HERE << cfg_filename << ':' << config_lineno << ": " <<
+        debugs(3, DBG_CRITICAL, cfg_filename << ':' << config_lineno << ": " <<
                "long resource name (>1024), probably wrong");
     }
 
@@ -297,7 +297,7 @@ Adaptation::ServiceConfig::grokBool(bool &var, const char *name, const char *val
     else if (!strcmp(value, "1") || !strcmp(value, "on"))
         var = true;
     else {
-        debugs(3, DBG_CRITICAL, HERE << cfg_filename << ':' << config_lineno << ": " <<
+        debugs(3, DBG_CRITICAL, cfg_filename << ':' << config_lineno << ": " <<
                "wrong value for boolean " << name << "; " <<
                "'0', '1', 'on', or 'off' expected but got: " << value);
         return false;

--- a/src/adaptation/ServiceGroups.cc
+++ b/src/adaptation/ServiceGroups.cc
@@ -93,7 +93,7 @@ Adaptation::ServiceGroup::finalize()
             finalizeMsg("ERROR: Unknown adaptation name", serviceId, true);
         }
     }
-    debugs(93,7, HERE << "finalized " << kind << ": " << id);
+    debugs(93,7, "finalized " << kind << ": " << id);
 }
 
 /// checks that the service name or URI is not repeated later in the group
@@ -141,7 +141,7 @@ bool
 Adaptation::ServiceGroup::findService(const ServiceFilter &filter, Pos &pos) const
 {
     if (method != filter.method || point != filter.point) {
-        debugs(93,5,HERE << id << " serves another location");
+        debugs(93,5,id << " serves another location");
         return false; // assume other services have the same wrong location
     }
 
@@ -149,7 +149,7 @@ Adaptation::ServiceGroup::findService(const ServiceFilter &filter, Pos &pos) con
     bool foundEssential = false;
     Pos essPos = 0;
     for (; has(pos); ++pos) {
-        debugs(93,9,HERE << id << " checks service at " << pos);
+        debugs(93,9,id << " checks service at " << pos);
         ServicePointer service = at(pos);
 
         if (!service)
@@ -159,34 +159,34 @@ Adaptation::ServiceGroup::findService(const ServiceFilter &filter, Pos &pos) con
             continue; // the service is not interested
 
         if (service->up() || !service->probed()) {
-            debugs(93,9,HERE << id << " has matching service at " << pos);
+            debugs(93,9,id << " has matching service at " << pos);
             return true;
         }
 
         if (service->cfg().bypass) { // we can safely ignore bypassable downers
-            debugs(93,9,HERE << id << " has bypassable service at " << pos);
+            debugs(93,9,id << " has bypassable service at " << pos);
             continue;
         }
 
         if (!allServicesSame) { // cannot skip (i.e., find best) service
-            debugs(93,9,HERE << id << " has essential service at " << pos);
+            debugs(93,9,id << " has essential service at " << pos);
             return true;
         }
 
         if (!foundEssential) {
-            debugs(93,9,HERE << id << " searches for best essential service from " << pos);
+            debugs(93,9,id << " searches for best essential service from " << pos);
             foundEssential = true;
             essPos = pos;
         }
     }
 
     if (foundEssential) {
-        debugs(93,9,HERE << id << " has best essential service at " << essPos);
+        debugs(93,9,id << " has best essential service at " << essPos);
         pos = essPos;
         return true;
     }
 
-    debugs(93,5,HERE << id << " has no matching services");
+    debugs(93,5,id << " has no matching services");
     return false;
 }
 

--- a/src/adaptation/ecap/ServiceRep.cc
+++ b/src/adaptation/ecap/ServiceRep.cc
@@ -194,7 +194,7 @@ Adaptation::Ecap::ServiceRep::finalize()
 void
 Adaptation::Ecap::ServiceRep::tryConfigureAndStart()
 {
-    debugs(93,2, HERE << "configuring eCAP service: " << theService->uri());
+    debugs(93,2, "configuring eCAP service: " << theService->uri());
     const ConfigRep cfgRep(dynamic_cast<const ServiceConfig&>(cfg()));
     theService->configure(cfgRep);
 

--- a/src/adaptation/ecap/XactionRep.cc
+++ b/src/adaptation/ecap/XactionRep.cc
@@ -351,7 +351,7 @@ Adaptation::Ecap::XactionRep::doneAll() const
 void
 Adaptation::Ecap::XactionRep::sinkVb(const char *reason)
 {
-    debugs(93,4, HERE << "sink for " << reason << "; status:" << status());
+    debugs(93,4, "sink for " << reason << "; status:" << status());
 
     // we reset raw().body_pipe when we are done, so use this one for checking
     const BodyPipePointer &permPipe = theVirginRep.raw().header->body_pipe;
@@ -365,7 +365,7 @@ Adaptation::Ecap::XactionRep::sinkVb(const char *reason)
 void
 Adaptation::Ecap::XactionRep::preserveVb(const char *reason)
 {
-    debugs(93,4, HERE << "preserve for " << reason << "; status:" << status());
+    debugs(93,4, "preserve for " << reason << "; status:" << status());
 
     // we reset raw().body_pipe when we are done, so use this one for checking
     const BodyPipePointer &permPipe = theVirginRep.raw().header->body_pipe;
@@ -381,7 +381,7 @@ Adaptation::Ecap::XactionRep::preserveVb(const char *reason)
 void
 Adaptation::Ecap::XactionRep::forgetVb(const char *reason)
 {
-    debugs(93,9, HERE << "forget vb " << reason << "; status:" << status());
+    debugs(93,9, "forget vb " << reason << "; status:" << status());
 
     BodyPipePointer &p = theVirginRep.raw().body_pipe;
     if (p != NULL && p->stillConsuming(this))
@@ -396,7 +396,7 @@ Adaptation::Ecap::XactionRep::forgetVb(const char *reason)
 void
 Adaptation::Ecap::XactionRep::useVirgin()
 {
-    debugs(93,3, HERE << status());
+    debugs(93,3, status());
     Must(proxyingAb == opUndecided);
     proxyingAb = opNever;
 
@@ -414,7 +414,7 @@ Adaptation::Ecap::XactionRep::useVirgin()
 void
 Adaptation::Ecap::XactionRep::useAdapted(const libecap::shared_ptr<libecap::Message> &m)
 {
-    debugs(93,3, HERE << status());
+    debugs(93,3, status());
     Must(m);
     theAnswerRep = m;
     Must(proxyingAb == opUndecided);
@@ -436,7 +436,7 @@ Adaptation::Ecap::XactionRep::useAdapted(const libecap::shared_ptr<libecap::Mess
         updateHistory(msg);
         sendAnswer(Answer::Forward(msg));
 
-        debugs(93,4, HERE << "adapter will produce body" << status());
+        debugs(93,4, "adapter will produce body" << status());
         theMaster->abMake(); // libecap will produce
     }
 }
@@ -444,7 +444,7 @@ Adaptation::Ecap::XactionRep::useAdapted(const libecap::shared_ptr<libecap::Mess
 void
 Adaptation::Ecap::XactionRep::blockVirgin()
 {
-    debugs(93,3, HERE << status());
+    debugs(93,3, status());
     Must(proxyingAb == opUndecided);
     proxyingAb = opNever;
 
@@ -588,7 +588,7 @@ Adaptation::Ecap::XactionRep::noteAbContentDone(bool atEnd)
     Must(proxyingAb == opOn && !abProductionFinished);
     abProductionFinished = true;
     abProductionAtEnd = atEnd; // store until ready to stop producing ourselves
-    debugs(93,5, HERE << "adapted body production ended");
+    debugs(93,5, "adapted body production ended");
     moveAbContent();
 }
 
@@ -613,7 +613,7 @@ Adaptation::Ecap::XactionRep::setAdaptedBodySize(const libecap::BodySize &size)
 void
 Adaptation::Ecap::XactionRep::adaptationDelayed(const libecap::Delay &d)
 {
-    debugs(93,3, HERE << "adapter needs time: " <<
+    debugs(93,3, "adapter needs time: " <<
            d.state << '/' << d.progress);
     // XXX: set timeout?
 }
@@ -680,11 +680,11 @@ Adaptation::Ecap::XactionRep::moveAbContent()
 {
     Must(proxyingAb == opOn);
     const libecap::Area c = theMaster->abContent(0, libecap::nsize);
-    debugs(93,5, HERE << "up to " << c.size << " bytes");
+    debugs(93,5, "up to " << c.size << " bytes");
     if (c.size == 0 && abProductionFinished) { // no ab now and in the future
         stopProducingFor(answer().body_pipe, abProductionAtEnd);
         proxyingAb = opComplete;
-        debugs(93,5, HERE << "last adapted body data retrieved");
+        debugs(93,5, "last adapted body data retrieved");
     } else if (c.size > 0) {
         if (const size_t used = answer().body_pipe->putMoreData(c.start, c.size))
             theMaster->abContentShift(used);

--- a/src/adaptation/icap/Client.cc
+++ b/src/adaptation/icap/Client.cc
@@ -12,7 +12,7 @@
 
 void Adaptation::Icap::InitModule()
 {
-    debugs(93,2, HERE << "module enabled.");
+    debugs(93,2, "module enabled.");
 }
 
 void Adaptation::Icap::CleanModule()

--- a/src/adaptation/icap/History.cc
+++ b/src/adaptation/icap/History.cc
@@ -26,20 +26,20 @@ void Adaptation::Icap::History::start(const char *context)
     if (!concurrencyLevel++)
         currentStart = current_time;
 
-    debugs(93,4, HERE << "start " << context << " level=" << concurrencyLevel
+    debugs(93,4, "start " << context << " level=" << concurrencyLevel
            << " time=" << tvToMsec(pastTime) << ' ' << this);
 }
 
 void Adaptation::Icap::History::stop(const char *context)
 {
     if (!concurrencyLevel) {
-        debugs(93, DBG_IMPORTANT, HERE << "Internal error: poor history accounting " << this);
+        debugs(93, DBG_IMPORTANT, "Internal error: poor history accounting " << this);
         return;
     }
 
     struct timeval current;
     currentTime(current);
-    debugs(93,4, HERE << "stop " << context << " level=" << concurrencyLevel <<
+    debugs(93,4, "stop " << context << " level=" << concurrencyLevel <<
            " time=" << tvToMsec(pastTime) << '+' << tvToMsec(current) << ' ' << this);
 
     if (!--concurrencyLevel)
@@ -51,7 +51,7 @@ Adaptation::Icap::History::processingTime(timeval &total) const
 {
     currentTime(total);
     tvAssignAdd(total, pastTime);
-    debugs(93,7, HERE << " current total: " << tvToMsec(total) << ' ' << this);
+    debugs(93,7, "current total: " << tvToMsec(total) << ' ' << this);
 }
 
 void

--- a/src/adaptation/icap/Launcher.cc
+++ b/src/adaptation/icap/Launcher.cc
@@ -44,7 +44,7 @@ void Adaptation::Icap::Launcher::launchXaction(const char *xkind)
 {
     Must(!theXaction);
     ++theLaunches;
-    debugs(93,4, HERE << "launching " << xkind << " xaction #" << theLaunches);
+    debugs(93,4, "launching " << xkind << " xaction #" << theLaunches);
     Adaptation::Icap::Xaction *x = createXaction();
     x->attempts = theLaunches;
     if (theLaunches > 1) {
@@ -59,7 +59,7 @@ void Adaptation::Icap::Launcher::launchXaction(const char *xkind)
 
 void Adaptation::Icap::Launcher::noteAdaptationAnswer(const Answer &answer)
 {
-    debugs(93,5, HERE << "launches: " << theLaunches << " answer: " << answer);
+    debugs(93,5, "launches: " << theLaunches << " answer: " << answer);
 
     // XXX: akError is unused by ICAPXaction in favor of noteXactAbort()
     Must(answer.kind != Answer::akError);
@@ -80,7 +80,7 @@ void Adaptation::Icap::Launcher::noteInitiatorAborted()
 
 void Adaptation::Icap::Launcher::noteXactAbort(XactAbortInfo info)
 {
-    debugs(93,5, HERE << "theXaction:" << theXaction << " launches: " << theLaunches);
+    debugs(93,5, "theXaction:" << theXaction << " launches: " << theLaunches);
 
     // TODO: add more checks from FwdState::checkRetry()?
     if (canRetry(info)) {
@@ -90,7 +90,7 @@ void Adaptation::Icap::Launcher::noteXactAbort(XactAbortInfo info)
         clearAdaptation(theXaction);
         launchXaction("repeat");
     } else {
-        debugs(93,3, HERE << "cannot retry or repeat a failed transaction");
+        debugs(93,3, "cannot retry or repeat a failed transaction");
         clearAdaptation(theXaction);
         tellQueryAborted(false); // caller decides based on bypass, consumption
         Must(done());
@@ -122,15 +122,15 @@ bool Adaptation::Icap::Launcher::canRetry(Adaptation::Icap::XactAbortInfo &info)
 
 bool Adaptation::Icap::Launcher::canRepeat(Adaptation::Icap::XactAbortInfo &info) const
 {
-    debugs(93,9, HERE << shutting_down);
+    debugs(93,9, shutting_down);
     if (theLaunches >= TheConfig.repeat_limit || shutting_down)
         return false;
 
-    debugs(93,9, HERE << info.isRepeatable); // TODO: update and use status()
+    debugs(93,9, info.isRepeatable); // TODO: update and use status()
     if (!info.isRepeatable)
         return false;
 
-    debugs(93,9, HERE << info.icapReply);
+    debugs(93,9, info.icapReply);
     if (!info.icapReply) // did not get to read an ICAP reply; a timeout?
         return true;
 

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -78,7 +78,7 @@ Adaptation::Icap::ModXact::ModXact(Http::Message *virginHeader,
     icapReply = new HttpReply;
     icapReply->protoPrefix = "ICAP/"; // TODO: make an IcapReply class?
 
-    debugs(93,7, HERE << "initialized." << status());
+    debugs(93,7, "initialized." << status());
 }
 
 // initiator wants us to start
@@ -128,7 +128,7 @@ void Adaptation::Icap::ModXact::waitForService()
             disableRetries();
             disableRepeats("ICAP service is not available");
 
-            debugs(93, 7, HERE << "will not wait for the service to be available" <<
+            debugs(93, 7, "will not wait for the service to be available" <<
                    status());
 
             throw TexcHere("ICAP service is not available");
@@ -140,7 +140,7 @@ void Adaptation::Icap::ModXact::waitForService()
         comment = "to be available";
     }
 
-    debugs(93, 7, HERE << "will wait for the service " << comment <<  status());
+    debugs(93, 7, "will wait for the service " << comment <<  status());
     state.serviceWaiting = true; // after callWhenReady() which may throw
     state.waitedForService = true;
 }
@@ -194,7 +194,7 @@ void Adaptation::Icap::ModXact::handleCommConnected()
     requestBuf.init();
 
     makeRequestHeaders(requestBuf);
-    debugs(93, 9, HERE << "will write" << status() << ":\n" <<
+    debugs(93, 9, "will write" << status() << ":\n" <<
            (requestBuf.terminate(), requestBuf.content()));
 
     // write headers
@@ -205,7 +205,7 @@ void Adaptation::Icap::ModXact::handleCommConnected()
 
 void Adaptation::Icap::ModXact::handleCommWrote(size_t sz)
 {
-    debugs(93, 5, HERE << "Wrote " << sz << " bytes");
+    debugs(93, 5, "Wrote " << sz << " bytes");
 
     if (state.writing == State::writingHeaders)
         handleCommWroteHeaders();
@@ -235,7 +235,7 @@ void Adaptation::Icap::ModXact::handleCommWroteHeaders()
 
 void Adaptation::Icap::ModXact::writeMore()
 {
-    debugs(93, 5, HERE << "checking whether to write more" << status());
+    debugs(93, 5, "checking whether to write more" << status());
 
     if (writer != NULL) // already writing something
         return;
@@ -273,7 +273,7 @@ void Adaptation::Icap::ModXact::writeMore()
 
 void Adaptation::Icap::ModXact::writePreviewBody()
 {
-    debugs(93, 8, HERE << "will write Preview body from " <<
+    debugs(93, 8, "will write Preview body from " <<
            virgin.body_pipe << status());
     Must(state.writing == State::writingPreview);
     Must(virgin.body_pipe != NULL);
@@ -298,7 +298,7 @@ void Adaptation::Icap::ModXact::decideWritingAfterPreview(const char *kind)
     else
         stopWriting(true); // ICAP server reply implies no post-preview writing
 
-    debugs(93, 6, HERE << "decided on writing after " << kind << " preview" <<
+    debugs(93, 6, "decided on writing after " << kind << " preview" <<
            status());
 }
 
@@ -311,7 +311,7 @@ void Adaptation::Icap::ModXact::writePrimeBody()
     writeSomeBody("prime virgin body", size);
 
     if (virginBodyEndReached(virginBodyWriting)) {
-        debugs(93, 5, HERE << "wrote entire body");
+        debugs(93, 5, "wrote entire body");
         stopWriting(true);
     }
 }
@@ -320,7 +320,7 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
 {
     Must(!writer && state.writing < state.writingAlmostDone);
     Must(virgin.body_pipe != NULL);
-    debugs(93, 8, HERE << "will write up to " << size << " bytes of " <<
+    debugs(93, 8, "will write up to " << size << " bytes of " <<
            label);
 
     MemBuf writeBuf; // TODO: suggest a min size based on size and lastChunk
@@ -331,7 +331,7 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
     const size_t chunkSize = min(writableSize, size);
 
     if (chunkSize) {
-        debugs(93, 7, HERE << "will write " << chunkSize <<
+        debugs(93, 7, "will write " << chunkSize <<
                "-byte chunk of " << label);
 
         openChunk(writeBuf, chunkSize, false);
@@ -341,7 +341,7 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
         virginBodyWriting.progress(chunkSize);
         virginConsume();
     } else {
-        debugs(93, 7, HERE << "has no writable " << label << " content");
+        debugs(93, 7, "has no writable " << label << " content");
     }
 
     const bool wroteEof = virginBodyEndReached(virginBodyWriting);
@@ -352,11 +352,11 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
     }
 
     if (lastChunk) {
-        debugs(93, 8, HERE << "will write last-chunk of " << label);
+        debugs(93, 8, "will write last-chunk of " << label);
         addLastRequestChunk(writeBuf);
     }
 
-    debugs(93, 7, HERE << "will write " << writeBuf.contentSize()
+    debugs(93, 7, "will write " << writeBuf.contentSize()
            << " raw bytes of " << label);
 
     if (writeBuf.hasContent()) {
@@ -423,7 +423,7 @@ const char *Adaptation::Icap::ModXact::virginContentData(const Adaptation::Icap:
 
 void Adaptation::Icap::ModXact::virginConsume()
 {
-    debugs(93, 9, HERE << "consumption guards: " << !virgin.body_pipe << isRetriable <<
+    debugs(93, 9, "consumption guards: " << !virgin.body_pipe << isRetriable <<
            isRepeatable << canStartBypass << protectGroupBypass);
 
     if (!virgin.body_pipe)
@@ -443,7 +443,7 @@ void Adaptation::Icap::ModXact::virginConsume()
         // down. Not postponing may increase the number of ICAP errors
         // if the ICAP service fails. We may also use "potential" space to
         // postpone more aggressively. Should the trade-off be configurable?
-        debugs(93, 8, HERE << "postponing consumption from " << bp.status());
+        debugs(93, 8, "postponing consumption from " << bp.status());
         return;
     }
 
@@ -451,7 +451,7 @@ void Adaptation::Icap::ModXact::virginConsume()
     const uint64_t end = virginConsumed + have;
     uint64_t offset = end;
 
-    debugs(93, 9, HERE << "max virgin consumption offset=" << offset <<
+    debugs(93, 9, "max virgin consumption offset=" << offset <<
            " acts " << virginBodyWriting.active() << virginBodySending.active() <<
            " consumed=" << virginConsumed <<
            " from " << virgin.body_pipe->status());
@@ -465,7 +465,7 @@ void Adaptation::Icap::ModXact::virginConsume()
     Must(virginConsumed <= offset && offset <= end);
 
     if (const size_t size = static_cast<size_t>(offset - virginConsumed)) {
-        debugs(93, 8, HERE << "consuming " << size << " out of " << have <<
+        debugs(93, 8, "consuming " << size << " out of " << have <<
                " virgin body bytes");
         bp.consume(size);
         virginConsumed += size;
@@ -490,12 +490,12 @@ void Adaptation::Icap::ModXact::stopWriting(bool nicely)
 
     if (writer != NULL) {
         if (nicely) {
-            debugs(93, 7, HERE << "will wait for the last write" << status());
+            debugs(93, 7, "will wait for the last write" << status());
             state.writing = State::writingAlmostDone; // may already be set
             checkConsuming();
             return;
         }
-        debugs(93, 3, HERE << "will NOT wait for the last write" << status());
+        debugs(93, 3, "will NOT wait for the last write" << status());
 
         // Comm does not have an interface to clear the writer callback nicely,
         // but without clearing the writer we cannot recycle the connection.
@@ -506,7 +506,7 @@ void Adaptation::Icap::ModXact::stopWriting(bool nicely)
         ignoreLastWrite = true;
     }
 
-    debugs(93, 7, HERE << "will no longer write" << status());
+    debugs(93, 7, "will no longer write" << status());
     if (virginBodyWriting.active()) {
         virginBodyWriting.disable();
         virginConsume();
@@ -520,7 +520,7 @@ void Adaptation::Icap::ModXact::stopBackup()
     if (!virginBodySending.active())
         return;
 
-    debugs(93, 7, HERE << "will no longer backup" << status());
+    debugs(93, 7, "will no longer backup" << status());
     virginBodySending.disable();
     virginConsume();
 }
@@ -546,21 +546,21 @@ void Adaptation::Icap::ModXact::startReading()
 void Adaptation::Icap::ModXact::readMore()
 {
     if (reader != NULL || doneReading()) {
-        debugs(93,3,HERE << "returning from readMore because reader or doneReading()");
+        debugs(93,3,"returning from readMore because reader or doneReading()");
         return;
     }
 
     // do not fill readBuf if we have no space to store the result
     if (adapted.body_pipe != NULL &&
             !adapted.body_pipe->buf().hasPotentialSpace()) {
-        debugs(93,3,HERE << "not reading because ICAP reply pipe is full");
+        debugs(93,3,"not reading because ICAP reply pipe is full");
         return;
     }
 
     if (readBuf.length() < SQUID_TCP_SO_RCVBUF)
         scheduleRead();
     else
-        debugs(93,3,HERE << "cannot read with a full buffer");
+        debugs(93,3,"cannot read with a full buffer");
 }
 
 // comm module read a portion of the ICAP response for us
@@ -579,14 +579,14 @@ void Adaptation::Icap::ModXact::echoMore()
     Must(virginBodySending.active());
 
     const size_t sizeMax = virginContentSize(virginBodySending);
-    debugs(93,5, HERE << "will echo up to " << sizeMax << " bytes from " <<
+    debugs(93,5, "will echo up to " << sizeMax << " bytes from " <<
            virgin.body_pipe->status());
-    debugs(93,5, HERE << "will echo up to " << sizeMax << " bytes to   " <<
+    debugs(93,5, "will echo up to " << sizeMax << " bytes to   " <<
            adapted.body_pipe->status());
 
     if (sizeMax > 0) {
         const size_t size = adapted.body_pipe->putMoreData(virginContentData(virginBodySending), sizeMax);
-        debugs(93,5, HERE << "echoed " << size << " out of " << sizeMax <<
+        debugs(93,5, "echoed " << size << " out of " << sizeMax <<
                " bytes");
         virginBodySending.progress(size);
         disableRepeats("echoed content");
@@ -595,10 +595,10 @@ void Adaptation::Icap::ModXact::echoMore()
     }
 
     if (virginBodyEndReached(virginBodySending)) {
-        debugs(93, 5, HERE << "echoed all" << status());
+        debugs(93, 5, "echoed all" << status());
         stopSending(true);
     } else {
-        debugs(93, 5, HERE << "has " <<
+        debugs(93, 5, "has " <<
                virgin.body_pipe->buf().contentSize() << " bytes " <<
                "and expects more to echo" << status());
         // TODO: timeout if virgin or adapted pipes are broken
@@ -613,13 +613,13 @@ bool Adaptation::Icap::ModXact::doneSending() const
 // stop (or do not start) sending adapted message body
 void Adaptation::Icap::ModXact::stopSending(bool nicely)
 {
-    debugs(93, 7, HERE << "Enter stop sending ");
+    debugs(93, 7, "Enter stop sending ");
     if (doneSending())
         return;
-    debugs(93, 7, HERE << "Proceed with stop sending ");
+    debugs(93, 7, "Proceed with stop sending ");
 
     if (state.sending != State::sendingUndecided) {
-        debugs(93, 7, HERE << "will no longer send" << status());
+        debugs(93, 7, "will no longer send" << status());
         if (adapted.body_pipe != NULL) {
             virginBodySending.disable();
             // we may leave debts if we were echoing and the virgin
@@ -628,7 +628,7 @@ void Adaptation::Icap::ModXact::stopSending(bool nicely)
             stopProducingFor(adapted.body_pipe, nicely && !leftDebts);
         }
     } else {
-        debugs(93, 7, HERE << "will not start sending" << status());
+        debugs(93, 7, "will not start sending" << status());
         Must(!adapted.body_pipe);
     }
 
@@ -643,7 +643,7 @@ void Adaptation::Icap::ModXact::checkConsuming()
     if (!virgin.body_pipe || !state.doneConsumingVirgin())
         return;
 
-    debugs(93, 7, HERE << "will stop consuming" << status());
+    debugs(93, 7, "will stop consuming" << status());
     stopConsumingFrom(virgin.body_pipe);
 }
 
@@ -676,7 +676,7 @@ void Adaptation::Icap::ModXact::callException(const std::exception &e)
     }
 
     try {
-        debugs(93, 3, HERE << "bypassing " << inCall << " exception: " <<
+        debugs(93, 3, "bypassing " << inCall << " exception: " <<
                e.what() << ' ' << status());
         bypassFailure();
     } catch (const TextException &bypassTe) {
@@ -708,7 +708,7 @@ void Adaptation::Icap::ModXact::bypassFailure()
         reuseConnection = false; // be conservative
         cancelRead(); // may not work; and we cannot stop connecting either
         if (!doneWithIo())
-            debugs(93, 7, HERE << "Warning: bypass failed to stop I/O" << status());
+            debugs(93, 7, "Warning: bypass failed to stop I/O" << status());
     }
 
     service().noteFailure(); // we are bypassing, but this is still a failure
@@ -717,11 +717,11 @@ void Adaptation::Icap::ModXact::bypassFailure()
 void Adaptation::Icap::ModXact::disableBypass(const char *reason, bool includingGroupBypass)
 {
     if (canStartBypass) {
-        debugs(93,7, HERE << "will never start bypass because " << reason);
+        debugs(93,7, "will never start bypass because " << reason);
         canStartBypass = false;
     }
     if (protectGroupBypass && includingGroupBypass) {
-        debugs(93,7, HERE << "not protecting group bypass because " << reason);
+        debugs(93,7, "not protecting group bypass because " << reason);
         protectGroupBypass = false;
     }
 }
@@ -748,12 +748,12 @@ void Adaptation::Icap::ModXact::parseHeaders()
     Must(state.parsingHeaders());
 
     if (state.parsing == State::psIcapHeader) {
-        debugs(93, 5, HERE << "parse ICAP headers");
+        debugs(93, 5, "parse ICAP headers");
         parseIcapHead();
     }
 
     if (state.parsing == State::psHttpHeader) {
-        debugs(93, 5, HERE << "parse HTTP headers");
+        debugs(93, 5, "parse HTTP headers");
         parseHttpHead();
     }
 
@@ -800,7 +800,7 @@ void Adaptation::Icap::ModXact::parseIcapHead()
 
     static SBuf close("close", 5);
     if (httpHeaderHasConnDir(&icapReply->header, close)) {
-        debugs(93, 5, HERE << "found connection close");
+        debugs(93, 5, "found connection close");
         reuseConnection = false;
     }
 
@@ -931,11 +931,11 @@ void Adaptation::Icap::ModXact::handle206PartialContent()
     if (state.writing == State::writingPaused) {
         Must(preview.enabled());
         Must(state.allowedPreview206);
-        debugs(93, 7, HERE << "206 inside preview");
+        debugs(93, 7, "206 inside preview");
     } else {
         Must(state.writing > State::writingPaused);
         Must(state.allowedPostview206);
-        debugs(93, 7, HERE << "206 outside preview");
+        debugs(93, 7, "206 outside preview");
     }
     state.parsing = State::psHttpHeader;
     state.sending = State::sendingAdapted;
@@ -959,7 +959,7 @@ void Adaptation::Icap::ModXact::prepEchoing()
     // TODO: use Http::Message::clone()!
 
     Http::Message *oldHead = virgin.header;
-    debugs(93, 7, HERE << "cloning virgin message " << oldHead);
+    debugs(93, 7, "cloning virgin message " << oldHead);
 
     MemBuf httpBuf;
 
@@ -992,12 +992,12 @@ void Adaptation::Icap::ModXact::prepEchoing()
 
     httpBuf.clean();
 
-    debugs(93, 7, HERE << "cloned virgin message " << oldHead << " to " <<
+    debugs(93, 7, "cloned virgin message " << oldHead << " to " <<
            adapted.header);
 
     // setup adapted body pipe if needed
     if (oldHead->body_pipe != NULL) {
-        debugs(93, 7, HERE << "will echo virgin body from " <<
+        debugs(93, 7, "will echo virgin body from " <<
                oldHead->body_pipe);
         if (!virginBodySending.active())
             virginBodySending.plan(); // will throw if not possible
@@ -1009,10 +1009,10 @@ void Adaptation::Icap::ModXact::prepEchoing()
         makeAdaptedBodyPipe("echoed virgin response");
         if (oldHead->body_pipe->bodySizeKnown())
             adapted.body_pipe->setBodySize(oldHead->body_pipe->bodySize());
-        debugs(93, 7, HERE << "will echo virgin body to " <<
+        debugs(93, 7, "will echo virgin body to " <<
                adapted.body_pipe);
     } else {
-        debugs(93, 7, HERE << "no virgin body to echo");
+        debugs(93, 7, "no virgin body to echo");
         stopSending(true);
     }
 }
@@ -1026,7 +1026,7 @@ void Adaptation::Icap::ModXact::prepPartialBodyEchoing(uint64_t pos)
 
     setOutcome(xoPartEcho);
 
-    debugs(93, 7, HERE << "will echo virgin body suffix from " <<
+    debugs(93, 7, "will echo virgin body suffix from " <<
            virgin.header->body_pipe << " offset " << pos );
 
     // check that use-original-body=N does not point beyond buffered data
@@ -1041,7 +1041,7 @@ void Adaptation::Icap::ModXact::prepPartialBodyEchoing(uint64_t pos)
     if (virgin.header->body_pipe->bodySizeKnown())
         adapted.body_pipe->expectProductionEndAfter(virgin.header->body_pipe->bodySize() - pos);
 
-    debugs(93, 7, HERE << "will echo virgin body suffix to " <<
+    debugs(93, 7, "will echo virgin body suffix to " <<
            adapted.body_pipe);
 
     // Start echoing data
@@ -1141,14 +1141,14 @@ bool Adaptation::Icap::ModXact::expectIcapTrailers() const
 void Adaptation::Icap::ModXact::decideOnParsingBody()
 {
     if (expectHttpBody()) {
-        debugs(93, 5, HERE << "expecting a body");
+        debugs(93, 5, "expecting a body");
         state.parsing = State::psBody;
         replyHttpBodySize = 0;
         bodyParser = new Http1::TeChunkedParser;
         makeAdaptedBodyPipe("adapted response from the ICAP server");
         Must(state.sending == State::sendingAdapted);
     } else {
-        debugs(93, 5, HERE << "not expecting a body");
+        debugs(93, 5, "not expecting a body");
         if (trailerParser)
             state.parsing = State::psIcapTrailer;
         else
@@ -1193,10 +1193,10 @@ void Adaptation::Icap::ModXact::parseBody()
         return;
     }
 
-    debugs(93,3,HERE << this << " needsMoreData = " << bodyParser->needsMoreData());
+    debugs(93,3,this << " needsMoreData = " << bodyParser->needsMoreData());
 
     if (bodyParser->needsMoreData()) {
-        debugs(93,3,HERE << this);
+        debugs(93,3,this);
         Must(mayReadMore());
         readMore();
     }
@@ -1290,7 +1290,7 @@ Adaptation::Icap::ModXact::~ModXact()
 // internal cleanup
 void Adaptation::Icap::ModXact::swanSong()
 {
-    debugs(93, 5, HERE << "swan sings" << status());
+    debugs(93, 5, "swan sings" << status());
 
     stopWriting(false);
     stopSending(false);
@@ -1635,7 +1635,7 @@ Adaptation::Icap::ModXact::packHead(MemBuf &httpBuf, const Http::Message *head)
 void Adaptation::Icap::ModXact::decideOnPreview()
 {
     if (!TheConfig.preview_enable) {
-        debugs(93, 5, HERE << "preview disabled by squid.conf");
+        debugs(93, 5, "preview disabled by squid.conf");
         return;
     }
 
@@ -1656,7 +1656,7 @@ void Adaptation::Icap::ModXact::decideOnPreview()
     else if (virginBody.knownSize())
         ad = min(static_cast<uint64_t>(ad), virginBody.size()); // not more than we have
 
-    debugs(93, 5, HERE << "should offer " << ad << "-byte preview " <<
+    debugs(93, 5, "should offer " << ad << "-byte preview " <<
            "(service wanted " << wantedSize << ")");
 
     preview.enable(ad);
@@ -1837,7 +1837,7 @@ void Adaptation::Icap::ModXact::estimateVirginBody()
     // expectingBody returns true for zero-sized bodies, but we will not
     // get a pipe for that body, so we treat the message as bodyless
     if (method != Http::METHOD_NONE && msg->expectingBody(method, size) && size) {
-        debugs(93, 6, HERE << "expects virgin body from " <<
+        debugs(93, 6, "expects virgin body from " <<
                virgin.body_pipe << "; size: " << size);
 
         virginBody.expect(size);
@@ -1851,7 +1851,7 @@ void Adaptation::Icap::ModXact::estimateVirginBody()
         // make sure TheBackupLimit is in-sync with the buffer size
         Must(TheBackupLimit <= static_cast<size_t>(msg->body_pipe->buf().max_capacity));
     } else {
-        debugs(93, 6, HERE << "does not expect virgin body");
+        debugs(93, 6, "does not expect virgin body");
         Must(msg->body_pipe == NULL);
         checkConsuming();
     }
@@ -1863,7 +1863,7 @@ void Adaptation::Icap::ModXact::makeAdaptedBodyPipe(const char *what)
     Must(!adapted.header->body_pipe);
     adapted.header->body_pipe = new BodyPipe(this);
     adapted.body_pipe = adapted.header->body_pipe;
-    debugs(93, 7, HERE << "will supply " << what << " via " <<
+    debugs(93, 7, "will supply " << what << " via " <<
            adapted.body_pipe << " pipe");
 }
 
@@ -2041,7 +2041,7 @@ Adaptation::Icap::Xaction *Adaptation::Icap::ModXactLauncher::createXaction()
 
 void Adaptation::Icap::ModXactLauncher::swanSong()
 {
-    debugs(93, 5, HERE << "swan sings");
+    debugs(93, 5, "swan sings");
     updateHistory(false);
     Adaptation::Icap::Launcher::swanSong();
 }

--- a/src/adaptation/icap/OptXact.cc
+++ b/src/adaptation/icap/OptXact.cc
@@ -44,7 +44,7 @@ void Adaptation::Icap::OptXact::handleCommConnected()
     MemBuf requestBuf;
     requestBuf.init();
     makeRequest(requestBuf);
-    debugs(93, 9, HERE << "request " << status() << ":\n" <<
+    debugs(93, 9, "request " << status() << ":\n" <<
            (requestBuf.terminate(), requestBuf.content()));
     icap_tio_start = current_time;
     scheduleWrite(requestBuf);
@@ -75,7 +75,7 @@ void Adaptation::Icap::OptXact::makeRequest(MemBuf &buf)
 
 void Adaptation::Icap::OptXact::handleCommWrote(size_t size)
 {
-    debugs(93, 9, HERE << "finished writing " << size <<
+    debugs(93, 9, "finished writing " << size <<
            "-byte request " << status());
 }
 
@@ -89,7 +89,7 @@ void Adaptation::Icap::OptXact::handleCommRead(size_t)
         // we leave readAll false which forces connection closure.
         readAll = !icapReply->header.getByNameListMember("Encapsulated",
                   "opt-body", ',').size();
-        debugs(93, 7, HERE << "readAll=" << readAll);
+        debugs(93, 7, "readAll=" << readAll);
         icap_tio_finish = current_time;
         setOutcome(xoOpt);
         sendAnswer(Answer::Forward(icapReply.getRaw()));

--- a/src/adaptation/icap/Options.cc
+++ b/src/adaptation/icap/Options.cc
@@ -151,7 +151,7 @@ void Adaptation::Icap::Options::cfgIntHeader(const HttpHeader *h, const char *fn
     else
         value = -1;
 
-    debugs(93,5, HERE << "int header: " << fname << ": " << value);
+    debugs(93,5, "int header: " << fname << ": " << value);
 }
 
 void Adaptation::Icap::Options::cfgTransferList(const HttpHeader *h, TransferList &list)
@@ -162,7 +162,7 @@ void Adaptation::Icap::Options::cfgTransferList(const HttpHeader *h, TransferLis
 
     if (foundStar) {
         theTransfers.byDefault = &list;
-        debugs(93,5, HERE << "set default transfer to " << list.name);
+        debugs(93,5, "set default transfer to " << list.name);
     }
 
     list.report(5, "Adaptation::Icap::Options::cfgTransferList: ");

--- a/src/adaptation/icap/ServiceRep.cc
+++ b/src/adaptation/icap/ServiceRep.cc
@@ -93,7 +93,7 @@ Adaptation::Icap::ServiceRep::finalize()
 void Adaptation::Icap::ServiceRep::noteFailure()
 {
     const int failures = theSessionFailures.count(1);
-    debugs(93,4, HERE << " failure " << failures << " out of " <<
+    debugs(93,4, "failure " << failures << " out of " <<
            TheConfig.service_failure_limit << " allowed in " <<
            TheConfig.oldest_service_failure << "sec " << status());
 
@@ -137,7 +137,7 @@ Adaptation::Icap::ServiceRep::getConnection(bool retriableXact, bool &reused)
 
     reused = Comm::IsConnOpen(connection);
     ++theBusyConns;
-    debugs(93,3, HERE << "got connection: " << connection);
+    debugs(93,3, "got connection: " << connection);
     return connection;
 }
 
@@ -147,11 +147,11 @@ void Adaptation::Icap::ServiceRep::putConnection(const Comm::ConnectionPointer &
     Must(Comm::IsConnOpen(conn));
     // do not pool an idle connection if we owe connections
     if (isReusable && excessConnections() == 0) {
-        debugs(93, 3, HERE << "pushing pconn" << comment);
+        debugs(93, 3, "pushing pconn" << comment);
         commUnsetConnTimeout(conn);
         theIdleConns->push(conn);
     } else {
-        debugs(93, 3, HERE << (sendReset ? "RST" : "FIN") << "-closing " <<
+        debugs(93, 3, (sendReset ? "RST" : "FIN") << "-closing " <<
                comment);
         // comm_close called from Connection::close will clear timeout
         // TODO: add "bool sendReset = false" to Connection::close()?
@@ -176,7 +176,7 @@ void Adaptation::Icap::ServiceRep::noteConnectionUse(const Comm::ConnectionPoint
 
 void Adaptation::Icap::ServiceRep::noteConnectionFailed(const char *comment)
 {
-    debugs(93, 3, HERE << "Connection failed: " << comment);
+    debugs(93, 3, "Connection failed: " << comment);
     --theBusyConns;
 }
 
@@ -262,7 +262,7 @@ void Adaptation::Icap::ServiceRep::busyCheckpoint()
         freed = available - notifiedWaiters;
     }
 
-    debugs(93,7, HERE << "Available connections: " << available <<
+    debugs(93,7, "Available connections: " << available <<
            " freed slots: " << freed <<
            " waiting in queue: " << theNotificationWaiters.size());
 
@@ -278,7 +278,7 @@ void Adaptation::Icap::ServiceRep::busyCheckpoint()
 void Adaptation::Icap::ServiceRep::suspend(const char *reason)
 {
     if (isSuspended) {
-        debugs(93,4, HERE << "keeping suspended, also for " << reason);
+        debugs(93,4, "keeping suspended, also for " << reason);
     } else {
         isSuspended = reason;
         debugs(93, DBG_IMPORTANT, "suspending ICAP service for " << reason);
@@ -369,11 +369,11 @@ void Adaptation::Icap::ServiceRep::noteTimeToUpdate()
         updateScheduled = false;
 
     if (detached() || theOptionsFetcher.set()) {
-        debugs(93,5, HERE << "ignores options update " << status());
+        debugs(93,5, "ignores options update " << status());
         return;
     }
 
-    debugs(93,5, HERE << "performs a regular options update " << status());
+    debugs(93,5, "performs a regular options update " << status());
     startGettingOptions();
 }
 
@@ -391,7 +391,7 @@ void Adaptation::Icap::ServiceRep::noteTimeToNotify()
 {
     Must(!notifying);
     notifying = true;
-    debugs(93,7, HERE << "notifies " << theClients.size() << " clients " <<
+    debugs(93,7, "notifies " << theClients.size() << " clients " <<
            status());
 
     // note: we must notify even if we are invalidated
@@ -430,7 +430,7 @@ void Adaptation::Icap::ServiceRep::callWhenReady(AsyncCall::Pointer &cb)
 {
     Must(cb!=NULL);
 
-    debugs(93,5, HERE << "Adaptation::Icap::Service is asked to call " << *cb <<
+    debugs(93,5, "Adaptation::Icap::Service is asked to call " << *cb <<
            " when ready " << status());
 
     Must(!broken()); // we do not wait for a broken service
@@ -451,7 +451,7 @@ void Adaptation::Icap::ServiceRep::callWhenReady(AsyncCall::Pointer &cb)
 
 void Adaptation::Icap::ServiceRep::scheduleNotification()
 {
-    debugs(93,7, HERE << "will notify " << theClients.size() << " clients");
+    debugs(93,7, "will notify " << theClients.size() << " clients");
     CallJobHere(93, 5, this, Adaptation::Icap::ServiceRep, noteTimeToNotify);
 }
 
@@ -462,7 +462,7 @@ bool Adaptation::Icap::ServiceRep::needNewOptions() const
 
 void Adaptation::Icap::ServiceRep::changeOptions(Adaptation::Icap::Options *newOptions)
 {
-    debugs(93,8, HERE << "changes options from " << theOptions << " to " <<
+    debugs(93,8, "changes options from " << theOptions << " to " <<
            newOptions << ' ' << status());
 
     delete theOptions;
@@ -549,7 +549,7 @@ void Adaptation::Icap::ServiceRep::noteAdaptationAnswer(const Answer &answer)
     clearAdaptation(theOptionsFetcher);
 
     if (answer.kind == Answer::akError) {
-        debugs(93,3, HERE << "failed to fetch options " << status());
+        debugs(93,3, "failed to fetch options " << status());
         handleNewOptions(0);
         return;
     }
@@ -558,7 +558,7 @@ void Adaptation::Icap::ServiceRep::noteAdaptationAnswer(const Answer &answer)
     const Http::Message *msg = answer.message.getRaw();
     Must(msg);
 
-    debugs(93,5, HERE << "is interpreting new options " << status());
+    debugs(93,5, "is interpreting new options " << status());
 
     Adaptation::Icap::Options *newOptions = NULL;
     if (const HttpReply *r = dynamic_cast<const HttpReply*>(msg)) {
@@ -586,7 +586,7 @@ void Adaptation::Icap::ServiceRep::handleNewOptions(Adaptation::Icap::Options *n
     // new options may be NULL
     changeOptions(newOptions);
 
-    debugs(93,3, HERE << "got new options and is now " << status());
+    debugs(93,3, "got new options and is now " << status());
 
     scheduleUpdate(optionsFetchTime());
 
@@ -596,7 +596,7 @@ void Adaptation::Icap::ServiceRep::handleNewOptions(Adaptation::Icap::Options *n
     // if we owe connections and have idle pconns, close the latter
     if (excess && theIdleConns->count() > 0) {
         const int n = min(excess, theIdleConns->count());
-        debugs(93,5, HERE << "closing " << n << " pconns to relief debt");
+        debugs(93,5, "closing " << n << " pconns to relief debt");
         theIdleConns->closeN(n);
     }
 
@@ -606,7 +606,7 @@ void Adaptation::Icap::ServiceRep::handleNewOptions(Adaptation::Icap::Options *n
 void Adaptation::Icap::ServiceRep::startGettingOptions()
 {
     Must(!theOptionsFetcher);
-    debugs(93,6, HERE << "will get new options " << status());
+    debugs(93,6, "will get new options " << status());
 
     // XXX: "this" here is "self"; works until refcounting API changes
     theOptionsFetcher = initiateAdaptation(
@@ -618,7 +618,7 @@ void Adaptation::Icap::ServiceRep::startGettingOptions()
 void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
 {
     if (updateScheduled) {
-        debugs(93,7, HERE << "reschedules update");
+        debugs(93,7, "reschedules update");
         // XXX: check whether the event is there because AR saw
         // an unreproducible eventDelete assertion on 2007/06/18
         if (eventFind(&ServiceRep_noteTimeToUpdate, this))
@@ -628,9 +628,9 @@ void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
         updateScheduled = false;
     }
 
-    debugs(93,7, HERE << "raw OPTIONS fetch at " << when << " or in " <<
+    debugs(93,7, "raw OPTIONS fetch at " << when << " or in " <<
            (when - squid_curtime) << " sec");
-    debugs(93,9, HERE << "last fetched at " << theLastUpdate << " or " <<
+    debugs(93,9, "last fetched at " << theLastUpdate << " or " <<
            (squid_curtime - theLastUpdate) << " sec ago");
 
     /* adjust update time to prevent too-frequent updates */
@@ -644,7 +644,7 @@ void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
         when = theLastUpdate + minUpdateGap;
 
     const int delay = when - squid_curtime;
-    debugs(93,5, HERE << "will fetch OPTIONS in " << delay << " sec");
+    debugs(93,5, "will fetch OPTIONS in " << delay << " sec");
 
     eventAdd("Adaptation::Icap::ServiceRep::noteTimeToUpdate",
              &ServiceRep_noteTimeToUpdate, this, delay, 0, true);
@@ -657,7 +657,7 @@ Adaptation::Icap::ServiceRep::optionsFetchTime() const
 {
     if (theOptions && theOptions->valid()) {
         const time_t expire = theOptions->expire();
-        debugs(93,7, HERE << "options expire on " << expire << " >= " << squid_curtime);
+        debugs(93,7, "options expire on " << expire << " >= " << squid_curtime);
 
         // conservative estimate of how long the OPTIONS transaction will take
         // XXX: move hard-coded constants from here to Adaptation::Icap::TheConfig
@@ -726,7 +726,7 @@ const char *Adaptation::Icap::ServiceRep::status() const
 
 void Adaptation::Icap::ServiceRep::detach()
 {
-    debugs(93,3, HERE << "detaching ICAP service: " << cfg().uri <<
+    debugs(93,3, "detaching ICAP service: " << cfg().uri <<
            ' ' << status());
     isDetached = true;
 }

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -235,7 +235,7 @@ Adaptation::Icap::Xaction::dnsLookupDone(const ipcache_addrs *ia)
 void
 Adaptation::Icap::Xaction::reusedConnection(void *data)
 {
-    debugs(93, 5, HERE << "reused connection");
+    debugs(93, 5, "reused connection");
     Adaptation::Icap::Xaction *x = (Adaptation::Icap::Xaction*)data;
     x->noteCommConnected(Comm::OK);
 }
@@ -254,7 +254,7 @@ void Adaptation::Icap::Xaction::closeConnection()
 
         if (reuseConnection && !doneWithIo()) {
             //status() adds leading spaces.
-            debugs(93,5, HERE << "not reusing pconn due to pending I/O" << status());
+            debugs(93,5, "not reusing pconn due to pending I/O" << status());
             reuseConnection = false;
         }
 
@@ -321,7 +321,7 @@ void Adaptation::Icap::Xaction::noteCommConnected(const CommConnectCbParams &io)
 
 void Adaptation::Icap::Xaction::dieOnConnectionFailure()
 {
-    debugs(93, 2, HERE << typeName <<
+    debugs(93, 2, typeName <<
            " failed to connect to " << service().cfg().uri);
     service().noteConnectionFailed("failure");
     detailError(ERR_DETAIL_ICAP_XACT_START);
@@ -349,7 +349,7 @@ void Adaptation::Icap::Xaction::noteCommWrote(const CommIoCbParams &io)
     if (ignoreLastWrite) {
         // a hack due to comm inability to cancel a pending write
         ignoreLastWrite = false;
-        debugs(93, 7, HERE << "ignoring last write; status: " << io.flag);
+        debugs(93, 7, "ignoring last write; status: " << io.flag);
     } else {
         Must(io.flag == Comm::OK);
         al.icap.bytesSent += io.size;
@@ -366,7 +366,7 @@ void Adaptation::Icap::Xaction::noteCommTimedout(const CommTimeoutCbParams &)
 
 void Adaptation::Icap::Xaction::handleCommTimedout()
 {
-    debugs(93, 2, HERE << typeName << " failed: timeout with " <<
+    debugs(93, 2, typeName << " failed: timeout with " <<
            theService->cfg().methodStr() << " " <<
            theService->cfg().uri << status());
     reuseConnection = false;
@@ -408,7 +408,7 @@ void Adaptation::Icap::Xaction::callException(const std::exception  &e)
 void Adaptation::Icap::Xaction::callEnd()
 {
     if (doneWithIo()) {
-        debugs(93, 5, HERE << typeName << " done with I/O" << status());
+        debugs(93, 5, typeName << " done with I/O" << status());
         closeConnection();
     }
     Adaptation::Initiate::callEnd(); // may destroy us
@@ -573,7 +573,7 @@ void Adaptation::Icap::Xaction::noteInitiatorAborted()
 {
 
     if (theInitiator.set()) {
-        debugs(93,4, HERE << "Initiator gone before ICAP transaction ended");
+        debugs(93,4, "Initiator gone before ICAP transaction ended");
         clearInitiator();
         detailError(ERR_DETAIL_ICAP_INIT_GONE);
         setOutcome(xoGone);
@@ -585,10 +585,10 @@ void Adaptation::Icap::Xaction::noteInitiatorAborted()
 void Adaptation::Icap::Xaction::setOutcome(const Adaptation::Icap::XactOutcome &xo)
 {
     if (al.icap.outcome != xoUnknown) {
-        debugs(93, 3, HERE << "Warning: reseting outcome: from " <<
+        debugs(93, 3, "Warning: reseting outcome: from " <<
                al.icap.outcome << " to " << xo);
     } else {
-        debugs(93, 4, HERE << xo);
+        debugs(93, 4, xo);
     }
     al.icap.outcome = xo;
 }
@@ -600,7 +600,7 @@ void Adaptation::Icap::Xaction::swanSong()
 {
     // kids should sing first and then call the parent method.
     if (cs.valid()) {
-        debugs(93,6, HERE << id << " about to notify ConnOpener!");
+        debugs(93,6, id << " about to notify ConnOpener!");
         CallJobHere(93, 3, cs, Comm::ConnOpener, noteAbort);
         cs = NULL;
         service().noteConnectionFailed("abort");

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -60,7 +60,7 @@ AuthenticateAcl(ACLChecklist *ch)
     switch (result) {
 
     case AUTH_ACL_CANNOT_AUTHENTICATE:
-        debugs(28, 4, HERE << "returning " << ACCESS_DENIED << " user authenticated but not authorised.");
+        debugs(28, 4, "returning " << ACCESS_DENIED << " user authenticated but not authorised.");
         return ACCESS_DENIED;
 
     case AUTH_AUTHENTICATED:
@@ -75,7 +75,7 @@ AuthenticateAcl(ACLChecklist *ch)
         return ACCESS_DUNNO; // XXX: break this down into DUNNO, EXPIRED_OK, EXPIRED_BAD states
 
     case AUTH_ACL_CHALLENGE:
-        debugs(28, 4, HERE << "returning " << ACCESS_AUTH_REQUIRED << " sending authentication challenge.");
+        debugs(28, 4, "returning " << ACCESS_AUTH_REQUIRED << " sending authentication challenge.");
         /* Client is required to resend the request with correct authentication
          * credentials. (This may be part of a stateful auth protocol.)
          * The request is denied.

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -128,7 +128,7 @@ ProxyAuthLookup::checkForAsync(ACLChecklist *cl) const
 {
     ACLFilledChecklist *checklist = Filled(cl);
 
-    debugs(28, 3, HERE << "checking password via authenticator");
+    debugs(28, 3, "checking password via authenticator");
 
     /* make sure someone created auth_user_request for us */
     assert(checklist->auth_user_request != NULL);

--- a/src/auth/Gadgets.cc
+++ b/src/auth/Gadgets.cc
@@ -44,7 +44,7 @@ authenticateActiveSchemeCount(void)
             ++rv;
     }
 
-    debugs(29, 9, HERE << rv << " active.");
+    debugs(29, 9, rv << " active.");
 
     return rv;
 }
@@ -54,7 +54,7 @@ authenticateSchemeCount(void)
 {
     int rv = Auth::Scheme::GetSchemes().size();
 
-    debugs(29, 9, HERE << rv << " active.");
+    debugs(29, 9, rv << " active.");
 
     return rv;
 }

--- a/src/auth/SchemeConfig.cc
+++ b/src/auth/SchemeConfig.cc
@@ -32,7 +32,7 @@ Auth::UserRequest::Pointer
 Auth::SchemeConfig::CreateAuthUser(const char *proxy_auth, AccessLogEntry::Pointer &al)
 {
     assert(proxy_auth != NULL);
-    debugs(29, 9, HERE << "header = '" << proxy_auth << "'");
+    debugs(29, 9, "header = '" << proxy_auth << "'");
 
     Auth::SchemeConfig *config = Find(proxy_auth);
 

--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -32,7 +32,7 @@ Auth::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm) :
 {
     proxy_match_cache.head = proxy_match_cache.tail = NULL;
     ip_list.head = ip_list.tail = NULL;
-    debugs(29, 5, HERE << "Initialised auth_user '" << this << "'.");
+    debugs(29, 5, "Initialised auth_user '" << this << "'.");
 }
 
 Auth::CredentialState
@@ -64,7 +64,7 @@ Auth::User::absorb(Auth::User::Pointer from)
      *  dlink_list proxy_match_cache;
      */
 
-    debugs(29, 5, HERE << "auth_user '" << from << "' into auth_user '" << this << "'.");
+    debugs(29, 5, "auth_user '" << from << "' into auth_user '" << this << "'.");
 
     // combine the helper response annotations. Ensuring no duplicates are copied.
     notes.appendNewOnly(&from->notes);
@@ -120,7 +120,7 @@ Auth::User::absorb(Auth::User::Pointer from)
 
 Auth::User::~User()
 {
-    debugs(29, 5, HERE << "Freeing auth_user '" << this << "'.");
+    debugs(29, 5, "Freeing auth_user '" << this << "'.");
     assert(LockCount() == 0);
 
     /* free cached acl results */
@@ -223,7 +223,7 @@ Auth::User::addIp(Ip::Address ipaddr)
 
     ++ipcount;
 
-    debugs(29, 2, HERE << "user '" << username() << "' has been seen at a new IP address (" << ipaddr << ")");
+    debugs(29, 2, "user '" << username() << "' has been seen at a new IP address (" << ipaddr << ")");
 }
 
 SBuf

--- a/src/auth/UserRequest.cc
+++ b/src/auth/UserRequest.cc
@@ -52,27 +52,27 @@ Auth::UserRequest::start(HttpRequest *request, AccessLogEntry::Pointer &al, AUTH
 bool
 Auth::UserRequest::valid() const
 {
-    debugs(29, 9, HERE << "Validating Auth::UserRequest '" << this << "'.");
+    debugs(29, 9, "Validating Auth::UserRequest '" << this << "'.");
 
     if (user() == NULL) {
-        debugs(29, 4, HERE << "No associated Auth::User data");
+        debugs(29, 4, "No associated Auth::User data");
         return false;
     }
 
     if (user()->auth_type == Auth::AUTH_UNKNOWN) {
-        debugs(29, 4, HERE << "Auth::User '" << user() << "' uses unknown scheme.");
+        debugs(29, 4, "Auth::User '" << user() << "' uses unknown scheme.");
         return false;
     }
 
     if (user()->auth_type == Auth::AUTH_BROKEN) {
-        debugs(29, 4, HERE << "Auth::User '" << user() << "' is broken for it's scheme.");
+        debugs(29, 4, "Auth::User '" << user() << "' is broken for it's scheme.");
         return false;
     }
 
     /* any other sanity checks that we need in the future */
 
     /* finally return ok */
-    debugs(29, 5, HERE << "Validated. Auth::UserRequest '" << this << "'.");
+    debugs(29, 5, "Validated. Auth::UserRequest '" << this << "'.");
     return true;
 }
 
@@ -94,13 +94,13 @@ Auth::UserRequest::UserRequest():
     message(NULL),
     lastReply(AUTH_ACL_CANNOT_AUTHENTICATE)
 {
-    debugs(29, 5, HERE << "initialised request " << this);
+    debugs(29, 5, "initialised request " << this);
 }
 
 Auth::UserRequest::~UserRequest()
 {
     assert(LockCount()==0);
-    debugs(29, 5, HERE << "freeing request " << this);
+    debugs(29, 5, "freeing request " << this);
 
     if (user() != NULL) {
         /* release our references to the user credentials */
@@ -289,7 +289,7 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
     /* a) can we find other credentials to use? and b) are they logged in already? */
     if (proxy_auth == NULL && !authenticateUserAuthenticated(authTryGetUser(*auth_user_request,conn,request))) {
         /* no header or authentication failed/got corrupted - restart */
-        debugs(29, 4, HERE << "No Proxy-Auth header and no working alternative. Requesting auth header.");
+        debugs(29, 4, "No Proxy-Auth header and no working alternative. Requesting auth header.");
 
         /* something wrong with the AUTH credentials. Force a new attempt */
 
@@ -327,11 +327,11 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
 
     /* we have a proxy auth header and as far as we know this connection has
      * not had bungled connection oriented authentication happen on it. */
-    debugs(29, 9, HERE << "header " << (proxy_auth ? proxy_auth : "-") << ".");
+    debugs(29, 9, "header " << (proxy_auth ? proxy_auth : "-") << ".");
 
     if (*auth_user_request == NULL) {
         if (conn != NULL) {
-            debugs(29, 9, HERE << "This is a new checklist test on:" << conn->clientConnection);
+            debugs(29, 9, "This is a new checklist test on:" << conn->clientConnection);
         }
 
         if (proxy_auth && request->auth_user_request == NULL && conn != NULL && conn->getAuth() != NULL) {
@@ -349,7 +349,7 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
 
         if (request->auth_user_request == NULL && (conn == NULL || conn->getAuth() == NULL)) {
             /* beginning of a new request check */
-            debugs(29, 4, HERE << "No connection authentication type");
+            debugs(29, 4, "No connection authentication type");
 
             *auth_user_request = Auth::SchemeConfig::CreateAuthUser(proxy_auth, al);
             if (*auth_user_request == NULL)
@@ -374,7 +374,7 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
                 *auth_user_request = conn->getAuth();
             } else {
                 /* failed connection based authentication */
-                debugs(29, 4, HERE << "Auth user request " << *auth_user_request << " conn-auth missing and failed to authenticate.");
+                debugs(29, 4, "Auth user request " << *auth_user_request << " conn-auth missing and failed to authenticate.");
                 *auth_user_request = NULL;
                 return AUTH_ACL_CHALLENGE;
             }
@@ -520,7 +520,7 @@ Auth::UserRequest::AddReplyAuthHeader(HttpReply * rep, Auth::UserRequest::Pointe
                     else
                         scheme->fixHeader(NULL, rep, type, request);
                 } else
-                    debugs(29, 4, HERE << "Configured scheme " << scheme->type() << " not Active");
+                    debugs(29, 4, "Configured scheme " << scheme->type() << " not Active");
             }
         }
 

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -58,11 +58,11 @@ bool
 Auth::Basic::Config::configured() const
 {
     if ((authenticateProgram != NULL) && (authenticateChildren.n_max != 0) && !realm.isEmpty()) {
-        debugs(29, 9, HERE << "returning configured");
+        debugs(29, 9, "returning configured");
         return true;
     }
 
-    debugs(29, 9, HERE << "returning unconfigured");
+    debugs(29, 9, "returning unconfigured");
     return false;
 }
 
@@ -173,7 +173,7 @@ Auth::Basic::Config::decodeCleartext(const char *httpAuthHeader)
          * Don't allow NL or CR in the credentials.
          * Oezguer Kesim <oec@codeblau.de>
          */
-        debugs(29, 9, HERE << "'" << cleartext << "'");
+        debugs(29, 9, "'" << cleartext << "'");
 
         if (strcspn(cleartext, "\r\n") != strlen(cleartext)) {
             debugs(29, DBG_IMPORTANT, "WARNING: Bad characters in authorization header '" << httpAuthHeader << "'");
@@ -222,11 +222,11 @@ Auth::Basic::Config::decode(char const *proxy_auth, const char *aRequestRealm)
     local_basic->username(cleartext);
 
     if (local_basic->passwd == NULL) {
-        debugs(29, 4, HERE << "no password in proxy authorization header '" << proxy_auth << "'");
+        debugs(29, 4, "no password in proxy authorization header '" << proxy_auth << "'");
         auth_user_request->setDenyMessage("no password was present in the HTTP [proxy-]authorization header. This is most likely a browser bug");
     } else {
         if (local_basic->passwd[0] == '\0') {
-            debugs(29, 4, HERE << "Disallowing empty password. User is '" << local_basic->username() << "'");
+            debugs(29, 4, "Disallowing empty password. User is '" << local_basic->username() << "'");
             safe_free(local_basic->passwd);
             auth_user_request->setDenyMessage("Request denied because you provided an empty password. Users MUST have a password.");
         }
@@ -246,7 +246,7 @@ Auth::Basic::Config::decode(char const *proxy_auth, const char *aRequestRealm)
     if (!(auth_user = Auth::Basic::User::Cache()->lookup(lb->userKey()))) {
         /* the user doesn't exist in the username cache yet */
         /* save the credentials */
-        debugs(29, 9, HERE << "Creating new user '" << lb->username() << "'");
+        debugs(29, 9, "Creating new user '" << lb->username() << "'");
         /* set the auth_user type */
         lb->auth_type = Auth::AUTH_BASIC;
         /* current time for timeouts */

--- a/src/auth/basic/User.cc
+++ b/src/auth/basic/User.cc
@@ -61,12 +61,12 @@ Auth::Basic::User::valid() const
 void
 Auth::Basic::User::updateCached(Auth::Basic::User *from)
 {
-    debugs(29, 9, HERE << "Found user '" << from->username() << "' already in the user cache as '" << this << "'");
+    debugs(29, 9, "Found user '" << from->username() << "' already in the user cache as '" << this << "'");
 
     assert(strcmp(from->username(), username()) == 0);
 
     if (strcmp(from->passwd, passwd)) {
-        debugs(29, 4, HERE << "new password found. Updating in user master record and resetting auth state to unchecked");
+        debugs(29, 4, "new password found. Updating in user master record and resetting auth state to unchecked");
         credentials(Auth::Unchecked);
         xfree(passwd);
         passwd = from->passwd;
@@ -74,7 +74,7 @@ Auth::Basic::User::updateCached(Auth::Basic::User *from)
     }
 
     if (credentials() == Auth::Failed) {
-        debugs(29, 4, HERE << "last attempt to authenticate this user failed, resetting auth state to unchecked");
+        debugs(29, 4, "last attempt to authenticate this user failed, resetting auth state to unchecked");
         credentials(Auth::Unchecked);
     }
 }

--- a/src/auth/basic/UserRequest.cc
+++ b/src/auth/basic/UserRequest.cc
@@ -59,12 +59,12 @@ Auth::Basic::UserRequest::authenticate(HttpRequest *, ConnStateData *, Http::Hdr
 
     /* are we about to recheck the credentials externally? */
     if ((user()->expiretime + static_cast<Auth::Basic::Config*>(Auth::SchemeConfig::Find("basic"))->credentialsTTL) <= squid_curtime) {
-        debugs(29, 4, HERE << "credentials expired - rechecking");
+        debugs(29, 4, "credentials expired - rechecking");
         return;
     }
 
     /* we have been through the external helper, and the credentials haven't expired */
-    debugs(29, 9, HERE << "user '" << user()->username() << "' authenticated");
+    debugs(29, 9, "user '" << user()->username() << "' authenticated");
 
     /* Decode now takes care of finding the AuthUser struct in the cache */
     /* after external auth occurs anyway */
@@ -104,7 +104,7 @@ Auth::Basic::UserRequest::startHelperLookup(HttpRequest *request, AccessLogEntry
     assert(user()->auth_type == Auth::AUTH_BASIC);
     Auth::Basic::User *basic_auth = dynamic_cast<Auth::Basic::User *>(user().getRaw());
     assert(basic_auth != NULL);
-    debugs(29, 9, HERE << "'" << basic_auth->username() << ":" << basic_auth->passwd << "'");
+    debugs(29, 9, "'" << basic_auth->username() << ":" << basic_auth->passwd << "'");
 
     if (static_cast<Auth::Basic::Config*>(Auth::SchemeConfig::Find("basic"))->authenticateProgram == NULL) {
         debugs(29, DBG_CRITICAL, "ERROR: No Basic authentication program configured.");
@@ -161,7 +161,7 @@ Auth::Basic::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 {
     Auth::StateData *r = static_cast<Auth::StateData *>(data);
     void *cbdata;
-    debugs(29, 5, HERE << "reply=" << reply);
+    debugs(29, 5, "reply=" << reply);
 
     assert(r->auth_user_request != NULL);
     assert(r->auth_user_request->user()->auth_type == Auth::AUTH_BASIC);

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -289,7 +289,7 @@ Auth::Digest::UserRequest::startHelperLookup(HttpRequest *request, AccessLogEntr
     char buf[8192];
 
     assert(user() != NULL && user()->auth_type == Auth::AUTH_DIGEST);
-    debugs(29, 9, HERE << "'\"" << user()->username() << "\":\"" << realm << "\"'");
+    debugs(29, 9, "'\"" << user()->username() << "\":\"" << realm << "\"'");
 
     if (static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->authenticateProgram == NULL) {
         debugs(29, DBG_CRITICAL, "ERROR: No Digest authentication program configured.");
@@ -320,7 +320,7 @@ void
 Auth::Digest::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 {
     Auth::StateData *replyData = static_cast<Auth::StateData *>(data);
-    debugs(29, 9, HERE << "reply=" << reply);
+    debugs(29, 9, "reply=" << reply);
 
     assert(replyData->auth_user_request != NULL);
     Auth::UserRequest::Pointer auth_user_request = replyData->auth_user_request;

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -126,11 +126,11 @@ bool
 Auth::Negotiate::Config::configured() const
 {
     if (authenticateProgram && (authenticateChildren.n_max != 0)) {
-        debugs(29, 9, HERE << "returning configured");
+        debugs(29, 9, "returning configured");
         return true;
     }
 
-    debugs(29, 9, HERE << "returning unconfigured");
+    debugs(29, 9, "returning unconfigured");
     return false;
 }
 
@@ -146,7 +146,7 @@ Auth::Negotiate::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request,
 
     /* New request, no user details */
     if (auth_user_request == NULL) {
-        debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate'");
+        debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate'");
         httpHeaderPutStrf(&rep->header, reqType, "Negotiate");
 
         if (!keep_alive) {
@@ -172,11 +172,11 @@ Auth::Negotiate::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request,
              * Need to start over to give the client another chance.
              */
             if (negotiate_request->server_blob) {
-                debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
+                debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
                 httpHeaderPutStrf(&rep->header, reqType, "Negotiate %s", negotiate_request->server_blob);
                 safe_free(negotiate_request->server_blob);
             } else {
-                debugs(29, 9, HERE << "Connection authenticated");
+                debugs(29, 9, "Connection authenticated");
                 httpHeaderPutStrf(&rep->header, reqType, "Negotiate");
             }
             break;
@@ -184,13 +184,13 @@ Auth::Negotiate::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request,
         case Auth::Unchecked:
             /* semantic change: do not drop the connection.
              * 2.5 implementation used to keep it open - Kinkie */
-            debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate'");
+            debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate'");
             httpHeaderPutStrf(&rep->header, reqType, "Negotiate");
             break;
 
         case Auth::Handshake:
             /* we're waiting for a response from the client. Pass it the blob */
-            debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
+            debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
             httpHeaderPutStrf(&rep->header, reqType, "Negotiate %s", negotiate_request->server_blob);
             safe_free(negotiate_request->server_blob);
             break;
@@ -226,7 +226,7 @@ Auth::Negotiate::Config::decode(char const *proxy_auth, const char *aRequestReal
     auth_user_request->user()->BuildUserKey(proxy_auth, aRequestRealm);
 
     /* all we have to do is identify that it's Negotiate - the helper does the rest */
-    debugs(29, 9, HERE << "decode Negotiate authentication");
+    debugs(29, 9, "decode Negotiate authentication");
     return auth_user_request;
 }
 

--- a/src/auth/negotiate/User.cc
+++ b/src/auth/negotiate/User.cc
@@ -19,7 +19,7 @@ Auth::Negotiate::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRea
 
 Auth::Negotiate::User::~User()
 {
-    debugs(29, 5, HERE << "doing nothing to clear Negotiate scheme data for '" << this << "'");
+    debugs(29, 5, "doing nothing to clear Negotiate scheme data for '" << this << "'");
 }
 
 int32_t

--- a/src/auth/negotiate/UserRequest.cc
+++ b/src/auth/negotiate/UserRequest.cc
@@ -59,11 +59,11 @@ int
 Auth::Negotiate::UserRequest::authenticated() const
 {
     if (user() != NULL && user()->credentials() == Auth::Ok) {
-        debugs(29, 9, HERE << "user authenticated.");
+        debugs(29, 9, "user authenticated.");
         return 1;
     }
 
-    debugs(29, 9, HERE << "user not fully authenticated.");
+    debugs(29, 9, "user not fully authenticated.");
     return 0;
 }
 
@@ -134,7 +134,7 @@ Auth::Negotiate::UserRequest::startHelperLookup(HttpRequest *, AccessLogEntry::P
         return;
     }
 
-    debugs(29, 8, HERE << "credentials state is '" << user()->credentials() << "'");
+    debugs(29, 8, "credentials state is '" << user()->credentials() << "'");
 
     const char *keyExtras = helperRequestKeyExtras(request, al);
     int printResult = 0;
@@ -175,11 +175,11 @@ void
 Auth::Negotiate::UserRequest::releaseAuthServer()
 {
     if (authserver) {
-        debugs(29, 6, HERE << "releasing Negotiate auth server '" << authserver << "'");
+        debugs(29, 6, "releasing Negotiate auth server '" << authserver << "'");
         helperStatefulReleaseServer(authserver);
         authserver = NULL;
     } else
-        debugs(29, 6, HERE << "No Negotiate auth server to release.");
+        debugs(29, 6, "No Negotiate auth server to release.");
 }
 
 void
@@ -200,7 +200,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
     }
 
     if (server_blob) {
-        debugs(29, 2, HERE << "need to challenge client '" << server_blob << "'!");
+        debugs(29, 2, "need to challenge client '" << server_blob << "'!");
         return;
     }
 
@@ -225,7 +225,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
 
     case Auth::Unchecked:
         /* we've received a negotiate request. pass to a helper */
-        debugs(29, 9, HERE << "auth state negotiate none. Received blob: '" << proxy_auth << "'");
+        debugs(29, 9, "auth state negotiate none. Received blob: '" << proxy_auth << "'");
         user()->credentials(Auth::Pending);
         safe_free(client_blob);
         client_blob=xstrdup(blob);
@@ -236,7 +236,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
         break;
 
     case Auth::Pending:
-        debugs(29, DBG_IMPORTANT, HERE << "need to ask helper");
+        debugs(29, DBG_IMPORTANT, "need to ask helper");
         break;
 
     case Auth::Handshake:
@@ -256,7 +256,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
 
     case Auth::Failed:
         /* we've failed somewhere in authentication */
-        debugs(29, 9, HERE << "auth state negotiate failed. " << proxy_auth);
+        debugs(29, 9, "auth state negotiate failed. " << proxy_auth);
         break;
     }
 }
@@ -266,7 +266,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
 {
     Auth::StateData *r = static_cast<Auth::StateData *>(data);
 
-    debugs(29, 8, HERE << "helper: '" << reply.whichServer << "' sent us reply=" << reply);
+    debugs(29, 8, "helper: '" << reply.whichServer << "' sent us reply=" << reply);
 
     if (!cbdataReferenceValid(r->data)) {
         debugs(29, DBG_IMPORTANT, "ERROR: Negotiate Authentication invalid callback data. helper '" << reply.whichServer << "'.");
@@ -308,7 +308,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
             lm_request->server_blob = xstrdup(tokenNote);
             auth_user_request->user()->credentials(Auth::Handshake);
             auth_user_request->setDenyMessage("Authentication in progress");
-            debugs(29, 4, HERE << "Need to challenge the client with a server token: '" << tokenNote << "'");
+            debugs(29, 4, "Need to challenge the client with a server token: '" << tokenNote << "'");
         } else {
             auth_user_request->user()->credentials(Auth::Failed);
             auth_user_request->setDenyMessage("Negotiate authentication requires a persistent connection");
@@ -333,7 +333,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
         lm_request->releaseAuthServer();
 
         /* connection is authenticated */
-        debugs(29, 4, HERE << "authenticated user " << auth_user_request->user()->username());
+        debugs(29, 4, "authenticated user " << auth_user_request->user()->username());
         auto local_auth_user = lm_request->user();
         auto cached_user = Auth::Negotiate::User::Cache()->lookup(auth_user_request->user()->userKey());
         if (!cached_user) {
@@ -352,7 +352,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
          * existing user or a new user */
         local_auth_user->expiretime = current_time.tv_sec;
         auth_user_request->user()->credentials(Auth::Ok);
-        debugs(29, 4, HERE << "Successfully validated user via Negotiate. Username '" << auth_user_request->user()->username() << "'");
+        debugs(29, 4, "Successfully validated user via Negotiate. Username '" << auth_user_request->user()->username() << "'");
     }
     break;
 

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -125,11 +125,11 @@ bool
 Auth::Ntlm::Config::configured() const
 {
     if ((authenticateProgram != NULL) && (authenticateChildren.n_max != 0)) {
-        debugs(29, 9, HERE << "returning configured");
+        debugs(29, 9, "returning configured");
         return true;
     }
 
-    debugs(29, 9, HERE << "returning unconfigured");
+    debugs(29, 9, "returning unconfigured");
     return false;
 }
 
@@ -147,7 +147,7 @@ Auth::Ntlm::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Http
 
     /* New request, no user details */
     if (auth_user_request == NULL) {
-        debugs(29, 9, HERE << "Sending type:" << hdrType << " header: 'NTLM'");
+        debugs(29, 9, "Sending type:" << hdrType << " header: 'NTLM'");
         httpHeaderPutStrf(&rep->header, hdrType, "NTLM");
 
         if (!keep_alive) {
@@ -175,13 +175,13 @@ Auth::Ntlm::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Http
         case Auth::Unchecked:
             /* semantic change: do not drop the connection.
              * 2.5 implementation used to keep it open - Kinkie */
-            debugs(29, 9, HERE << "Sending type:" << hdrType << " header: 'NTLM'");
+            debugs(29, 9, "Sending type:" << hdrType << " header: 'NTLM'");
             httpHeaderPutStrf(&rep->header, hdrType, "NTLM");
             break;
 
         case Auth::Handshake:
             /* we're waiting for a response from the client. Pass it the blob */
-            debugs(29, 9, HERE << "Sending type:" << hdrType << " header: 'NTLM " << ntlm_request->server_blob << "'");
+            debugs(29, 9, "Sending type:" << hdrType << " header: 'NTLM " << ntlm_request->server_blob << "'");
             httpHeaderPutStrf(&rep->header, hdrType, "NTLM %s", ntlm_request->server_blob);
             safe_free(ntlm_request->server_blob);
             break;
@@ -217,7 +217,7 @@ Auth::Ntlm::Config::decode(char const *proxy_auth, const char *aRequestRealm)
     auth_user_request->user()->BuildUserKey(proxy_auth, aRequestRealm);
 
     /* all we have to do is identify that it's NTLM - the helper does the rest */
-    debugs(29, 9, HERE << "decode: NTLM authentication");
+    debugs(29, 9, "decode: NTLM authentication");
     return auth_user_request;
 }
 

--- a/src/auth/ntlm/User.cc
+++ b/src/auth/ntlm/User.cc
@@ -19,7 +19,7 @@ Auth::Ntlm::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm) :
 
 Auth::Ntlm::User::~User()
 {
-    debugs(29, 5, HERE << "doing nothing to clear NTLM scheme data for '" << this << "'");
+    debugs(29, 5, "doing nothing to clear NTLM scheme data for '" << this << "'");
 }
 
 int32_t

--- a/src/auth/ntlm/UserRequest.cc
+++ b/src/auth/ntlm/UserRequest.cc
@@ -57,11 +57,11 @@ int
 Auth::Ntlm::UserRequest::authenticated() const
 {
     if (user() != NULL && user()->credentials() == Auth::Ok) {
-        debugs(29, 9, HERE << "user authenticated.");
+        debugs(29, 9, "user authenticated.");
         return 1;
     }
 
-    debugs(29, 9, HERE << "user not fully authenticated.");
+    debugs(29, 9, "user not fully authenticated.");
     return 0;
 }
 
@@ -129,7 +129,7 @@ Auth::Ntlm::UserRequest::startHelperLookup(HttpRequest *, AccessLogEntry::Pointe
         return;
     }
 
-    debugs(29, 8, HERE << "credentials state is '" << user()->credentials() << "'");
+    debugs(29, 8, "credentials state is '" << user()->credentials() << "'");
 
     const char *keyExtras = helperRequestKeyExtras(request, al);
     int printResult = 0;
@@ -168,11 +168,11 @@ void
 Auth::Ntlm::UserRequest::releaseAuthServer()
 {
     if (authserver) {
-        debugs(29, 6, HERE << "releasing NTLM auth server '" << authserver << "'");
+        debugs(29, 6, "releasing NTLM auth server '" << authserver << "'");
         helperStatefulReleaseServer(authserver);
         authserver = NULL;
     } else
-        debugs(29, 6, HERE << "No NTLM auth server to release.");
+        debugs(29, 6, "No NTLM auth server to release.");
 }
 
 void
@@ -193,7 +193,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
     }
 
     if (server_blob) {
-        debugs(29, 2, HERE << "need to challenge client '" << server_blob << "'!");
+        debugs(29, 2, "need to challenge client '" << server_blob << "'!");
         return;
     }
 
@@ -219,7 +219,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
 
     case Auth::Unchecked:
         /* we've received a ntlm request. pass to a helper */
-        debugs(29, 9, HERE << "auth state ntlm none. Received blob: '" << proxy_auth << "'");
+        debugs(29, 9, "auth state ntlm none. Received blob: '" << proxy_auth << "'");
         user()->credentials(Auth::Pending);
         safe_free(client_blob);
         client_blob=xstrdup(blob);
@@ -230,7 +230,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
         break;
 
     case Auth::Pending:
-        debugs(29, DBG_IMPORTANT, HERE << "need to ask helper");
+        debugs(29, DBG_IMPORTANT, "need to ask helper");
         break;
 
     case Auth::Handshake:
@@ -250,7 +250,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
 
     case Auth::Failed:
         /* we've failed somewhere in authentication */
-        debugs(29, 9, HERE << "auth state ntlm failed. " << proxy_auth);
+        debugs(29, 9, "auth state ntlm failed. " << proxy_auth);
         break;
     }
 }
@@ -260,7 +260,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 {
     Auth::StateData *r = static_cast<Auth::StateData *>(data);
 
-    debugs(29, 8, HERE << "helper: '" << reply.whichServer << "' sent us reply=" << reply);
+    debugs(29, 8, "helper: '" << reply.whichServer << "' sent us reply=" << reply);
 
     if (!cbdataReferenceValid(r->data)) {
         debugs(29, DBG_IMPORTANT, "ERROR: NTLM Authentication invalid callback data. helper '" << reply.whichServer << "'.");
@@ -302,7 +302,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
             lm_request->server_blob = xstrdup(serverBlob);
             auth_user_request->user()->credentials(Auth::Handshake);
             auth_user_request->setDenyMessage("Authentication in progress");
-            debugs(29, 4, HERE << "Need to challenge the client with a server token: '" << serverBlob << "'");
+            debugs(29, 4, "Need to challenge the client with a server token: '" << serverBlob << "'");
         } else {
             auth_user_request->user()->credentials(Auth::Failed);
             auth_user_request->setDenyMessage("NTLM authentication requires a persistent connection");
@@ -324,9 +324,9 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
         safe_free(lm_request->server_blob);
         lm_request->releaseAuthServer();
 
-        debugs(29, 4, HERE << "Successfully validated user via NTLM. Username '" << userLabel << "'");
+        debugs(29, 4, "Successfully validated user via NTLM. Username '" << userLabel << "'");
         /* connection is authenticated */
-        debugs(29, 4, HERE << "authenticated user " << auth_user_request->user()->username());
+        debugs(29, 4, "authenticated user " << auth_user_request->user()->username());
         /* see if this is an existing user */
         auto local_auth_user = lm_request->user();
         auto cached_user = Auth::Ntlm::User::Cache()->lookup(auth_user_request->user()->userKey());
@@ -346,7 +346,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
          * existing user or a new user */
         local_auth_user->expiretime = current_time.tv_sec;
         auth_user_request->user()->credentials(Auth::Ok);
-        debugs(29, 4, HERE << "Successfully validated user via NTLM. Username '" << auth_user_request->user()->username() << "'");
+        debugs(29, 4, "Successfully validated user via NTLM. Username '" << auth_user_request->user()->username() << "'");
     }
     break;
 

--- a/src/base/AsyncCall.cc
+++ b/src/base/AsyncCall.cc
@@ -34,7 +34,7 @@ AsyncCall::~AsyncCall()
 void
 AsyncCall::make()
 {
-    debugs(debugSection, debugLevel, HERE << "make call " << name <<
+    debugs(debugSection, debugLevel, "make call " << name <<
            " [" << id << ']');
     if (canFire()) {
         fire();
@@ -44,14 +44,14 @@ AsyncCall::make()
     if (!isCanceled) // we did not cancel() when returning false from canFire()
         isCanceled = "unknown reason";
 
-    debugs(debugSection, debugLevel, HERE << "will not call " << name <<
+    debugs(debugSection, debugLevel, "will not call " << name <<
            " [" << id << ']' << " because of " << isCanceled);
 }
 
 bool
 AsyncCall::cancel(const char *reason)
 {
-    debugs(debugSection, debugLevel, HERE << "will not call " << name <<
+    debugs(debugSection, debugLevel, "will not call " << name <<
            " [" << id << "] " << (isCanceled ? "also " : "") <<
            "because " << reason);
 

--- a/src/base/AsyncJob.cc
+++ b/src/base/AsyncJob.cc
@@ -103,7 +103,7 @@ bool AsyncJob::canBeCalled(AsyncCall &call) const
     if (inCall != NULL) {
         // This may happen when we have bugs or some module is not calling
         // us asynchronously (comm used to do that).
-        debugs(93, 5, HERE << inCall << " is in progress; " <<
+        debugs(93, 5, inCall << " is in progress; " <<
                call << " canot reenter the job.");
         return call.cancel("reentrant job call");
     }
@@ -146,7 +146,7 @@ void AsyncJob::callEnd()
         delete this; // this is the only place where the object is deleted
 
         // careful: this object does not exist any more
-        debugs(93, 6, HERE << *inCallSaved << " ended " << thisSaved);
+        debugs(93, 6, *inCallSaved << " ended " << thisSaved);
         return;
     }
 

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -174,7 +174,7 @@ JobDialer<Job>::dial(AsyncCall &call)
         doDial();
     } catch (const std::exception &e) {
         debugs(call.debugSection, 3,
-               HERE << call.name << " threw exception: " << e.what());
+               call.name << " threw exception: " << e.what());
         job->callException(e);
     }
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -539,7 +539,7 @@ parseOneConfigFile(const char *file_name, unsigned int depth)
             if (tmp_line_len >= 9 && strncmp(tmp_line, "include", 7) == 0 && xisspace(tmp_line[7])) {
                 err_count += parseManyConfigFiles(tmp_line + 8, depth + 1);
             } else if (!parse_line(tmp_line)) {
-                debugs(3, DBG_CRITICAL, HERE << cfg_filename << ":" << config_lineno << " unrecognized: '" << tmp_line << "'");
+                debugs(3, DBG_CRITICAL, cfg_filename << ":" << config_lineno << " unrecognized: '" << tmp_line << "'");
                 ++err_count;
             }
         }
@@ -573,7 +573,7 @@ parseConfigFileOrThrow(const char *file_name)
 {
     int err_count = 0;
 
-    debugs(5, 4, HERE);
+    debugs(5, 4, "");
 
     configFreeMemory();
 

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -62,9 +62,9 @@ CacheManager::registerProfile(const Mgr::ActionProfile::Pointer &profile)
     Must(profile != NULL);
     if (!CacheManager::findAction(profile->name)) {
         menu_.push_back(profile);
-        debugs(16, 3, HERE << "registered profile: " << *profile);
+        debugs(16, 3, "registered profile: " << *profile);
     } else {
-        debugs(16, 2, HERE << "skipped duplicate profile: " << *profile);
+        debugs(16, 2, "skipped duplicate profile: " << *profile);
     }
 }
 
@@ -77,7 +77,7 @@ CacheManager::registerProfile(const Mgr::ActionProfile::Pointer &profile)
 void
 CacheManager::registerProfile(char const * action, char const * desc, OBJH * handler, int pw_req_flag, int atomic)
 {
-    debugs(16, 3, HERE << "registering legacy " << action);
+    debugs(16, 3, "registering legacy " << action);
     const Mgr::ActionProfile::Pointer profile = new Mgr::ActionProfile(action,
             desc, pw_req_flag, atomic, new Mgr::FunActionCreator(handler));
     registerProfile(profile);
@@ -199,7 +199,7 @@ CacheManager::ParseUrl(const char *url)
     }
 #endif
 
-    debugs(16, 3, HERE << "MGR request: t=" << t << ", host='" << host << "', request='" << request << "', pos=" << pos <<
+    debugs(16, 3, "MGR request: t=" << t << ", host='" << host << "', request='" << request << "', pos=" << pos <<
            ", password='" << password << "', params='" << params << "'");
 
     Mgr::ActionProfile::Pointer profile = findAction(request);

--- a/src/cf_gen.cc
+++ b/src/cf_gen.cc
@@ -679,7 +679,7 @@ gen_dump(const EntryList &head, std::ostream &fout)
          "static void" << std::endl <<
          "dump_config(StoreEntry *entry)" << std::endl <<
          "{" << std::endl <<
-         "    debugs(5, 4, HERE);" << std::endl;
+         "    debugs(5, 4, \"\");" << std::endl;
 
     for (EntryList::const_iterator e = head.begin(); e != head.end(); ++e) {
 
@@ -708,7 +708,7 @@ gen_free(const EntryList &head, std::ostream &fout)
          "static void" << std::endl <<
          "free_all(void)" << std::endl <<
          "{" << std::endl <<
-         "    debugs(5, 4, HERE);" << std::endl;
+         "    debugs(5, 4, \"\");" << std::endl;
 
     for (EntryList::const_iterator e = head.begin(); e != head.end(); ++e) {
         if (!e->loc.size() || e->loc.compare("none") == 0)

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -456,7 +456,7 @@ snmp_meshCtblFn(variable_list * Var, snint * ErrP)
 
     *ErrP = SNMP_ERR_NOERROR;
     MemBuf tmp;
-    debugs(49, 6, HERE << "Current : length=" << Var->name_length << ": " << snmpDebugOid(Var->name, Var->name_length, tmp));
+    debugs(49, 6, "Current : length=" << Var->name_length << ": " << snmpDebugOid(Var->name, Var->name_length, tmp));
     if (Var->name_length == 16) {
         oid2addr(&(Var->name[12]), keyIp, 4);
     } else if (Var->name_length == 28) {
@@ -467,11 +467,11 @@ snmp_meshCtblFn(variable_list * Var, snint * ErrP)
     }
 
     keyIp.toStr(key, sizeof(key));
-    debugs(49, 5, HERE << "[" << key << "] requested!");
+    debugs(49, 5, "[" << key << "] requested!");
     c = (ClientInfo *) hash_lookup(client_table, key);
 
     if (c == NULL) {
-        debugs(49, 5, HERE << "not found.");
+        debugs(49, 5, "not found.");
         *ErrP = SNMP_ERR_NOSUCHNAME;
         return NULL;
     }

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1184,7 +1184,7 @@ clientReplyContext::storeOKTransferDone() const
     assert(http->storeEntry()->objectLen() >= 0);
     assert(http->storeEntry()->objectLen() >= headers_sz);
     if (http->out.offset >= http->storeEntry()->objectLen() - headers_sz) {
-        debugs(88,3,HERE << "storeOKTransferDone " <<
+        debugs(88,3,"storeOKTransferDone " <<
                " out.offset=" << http->out.offset <<
                " objectLen()=" << http->storeEntry()->objectLen() <<
                " headers_sz=" << headers_sz);
@@ -1224,7 +1224,7 @@ clientReplyContext::storeNotOKTransferDone() const
     if (http->out.size < expectedLength)
         return 0;
     else {
-        debugs(88,3,HERE << "storeNotOKTransferDone " <<
+        debugs(88,3,"storeNotOKTransferDone " <<
                " out.size=" << http->out.size <<
                " expectedLength=" << expectedLength);
         return 1;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -537,7 +537,7 @@ ClientRequestContext::hostHeaderIpVerify(const ipcache_addrs* ia, const Dns::Loo
         http->doCallouts();
         return;
     }
-    debugs(85, 3, HERE << "FAIL: validate IP " << clientConn->local << " possible from Host:");
+    debugs(85, 3, "FAIL: validate IP " << clientConn->local << " possible from Host:");
     hostHeaderVerifyFailed("local IP", "any domain IP");
 }
 
@@ -594,7 +594,7 @@ ClientRequestContext::hostHeaderVerify()
     if (!host) {
         // TODO: dump out the HTTP/1.1 error about missing host header.
         // otherwise this is fine, can't forge a header value when its not even set.
-        debugs(85, 3, HERE << "validate skipped with no Host: header present.");
+        debugs(85, 3, "validate skipped with no Host: header present.");
         http->doCallouts();
         return;
     }
@@ -602,7 +602,7 @@ ClientRequestContext::hostHeaderVerify()
     if (http->request->flags.internal) {
         // TODO: kill this when URL handling allows partial URLs out of accel mode
         //       and we no longer screw with the URL just to add our internal host there
-        debugs(85, 6, HERE << "validate skipped due to internal composite URL.");
+        debugs(85, 6, "validate skipped due to internal composite URL.");
         http->doCallouts();
         return;
     }
@@ -723,7 +723,7 @@ ClientRequestContext::clientAccessCheck2()
         acl_checklist = clientAclChecklistCreate(Config.accessList.adapted_http, http);
         acl_checklist->nonBlockingCheck(clientAccessCheckDoneWrapper, this);
     } else {
-        debugs(85, 2, HERE << "No adapted_http_access configuration. default: ALLOW");
+        debugs(85, 2, "No adapted_http_access configuration. default: ALLOW");
         clientAccessCheckDone(ACCESS_ALLOWED);
     }
 }
@@ -832,7 +832,7 @@ ClientRequestContext::clientAccessCheckDone(const allow_t &answer)
 void
 ClientHttpRequest::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer g)
 {
-    debugs(93,3,HERE << this << " adaptationAclCheckDone called");
+    debugs(93,3,this << " adaptationAclCheckDone called");
 
 #if ICAP_CLIENT
     Adaptation::Icap::History::Pointer ih = request->icapHistory();
@@ -851,7 +851,7 @@ ClientHttpRequest::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer g)
 #endif
 
     if (!g) {
-        debugs(85,3, HERE << "no adaptation needed");
+        debugs(85,3, "no adaptation needed");
         doCallouts();
         return;
     }
@@ -879,7 +879,7 @@ clientRedirectAccessCheckDone(allow_t answer, void *data)
 void
 ClientRequestContext::clientRedirectStart()
 {
-    debugs(33, 5, HERE << "'" << http->uri << "'");
+    debugs(33, 5, "'" << http->uri << "'");
     http->al->syncNotes(http->request);
     if (Config.accessList.redirector) {
         acl_checklist = clientAclChecklistCreate(Config.accessList.redirector, http);
@@ -1186,7 +1186,7 @@ void
 ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
 {
     HttpRequest *old_request = http->request;
-    debugs(85, 5, HERE << "'" << http->uri << "' result=" << reply);
+    debugs(85, 5, "'" << http->uri << "' result=" << reply);
     assert(redirect_state == REDIRECT_PENDING);
     redirect_state = REDIRECT_DONE;
 
@@ -1271,7 +1271,7 @@ ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
                     // unlink bodypipe from the old request. Not needed there any longer.
                     if (old_request->body_pipe != NULL) {
                         old_request->body_pipe = NULL;
-                        debugs(61,2, HERE << "URL-rewriter diverts body_pipe " << new_request->body_pipe <<
+                        debugs(61,2, "URL-rewriter diverts body_pipe " << new_request->body_pipe <<
                                " from request " << old_request << " to " << new_request);
                     }
 
@@ -1410,7 +1410,7 @@ ClientRequestContext::sslBumpAccessCheck()
 
     // If SSL connection tunneling or bumping decision has been made, obey it.
     if (bumpMode != Ssl::bumpEnd) {
-        debugs(85, 5, HERE << "SslBump already decided (" << bumpMode <<
+        debugs(85, 5, "SslBump already decided (" << bumpMode <<
                "), " << "ignoring ssl_bump for " << http->getConn());
 
         // We need the following "if" for transparently bumped TLS connection,
@@ -1437,7 +1437,7 @@ ClientRequestContext::sslBumpAccessCheck()
             !Config.accessList.ssl_bump ||
             !http->getConn()->port->flags.tunnelSslBumping) {
         http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
-        debugs(85, 5, HERE << "cannot SslBump this request");
+        debugs(85, 5, "cannot SslBump this request");
         return false;
     }
 
@@ -1445,7 +1445,7 @@ ClientRequestContext::sslBumpAccessCheck()
     // if we delay a 407 response and respond with 200 OK to CONNECT.
     if (error && error->httpStatus == Http::scProxyAuthenticationRequired) {
         http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
-        debugs(85, 5, HERE << "no SslBump during proxy authentication");
+        debugs(85, 5, "no SslBump during proxy authentication");
         return false;
     }
 
@@ -1456,7 +1456,7 @@ ClientRequestContext::sslBumpAccessCheck()
         return false;
     }
 
-    debugs(85, 5, HERE << "SslBump possible, checking ACL");
+    debugs(85, 5, "SslBump possible, checking ACL");
 
     ACLFilledChecklist *aclChecklist = clientAclChecklistCreate(Config.accessList.ssl_bump, http);
     aclChecklist->nonBlockingCheck(sslBumpAccessCheckDoneWrapper, this);
@@ -1550,7 +1550,7 @@ ClientHttpRequest::httpStart()
 void
 ClientHttpRequest::sslBumpNeed(Ssl::BumpMode mode)
 {
-    debugs(83, 3, HERE << "sslBump required: "<< Ssl::bumpMode(mode));
+    debugs(83, 3, "sslBump required: "<< Ssl::bumpMode(mode));
     sslBumpNeed_ = mode;
 }
 
@@ -1559,7 +1559,7 @@ static void
 SslBumpEstablish(const Comm::ConnectionPointer &, char *, size_t, Comm::Flag errflag, int, void *data)
 {
     ClientHttpRequest *r = static_cast<ClientHttpRequest*>(data);
-    debugs(85, 5, HERE << "responded to CONNECT: " << r << " ? " << errflag);
+    debugs(85, 5, "responded to CONNECT: " << r << " ? " << errflag);
 
     assert(r && cbdataReferenceValid(r));
     r->sslBumpEstablish(errflag);
@@ -1573,7 +1573,7 @@ ClientHttpRequest::sslBumpEstablish(Comm::Flag errflag)
         return;
 
     if (errflag) {
-        debugs(85, 3, HERE << "CONNECT response failure in SslBump: " << errflag);
+        debugs(85, 3, "CONNECT response failure in SslBump: " << errflag);
         getConn()->clientConnection->close();
         return;
     }
@@ -1595,7 +1595,7 @@ ClientHttpRequest::sslBumpEstablish(Comm::Flag errflag)
 void
 ClientHttpRequest::sslBumpStart()
 {
-    debugs(85, 5, HERE << "Confirming " << Ssl::bumpMode(sslBumpNeed_) <<
+    debugs(85, 5, "Confirming " << Ssl::bumpMode(sslBumpNeed_) <<
            "-bumped CONNECT tunnel on FD " << getConn()->clientConnection);
     getConn()->sslBumpMode = sslBumpNeed_;
 
@@ -1707,14 +1707,14 @@ ClientHttpRequest::doCallouts()
     if (!calloutContext->error) {
         // CVE-2009-0801: verify the Host: header is consistent with other known details.
         if (!calloutContext->host_header_verify_done) {
-            debugs(83, 3, HERE << "Doing calloutContext->hostHeaderVerify()");
+            debugs(83, 3, "Doing calloutContext->hostHeaderVerify()");
             calloutContext->host_header_verify_done = true;
             calloutContext->hostHeaderVerify();
             return;
         }
 
         if (!calloutContext->http_access_done) {
-            debugs(83, 3, HERE << "Doing calloutContext->clientAccessCheck()");
+            debugs(83, 3, "Doing calloutContext->clientAccessCheck()");
             calloutContext->http_access_done = true;
             calloutContext->clientAccessCheck();
             return;
@@ -1734,7 +1734,7 @@ ClientHttpRequest::doCallouts()
             calloutContext->redirect_done = true;
 
             if (Config.Program.redirect) {
-                debugs(83, 3, HERE << "Doing calloutContext->clientRedirectStart()");
+                debugs(83, 3, "Doing calloutContext->clientRedirectStart()");
                 calloutContext->redirect_state = REDIRECT_PENDING;
                 calloutContext->clientRedirectStart();
                 return;
@@ -1742,7 +1742,7 @@ ClientHttpRequest::doCallouts()
         }
 
         if (!calloutContext->adapted_http_access_done) {
-            debugs(83, 3, HERE << "Doing calloutContext->clientAccessCheck2()");
+            debugs(83, 3, "Doing calloutContext->clientAccessCheck2()");
             calloutContext->adapted_http_access_done = true;
             calloutContext->clientAccessCheck2();
             return;
@@ -1760,7 +1760,7 @@ ClientHttpRequest::doCallouts()
         }
 
         if (!calloutContext->interpreted_req_hdrs) {
-            debugs(83, 3, HERE << "Doing clientInterpretRequestHeaders()");
+            debugs(83, 3, "Doing clientInterpretRequestHeaders()");
             calloutContext->interpreted_req_hdrs = 1;
             clientInterpretRequestHeaders(this);
         }
@@ -1769,7 +1769,7 @@ ClientHttpRequest::doCallouts()
             calloutContext->no_cache_done = true;
 
             if (Config.accessList.noCache && request->flags.cachable) {
-                debugs(83, 3, HERE << "Doing calloutContext->checkNoCache()");
+                debugs(83, 3, "Doing calloutContext->checkNoCache()");
                 calloutContext->checkNoCache();
                 return;
             }
@@ -1854,7 +1854,7 @@ ClientHttpRequest::doCallouts()
     headersLog(0, 1, request->method, request);
 #endif
 
-    debugs(83, 3, HERE << "calling processRequest()");
+    debugs(83, 3, "calling processRequest()");
     processRequest();
 
 #if ICAP_CLIENT
@@ -1869,7 +1869,7 @@ ClientHttpRequest::doCallouts()
 void
 ClientHttpRequest::startAdaptation(const Adaptation::ServiceGroupPointer &g)
 {
-    debugs(85, 3, HERE << "adaptation needed for " << this);
+    debugs(85, 3, "adaptation needed for " << this);
     assert(!virginHeadSource);
     assert(!adaptedBodySource);
     virginHeadSource = initiateAdaptation(
@@ -1927,7 +1927,7 @@ ClientHttpRequest::handleAdaptedHeader(Http::Message *msg)
         setLogUri(this, urlCanonicalClean(request));
         assert(request->method.id());
     } else if (HttpReply *new_rep = dynamic_cast<HttpReply*>(msg)) {
-        debugs(85,3,HERE << "REQMOD reply is HTTP reply");
+        debugs(85,3,"REQMOD reply is HTTP reply");
 
         // subscribe to receive reply body
         if (new_rep->body_pipe != NULL) {
@@ -2027,7 +2027,7 @@ ClientHttpRequest::noteBodyProductionEnded(BodyPipe::Pointer)
 void
 ClientHttpRequest::endRequestSatisfaction()
 {
-    debugs(85,4, HERE << this << " ends request satisfaction");
+    debugs(85,4, this << " ends request satisfaction");
     assert(request_satisfaction_mode);
     stopConsumingFrom(adaptedBodySource);
 
@@ -2041,7 +2041,7 @@ ClientHttpRequest::noteBodyProducerAborted(BodyPipe::Pointer)
     assert(!virginHeadSource);
     stopConsumingFrom(adaptedBodySource);
 
-    debugs(85,3, HERE << "REQMOD body production failed");
+    debugs(85,3, "REQMOD body production failed");
     if (request_satisfaction_mode) { // too late to recover or serve an error
         request->detailError(ERR_ICAP_FAILURE, ERR_DETAIL_CLT_REQMOD_RESP_BODY);
         const Comm::ConnectionPointer c = getConn()->clientConnection;
@@ -2055,20 +2055,20 @@ ClientHttpRequest::noteBodyProducerAborted(BodyPipe::Pointer)
 void
 ClientHttpRequest::handleAdaptationFailure(int errDetail, bool bypassable)
 {
-    debugs(85,3, HERE << "handleAdaptationFailure(" << bypassable << ")");
+    debugs(85,3, "handleAdaptationFailure(" << bypassable << ")");
 
     const bool usedStore = storeEntry() && !storeEntry()->isEmpty();
     const bool usedPipe = request->body_pipe != NULL &&
                           request->body_pipe->consumedSize() > 0;
 
     if (bypassable && !usedStore && !usedPipe) {
-        debugs(85,3, HERE << "ICAP REQMOD callout failed, bypassing: " << calloutContext);
+        debugs(85,3, "ICAP REQMOD callout failed, bypassing: " << calloutContext);
         if (calloutContext)
             doCallouts();
         return;
     }
 
-    debugs(85,3, HERE << "ICAP REQMOD callout failed, responding with error");
+    debugs(85,3, "ICAP REQMOD callout failed, responding with error");
 
     clientStreamNode *node = (clientStreamNode *)client_stream.tail->prev->data;
     clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -117,7 +117,7 @@ Client::virginReply() const
 HttpReply *
 Client::setVirginReply(HttpReply *rep)
 {
-    debugs(11,5, HERE << this << " setting virgin reply to " << rep);
+    debugs(11,5, this << " setting virgin reply to " << rep);
     assert(!theVirginReply);
     assert(rep);
     theVirginReply = rep;
@@ -135,7 +135,7 @@ Client::finalReply()
 HttpReply *
 Client::setFinalReply(HttpReply *rep)
 {
-    debugs(11,5, HERE << this << " setting final reply to " << rep);
+    debugs(11,5, this << " setting final reply to " << rep);
 
     assert(!theFinalReply);
     assert(rep);
@@ -156,7 +156,7 @@ Client::setFinalReply(HttpReply *rep)
 void
 Client::serverComplete()
 {
-    debugs(11,5,HERE << "serverComplete " << this);
+    debugs(11,5,"serverComplete " << this);
 
     if (!doneWithServer()) {
         closeServer();
@@ -178,7 +178,7 @@ Client::serverComplete()
 void
 Client::serverComplete2()
 {
-    debugs(11,5,HERE << "serverComplete2 " << this);
+    debugs(11,5,"serverComplete2 " << this);
 
 #if USE_ADAPTATION
     if (virginBodyDestination != NULL)
@@ -206,7 +206,7 @@ bool Client::doneAll() const
 void
 Client::completeForwarding()
 {
-    debugs(11,5, HERE << "completing forwarding for "  << fwd);
+    debugs(11,5, "completing forwarding for "  << fwd);
     assert(fwd != NULL);
     doneWithFwd = "completeForwarding()";
     fwd->complete();
@@ -219,12 +219,12 @@ bool Client::startRequestBodyFlow()
     assert(r->body_pipe != NULL);
     requestBodySource = r->body_pipe;
     if (requestBodySource->setConsumerIfNotLate(this)) {
-        debugs(11,3, HERE << "expecting request body from " <<
+        debugs(11,3, "expecting request body from " <<
                requestBodySource->status());
         return true;
     }
 
-    debugs(11,3, HERE << "aborting on partially consumed request body: " <<
+    debugs(11,3, "aborting on partially consumed request body: " <<
            requestBodySource->status());
     requestBodySource = NULL;
     return false;
@@ -237,7 +237,7 @@ Client::abortOnBadEntry(const char *abortReason)
     if (entry->isAccepting())
         return false;
 
-    debugs(11,5, HERE << "entry is not Accepting!");
+    debugs(11,5, "entry is not Accepting!");
     abortOnData(abortReason);
     return true;
 }
@@ -298,7 +298,7 @@ Client::handleMoreRequestBodyAvailable()
     if (!requestSender)
         sendMoreRequestBody();
     else
-        debugs(9,3, HERE << "waiting for request body write to complete");
+        debugs(9,3, "waiting for request body write to complete");
 }
 
 // there will be no more handleMoreRequestBodyAvailable calls
@@ -309,14 +309,14 @@ Client::handleRequestBodyProductionEnded()
     if (!requestSender)
         doneSendingRequestBody();
     else
-        debugs(9,3, HERE << "waiting for request body write to complete");
+        debugs(9,3, "waiting for request body write to complete");
 }
 
 // called when we are done sending request body; kids extend this
 void
 Client::doneSendingRequestBody()
 {
-    debugs(9,3, HERE << "done sending request body");
+    debugs(9,3, "done sending request body");
     assert(requestBodySource != NULL);
     stopConsumingFrom(requestBodySource);
 
@@ -328,7 +328,7 @@ void
 Client::handleRequestBodyProducerAborted()
 {
     if (requestSender != NULL)
-        debugs(9,3, HERE << "fyi: request body aborted while we were sending");
+        debugs(9,3, "fyi: request body aborted while we were sending");
 
     fwd->dontRetry(true); // the problem is not with the server
     stopConsumingFrom(requestBodySource); // requestSender, if any, will notice
@@ -341,7 +341,7 @@ void
 Client::sentRequestBody(const CommIoCbParams &io)
 {
     debugs(11, 5, "sentRequestBody: FD " << io.fd << ": size " << io.size << ": errflag " << io.flag << ".");
-    debugs(32,3,HERE << "sentRequestBody called");
+    debugs(32,3,"sentRequestBody called");
 
     requestSender = NULL;
 
@@ -355,7 +355,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
         return;
 
     if (!requestBodySource) {
-        debugs(9,3, HERE << "detected while-we-were-sending abort");
+        debugs(9,3, "detected while-we-were-sending abort");
         return; // do nothing;
     }
 
@@ -379,7 +379,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     else if (receivedWholeRequestBody)
         doneSendingRequestBody();
     else
-        debugs(9,3, HERE << "waiting for body production end or abort");
+        debugs(9,3, "waiting for body production end or abort");
 }
 
 void
@@ -391,18 +391,18 @@ Client::sendMoreRequestBody()
     const Comm::ConnectionPointer conn = dataConnection();
 
     if (!Comm::IsConnOpen(conn)) {
-        debugs(9,3, HERE << "cannot send request body to closing " << conn);
+        debugs(9,3, "cannot send request body to closing " << conn);
         return; // wait for the kid's close handler; TODO: assert(closer);
     }
 
     MemBuf buf;
     if (getMoreRequestBody(buf) && buf.contentSize() > 0) {
-        debugs(9,3, HERE << "will write " << buf.contentSize() << " request body bytes");
+        debugs(9,3, "will write " << buf.contentSize() << " request body bytes");
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         requestSender = JobCallback(93,3, Dialer, this, Client::sentRequestBody);
         Comm::Write(conn, &buf, requestSender);
     } else {
-        debugs(9,3, HERE << "will wait for more request body bytes or eof");
+        debugs(9,3, "will wait for more request body bytes or eof");
         requestSender = NULL;
     }
 }
@@ -551,7 +551,7 @@ Client::startAdaptation(const Adaptation::ServiceGroupPointer &group, HttpReques
     if (vrep->expectingBody(cause->method, size) && size) {
         virginBodyDestination = new BodyPipe(this);
         vrep->body_pipe = virginBodyDestination;
-        debugs(93, 6, HERE << "will send virgin reply body to " <<
+        debugs(93, 6, "will send virgin reply body to " <<
                virginBodyDestination << "; size: " << size);
         if (size > 0)
             virginBodyDestination->setBodySize(size);
@@ -567,7 +567,7 @@ Client::startAdaptation(const Adaptation::ServiceGroupPointer &group, HttpReques
 // may be called multiple times
 void Client::cleanAdaptation()
 {
-    debugs(11,5, HERE << "cleaning ICAP; ACL: " << adaptationAccessCheckPending);
+    debugs(11,5, "cleaning ICAP; ACL: " << adaptationAccessCheckPending);
 
     if (virginBodyDestination != NULL)
         stopProducingFor(virginBodyDestination, false);
@@ -595,7 +595,7 @@ Client::adaptVirginReplyBody(const char *data, ssize_t len)
     assert(startedAdaptation);
 
     if (!virginBodyDestination) {
-        debugs(11,3, HERE << "ICAP does not want more virgin body");
+        debugs(11,3, "ICAP does not want more virgin body");
         return;
     }
 
@@ -694,7 +694,7 @@ Client::handleAdaptedHeader(Http::Message *msg)
 
     HttpReply *rep = dynamic_cast<HttpReply*>(msg);
     assert(rep);
-    debugs(11,5, HERE << this << " setting adapted reply to " << rep);
+    debugs(11,5, this << " setting adapted reply to " << rep);
     setFinalReply(rep);
 
     assert(!adaptedBodySource);
@@ -751,18 +751,18 @@ Client::handleMoreAdaptedBodyAvailable()
     }
 
     if (!spaceAvailable)  {
-        debugs(11, 5, HERE << "NOT storing " << contentSize << " bytes of adapted " <<
+        debugs(11, 5, "NOT storing " << contentSize << " bytes of adapted " <<
                "response body at offset " << adaptedBodySource->consumedSize());
         return;
     }
 
     if (spaceAvailable < contentSize ) {
-        debugs(11, 5, HERE << "postponing storage of " <<
+        debugs(11, 5, "postponing storage of " <<
                (contentSize - spaceAvailable) << " body bytes");
         contentSize = spaceAvailable;
     }
 
-    debugs(11,5, HERE << "storing " << contentSize << " bytes of adapted " <<
+    debugs(11,5, "storing " << contentSize << " bytes of adapted " <<
            "response body at offset " << adaptedBodySource->consumedSize());
 
     BodyPipeCheckout bpc(*adaptedBodySource);
@@ -818,7 +818,7 @@ void Client::handleAdaptedBodyProducerAborted()
 void
 Client::handleAdaptationCompleted()
 {
-    debugs(11,5, HERE << "handleAdaptationCompleted");
+    debugs(11,5, "handleAdaptationCompleted");
     cleanAdaptation();
 
     // We stop reading origin response because we have no place to put it(*) and
@@ -826,7 +826,7 @@ Client::handleAdaptationCompleted()
     // reuse more pconns, we can add code to discard unneeded origin responses.
     // (*) TODO: Is it possible that the adaptation xaction is still running?
     if (mayReadVirginReplyBody()) {
-        debugs(11,3, HERE << "closing origin conn due to ICAP completion");
+        debugs(11,3, "closing origin conn due to ICAP completion");
         closeServer();
     }
 
@@ -837,7 +837,7 @@ Client::handleAdaptationCompleted()
 void
 Client::handleAdaptationAborted(bool bypassable)
 {
-    debugs(11,5, HERE << "handleAdaptationAborted; bypassable: " << bypassable <<
+    debugs(11,5, "handleAdaptationAborted; bypassable: " << bypassable <<
            ", entry empty: " << entry->isEmpty());
 
     if (abortOnBadEntry("entry went bad while ICAP aborted"))
@@ -873,7 +873,7 @@ Client::handledEarlyAdaptationAbort()
 void
 Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
 {
-    debugs(11,5, HERE << answer.ruleId);
+    debugs(11,5, answer.ruleId);
 
     if (abortOnBadEntry("entry went bad while ICAP aborted"))
         return;
@@ -885,7 +885,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
         return;
     }
 
-    debugs(11,7, HERE << "creating adaptation block response");
+    debugs(11,7, "creating adaptation block response");
 
     err_type page_id =
         aclGetDenyInfoPage(&Config.denyInfoList, answer.ruleId.termedBuf(), 1);
@@ -917,7 +917,7 @@ Client::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer group)
     // TODO: Should we check receivedBodyTooLarge as well?
 
     if (!group) {
-        debugs(11,3, HERE << "no adapation needed");
+        debugs(11,3, "no adapation needed");
         setFinalReply(virginReply());
         processReplyBody();
         return;
@@ -948,7 +948,7 @@ Client::adaptOrFinalizeReply()
     adaptationAccessCheckPending = Adaptation::AccessCheck::Start(
                                        Adaptation::methodRespmod, Adaptation::pointPreCache,
                                        originalRequest().getRaw(), virginReply(), fwd->al, this);
-    debugs(11,5, HERE << "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
+    debugs(11,5, "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
     if (adaptationAccessCheckPending)
         return;
 #endif

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -461,10 +461,10 @@ Ftp::Gateway::listenForDataChannel(const Comm::ConnectionPointer &conn)
     if (!Comm::IsConnOpen(conn)) {
         conn->fd = comm_open_listener(SOCK_STREAM, IPPROTO_TCP, conn->local, conn->flags, note);
         if (!Comm::IsConnOpen(conn)) {
-            debugs(5, DBG_CRITICAL, HERE << "comm_open_listener failed:" << conn->local << " error: " << errno);
+            debugs(5, DBG_CRITICAL, "comm_open_listener failed:" << conn->local << " error: " << errno);
             return;
         }
-        debugs(9, 3, HERE << "Unconnected data socket created on " << conn);
+        debugs(9, 3, "Unconnected data socket created on " << conn);
     }
 
     conn->tos = ctrl.conn->tos;
@@ -779,7 +779,7 @@ Ftp::Gateway::htmlifyListEntry(const char *line)
     ftpListParts *parts;
     *icon = *href = *text = *size = *chdir = *view = *download = *link = '\0';
 
-    debugs(9, 7, HERE << " line ={" << line << "}");
+    debugs(9, 7, "line ={" << line << "}");
 
     if (strlen(line) > 1024) {
         html = new MemBuf();
@@ -914,7 +914,7 @@ Ftp::Gateway::parseListing()
     size_t len = data.readBuf->contentSize();
 
     if (!len) {
-        debugs(9, 3, HERE << "no content to parse for " << entry->url()  );
+        debugs(9, 3, "no content to parse for " << entry->url()  );
         return;
     }
 
@@ -930,21 +930,21 @@ Ftp::Gateway::parseListing()
 
     usable = end - sbuf;
 
-    debugs(9, 3, HERE << "usable = " << usable << " of " << len << " bytes.");
+    debugs(9, 3, "usable = " << usable << " of " << len << " bytes.");
 
     if (usable == 0) {
         if (buf[0] == '\0' && len == 1) {
-            debugs(9, 3, HERE << "NIL ends data from " << entry->url() << " transfer problem?");
+            debugs(9, 3, "NIL ends data from " << entry->url() << " transfer problem?");
             data.readBuf->consume(len);
         } else {
-            debugs(9, 3, HERE << "didn't find end for " << entry->url());
-            debugs(9, 3, HERE << "buffer remains (" << len << " bytes) '" << rfc1738_do_escape(buf,0) << "'");
+            debugs(9, 3, "didn't find end for " << entry->url());
+            debugs(9, 3, "buffer remains (" << len << " bytes) '" << rfc1738_do_escape(buf,0) << "'");
         }
         xfree(sbuf);
         return;
     }
 
-    debugs(9, 3, HERE << (unsigned long int)len << " bytes to play with");
+    debugs(9, 3, (unsigned long int)len << " bytes to play with");
 
     line = (char *)memAllocate(MEM_4K_BUF);
     ++end;
@@ -952,7 +952,7 @@ Ftp::Gateway::parseListing()
     s += strspn(s, crlf);
 
     for (; s < end; s += strcspn(s, crlf), s += strspn(s, crlf)) {
-        debugs(9, 7, HERE << "s = {" << s << "}");
+        debugs(9, 7, "s = {" << s << "}");
         linelen = strcspn(s, crlf) + 1;
 
         if (linelen < 2)
@@ -963,7 +963,7 @@ Ftp::Gateway::parseListing()
 
         xstrncpy(line, s, linelen);
 
-        debugs(9, 7, HERE << "{" << line << "}");
+        debugs(9, 7, "{" << line << "}");
 
         if (!strncmp(line, "total", 5))
             continue;
@@ -971,13 +971,13 @@ Ftp::Gateway::parseListing()
         t = htmlifyListEntry(line);
 
         if ( t != NULL) {
-            debugs(9, 7, HERE << "listing append: t = {" << t->contentSize() << ", '" << t->content() << "'}");
+            debugs(9, 7, "listing append: t = {" << t->contentSize() << ", '" << t->content() << "'}");
             listing.append(t->content(), t->contentSize());
             delete t;
         }
     }
 
-    debugs(9, 7, HERE << "Done.");
+    debugs(9, 7, "Done.");
     data.readBuf->consume(usable);
     memFree(line, MEM_4K_BUF);
     xfree(sbuf);
@@ -1025,7 +1025,7 @@ Ftp::Gateway::processReplyBody()
         return;
     } else if (const int csize = data.readBuf->contentSize()) {
         writeReplyBody(data.readBuf->content(), csize);
-        debugs(9, 5, HERE << "consuming " << csize << " bytes of readBuf");
+        debugs(9, 5, "consuming " << csize << " bytes of readBuf");
         data.readBuf->consume(csize);
     }
 
@@ -1210,7 +1210,7 @@ static void
 ftpReadWelcome(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (ftpState->flags.pasv_only)
         ++ ftpState->login_att;
@@ -1319,7 +1319,7 @@ static void
 ftpReadUser(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code == 230) {
         ftpReadPass(ftpState);
@@ -1346,7 +1346,7 @@ static void
 ftpReadPass(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE << "code=" << code);
+    debugs(9, 3, "code=" << code);
 
     if (code == 230) {
         ftpSendType(ftpState);
@@ -1410,7 +1410,7 @@ ftpReadType(Ftp::Gateway * ftpState)
     int code = ftpState->ctrl.replycode;
     char *path;
     char *d, *p;
-    debugs(9, 3, HERE << "code=" << code);
+    debugs(9, 3, "code=" << code);
 
     if (code == 200) {
         p = path = SBufToCstring(ftpState->request->url.path());
@@ -1447,7 +1447,7 @@ ftpReadType(Ftp::Gateway * ftpState)
 static void
 ftpTraverseDirectory(Ftp::Gateway * ftpState)
 {
-    debugs(9, 4, HERE << (ftpState->filepath ? ftpState->filepath : "<NULL>"));
+    debugs(9, 4, (ftpState->filepath ? ftpState->filepath : "<NULL>"));
 
     safe_free(ftpState->dirpath);
     ftpState->dirpath = ftpState->filepath;
@@ -1456,7 +1456,7 @@ ftpTraverseDirectory(Ftp::Gateway * ftpState)
     /* Done? */
 
     if (ftpState->pathcomps == NULL) {
-        debugs(9, 3, HERE << "the final component was a directory");
+        debugs(9, 3, "the final component was a directory");
         ftpListDir(ftpState);
         return;
     }
@@ -1468,7 +1468,7 @@ ftpTraverseDirectory(Ftp::Gateway * ftpState)
     if (ftpState->pathcomps != NULL || ftpState->flags.isdir) {
         ftpSendCwd(ftpState);
     } else {
-        debugs(9, 3, HERE << "final component is probably a file");
+        debugs(9, 3, "final component is probably a file");
         ftpGetFile(ftpState);
         return;
     }
@@ -1483,7 +1483,7 @@ ftpSendCwd(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendCwd"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     path = ftpState->filepath;
 
@@ -1504,7 +1504,7 @@ static void
 ftpReadCwd(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code >= 200 && code < 300) {
         /* CWD OK */
@@ -1540,7 +1540,7 @@ ftpSendMkdir(Ftp::Gateway * ftpState)
         return;
 
     path = ftpState->filepath;
-    debugs(9, 3, HERE << "with path=" << path);
+    debugs(9, 3, "with path=" << path);
     snprintf(cbuf, CTRL_BUFLEN, "MKD %s\r\n", path);
     ftpState->writeCommand(cbuf);
     ftpState->state = Ftp::Client::SENT_MKDIR;
@@ -1552,7 +1552,7 @@ ftpReadMkdir(Ftp::Gateway * ftpState)
     char *path = ftpState->filepath;
     int code = ftpState->ctrl.replycode;
 
-    debugs(9, 3, HERE << "path " << path << ", code " << code);
+    debugs(9, 3, "path " << path << ", code " << code);
 
     if (code == 257) {      /* success */
         ftpSendCwd(ftpState);
@@ -1579,7 +1579,7 @@ static void
 ftpListDir(Ftp::Gateway * ftpState)
 {
     if (ftpState->flags.dir_slash) {
-        debugs(9, 3, HERE << "Directory path did not end in /");
+        debugs(9, 3, "Directory path did not end in /");
         ftpState->title_url.append("/");
         ftpState->flags.isdir = 1;
     }
@@ -1604,7 +1604,7 @@ static void
 ftpReadMdtm(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code == 213) {
         ftpState->mdtm = parse_iso3307_time(ftpState->ctrl.last_reply);
@@ -1642,7 +1642,7 @@ static void
 ftpReadSize(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code == 213) {
         ftpState->unhack();
@@ -1685,7 +1685,7 @@ ftpSendPassive(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendPassive"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     /** \par
       * Checks for 'HEAD' method request and passes off for special handling by Ftp::Gateway::processHeadResponse(). */
@@ -1704,7 +1704,7 @@ ftpSendPassive(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::processHeadResponse()
 {
-    debugs(9, 5, HERE << "handling HEAD response");
+    debugs(9, 5, "handling HEAD response");
     ftpSendQuit(this);
     appendSuccessHeader();
 
@@ -1720,7 +1720,7 @@ Ftp::Gateway::processHeadResponse()
 
 #if USE_ADAPTATION
     if (adaptationAccessCheckPending) {
-        debugs(9,3, HERE << "returning due to adaptationAccessCheckPending");
+        debugs(9,3, "returning due to adaptationAccessCheckPending");
         return;
     }
 #endif
@@ -1746,11 +1746,11 @@ ftpReadPasv(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::dataChannelConnected(const CommConnectCbParams &io)
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
     data.opener = NULL;
 
     if (io.flag != Comm::OK) {
-        debugs(9, 2, HERE << "Failed to connect. Retrying via another method.");
+        debugs(9, 2, "Failed to connect. Retrying via another method.");
 
         // ABORT on timeouts. server may be waiting on a broken TCP link.
         if (io.xerrno == Comm::TIMEOUT)
@@ -1825,7 +1825,7 @@ ftpSendPORT(Ftp::Gateway * ftpState)
         return;
     }
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
     ftpState->flags.pasv_supported = 0;
     ftpOpenListenSocket(ftpState, 0);
 
@@ -1863,7 +1863,7 @@ static void
 ftpReadPORT(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code != 200) {
         /* Fall back on using the same port as the control connection */
@@ -1894,7 +1894,7 @@ ftpSendEPRT(Ftp::Gateway * ftpState)
         return;
     }
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
     ftpState->flags.pasv_supported = 0;
 
     ftpOpenListenSocket(ftpState, 0);
@@ -1923,7 +1923,7 @@ static void
 ftpReadEPRT(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code != 200) {
         /* Failover to attempting old PORT command. */
@@ -1942,7 +1942,7 @@ ftpReadEPRT(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (!Comm::IsConnOpen(ctrl.conn)) { /*Close handlers will cleanup*/
         debugs(9, 5, "The control connection to the remote end is closed");
@@ -2005,7 +2005,7 @@ Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
     data.opened(io.conn, dataCloser());
     data.addr(io.conn->remote);
 
-    debugs(9, 3, HERE << "Connected data socket on " <<
+    debugs(9, 3, "Connected data socket on " <<
            io.conn << ". FD table says: " <<
            "ctrl-peer= " << fd_table[ctrl.conn->fd].ipaddr << ", " <<
            "data-peer= " << fd_table[data.conn->fd].ipaddr);
@@ -2019,7 +2019,7 @@ Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
 static void
 ftpRestOrList(Ftp::Gateway * ftpState)
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (ftpState->typecode == 'D') {
         ftpState->flags.isdir = 1;
@@ -2046,7 +2046,7 @@ ftpSendStor(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendStor"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (ftpState->filepath != NULL) {
         /* Plain file upload */
@@ -2074,7 +2074,7 @@ ftpReadStor(Ftp::Gateway * ftpState)
 void Ftp::Gateway::readStor()
 {
     int code = ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code == 125 || (code == 150 && Comm::IsConnOpen(data.conn))) {
         if (!originalRequest()->body_pipe) {
@@ -2090,18 +2090,18 @@ void Ftp::Gateway::readStor()
         }
 
         /* When client status is 125, or 150 and the data connection is open, Begin data transfer. */
-        debugs(9, 3, HERE << "starting data transfer");
+        debugs(9, 3, "starting data transfer");
         switchTimeoutToDataChannel();
         sendMoreRequestBody();
         fwd->dontRetry(true); // dont permit re-trying if the body was sent.
         state = WRITING_DATA;
-        debugs(9, 3, HERE << "writing data channel");
+        debugs(9, 3, "writing data channel");
     } else if (code == 150) {
         /* When client code is 150 with no data channel, Accept data channel. */
         debugs(9, 3, "ftpReadStor: accepting data channel");
         listenForDataChannel(data.conn);
     } else {
-        debugs(9, DBG_IMPORTANT, HERE << "Unexpected reply code "<< std::setfill('0') << std::setw(3) << code);
+        debugs(9, DBG_IMPORTANT, "Unexpected reply code "<< std::setfill('0') << std::setw(3) << code);
         ftpFail(this);
     }
 }
@@ -2113,7 +2113,7 @@ ftpSendRest(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendRest"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     snprintf(cbuf, CTRL_BUFLEN, "REST %" PRId64 "\r\n", ftpState->restart_offset);
     ftpState->writeCommand(cbuf);
@@ -2151,14 +2151,14 @@ static void
 ftpReadRest(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
     assert(ftpState->restart_offset > 0);
 
     if (code == 350) {
         ftpState->setCurrentOffset(ftpState->restart_offset);
         ftpSendRetr(ftpState);
     } else if (code > 0) {
-        debugs(9, 3, HERE << "REST not supported");
+        debugs(9, 3, "REST not supported");
         ftpState->flags.rest_supported = 0;
         ftpSendRetr(ftpState);
     } else {
@@ -2173,7 +2173,7 @@ ftpSendList(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendList"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (ftpState->filepath) {
         snprintf(cbuf, CTRL_BUFLEN, "LIST %s\r\n", ftpState->filepath);
@@ -2192,7 +2192,7 @@ ftpSendNlst(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendNlst"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     ftpState->flags.tried_nlst = 1;
 
@@ -2210,18 +2210,18 @@ static void
 ftpReadList(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code == 125 || (code == 150 && Comm::IsConnOpen(ftpState->data.conn))) {
         /* Begin data transfer */
-        debugs(9, 3, HERE << "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
+        debugs(9, 3, "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
         ftpState->switchTimeoutToDataChannel();
         ftpState->maybeReadVirginBody();
         ftpState->state = Ftp::Client::READING_DATA;
         return;
     } else if (code == 150) {
         /* Accept data channel */
-        debugs(9, 3, HERE << "accept data channel from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
+        debugs(9, 3, "accept data channel from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
         ftpState->listenForDataChannel(ftpState->data.conn);
         return;
     } else if (!ftpState->flags.tried_nlst && code > 300) {
@@ -2239,7 +2239,7 @@ ftpSendRetr(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendRetr"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     assert(ftpState->filepath != NULL);
     snprintf(cbuf, CTRL_BUFLEN, "RETR %s\r\n", ftpState->filepath);
@@ -2251,11 +2251,11 @@ static void
 ftpReadRetr(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code == 125 || (code == 150 && Comm::IsConnOpen(ftpState->data.conn))) {
         /* Begin data transfer */
-        debugs(9, 3, HERE << "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
+        debugs(9, 3, "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
         ftpState->switchTimeoutToDataChannel();
         ftpState->maybeReadVirginBody();
         ftpState->state = Ftp::Client::READING_DATA;
@@ -2298,7 +2298,7 @@ static void
 ftpReadTransferDone(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (code == 226 || code == 250) {
         /* Connection closed; retrieval done. */
@@ -2308,7 +2308,7 @@ ftpReadTransferDone(Ftp::Gateway * ftpState)
         }
         ftpSendQuit(ftpState);
     } else {            /* != 226 */
-        debugs(9, DBG_IMPORTANT, HERE << "Got code " << code << " after reading data");
+        debugs(9, DBG_IMPORTANT, "Got code " << code << " after reading data");
         ftpState->failed(ERR_FTP_FAILURE, 0);
         /* failed closes ctrl.conn and frees ftpState */
         return;
@@ -2320,7 +2320,7 @@ void
 Ftp::Gateway::handleRequestBodyProducerAborted()
 {
     Client::handleRequestBodyProducerAborted();
-    debugs(9, 3, HERE << "ftpState=" << this);
+    debugs(9, 3, "ftpState=" << this);
     failed(ERR_READ_ERROR, 0);
 }
 
@@ -2328,10 +2328,10 @@ static void
 ftpWriteTransferDone(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (!(code == 226 || code == 250)) {
-        debugs(9, DBG_IMPORTANT, HERE << "Got code " << code << " after sending data");
+        debugs(9, DBG_IMPORTANT, "Got code " << code << " after sending data");
         ftpState->failed(ERR_FTP_PUT_ERROR, 0);
         return;
     }
@@ -2368,7 +2368,7 @@ ftpTrySlashHack(Ftp::Gateway * ftpState)
     ftpState->flags.try_slash_hack = 1;
     /* Free old paths */
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (ftpState->pathcomps)
         wordlistDestroy(&ftpState->pathcomps);
@@ -2392,7 +2392,7 @@ ftpTrySlashHack(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::unhack()
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (old_request != NULL) {
         safe_free(old_request);
@@ -2408,7 +2408,7 @@ Ftp::Gateway::hackShortcut(FTPSM * nextState)
     restart_offset = 0;
     /* Save old error message & some state info */
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (old_request == NULL) {
         old_request = ctrl.last_command;
@@ -2510,10 +2510,10 @@ ftpSendReply(Ftp::Gateway * ftpState)
     Http::StatusCode http_code;
     err_type err_code = ERR_NONE;
 
-    debugs(9, 3, HERE << ftpState->entry->url() << ", code " << code);
+    debugs(9, 3, ftpState->entry->url() << ", code " << code);
 
     if (cbdataReferenceValid(ftpState))
-        debugs(9, 5, HERE << "ftpState (" << ftpState << ") is valid!");
+        debugs(9, 5, "ftpState (" << ftpState << ") is valid!");
 
     if (code == 226 || code == 250) {
         err_code = (ftpState->mdtm > 0) ? ERR_FTP_PUT_MODIFIED : ERR_FTP_PUT_CREATED;
@@ -2551,7 +2551,7 @@ ftpSendReply(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::appendSuccessHeader()
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, "");
 
     if (flags.http_header_sent)
         return;
@@ -2608,7 +2608,7 @@ Ftp::Gateway::appendSuccessHeader()
          * not be seeing this condition any more because we'll only
          * send REST if we know the theSize and if it is less than theSize.
          */
-        debugs(0,DBG_CRITICAL,HERE << "Whoops! " <<
+        debugs(0,DBG_CRITICAL,"Whoops! " <<
                " current offset=" << getCurrentOffset() <<
                ", but theSize=" << theSize <<
                ".  assuming full content response");
@@ -2705,7 +2705,7 @@ Ftp::Gateway::printfReplyBody(const char *fmt, ...)
 void
 Ftp::Gateway::writeReplyBody(const char *dataToWrite, size_t dataLength)
 {
-    debugs(9, 5, HERE << "writing " << dataLength << " bytes to the reply");
+    debugs(9, 5, "writing " << dataLength << " bytes to the reply");
     addVirginReplyBody(dataToWrite, dataLength);
 }
 

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -421,7 +421,7 @@ comm_init_opened(const Comm::ConnectionPointer &conn,
     assert(AI);
 
     /* update fdstat */
-    debugs(5, 5, HERE << conn << " is a new socket");
+    debugs(5, 5, conn << " is a new socket");
 
     assert(!isOpen(conn->fd)); // NP: global isOpen checks the fde entry for openness not the Comm::Connection
     fd_open(conn->fd, FD_SOCKET, note);
@@ -500,7 +500,7 @@ comm_import_opened(const Comm::ConnectionPointer &conn,
                    const char *note,
                    struct addrinfo *AI)
 {
-    debugs(5, 2, HERE << conn);
+    debugs(5, 2, conn);
     assert(Comm::IsConnOpen(conn));
     assert(AI);
 
@@ -538,7 +538,7 @@ comm_import_opened(const Comm::ConnectionPointer &conn,
 void
 commUnsetFdTimeout(int fd)
 {
-    debugs(5, 3, HERE << "Remove timeout for FD " << fd);
+    debugs(5, 3, "Remove timeout for FD " << fd);
     assert(fd >= 0);
     assert(fd < Squid_MaxFD);
     fde *F = &fd_table[fd];
@@ -551,7 +551,7 @@ commUnsetFdTimeout(int fd)
 int
 commSetConnTimeout(const Comm::ConnectionPointer &conn, int timeout, AsyncCall::Pointer &callback)
 {
-    debugs(5, 3, HERE << conn << " timeout " << timeout);
+    debugs(5, 3, conn << " timeout " << timeout);
     assert(Comm::IsConnOpen(conn));
     assert(conn->fd < Squid_MaxFD);
     fde *F = &fd_table[conn->fd];
@@ -577,7 +577,7 @@ commSetConnTimeout(const Comm::ConnectionPointer &conn, int timeout, AsyncCall::
 int
 commUnsetConnTimeout(const Comm::ConnectionPointer &conn)
 {
-    debugs(5, 3, HERE << "Remove timeout for " << conn);
+    debugs(5, 3, "Remove timeout for " << conn);
     AsyncCall::Pointer nil;
     return commSetConnTimeout(conn, -1, nil);
 }
@@ -600,7 +600,7 @@ comm_connect_addr(int sock, const Ip::Address &address)
 
     assert(address.port() != 0);
 
-    debugs(5, 9, HERE << "connecting socket FD " << sock << " to " << address << " (want family: " << F->sock_family << ")");
+    debugs(5, 9, "connecting socket FD " << sock << " to " << address << " (want family: " << F->sock_family << ")");
 
     /* Handle IPv6 over IPv4-only socket case.
      * this case must presently be handled here since the getAddrInfo asserts on bad mappings.
@@ -769,7 +769,7 @@ comm_lingering_close(int fd)
     fd_note(fd, "lingering close");
     AsyncCall::Pointer call = commCbCall(5,4, "commLingerTimeout", FdeCbPtrFun(commLingerTimeout, NULL));
 
-    debugs(5, 3, HERE << "FD " << fd << " timeout " << timeout);
+    debugs(5, 3, "FD " << fd << " timeout " << timeout);
     assert(fd_table[fd].flags.open);
     if (callback != NULL) {
         typedef FdeCbParams Params;
@@ -866,7 +866,7 @@ _comm_close(int fd, char const *file, int line)
 
     /* The following fails because ipc.c is doing calls to pipe() to create sockets! */
     if (!isOpen(fd)) {
-        debugs(50, DBG_IMPORTANT, HERE << "BUG 3556: FD " << fd << " is not an open socket.");
+        debugs(50, DBG_IMPORTANT, "BUG 3556: FD " << fd << " is not an open socket.");
         // XXX: do we need to run close(fd) or fd_close(fd) here?
         return;
     }
@@ -1277,7 +1277,7 @@ commHandleWriteHelper(void * data)
         // and continue looking for a relevant one
     } while (clientInfo->hasQueue());
 
-    debugs(77,3, HERE << "emptied queue");
+    debugs(77,3, "emptied queue");
 }
 
 bool
@@ -1357,12 +1357,12 @@ ClientInfo::quota()
         // Rounding errors do not accumulate here, but we round down to avoid
         // negative bucket sizes after write with rationedCount=1.
         rationedQuota = static_cast<int>(floor(bucketLevel/rationedCount));
-        debugs(77,5, HERE << "new rationedQuota: " << rationedQuota <<
+        debugs(77,5, "new rationedQuota: " << rationedQuota <<
                '*' << rationedCount);
     }
 
     --rationedCount;
-    debugs(77,7, HERE << "rationedQuota: " << rationedQuota <<
+    debugs(77,7, "rationedQuota: " << rationedQuota <<
            " rations remaining: " << rationedCount);
 
     // update 'last seen' time to prevent clientdb GC from dropping us
@@ -1607,7 +1607,7 @@ checkTimeouts(void)
 void
 commStartHalfClosedMonitor(int fd)
 {
-    debugs(5, 5, HERE << "adding FD " << fd << " to " << *TheHalfClosed);
+    debugs(5, 5, "adding FD " << fd << " to " << *TheHalfClosed);
     assert(isOpen(fd) && !commHasHalfClosedMonitor(fd));
     (void)TheHalfClosed->add(fd); // could also assert the result
     commPlanHalfClosedCheck(); // may schedule check if we added the first FD
@@ -1629,7 +1629,7 @@ static
 void
 commHalfClosedCheck(void *)
 {
-    debugs(5, 5, HERE << "checking " << *TheHalfClosed);
+    debugs(5, 5, "checking " << *TheHalfClosed);
 
     typedef DescriptorSet::const_iterator DSCI;
     const DSCI end = TheHalfClosed->end();
@@ -1661,7 +1661,7 @@ commHasHalfClosedMonitor(int fd)
 void
 commStopHalfClosedMonitor(int const fd)
 {
-    debugs(5, 5, HERE << "removing FD " << fd << " from " << *TheHalfClosed);
+    debugs(5, 5, "removing FD " << fd << " from " << *TheHalfClosed);
 
     // cancel the read if one was scheduled
     AsyncCall::Pointer reader = fd_table[fd].halfClosedReader;
@@ -1689,7 +1689,7 @@ commHalfClosedReader(const Comm::ConnectionPointer &conn, char *, size_t size, C
 
     // if read failed, close the connection
     if (flag != Comm::OK) {
-        debugs(5, 3, HERE << "closing " << conn);
+        debugs(5, 3, "closing " << conn);
         conn->close();
         return;
     }
@@ -1890,7 +1890,7 @@ comm_open_uds(int sock_type,
     AI.ai_canonname = NULL;
     AI.ai_next = NULL;
 
-    debugs(50, 3, HERE << "Attempt open socket for: " << addr->sun_path);
+    debugs(50, 3, "Attempt open socket for: " << addr->sun_path);
 
     if ((new_socket = socket(AI.ai_family, AI.ai_socktype, AI.ai_protocol)) < 0) {
         int xerrno = errno;
@@ -1912,7 +1912,7 @@ comm_open_uds(int sock_type,
     debugs(50, 3, "Opened UDS FD " << new_socket << " : family=" << AI.ai_family << ", type=" << AI.ai_socktype << ", protocol=" << AI.ai_protocol);
 
     /* update fdstat */
-    debugs(50, 5, HERE << "FD " << new_socket << " is a new socket");
+    debugs(50, 5, "FD " << new_socket << " is a new socket");
 
     assert(!isOpen(new_socket));
     fd_open(new_socket, FD_MSGHDR, addr->sun_path);

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -152,7 +152,7 @@ Comm::ConnOpener::sendAnswer(Comm::Flag errFlag, int xerrno, const char *why)
 void
 Comm::ConnOpener::cleanFd()
 {
-    debugs(5, 4, HERE << conn_ << " closing temp FD " << temporaryFd_);
+    debugs(5, 4, conn_ << " closing temp FD " << temporaryFd_);
 
     Must(temporaryFd_ >= 0);
     fde &f = fd_table[temporaryFd_];
@@ -342,12 +342,12 @@ Comm::ConnOpener::doConnect()
     switch (comm_connect_addr(temporaryFd_, conn_->remote) ) {
 
     case Comm::INPROGRESS:
-        debugs(5, 5, HERE << conn_ << ": Comm::INPROGRESS");
+        debugs(5, 5, conn_ << ": Comm::INPROGRESS");
         Comm::SetSelect(temporaryFd_, COMM_SELECT_WRITE, Comm::ConnOpener::InProgressConnectRetry, new Pointer(this), 0);
         break;
 
     case Comm::OK:
-        debugs(5, 5, HERE << conn_ << ": Comm::OK - connected");
+        debugs(5, 5, conn_ << ": Comm::OK - connected");
         connected();
         break;
 
@@ -359,12 +359,12 @@ Comm::ConnOpener::doConnect()
                Config.connect_retries << ": " << xstrerr(xerrno));
 
         if (failRetries_ < Config.connect_retries) {
-            debugs(5, 5, HERE << conn_ << ": * - try again");
+            debugs(5, 5, conn_ << ": * - try again");
             retrySleep();
             return;
         } else {
             // send ERROR back to the upper layer.
-            debugs(5, 5, HERE << conn_ << ": * - ERR tried too many times already.");
+            debugs(5, 5, conn_ << ": * - ERR tried too many times already.");
             sendAnswer(Comm::ERR_CONNECT, xerrno, "Comm::ConnOpener::doConnect");
         }
     }
@@ -420,7 +420,7 @@ Comm::ConnOpener::lookupLocalAddress()
 
     conn_->local = *addr;
     Ip::Address::FreeAddr(addr);
-    debugs(5, 6, HERE << conn_);
+    debugs(5, 6, conn_);
 }
 
 /** Abort connection attempt.
@@ -429,7 +429,7 @@ Comm::ConnOpener::lookupLocalAddress()
 void
 Comm::ConnOpener::earlyAbort(const CommCloseCbParams &io)
 {
-    debugs(5, 3, HERE << io.conn);
+    debugs(5, 3, io.conn);
     calls_.earlyAbort_ = NULL;
     // NP: is closing or shutdown better?
     sendAnswer(Comm::ERR_CLOSING, io.xerrno, "Comm::ConnOpener::earlyAbort");
@@ -442,7 +442,7 @@ Comm::ConnOpener::earlyAbort(const CommCloseCbParams &io)
 void
 Comm::ConnOpener::timeout(const CommTimeoutCbParams &)
 {
-    debugs(5, 5, HERE << conn_ << ": * - ERR took too long to receive response.");
+    debugs(5, 5, conn_ << ": * - ERR took too long to receive response.");
     calls_.timeout_ = NULL;
     sendAnswer(Comm::TIMEOUT, ETIMEDOUT, "Comm::ConnOpener::timeout");
 }

--- a/src/comm/ModDevPoll.cc
+++ b/src/comm/ModDevPoll.cc
@@ -107,7 +107,7 @@ comm_flush_updates(void)
     debugs(
         5,
         DEBUG_DEVPOLL ? 0 : 8,
-        HERE << (devpoll_update.cur + 1) << " fds queued"
+        (devpoll_update.cur + 1) << " fds queued"
     );
 
     i = write(
@@ -135,7 +135,7 @@ comm_update_fd(int fd, int events)
     debugs(
         5,
         DEBUG_DEVPOLL ? 0 : 8,
-        HERE << "FD " << fd << ", events=" << events
+        "FD " << fd << ", events=" << events
     );
 
     /* Is the array already full and in need of flushing? */
@@ -225,7 +225,7 @@ void
 Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time_t timeout)
 {
     assert(fd >= 0);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 
@@ -369,7 +369,7 @@ Comm::DoSelect(int msec)
         debugs(
             5,
             DEBUG_DEVPOLL ? 0 : 8,
-            HERE << "got FD " << fd
+            "got FD " << fd
             << ",events=" << std::hex << do_poll.dp_fds[i].revents
             << ",monitoring=" << devpoll_state[fd].state
             << ",F->read_handler=" << F->read_handler
@@ -381,7 +381,7 @@ Comm::DoSelect(int msec)
             debugs(
                 5,
                 DEBUG_DEVPOLL ? 0 : 8,
-                HERE << "devpoll event error: fd " << fd
+                "devpoll event error: fd " << fd
             );
             continue;
         }
@@ -392,7 +392,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "Calling read handler on FD " << fd
+                    "Calling read handler on FD " << fd
                 );
                 PROF_start(comm_read_handler);
                 F->flags.read_pending = 0;
@@ -404,7 +404,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "no read handler for FD " << fd
+                    "no read handler for FD " << fd
                 );
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_READ, NULL, NULL, 0);
@@ -417,7 +417,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "Calling write handler on FD " << fd
+                    "Calling write handler on FD " << fd
                 );
                 PROF_start(comm_write_handler);
                 F->write_handler = NULL;
@@ -428,7 +428,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "no write handler for FD " << fd
+                    "no write handler for FD " << fd
                 );
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_WRITE, NULL, NULL, 0);

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -112,7 +112,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     int epoll_ctl_type = 0;
 
     assert(fd >= 0);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 
@@ -261,7 +261,7 @@ Comm::DoSelect(int msec)
     for (i = 0, cevents = pevents; i < num; ++i, ++cevents) {
         fd = cevents->data.fd;
         F = &fd_table[fd];
-        debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "got FD " << fd << " events=" <<
+        debugs(5, DEBUG_EPOLL ? 0 : 8, "got FD " << fd << " events=" <<
                std::hex << cevents->events << " monitoring=" << F->epoll_state <<
                " F->read_handler=" << F->read_handler << " F->write_handler=" << F->write_handler);
 
@@ -269,7 +269,7 @@ Comm::DoSelect(int msec)
 
         if (cevents->events & (EPOLLIN|EPOLLHUP|EPOLLERR) || F->flags.read_pending) {
             if ((hdl = F->read_handler) != NULL) {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "Calling read handler on FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "Calling read handler on FD " << fd);
                 PROF_start(comm_write_handler);
                 F->flags.read_pending = 0;
                 F->read_handler = NULL;
@@ -277,7 +277,7 @@ Comm::DoSelect(int msec)
                 PROF_stop(comm_write_handler);
                 ++ statCounter.select_fds;
             } else {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "no read handler for FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "no read handler for FD " << fd);
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_READ, NULL, NULL, 0);
             }
@@ -285,14 +285,14 @@ Comm::DoSelect(int msec)
 
         if (cevents->events & (EPOLLOUT|EPOLLHUP|EPOLLERR)) {
             if ((hdl = F->write_handler) != NULL) {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "Calling write handler on FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "Calling write handler on FD " << fd);
                 PROF_start(comm_read_handler);
                 F->write_handler = NULL;
                 hdl(fd, F->write_data);
                 PROF_stop(comm_read_handler);
                 ++ statCounter.select_fds;
             } else {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "no write handler for FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "no write handler for FD " << fd);
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_WRITE, NULL, NULL, 0);
             }

--- a/src/comm/ModKqueue.cc
+++ b/src/comm/ModKqueue.cc
@@ -169,7 +169,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/ModPoll.cc
+++ b/src/comm/ModPoll.cc
@@ -126,7 +126,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/ModSelect.cc
+++ b/src/comm/ModSelect.cc
@@ -125,7 +125,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/ModSelectWin32.cc
+++ b/src/comm/ModSelectWin32.cc
@@ -119,7 +119,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -61,7 +61,7 @@ Comm::TcpAcceptor::TcpAcceptor(const AnyP::PortCfgPointer &p, const char *, cons
 void
 Comm::TcpAcceptor::subscribe(const Subscription::Pointer &aSub)
 {
-    debugs(5, 5, HERE << status() << " AsyncCall Subscription: " << aSub);
+    debugs(5, 5, status() << " AsyncCall Subscription: " << aSub);
     unsubscribe("subscription change");
     theCallSub = aSub;
 }
@@ -69,14 +69,14 @@ Comm::TcpAcceptor::subscribe(const Subscription::Pointer &aSub)
 void
 Comm::TcpAcceptor::unsubscribe(const char *reason)
 {
-    debugs(5, 5, HERE << status() << " AsyncCall Subscription " << theCallSub << " removed: " << reason);
+    debugs(5, 5, status() << " AsyncCall Subscription " << theCallSub << " removed: " << reason);
     theCallSub = NULL;
 }
 
 void
 Comm::TcpAcceptor::start()
 {
-    debugs(5, 5, HERE << status() << " AsyncCall Subscription: " << theCallSub);
+    debugs(5, 5, status() << " AsyncCall Subscription: " << theCallSub);
 
     Must(IsConnOpen(conn));
 
@@ -109,7 +109,7 @@ Comm::TcpAcceptor::doneAll() const
 void
 Comm::TcpAcceptor::swanSong()
 {
-    debugs(5,5, HERE);
+    debugs(5, 5, "");
     unsubscribe("swanSong");
     if (IsConnOpen(conn)) {
         if (closer_ != NULL)
@@ -223,7 +223,7 @@ void
 Comm::TcpAcceptor::doAccept(int fd, void *data)
 {
     try {
-        debugs(5, 2, HERE << "New connection on FD " << fd);
+        debugs(5, 2, "New connection on FD " << fd);
 
         Must(isOpen(fd));
         TcpAcceptor *afd = static_cast<TcpAcceptor*>(data);
@@ -288,13 +288,13 @@ Comm::TcpAcceptor::acceptOne()
 
         if (flag == Comm::NOMESSAGE) {
             /* register interest again */
-            debugs(5, 5, HERE << "try later: " << conn << " handler Subscription: " << theCallSub);
+            debugs(5, 5, "try later: " << conn << " handler Subscription: " << theCallSub);
             SetSelect(conn->fd, COMM_SELECT_READ, doAccept, this, 0);
             return;
         }
 
         // A non-recoverable error; notify the caller */
-        debugs(5, 5, HERE << "non-recoverable error:" << status() << " handler Subscription: " << theCallSub);
+        debugs(5, 5, "non-recoverable error:" << status() << " handler Subscription: " << theCallSub);
         if (intendedForUserConnections())
             logAcceptError(newConnDetails);
         notify(flag, newConnDetails);
@@ -302,7 +302,7 @@ Comm::TcpAcceptor::acceptOne()
         return;
     }
 
-    debugs(5, 5, HERE << "Listener: " << conn <<
+    debugs(5, 5, "Listener: " << conn <<
            " accepted new connection " << newConnDetails <<
            " handler Subscription: " << theCallSub);
     notify(flag, newConnDetails);
@@ -312,7 +312,7 @@ void
 Comm::TcpAcceptor::acceptNext()
 {
     Must(IsConnOpen(conn));
-    debugs(5, 2, HERE << "connection on " << conn);
+    debugs(5, 2, "connection on " << conn);
     acceptOne();
 }
 

--- a/src/comm/Write.cc
+++ b/src/comm/Write.cc
@@ -34,7 +34,7 @@ Comm::Write(const Comm::ConnectionPointer &conn, MemBuf *mb, AsyncCall::Pointer 
 void
 Comm::Write(const Comm::ConnectionPointer &conn, const char *buf, int size, AsyncCall::Pointer &callback, FREE * free_func)
 {
-    debugs(5, 5, HERE << conn << ": sz " << size << ": asynCall " << callback);
+    debugs(5, 5, conn << ": sz " << size << ": asynCall " << callback);
 
     /* Make sure we are open, not closing, and not writing */
     assert(fd_table[conn->fd].flags.open);
@@ -65,7 +65,7 @@ Comm::HandleWrite(int fd, void *data)
     assert(state->conn->fd == fd);
 
     PROF_start(commHandleWrite);
-    debugs(5, 5, HERE << state->conn << ": off " <<
+    debugs(5, 5, state->conn << ": off " <<
            (long int) state->offset << ", sz " << (long int) state->size << ".");
 
     nleft = state->size - state->offset;
@@ -86,7 +86,7 @@ Comm::HandleWrite(int fd, void *data)
     int xerrno = errno = 0;
     len = FD_WRITE_METHOD(fd, state->buf + state->offset, nleft);
     xerrno = errno;
-    debugs(5, 5, HERE << "write() returns " << len);
+    debugs(5, 5, "write() returns " << len);
 
 #if USE_DELAY_POOLS
     if (bucket) {

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -877,7 +877,7 @@ idnsInitVCConnected(const Comm::ConnectionPointer &conn, Comm::Flag status, int,
         char buf[MAX_IPSTRLEN] = "";
         if (vc->ns < nns)
             nameservers[vc->ns].S.toStr(buf,MAX_IPSTRLEN);
-        debugs(78, DBG_IMPORTANT, HERE << "Failed to connect to nameserver " << buf << " using TCP.");
+        debugs(78, DBG_IMPORTANT, "Failed to connect to nameserver " << buf << " using TCP.");
         return;
     }
 
@@ -1229,7 +1229,7 @@ idnsGrokReply(const char *buf, size_t sz, int /*from_ns*/)
     q->pending = 0;
 
     if (message->tc) {
-        debugs(78, 3, HERE << "Resolver requested TC (" << q->query.name << ")");
+        debugs(78, 3, "Resolver requested TC (" << q->query.name << ")");
         rfc1035MessageDestroy(&message);
 
         if (!q->need_vc) {
@@ -1239,7 +1239,7 @@ idnsGrokReply(const char *buf, size_t sz, int /*from_ns*/)
         } else {
             // Strange: A TCP DNS response with the truncation bit (TC) set.
             // Return an error and cleanup; no point in trying TCP again.
-            debugs(78, 3, HERE << "TCP DNS response");
+            debugs(78, 3, "TCP DNS response");
             idnsCallback(q, "Truncated TCP DNS response");
         }
 
@@ -1486,7 +1486,7 @@ idnsReadVC(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm::Fla
     }
 
     assert(vc->ns < nns);
-    debugs(78, 3, HERE << conn << ": received " << vc->msg->contentSize() << " bytes via TCP from " << nameservers[vc->ns].S << ".");
+    debugs(78, 3, conn << ": received " << vc->msg->contentSize() << " bytes via TCP from " << nameservers[vc->ns].S << ".");
 
     idnsGrokReply(vc->msg->buf, vc->msg->contentSize(), vc->ns);
     vc->msg->clean();
@@ -1738,7 +1738,7 @@ idnsSendSlaveAAAAQuery(idns_query *master)
     q->query_id = idnsQueryID();
     q->sz = rfc3596BuildAAAAQuery(q->name, q->buf, sizeof(q->buf), q->query_id, &q->query, Config.dns.packet_max);
 
-    debugs(78, 3, HERE << "buf is " << q->sz << " bytes for " << q->name <<
+    debugs(78, 3, "buf is " << q->sz << " bytes for " << q->name <<
            ", id = 0x" << std::hex << q->query_id);
     if (!q->sz) {
         delete q;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -309,7 +309,7 @@ TemplateFile::tryLoadTemplate(const char *lang)
     if ( strlen(lang) == 2) {
         /* TODO glob the error directory for sub-dirs matching: <tag> '-*'   */
         /* use first result. */
-        debugs(4,2, HERE << "wildcard fallback errors not coded yet.");
+        debugs(4,2, "wildcard fallback errors not coded yet.");
     }
 #endif
 
@@ -426,17 +426,17 @@ TemplateFile::loadFor(const HttpRequest *request)
     char lang[256];
     size_t pos = 0; // current parsing position in header string
 
-    debugs(4, 6, HERE << "Testing Header: '" << hdr << "'");
+    debugs(4, 6, "Testing Header: '" << hdr << "'");
 
     while ( strHdrAcptLangGetItem(hdr, lang, 256, pos) ) {
 
         /* wildcard uses the configured default language */
         if (lang[0] == '*' && lang[1] == '\0') {
-            debugs(4, 6, HERE << "Found language '" << lang << "'. Using configured default.");
+            debugs(4, 6, "Found language '" << lang << "'. Using configured default.");
             return false;
         }
 
-        debugs(4, 6, HERE << "Found language '" << lang << "', testing for available template");
+        debugs(4, 6, "Found language '" << lang << "', testing for available template");
 
         if (tryLoadTemplate(lang)) {
             /* store the language we found for the Content-Language reply header */
@@ -633,7 +633,7 @@ static void
 errorSendComplete(const Comm::ConnectionPointer &conn, char *, size_t size, Comm::Flag errflag, int, void *data)
 {
     ErrorState *err = static_cast<ErrorState *>(data);
-    debugs(4, 3, HERE << conn << ", size=" << size);
+    debugs(4, 3, conn << ", size=" << size);
 
     if (errflag != Comm::ERR_CLOSING) {
         if (err->callback) {
@@ -1227,7 +1227,7 @@ ErrorState::BuildContent()
         if (!Config.errorDirectory)
             err_language = Config.errorDefaultLanguage;
 #endif
-        debugs(4, 2, HERE << "No existing error page language negotiated for " << errorPageName(page_id) << ". Using default error file.");
+        debugs(4, 2, "No existing error page language negotiated for " << errorPageName(page_id) << ". Using default error file.");
     }
 
     MemBuf *result = ConvertText(m, true);

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1383,7 +1383,7 @@ ESIContext::ParserState::popAll()
 void
 ESIContext::freeResources ()
 {
-    debugs(86, 5, HERE << "Freeing for this=" << this);
+    debugs(86, 5, "Freeing for this=" << this);
 
     rep = nullptr; // refcounted
 

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -80,7 +80,7 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
     assert (receivedData.length <= sizeof(esiStream->localbuffer->buf));
     assert (!esiStream->finished);
 
-    debugs (86,5, HERE << "rep " << rep << " body " << receivedData.data << " len " << receivedData.length);
+    debugs (86,5, "rep " << rep << " body " << receivedData.data << " len " << receivedData.length);
     assert (node->readBuffer.offset == receivedData.offset || receivedData.length == 0);
 
     /* trivial case */
@@ -128,7 +128,7 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
     /* EOF / Read error /  aborted entry */
     if (rep == NULL && receivedData.data == NULL && receivedData.length == 0) {
         /* TODO: get stream status to test the entry for aborts */
-        debugs(86, 5, HERE << "Finished reading upstream data in subrequest");
+        debugs(86, 5, "Finished reading upstream data in subrequest");
         esiStream->include->subRequestDone (esiStream, true);
         esiStream->finished = 1;
         httpRequestFree (http);
@@ -183,7 +183,7 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
         tempBuffer.data = esiStream->buffer->buf;
         /* now just read into 'buffer' */
         clientStreamRead (node, http, tempBuffer);
-        debugs(86, 5, HERE << "Requested more data for ESI subrequest");
+        debugs(86, 5, "Requested more data for ESI subrequest");
     }
 
     break;

--- a/src/event.cc
+++ b/src/event.cc
@@ -323,7 +323,7 @@ EventScheduler::schedule(const char *name, EVH * func, void *arg, double when, i
     ev_entry *event = new ev_entry(name, func, arg, timestamp, weight, cbdata);
 
     ev_entry **E;
-    debugs(41, 7, HERE << "schedule: Adding '" << name << "', in " << when << " seconds");
+    debugs(41, 7, "schedule: Adding '" << name << "', in " << when << " seconds");
     /* Insert after the last event with the same or earlier time */
 
     for (E = &tasks; *E; E = &(*E)->next) {

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -580,7 +580,7 @@ copyResultsFromEntry(HttpRequest *req, const ExternalACLEntryPointer &entry)
 static allow_t
 aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
 {
-    debugs(82, 9, HERE << "acl=\"" << acl->def->name << "\"");
+    debugs(82, 9, "acl=\"" << acl->def->name << "\"");
     ExternalACLEntryPointer entry = ch->extacl_entry;
 
     external_acl_message = "MISSING REQUIRED INFORMATION";
@@ -609,17 +609,17 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
     }
 
     if (!entry) {
-        debugs(82, 9, HERE << "No helper entry available");
+        debugs(82, 9, "No helper entry available");
 #if USE_AUTH
         if (acl->def->require_auth) {
             /* Make sure the user is authenticated */
-            debugs(82, 3, HERE << acl->def->name << " check user authenticated.");
+            debugs(82, 3, acl->def->name << " check user authenticated.");
             const allow_t ti = AuthenticateAcl(ch);
             if (!ti.allowed()) {
-                debugs(82, 2, HERE << acl->def->name << " user not authenticated (" << ti << ")");
+                debugs(82, 2, acl->def->name << " user not authenticated (" << ti << ")");
                 return ti;
             }
-            debugs(82, 3, HERE << acl->def->name << " user is authenticated.");
+            debugs(82, 3, acl->def->name << " user is authenticated.");
         }
 #endif
         const char *key = makeExternalAclKey(ch, acl);
@@ -638,19 +638,19 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
         if (entry != NULL && external_acl_grace_expired(acl->def, entry)) {
             // refresh in the background
             ExternalACLLookup::Start(ch, acl, true);
-            debugs(82, 4, HERE << "no need to wait for the refresh of '" <<
+            debugs(82, 4, "no need to wait for the refresh of '" <<
                    key << "' in '" << acl->def->name << "' (ch=" << ch << ").");
         }
 
         if (!entry) {
-            debugs(82, 2, HERE << acl->def->name << "(\"" << key << "\") = lookup needed");
+            debugs(82, 2, acl->def->name << "(\"" << key << "\") = lookup needed");
 
             // TODO: All other helpers allow temporary overload. Should not we?
             if (!acl->def->theHelper->willOverload()) {
-                debugs(82, 2, HERE << "\"" << key << "\": queueing a call.");
+                debugs(82, 2, "\"" << key << "\": queueing a call.");
                 if (!ch->goAsync(ExternalACLLookup::Instance()))
                     debugs(82, 2, "\"" << key << "\": no async support!");
-                debugs(82, 2, HERE << "\"" << key << "\": return -1.");
+                debugs(82, 2, "\"" << key << "\": return -1.");
                 return ACCESS_DUNNO; // expired cached or simply absent entry
             } else {
                 if (!staleEntry) {
@@ -668,19 +668,19 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
         }
     }
 
-    debugs(82, 4, HERE << "entry = { date=" <<
+    debugs(82, 4, "entry = { date=" <<
            (long unsigned int) entry->date <<
            ", result=" << entry->result <<
            " tag=" << entry->tag <<
            " log=" << entry->log << " }");
 #if USE_AUTH
-    debugs(82, 4, HERE << "entry user=" << entry->user);
+    debugs(82, 4, "entry user=" << entry->user);
 #endif
 
     external_acl_cache_touch(acl->def, entry);
     external_acl_message = entry->message.termedBuf();
 
-    debugs(82, 2, HERE << acl->def->name << " = " << entry->result);
+    debugs(82, 2, acl->def->name << " = " << entry->result);
     copyResultsFromEntry(ch->request, entry);
     return entry->result;
 }
@@ -830,7 +830,7 @@ external_acl_cache_add(external_acl * def, const char *key, ExternalACLEntryData
     ExternalACLEntryPointer entry;
 
     if (!def->maybeCacheable(data.result)) {
-        debugs(82,6, HERE);
+        debugs(82, 6, "");
 
         if (data.result == ACCESS_DUNNO) {
             if (const ExternalACLEntryPointer oldentry = static_cast<ExternalACLEntry *>(hash_lookup(def->cache, key)))
@@ -938,7 +938,7 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
     externalAclState *next;
     ExternalACLEntryData entryData;
 
-    debugs(82, 2, HERE << "reply=" << reply);
+    debugs(82, 2, "reply=" << reply);
 
     if (reply.result == Helper::Okay)
         entryData.result = ACCESS_ALLOWED;
@@ -1008,7 +1008,7 @@ ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool i
     const char *key = makeExternalAclKey(ch, acl);
     assert(key); // XXX: will fail if EXT_ACL_IDENT case needs an async lookup
 
-    debugs(82, 2, HERE << (inBackground ? "bg" : "fg") << " lookup in '" <<
+    debugs(82, 2, (inBackground ? "bg" : "fg") << " lookup in '" <<
            def->name << "' for '" << key << "'");
 
     /* Check for a pending lookup to hook into */
@@ -1028,7 +1028,7 @@ ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool i
     // A background refresh has no need to piggiback on a pending request:
     // When the pending request completes, the cache will be refreshed anyway.
     if (oldstate && inBackground) {
-        debugs(82, 7, HERE << "'" << def->name << "' queue is already being refreshed (ch=" << ch << ")");
+        debugs(82, 7, "'" << def->name << "' queue is already being refreshed (ch=" << ch << ")");
         return;
     }
 
@@ -1052,7 +1052,7 @@ ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool i
         debugs(82, 4, "externalAclLookup: looking up for '" << key << "' in '" << def->name << "'.");
 
         if (!def->theHelper->trySubmit(buf.buf, externalAclHandleReply, state)) {
-            debugs(82, 7, HERE << "'" << def->name << "' submit to helper failed");
+            debugs(82, 7, "'" << def->name << "' submit to helper failed");
             assert(inBackground); // or the caller should have checked
             delete state;
             return;

--- a/src/filemap.cc
+++ b/src/filemap.cc
@@ -36,7 +36,7 @@ FileMap::FileMap() :
     capacity_(FM_INITIAL_NUMBER), usedSlots_(0),
     nwords(capacity_ >> LONG_BIT_SHIFT)
 {
-    debugs(8, 3, HERE << "creating space for " << capacity_ << " files");
+    debugs(8, 3, "creating space for " << capacity_ << " files");
     debugs(8, 5, "--> " << nwords << " words of " << sizeof(*bitmap) << " bytes each");
     bitmap = (unsigned long *)xcalloc(nwords, sizeof(*bitmap));
 }
@@ -49,7 +49,7 @@ FileMap::grow()
     capacity_ <<= 1;
     assert(capacity_ <= (1 << 24)); /* swap_filen is 25 bits, signed */
     nwords = capacity_ >> LONG_BIT_SHIFT;
-    debugs(8, 3, HERE << " creating space for " << capacity_ << " files");
+    debugs(8, 3, "creating space for " << capacity_ << " files");
     debugs(8, 5, "--> " << nwords << " words of " << sizeof(*bitmap) << " bytes each");
     bitmap = (unsigned long *)xcalloc(nwords, sizeof(*bitmap));
     debugs(8, 3, "copying " << old_sz << " old bytes");

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -68,7 +68,7 @@ Format::Format::parse(const char *def)
     Token *new_lt, *last_lt;
     enum Quoting quote = LOG_QUOTE_NONE;
 
-    debugs(46, 2, HERE << "got definition '" << def << "'");
+    debugs(46, 2, "got definition '" << def << "'");
 
     if (format) {
         debugs(46, DBG_IMPORTANT, "WARNING: existing format for '" << name << " " << def << "'");
@@ -97,11 +97,11 @@ Format::Format::parse(const char *def)
 void
 Format::Format::dump(StoreEntry * entry, const char *directiveName, bool eol) const
 {
-    debugs(46, 4, HERE);
+    debugs(46, 4, "");
 
     // loop rather than recursing to conserve stack space.
     for (const Format *fmt = this; fmt; fmt = fmt->next) {
-        debugs(46, 3, HERE << "Dumping format definition for " << fmt->name);
+        debugs(46, 3, "Dumping format definition for " << fmt->name);
         if (directiveName)
             storeAppendPrintf(entry, "%s %s ", directiveName, fmt->name);
 

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -256,11 +256,11 @@ const char *
 Format::Token::scanForToken(TokenTableEntry const table[], const char *cur)
 {
     for (TokenTableEntry const *lte = table; lte->configTag != NULL; ++lte) {
-        debugs(46, 8, HERE << "compare tokens '" << lte->configTag << "' with '" << cur << "'");
+        debugs(46, 8, "compare tokens '" << lte->configTag << "' with '" << cur << "'");
         if (strncmp(lte->configTag, cur, strlen(lte->configTag)) == 0) {
             type = lte->tokenType;
             label = lte->configTag;
-            debugs(46, 7, HERE << "Found token '" << label << "'");
+            debugs(46, 7, "Found token '" << label << "'");
             return cur + strlen(lte->configTag);
         }
     }
@@ -418,16 +418,16 @@ Format::Token::parse(const char *def, Quoting *quoting)
             //     mistakes made with overlapping names. (Bug 3310)
 
             // Scan for various long tokens
-            debugs(46, 5, HERE << "scan for possible Misc token");
+            debugs(46, 5, "scan for possible Misc token");
             cur = scanForToken(TokenTableMisc, cur);
             // scan for 2-char tokens
             if (type == LFT_NONE) {
-                debugs(46, 5, HERE << "scan for possible 2C token");
+                debugs(46, 5, "scan for possible 2C token");
                 cur = scanForToken(TokenTable2C, cur);
             }
             // finally scan for 1-char tokens.
             if (type == LFT_NONE) {
-                debugs(46, 5, HERE << "scan for possible 1C token");
+                debugs(46, 5, "scan for possible 1C token");
                 cur = scanForToken(TokenTable1C, cur);
             }
         }

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -292,7 +292,7 @@ Rock::IoState::writeBufToDisk(const SlotId sidNext, const bool eof, const bool l
     memcpy(wBuf, theBuf.mem, theBuf.size);
 
     const uint64_t diskOffset = dir->diskOffset(sidCurrent);
-    debugs(79, 5, HERE << swap_filen << " at " << diskOffset << '+' <<
+    debugs(79, 5, swap_filen << " at " << diskOffset << '+' <<
            theBuf.size);
 
     WriteRequest *const r = new WriteRequest(
@@ -417,7 +417,7 @@ private:
 void
 Rock::IoState::callBack(int errflag)
 {
-    debugs(79,3, HERE << "errflag=" << errflag);
+    debugs(79,3, "errflag=" << errflag);
     theFile = NULL;
 
     AsyncCall::Pointer call = asyncCall(79,3, "SomeIoStateCloseCb",

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -336,7 +336,7 @@ Rock::Rebuild::loadingSteps()
         getCurrentTime();
         const double elapsedMsec = tvSubMsec(loopStart, current_time);
         if (elapsedMsec > maxSpentMsec || elapsedMsec < 0) {
-            debugs(47, 5, HERE << "pausing after " << loaded << " entries in " <<
+            debugs(47, 5, "pausing after " << loaded << " entries in " <<
                    elapsedMsec << "ms; " << (elapsedMsec/loaded) << "ms per entry");
             break;
         }
@@ -558,7 +558,7 @@ Rock::Rebuild::freeBadEntry(const sfileno fileno, const char *eDescription)
 void
 Rock::Rebuild::swanSong()
 {
-    debugs(47,3, HERE << "cache_dir #" << sd->index << " rebuild level: " <<
+    debugs(47,3, "cache_dir #" << sd->index << " rebuild level: " <<
            StoreController::store_dirs_rebuilding);
     --StoreController::store_dirs_rebuilding;
     storeRebuildComplete(&counts);

--- a/src/fs/rock/RockStoreFileSystem.cc
+++ b/src/fs/rock/RockStoreFileSystem.cc
@@ -47,7 +47,7 @@ Rock::StoreFileSystem::registerWithCacheManager()
 void
 Rock::StoreFileSystem::setup()
 {
-    debugs(92,2, HERE << "Will use Rock FS");
+    debugs(92,2, "Will use Rock FS");
 }
 
 void

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -235,11 +235,11 @@ Rock::SwapDir::create()
     assert(filePath);
 
     if (UsingSmp() && !IamDiskProcess()) {
-        debugs (47,3, HERE << "disker will create in " << path);
+        debugs (47,3, "disker will create in " << path);
         return;
     }
 
-    debugs (47,3, HERE << "creating in " << path);
+    debugs (47,3, "creating in " << path);
 
     struct stat dir_sb;
     if (::stat(path, &dir_sb) == 0) {
@@ -300,7 +300,7 @@ Rock::SwapDir::createError(const char *const msg)
 void
 Rock::SwapDir::init()
 {
-    debugs(47,2, HERE);
+    debugs(47, 2, "");
 
     // XXX: SwapDirs aren't refcounted. We make IORequestor calls, which
     // are refcounted. We up our count once to avoid implicit delete's.
@@ -314,7 +314,7 @@ Rock::SwapDir::init()
 
     const char *ioModule = needsDiskStrand() ? "IpcIo" : "Blocking";
     if (DiskIOModule *m = DiskIOModule::Find(ioModule)) {
-        debugs(47,2, HERE << "Using DiskIO module: " << ioModule);
+        debugs(47,2, "Using DiskIO module: " << ioModule);
         io = m->createStrategy();
         io->init();
     } else {
@@ -630,7 +630,7 @@ Rock::SwapDir::canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load)
     // TODO: reserve page instead
     if (needsDiskStrand() &&
             Ipc::Mem::PageLevel(Ipc::Mem::PageId::ioPage) >= 0.9 * Ipc::Mem::PageLimit(Ipc::Mem::PageId::ioPage)) {
-        debugs(47, 5, HERE << "too few shared pages for IPC I/O left");
+        debugs(47, 5, "too few shared pages for IPC I/O left");
         return false;
     }
 
@@ -645,7 +645,7 @@ StoreIOState::Pointer
 Rock::SwapDir::createStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOState::STIOCB *cbIo, void *data)
 {
     if (!theFile || theFile->error()) {
-        debugs(47,4, HERE << theFile);
+        debugs(47,4, theFile);
         return NULL;
     }
 
@@ -653,7 +653,7 @@ Rock::SwapDir::createStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreI
     Ipc::StoreMapAnchor *const slot =
         map->openForWriting(reinterpret_cast<const cache_key *>(e.key), filen);
     if (!slot) {
-        debugs(47, 5, HERE << "map->add failed");
+        debugs(47, 5, "map->add failed");
         return NULL;
     }
 
@@ -670,7 +670,7 @@ Rock::SwapDir::createStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreI
     sio->swap_filen = filen;
     sio->writeableAnchor_ = slot;
 
-    debugs(47,5, HERE << "dir " << index << " created new filen " <<
+    debugs(47,5, "dir " << index << " created new filen " <<
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) <<
            sio->swap_filen << std::dec << " starting at " <<
            diskOffset(sio->swap_filen));
@@ -778,12 +778,12 @@ StoreIOState::Pointer
 Rock::SwapDir::openStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOState::STIOCB *cbIo, void *data)
 {
     if (!theFile || theFile->error()) {
-        debugs(47,4, HERE << theFile);
+        debugs(47,4, theFile);
         return NULL;
     }
 
     if (e.swap_filen < 0) {
-        debugs(47,4, HERE << e);
+        debugs(47,4, e);
         return NULL;
     }
 
@@ -791,7 +791,7 @@ Rock::SwapDir::openStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOS
     // TODO: reserve page instead
     if (needsDiskStrand() &&
             Ipc::Mem::PageLevel(Ipc::Mem::PageId::ioPage) >= 0.9 * Ipc::Mem::PageLimit(Ipc::Mem::PageId::ioPage)) {
-        debugs(47, 5, HERE << "too few shared pages for IPC I/O left");
+        debugs(47, 5, "too few shared pages for IPC I/O left");
         return NULL;
     }
 
@@ -810,7 +810,7 @@ Rock::SwapDir::openStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOS
     sio->readableAnchor_ = slot;
     sio->file(theFile);
 
-    debugs(47,5, HERE << "dir " << index << " has old filen: " <<
+    debugs(47,5, "dir " << index << " has old filen: " <<
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) <<
            sio->swap_filen);
 
@@ -975,7 +975,7 @@ Rock::SwapDir::maintain()
 void
 Rock::SwapDir::reference(StoreEntry &e)
 {
-    debugs(47, 5, HERE << &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
+    debugs(47, 5, &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
     if (repl && repl->Referenced)
         repl->Referenced(repl, &e, &e.repl);
 }
@@ -983,7 +983,7 @@ Rock::SwapDir::reference(StoreEntry &e)
 bool
 Rock::SwapDir::dereference(StoreEntry &e)
 {
-    debugs(47, 5, HERE << &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
+    debugs(47, 5, &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
     if (repl && repl->Dereferenced)
         repl->Dereferenced(repl, &e, &e.repl);
 
@@ -1001,7 +1001,7 @@ Rock::SwapDir::unlinkdUseful() const
 void
 Rock::SwapDir::unlink(StoreEntry &e)
 {
-    debugs(47, 5, HERE << e);
+    debugs(47, 5, e);
     ignoreReferences(e);
     map->freeEntry(e.swap_filen);
     disconnect(e);
@@ -1017,7 +1017,7 @@ Rock::SwapDir::markForUnlink(StoreEntry &e)
 void
 Rock::SwapDir::trackReferences(StoreEntry &e)
 {
-    debugs(47, 5, HERE << e);
+    debugs(47, 5, e);
     if (repl)
         repl->Add(repl, &e, &e.repl);
 }
@@ -1025,7 +1025,7 @@ Rock::SwapDir::trackReferences(StoreEntry &e)
 void
 Rock::SwapDir::ignoreReferences(StoreEntry &e)
 {
-    debugs(47, 5, HERE << e);
+    debugs(47, 5, e);
     if (repl)
         repl->Remove(repl, &e, &e.repl);
 }

--- a/src/fs/ufs/RebuildState.cc
+++ b/src/fs/ufs/RebuildState.cc
@@ -134,7 +134,7 @@ Fs::Ufs::RebuildState::rebuildStep()
         getCurrentTime();
         const double elapsedMsec = tvSubMsec(loopStart, current_time);
         if (elapsedMsec > maxSpentMsec || elapsedMsec < 0) {
-            debugs(47, 5, HERE << "pausing after " << n_read << " entries in " <<
+            debugs(47, 5, "pausing after " << n_read << " entries in " <<
                    elapsedMsec << "ms; " << (elapsedMsec/n_read) << "ms per entry");
             break;
         }
@@ -149,7 +149,7 @@ Fs::Ufs::RebuildState::rebuildFromDirectory()
 
     struct stat sb;
     int fd = -1;
-    debugs(47, 3, HERE << "DIR #" << sd->index);
+    debugs(47, 3, "DIR #" << sd->index);
 
     assert(fd == -1);
     sfileno filn = 0;
@@ -270,7 +270,7 @@ Fs::Ufs::RebuildState::rebuildFromSwapLog()
      */
     swapData.swap_filen &= 0x00FFFFFF;
 
-    debugs(47, 3, HERE << swap_log_op_str[(int) swapData.op]  << " " <<
+    debugs(47, 3, swap_log_op_str[(int) swapData.op]  << " " <<
            storeKeyText(swapData.key)  << " "<< std::setfill('0') <<
            std::hex << std::uppercase << std::setw(8) <<
            swapData.swap_filen);
@@ -352,7 +352,7 @@ Fs::Ufs::RebuildState::rebuildFromSwapLog()
             sd->dereference(*currentEntry());
         } else {
             debug_trap("commonUfsDirRebuildFromSwapLog: bad condition");
-            debugs(47, DBG_IMPORTANT, HERE << "bad condition");
+            debugs(47, DBG_IMPORTANT, "bad condition");
         }
         return;
     } else if (used) {
@@ -441,7 +441,7 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
 {
     int fd = -1;
     int dirs_opened = 0;
-    debugs(47, 3, HERE << "flag=" << flags.init  << ", " <<
+    debugs(47, 3, "flag=" << flags.init  << ", " <<
            sd->index  << ": /"<< std::setfill('0') << std::hex <<
            std::uppercase << std::setw(2) << curlvl1  << "/" << std::setw(2) <<
            curlvl2);
@@ -482,8 +482,8 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
                 entry = readdir(td);
 
                 if (entry == NULL && errno == ENOENT)
-                    debugs(47, DBG_IMPORTANT, HERE << "WARNING: directory does not exist!");
-                debugs(47, 3, HERE << "Directory " << fullpath);
+                    debugs(47, DBG_IMPORTANT, "WARNING: directory does not exist!");
+                debugs(47, 3, "Directory " << fullpath);
             }
         }
 
@@ -491,12 +491,12 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
             ++in_dir;
 
             if (sscanf(entry->d_name, "%x", &fn) != 1) {
-                debugs(47, 3, HERE << "invalid entry " << entry->d_name);
+                debugs(47, 3, "invalid entry " << entry->d_name);
                 continue;
             }
 
             if (!UFSSwapDir::FilenoBelongsHere(fn, sd->index, curlvl1, curlvl2)) {
-                debugs(47, 3, HERE << std::setfill('0') <<
+                debugs(47, 3, std::setfill('0') <<
                        std::hex << std::uppercase << std::setw(8) << fn  <<
                        " does not belong in " << std::dec << sd->index  << "/" <<
                        curlvl1  << "/" << curlvl2);
@@ -505,13 +505,13 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
             }
 
             if (sd->mapBitTest(fn)) {
-                debugs(47, 3, HERE << "Locked, continuing with next.");
+                debugs(47, 3, "Locked, continuing with next.");
                 continue;
             }
 
             snprintf(fullfilename, sizeof(fullfilename), "%s/%s",
                      fullpath, entry->d_name);
-            debugs(47, 3, HERE << "Opening " << fullfilename);
+            debugs(47, 3, "Opening " << fullfilename);
             fd = file_open(fullfilename, O_RDONLY | O_BINARY);
 
             if (fd < 0) {

--- a/src/fs/ufs/UFSStoreState.cc
+++ b/src/fs/ufs/UFSStoreState.cc
@@ -64,7 +64,7 @@ void
 Fs::Ufs::UFSStoreState::openDone()
 {
     if (closing)
-        debugs(0, DBG_CRITICAL, HERE << "already closing in openDone()!?");
+        debugs(0, DBG_CRITICAL, "already closing in openDone()!?");
 
     if (theFile->error()) {
         tryClosing();
@@ -95,7 +95,7 @@ Fs::Ufs::UFSStoreState::closeCompleted()
            theFile->error());
 
     if (theFile->error()) {
-        debugs(79,3,HERE<< "theFile->error() ret " << theFile->error());
+        debugs(79,3,"theFile->error() ret " << theFile->error());
         doCloseCallback(DISK_ERROR);
     } else {
         doCloseCallback(DISK_OK);
@@ -162,8 +162,8 @@ Fs::Ufs::UFSStoreState::write(char const *buf, size_t size, off_t aOffset, FREE 
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) << swap_filen);
 
     if (theFile->error()) {
-        debugs(79, DBG_IMPORTANT,HERE << "avoid write on theFile with error");
-        debugs(79, DBG_IMPORTANT,HERE << "calling free_func for " << (void*) buf);
+        debugs(79, DBG_IMPORTANT,"avoid write on theFile with error");
+        debugs(79, DBG_IMPORTANT,"calling free_func for " << (void*) buf);
         free_func((void*)buf);
         return false;
     }
@@ -272,7 +272,7 @@ Fs::Ufs::UFSStoreState::readCompleted(const char *buf, int len, int, RefCount<Re
 void
 Fs::Ufs::UFSStoreState::writeCompleted(int, size_t len, RefCount<WriteRequest>)
 {
-    debugs(79, 3, HERE << "dirno " << swap_dirn << ", fileno " <<
+    debugs(79, 3, "dirno " << swap_dirn << ", fileno " <<
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) << swap_filen <<
            ", len " << len);
     /*
@@ -284,7 +284,7 @@ Fs::Ufs::UFSStoreState::writeCompleted(int, size_t len, RefCount<WriteRequest>)
     offset_ += len;
 
     if (theFile->error()) {
-        debugs(79,2,HERE << " detected an error, will try to close");
+        debugs(79,2,"detected an error, will try to close");
         tryClosing();
     }
 
@@ -429,13 +429,13 @@ Fs::Ufs::UFSStoreState::drainWriteQueue()
 void
 Fs::Ufs::UFSStoreState::tryClosing()
 {
-    debugs(79,3,HERE << this << " tryClosing()" <<
+    debugs(79,3,this << " tryClosing()" <<
            " closing = " << closing <<
            " flags.try_closing = " << flags.try_closing <<
            " ioInProgress = " << theFile->ioInProgress());
 
     if (theFile->ioInProgress()) {
-        debugs(79, 3, HERE << this <<
+        debugs(79, 3, this <<
                " won't close since ioInProgress is true, bailing");
         flags.try_closing = true;
         return;

--- a/src/fs/ufs/UFSStrategy.cc
+++ b/src/fs/ufs/UFSStrategy.cc
@@ -58,7 +58,7 @@ Fs::Ufs::UFSStrategy::open(SwapDir * SD, StoreEntry * e, StoreIOState::STFNCB *,
                            StoreIOState::STIOCB * aCallback, void *callback_data)
 {
     assert (((UFSSwapDir *)SD)->IO == this);
-    debugs(79, 3, HERE << "fileno "<< std::setfill('0') << std::hex
+    debugs(79, 3, "fileno "<< std::setfill('0') << std::hex
            << std::uppercase << std::setw(8) << e->swap_filen);
 
     /* to consider: make createstate a private UFSStrategy call */
@@ -96,7 +96,7 @@ Fs::Ufs::UFSStrategy::create(SwapDir * SD, StoreEntry * e, StoreIOState::STFNCB 
     assert (((UFSSwapDir *)SD)->IO == this);
     /* Allocate a number */
     sfileno filn = ((UFSSwapDir *)SD)->mapBitAllocate();
-    debugs(79, 3, HERE << "fileno "<< std::setfill('0') <<
+    debugs(79, 3, "fileno "<< std::setfill('0') <<
            std::hex << std::uppercase << std::setw(8) << filn);
 
     /* Shouldn't we handle a 'bitmap full' error here? */

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -276,7 +276,7 @@ Fs::Ufs::UFSSwapDir::getOptionTree() const
 void
 Fs::Ufs::UFSSwapDir::init()
 {
-    debugs(47, 3, HERE << "Initialising UFS SwapDir engine.");
+    debugs(47, 3, "Initialising UFS SwapDir engine.");
     /* Parsing must be finished by now - force to NULL, don't delete */
     currentIOOptions = NULL;
     static int started_clean_event = 0;
@@ -345,8 +345,8 @@ Fs::Ufs::UFSSwapDir::~UFSSwapDir()
 void
 Fs::Ufs::UFSSwapDir::dumpEntry(StoreEntry &e) const
 {
-    debugs(47, DBG_CRITICAL, HERE << "FILENO "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << e.swap_filen);
-    debugs(47, DBG_CRITICAL, HERE << "PATH " << fullPath(e.swap_filen, NULL)   );
+    debugs(47, DBG_CRITICAL, "FILENO "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << e.swap_filen);
+    debugs(47, DBG_CRITICAL, "PATH " << fullPath(e.swap_filen, NULL)   );
     e.dump(0);
 }
 
@@ -357,13 +357,13 @@ Fs::Ufs::UFSSwapDir::doubleCheck(StoreEntry & e)
     struct stat sb;
 
     if (::stat(fullPath(e.swap_filen, NULL), &sb) < 0) {
-        debugs(47, DBG_CRITICAL, HERE << "WARNING: Missing swap file");
+        debugs(47, DBG_CRITICAL, "WARNING: Missing swap file");
         dumpEntry(e);
         return true;
     }
 
     if ((off_t)e.swap_file_sz != sb.st_size) {
-        debugs(47, DBG_CRITICAL, HERE << "WARNING: Size Mismatch. Entry size: "
+        debugs(47, DBG_CRITICAL, "WARNING: Size Mismatch. Entry size: "
                << e.swap_file_sz << ", file size: " << sb.st_size);
         dumpEntry(e);
         return true;
@@ -528,7 +528,7 @@ Fs::Ufs::UFSSwapDir::maintain()
 void
 Fs::Ufs::UFSSwapDir::reference(StoreEntry &e)
 {
-    debugs(47, 3, HERE << "referencing " << &e << " " <<
+    debugs(47, 3, "referencing " << &e << " " <<
            e.swap_dirn << "/" << e.swap_filen);
 
     if (repl->Referenced)
@@ -538,7 +538,7 @@ Fs::Ufs::UFSSwapDir::reference(StoreEntry &e)
 bool
 Fs::Ufs::UFSSwapDir::dereference(StoreEntry & e)
 {
-    debugs(47, 3, HERE << "dereferencing " << &e << " " <<
+    debugs(47, 3, "dereferencing " << &e << " " <<
            e.swap_dirn << "/" << e.swap_filen);
 
     if (repl->Dereferenced)
@@ -749,7 +749,7 @@ Fs::Ufs::UFSSwapDir::openLog()
         fatal("UFSSwapDir::openLog: Failed to open swap log.");
     }
 
-    debugs(50, 3, HERE << "Cache Dir #" << index << " log opened on FD " << swaplog_fd);
+    debugs(50, 3, "Cache Dir #" << index << " log opened on FD " << swaplog_fd);
 }
 
 void
@@ -798,7 +798,7 @@ Fs::Ufs::UFSSwapDir::addDiskRestore(const cache_key * key,
                                     int)
 {
     StoreEntry *e = NULL;
-    debugs(47, 5, HERE << storeKeyText(key)  <<
+    debugs(47, 5, storeKeyText(key)  <<
            ", fileno="<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << file_number);
     /* if you call this you'd better be sure file_number is not
      * already in use! */
@@ -830,7 +830,7 @@ Fs::Ufs::UFSSwapDir::addDiskRestore(const cache_key * key,
 void
 Fs::Ufs::UFSSwapDir::undoAddDiskRestore(StoreEntry *e)
 {
-    debugs(47, 5, HERE << *e);
+    debugs(47, 5, *e);
     replacementRemove(e); // checks swap_dirn so do it before we invalidate it
     // Do not unlink the file as it might be used by a subsequent entry.
     mapBitReset(e->swap_filen);
@@ -995,7 +995,7 @@ Fs::Ufs::UFSSwapDir::writeCleanStart()
 
     state->walker = repl->WalkInit(repl);
     ::unlink(state->cln);
-    debugs(47, 3, HERE << "opened " << state->newLog << ", FD " << state->fd);
+    debugs(47, 3, "opened " << state->newLog << ", FD " << state->fd);
 #if HAVE_FCHMOD
 
     if (::stat(state->cur, &sb) == 0)
@@ -1201,7 +1201,7 @@ Fs::Ufs::UFSSwapDir::validFileno(sfileno filn, int flag) const
 void
 Fs::Ufs::UFSSwapDir::unlinkFile(sfileno f)
 {
-    debugs(79, 3, HERE << "unlinking fileno " <<  std::setfill('0') <<
+    debugs(79, 3, "unlinking fileno " <<  std::setfill('0') <<
            std::hex << std::uppercase << std::setw(8) << f << " '" <<
            fullPath(f,NULL) << "'");
     /* commonUfsDirMapBitReset(this, f); */
@@ -1218,7 +1218,7 @@ Fs::Ufs::UFSSwapDir::unlinkdUseful() const
 void
 Fs::Ufs::UFSSwapDir::unlink(StoreEntry & e)
 {
-    debugs(79, 3, HERE << "dirno " << index  << ", fileno "<<
+    debugs(79, 3, "dirno " << index  << ", fileno "<<
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) << e.swap_filen);
     if (e.swap_status == SWAPOUT_DONE) {
         cur_size -= fs.blksize * sizeInBlocks(e.swap_file_sz);
@@ -1235,7 +1235,7 @@ Fs::Ufs::UFSSwapDir::unlink(StoreEntry & e)
 void
 Fs::Ufs::UFSSwapDir::replacementAdd(StoreEntry * e)
 {
-    debugs(47, 4, HERE << "added node " << e << " to dir " << index);
+    debugs(47, 4, "added node " << e << " to dir " << index);
     repl->Add(repl, e, &e->repl);
 }
 
@@ -1249,7 +1249,7 @@ Fs::Ufs::UFSSwapDir::replacementRemove(StoreEntry * e)
 
     assert (dynamic_cast<UFSSwapDir *>(SD.getRaw()) == this);
 
-    debugs(47, 4, HERE << "remove node " << e << " from dir " << index);
+    debugs(47, 4, "remove node " << e << " from dir " << index);
 
     repl->Remove(repl, e, &e->repl);
 }
@@ -1356,7 +1356,7 @@ Fs::Ufs::UFSSwapDir::DirClean(int swap_index)
     D2 = ((swap_index / N0) / N1) % N2;
     snprintf(p1, MAXPATHLEN, "%s/%02X/%02X",
              SD->path, D1, D2);
-    debugs(36, 3, HERE << "Cleaning directory " << p1);
+    debugs(36, 3, "Cleaning directory " << p1);
     dir_pointer = opendir(p1);
 
     if (!dir_pointer) {
@@ -1399,13 +1399,13 @@ Fs::Ufs::UFSSwapDir::DirClean(int swap_index)
         k = 10;
 
     for (n = 0; n < k; ++n) {
-        debugs(36, 3, HERE << "Cleaning file "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << files[n]);
+        debugs(36, 3, "Cleaning file "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << files[n]);
         snprintf(p2, MAXPATHLEN + 1, "%s/%08X", p1, files[n]);
         safeunlink(p2, 0);
         ++statCounter.swap.files_cleaned;
     }
 
-    debugs(36, 3, HERE << "Cleaned " << k << " unused files from " << p1);
+    debugs(36, 3, "Cleaned " << k << " unused files from " << p1);
     return k;
 }
 

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -709,7 +709,7 @@ static void
 gopherTimeout(const CommTimeoutCbParams &io)
 {
     GopherStateData *gopherState = static_cast<GopherStateData *>(io.data);
-    debugs(10, 4, HERE << io.conn << ": '" << gopherState->entry->url() << "'" );
+    debugs(10, 4, io.conn << ": '" << gopherState->entry->url() << "'" );
 
     gopherState->fwd->fail(new ErrorState(ERR_READ_TIMEOUT, Http::scGatewayTimeout, gopherState->fwd->request));
 
@@ -761,7 +761,7 @@ gopherReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm
         statCounter.server.other.kbytes_in += len;
     }
 
-    debugs(10, 5, HERE << conn << " read len=" << len);
+    debugs(10, 5, conn << " read len=" << len);
 
     if (flag == Comm::OK && len > 0) {
         AsyncCall::Pointer nil;
@@ -830,7 +830,7 @@ gopherSendComplete(const Comm::ConnectionPointer &conn, char *, size_t size, Com
 {
     GopherStateData *gopherState = (GopherStateData *) data;
     StoreEntry *entry = gopherState->entry;
-    debugs(10, 5, HERE << conn << " size: " << size << " errflag: " << errflag);
+    debugs(10, 5, conn << " size: " << size << " errflag: " << errflag);
 
     if (size > 0) {
         fd_bytes(conn->fd, size, FD_WRITE);

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -538,7 +538,7 @@ void statefulhelper::submit(const char *buf, HLPCB * callback, void *data, helpe
 void
 helperStatefulReleaseServer(helper_stateful_server * srv)
 {
-    debugs(84, 3, HERE << "srv-" << srv->index << " flags.reserved = " << srv->flags.reserved);
+    debugs(84, 3, "srv-" << srv->index << " flags.reserved = " << srv->flags.reserved);
     if (!srv->flags.reserved)
         return;
 
@@ -1494,7 +1494,7 @@ helper_server::checkForTimedOutRequests(bool const retry)
 void
 helper_server::requestTimeout(const CommTimeoutCbParams &io)
 {
-    debugs(26, 3, HERE << io.conn);
+    debugs(26, 3, io.conn);
     helper_server *srv = static_cast<helper_server *>(io.data);
 
     if (!cbdataReferenceValid(srv))
@@ -1502,7 +1502,7 @@ helper_server::requestTimeout(const CommTimeoutCbParams &io)
 
     srv->checkForTimedOutRequests(srv->parent->retryTimedOut);
 
-    debugs(84, 3, HERE << io.conn << " establish new helper_server::requestTimeout");
+    debugs(84, 3, io.conn << " establish new helper_server::requestTimeout");
     AsyncCall::Pointer timeoutCall = commCbCall(84, 4, "helper_server::requestTimeout",
                                      CommTimeoutCbPtrFun(helper_server::requestTimeout, srv));
 

--- a/src/http.cc
+++ b/src/http.cc
@@ -92,7 +92,7 @@ HttpStateData::HttpStateData(FwdState *theFwdState) :
     payloadTruncated(0),
     sawDateGoBack(false)
 {
-    debugs(11,5,HERE << "HttpStateData " << this << " created");
+    debugs(11,5,"HttpStateData " << this << " created");
     ignoreCacheControl = false;
     surrogateNoStore = false;
     serverConnection = fwd->serverConnection();
@@ -138,7 +138,7 @@ HttpStateData::~HttpStateData()
 
     cbdataReferenceDone(_peer);
 
-    debugs(11,5, HERE << "HttpStateData " << this << " destroyed; " << serverConnection);
+    debugs(11,5, "HttpStateData " << this << " destroyed; " << serverConnection);
 }
 
 const Comm::ConnectionPointer &
@@ -413,12 +413,12 @@ HttpStateData::reusableReply(HttpStateData::ReuseDecision &decision)
         bool mayStore = false;
         // HTTPbis pt6 section 3.2: a response CC:public is present
         if (rep->cache_control->hasPublic()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:public");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:public");
             mayStore = true;
 
             // HTTPbis pt6 section 3.2: a response CC:must-revalidate is present
         } else if (rep->cache_control->hasMustRevalidate()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:must-revalidate");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:must-revalidate");
             mayStore = true;
 
 #if USE_HTTP_VIOLATIONS
@@ -427,13 +427,13 @@ HttpStateData::reusableReply(HttpStateData::ReuseDecision &decision)
             // some. The caching+revalidate is not exactly unsafe though with Squids interpretation of no-cache
             // (without parameters) as equivalent to must-revalidate in the reply.
         } else if (rep->cache_control->hasNoCacheWithoutParameters()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:no-cache (equivalent to must-revalidate)");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:no-cache (equivalent to must-revalidate)");
             mayStore = true;
 #endif
 
             // HTTPbis pt6 section 3.2: a response CC:s-maxage is present
         } else if (rep->cache_control->hasSMaxAge()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:s-maxage");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:s-maxage");
             mayStore = true;
         }
 
@@ -808,14 +808,14 @@ HttpStateData::handle1xx(HttpReply *reply)
         ch.reply = reply;
         HTTPMSGLOCK(ch.reply);
         if (!ch.fastCheck().allowed()) { // TODO: support slow lookups?
-            debugs(11, 3, HERE << "ignoring denied 1xx");
+            debugs(11, 3, "ignoring denied 1xx");
             proceedAfter1xx();
             return;
         }
     }
 #endif // USE_HTTP_VIOLATIONS
 
-    debugs(11, 2, HERE << "forwarding 1xx to client");
+    debugs(11, 2, "forwarding 1xx to client");
 
     // the Sink will use this to call us back after writing 1xx to the client
     typedef NullaryMemFunT<HttpStateData> CbDialer;
@@ -1067,7 +1067,7 @@ HttpStateData::statusIfComplete() const
 HttpStateData::ConnectionStatus
 HttpStateData::persistentConnStatus() const
 {
-    debugs(11, 3, HERE << serverConnection << " eof=" << eof);
+    debugs(11, 3, serverConnection << " eof=" << eof);
     if (eof) // already reached EOF
         return COMPLETE_NONPERSISTENT_MSG;
 
@@ -1230,7 +1230,7 @@ HttpStateData::processReply()
 {
 
     if (flags.handling1xx) { // we came back after handling a 1xx response
-        debugs(11, 5, HERE << "done with 1xx handling");
+        debugs(11, 5, "done with 1xx handling");
         flags.handling1xx = false;
         Must(!flags.headers_parsed);
     }
@@ -1259,7 +1259,7 @@ bool
 HttpStateData::continueAfterParsingHeader()
 {
     if (flags.handling1xx) {
-        debugs(11, 5, HERE << "wait for 1xx handling");
+        debugs(11, 5, "wait for 1xx handling");
         Must(!flags.headers_parsed);
         return false;
     }
@@ -1402,7 +1402,7 @@ HttpStateData::processReplyBody()
     }
 
 #if USE_ADAPTATION
-    debugs(11,5, HERE << "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
+    debugs(11,5, "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
     if (adaptationAccessCheckPending)
         return;
 
@@ -1575,7 +1575,7 @@ HttpStateData::maybeMakeSpaceAvailable(bool doGrow)
 void
 HttpStateData::wroteLast(const CommIoCbParams &io)
 {
-    debugs(11, 5, HERE << serverConnection << ": size " << io.size << ": errflag " << io.flag << ".");
+    debugs(11, 5, serverConnection << ": size " << io.size << ": errflag " << io.flag << ".");
 #if URL_CHECKSUM_DEBUG
 
     entry->mem_obj->checkUrlChecksum();
@@ -1626,7 +1626,7 @@ HttpStateData::sendComplete()
 void
 HttpStateData::closeServer()
 {
-    debugs(11,5, HERE << "closing HTTP server " << serverConnection << " this " << this);
+    debugs(11,5, "closing HTTP server " << serverConnection << " this " << this);
 
     if (Comm::IsConnOpen(serverConnection)) {
         fwd->unregister(serverConnection);
@@ -2176,10 +2176,10 @@ HttpStateData::sendRequest()
 {
     MemBuf mb;
 
-    debugs(11, 5, HERE << serverConnection << ", request " << request << ", this " << this << ".");
+    debugs(11, 5, serverConnection << ", request " << request << ", this " << this << ".");
 
     if (!Comm::IsConnOpen(serverConnection)) {
-        debugs(11,3, HERE << "cannot send request to closing " << serverConnection);
+        debugs(11,3, "cannot send request to closing " << serverConnection);
         assert(closeHandler != NULL);
         return false;
     }
@@ -2324,18 +2324,18 @@ HttpStateData::finishingBrokenPost()
 {
 #if USE_HTTP_VIOLATIONS
     if (!Config.accessList.brokenPosts) {
-        debugs(11, 5, HERE << "No brokenPosts list");
+        debugs(11, 5, "No brokenPosts list");
         return false;
     }
 
     ACLFilledChecklist ch(Config.accessList.brokenPosts, originalRequest().getRaw());
     if (!ch.fastCheck().allowed()) {
-        debugs(11, 5, HERE << "didn't match brokenPosts");
+        debugs(11, 5, "didn't match brokenPosts");
         return false;
     }
 
     if (!Comm::IsConnOpen(serverConnection)) {
-        debugs(11, 3, HERE << "ignoring broken POST for closed " << serverConnection);
+        debugs(11, 3, "ignoring broken POST for closed " << serverConnection);
         assert(closeHandler != NULL);
         return true; // prevent caller from proceeding as if nothing happened
     }
@@ -2356,7 +2356,7 @@ bool
 HttpStateData::finishingChunkedRequest()
 {
     if (flags.sentLastChunk) {
-        debugs(11, 5, HERE << "already sent last-chunk");
+        debugs(11, 5, "already sent last-chunk");
         return false;
     }
 
@@ -2373,7 +2373,7 @@ void
 HttpStateData::doneSendingRequestBody()
 {
     Client::doneSendingRequestBody();
-    debugs(11,5, HERE << serverConnection);
+    debugs(11,5, serverConnection);
 
     // do we need to write something after the last body byte?
     if (flags.chunked_request && finishingChunkedRequest())
@@ -2392,7 +2392,7 @@ HttpStateData::handleMoreRequestBodyAvailable()
         // XXX: we should check this condition in other callbacks then!
         // TODO: Check whether this can actually happen: We should unsubscribe
         // as a body consumer when the above condition(s) are detected.
-        debugs(11, DBG_IMPORTANT, HERE << "Transaction aborted while reading HTTP body");
+        debugs(11, DBG_IMPORTANT, "Transaction aborted while reading HTTP body");
         return;
     }
 
@@ -2448,7 +2448,7 @@ HttpStateData::sentRequestBody(const CommIoCbParams &io)
 void
 HttpStateData::abortAll(const char *reason)
 {
-    debugs(11,5, HERE << "aborting transaction for " << reason <<
+    debugs(11,5, "aborting transaction for " << reason <<
            "; " << serverConnection << ", this " << this);
     mustStop(reason);
 }

--- a/src/icmp/Icmp4.cc
+++ b/src/icmp/Icmp4.cc
@@ -133,7 +133,7 @@ Icmp4::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
     ((sockaddr_in*)S->ai_addr)->sin_port = 0;
     assert(icmp_pktsize <= MAX_PKT4_SZ);
 
-    debugs(42, 5, HERE << "Send ICMP packet to " << to << ".");
+    debugs(42, 5, "Send ICMP packet to " << to << ".");
 
     x = sendto(icmp_sock,
                (const void *) pkt,
@@ -165,7 +165,7 @@ Icmp4::Recv(void)
     static pingerReplyData preply;
 
     if (icmp_sock < 0) {
-        debugs(42, DBG_CRITICAL, HERE << "No socket! Recv() should not be called.");
+        debugs(42, DBG_CRITICAL, "No socket! Recv() should not be called.");
         return;
     }
 
@@ -181,7 +181,7 @@ Icmp4::Recv(void)
                  &from->ai_addrlen);
 
     if (n <= 0) {
-        debugs(42, DBG_CRITICAL, HERE << "Error when calling recvfrom() on ICMP socket.");
+        debugs(42, DBG_CRITICAL, "Error when calling recvfrom() on ICMP socket.");
         Ip::Address::FreeAddr(from);
         return;
     }
@@ -198,7 +198,7 @@ Icmp4::Recv(void)
 
 #endif
 
-    debugs(42, 8, HERE << n << " bytes from " << preply.from);
+    debugs(42, 8, n << " bytes from " << preply.from);
 
     ip = (struct iphdr *) (void *) pkt;
 
@@ -243,7 +243,7 @@ Icmp4::Recv(void)
     preply.psize = n - iphdrlen - (sizeof(icmpEchoData) - MAX_PKT4_SZ);
 
     if (preply.psize < 0) {
-        debugs(42, DBG_CRITICAL, HERE << "Malformed ICMP packet.");
+        debugs(42, DBG_CRITICAL, "Malformed ICMP packet.");
         Ip::Address::FreeAddr(from);
         return;
     }

--- a/src/icmp/Icmp6.cc
+++ b/src/icmp/Icmp6.cc
@@ -169,7 +169,7 @@ Icmp6::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     assert(icmp6_pktsize <= MAX_PKT6_SZ);
 
-    debugs(42, 5, HERE << "Send Icmp6 packet to " << to << ".");
+    debugs(42, 5, "Send Icmp6 packet to " << to << ".");
 
     x = sendto(icmp_sock,
                (const void *) pkt,
@@ -182,7 +182,7 @@ Icmp6::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
         int xerrno = errno;
         debugs(42, DBG_IMPORTANT, MYNAME << "ERROR: sending to ICMPv6 packet to " << to << ": " << xstrerr(xerrno));
     }
-    debugs(42,9, HERE << "x=" << x);
+    debugs(42,9, "x=" << x);
 
     Log(to, 0, NULL, 0, 0);
     Ip::Address::FreeAddr(S);
@@ -204,7 +204,7 @@ Icmp6::Recv(void)
     static pingerReplyData preply;
 
     if (icmp_sock < 0) {
-        debugs(42, DBG_CRITICAL, HERE << "dropping ICMPv6 read. No socket!?");
+        debugs(42, DBG_CRITICAL, "dropping ICMPv6 read. No socket!?");
         return;
     }
 
@@ -222,7 +222,7 @@ Icmp6::Recv(void)
                  &from->ai_addrlen);
 
     if (n <= 0) {
-        debugs(42, DBG_CRITICAL, HERE << "Error when calling recvfrom() on ICMPv6 socket.");
+        debugs(42, DBG_CRITICAL, "Error when calling recvfrom() on ICMPv6 socket.");
         Ip::Address::FreeAddr(from);
         return;
     }
@@ -239,7 +239,7 @@ Icmp6::Recv(void)
 
 #endif
 
-    debugs(42, 8, HERE << n << " bytes from " << preply.from);
+    debugs(42, 8, n << " bytes from " << preply.from);
 
 // FIXME INET6 : The IPv6 Header (ip6_hdr) is not availble directly >:-(
 //
@@ -260,7 +260,7 @@ Icmp6::Recv(void)
         ip = (struct ip6_hdr *) pkt;
         FIXME  += sizeof(ip6_hdr);
 
-    debugs(42, DBG_CRITICAL, HERE << "ip6_nxt=" << ip->ip6_nxt <<
+    debugs(42, DBG_CRITICAL, "ip6_nxt=" << ip->ip6_nxt <<
             ", ip6_plen=" << ip->ip6_plen <<
             ", ip6_hlim=" << ip->ip6_hlim <<
             ", ip6_hops=" << ip->ip6_hops   <<
@@ -280,7 +280,7 @@ Icmp6::Recv(void)
             break;
 
         default:
-            debugs(42, 8, HERE << preply.from << " said: " << icmp6header->icmp6_type << "/" << (int)icmp6header->icmp6_code << " " <<
+            debugs(42, 8, preply.from << " said: " << icmp6header->icmp6_type << "/" << (int)icmp6header->icmp6_code << " " <<
                    IcmpPacketType(icmp6header->icmp6_type));
         }
         Ip::Address::FreeAddr(from);
@@ -288,7 +288,7 @@ Icmp6::Recv(void)
     }
 
     if (icmp6header->icmp6_id != icmp_ident) {
-        debugs(42, 8, HERE << "dropping Icmp6 read. IDENT check failed. ident=='" << icmp_ident << "'=='" << icmp6header->icmp6_id << "'");
+        debugs(42, 8, "dropping Icmp6 read. IDENT check failed. ident=='" << icmp_ident << "'=='" << icmp6header->icmp6_id << "'");
         Ip::Address::FreeAddr(from);
         return;
     }

--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -186,14 +186,14 @@ IcmpPinger::Recv(void)
     guess_size = n - (sizeof(pingerEchoData) - PINGER_PAYLOAD_SZ);
 
     if (guess_size != pecho.psize) {
-        debugs(42, 2, HERE << "size mismatch, guess=" << guess_size << ", psize=" << pecho.psize);
+        debugs(42, 2, "size mismatch, guess=" << guess_size << ", psize=" << pecho.psize);
         /* don't process this message, but keep running */
         return;
     }
 
     /* pass request for ICMPv6 handing */
     if (pecho.to.isIPv6()) {
-        debugs(42, 2, HERE << " Pass " << pecho.to << " off to ICMPv6 module.");
+        debugs(42, 2, "Pass " << pecho.to << " off to ICMPv6 module.");
         icmp6.SendEcho(pecho.to,
                        pecho.opcode,
                        pecho.payload,
@@ -202,20 +202,20 @@ IcmpPinger::Recv(void)
 
     /* pass the packet for ICMP handling */
     else if (pecho.to.isIPv4()) {
-        debugs(42, 2, HERE << " Pass " << pecho.to << " off to ICMPv4 module.");
+        debugs(42, 2, "Pass " << pecho.to << " off to ICMPv4 module.");
         icmp4.SendEcho(pecho.to,
                        pecho.opcode,
                        pecho.payload,
                        pecho.psize);
     } else {
-        debugs(42, DBG_IMPORTANT, HERE << " IP has unknown Type. " << pecho.to );
+        debugs(42, DBG_IMPORTANT, "IP has unknown Type. " << pecho.to );
     }
 }
 
 void
 IcmpPinger::SendResult(pingerReplyData &preply, int len)
 {
-    debugs(42, 2, HERE << "return result to squid. len=" << len);
+    debugs(42, 2, "return result to squid. len=" << len);
 
     if (send(socket_to_squid, &preply, len, 0) < 0) {
         int xerrno = errno;

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -56,7 +56,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     /** \li Does nothing if the pinger socket is not available. */
     if (icmp_sock < 0) {
-        debugs(37, 2, HERE << " Socket Closed. Aborted send to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
+        debugs(37, 2, "Socket Closed. Aborted send to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
         return;
     }
 
@@ -88,7 +88,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     slen = sizeof(pingerEchoData) - PINGER_PAYLOAD_SZ + pecho.psize;
 
-    debugs(37, 2, HERE << "to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
+    debugs(37, 2, "to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
 
     x = comm_udp_send(icmp_sock, (char *)&pecho, slen, 0);
 
@@ -104,7 +104,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
         }
         /** All other send errors are ignored. */
     } else if (x != slen) {
-        debugs(37, DBG_IMPORTANT, HERE << "Wrote " << x << " of " << slen << " bytes");
+        debugs(37, DBG_IMPORTANT, "Wrote " << x << " of " << slen << " bytes");
     }
 }
 
@@ -161,16 +161,16 @@ IcmpSquid::Recv()
     switch (preply.opcode) {
 
     case S_ICMP_ECHO:
-        debugs(37,4, HERE << " ICMP_ECHO of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
+        debugs(37,4, "ICMP_ECHO of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
         break;
 
     case S_ICMP_DOM:
-        debugs(37,4, HERE << " DomainPing of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
+        debugs(37,4, "DomainPing of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
         netdbHandlePingReply(F, preply.hops, preply.rtt);
         break;
 
     default:
-        debugs(37, DBG_IMPORTANT, HERE << "Bad opcode: " << preply.opcode << " from " << F);
+        debugs(37, DBG_IMPORTANT, "Bad opcode: " << preply.opcode << " from " << F);
         break;
     }
 }
@@ -181,7 +181,7 @@ void
 IcmpSquid::DomainPing(Ip::Address &to, const char *domain)
 {
 #if USE_ICMP
-    debugs(37, 4, HERE << "'" << domain << "' (" << to << ")");
+    debugs(37, 4, "'" << domain << "' (" << to << ")");
     SendEcho(to, S_ICMP_DOM, domain, 0);
 #endif
 }
@@ -232,7 +232,7 @@ IcmpSquid::Open(void)
 
     commUnsetFdTimeout(icmp_sock);
 
-    debugs(37, DBG_IMPORTANT, HERE << "Pinger socket opened on FD " << icmp_sock);
+    debugs(37, DBG_IMPORTANT, "Pinger socket opened on FD " << icmp_sock);
 
     /* Tests the pinger immediately using localhost */
     if (Ip::EnableIpv6)
@@ -242,7 +242,7 @@ IcmpSquid::Open(void)
 
 #if _SQUID_WINDOWS_
 
-    debugs(37, 4, HERE << "Pinger handle: 0x" << std::hex << hIpc << std::dec << ", PID: " << pid);
+    debugs(37, 4, "Pinger handle: 0x" << std::hex << hIpc << std::dec << ", PID: " << pid);
 
 #endif /* _SQUID_WINDOWS_ */
     return icmp_sock;
@@ -259,7 +259,7 @@ IcmpSquid::Close(void)
     if (icmp_sock < 0)
         return;
 
-    debugs(37, DBG_IMPORTANT, HERE << "Closing Pinger socket on FD " << icmp_sock);
+    debugs(37, DBG_IMPORTANT, "Closing Pinger socket on FD " << icmp_sock);
 
 #if _SQUID_WINDOWS_
 
@@ -274,7 +274,7 @@ IcmpSquid::Close(void)
     if (hIpc) {
         if (WaitForSingleObject(hIpc, 12000) != WAIT_OBJECT_0) {
             getCurrentTime();
-            debugs(37, DBG_CRITICAL, HERE << "WARNING: (pinger," << pid << ") didn't exit in 12 seconds");
+            debugs(37, DBG_CRITICAL, "WARNING: (pinger," << pid << ") didn't exit in 12 seconds");
         }
 
         CloseHandle(hIpc);

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -221,7 +221,7 @@ main(int argc, char *argv[])
 
         if (x < 0) {
             int xerrno = errno;
-            debugs(42, DBG_CRITICAL, HERE << " FATAL Shutdown. select()==" << x << ", ERR: " << xstrerr(xerrno));
+            debugs(42, DBG_CRITICAL, "FATAL Shutdown. select()==" << x << ", ERR: " << xstrerr(xerrno));
             control.Close();
             exit(EXIT_FAILURE);
         }

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -56,7 +56,7 @@ void
 ACLIdent::parse()
 {
     if (!data) {
-        debugs(28, 3, HERE << "current is null. Creating");
+        debugs(28, 3, "current is null. Creating");
         data = new ACLUserData;
     }
 
@@ -78,7 +78,7 @@ ACLIdent::match(ACLChecklist *cl)
         }
         // else fall through to ACCESS_DUNNO failure below
     } else {
-        debugs(28, DBG_IMPORTANT, HERE << "Can't start ident lookup. No client connection" );
+        debugs(28, DBG_IMPORTANT, "Can't start ident lookup. No client connection" );
         // fall through to ACCESS_DUNNO failure below
     }
 
@@ -119,7 +119,7 @@ IdentLookup::checkForAsync(ACLChecklist *cl)const
     const ConnStateData *conn = checklist->conn();
     // check that ACLIdent::match() tested this lookup precondition
     assert(conn && Comm::IsConnOpen(conn->clientConnection));
-    debugs(28, 3, HERE << "Doing ident lookup" );
+    debugs(28, 3, "Doing ident lookup" );
     Ident::Start(checklist->conn()->clientConnection, LookupDone, checklist);
 }
 

--- a/src/ident/Ident.cc
+++ b/src/ident/Ident.cc
@@ -118,7 +118,7 @@ Ident::Close(const CommCloseCbParams &params)
 void
 Ident::Timeout(const CommTimeoutCbParams &io)
 {
-    debugs(30, 3, HERE << io.conn);
+    debugs(30, 3, io.conn);
     IdentStateData *state = (IdentStateData *)io.data;
     state->deleteThis("timeout");
 }
@@ -166,11 +166,11 @@ Ident::ConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int, 
 void
 Ident::WriteFeedback(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::Flag flag, int xerrno, void *data)
 {
-    debugs(30, 5, HERE << conn << ": Wrote IDENT request " << len << " bytes.");
+    debugs(30, 5, conn << ": Wrote IDENT request " << len << " bytes.");
 
     // TODO handle write errors better. retry or abort?
     if (flag != Comm::OK) {
-        debugs(30, 2, HERE << conn << " err-flags=" << flag << " IDENT write error: " << xstrerr(xerrno));
+        debugs(30, 2, conn << " err-flags=" << flag << " IDENT write error: " << xstrerr(xerrno));
         IdentStateData *state = (IdentStateData *)data;
         state->deleteThis("write error");
     }
@@ -204,7 +204,7 @@ Ident::ReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Com
     if ((t = strchr(buf, '\n')))
         *t = '\0';
 
-    debugs(30, 5, HERE << conn << ": Read '" << buf << "'");
+    debugs(30, 5, conn << ": Read '" << buf << "'");
 
     if (strstr(buf, "USERID")) {
         if ((ident = strrchr(buf, ':'))) {

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -386,7 +386,7 @@ Ip::Address::lookupHostIP(const char *s, bool nodns)
     int err = 0;
     struct addrinfo *res = NULL;
     if ( (err = getaddrinfo(s, NULL, &want, &res)) != 0) {
-        debugs(14,3, HERE << "Given Non-IP '" << s << "': " << gai_strerror(err) );
+        debugs(14,3, "Given Non-IP '" << s << "': " << gai_strerror(err) );
         /* free the memory getaddrinfo() dynamically allocated. */
         if (res)
             freeaddrinfo(res);
@@ -945,7 +945,7 @@ Ip::Address::getSockAddr(struct sockaddr_storage &addr, const int family) const
 
     if ( family == AF_INET && !isIPv4()) {
         // FIXME INET6: caller using the wrong socket type!
-        debugs(14, DBG_CRITICAL, HERE << "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this);
+        debugs(14, DBG_CRITICAL, "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this);
         assert(false);
     }
 
@@ -968,7 +968,7 @@ Ip::Address::getSockAddr(struct sockaddr_in &buf) const
         buf.sin_port = mSocketAddr_.sin6_port;
         map6to4( mSocketAddr_.sin6_addr, buf.sin_addr);
     } else {
-        debugs(14, DBG_CRITICAL, HERE << "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this );
+        debugs(14, DBG_CRITICAL, "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this );
 
         memset(&buf,0xFFFFFFFF,sizeof(struct sockaddr_in));
         assert(false);
@@ -1045,7 +1045,7 @@ Ip::Address::getInAddr(struct in_addr &buf) const
     // default:
     // non-compatible IPv6 Pure Address
 
-    debugs(14, DBG_IMPORTANT, HERE << "Ip::Address::getInAddr : Cannot convert non-IPv4 to IPv4. IPA=" << *this);
+    debugs(14, DBG_IMPORTANT, "Ip::Address::getInAddr : Cannot convert non-IPv4 to IPv4. IPA=" << *this);
     memset(&buf,0xFFFFFFFF,sizeof(struct in_addr));
     assert(false);
     return false;

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -170,7 +170,7 @@ Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn, int)
      * We will simply attempt a bind outgoing on our own IP.
      */
     newConn->remote.port(0); // allow random outgoing port to prevent address clashes
-    debugs(89, 5, HERE << "address TPROXY: " << newConn);
+    debugs(89, 5, "address TPROXY: " << newConn);
     return true;
 #else
     return false;
@@ -185,7 +185,7 @@ Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn, int)
      * There is no way to identify whether they came from NAT or not.
      * Trust the user configured properly.
      */
-    debugs(89, 5, HERE << "address NAT: " << newConn);
+    debugs(89, 5, "address NAT: " << newConn);
     return true;
 #else
     return false;
@@ -290,7 +290,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
             natfd = -1;
         }
 
-        debugs(89, 9, HERE << "address: " << newConn);
+        debugs(89, 9, "address: " << newConn);
         return false;
     } else {
 #if IPFILTER_VERSION < 5000003
@@ -302,7 +302,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
             newConn->local = natLookup.nl_realipaddr.in4;
 #endif
         newConn->local.port(ntohs(natLookup.nl_realport));
-        debugs(89, 5, HERE << "address NAT: " << newConn);
+        debugs(89, 5, "address NAT: " << newConn);
         return true;
     }
 
@@ -322,7 +322,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
      *
      * Trust the user configured properly.
      */
-    debugs(89, 5, HERE << "address NAT divert-to: " << newConn);
+    debugs(89, 5, "address NAT divert-to: " << newConn);
     return true;
 
 #else /* USE_NAT_DEVPF / --with-nat-devpf */
@@ -364,13 +364,13 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
         int xerrno = errno;
         if (xerrno != ENOENT) {
             if (!silent) {
-                debugs(89, DBG_IMPORTANT, HERE << "PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
+                debugs(89, DBG_IMPORTANT, "PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
                 lastReported_ = squid_curtime;
             }
             close(pffd);
             pffd = -1;
         }
-        debugs(89, 9, HERE << "address: " << newConn);
+        debugs(89, 9, "address: " << newConn);
         return false;
     } else {
         if (newConn->remote.isIPv6())
@@ -378,7 +378,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
         else
             newConn->local = nl.rdaddr.v4;
         newConn->local.port(ntohs(nl.rdport));
-        debugs(89, 5, HERE << "address NAT: " << newConn);
+        debugs(89, 5, "address NAT: " << newConn);
         return true;
     }
 #endif /* --with-nat-devpf */
@@ -403,7 +403,7 @@ Ip::Intercept::Lookup(const Comm::ConnectionPointer &newConn, const Comm::Connec
     int silent = 0;
 #endif
 
-    debugs(89, 5, HERE << "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
+    debugs(89, 5, "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
 
     newConn->flags |= (listenConn->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION));
 

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -53,7 +53,7 @@ Ipc::StrandCoord* Ipc::Coordinator::findStrand(int kidId)
 
 void Ipc::Coordinator::registerStrand(const StrandCoord& strand)
 {
-    debugs(54, 3, HERE << "registering kid" << strand.kidId <<
+    debugs(54, 3, "registering kid" << strand.kidId <<
            ' ' << strand.tag);
     if (StrandCoord* found = findStrand(strand.kidId)) {
         const String oldTag = found->tag;
@@ -80,32 +80,32 @@ void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 {
     switch (message.type()) {
     case mtRegistration:
-        debugs(54, 6, HERE << "Registration request");
+        debugs(54, 6, "Registration request");
         handleRegistrationRequest(HereIamMessage(message));
         break;
 
     case mtStrandSearchRequest: {
         const StrandSearchRequest sr(message);
-        debugs(54, 6, HERE << "Strand search request: " << sr.requestorId <<
+        debugs(54, 6, "Strand search request: " << sr.requestorId <<
                " tag: " << sr.tag);
         handleSearchRequest(sr);
         break;
     }
 
     case mtSharedListenRequest:
-        debugs(54, 6, HERE << "Shared listen request");
+        debugs(54, 6, "Shared listen request");
         handleSharedListenRequest(SharedListenRequest(message));
         break;
 
     case mtCacheMgrRequest: {
-        debugs(54, 6, HERE << "Cache manager request");
+        debugs(54, 6, "Cache manager request");
         const Mgr::Request req(message);
         handleCacheMgrRequest(req);
     }
     break;
 
     case mtCacheMgrResponse: {
-        debugs(54, 6, HERE << "Cache manager response");
+        debugs(54, 6, "Cache manager response");
         const Mgr::Response resp(message);
         handleCacheMgrResponse(resp);
     }
@@ -113,14 +113,14 @@ void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 
 #if SQUID_SNMP
     case mtSnmpRequest: {
-        debugs(54, 6, HERE << "SNMP request");
+        debugs(54, 6, "SNMP request");
         const Snmp::Request req(message);
         handleSnmpRequest(req);
     }
     break;
 
     case mtSnmpResponse: {
-        debugs(54, 6, HERE << "SNMP response");
+        debugs(54, 6, "SNMP response");
         const Snmp::Response resp(message);
         handleSnmpResponse(resp);
     }
@@ -128,7 +128,7 @@ void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 #endif
 
     default:
-        debugs(54, DBG_IMPORTANT, HERE << "Unhandled message type: " << message.type());
+        debugs(54, DBG_IMPORTANT, "Unhandled message type: " << message.type());
         break;
     }
 }
@@ -146,14 +146,14 @@ void Ipc::Coordinator::handleRegistrationRequest(const HereIamMessage& msg)
 void
 Ipc::Coordinator::handleSharedListenRequest(const SharedListenRequest& request)
 {
-    debugs(54, 4, HERE << "kid" << request.requestorId <<
+    debugs(54, 4, "kid" << request.requestorId <<
            " needs shared listen FD for " << request.params.addr);
     Listeners::const_iterator i = listeners.find(request.params);
     int errNo = 0;
     const Comm::ConnectionPointer c = (i != listeners.end()) ?
                                       i->second : openListenSocket(request, errNo);
 
-    debugs(54, 3, HERE << "sending shared listen " << c << " for " <<
+    debugs(54, 3, "sending shared listen " << c << " for " <<
            request.params.addr << " to kid" << request.requestorId <<
            " mapId=" << request.mapId);
 
@@ -166,7 +166,7 @@ Ipc::Coordinator::handleSharedListenRequest(const SharedListenRequest& request)
 void
 Ipc::Coordinator::handleCacheMgrRequest(const Mgr::Request& request)
 {
-    debugs(54, 4, HERE);
+    debugs(54, 4, "");
 
     try {
         Mgr::Action::Pointer action =
@@ -212,7 +212,7 @@ Ipc::Coordinator::handleSearchRequest(const Ipc::StrandSearchRequest &request)
     }
 
     searchers.push_back(request);
-    debugs(54, 3, HERE << "cannot yet tell kid" << request.requestorId <<
+    debugs(54, 3, "cannot yet tell kid" << request.requestorId <<
            " who " << request.tag << " is");
 }
 
@@ -220,7 +220,7 @@ void
 Ipc::Coordinator::notifySearcher(const Ipc::StrandSearchRequest &request,
                                  const StrandCoord& strand)
 {
-    debugs(54, 3, HERE << "tell kid" << request.requestorId << " that " <<
+    debugs(54, 3, "tell kid" << request.requestorId << " that " <<
            request.tag << " is kid" << strand.kidId);
     const StrandSearchResponse response(strand);
     TypedMsgHdr message;
@@ -232,7 +232,7 @@ Ipc::Coordinator::notifySearcher(const Ipc::StrandSearchRequest &request,
 void
 Ipc::Coordinator::handleSnmpRequest(const Snmp::Request& request)
 {
-    debugs(54, 4, HERE);
+    debugs(54, 4, "");
 
     Snmp::Response response(request.requestId);
     TypedMsgHdr message;
@@ -245,7 +245,7 @@ Ipc::Coordinator::handleSnmpRequest(const Snmp::Request& request)
 void
 Ipc::Coordinator::handleSnmpResponse(const Snmp::Response& response)
 {
-    debugs(54, 4, HERE);
+    debugs(54, 4, "");
     Snmp::Inquirer::HandleRemoteAck(response);
 }
 #endif
@@ -256,7 +256,7 @@ Ipc::Coordinator::openListenSocket(const SharedListenRequest& request,
 {
     const OpenListenerParams &p = request.params;
 
-    debugs(54, 6, HERE << "opening listen FD at " << p.addr << " for kid" <<
+    debugs(54, 6, "opening listen FD at " << p.addr << " for kid" <<
            request.requestorId);
 
     Comm::ConnectionPointer newConn = new Comm::Connection;
@@ -268,7 +268,7 @@ Ipc::Coordinator::openListenSocket(const SharedListenRequest& request,
     errNo = Comm::IsConnOpen(newConn) ? 0 : errno;
     leave_suid();
 
-    debugs(54, 6, HERE << "tried listening on " << newConn << " for kid" <<
+    debugs(54, 6, "tried listening on " << newConn << " for kid" <<
            request.requestorId);
 
     // cache positive results
@@ -282,7 +282,7 @@ void Ipc::Coordinator::broadcastSignal(int sig) const
 {
     typedef StrandCoords::const_iterator SCI;
     for (SCI iter = strands_.begin(); iter != strands_.end(); ++iter) {
-        debugs(54, 5, HERE << "signal " << sig << " to kid" << iter->kidId <<
+        debugs(54, 5, "signal " << sig << " to kid" << iter->kidId <<
                ", PID=" << iter->pid);
         kill(iter->pid, sig);
     }

--- a/src/ipc/FdNotes.cc
+++ b/src/ipc/FdNotes.cc
@@ -31,7 +31,7 @@ Ipc::FdNote(int fdNoteId)
     if (fdnNone < fdNoteId && fdNoteId < fdnEnd)
         return FdNotes[fdNoteId];
 
-    debugs(54, DBG_IMPORTANT, HERE << "salvaged bug: wrong fd_note ID: " << fdNoteId);
+    debugs(54, DBG_IMPORTANT, "salvaged bug: wrong fd_note ID: " << fdNoteId);
     return FdNotes[fdnNone];
 }
 

--- a/src/ipc/Forwarder.cc
+++ b/src/ipc/Forwarder.cc
@@ -27,12 +27,12 @@ Ipc::Forwarder::Forwarder(Request::Pointer aRequest, double aTimeout):
     AsyncJob("Ipc::Forwarder"),
     request(aRequest), timeout(aTimeout)
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
 }
 
 Ipc::Forwarder::~Forwarder()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
     Must(request->requestId == 0);
     cleanup();
 }
@@ -46,7 +46,7 @@ Ipc::Forwarder::cleanup()
 void
 Ipc::Forwarder::start()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
 
     typedef NullaryMemFunT<Forwarder> Dialer;
     AsyncCall::Pointer callback = JobCallback(54, 5, Dialer, this, Forwarder::handleRemoteAck);
@@ -73,7 +73,7 @@ Ipc::Forwarder::start()
 void
 Ipc::Forwarder::swanSong()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
     removeTimeoutEvent();
     if (request->requestId > 0) {
         DequeueRequest(request->requestId);
@@ -85,7 +85,7 @@ Ipc::Forwarder::swanSong()
 bool
 Ipc::Forwarder::doneAll() const
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
     return request->requestId == 0;
 }
 
@@ -93,7 +93,7 @@ Ipc::Forwarder::doneAll() const
 void
 Ipc::Forwarder::handleRemoteAck()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     request->requestId = 0;
     // Do not clear ENTRY_FWD_HDR_WAIT or do entry->complete() because
     // it will trigger our client side processing. Let job cleanup close.
@@ -103,7 +103,7 @@ Ipc::Forwarder::handleRemoteAck()
 void
 Ipc::Forwarder::RequestTimedOut(void* param)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     Must(param != NULL);
     Forwarder* fwdr = static_cast<Forwarder*>(param);
     // use async call to enable job call protection that time events lack
@@ -114,7 +114,7 @@ Ipc::Forwarder::RequestTimedOut(void* param)
 void
 Ipc::Forwarder::requestTimedOut()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     handleTimeout();
 }
 
@@ -134,7 +134,7 @@ Ipc::Forwarder::handleTimeout()
 void
 Ipc::Forwarder::handleException(const std::exception& e)
 {
-    debugs(54, 3, HERE << e.what());
+    debugs(54, 3, e.what());
     mustStop("exception");
 }
 
@@ -144,7 +144,7 @@ Ipc::Forwarder::callException(const std::exception& e)
     try {
         handleException(e);
     } catch (const std::exception& ex) {
-        debugs(54, DBG_CRITICAL, HERE << ex.what());
+        debugs(54, DBG_CRITICAL, ex.what());
     }
     AsyncJob::callException(e);
 }
@@ -153,7 +153,7 @@ Ipc::Forwarder::callException(const std::exception& e)
 AsyncCall::Pointer
 Ipc::Forwarder::DequeueRequest(unsigned int requestId)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     Must(requestId != 0);
     AsyncCall::Pointer call;
     RequestsMap::iterator request = TheRequestsMap.find(requestId);
@@ -176,7 +176,7 @@ Ipc::Forwarder::removeTimeoutEvent()
 void
 Ipc::Forwarder::HandleRemoteAck(unsigned int requestId)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     Must(requestId != 0);
 
     AsyncCall::Pointer call = DequeueRequest(requestId);

--- a/src/ipc/Inquirer.cc
+++ b/src/ipc/Inquirer.cc
@@ -35,7 +35,7 @@ Ipc::Inquirer::Inquirer(Request::Pointer aRequest, const StrandCoords& coords,
     AsyncJob("Ipc::Inquirer"),
     request(aRequest), strands(coords), pos(strands.begin()), timeout(aTimeout)
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
 
     // order by ascending kid IDs; useful for non-aggregatable stats
     std::sort(strands.begin(), strands.end(), LesserStrandByKidId);
@@ -43,7 +43,7 @@ Ipc::Inquirer::Inquirer(Request::Pointer aRequest, const StrandCoords& coords,
 
 Ipc::Inquirer::~Inquirer()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
     cleanup();
 }
 
@@ -73,7 +73,7 @@ Ipc::Inquirer::inquire()
         ++LastRequestId;
     request->requestId = LastRequestId;
     const int kidId = pos->kidId;
-    debugs(54, 4, HERE << "inquire kid: " << kidId << status());
+    debugs(54, 4, "inquire kid: " << kidId << status());
     TheRequestsMap[request->requestId] = callback;
     TypedMsgHdr message;
     request->pack(message);
@@ -86,7 +86,7 @@ Ipc::Inquirer::inquire()
 void
 Ipc::Inquirer::handleRemoteAck(Response::Pointer response)
 {
-    debugs(54, 4, HERE << status());
+    debugs(54, 4, status());
     request->requestId = 0;
     removeTimeoutEvent();
     if (aggregate(response)) {
@@ -101,7 +101,7 @@ Ipc::Inquirer::handleRemoteAck(Response::Pointer response)
 void
 Ipc::Inquirer::swanSong()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
     removeTimeoutEvent();
     if (request->requestId > 0) {
         DequeueRequest(request->requestId);
@@ -120,18 +120,18 @@ Ipc::Inquirer::doneAll() const
 void
 Ipc::Inquirer::handleException(const std::exception& e)
 {
-    debugs(54, 3, HERE << e.what());
+    debugs(54, 3, e.what());
     mustStop("exception");
 }
 
 void
 Ipc::Inquirer::callException(const std::exception& e)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     try {
         handleException(e);
     } catch (const std::exception& ex) {
-        debugs(54, DBG_CRITICAL, HERE << ex.what());
+        debugs(54, DBG_CRITICAL, ex.what());
     }
     AsyncJob::callException(e);
 }
@@ -140,7 +140,7 @@ Ipc::Inquirer::callException(const std::exception& e)
 AsyncCall::Pointer
 Ipc::Inquirer::DequeueRequest(unsigned int requestId)
 {
-    debugs(54, 3, HERE << " requestId " << requestId);
+    debugs(54, 3, "requestId " << requestId);
     Must(requestId != 0);
     AsyncCall::Pointer call;
     RequestsMap::iterator request = TheRequestsMap.find(requestId);
@@ -177,7 +177,7 @@ Ipc::Inquirer::removeTimeoutEvent()
 void
 Ipc::Inquirer::RequestTimedOut(void* param)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     Must(param != NULL);
     Inquirer* cmi = static_cast<Inquirer*>(param);
     // use async call to enable job call protection that time events lack
@@ -188,7 +188,7 @@ Ipc::Inquirer::RequestTimedOut(void* param)
 void
 Ipc::Inquirer::requestTimedOut()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, "");
     if (request->requestId != 0) {
         DequeueRequest(request->requestId);
         request->requestId = 0;

--- a/src/ipc/Port.cc
+++ b/src/ipc/Port.cc
@@ -35,7 +35,7 @@ void Ipc::Port::start()
 
 void Ipc::Port::doListen()
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, "");
     buf.prepForReading();
     typedef CommCbMemFunT<Port, CommIoCbParams> Dialer;
     AsyncCall::Pointer readHandler = JobCallback(54, 6,
@@ -75,7 +75,7 @@ Ipc::Port::CoordinatorAddr()
 
 void Ipc::Port::noteRead(const CommIoCbParams& params)
 {
-    debugs(54, 6, HERE << params.conn << " flag " << params.flag <<
+    debugs(54, 6, params.conn << " flag " << params.flag <<
            " [" << this << ']');
     if (params.flag == Comm::OK) {
         assert(params.buf == buf.raw());

--- a/src/ipc/Queue.cc
+++ b/src/ipc/Queue.cc
@@ -47,7 +47,7 @@ InstanceIdDefinitions(Ipc::QueueReader, "ipcQR");
 Ipc::QueueReader::QueueReader(): popBlocked(true), popSignal(false),
     rateLimit(0), balance(0)
 {
-    debugs(54, 7, HERE << "constructed " << id);
+    debugs(54, 7, "constructed " << id);
 }
 
 /* QueueReaders */

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -439,7 +439,7 @@ BaseMultiQueue::pop(int &remoteProcessId, Value &value)
         OneToOneUniQueue &queue = inQueue(theLastPopProcessId);
         if (queue.pop(value, &localReader())) {
             remoteProcessId = theLastPopProcessId;
-            debugs(54, 7, HERE << "popped from " << remoteProcessId << " to " << theLocalProcessId << " at " << queue.size());
+            debugs(54, 7, "popped from " << remoteProcessId << " to " << theLocalProcessId << " at " << queue.size());
             return true;
         }
     }
@@ -452,7 +452,7 @@ BaseMultiQueue::push(const int remoteProcessId, const Value &value)
 {
     OneToOneUniQueue &remoteQueue = outQueue(remoteProcessId);
     QueueReader &reader = remoteReader(remoteProcessId);
-    debugs(54, 7, HERE << "pushing from " << theLocalProcessId << " to " << remoteProcessId << " at " << remoteQueue.size());
+    debugs(54, 7, "pushing from " << theLocalProcessId << " to " << remoteProcessId << " at " << remoteQueue.size());
     return remoteQueue.push(value, &reader);
 }
 
@@ -486,14 +486,14 @@ FewToFewBiQueue::findOldest(const int remoteProcessId, Value &value) const
 
     // we need the oldest value, so start with the incoming, them-to-us queue:
     const OneToOneUniQueue &in = inQueue(remoteProcessId);
-    debugs(54, 2, HERE << "peeking from " << remoteProcessId << " to " <<
+    debugs(54, 2, "peeking from " << remoteProcessId << " to " <<
            theLocalProcessId << " at " << in.size());
     if (in.peek(value))
         return true;
 
     // if the incoming queue is empty, check the outgoing, us-to-them queue:
     const OneToOneUniQueue &out = outQueue(remoteProcessId);
-    debugs(54, 2, HERE << "peeking from " << theLocalProcessId << " to " <<
+    debugs(54, 2, "peeking from " << theLocalProcessId << " to " <<
            remoteProcessId << " at " << out.size());
     return out.peek(value);
 }

--- a/src/ipc/StartListening.cc
+++ b/src/ipc/StartListening.cc
@@ -55,7 +55,7 @@ Ipc::StartListening(int sock_type, int proto, const Comm::ConnectionPointer &lis
     cbd->errNo = Comm::IsConnOpen(cbd->conn) ? 0 : errno;
     leave_suid();
 
-    debugs(54, 3, HERE << "opened listen " << cbd->conn);
+    debugs(54, 3, "opened listen " << cbd->conn);
     ScheduleCallHere(callback);
 }
 

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -50,7 +50,7 @@ void Ipc::Strand::start()
 
 void Ipc::Strand::registerSelf()
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, "");
     Must(!isRegistered);
 
     HereIamMessage ann(StrandCoord(KidIdentifier, getpid()));
@@ -62,7 +62,7 @@ void Ipc::Strand::registerSelf()
 
 void Ipc::Strand::receive(const TypedMsgHdr &message)
 {
-    debugs(54, 6, HERE << message.type());
+    debugs(54, 6, message.type());
     switch (message.type()) {
 
     case mtRegistration:
@@ -114,7 +114,7 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 #endif
 
     default:
-        debugs(54, DBG_IMPORTANT, HERE << "Unhandled message type: " << message.type());
+        debugs(54, DBG_IMPORTANT, "Unhandled message type: " << message.type());
         break;
     }
 }
@@ -147,20 +147,20 @@ void Ipc::Strand::handleCacheMgrResponse(const Mgr::Response& response)
 #if SQUID_SNMP
 void Ipc::Strand::handleSnmpRequest(const Snmp::Request& request)
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, "");
     Snmp::SendResponse(request.requestId, request.pdu);
 }
 
 void Ipc::Strand::handleSnmpResponse(const Snmp::Response& response)
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, "");
     Snmp::Forwarder::HandleRemoteAck(response.requestId);
 }
 #endif
 
 void Ipc::Strand::timedout()
 {
-    debugs(54, 6, HERE << isRegistered);
+    debugs(54, 6, isRegistered);
     if (!isRegistered)
         fatalf("kid%d registration timed out", KidIdentifier);
 }

--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -21,12 +21,12 @@ Ipc::UdsOp::UdsOp(const String& pathAddr):
     address(PathToAddress(pathAddr)),
     options(COMM_NONBLOCKING)
 {
-    debugs(54, 5, HERE << '[' << this << "] pathAddr=" << pathAddr);
+    debugs(54, 5, '[' << this << "] pathAddr=" << pathAddr);
 }
 
 Ipc::UdsOp::~UdsOp()
 {
-    debugs(54, 5, HERE << '[' << this << ']');
+    debugs(54, 5, '[' << this << ']');
     if (Comm::IsConnOpen(conn_))
         conn_->close();
     conn_ = NULL;
@@ -116,7 +116,7 @@ bool Ipc::UdsSender::doneAll() const
 
 void Ipc::UdsSender::write()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
     typedef CommCbMemFunT<UdsSender, CommIoCbParams> Dialer;
     AsyncCall::Pointer writeHandler = JobCallback(54, 5,
                                       Dialer, this, UdsSender::wrote);
@@ -126,7 +126,7 @@ void Ipc::UdsSender::write()
 
 void Ipc::UdsSender::wrote(const CommIoCbParams& params)
 {
-    debugs(54, 5, HERE << params.conn << " flag " << params.flag << " retries " << retries << " [" << this << ']');
+    debugs(54, 5, params.conn << " flag " << params.flag << " retries " << retries << " [" << this << ']');
     writing = false;
     if (params.flag != Comm::OK && retries-- > 0) {
         // perhaps a fresh connection and more time will help?
@@ -172,7 +172,7 @@ void Ipc::UdsSender::DelayedRetry(void *data)
 /// make another sending attempt after a pause
 void Ipc::UdsSender::delayedRetry()
 {
-    debugs(54, 5, HERE << sleeping);
+    debugs(54, 5, sleeping);
     if (sleeping) {
         sleeping = false;
         write(); // reopens the connection if needed
@@ -181,7 +181,7 @@ void Ipc::UdsSender::delayedRetry()
 
 void Ipc::UdsSender::timedout()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, "");
     mustStop("timedout");
 }
 

--- a/src/ipc/mem/Segment.cc
+++ b/src/ipc/mem/Segment.cc
@@ -144,7 +144,7 @@ Ipc::Mem::Segment::open()
 
     theSize = statSize("Ipc::Mem::Segment::open");
 
-    debugs(54, 3, HERE << "opened " << theName << " segment: " << theSize);
+    debugs(54, 3, "opened " << theName << " segment: " << theSize);
 
     attach();
 }
@@ -313,7 +313,7 @@ Ipc::Mem::Segment::~Segment()
         delete [] static_cast<char *>(theMem);
         theMem = NULL;
         Segments.erase(theName);
-        debugs(54, 3, HERE << "unlinked " << theName << " fake segment");
+        debugs(54, 3, "unlinked " << theName << " fake segment");
     }
 }
 
@@ -338,7 +338,7 @@ Ipc::Mem::Segment::create(const off_t aSize)
     theSize = aSize;
     doUnlink = true;
 
-    debugs(54, 3, HERE << "created " << theName << " fake segment: " << theSize);
+    debugs(54, 3, "created " << theName << " fake segment: " << theSize);
 }
 
 void
@@ -355,14 +355,14 @@ Ipc::Mem::Segment::open()
     theMem = segment.theMem;
     theSize = segment.theSize;
 
-    debugs(54, 3, HERE << "opened " << theName << " fake segment: " << theSize);
+    debugs(54, 3, "opened " << theName << " fake segment: " << theSize);
 }
 
 void
 Ipc::Mem::Segment::checkSupport(const char *const context)
 {
     if (!Enabled()) {
-        debugs(54, 5, HERE << context <<
+        debugs(54, 5, context <<
                ": True shared memory segments are not supported. "
                "Cannot fake shared segments in SMP config.");
         fatalf("Ipc::Mem::Segment: Cannot fake shared segments in SMP config (%s)\n",

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -763,12 +763,12 @@ ipcacheStatPrint(ipcache_entry * i, StoreEntry * sentry)
     char buf[MAX_IPSTRLEN];
 
     if (!sentry) {
-        debugs(14, DBG_CRITICAL, HERE << "CRITICAL: sentry is NULL!");
+        debugs(14, DBG_CRITICAL, "CRITICAL: sentry is NULL!");
         return;
     }
 
     if (!i) {
-        debugs(14, DBG_CRITICAL, HERE << "CRITICAL: ipcache_entry is NULL!");
+        debugs(14, DBG_CRITICAL, "CRITICAL: ipcache_entry is NULL!");
         storeAppendPrintf(sentry, "CRITICAL ERROR\n");
         return;
     }

--- a/src/mgr/Action.cc
+++ b/src/mgr/Action.cc
@@ -67,7 +67,7 @@ Mgr::Action::add(const Action &)
 void
 Mgr::Action::respond(const Request &request)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 
     // Assume most kid classes are fully aggregatable (i.e., they do not dump
     // local info at all). Do not import the remote HTTP fd into our Comm
@@ -90,7 +90,7 @@ Mgr::Action::sendResponse(unsigned int requestId)
 void
 Mgr::Action::run(StoreEntry* entry, bool writeHttpHeader)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     collect();
     fillEntry(entry, writeHttpHeader);
 }
@@ -98,7 +98,7 @@ Mgr::Action::run(StoreEntry* entry, bool writeHttpHeader)
 void
 Mgr::Action::fillEntry(StoreEntry* entry, bool writeHttpHeader)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     entry->buffer();
 
     if (writeHttpHeader) {

--- a/src/mgr/ActionWriter.cc
+++ b/src/mgr/ActionWriter.cc
@@ -20,13 +20,13 @@ Mgr::ActionWriter::ActionWriter(const Action::Pointer &anAction, const Comm::Con
     StoreToCommWriter(conn, anAction->createStoreEntry()),
     action(anAction)
 {
-    debugs(16, 5, HERE << conn << " action: " << action);
+    debugs(16, 5, conn << " action: " << action);
 }
 
 void
 Mgr::ActionWriter::start()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(action != NULL);
 
     StoreToCommWriter::start();

--- a/src/mgr/BasicActions.cc
+++ b/src/mgr/BasicActions.cc
@@ -27,13 +27,13 @@ Mgr::IndexAction::Create(const Command::Pointer &cmd)
 
 Mgr::IndexAction::IndexAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::IndexAction::dump(StoreEntry *)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 Mgr::MenuAction::Pointer
@@ -44,13 +44,13 @@ Mgr::MenuAction::Create(const Command::Pointer &cmd)
 
 Mgr::MenuAction::MenuAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::MenuAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
 
     typedef CacheManager::Menu::const_iterator Iterator;
@@ -71,7 +71,7 @@ Mgr::ShutdownAction::Create(const Command::Pointer &cmd)
 
 Mgr::ShutdownAction::ShutdownAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
@@ -90,7 +90,7 @@ Mgr::ReconfigureAction::Create(const Command::Pointer &cmd)
 Mgr::ReconfigureAction::ReconfigureAction(const Command::Pointer &aCmd):
     Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
@@ -109,7 +109,7 @@ Mgr::RotateAction::Create(const Command::Pointer &cmd)
 
 Mgr::RotateAction::RotateAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
@@ -133,7 +133,7 @@ Mgr::OfflineToggleAction::Create(const Command::Pointer &cmd)
 Mgr::OfflineToggleAction::OfflineToggleAction(const Command::Pointer &aCmd):
     Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void

--- a/src/mgr/CountersAction.cc
+++ b/src/mgr/CountersAction.cc
@@ -98,27 +98,27 @@ Mgr::CountersAction::Create(const CommandPointer &cmd)
 Mgr::CountersAction::CountersAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::CountersAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     data += dynamic_cast<const CountersAction&>(action).data;
 }
 
 void
 Mgr::CountersAction::collect()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     GetCountersStats(data);
 }
 
 void
 Mgr::CountersAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
     DumpCountersStats(data, entry);
 }

--- a/src/mgr/Filler.cc
+++ b/src/mgr/Filler.cc
@@ -23,13 +23,13 @@ Mgr::Filler::Filler(const Action::Pointer &anAction, const Comm::ConnectionPoint
     action(anAction),
     requestId(aRequestId)
 {
-    debugs(16, 5, HERE << conn << " action: " << action);
+    debugs(16, 5, conn << " action: " << action);
 }
 
 void
 Mgr::Filler::start()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(requestId != 0);
     Must(action != NULL);
 
@@ -40,7 +40,7 @@ Mgr::Filler::start()
 void
 Mgr::Filler::swanSong()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     action->sendResponse(requestId);
     StoreToCommWriter::swanSong();
 }

--- a/src/mgr/Forwarder.cc
+++ b/src/mgr/Forwarder.cc
@@ -30,7 +30,7 @@ Mgr::Forwarder::Forwarder(const Comm::ConnectionPointer &aConn, const ActionPara
     Ipc::Forwarder(new Request(KidIdentifier, 0, aConn, aParams), 10),
     httpRequest(aRequest), entry(anEntry), conn(aConn)
 {
-    debugs(16, 5, HERE << conn);
+    debugs(16, 5, conn);
     Must(Comm::IsConnOpen(conn));
     Must(httpRequest != NULL);
     Must(entry != NULL);
@@ -46,7 +46,7 @@ Mgr::Forwarder::Forwarder(const Comm::ConnectionPointer &aConn, const ActionPara
 
 Mgr::Forwarder::~Forwarder()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(httpRequest != NULL);
     Must(entry != NULL);
 
@@ -97,7 +97,7 @@ Mgr::Forwarder::handleException(const std::exception &e)
 void
 Mgr::Forwarder::noteCommClosed(const CommCloseCbParams &)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     conn = NULL; // needed?
     mustStop("commClosed");
 }
@@ -106,7 +106,7 @@ Mgr::Forwarder::noteCommClosed(const CommCloseCbParams &)
 void
 Mgr::Forwarder::sendError(ErrorState *error)
 {
-    debugs(16, 3, HERE);
+    debugs(16, 3, "");
     Must(error != NULL);
     Must(entry != NULL);
     Must(httpRequest != NULL);

--- a/src/mgr/FunAction.cc
+++ b/src/mgr/FunAction.cc
@@ -30,13 +30,13 @@ Mgr::FunAction::FunAction(const Command::Pointer &aCmd, OBJH* aHandler):
     Action(aCmd), handler(aHandler)
 {
     Must(handler != NULL);
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::FunAction::respond(const Request& request)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Ipc::ImportFdIntoComm(request.conn, SOCK_STREAM, IPPROTO_TCP, Ipc::fdnHttpSocket);
     Must(Comm::IsConnOpen(request.conn));
     Must(request.requestId != 0);
@@ -46,7 +46,7 @@ Mgr::FunAction::respond(const Request& request)
 void
 Mgr::FunAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
     if (UsingSmp())
         storeAppendPrintf(entry, "by kid%d {\n", KidIdentifier);

--- a/src/mgr/InfoAction.cc
+++ b/src/mgr/InfoAction.cc
@@ -115,20 +115,20 @@ Mgr::InfoAction::Create(const CommandPointer &cmd)
 Mgr::InfoAction::InfoAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::InfoAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     data += dynamic_cast<const InfoAction&>(action).data;
 }
 
 void
 Mgr::InfoAction::respond(const Request& request)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Ipc::ImportFdIntoComm(request.conn, SOCK_STREAM, IPPROTO_TCP, Ipc::fdnHttpSocket);
     Must(Comm::IsConnOpen(request.conn));
     Must(request.requestId != 0);
@@ -144,7 +144,7 @@ Mgr::InfoAction::collect()
 void
 Mgr::InfoAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
 
 #if XMALLOC_STATISTICS

--- a/src/mgr/Inquirer.cc
+++ b/src/mgr/Inquirer.cc
@@ -38,7 +38,7 @@ Mgr::Inquirer::Inquirer(Action::Pointer anAction,
     conn = aCause.conn;
     Ipc::ImportFdIntoComm(conn, SOCK_STREAM, IPPROTO_TCP, Ipc::fdnHttpSocket);
 
-    debugs(16, 5, HERE << conn << " action: " << aggrAction);
+    debugs(16, 5, conn << " action: " << aggrAction);
 
     closer = asyncCall(16, 5, "Mgr::Inquirer::noteCommClosed",
                        CommCbMemFunT<Inquirer, CommCloseCbParams>(this, &Inquirer::noteCommClosed));
@@ -67,7 +67,7 @@ Mgr::Inquirer::removeCloseHandler()
 void
 Mgr::Inquirer::start()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Ipc::Inquirer::start();
     Must(Comm::IsConnOpen(conn));
     Must(aggrAction != NULL);
@@ -95,7 +95,7 @@ Mgr::Inquirer::start()
 void
 Mgr::Inquirer::noteWroteHeader(const CommIoCbParams& params)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     writer = NULL;
     Must(params.flag == Comm::OK);
     Must(params.conn.getRaw() == conn.getRaw());
@@ -108,7 +108,7 @@ Mgr::Inquirer::noteWroteHeader(const CommIoCbParams& params)
 void
 Mgr::Inquirer::noteCommClosed(const CommCloseCbParams& params)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(!Comm::IsConnOpen(conn) && params.conn.getRaw() == conn.getRaw());
     conn = NULL;
     mustStop("commClosed");
@@ -172,9 +172,9 @@ Mgr::Inquirer::applyQueryParams(const Ipc::StrandCoords& aStrands, const QueryPa
         }
     }
 
-    debugs(16, 4, HERE << "strands kid IDs = ");
+    debugs(16, 4, "strands kid IDs = ");
     for (Ipc::StrandCoords::const_iterator iter = sc.begin(); iter != sc.end(); ++iter) {
-        debugs(16, 4, HERE << iter->kidId);
+        debugs(16, 4, iter->kidId);
     }
 
     return sc;

--- a/src/mgr/IntervalAction.cc
+++ b/src/mgr/IntervalAction.cc
@@ -123,13 +123,13 @@ Mgr::IntervalAction::Create60min(const CommandPointer &cmd)
 Mgr::IntervalAction::IntervalAction(const CommandPointer &aCmd, int aMinutes, int aHours):
     Action(aCmd), minutes(aMinutes), hours(aHours), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::IntervalAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     data += dynamic_cast<const IntervalAction&>(action).data;
 }
 
@@ -142,7 +142,7 @@ Mgr::IntervalAction::collect()
 void
 Mgr::IntervalAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
     DumpAvgStat(data, entry);
 }

--- a/src/mgr/IoAction.cc
+++ b/src/mgr/IoAction.cc
@@ -51,13 +51,13 @@ Mgr::IoAction::Create(const CommandPointer &cmd)
 Mgr::IoAction::IoAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::IoAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     data += dynamic_cast<const IoAction&>(action).data;
 }
 
@@ -70,7 +70,7 @@ Mgr::IoAction::collect()
 void
 Mgr::IoAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
     DumpIoStats(data, entry);
 }

--- a/src/mgr/ServiceTimesAction.cc
+++ b/src/mgr/ServiceTimesAction.cc
@@ -63,27 +63,27 @@ Mgr::ServiceTimesAction::Create(const CommandPointer &cmd)
 Mgr::ServiceTimesAction::ServiceTimesAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::ServiceTimesAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     data += dynamic_cast<const ServiceTimesAction&>(action).data;
 }
 
 void
 Mgr::ServiceTimesAction::collect()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     GetServiceTimesStats(data);
 }
 
 void
 Mgr::ServiceTimesAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
     DumpServiceTimesStats(data, entry);
 }

--- a/src/mgr/StoreIoAction.cc
+++ b/src/mgr/StoreIoAction.cc
@@ -41,13 +41,13 @@ Mgr::StoreIoAction::Create(const CommandPointer &cmd)
 Mgr::StoreIoAction::StoreIoAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
 }
 
 void
 Mgr::StoreIoAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     data += dynamic_cast<const StoreIoAction&>(action).data;
 }
 
@@ -63,7 +63,7 @@ Mgr::StoreIoAction::collect()
 void
 Mgr::StoreIoAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, "");
     Must(entry != NULL);
     storeAppendPrintf(entry, "Store IO Interface Stats\n");
     storeAppendPrintf(entry, "create.calls %.0f\n", data.create_calls);

--- a/src/mgr/StoreToCommWriter.cc
+++ b/src/mgr/StoreToCommWriter.cc
@@ -24,7 +24,7 @@ Mgr::StoreToCommWriter::StoreToCommWriter(const Comm::ConnectionPointer &conn, S
     AsyncJob("Mgr::StoreToCommWriter"),
     clientConnection(conn), entry(anEntry), sc(NULL), writeOffset(0), closer(NULL)
 {
-    debugs(16, 6, HERE << clientConnection);
+    debugs(16, 6, clientConnection);
     closer = asyncCall(16, 5, "Mgr::StoreToCommWriter::noteCommClosed",
                        CommCbMemFunT<StoreToCommWriter, CommCloseCbParams>(this, &StoreToCommWriter::noteCommClosed));
     comm_add_close_handler(clientConnection->fd, closer);
@@ -32,7 +32,7 @@ Mgr::StoreToCommWriter::StoreToCommWriter(const Comm::ConnectionPointer &conn, S
 
 Mgr::StoreToCommWriter::~StoreToCommWriter()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     assert(!entry);
     assert(!sc);
     close();
@@ -54,7 +54,7 @@ Mgr::StoreToCommWriter::close()
 void
 Mgr::StoreToCommWriter::start()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     Must(Comm::IsConnOpen(clientConnection));
     Must(entry != NULL);
     entry->registerAbort(&StoreToCommWriter::Abort, this);
@@ -68,7 +68,7 @@ Mgr::StoreToCommWriter::start()
 void
 Mgr::StoreToCommWriter::scheduleStoreCopy()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     Must(entry != NULL);
     Must(sc != NULL);
     StoreIOBuffer readBuf(sizeof(buffer), writeOffset, buffer);
@@ -91,7 +91,7 @@ Mgr::StoreToCommWriter::NoteStoreCopied(void* data, StoreIOBuffer ioBuf)
 void
 Mgr::StoreToCommWriter::noteStoreCopied(StoreIOBuffer ioBuf)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     Must(!ioBuf.flags.error);
     if (ioBuf.length > 0)
         scheduleCommWrite(ioBuf); // write received action results to client
@@ -102,7 +102,7 @@ Mgr::StoreToCommWriter::noteStoreCopied(StoreIOBuffer ioBuf)
 void
 Mgr::StoreToCommWriter::scheduleCommWrite(const StoreIOBuffer& ioBuf)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     Must(Comm::IsConnOpen(clientConnection));
     Must(ioBuf.data != NULL);
     // write filled buffer
@@ -116,7 +116,7 @@ Mgr::StoreToCommWriter::scheduleCommWrite(const StoreIOBuffer& ioBuf)
 void
 Mgr::StoreToCommWriter::noteCommWrote(const CommIoCbParams& params)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     Must(params.flag == Comm::OK);
     Must(clientConnection != NULL && params.fd == clientConnection->fd);
     Must(params.size != 0);
@@ -128,7 +128,7 @@ Mgr::StoreToCommWriter::noteCommWrote(const CommIoCbParams& params)
 void
 Mgr::StoreToCommWriter::noteCommClosed(const CommCloseCbParams &)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     Must(!Comm::IsConnOpen(clientConnection));
     mustStop("commClosed");
 }
@@ -136,7 +136,7 @@ Mgr::StoreToCommWriter::noteCommClosed(const CommCloseCbParams &)
 void
 Mgr::StoreToCommWriter::swanSong()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, "");
     if (entry != NULL) {
         if (sc != NULL) {
             storeUnregister(sc, entry, this);

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -330,7 +330,7 @@ getRoundRobinParent(HttpRequest * request)
     if (q)
         ++ q->rr_count;
 
-    debugs(15, 3, HERE << "returning " << (q ? q->host : "NULL"));
+    debugs(15, 3, "returning " << (q ? q->host : "NULL"));
 
     return q;
 }

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -73,12 +73,12 @@ IdleConnList::findIndexOf(const Comm::ConnectionPointer &conn) const
 {
     for (int index = size_ - 1; index >= 0; --index) {
         if (conn->fd == theList_[index]->fd) {
-            debugs(48, 3, HERE << "found " << conn << " at index " << index);
+            debugs(48, 3, "found " << conn << " at index " << index);
             return index;
         }
     }
 
-    debugs(48, 2, HERE << conn << " NOT FOUND!");
+    debugs(48, 2, conn << " NOT FOUND!");
     return -1;
 }
 
@@ -113,10 +113,10 @@ void
 IdleConnList::closeN(size_t n)
 {
     if (n < 1) {
-        debugs(48, 2, HERE << "Nothing to do.");
+        debugs(48, 2, "Nothing to do.");
         return;
     } else if (n >= (size_t)size_) {
-        debugs(48, 2, HERE << "Closing all entries.");
+        debugs(48, 2, "Closing all entries.");
         while (size_ > 0) {
             const Comm::ConnectionPointer conn = theList_[--size_];
             theList_[size_] = NULL;
@@ -126,7 +126,7 @@ IdleConnList::closeN(size_t n)
                 parent_->noteConnectionRemoved();
         }
     } else { //if (n < size_)
-        debugs(48, 2, HERE << "Closing " << n << " of " << size_ << " entries.");
+        debugs(48, 2, "Closing " << n << " of " << size_ << " entries.");
 
         size_t index;
         // ensure the first N entries are closed
@@ -159,7 +159,7 @@ IdleConnList::closeN(size_t n)
 void
 IdleConnList::clearHandlers(const Comm::ConnectionPointer &conn)
 {
-    debugs(48, 3, HERE << "removing close handler for " << conn);
+    debugs(48, 3, "removing close handler for " << conn);
     comm_read_cancel(conn->fd, IdleConnList::Read, this);
     commUnsetConnTimeout(conn);
 }
@@ -168,7 +168,7 @@ void
 IdleConnList::push(const Comm::ConnectionPointer &conn)
 {
     if (size_ == capacity_) {
-        debugs(48, 3, HERE << "growing idle Connection array");
+        debugs(48, 3, "growing idle Connection array");
         capacity_ <<= 1;
         const Comm::ConnectionPointer *oldList = theList_;
         theList_ = new Comm::ConnectionPointer[capacity_];
@@ -297,10 +297,10 @@ IdleConnList::findAndClose(const Comm::ConnectionPointer &conn)
 void
 IdleConnList::Read(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::Flag flag, int, void *data)
 {
-    debugs(48, 3, HERE << len << " bytes from " << conn);
+    debugs(48, 3, len << " bytes from " << conn);
 
     if (flag == Comm::ERR_CLOSING) {
-        debugs(48, 3, HERE << "Comm::ERR_CLOSING from " << conn);
+        debugs(48, 3, "Comm::ERR_CLOSING from " << conn);
         /* Bail out on Comm::ERR_CLOSING - may happen when shutdown aborts our idle FD */
         return;
     }
@@ -313,7 +313,7 @@ IdleConnList::Read(const Comm::ConnectionPointer &conn, char *, size_t len, Comm
 void
 IdleConnList::Timeout(const CommTimeoutCbParams &io)
 {
-    debugs(48, 3, HERE << io.conn);
+    debugs(48, 3, io.conn);
     IdleConnList *list = static_cast<IdleConnList *>(io.data);
     /* may delete list/data */
     list->findAndClose(io.conn);
@@ -407,12 +407,12 @@ void
 PconnPool::push(const Comm::ConnectionPointer &conn, const char *domain)
 {
     if (fdUsageHigh()) {
-        debugs(48, 3, HERE << "Not many unused FDs");
+        debugs(48, 3, "Not many unused FDs");
         conn->close();
         return;
     } else if (shutting_down) {
         conn->close();
-        debugs(48, 3, HERE << "Squid is shutting down. Refusing to do anything");
+        debugs(48, 3, "Squid is shutting down. Refusing to do anything");
         return;
     }
     // TODO: also close used pconns if we exceed peer max-conn limit
@@ -434,7 +434,7 @@ PconnPool::push(const Comm::ConnectionPointer &conn, const char *domain)
     LOCAL_ARRAY(char, desc, FD_DESC_SZ);
     snprintf(desc, FD_DESC_SZ, "Idle server: %s", aKey);
     fd_note(conn->fd, desc);
-    debugs(48, 3, HERE << "pushed " << conn << " for " << aKey);
+    debugs(48, 3, "pushed " << conn << " for " << aKey);
 
     // successful push notifications resume multi-connection opening sequence
     notifyManager("push");
@@ -448,7 +448,7 @@ PconnPool::pop(const Comm::ConnectionPointer &dest, const char *domain, bool kee
 
     IdleConnList *list = (IdleConnList *)hash_lookup(table, aKey);
     if (list == NULL) {
-        debugs(48, 3, HERE << "lookup for key {" << aKey << "} failed.");
+        debugs(48, 3, "lookup for key {" << aKey << "} failed.");
         // failure notifications resume standby conn creation after fdUsageHigh
         notifyManager("pop failure");
         return Comm::ConnectionPointer();

--- a/src/peer_proxy_negotiate_auth.cc
+++ b/src/peer_proxy_negotiate_auth.cc
@@ -174,14 +174,14 @@ int check_gss_err(OM_uint32 major_status, OM_uint32 minor_status,
             }
             gss_release_buffer(&min_stat, &status_string);
         }
-        debugs(11, 5, HERE << function << "failed: " << buf);
+        debugs(11, 5, function << "failed: " << buf);
         return (1);
     }
     return (0);
 }
 
 void krb5_cleanup() {
-    debugs(11, 5, HERE << "Cleanup kerberos context");
+    debugs(11, 5, "Cleanup kerberos context");
     if (kparam.context) {
         if (kparam.cc)
             krb5_cc_destroy(kparam.context, kparam.cc);
@@ -251,7 +251,6 @@ restart:
                                       &creds2.client);
             if (code) {
                 debugs(11, 5,
-                       HERE <<
                        "Error while getting principal from credential cache : "
                        << error_message(code));
                 return (1);
@@ -267,7 +266,7 @@ restart:
                                     (krb5_const_realm)&client_realm, NULL);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while getting krbtgt principal : " <<
+                       "Error while getting krbtgt principal : " <<
                        error_message(code));
                 return (1);
             }
@@ -284,7 +283,7 @@ restart:
                     goto restart;
                 }
                 debugs(11, 5,
-                       HERE << "Error while get credentials : " <<
+                       "Error while get credentials : " <<
                        error_message(code));
                 return (1);
             }
@@ -295,7 +294,7 @@ restart:
             code = krb5_init_context(&kparam.context);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while initialising Kerberos library : "
+                       "Error while initialising Kerberos library : "
                        << error_message(code));
                 return (1);
             }
@@ -306,7 +305,7 @@ restart:
             if (profile)
                 profile_release(profile);
             debugs(11, 5,
-                   HERE << "Error while getting profile : " <<
+                   "Error while getting profile : " <<
                    error_message(code));
             return (1);
         }
@@ -317,7 +316,7 @@ restart:
             profile_release(profile);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while getting clockskew : " <<
+                   "Error while getting clockskew : " <<
                    error_message(code));
             return (1);
         }
@@ -345,7 +344,7 @@ restart:
         code = krb5_kt_resolve(kparam.context, keytab_filename, &keytab);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while resolving keytab filename " <<
+                   "Error while resolving keytab filename " <<
                    keytab_filename << " : " << error_message(code));
             return (1);
         }
@@ -354,7 +353,7 @@ restart:
             code = krb5_kt_start_seq_get(kparam.context, keytab, &cursor);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while starting keytab scan : " <<
+                       "Error while starting keytab scan : " <<
                        error_message(code));
                 return (1);
             }
@@ -364,7 +363,7 @@ restart:
                                 &principal);
             if (code && code != KRB5_KT_END) {
                 debugs(11, 5,
-                       HERE << "Error while scanning keytab : " <<
+                       "Error while scanning keytab : " <<
                        error_message(code));
                 return (1);
             }
@@ -372,7 +371,7 @@ restart:
             code = krb5_kt_end_seq_get(kparam.context, keytab, &cursor);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while ending keytab scan : " <<
+                       "Error while ending keytab scan : " <<
                        error_message(code));
                 return (1);
             }
@@ -383,7 +382,7 @@ restart:
 #endif
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while freeing keytab entry : " <<
+                       "Error while freeing keytab entry : " <<
                        error_message(code));
                 return (1);
             }
@@ -397,7 +396,7 @@ restart:
                 krb5_parse_name(kparam.context, principal_name, &principal);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while parsing principal name " <<
+                       "Error while parsing principal name " <<
                        principal_name << " : " << error_message(code));
                 return (1);
             }
@@ -413,7 +412,7 @@ restart:
         code = krb5_string_to_deltat((char *) MAX_RENEW_TIME, &rlife);
         if (code != 0 || rlife == 0) {
             debugs(11, 5,
-                   HERE << "Error bad lifetime value " << MAX_RENEW_TIME <<
+                   "Error bad lifetime value " << MAX_RENEW_TIME <<
                    " : " << error_message(code));
             return (1);
         }
@@ -435,7 +434,6 @@ restart:
 #endif
         if (code) {
             debugs(11, 5,
-                   HERE <<
                    "Error while initializing credentials from keytab : " <<
                    error_message(code));
             return (1);
@@ -469,14 +467,13 @@ restart:
         xfree(mem_cache);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while resolving memory credential cache : "
+                   "Error while resolving memory credential cache : "
                    << error_message(code));
             return (1);
         }
         code = krb5_cc_initialize(kparam.context, kparam.cc, principal);
         if (code) {
             debugs(11, 5,
-                   HERE <<
                    "Error while initializing memory credential cache : " <<
                    error_message(code));
             return (1);
@@ -484,7 +481,7 @@ restart:
         code = krb5_cc_store_cred(kparam.context, kparam.cc, creds);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while storing credentials : " <<
+                   "Error while storing credentials : " <<
                    error_message(code));
             return (1);
         }
@@ -513,19 +510,19 @@ char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags) {
     setbuf(stdin, NULL);
 
     if (!proxy) {
-        debugs(11, 5, HERE << "Error : No proxy server name");
+        debugs(11, 5, "Error : No proxy server name");
         return NULL;
     }
 
     if (!(flags & PEER_PROXY_NEGOTIATE_NOKEYTAB)) {
         if (principal_name)
             debugs(11, 5,
-                   HERE << "Creating credential cache for " << principal_name);
+                   "Creating credential cache for " << principal_name);
         else
-            debugs(11, 5, HERE << "Creating credential cache");
+            debugs(11, 5, "Creating credential cache");
         rc = krb5_create_cache(NULL, principal_name);
         if (rc) {
-            debugs(11, 5, HERE << "Error : Failed to create Kerberos cache");
+            debugs(11, 5, "Error : Failed to create Kerberos cache");
             krb5_cleanup();
             return NULL;
         }
@@ -536,14 +533,14 @@ char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags) {
              "%s@%s", "HTTP", proxy);
     service.length = strlen((char *) service.value);
 
-    debugs(11, 5, HERE << "Import gss name");
+    debugs(11, 5, "Import gss name");
     major_status = gss_import_name(&minor_status, &service,
                                    gss_nt_service_name, &server_name);
 
     if (check_gss_err(major_status, minor_status, "gss_import_name()"))
         goto cleanup;
 
-    debugs(11, 5, HERE << "Initialize gss security context");
+    debugs(11, 5, "Initialize gss security context");
     major_status = gss_init_sec_context(&minor_status,
                                         GSS_C_NO_CREDENTIAL,
                                         &gss_context,
@@ -557,7 +554,7 @@ char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags) {
     if (check_gss_err(major_status, minor_status, "gss_init_sec_context()"))
         goto cleanup;
 
-    debugs(11, 5, HERE << "Got token with length " << output_token.length);
+    debugs(11, 5, "Got token with length " << output_token.length);
     if (output_token.length) {
         static uint8_t b64buf[8192]; // XXX: 8KB only because base64_encode_bin() used to.
         struct base64_encode_ctx ctx;

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -197,7 +197,7 @@ peerCheckNeverDirectDone(allow_t answer, void *data)
     case ACCESS_ALLOWED:
         /** if never_direct says YES, do that. */
         psstate->direct = DIRECT_NO;
-        debugs(44, 3, HERE << "direct = " << DirectStr[psstate->direct] << " (never_direct allow)");
+        debugs(44, 3, "direct = " << DirectStr[psstate->direct] << " (never_direct allow)");
         break;
     case ACCESS_DENIED: // not relevant.
     case ACCESS_DUNNO:  // not relevant.
@@ -220,7 +220,7 @@ peerCheckAlwaysDirectDone(allow_t answer, void *data)
     case ACCESS_ALLOWED:
         /** if always_direct says YES, do that. */
         psstate->direct = DIRECT_YES;
-        debugs(44, 3, HERE << "direct = " << DirectStr[psstate->direct] << " (always_direct allow)");
+        debugs(44, 3, "direct = " << DirectStr[psstate->direct] << " (always_direct allow)");
         break;
     case ACCESS_DENIED: // not relevant.
     case ACCESS_DUNNO:  // not relevant.

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -80,7 +80,7 @@ static void
 redirectHandleReply(void *data, const Helper::Reply &reply)
 {
     RedirectStateData *r = static_cast<RedirectStateData *>(data);
-    debugs(61, 5, HERE << "reply=" << reply);
+    debugs(61, 5, "reply=" << reply);
 
     // XXX: This function is now kept only to check for and display the garbage use-case
     // and to map the old helper response format(s) into new format result code and key=value pairs
@@ -278,7 +278,7 @@ constructHelperQuery(const char *name, helper *hlp, HLPCB *replyHandler, ClientH
         return;
     }
 
-    debugs(61,6, HERE << "sending '" << buf << "' to the " << name << " helper");
+    debugs(61,6, "sending '" << buf << "' to the " << name << " helper");
     helperSubmit(hlp, buf, replyHandler, r);
 }
 

--- a/src/sbuf/MemBlob.cc
+++ b/src/sbuf/MemBlob.cc
@@ -51,7 +51,7 @@ MemBlobStats::dump(std::ostream &os) const
 MemBlob::MemBlob(const MemBlob::size_type reserveSize) :
     mem(NULL), capacity(0), size(0) // will be set by memAlloc
 {
-    debugs(MEMBLOB_DEBUGSECTION,9, HERE << "constructed, this="
+    debugs(MEMBLOB_DEBUGSECTION,9, "constructed, this="
            << static_cast<void*>(this) << " id=" << id
            << " reserveSize=" << reserveSize);
     memAlloc(reserveSize);
@@ -60,7 +60,7 @@ MemBlob::MemBlob(const MemBlob::size_type reserveSize) :
 MemBlob::MemBlob(const char *buffer, const MemBlob::size_type bufSize) :
     mem(NULL), capacity(0), size(0) // will be set by memAlloc
 {
-    debugs(MEMBLOB_DEBUGSECTION,9, HERE << "constructed, this="
+    debugs(MEMBLOB_DEBUGSECTION,9, "constructed, this="
            << static_cast<void*>(this) << " id=" << id
            << " buffer=" << static_cast<const void*>(buffer)
            << " bufSize=" << bufSize);
@@ -76,7 +76,7 @@ MemBlob::~MemBlob()
     --Stats.live;
     recordMemBlobSizeAtDestruct(capacity);
 
-    debugs(MEMBLOB_DEBUGSECTION,9, HERE << "destructed, this="
+    debugs(MEMBLOB_DEBUGSECTION,9, "destructed, this="
            << static_cast<void*>(this) << " id=" << id
            << " capacity=" << capacity
            << " size=" << size);

--- a/src/security/cert_generators/file/certificate_db.cc
+++ b/src/security/cert_generators/file/certificate_db.cc
@@ -24,8 +24,6 @@
 #include <fcntl.h>
 #endif
 
-#define HERE "(security_file_certgen) " << __FILE__ << ':' << __LINE__ << ": "
-
 Ssl::Lock::Lock(std::string const &aFilename) :
     filename(aFilename),
 #if _SQUID_WINDOWS_

--- a/src/snmp/Forwarder.cc
+++ b/src/snmp/Forwarder.cc
@@ -26,7 +26,7 @@ Snmp::Forwarder::Forwarder(const Pdu& aPdu, const Session& aSession, int aFd,
     Ipc::Forwarder(new Request(KidIdentifier, 0, aPdu, aSession, aFd, anAddress), 2),
     fd(aFd)
 {
-    debugs(49, 5, HERE << "FD " << aFd);
+    debugs(49, 5, "FD " << aFd);
     Must(fd >= 0);
     closer = asyncCall(49, 5, "Snmp::Forwarder::noteCommClosed",
                        CommCbMemFunT<Forwarder, CommCloseCbParams>(this, &Forwarder::noteCommClosed));
@@ -50,7 +50,7 @@ Snmp::Forwarder::cleanup()
 void
 Snmp::Forwarder::noteCommClosed(const CommCloseCbParams& params)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, "");
     Must(fd == params.fd);
     fd = -1;
     mustStop("commClosed");
@@ -66,7 +66,7 @@ Snmp::Forwarder::handleTimeout()
 void
 Snmp::Forwarder::handleException(const std::exception& e)
 {
-    debugs(49, 3, HERE << e.what());
+    debugs(49, 3, e.what());
     if (fd >= 0)
         sendError(SNMP_ERR_GENERR);
     Ipc::Forwarder::handleException(e);
@@ -76,7 +76,7 @@ Snmp::Forwarder::handleException(const std::exception& e)
 void
 Snmp::Forwarder::sendError(int error)
 {
-    debugs(49, 3, HERE);
+    debugs(49, 3, "");
     Snmp::Request& req = static_cast<Snmp::Request&>(*request);
     req.pdu.command = SNMP_PDU_RESPONSE;
     req.pdu.errstat = error;
@@ -89,7 +89,7 @@ Snmp::Forwarder::sendError(int error)
 void
 Snmp::SendResponse(unsigned int requestId, const Pdu& pdu)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, "");
     // snmpAgentResponse() can modify arg
     Pdu tmp = pdu;
     Snmp::Response response(requestId);
@@ -100,7 +100,7 @@ Snmp::SendResponse(unsigned int requestId, const Pdu& pdu)
         response.pdu = static_cast<Pdu&>(*response_pdu);
         snmp_free_pdu(response_pdu);
     } catch (const std::exception& e) {
-        debugs(49, DBG_CRITICAL, HERE << e.what());
+        debugs(49, DBG_CRITICAL, e.what());
         response.pdu.command = SNMP_PDU_RESPONSE;
         response.pdu.errstat = SNMP_ERR_GENERR;
     }

--- a/src/snmp/Inquirer.cc
+++ b/src/snmp/Inquirer.cc
@@ -29,7 +29,7 @@ Snmp::Inquirer::Inquirer(const Request& aRequest, const Ipc::StrandCoords& coord
     conn->fd = aRequest.fd;
     ImportFdIntoComm(conn, SOCK_DGRAM, IPPROTO_UDP, Ipc::fdnInSnmpSocket);
 
-    debugs(49, 5, HERE);
+    debugs(49, 5, "");
     closer = asyncCall(49, 5, "Snmp::Inquirer::noteCommClosed",
                        CommCbMemFunT<Inquirer, CommCloseCbParams>(this, &Inquirer::noteCommClosed));
     comm_add_close_handler(conn->fd, closer);
@@ -56,7 +56,7 @@ Snmp::Inquirer::cleanup()
 void
 Snmp::Inquirer::start()
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, "");
     Ipc::Inquirer::start();
     Must(Comm::IsConnOpen(conn));
     inquire();
@@ -86,7 +86,7 @@ Snmp::Inquirer::aggregate(Response::Pointer aResponse)
 void
 Snmp::Inquirer::noteCommClosed(const CommCloseCbParams& params)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, "");
     Must(!Comm::IsConnOpen(conn) || conn->fd == params.conn->fd);
     conn = NULL;
     mustStop("commClosed");
@@ -101,7 +101,7 @@ Snmp::Inquirer::doneAll() const
 void
 Snmp::Inquirer::sendResponse()
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, "");
     aggrPdu.fixAggregate();
     aggrPdu.command = SNMP_PDU_RESPONSE;
     u_char buffer[SNMP_REQUEST_SIZE];

--- a/src/snmp/Var.cc
+++ b/src/snmp/Var.cc
@@ -67,7 +67,7 @@ Snmp::Var::operator += (const Var& var)
         setTimeTicks(asTimeTicks() + var.asTimeTicks());
         break;
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }
@@ -95,7 +95,7 @@ Snmp::Var::operator /= (int num)
         setTimeTicks(asTimeTicks() / num);
         break;
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }
@@ -117,7 +117,7 @@ Snmp::Var::operator < (const Var& var) const
     case SMI_TIMETICKS:
         return asTimeTicks() < var.asTimeTicks();
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }
@@ -139,7 +139,7 @@ Snmp::Var::operator > (const Var& var) const
     case SMI_TIMETICKS:
         return asTimeTicks() > var.asTimeTicks();
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }

--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -389,7 +389,7 @@ snmpDecodePacket(SnmpRequest * rq)
         return;
     }
 
-    debugs(49, 5, HERE << "Called.");
+    debugs(49, 5, "Called.");
     PDU = snmp_pdu_create(0);
     /* Allways answer on SNMPv1 */
     rq->session.Version = SNMP_VERSION_1;
@@ -567,7 +567,7 @@ snmpTreeGet(oid * Current, snint CurrentLen)
 AggrType
 snmpAggrType(oid* Current, snint CurrentLen)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, "");
 
     mib_tree_entry* mibTreeEntry = mib_tree_head;
     AggrType type = atNone;
@@ -780,7 +780,7 @@ client_Inst(oid * name, snint * len, mib_tree_entry * current, oid_ParseFn ** Fn
         else
             size = sizeof(in6_addr);
 
-        debugs(49, 6, HERE << "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", size=" << size);
+        debugs(49, 6, "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", size=" << size);
 
         instance = (oid *)xmalloc(sizeof(*name) * (*len + size ));
         memcpy(instance, name, (sizeof(*name) * (*len)));
@@ -804,7 +804,7 @@ client_Inst(oid * name, snint * len, mib_tree_entry * current, oid_ParseFn ** Fn
             else
                 newshift = sizeof(in6_addr);
 
-            debugs(49, 6, HERE << "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", newshift=" << newshift);
+            debugs(49, 6, "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", newshift=" << newshift);
 
             instance = (oid *)xmalloc(sizeof(*name) * (current->len +  newshift));
             memcpy(instance, name, (sizeof(*name) * (current->len)));

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -107,7 +107,7 @@ Ssl::ErrorDetailsList::Pointer Ssl::ErrorDetailsManager::getCachedDetails(const 
     Cache::iterator it;
     it = cache.find(lang);
     if (it != cache.end()) {
-        debugs(83, 8, HERE << "Found template details in cache for language: " << lang);
+        debugs(83, 8, "Found template details in cache for language: " << lang);
         return it->second;
     }
 
@@ -137,12 +137,12 @@ Ssl::ErrorDetailsManager::getErrorDetail(Security::ErrorCode value, const HttpRe
         errDetails = getCachedDetails(lang); // search in cache
 
         if (!errDetails) { // Else try to load from disk
-            debugs(83, 8, HERE << "Creating new ErrDetailList to read from disk");
+            debugs(83, 8, "Creating new ErrDetailList to read from disk");
             errDetails = new ErrorDetailsList();
             ErrorDetailFile detailTmpl(errDetails);
             if (detailTmpl.loadFor(request.getRaw())) {
                 if (detailTmpl.language()) {
-                    debugs(83, 8, HERE << "Found details on disk for language " << detailTmpl.language());
+                    debugs(83, 8, "Found details on disk for language " << detailTmpl.language());
                     errDetails->errLanguage = detailTmpl.language();
                     cacheDetails(errDetails);
                 }
@@ -156,7 +156,7 @@ Ssl::ErrorDetailsManager::getErrorDetail(Security::ErrorCode value, const HttpRe
 
     // else try the default
     if (theDefaultErrorDetails->getRecord(value, entry)) {
-        debugs(83, 8, HERE << "Found default details record for error: " << GetErrorName(value));
+        debugs(83, 8, "Found default details record for error: " << GetErrorName(value));
         return true;
     }
 
@@ -213,14 +213,14 @@ Ssl::ErrorDetailFile::parse(const char *buffer, int len, bool eof)
         if ( s != e) {
             DetailEntryParser parser;
             if (!parser.parse(s, e - s)) {
-                debugs(83, DBG_IMPORTANT, HERE <<
+                debugs(83, DBG_IMPORTANT,
                        "WARNING! parse error on:" << s);
                 return false;
             }
 
             const String errorName = parser.getByName("name");
             if (!errorName.size()) {
-                debugs(83, DBG_IMPORTANT, HERE <<
+                debugs(83, DBG_IMPORTANT,
                        "WARNING! invalid or no error detail name on:" << s);
                 return false;
             }
@@ -229,7 +229,7 @@ Ssl::ErrorDetailFile::parse(const char *buffer, int len, bool eof)
             if (ssl_error != SSL_ERROR_NONE) {
 
                 if (theDetails->getErrorDetail(ssl_error)) {
-                    debugs(83, DBG_IMPORTANT, HERE <<
+                    debugs(83, DBG_IMPORTANT,
                            "WARNING! duplicate entry: " << errorName);
                     return false;
                 }
@@ -243,13 +243,13 @@ Ssl::ErrorDetailFile::parse(const char *buffer, int len, bool eof)
                 const int descrParseOk = httpHeaderParseQuotedString(tmp.termedBuf(), tmp.size(), &entry.descr);
 
                 if (!detailsParseOk || !descrParseOk) {
-                    debugs(83, DBG_IMPORTANT, HERE <<
+                    debugs(83, DBG_IMPORTANT,
                            "WARNING! missing important field for detail error: " <<  errorName);
                     return false;
                 }
 
             } else if (!Ssl::ErrorIsOptional(errorName.termedBuf())) {
-                debugs(83, DBG_IMPORTANT, HERE <<
+                debugs(83, DBG_IMPORTANT,
                        "WARNING! invalid error detail name: " << errorName);
                 return false;
             }
@@ -258,7 +258,7 @@ Ssl::ErrorDetailFile::parse(const char *buffer, int len, bool eof)
 
         buf.consume(size);
     }
-    debugs(83, 9, HERE << " Remain size: " << buf.contentSize() << " Content: " << buf.content());
+    debugs(83, 9, "Remain size: " << buf.contentSize() << " Content: " << buf.content());
     return true;
 }
 

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -44,9 +44,9 @@ Ssl::ServerBump::ServerBump(HttpRequest *fakeRequest, StoreEntry *e, Ssl::BumpMo
 
 Ssl::ServerBump::~ServerBump()
 {
-    debugs(33, 4, HERE << "destroying");
+    debugs(33, 4, "destroying");
     if (entry) {
-        debugs(33, 4, HERE << *entry);
+        debugs(33, 4, *entry);
         storeUnregister(sc, entry, this);
         entry->unlock("Ssl::ServerBump");
     }

--- a/src/stmem.cc
+++ b/src/stmem.cc
@@ -61,7 +61,7 @@ mem_hdr::freeContent()
 {
     nodes.destroy();
     inmem_hi = 0;
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << inmem_hi);
 }
 
 bool
@@ -122,15 +122,15 @@ mem_hdr::writeAvailable(mem_node *aNode, int64_t location, size_t amount, char c
 
     memcpy(aNode->nodeBuffer.data + aNode->nodeBuffer.length, source, copyLen);
 
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << inmem_hi);
     if (inmem_hi <= location)
         inmem_hi = location + copyLen;
 
     /* Adjust the ptr and len according to what was deposited in the page */
     aNode->nodeBuffer.length += copyLen;
 
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
-    debugs(19, 9, HERE << this << " hi: " << endOffset());
+    debugs(19, 9, this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << endOffset());
     return copyLen;
 }
 
@@ -373,7 +373,7 @@ mem_hdr::write (StoreIOBuffer const &writeBuffer)
 
 mem_hdr::mem_hdr() : inmem_hi(0)
 {
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << inmem_hi);
 }
 
 mem_hdr::~mem_hdr()

--- a/src/store.cc
+++ b/src/store.cc
@@ -214,7 +214,7 @@ StoreEntry::delayAwareRead(const Comm::ConnectionPointer &conn, char *buf, int l
         // readers appeared to care around 2009/12/14 as they skipped reading
         // for other reasons. Closing may already be true at the delyaAwareRead
         // call time or may happen while we wait after delayRead() above.
-        debugs(20, 3, HERE << "wont read from closing " << conn << " for " <<
+        debugs(20, 3, "wont read from closing " << conn << " for " <<
                callback);
         return; // the read callback will never be called
     }
@@ -283,7 +283,7 @@ StoreEntry::storeClientType() const
 
         if (mem_obj->inmem_lo == 0 && !isEmpty()) {
             if (swap_status == SWAPOUT_DONE) {
-                debugs(20,7, HERE << mem_obj << " lo: " << mem_obj->inmem_lo << " hi: " << mem_obj->endOffset() << " size: " << mem_obj->object_sz);
+                debugs(20,7, mem_obj << " lo: " << mem_obj->inmem_lo << " hi: " << mem_obj->endOffset() << " size: " << mem_obj->object_sz);
                 if (mem_obj->endOffset() == mem_obj->object_sz) {
                     /* hot object fully swapped in (XXX: or swapped out?) */
                     return STORE_MEM_CLIENT;
@@ -352,7 +352,7 @@ StoreEntry::deferProducer(const AsyncCall::Pointer &producer)
     if (!deferredProducer)
         deferredProducer = producer;
     else
-        debugs(20, 5, HERE << "Deferred producer call is allready set to: " <<
+        debugs(20, 5, "Deferred producer call is allready set to: " <<
                *deferredProducer << ", requested call: " << *producer);
 }
 
@@ -369,7 +369,7 @@ StoreEntry::kickProducer()
 void
 StoreEntry::destroyMemObject()
 {
-    debugs(20, 3, HERE << "destroyMemObject " << mem_obj);
+    debugs(20, 3, "destroyMemObject " << mem_obj);
 
     if (MemObject *mem = mem_obj) {
         // Store::Root() is FATALly missing during shutdown
@@ -387,7 +387,7 @@ StoreEntry::destroyMemObject()
 void
 destroyStoreEntry(void *data)
 {
-    debugs(20, 3, HERE << "destroyStoreEntry: destroying " <<  data);
+    debugs(20, 3, "destroyStoreEntry: destroying " <<  data);
     StoreEntry *e = static_cast<StoreEntry *>(static_cast<hash_link *>(data));
     assert(e != NULL);
 
@@ -1158,7 +1158,7 @@ StoreEntry::abort()
      */
     if (mem_obj->abort.callback) {
         if (!cbdataReferenceValid(mem_obj->abort.data))
-            debugs(20, DBG_IMPORTANT,HERE << "queueing event when abort.data is not valid");
+            debugs(20, DBG_IMPORTANT,"queueing event when abort.data is not valid");
         eventAdd("mem_obj->abort.callback",
                  mem_obj->abort.callback,
                  mem_obj->abort.data,

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -308,7 +308,7 @@ Store::Controller::find(const cache_key *key)
     if (StoreEntry *e = static_cast<StoreEntry*>(hash_lookup(store_table, key))) {
         // TODO: ignore and maybe handleIdleEntry() unlocked intransit entries
         // because their backing store slot may be gone already.
-        debugs(20, 3, HERE << "got in-transit entry: " << *e);
+        debugs(20, 3, "got in-transit entry: " << *e);
         return e;
     }
 
@@ -328,7 +328,7 @@ Store::Controller::find(const cache_key *key)
 
     if (memStore) {
         if (StoreEntry *e = memStore->get(key)) {
-            debugs(20, 3, HERE << "got mem-cached entry: " << *e);
+            debugs(20, 3, "got mem-cached entry: " << *e);
             return e;
         }
     }
@@ -398,7 +398,7 @@ Store::Controller::memoryOut(StoreEntry &e, const bool preserveSwappable)
     else
         keepInLocalMemory = keepForLocalMemoryCache(e);
 
-    debugs(20, 7, HERE << "keepInLocalMemory: " << keepInLocalMemory);
+    debugs(20, 7, "keepInLocalMemory: " << keepInLocalMemory);
 
     if (!keepInLocalMemory)
         e.trimMemory(preserveSwappable);
@@ -476,12 +476,12 @@ Store::Controller::handleIdleEntry(StoreEntry &e)
     // An idle, unlocked entry that only belongs to a SwapDir which controls
     // its own index, should not stay in the global store_table.
     if (!dereferenceIdle(e, keepInLocalMemory)) {
-        debugs(20, 5, HERE << "destroying unlocked entry: " << &e << ' ' << e);
+        debugs(20, 5, "destroying unlocked entry: " << &e << ' ' << e);
         destroyStoreEntry(static_cast<hash_link*>(&e));
         return;
     }
 
-    debugs(20, 5, HERE << "keepInLocalMemory: " << keepInLocalMemory);
+    debugs(20, 5, "keepInLocalMemory: " << keepInLocalMemory);
 
     // TODO: move this into [non-shared] memory cache class when we have one
     if (keepInLocalMemory) {

--- a/src/store/Disk.cc
+++ b/src/store/Disk.cc
@@ -163,7 +163,7 @@ Store::Disk::objectSizeIsAcceptable(int64_t objsize) const
 bool
 Store::Disk::canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const
 {
-    debugs(47,8, HERE << "cache_dir[" << index << "]: needs " <<
+    debugs(47,8, "cache_dir[" << index << "]: needs " <<
            diskSpaceNeeded << " <? " << max_objsize);
 
     if (EBIT_TEST(e.flags, ENTRY_SPECIAL))

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -325,7 +325,7 @@ store_client::doCopy(StoreEntry *anEntry)
 
     if (!moreToSend()) {
         /* There is no more to send! */
-        debugs(33, 3, HERE << "There is no more to send!");
+        debugs(33, 3, "There is no more to send!");
         callback(0);
         flags.store_copying = false;
         return;

--- a/src/store_io.cc
+++ b/src/store_io.cc
@@ -68,13 +68,13 @@ void
 storeClose(StoreIOState::Pointer sio, int how)
 {
     if (sio->flags.closing) {
-        debugs(20,3,HERE << "storeClose: flags.closing already set, bailing");
+        debugs(20,3,"storeClose: flags.closing already set, bailing");
         return;
     }
 
     sio->flags.closing = true;
 
-    debugs(20,3,HERE << "storeClose: calling sio->close(" << how << ")");
+    debugs(20,3,"storeClose: calling sio->close(" << how << ")");
     sio->close(how);
 }
 

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -305,7 +305,7 @@ storeRebuildParseEntry(MemBuf &buf, StoreEntry &tmpe, cache_key *key,
     int swap_hdr_len = 0;
     StoreMetaUnpacker aBuilder(buf.content(), buf.contentSize(), &swap_hdr_len);
     if (aBuilder.isBufferZero()) {
-        debugs(47,5, HERE << "skipping empty record.");
+        debugs(47,5, "skipping empty record.");
         return false;
     }
 

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -29,7 +29,7 @@ storeSwapInStart(store_client * sc)
     }
 
     if (e->mem_status != NOT_IN_MEMORY)
-        debugs(20, 3, HERE << "already IN_MEMORY");
+        debugs(20, 3, "already IN_MEMORY");
 
     debugs(20, 3, "storeSwapInStart: called for : " << e->swap_dirn << " " <<
            std::hex << std::setw(8) << std::setfill('0') << std::uppercase <<

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -190,16 +190,16 @@ StoreEntry::swapOut()
     // Aborted entries have STORE_OK, but swapoutPossible rejects them. Thus,
     // store_status == STORE_OK below means we got everything we wanted.
 
-    debugs(20, 7, HERE << "storeSwapOut: mem->inmem_lo = " << mem_obj->inmem_lo);
-    debugs(20, 7, HERE << "storeSwapOut: mem->endOffset() = " << mem_obj->endOffset());
-    debugs(20, 7, HERE << "storeSwapOut: swapout.queue_offset = " << mem_obj->swapout.queue_offset);
+    debugs(20, 7, "storeSwapOut: mem->inmem_lo = " << mem_obj->inmem_lo);
+    debugs(20, 7, "storeSwapOut: mem->endOffset() = " << mem_obj->endOffset());
+    debugs(20, 7, "storeSwapOut: swapout.queue_offset = " << mem_obj->swapout.queue_offset);
 
     if (mem_obj->swapout.sio != NULL)
         debugs(20, 7, "storeSwapOut: storeOffset() = " << mem_obj->swapout.sio->offset()  );
 
     int64_t const lowest_offset = mem_obj->lowestMemReaderOffset();
 
-    debugs(20, 7, HERE << "storeSwapOut: lowest_offset = " << lowest_offset);
+    debugs(20, 7, "storeSwapOut: lowest_offset = " << lowest_offset);
 
 #if SIZEOF_OFF_T <= 4
 
@@ -315,7 +315,7 @@ storeSwapOutFileClosed(void *data, int errflag, StoreIOState::Pointer self)
         debugs(20, 3, "storeSwapOutFileClosed: SwapOut complete: '" << e->url() << "' to " <<
                e->swap_dirn  << ", " << std::hex << std::setw(8) << std::setfill('0') <<
                std::uppercase << e->swap_filen);
-        debugs(20, 5, HERE << "swap_file_sz = " <<
+        debugs(20, 5, "swap_file_sz = " <<
                e->objectLen() << " + " << mem->swap_hdr_sz);
 
         e->swap_file_sz = e->objectLen() + mem->swap_hdr_sz;
@@ -354,7 +354,7 @@ StoreEntry::mayStartSwapOut()
 
     // if we decided that starting is not possible, do not repeat same checks
     if (decision == MemObject::SwapOut::swImpossible) {
-        debugs(20, 3, HERE << " already rejected");
+        debugs(20, 3, "already rejected");
         return false;
     }
 
@@ -379,13 +379,13 @@ StoreEntry::mayStartSwapOut()
     }
 
     if (!checkCachable()) {
-        debugs(20, 3,  HERE << "not cachable");
+        debugs(20, 3,  "not cachable");
         swapOutDecision(MemObject::SwapOut::swImpossible);
         return false;
     }
 
     if (EBIT_TEST(flags, ENTRY_SPECIAL)) {
-        debugs(20, 3,  HERE  << url() << " SPECIAL");
+        debugs(20, 3,  url() << " SPECIAL");
         swapOutDecision(MemObject::SwapOut::swImpossible);
         return false;
     }
@@ -408,9 +408,9 @@ StoreEntry::mayStartSwapOut()
 
         // use guaranteed maximum if it is known
         const int64_t expectedEnd = mem_obj->expectedReplySize();
-        debugs(20, 7,  HERE << "expectedEnd = " << expectedEnd);
+        debugs(20, 7,  "expectedEnd = " << expectedEnd);
         if (expectedEnd > store_maxobjsize) {
-            debugs(20, 3,  HERE << "will not fit: " << expectedEnd <<
+            debugs(20, 3,  "will not fit: " << expectedEnd <<
                    " > " << store_maxobjsize);
             swapOutDecision(MemObject::SwapOut::swImpossible);
             return false; // known to outgrow the limit eventually
@@ -419,7 +419,7 @@ StoreEntry::mayStartSwapOut()
         // use current minimum (always known)
         const int64_t currentEnd = mem_obj->endOffset();
         if (currentEnd > store_maxobjsize) {
-            debugs(20, 3,  HERE << "does not fit: " << currentEnd <<
+            debugs(20, 3,  "does not fit: " << currentEnd <<
                    " > " << store_maxobjsize);
             swapOutDecision(MemObject::SwapOut::swImpossible);
             return false; // already does not fit and may only get bigger

--- a/src/tests/stub_cache_manager.cc
+++ b/src/tests/stub_cache_manager.cc
@@ -17,7 +17,7 @@
 Mgr::Action::Pointer CacheManager::createNamedAction(char const* action) STUB_RETVAL(NULL)
 void CacheManager::Start(const Comm::ConnectionPointer &conn, HttpRequest * request, StoreEntry * entry)
 {
-    std::cerr << HERE << "\n";
+    std::cerr << "\n";
     STUB
 }
 CacheManager* CacheManager::instance=0;

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -491,7 +491,7 @@ getMyHostname(void)
 const char *
 uniqueHostname(void)
 {
-    debugs(21, 3, HERE << " Config: '" << Config.uniqueHostname << "'");
+    debugs(21, 3, "Config: '" << Config.uniqueHostname << "'");
     return Config.uniqueHostname ? Config.uniqueHostname : getMyHostname();
 }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -253,7 +253,7 @@ static void
 tunnelServerClosed(const CommCloseCbParams &params)
 {
     TunnelStateData *tunnelState = (TunnelStateData *)params.data;
-    debugs(26, 3, HERE << tunnelState->server.conn);
+    debugs(26, 3, tunnelState->server.conn);
     tunnelState->server.conn = NULL;
     tunnelState->server.writer = NULL;
 
@@ -282,7 +282,7 @@ static void
 tunnelClientClosed(const CommCloseCbParams &params)
 {
     TunnelStateData *tunnelState = (TunnelStateData *)params.data;
-    debugs(26, 3, HERE << tunnelState->client.conn);
+    debugs(26, 3, tunnelState->client.conn);
     tunnelState->client.conn = NULL;
     tunnelState->client.writer = NULL;
 
@@ -363,7 +363,7 @@ TunnelStateData::Connection::bytesWanted(int lowerbound, int upperbound) const
 void
 TunnelStateData::Connection::bytesIn(int const &count)
 {
-    debugs(26, 3, HERE << "len=" << len << " + count=" << count);
+    debugs(26, 3, "len=" << len << " + count=" << count);
 #if USE_DELAY_POOLS
     delayId.bytesIn(count);
 #endif
@@ -393,7 +393,7 @@ TunnelStateData::ReadServer(const Comm::ConnectionPointer &c, char *buf, size_t 
 {
     TunnelStateData *tunnelState = (TunnelStateData *)data;
     assert(cbdataReferenceValid(tunnelState));
-    debugs(26, 3, HERE << c);
+    debugs(26, 3, c);
 
     tunnelState->readServer(buf, len, errcode, xerrno);
 }
@@ -401,7 +401,7 @@ TunnelStateData::ReadServer(const Comm::ConnectionPointer &c, char *buf, size_t 
 void
 TunnelStateData::readServer(char *, size_t len, Comm::Flag errcode, int xerrno)
 {
-    debugs(26, 3, HERE << server.conn << ", read " << len << " bytes, err=" << errcode);
+    debugs(26, 3, server.conn << ", read " << len << " bytes, err=" << errcode);
     server.delayedLoops=0;
 
     /*
@@ -555,7 +555,7 @@ TunnelStateData::handleConnectResponse(const size_t chunkSize)
 void
 TunnelStateData::Connection::error(int const xerrno)
 {
-    debugs(50, debugLevelForError(xerrno), HERE << conn << ": read/write failure: " << xstrerr(xerrno));
+    debugs(50, debugLevelForError(xerrno), conn << ": read/write failure: " << xstrerr(xerrno));
 
     if (!ignoreErrno(xerrno))
         conn->close();
@@ -574,7 +574,7 @@ TunnelStateData::ReadClient(const Comm::ConnectionPointer &, char *buf, size_t l
 void
 TunnelStateData::readClient(char *, size_t len, Comm::Flag errcode, int xerrno)
 {
-    debugs(26, 3, HERE << client.conn << ", read " << len << " bytes, err=" << errcode);
+    debugs(26, 3, client.conn << ", read " << len << " bytes, err=" << errcode);
     client.delayedLoops=0;
 
     /*
@@ -599,7 +599,7 @@ TunnelStateData::readClient(char *, size_t len, Comm::Flag errcode, int xerrno)
 bool
 TunnelStateData::keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, Connection &from, Connection &to)
 {
-    debugs(26, 3, HERE << "from={" << from.conn << "}, to={" << to.conn << "}");
+    debugs(26, 3, "from={" << from.conn << "}, to={" << to.conn << "}");
 
     /* I think this is to prevent free-while-in-a-callback behaviour
      * - RBC 20030229
@@ -625,7 +625,7 @@ TunnelStateData::keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, 
     if (errcode)
         from.error (xerrno);
     else if (len == 0 || !Comm::IsConnOpen(to.conn)) {
-        debugs(26, 3, HERE << "Nothing to write or client gone. Terminate the tunnel.");
+        debugs(26, 3, "Nothing to write or client gone. Terminate the tunnel.");
         from.conn->close();
 
         /* Only close the remote end if we've finished queueing data to it */
@@ -642,7 +642,7 @@ TunnelStateData::keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, 
 void
 TunnelStateData::copy(size_t len, Connection &from, Connection &to, IOCB *completion)
 {
-    debugs(26, 3, HERE << "Schedule Write");
+    debugs(26, 3, "Schedule Write");
     AsyncCall::Pointer call = commCbCall(5,5, "TunnelBlindCopyWriteHandler",
                                          CommIoCbPtrFun(completion, this));
     to.write(from.buf, len, call, NULL);
@@ -662,12 +662,12 @@ TunnelStateData::WriteServerDone(const Comm::ConnectionPointer &, char *buf, siz
 void
 TunnelStateData::writeServerDone(char *, size_t len, Comm::Flag flag, int xerrno)
 {
-    debugs(26, 3, HERE  << server.conn << ", " << len << " bytes written, flag=" << flag);
+    debugs(26, 3, server.conn << ", " << len << " bytes written, flag=" << flag);
 
     /* Error? */
     if (flag != Comm::OK) {
         if (flag != Comm::ERR_CLOSING) {
-            debugs(26, 4, HERE << "calling TunnelStateData::server.error(" << xerrno <<")");
+            debugs(26, 4, "calling TunnelStateData::server.error(" << xerrno <<")");
             server.error(xerrno); // may call comm_close
         }
         return;
@@ -675,7 +675,7 @@ TunnelStateData::writeServerDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* EOF? */
     if (len == 0) {
-        debugs(26, 4, HERE << "No read input. Closing server connection.");
+        debugs(26, 4, "No read input. Closing server connection.");
         server.conn->close();
         return;
     }
@@ -687,7 +687,7 @@ TunnelStateData::writeServerDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* If the other end has closed, so should we */
     if (!Comm::IsConnOpen(client.conn)) {
-        debugs(26, 4, HERE << "Client gone away. Shutting down server connection.");
+        debugs(26, 4, "Client gone away. Shutting down server connection.");
         server.conn->close();
         return;
     }
@@ -712,7 +712,7 @@ TunnelStateData::WriteClientDone(const Comm::ConnectionPointer &, char *buf, siz
 void
 TunnelStateData::Connection::dataSent(size_t amount)
 {
-    debugs(26, 3, HERE << "len=" << len << " - amount=" << amount);
+    debugs(26, 3, "len=" << len << " - amount=" << amount);
     assert(amount == (size_t)len);
     len =0;
     /* increment total object size */
@@ -731,12 +731,12 @@ TunnelStateData::Connection::write(const char *b, int size, AsyncCall::Pointer &
 void
 TunnelStateData::writeClientDone(char *, size_t len, Comm::Flag flag, int xerrno)
 {
-    debugs(26, 3, HERE << client.conn << ", " << len << " bytes written, flag=" << flag);
+    debugs(26, 3, client.conn << ", " << len << " bytes written, flag=" << flag);
 
     /* Error? */
     if (flag != Comm::OK) {
         if (flag != Comm::ERR_CLOSING) {
-            debugs(26, 4, HERE << "Closing client connection due to comm flags.");
+            debugs(26, 4, "Closing client connection due to comm flags.");
             client.error(xerrno); // may call comm_close
         }
         return;
@@ -744,7 +744,7 @@ TunnelStateData::writeClientDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* EOF? */
     if (len == 0) {
-        debugs(26, 4, HERE << "Closing client connection due to 0 byte read.");
+        debugs(26, 4, "Closing client connection due to 0 byte read.");
         client.conn->close();
         return;
     }
@@ -755,7 +755,7 @@ TunnelStateData::writeClientDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* If the other end has closed, so should we */
     if (!Comm::IsConnOpen(server.conn)) {
-        debugs(26, 4, HERE << "Server has gone away. Terminating client connection.");
+        debugs(26, 4, "Server has gone away. Terminating client connection.");
         client.conn->close();
         return;
     }
@@ -770,7 +770,7 @@ static void
 tunnelTimeout(const CommTimeoutCbParams &io)
 {
     TunnelStateData *tunnelState = static_cast<TunnelStateData *>(io.data);
-    debugs(26, 3, HERE << io.conn);
+    debugs(26, 3, io.conn);
     /* Temporary lock to protect our own feets (comm_close -> tunnelClientClosed -> Free) */
     CbcPointer<TunnelStateData> safetyLock(tunnelState);
 
@@ -909,7 +909,7 @@ static void
 tunnelConnectedWriteDone(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::Flag flag, int, void *data)
 {
     TunnelStateData *tunnelState = (TunnelStateData *)data;
-    debugs(26, 3, HERE << conn << ", flag=" << flag);
+    debugs(26, 3, conn << ", flag=" << flag);
     tunnelState->client.writer = NULL;
 
     if (flag != Comm::OK) {
@@ -966,7 +966,7 @@ static void
 tunnelConnected(const Comm::ConnectionPointer &server, void *data)
 {
     TunnelStateData *tunnelState = (TunnelStateData *)data;
-    debugs(26, 3, HERE << server << ", tunnelState=" << tunnelState);
+    debugs(26, 3, server << ", tunnelState=" << tunnelState);
 
     if (!tunnelState->clientExpectsConnectResponse())
         tunnelStartShoveling(tunnelState); // ssl-bumped connection, be quiet
@@ -981,7 +981,7 @@ static void
 tunnelErrorComplete(int fd/*const Comm::ConnectionPointer &*/, void *data, size_t)
 {
     TunnelStateData *tunnelState = (TunnelStateData *)data;
-    debugs(26, 3, HERE << "FD " << fd);
+    debugs(26, 3, "FD " << fd);
     assert(tunnelState != NULL);
     /* temporary lock to save our own feets (comm_close -> tunnelClientClosed -> Free) */
     CbcPointer<TunnelStateData> safetyLock(tunnelState);
@@ -1049,7 +1049,7 @@ tunnelConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xe
     tunnelState->request->peer_host = conn->getPeer() ? conn->getPeer()->host : NULL;
     comm_add_close_handler(conn->fd, tunnelServerClosed, tunnelState);
 
-    debugs(26, 4, HERE << "determine post-connect handling pathway.");
+    debugs(26, 4, "determine post-connect handling pathway.");
     if (conn->getPeer()) {
         tunnelState->request->peer_login = conn->getPeer()->login;
         tunnelState->request->peer_domain = conn->getPeer()->domain;
@@ -1076,7 +1076,7 @@ tunnelConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xe
 void
 tunnelStart(ClientHttpRequest * http)
 {
-    debugs(26, 3, HERE);
+    debugs(26, 3, "");
     /* Create state structure. */
     TunnelStateData *tunnelState = NULL;
     ErrorState *err = NULL;
@@ -1098,7 +1098,7 @@ tunnelStart(ClientHttpRequest * http)
         ch.src_addr = request->client_addr;
         ch.my_addr = request->my_addr;
         if (ch.fastCheck().denied()) {
-            debugs(26, 4, HERE << "MISS access forbidden.");
+            debugs(26, 4, "MISS access forbidden.");
             err = new ErrorState(ERR_FORWARDING_DENIED, Http::scForbidden, request);
             http->al->http.code = Http::scForbidden;
             errorSend(http->getConn()->clientConnection, err);
@@ -1154,7 +1154,7 @@ tunnelRelayConnectRequest(const Comm::ConnectionPointer &srv, void *data)
     assert(!tunnelState->waitingForConnectExchange());
     HttpHeader hdr_out(hoRequest);
     Http::StateFlags flags;
-    debugs(26, 3, HERE << srv << ", tunnelState=" << tunnelState);
+    debugs(26, 3, srv << ", tunnelState=" << tunnelState);
     memset(&flags, '\0', sizeof(flags));
     flags.proxying = tunnelState->request->flags.proxying;
     MemBuf mb;

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -88,7 +88,7 @@ static void
 whoisTimeout(const CommTimeoutCbParams &io)
 {
     WhoisState *p = static_cast<WhoisState *>(io.data);
-    debugs(75, 3, HERE << io.conn << ", URL " << p->entry->url());
+    debugs(75, 3, io.conn << ", URL " << p->entry->url());
     io.conn->close();
 }
 
@@ -117,7 +117,7 @@ WhoisState::readReply(const Comm::ConnectionPointer &conn, char *aBuffer, size_t
         return;
 
     aBuffer[aBufferLength] = '\0';
-    debugs(75, 3, HERE << conn << " read " << aBufferLength << " bytes");
+    debugs(75, 3, conn << " read " << aBufferLength << " bytes");
     debugs(75, 5, "{" << aBuffer << "}");
 
     if (flag != Comm::OK) {


### PR DESCRIPTION
This is a controversial change because it brings no runtime benefits,
creates significant cross-branch patch porting headaches and branch
maintenance overheads, but it also removes one source of persistent
bickering during code review and improves code consistency. Global
removal is the only practical way we can remove all HEREs -- restricting
removal of HEREs to changed-for-other-reasons lines would take forever.

The (simple) script to remove HEREs will be published separately because
it is not really needed in this source tree (which no longer uses HERE).

This pull request has two commits that should not be squashed IMO. One
automatically removes HERE usage (using a script) and another manually
removes HERE declarations.