### PR TITLE
Fixed build and Ssl::BIO_new_SBuf() broken/added by 5107d2c

### DIFF
--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -330,7 +330,8 @@ void InRamCertificateDbKey(const Ssl::CertificateProperties &certProperties, SBu
 
 /**
   \ingroup ServerProtocolSSLAPI
-  Generates an OpenSSL BIO for writting to an SBuf object
+  Creates and returns an OpenSSL BIO object for writing to `buf` (or throws).
+  TODO: Add support for reading from `buf`.
  */
 BIO *BIO_new_SBuf(SBuf *buf);
 } //namespace Ssl


### PR DESCRIPTION
Fixed BIO_new_SBuf() compilation with OpenSSL v1.1 (and others that
HAVE_LIBCRYPTO_BIO_METH_NEW).

Do not leak the BIO object allocated in Ssl::InRamCertificateDbKey().

Throw instead of returning nil from Ssl::BIO_new_SBuf().

Polished BIO_new_SBuf() description to better reflect reality.