### PR TITLE
Add allow_idempotent_keepalives

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -596,8 +596,10 @@ FwdState::checkRetriable()
     if (request->body_pipe != NULL)
         return false;
 
-    // RFC2616 9.1 Safe and Idempotent Methods
-    return (request->method.isHttpSafe() || request->method.isIdempotent());
+    // Allow idempotent keepalives (which might be dangerous) if configured,
+    // or fall back to a single request per connection for RFC2616 9.1 Safe and
+    // Idempotent Methods
+    return Config.onoff.allow_idempotent_keepalives || (request->method.isHttpSafe() || request->method.isIdempotent());
 }
 
 void

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -326,6 +326,7 @@ public:
         int hostStrictVerify;
         int client_dst_passthru;
         int dns_mdns;
+        int allow_idempotent_keepalives;
     } onoff;
 
     int pipeline_max_prefetch;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -9449,4 +9449,23 @@ DOC_START
 	not all I/O types supports large values (eg on Windows).
 DOC_END
 
+NAME: allow_idempotent_keepalives
+COMMENT: on|off
+TYPE: onoff
+DEFAULT: off
+LOC: Config.onoff.allow_idempotent_keepalives
+DOC_START
+	If set to OFF, squid will not attempt to keep alive connections which
+	have processed an idempotent request (RFC2616 9.1.2 Idempotent Methods).
+	When turned ON, squid will keep the connection open after an idempotent
+	request, if possible. Future requests, idempotent and otherwise, will
+	reuse the connection.
+
+	WARNING: this is potentially unsafe and can lead to unexpected behavior
+	for servers which do not handle multiple requests for a persistent
+	connection that performs an idempotent request.
+	Do not allow unless you are sure that remote endpoints can safely deal
+	with persistent connections and idempotent requests.
+DOC_END
+
 EOF


### PR DESCRIPTION
This pull request adds the configuration parameter, `allow_idempotent_keepalives`.

When `allow_idempotent_keepalives` is set to `on`, squid is configured to allow persistent (Keep-Alive) connections even though they have performed a request with an idempotent method.

When `allow_idempotent_keepalives` is set to `off`, the current behavior is retained, squid automatically closes a connection which performs a request with an idempotent method.

By default `allow_idempotent_keepalives` is `off`.

Background/use case:

An internal team is doing approximately 54k/requests per second. The service endpoint that they are connecting to processes PUT requests. To make things more interesting, a good chunk of their traffic is traversing the Atlantic.

The frequent TCP setup is prohibitive for their use case(s) and therefore this team had gone with different proxy server solution (ATS), mainly because it persisted connections even if idempotent methods were requested.

Looking through the squid bugzilla/backlog, I understand why squid did not necessarily persist connections through idempotent requests: it can be dangerous and the remote endpoint can behave unexpectedly...most services and use cases will be fine, some may not be.

Even with the dangers, this behavior should be user configurable. The disclaimers should be front and center, after that, it should be left up to the system folks.

In ATS, persistent connection behavior with idempotent methods is not configurable (AFAICS). ATS will always respect the Keep-Alive regardless of the method.

The PR is for v3.5, I can port it forward to 4.x/5.x if folks are okay with this approach.