### PR TITLE
Move TLS/SSL http_port config values from libanyp objects to libsecurity

### DIFF
--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -40,17 +40,6 @@ AnyP::PortCfg::PortCfg() :
     vport(0),
     disable_pmtu_discovery(0),
     listenConn()
-#if USE_OPENSSL
-    ,
-    sslContextSessionId(NULL),
-    generateHostCertificates(true),
-    dynamicCertMemCacheSize(4*1024*1024), // 4 MB
-    signingCert(),
-    signPkey(),
-    certsToChain(),
-    untrustedSigningCert(),
-    untrustedSignPkey()
-#endif
 {
     memset(&tcp_keepalive, 0, sizeof(tcp_keepalive));
 }
@@ -64,10 +53,6 @@ AnyP::PortCfg::~PortCfg()
 
     safe_free(name);
     safe_free(defaultsite);
-
-#if USE_OPENSSL
-    safe_free(sslContextSessionId);
-#endif
 }
 
 AnyP::PortCfgPointer
@@ -91,50 +76,6 @@ AnyP::PortCfg::clone() const
     b->tcp_keepalive = tcp_keepalive;
     b->secure = secure;
 
-#if USE_OPENSSL
-    if (sslContextSessionId)
-        b->sslContextSessionId = xstrdup(sslContextSessionId);
-
-#if 0
-    // TODO: AYJ: 2015-01-15: for now SSL does not clone the context object.
-    // cloning should only be done before the PortCfg is post-configure initialized and opened
-    Security::ContextPointer sslContext;
-#endif
-
-#endif /*0*/
-
     return b;
 }
-
-#if USE_OPENSSL
-void
-AnyP::PortCfg::configureSslServerContext()
-{
-    if (!secure.certs.empty()) {
-        Security::KeyData &keys = secure.certs.front();
-        Ssl::readCertChainAndPrivateKeyFromFiles(signingCert, signPkey, certsToChain, keys.certFile.c_str(), keys.privateKeyFile.c_str());
-    }
-
-    if (!signingCert) {
-        char buf[128];
-        fatalf("No valid signing SSL certificate configured for %s_port %s", AnyP::ProtocolType_str[transport.protocol],  s.toUrl(buf, sizeof(buf)));
-    }
-
-    if (!signPkey)
-        debugs(3, DBG_IMPORTANT, "No SSL private key configured for  " << AnyP::ProtocolType_str[transport.protocol] << "_port " << s);
-
-    Ssl::generateUntrustedCert(untrustedSigningCert, untrustedSignPkey,
-                               signingCert, signPkey);
-
-    if (!untrustedSigningCert) {
-        char buf[128];
-        fatalf("Unable to generate signing SSL certificate for untrusted sites for %s_port %s", AnyP::ProtocolType_str[transport.protocol], s.toUrl(buf, sizeof(buf)));
-    }
-
-    if (!secure.createStaticServerContext(*this)) {
-        char buf[128];
-        fatalf("%s_port %s initialization error", AnyP::ProtocolType_str[transport.protocol], s.toUrl(buf, sizeof(buf)));
-    }
-}
-#endif
 

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -16,10 +16,6 @@
 #include "sbuf/SBuf.h"
 #include "security/ServerOptions.h"
 
-#if USE_OPENSSL
-#include "ssl/gadgets.h"
-#endif
-
 namespace AnyP
 {
 
@@ -29,10 +25,6 @@ public:
     PortCfg();
     ~PortCfg();
     AnyP::PortCfgPointer clone() const;
-#if USE_OPENSSL
-    /// creates, configures, and validates SSL context and related port options
-    void configureSslServerContext();
-#endif
 
     PortCfgPointer next;
 
@@ -71,18 +63,6 @@ public:
 
     /// TLS configuration options for this listening port
     Security::ServerOptions secure;
-
-#if USE_OPENSSL
-    char *sslContextSessionId; ///< "session id context" for secure.staticSslContext
-    bool generateHostCertificates; ///< dynamically make host cert for sslBump
-    size_t dynamicCertMemCacheSize; ///< max size of generated certificates memory cache
-
-    Security::CertPointer signingCert; ///< x509 certificate for signing generated certificates
-    Ssl::EVP_PKEY_Pointer signPkey; ///< private key for sighing generated certificates
-    Ssl::X509_STACK_Pointer certsToChain; ///<  x509 certificates to send with the generated cert
-    Security::CertPointer untrustedSigningCert; ///< x509 certificate for signing untrusted generated certificates
-    Ssl::EVP_PKEY_Pointer untrustedSignPkey; ///< private key for signing untrusted generated certificates
-#endif
 };
 
 } // namespace AnyP

--- a/src/cache_cf.h
+++ b/src/cache_cf.h
@@ -24,6 +24,8 @@ void parse_eol(char *volatile *var);
 void parse_wordlist(wordlist ** list);
 void requirePathnameExists(const char *name, const char *path);
 void parse_time_t(time_t * var);
+/// Parse bytes number from a string
+void parseBytesOptionValue(size_t * bptr, const char *units, char const * value);
 
 #endif /* SQUID_CACHE_CF_H_ */
 

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -282,10 +282,9 @@ Security::PeerOptions::createClientContext(bool setOptions)
 
     Security::ContextPointer t(createBlankContext());
     if (t) {
+        if (setOptions)
+            updateContextOptions(t);
 #if USE_OPENSSL
-        // NP: GnuTLS uses 'priorities' which are set per-session instead.
-        SSL_CTX_set_options(t.get(), (setOptions ? parsedOptions : 0));
-
         // XXX: temporary performance regression. c_str() data copies and prevents this being a const method
         Ssl::InitClientContext(t, *this, parsedFlags);
 #endif
@@ -591,6 +590,16 @@ Security::PeerOptions::loadCrlFile()
         parsedCrl.emplace_back(Security::CrlPointer(crl));
     }
     BIO_free(in);
+#endif
+}
+
+void
+Security::PeerOptions::updateContextOptions(Security::ContextPointer &ctx) const
+{
+#if USE_OPENSSL
+    SSL_CTX_set_options(ctx.get(), parsedOptions);
+#elif USE_GNUTLS
+    // NP: GnuTLS uses 'priorities' which are set per-session instead.
 #endif
 }
 

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -44,6 +44,9 @@ public:
     /// sync the context options with tls-min-version=N configuration
     void updateTlsVersionLimits();
 
+    /// Setup the library specific 'options=' parameters for the given context.
+    void updateContextOptions(Security::ContextPointer &) const;
+
     /// setup the NPN extension details for the given context
     void updateContextNpn(Security::ContextPointer &);
 

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -46,11 +46,21 @@ public:
     /// \returns true if a context could be created
     bool createStaticServerContext(AnyP::PortCfg &);
 
+    /// initialize contexts for signing dynamic TLS certificates (if needed)
+    /// the resulting context is stored in signingCert, signPKey, untrustedSigningCert, untrustedSignPKey
+    void createSigningContexts(AnyP::PortCfg &);
+
+    /// update the given TLS security context using squid.conf settings
+    bool updateContextConfig(Security::ContextPointer &);
+
     /// update the context with DH, EDH, EECDH settings
     void updateContextEecdh(Security::ContextPointer &);
 
     /// update the context with CA details used to verify client certificates
     void updateContextClientCa(Security::ContextPointer &);
+
+    /// update the context with a configured session ID (if any)
+    void updateContextSessionId(Security::ContextPointer &);
 
     /// sync the various sources of CA files to be loaded
     void syncCaFiles();
@@ -58,6 +68,18 @@ public:
 public:
     /// TLS context to use for HTTPS accelerator or static SSL-Bump
     Security::ContextPointer staticContext;
+    SBuf staticContextSessionId; ///< "session id context" for staticContext
+
+    bool generateHostCertificates = true; ///< dynamically make host cert
+
+    Security::CertPointer signingCert; ///< x509 certificate for signing generated certificates
+    Security::PrivateKeyPointer signPkey; ///< private key for signing generated certificates
+    Security::CertList certsToChain; ///<  x509 certificates to send with the generated cert
+    Security::CertPointer untrustedSigningCert; ///< x509 certificate for signing untrusted generated certificates
+    Security::PrivateKeyPointer untrustedSignPkey; ///< private key for signing untrusted generated certificates
+
+    /// max size of generated certificates memory cache (4 MB default)
+    size_t dynamicCertMemCacheSize = 4*1024*1024;
 
 private:
     bool loadClientCaFile();

--- a/src/security/Session.h
+++ b/src/security/Session.h
@@ -78,7 +78,7 @@ void MaybeGetSessionResumeData(const Security::SessionPointer &, Security::Sessi
 void SetSessionResumeData(const Security::SessionPointer &, const Security::SessionStatePointer &);
 
 #if USE_OPENSSL
-// TODO: remove from public API. It is only public because of configureSslContext() in ssl/support.cc
+// TODO: remove from public API. It is only public because of Security::ServerOptions::updateContextConfig
 /// Setup the given TLS context with callbacks used to manage the session cache
 void SetSessionCacheCallbacks(Security::ContextPointer &);
 

--- a/src/security/cert_generators/file/certificate_db.cc
+++ b/src/security/cert_generators/file/certificate_db.cc
@@ -265,7 +265,7 @@ Ssl::CertificateDb::CertificateDb(std::string const & aDb_path, size_t aMax_db_s
 }
 
 bool
-Ssl::CertificateDb::find(std::string const &key,  const Security::CertPointer &expectedOrig, Security::CertPointer & cert, Ssl::EVP_PKEY_Pointer & pkey)
+Ssl::CertificateDb::find(std::string const &key, const Security::CertPointer &expectedOrig, Security::CertPointer &cert, Security::PrivateKeyPointer &pkey)
 {
     const Locker locker(dbLock, Here);
     load();
@@ -286,7 +286,8 @@ bool Ssl::CertificateDb::purgeCert(std::string const & key) {
 }
 
 bool
-Ssl::CertificateDb::addCertAndPrivateKey(std::string const & useKey, const Security::CertPointer & cert, const Ssl::EVP_PKEY_Pointer & pkey, const Security::CertPointer &orig) {
+Ssl::CertificateDb::addCertAndPrivateKey(std::string const &useKey, const Security::CertPointer &cert, const Security::PrivateKeyPointer &pkey, const Security::CertPointer &orig)
+{
     const Locker locker(dbLock, Here);
     load();
     if (!db || !cert || !pkey)
@@ -424,7 +425,7 @@ size_t Ssl::CertificateDb::rebuildSize()
 }
 
 bool
-Ssl::CertificateDb::pure_find(std::string const &key, const Security::CertPointer &expectedOrig, Security::CertPointer & cert, Ssl::EVP_PKEY_Pointer & pkey)
+Ssl::CertificateDb::pure_find(std::string const &key, const Security::CertPointer &expectedOrig, Security::CertPointer &cert, Security::PrivateKeyPointer &pkey)
 {
     if (!db)
         return false;
@@ -636,7 +637,7 @@ bool Ssl::CertificateDb::IsEnabledDiskStore() const {
 }
 
 bool
-Ssl::CertificateDb::WriteEntry(const std::string &filename, const Security::CertPointer & cert, const Ssl::EVP_PKEY_Pointer & pkey, const Security::CertPointer &orig)
+Ssl::CertificateDb::WriteEntry(const std::string &filename, const Security::CertPointer &cert, const Security::PrivateKeyPointer &pkey, const Security::CertPointer &orig)
 {
     Ssl::BIO_Pointer bio;
     if (!Ssl::OpenCertsFileForWriting(bio, filename.c_str()))
@@ -651,7 +652,7 @@ Ssl::CertificateDb::WriteEntry(const std::string &filename, const Security::Cert
 }
 
 bool
-Ssl::CertificateDb::ReadEntry(std::string filename, Security::CertPointer & cert, Ssl::EVP_PKEY_Pointer & pkey, Security::CertPointer &orig)
+Ssl::CertificateDb::ReadEntry(std::string filename, Security::CertPointer &cert, Security::PrivateKeyPointer &pkey, Security::CertPointer &orig)
 {
     Ssl::BIO_Pointer bio;
     if (!Ssl::OpenCertsFileForReading(bio, filename.c_str()))

--- a/src/security/cert_generators/file/certificate_db.h
+++ b/src/security/cert_generators/file/certificate_db.h
@@ -97,11 +97,11 @@ public:
 
     CertificateDb(std::string const & db_path, size_t aMax_db_size, size_t aFs_block_size);
     /// finds matching generated certificate and its private key
-    bool find(std::string const & key,  const Security::CertPointer &expectedOrig, Security::CertPointer & cert, Ssl::EVP_PKEY_Pointer & pkey);
+    bool find(std::string const & key,  const Security::CertPointer &expectedOrig, Security::CertPointer & cert, Security::PrivateKeyPointer & pkey);
     /// Delete a certificate from database
     bool purgeCert(std::string const & key);
     /// Save certificate to disk.
-    bool addCertAndPrivateKey(std::string const & useKey, const Security::CertPointer & cert, const Ssl::EVP_PKEY_Pointer & pkey, const Security::CertPointer &orig);
+    bool addCertAndPrivateKey(std::string const & useKey, const Security::CertPointer & cert, const Security::PrivateKeyPointer & pkey, const Security::CertPointer &orig);
 
     bool IsEnabledDiskStore() const; ///< Check enabled of dist store.
 
@@ -122,7 +122,7 @@ private:
     size_t getFileSize(std::string const & filename); ///< get file size on disk.
     size_t rebuildSize(); ///< Rebuild size_file
     /// Only find certificate in current db and return it.
-    bool pure_find(std::string const & key, const Security::CertPointer & expectedOrig, Security::CertPointer & cert, Ssl::EVP_PKEY_Pointer & pkey);
+    bool pure_find(std::string const & key, const Security::CertPointer & expectedOrig, Security::CertPointer & cert, Security::PrivateKeyPointer & pkey);
 
     void deleteRow(const char **row, int rowIndex); ///< Delete a row from TXT_DB
     bool deleteInvalidCertificate(); ///< Delete invalid certificate.
@@ -131,10 +131,10 @@ private:
     bool hasRows() const; ///< Whether the TXT_DB has stored items.
 
     /// stores the db entry into a file
-    static bool WriteEntry(const std::string &filename, const Security::CertPointer & cert, const Ssl::EVP_PKEY_Pointer & pkey, const Security::CertPointer &orig);
+    static bool WriteEntry(const std::string &filename, const Security::CertPointer & cert, const Security::PrivateKeyPointer & pkey, const Security::CertPointer &orig);
 
     /// loads a db entry from the file
-    static bool ReadEntry(std::string filename, Security::CertPointer & cert, Ssl::EVP_PKEY_Pointer & pkey, Security::CertPointer &orig);
+    static bool ReadEntry(std::string filename, Security::CertPointer & cert, Security::PrivateKeyPointer & pkey, Security::CertPointer &orig);
 
     /// Removes the first matching row from TXT_DB. Ignores failures.
     static void sq_TXT_DB_delete(TXT_DB *db, const char **row);

--- a/src/security/cert_generators/file/security_file_certgen.cc
+++ b/src/security/cert_generators/file/security_file_certgen.cc
@@ -189,7 +189,7 @@ static bool processNewRequest(Ssl::CrtdMessage & request_message, std::string co
     Ssl::CertificateDb db(db_path, max_db_size, fs_block_size);
 
     Security::CertPointer cert;
-    Ssl::EVP_PKEY_Pointer pkey;
+    Security::PrivateKeyPointer pkey;
     Security::CertPointer orig;
     std::string &certKey = Ssl::OnDiskCertificateDbKey(certProperties);
 

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -55,6 +55,14 @@ inline int DH_up_ref(DH *t) {if (t) CRYPTO_add(&t->references, 1, CRYPTO_LOCK_DH
 #endif /* OpenSSL 1.0 CRYPTO_LOCK_X509_CRL */
 #endif /* OpenSSL 1.1 DH_up_ref */
 
+#if !HAVE_LIBCRYPTO_EVP_PKEY_UP_REF
+#if defined(CRYPTO_LOCK_EVP_PKEY) // OpenSSL 1.0
+inline int EVP_PKEY_up_ref(EVP_PKEY *t) {if (t) CRYPTO_add(&t->references, 1, CRYPTO_LOCK_EVP_PKEY); return 0;}
+#endif
+#else
+#error missing both OpenSSL API features EVP_PKEY_up_ref (v1.1) and CRYPTO_LOCK_EVP_PKEY (v1.0)
+#endif
+
 #endif /* USE_OPENSSL */
 
 /* flags a SSL connection can be configured with */
@@ -155,6 +163,15 @@ class ParsedOptions {}; // we never parse/use TLS options in this case
 
 class PeerConnector;
 class PeerOptions;
+
+#if USE_OPENSSL
+CtoCpp1(EVP_PKEY_free, EVP_PKEY *)
+typedef Security::LockingPointer<EVP_PKEY, EVP_PKEY_free_cpp, HardFun<int, EVP_PKEY *, EVP_PKEY_up_ref> > PrivateKeyPointer;
+#else
+// XXX: incompatible with the other PrivateKeyPointer declaration (lacks self-initialization)
+typedef void *PrivateKeyPointer;
+#endif
+
 class ServerOptions;
 
 } // namespace Security

--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -16,7 +16,7 @@
 
 EVP_PKEY * Ssl::createSslPrivateKey()
 {
-    Ssl::EVP_PKEY_Pointer pkey(EVP_PKEY_new());
+    Security::PrivateKeyPointer pkey(EVP_PKEY_new());
 
     if (!pkey)
         return NULL;
@@ -70,7 +70,7 @@ static bool setSerialNumber(ASN1_INTEGER *ai, BIGNUM const* serial)
     return true;
 }
 
-bool Ssl::writeCertAndPrivateKeyToMemory(Security::CertPointer const & cert, Ssl::EVP_PKEY_Pointer const & pkey, std::string & bufferToWrite)
+bool Ssl::writeCertAndPrivateKeyToMemory(Security::CertPointer const & cert, Security::PrivateKeyPointer const & pkey, std::string & bufferToWrite)
 {
     bufferToWrite.clear();
     if (!pkey || !cert)
@@ -118,7 +118,7 @@ bool Ssl::appendCertToMemory(Security::CertPointer const & cert, std::string & b
     return true;
 }
 
-bool Ssl::readCertAndPrivateKeyFromMemory(Security::CertPointer & cert, Ssl::EVP_PKEY_Pointer & pkey, char const * bufferToRead)
+bool Ssl::readCertAndPrivateKeyFromMemory(Security::CertPointer & cert, Security::PrivateKeyPointer & pkey, char const * bufferToRead)
 {
     Ssl::BIO_Pointer bio(BIO_new(BIO_s_mem()));
     BIO_puts(bio.get(), bufferToRead);
@@ -554,9 +554,9 @@ static bool buildCertificate(Security::CertPointer & cert, Ssl::CertificatePrope
     return true;
 }
 
-static bool generateFakeSslCertificate(Security::CertPointer & certToStore, Ssl::EVP_PKEY_Pointer & pkeyToStore, Ssl::CertificateProperties const &properties,  Ssl::BIGNUM_Pointer const &serial)
+static bool generateFakeSslCertificate(Security::CertPointer & certToStore, Security::PrivateKeyPointer & pkeyToStore, Ssl::CertificateProperties const &properties,  Ssl::BIGNUM_Pointer const &serial)
 {
-    Ssl::EVP_PKEY_Pointer pkey;
+    Security::PrivateKeyPointer pkey;
     // Use signing certificates private key as generated certificate private key
     if (properties.signWithPkey.get())
         pkey.resetAndLock(properties.signWithPkey.get());
@@ -660,7 +660,7 @@ static BIGNUM *x509Pubkeydigest(Security::CertPointer const & cert)
 /// for a new generated certificate
 static bool createSerial(Ssl::BIGNUM_Pointer &serial, Ssl::CertificateProperties const &properties)
 {
-    Ssl::EVP_PKEY_Pointer fakePkey;
+    Security::PrivateKeyPointer fakePkey;
     Security::CertPointer fakeCert;
 
     serial.reset(x509Pubkeydigest(properties.signWithX509));
@@ -682,7 +682,7 @@ static bool createSerial(Ssl::BIGNUM_Pointer &serial, Ssl::CertificateProperties
     return true;
 }
 
-bool Ssl::generateSslCertificate(Security::CertPointer & certToStore, Ssl::EVP_PKEY_Pointer & pkeyToStore, Ssl::CertificateProperties const &properties)
+bool Ssl::generateSslCertificate(Security::CertPointer & certToStore, Security::PrivateKeyPointer & pkeyToStore, Ssl::CertificateProperties const &properties)
 {
     Ssl::BIGNUM_Pointer serial;
 
@@ -715,7 +715,7 @@ Ssl::ReadX509Certificate(Ssl::BIO_Pointer &bio, Security::CertPointer & cert)
 }
 
 bool
-Ssl::ReadPrivateKey(Ssl::BIO_Pointer &bio, Ssl::EVP_PKEY_Pointer &pkey, pem_password_cb *passwd_callback)
+Ssl::ReadPrivateKey(Ssl::BIO_Pointer &bio, Security::PrivateKeyPointer &pkey, pem_password_cb *passwd_callback)
 {
     assert(bio);
     if (EVP_PKEY *akey = PEM_read_bio_PrivateKey(bio.get(), NULL, passwd_callback, NULL)) {
@@ -726,7 +726,7 @@ Ssl::ReadPrivateKey(Ssl::BIO_Pointer &bio, Ssl::EVP_PKEY_Pointer &pkey, pem_pass
 }
 
 void
-Ssl::ReadPrivateKeyFromFile(char const * keyFilename, Ssl::EVP_PKEY_Pointer &pkey, pem_password_cb *passwd_callback)
+Ssl::ReadPrivateKeyFromFile(char const * keyFilename, Security::PrivateKeyPointer &pkey, pem_password_cb *passwd_callback)
 {
     if (!keyFilename)
         return;
@@ -758,7 +758,7 @@ Ssl::WriteX509Certificate(Ssl::BIO_Pointer &bio, const Security::CertPointer & c
 }
 
 bool
-Ssl::WritePrivateKey(Ssl::BIO_Pointer &bio, const Ssl::EVP_PKEY_Pointer &pkey)
+Ssl::WritePrivateKey(Ssl::BIO_Pointer &bio, const Security::PrivateKeyPointer &pkey)
 {
     if (!pkey || !bio)
         return false;

--- a/src/ssl/gadgets.h
+++ b/src/ssl/gadgets.h
@@ -45,12 +45,6 @@ typedef SSL_METHOD * ContextMethod;
 sk_dtor_wrapper(sk_X509, STACK_OF(X509) *, X509_free);
 typedef std::unique_ptr<STACK_OF(X509), sk_X509_free_wrapper> X509_STACK_Pointer;
 
-CtoCpp1(EVP_PKEY_free, EVP_PKEY *)
-#if defined(CRYPTO_LOCK_EVP_PKEY) // OpenSSL 1.0
-inline int EVP_PKEY_up_ref(EVP_PKEY *t) {if (t) CRYPTO_add(&t->references, 1, CRYPTO_LOCK_EVP_PKEY); return 0;}
-#endif
-typedef Security::LockingPointer<EVP_PKEY, EVP_PKEY_free_cpp, HardFun<int, EVP_PKEY *, EVP_PKEY_up_ref> > EVP_PKEY_Pointer;
-
 typedef std::unique_ptr<BIGNUM, HardFun<void, BIGNUM*, &BN_free>> BIGNUM_Pointer;
 
 typedef std::unique_ptr<BIO, HardFun<void, BIO*, &BIO_vfree>> BIO_Pointer;
@@ -86,7 +80,7 @@ EVP_PKEY * createSslPrivateKey();
  \ingroup SslCrtdSslAPI
  * Write private key and SSL certificate to memory.
  */
-bool writeCertAndPrivateKeyToMemory(Security::CertPointer const & cert, EVP_PKEY_Pointer const & pkey, std::string & bufferToWrite);
+bool writeCertAndPrivateKeyToMemory(Security::CertPointer const & cert, Security::PrivateKeyPointer const & pkey, std::string & bufferToWrite);
 
 /**
  \ingroup SslCrtdSslAPI
@@ -98,7 +92,7 @@ bool appendCertToMemory(Security::CertPointer const & cert, std::string & buffer
  \ingroup SslCrtdSslAPI
  * Write private key and SSL certificate to memory.
  */
-bool readCertAndPrivateKeyFromMemory(Security::CertPointer & cert, EVP_PKEY_Pointer & pkey, char const * bufferToRead);
+bool readCertAndPrivateKeyFromMemory(Security::CertPointer & cert, Security::PrivateKeyPointer & pkey, char const * bufferToRead);
 
 /**
  \ingroup SslCrtdSslAPI
@@ -110,7 +104,7 @@ bool readCertFromMemory(Security::CertPointer & cert, char const * bufferToRead)
  \ingroup SslCrtdSslAPI
  * Read private key from file.
  */
-void ReadPrivateKeyFromFile(char const * keyFilename, EVP_PKEY_Pointer &pkey, pem_password_cb *passwd_callback);
+void ReadPrivateKeyFromFile(char const * keyFilename, Security::PrivateKeyPointer &pkey, pem_password_cb *passwd_callback);
 
 /**
  \ingroup SslCrtdSslAPI
@@ -128,7 +122,7 @@ bool ReadX509Certificate(BIO_Pointer &bio, Security::CertPointer & cert);
  \ingroup SslCrtdSslAPI
  * Read a private key from bio
  */
-bool ReadPrivateKey(BIO_Pointer &bio, EVP_PKEY_Pointer &pkey, pem_password_cb *passwd_callback);
+bool ReadPrivateKey(BIO_Pointer &bio, Security::PrivateKeyPointer &pkey, pem_password_cb *passwd_callback);
 
 /**
  \ingroup SslCrtdSslAPI
@@ -147,7 +141,7 @@ bool WriteX509Certificate(BIO_Pointer &bio, const Security::CertPointer & cert);
  \ingroup SslCrtdSslAPI
  * Write private key to BIO.
  */
-bool WritePrivateKey(BIO_Pointer &bio, const EVP_PKEY_Pointer &pkey);
+bool WritePrivateKey(BIO_Pointer &bio, const Security::PrivateKeyPointer &pkey);
 
 /**
   \ingroup SslCrtdSslAPI
@@ -221,7 +215,7 @@ public:
     CertificateProperties();
     Security::CertPointer mimicCert; ///< Certificate to mimic
     Security::CertPointer signWithX509; ///< Certificate to sign the generated request
-    EVP_PKEY_Pointer signWithPkey; ///< The key of the signing certificate
+    Security::PrivateKeyPointer signWithPkey; ///< The key of the signing certificate
     bool setValidAfter; ///< Do not mimic "Not Valid After" field
     bool setValidBefore; ///< Do not mimic "Not Valid Before" field
     bool setCommonName; ///< Replace the CN field of the mimicing subject with the given
@@ -244,7 +238,7 @@ std::string & OnDiskCertificateDbKey(const CertificateProperties &);
  * Return generated certificate and private key in resultX509 and resultPkey
  * variables.
  */
-bool generateSslCertificate(Security::CertPointer & cert, EVP_PKEY_Pointer & pkey, CertificateProperties const &properties);
+bool generateSslCertificate(Security::CertPointer & cert, Security::PrivateKeyPointer & pkey, CertificateProperties const &properties);
 
 /**
  \ingroup SslCrtdSslAPI

--- a/src/ssl/helper.cc
+++ b/src/ssl/helper.cc
@@ -90,7 +90,7 @@ void Ssl::Helper::Init()
     // TODO: generate host certificates for SNI enabled accel ports
     bool found = false;
     for (AnyP::PortCfgPointer s = HttpPortList; !found && s != NULL; s = s->next)
-        found = s->flags.tunnelSslBumping && s->generateHostCertificates;
+        found = s->flags.tunnelSslBumping && s->secure.generateHostCertificates;
     if (!found)
         return;
 

--- a/src/ssl/stub_libsslutil.cc
+++ b/src/ssl/stub_libsslutil.cc
@@ -27,13 +27,13 @@ void Ssl::CrtdMessage::parseBody(BodyParams & map, std::string & other_part) con
 void Ssl::CrtdMessage::composeBody(BodyParams const & map, std::string const & other_part) STUB
 
 #include "ssl/gadgets.h"
-X509_REQ * Ssl::createNewX509Request(EVP_PKEY_Pointer const &, const char *) STUB_RETVAL(NULL)
-bool Ssl::writeCertAndPrivateKeyToMemory(Security::CertPointer const &, EVP_PKEY_Pointer const &, std::string &) STUB_RETVAL(false)
-bool Ssl::writeCertAndPrivateKeyToFile(Security::CertPointer const &, EVP_PKEY_Pointer const &, char const *) STUB_RETVAL(false)
-bool Ssl::readCertAndPrivateKeyFromMemory(Security::CertPointer &, EVP_PKEY_Pointer &, char const *) STUB_RETVAL(false)
-X509 * Ssl::signRequest(X509_REQ_Pointer const &, Security::CertPointer const &, EVP_PKEY_Pointer const &, ASN1_TIME *, BIGNUM const *) STUB_RETVAL(NULL)
-bool Ssl::generateSslCertificateAndPrivateKey(char const *, Security::CertPointer const &, EVP_PKEY_Pointer const &, Security::CertPointer &, EVP_PKEY_Pointer &, BIGNUM const *) STUB_RETVAL(false)
-void Ssl::readCertAndPrivateKeyFromFiles(Security::CertPointer &, EVP_PKEY_Pointer &, char const *, char const *) STUB
+X509_REQ * Ssl::createNewX509Request(Security::PrivateKeyPointer const &, const char *) STUB_RETVAL(nullptr)
+bool Ssl::writeCertAndPrivateKeyToMemory(Security::CertPointer const &, Security::PrivateKeyPointer const &, std::string &) STUB_RETVAL(false)
+bool Ssl::writeCertAndPrivateKeyToFile(Security::CertPointer const &, Security::PrivateKeyPointer const &, char const *) STUB_RETVAL(false)
+bool Ssl::readCertAndPrivateKeyFromMemory(Security::CertPointer &, Security::PrivateKeyPointer &, char const *) STUB_RETVAL(false)
+X509 * Ssl::signRequest(X509_REQ_Pointer const &, Security::CertPointer const &, Security::PrivateKeyPointer const &, ASN1_TIME *, BIGNUM const *) STUB_RETVAL(nullptr)
+bool Ssl::generateSslCertificateAndPrivateKey(char const *, Security::CertPointer const &, Security::PrivateKeyPointer const &, Security::CertPointer &, Security::PrivateKeyPointer &, BIGNUM const *) STUB_RETVAL(false)
+void Ssl::readCertAndPrivateKeyFromFiles(Security::CertPointer &, Security::PrivateKeyPointer &, char const *, char const *) STUB
 bool Ssl::sslDateIsInTheFuture(char const *) STUB_RETVAL(false)
 
 #include "ssl/helper.h"

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -82,6 +82,9 @@ bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, long
 /// set the certificate verify callback for a context
 void SetupVerifyCallback(Security::ContextPointer &);
 
+/// if required, setup callback for generating ephemeral RSA keys
+void MaybeSetupRsaCallback(Security::ContextPointer &);
+
 } //namespace Ssl
 
 /// \ingroup ServerProtocolSSLAPI
@@ -182,7 +185,7 @@ void missingChainCertificatesUrls(std::queue<SBuf> &URIs, Security::CertList con
   \ingroup ServerProtocolSSLAPI
   * Generate a certificate to be used as untrusted signing certificate, based on a trusted CA
 */
-bool generateUntrustedCert(Security::CertPointer & untrustedCert, EVP_PKEY_Pointer & untrustedPkey, Security::CertPointer const & cert, EVP_PKEY_Pointer const & pkey);
+bool generateUntrustedCert(Security::CertPointer & untrustedCert, Security::PrivateKeyPointer & untrustedPkey, Security::CertPointer const & cert, Security::PrivateKeyPointer const & pkey);
 
 /// certificates indexed by issuer name
 typedef std::multimap<SBuf, X509 *> CertsIndexedList;
@@ -211,7 +214,7 @@ void unloadSquidUntrusted();
   \ingroup ServerProtocolSSLAPI
   * Decide on the kind of certificate and generate a CA- or self-signed one
 */
-Security::ContextPointer GenerateSslContext(CertificateProperties const &properties, AnyP::PortCfg &port, bool trusted);
+Security::ContextPointer GenerateSslContext(CertificateProperties const &, Security::ServerOptions &, bool trusted);
 
 /**
   \ingroup ServerProtocolSSLAPI
@@ -227,19 +230,19 @@ bool verifySslCertificate(Security::ContextPointer &, CertificateProperties cons
   * Read private key and certificate from memory and generate SSL context
   * using their.
  */
-Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char * data, AnyP::PortCfg &port, bool trusted);
+Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char * data, Security::ServerOptions &, bool trusted);
 
 /**
   \ingroup ServerProtocolSSLAPI
   * Create an SSL context using the provided certificate and key
  */
-Security::ContextPointer createSSLContext(Security::CertPointer & x509, Ssl::EVP_PKEY_Pointer & pkey, AnyP::PortCfg &port);
+Security::ContextPointer createSSLContext(Security::CertPointer & x509, Security::PrivateKeyPointer & pkey, Security::ServerOptions &);
 
 /**
  \ingroup ServerProtocolSSLAPI
  * Chain signing certificate and chained certificates to an SSL Context
  */
-void chainCertificatesToSSLContext(Security::ContextPointer &, AnyP::PortCfg &);
+void chainCertificatesToSSLContext(Security::ContextPointer &, Security::ServerOptions &);
 
 /**
  \ingroup ServerProtocolSSLAPI
@@ -265,7 +268,7 @@ bool configureSSLUsingPkeyAndCertFromMemory(SSL *ssl, const char *data, AnyP::Po
   \ingroup ServerProtocolSSLAPI
   * Adds the certificates in certList to the certificate chain of the SSL context
  */
-void addChainToSslContext(Security::ContextPointer &, STACK_OF(X509) *certList);
+void addChainToSslContext(Security::ContextPointer &, Security::CertList &);
 
 /**
   \ingroup ServerProtocolSSLAPI
@@ -281,7 +284,7 @@ void useSquidUntrusted(SSL_CTX *sslContext);
  * \param certFilename name of file with certificate and certificates which must be chainned.
  * \param keyFilename name of file with private key.
  */
-void readCertChainAndPrivateKeyFromFiles(Security::CertPointer & cert, EVP_PKEY_Pointer & pkey, X509_STACK_Pointer & chain, char const * certFilename, char const * keyFilename);
+void readCertChainAndPrivateKeyFromFiles(Security::CertPointer & cert, Security::PrivateKeyPointer & pkey, Security::CertList &chain, char const * certFilename, char const * keyFilename);
 
 /**
    \ingroup ServerProtocolSSLAPI

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -92,9 +92,12 @@ void Security::ServerOptions::parse(const char *) STUB
 void Security::ServerOptions::dumpCfg(Packable *, const char *) const STUB
 Security::ContextPointer Security::ServerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer())
 bool Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &) STUB_RETVAL(false)
+void Security::ServerOptions::createSigningContexts(AnyP::PortCfg &) STUB
+bool Security::ServerOptions::updateContextConfig(Security::ContextPointer &) STUB_RETVAL(false)
 void Security::ServerOptions::updateContextEecdh(Security::ContextPointer &) STUB
 void Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB
 void Security::ServerOptions::syncCaFiles() STUB
+void Security::ServerOptions::updateContextSessionId(Security::ContextPointer &) STUB
 
 #include "security/Session.h"
 namespace Security {

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -52,6 +52,8 @@ namespace Ssl
 {
 bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &) STUB_RETVAL(false)
 bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, const char *) STUB_RETVAL(false)
+void SetupVerifyCallback(Security::ContextPointer &) STUB
+void MaybeSetupRsaCallback(Security::ContextPointer &) STUB
 } // namespace Ssl
 const char *sslGetUserEmail(SSL *ssl) STUB_RETVAL(NULL)
 const char *sslGetUserAttribute(SSL *ssl, const char *attribute_name) STUB_RETVAL(NULL)
@@ -64,12 +66,12 @@ namespace Ssl
 //GETX509ATTRIBUTE GetX509CAAttribute;
 //GETX509ATTRIBUTE GetX509Fingerprint;
 std::vector<const char *> BumpModeStr = {""};
-bool generateUntrustedCert(Security::CertPointer & untrustedCert, EVP_PKEY_Pointer & untrustedPkey, Security::CertPointer const & cert, EVP_PKEY_Pointer const & pkey) STUB_RETVAL(false)
-Security::ContextPointer GenerateSslContext(CertificateProperties const &, AnyP::PortCfg &, bool) STUB_RETVAL(Security::ContextPointer())
+bool generateUntrustedCert(Security::CertPointer &, Security::PrivateKeyPointer &, Security::CertPointer const &, Security::PrivateKeyPointer const &) STUB_RETVAL(false)
+Security::ContextPointer GenerateSslContext(CertificateProperties const &, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer())
 bool verifySslCertificate(Security::ContextPointer &, CertificateProperties const &) STUB_RETVAL(false)
-Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char *, AnyP::PortCfg &, bool) STUB_RETVAL(Security::ContextPointer())
+Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char *, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer())
 void addChainToSslContext(Security::ContextPointer &, STACK_OF(X509) *) STUB
-void readCertChainAndPrivateKeyFromFiles(Security::CertPointer & cert, EVP_PKEY_Pointer & pkey, X509_STACK_Pointer & chain, char const * certFilename, char const * keyFilename) STUB
+void readCertChainAndPrivateKeyFromFiles(Security::CertPointer &, Security::PrivateKeyPointer &, Security::CertList &, char const *, char const *) STUB
 int matchX509CommonNames(X509 *peer_cert, void *check_data, int (*check_func)(void *check_data,  ASN1_STRING *cn_data)) STUB_RETVAL(0)
 bool checkX509ServerValidity(X509 *cert, const char *server) STUB_RETVAL(false)
 int asn1timeToString(ASN1_TIME *tm, char *buf, int len) STUB_RETVAL(0)


### PR DESCRIPTION
These are most of the minor shuffling prerequisite for the proposal to allow generate-host-certificates to set a CA filename. These are required in libsecurity in order to prevent circular dependencies between libsecurity, libssl and libanyp.

Also contains some improvements to how configuration errors are displayed for these affected settings and some bugs fixed where the configured values were handled incorrectly.