### PR TITLE
Fix build errors with clang 3.8

### DIFF
--- a/src/acl/Options.cc
+++ b/src/acl/Options.cc
@@ -246,14 +246,14 @@ Acl::ParseFlags(const Options &options, const ParameterFlags &flags)
 const Acl::Options &
 Acl::NoOptions()
 {
-    static const Options none;
+    static const Options none = {};
     return none;
 }
 
 const Acl::ParameterFlags &
 Acl::NoFlags()
 {
-    static const ParameterFlags none;
+    static const ParameterFlags none = {};
     return none;
 }
 


### PR DESCRIPTION
clang 3.8 complains about lack of user provided constructors for several typedef defined types.
Initializing the relevant static variables with empty/nil value removes the need for implicit constructors.