### PR TITLE
Bug 4767: SMP breaks IPv6 SNMP and cache manager queries

### DIFF
--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -193,7 +193,7 @@ void Ipc::SendMessage(const String& toAddress, const TypedMsgHdr &message)
 const Comm::ConnectionPointer &
 Ipc::ImportFdIntoComm(const Comm::ConnectionPointer &conn, int socktype, int protocol, Ipc::FdNoteId noteId)
 {
-    struct sockaddr_in addr;
+    struct sockaddr_storage addr;
     socklen_t len = sizeof(addr);
     if (getsockname(conn->fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
         conn->remote = addr;


### PR DESCRIPTION
See [bug #4767](http://bugs.squid-cache.org/show_bug.cgi?id=4767).  This makes IPv6 SNMP queries work when there are multiple workers.