### PR TITLE
Backwards compatibility for 3.5 external_acl_type formats

### DIFF
--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -301,7 +301,23 @@ parse_externalAclHelper(external_acl ** list)
             (*fmt)->data.header.header = (*fmt)->data.string;
         } else
 #endif
-        {
+        if (strncmp(token,"%<{", 3) == 0) {
+            SBuf tmp("%<h");
+            tmp.append(token+2);
+            debugs(82, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: external_acl_type format %<{...} is deprecated. Use " << tmp);
+            const size_t parsedLen = (*fmt)->parse(tmp.c_str(), &quote);
+            assert(parsedLen == tmp.length());
+            assert((*fmt)->type == Format::LFT_REPLY_HEADER);
+
+        } else if (strncmp(token,"%>{", 3) == 0) {
+            SBuf tmp("%>ha");
+            tmp.append(token+2);
+            debugs(82, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: external_acl_type format %>{...} is deprecated. Use " << tmp);
+            const size_t parsedLen = (*fmt)->parse(tmp.c_str(), &quote);
+            assert(parsedLen == tmp.length());
+            assert((*fmt)->type == Format::LFT_ADAPTED_REQUEST_HEADER);
+
+        } else {
             // we can use the Format::Token::parse() method since it
             // only pulls off one token. Since we already checked
             // for '%' prefix above this is guaranteed to be a token.

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -307,7 +307,8 @@ parse_externalAclHelper(external_acl ** list)
             debugs(82, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: external_acl_type format %<{...} is deprecated. Use " << tmp);
             const size_t parsedLen = (*fmt)->parse(tmp.c_str(), &quote);
             assert(parsedLen == tmp.length());
-            assert((*fmt)->type == Format::LFT_REPLY_HEADER);
+            assert((*fmt)->type == Format::LFT_REPLY_HEADER ||
+                   (*fmt)->type == Format::LFT_REPLY_HEADER_ELEM);
 
         } else if (strncmp(token,"%>{", 3) == 0) {
             SBuf tmp("%>ha");
@@ -315,7 +316,8 @@ parse_externalAclHelper(external_acl ** list)
             debugs(82, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: external_acl_type format %>{...} is deprecated. Use " << tmp);
             const size_t parsedLen = (*fmt)->parse(tmp.c_str(), &quote);
             assert(parsedLen == tmp.length());
-            assert((*fmt)->type == Format::LFT_ADAPTED_REQUEST_HEADER);
+            assert((*fmt)->type == Format::LFT_ADAPTED_REQUEST_HEADER ||
+                   (*fmt)->type == Format::LFT_ADAPTED_REQUEST_HEADER_ELEM);
 
         } else {
             // we can use the Format::Token::parse() method since it

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -152,6 +152,7 @@ static TokenTableEntry TokenTableMisc[] = {
     TokenTableEntry("DATA", LFT_EXT_ACL_DATA),
     TokenTableEntry("DST", LFT_CLIENT_REQ_URLDOMAIN),
     TokenTableEntry("EXT_LOG", LFT_EXT_LOG),
+    TokenTableEntry("EXT_TAG", LFT_TAG),
     TokenTableEntry("EXT_USER", LFT_USER_EXTERNAL),
     TokenTableEntry("IDENT", LFT_USER_IDENT),
     TokenTableEntry("LOGIN", LFT_USER_LOGIN),

--- a/test-suite/squidconf/external_acl_type
+++ b/test-suite/squidconf/external_acl_type
@@ -24,14 +24,6 @@ external_acl_type foo \
 	%MYADDR \
 	%MYPORT \
 	%PATH \
-# TODO: enable when these are no longer requiring OpenSSL
-#	%USER_CERT \
-#	%USER_CERTCHAIN \
-#	%USER_CERT_xx \
-#	%USER_CA_CERT_xx \
-#	%ssl::>sni \
-#	%ssl::<cert_subject \
-#	%ssl::<cert_issuer \
 	%>{Header} \
 	%>{Hdr:member} \
 	%>{Hdr:;member} \
@@ -43,3 +35,12 @@ external_acl_type foo \
 	%ACL \
 	%DATA \
 	%%  /bin/true
+
+# TODO: enable when these are no longer requiring OpenSSL
+#	%USER_CERT
+#	%USER_CERTCHAIN
+#	%USER_CERT_xx
+#	%USER_CA_CERT_xx
+#	%ssl::>sni
+#	%ssl::<cert_subject
+#	%ssl::<cert_issuer

--- a/test-suite/squidconf/external_acl_type
+++ b/test-suite/squidconf/external_acl_type
@@ -1,0 +1,45 @@
+## Copyright (C) 1996-2017 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+# Check Backward Compatibility with Squid-3 formats
+external_acl_type foo \
+	%LOGIN \
+	%un \
+	%EXT_USER \
+	%EXT_LOG \
+	%EXT_TAG \
+	%IDENT \
+	%SRC \
+	%SRCPORT \
+	%URI \
+	%DST \
+	%PROTO \
+	%PORT \
+	%PATH \
+	%METHOD \
+	%MYADDR \
+	%MYPORT \
+	%PATH \
+# TODO: enable when these are no longer requiring OpenSSL
+#	%USER_CERT \
+#	%USER_CERTCHAIN \
+#	%USER_CERT_xx \
+#	%USER_CA_CERT_xx \
+#	%ssl::>sni \
+#	%ssl::<cert_subject \
+#	%ssl::<cert_issuer \
+	%>{Header} \
+	%>{Hdr:member} \
+	%>{Hdr:;member} \
+	%>{Hdr:Xmember} \
+	%<{Header} \
+	%<{Hdr:member} \
+	%<{Hdr:;member} \
+	%<{Hdr:Xmember} \
+	%ACL \
+	%DATA \
+	%%  /bin/true


### PR DESCRIPTION
Adds backward compatibility for the %<{...} and %>{...} format codes.

Also, fix a bug with the %EXT_TAG format code (was accepting %TAG instead).

Add a squid.conf test for checking the deprecated format codes are still accepted.