### PR TITLE
Bug 4718: Support filling raw buffer space of shared SBufs

### DIFF
--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -463,7 +463,7 @@ void Adaptation::Icap::Xaction::noteCommRead(const CommIoCbParams &io)
     Must(readBuf.length() < SQUID_TCP_SO_RCVBUF);
     // now we can ensure that there is space to read new data,
     // even if readBuf.spaceSize() currently returns zero.
-    readBuf.rawSpace(1);
+    readBuf.rawAppendStart(1);
 
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;

--- a/src/comm/Read.cc
+++ b/src/comm/Read.cc
@@ -84,7 +84,7 @@ Comm::ReadNow(CommIoCbParams &params, SBuf &buf)
     SBuf::size_type sz = buf.spaceSize();
     if (params.size > 0 && params.size < sz)
         sz = params.size;
-    char *inbuf = buf.rawSpace(sz);
+    char *inbuf = buf.rawAppendStart(sz);
     errno = 0;
     const int retval = FD_READ_METHOD(params.conn->fd, inbuf, sz);
     params.xerrno = errno;
@@ -92,7 +92,7 @@ Comm::ReadNow(CommIoCbParams &params, SBuf &buf)
     debugs(5, 3, params.conn << ", size " << sz << ", retval " << retval << ", errno " << params.xerrno);
 
     if (retval > 0) { // data read most common case
-        buf.append(inbuf, retval);
+        buf.rawAppendFinish(inbuf, retval);
         fd_bytes(params.conn->fd, retval, FD_READ);
         params.flag = Comm::OK;
         params.size = retval;

--- a/src/fs/rock/RockHeaderUpdater.h
+++ b/src/fs/rock/RockHeaderUpdater.h
@@ -28,6 +28,12 @@ class HeaderUpdater: public AsyncJob
     CBDATA_CHILD(HeaderUpdater);
 
 public:
+    class IoCbParams {
+    public:
+        IoCbParams(const char *aBuf, ssize_t aSize) : buf(aBuf), size(aSize) {}
+        const char *buf;
+        ssize_t size;
+    };
     HeaderUpdater(const Rock::SwapDir::Pointer &aStore, const Ipc::StoreMapUpdate &update);
     virtual ~HeaderUpdater() override = default;
 
@@ -45,7 +51,7 @@ private:
     void startReading();
     void stopReading(const char *why);
     void readMore(const char *why);
-    void noteRead(ssize_t result);
+    void noteRead(const IoCbParams result);
     void noteDoneReading(int errflag);
     void parseReadBytes();
 
@@ -66,6 +72,13 @@ private:
 
     SlotId staleSplicingPointNext; ///< non-updatable old HTTP body suffix start
 };
+
+inline
+std::ostream &operator <<(std::ostream &os, const HeaderUpdater::IoCbParams &params)
+{
+    os << static_cast<const void *>(params.buf) << "," << params.size;
+    return os;
+}
 
 } // namespace Rock
 

--- a/src/sbuf/SBuf.h
+++ b/src/sbuf/SBuf.h
@@ -362,24 +362,18 @@ public:
      */
     const char* rawContent() const;
 
-    /** Exports a writable pointer to the SBuf internal storage.
-     * \warning Use with EXTREME caution, this is a dangerous operation.
-     *
-     * Returns a pointer to the first unused byte in the SBuf's storage,
-     * which can be be used for appending. At least minSize bytes will
-     * be available for writing.
-     * The returned pointer must not be stored by the caller, as it will
-     * be invalidated by the first call to a non-const method call
-     * on the SBuf.
-     * This call guarantees to never return NULL.
-     * \see reserveSpace
-     * \note Unlike reserveSpace(), this method does not guarantee exclusive
-     *       buffer ownership. It is instead optimized for a one writer
-     *       (appender), many readers scenario by avoiding unnecessary
-     *       copying and allocations.
-     * \throw SBufTooBigException if the user tries to allocate too big a SBuf
-     */
-    char *rawSpace(size_type minSize);
+    /// \returns a buffer suitable for appending at most `anticipatedSize` bytes
+    /// The buffer must be used "immediately" because it is invalidated by most
+    /// non-constant SBuf method calls, including such calls against other SBuf
+    /// objects that just happen to share the same underlying MemBlob storage!
+    char *rawAppendStart(size_type anticipatedSize);
+
+    /// Updates SBuf metadata to reflect appending `actualSize` bytes to the
+    /// buffer returned by the corresponding rawAppendStart() call. Throws if
+    /// rawAppendStart(actualSize) would have returned a different value now.
+    /// \param start raw buffer previously returned by rawAppendStart()
+    /// \param actualSize the number of appended bytes
+    void rawAppendFinish(const char *start, size_type actualSize);
 
     /** Obtain how much free space is available in the backing store.
      *
@@ -387,16 +381,6 @@ public:
      *        the free space can be used.
      */
     size_type spaceSize() const { return store_->spaceSize(); }
-
-    /** Force a SBuf's size
-     * \warning use with EXTREME caution, this is a dangerous operation
-     *
-     * Adapt the SBuf internal state after external interference
-     * such as writing into it via rawSpace.
-     * \throw TextException if SBuf doesn't have exclusive ownership of store
-     * \throw SBufTooBigException if new size is bigger than available store space
-     */
-    void forceSize(size_type newSize);
 
     /** exports a null-terminated reference to the SBuf internal storage.
      * \warning ACCESSING RAW STORAGE IS DANGEROUS! DO NOT EVER USE
@@ -669,6 +653,25 @@ private:
     void cow(size_type minsize = npos);
 
     void checkAccessBounds(size_type pos) const;
+
+    /** Exports a writable pointer to the SBuf internal storage.
+     * \warning Use with EXTREME caution, this is a dangerous operation.
+     *
+     * Returns a pointer to the first unused byte in the SBuf's storage,
+     * which can be be used for appending. At least minSize bytes will
+     * be available for writing.
+     * The returned pointer must not be stored by the caller, as it will
+     * be invalidated by the first call to a non-const method call
+     * on the SBuf.
+     * This call guarantees to never return nullptr.
+     * \see reserveSpace
+     * \note Unlike reserveSpace(), this method does not guarantee exclusive
+     *       buffer ownership. It is instead optimized for a one writer
+     *       (appender), many readers scenario by avoiding unnecessary
+     *       copying and allocations.
+     * \throw SBufTooBigException if the user tries to allocate too big a SBuf
+     */
+    char *rawSpace(size_type minSize);
 
     /** Low-level append operation
      *

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -336,12 +336,12 @@ Ssl::ServerBio::readAndParse(char *buf, const int size, BIO *table)
 int
 Ssl::ServerBio::readAndBuffer(BIO *table)
 {
-    char *space = rbuf.rawSpace(SQUID_TCP_SO_RCVBUF);
-    const int result = Ssl::Bio::read(space, rbuf.spaceSize(), table);
+    char *space = rbuf.rawAppendStart(SQUID_TCP_SO_RCVBUF);
+    const int result = Ssl::Bio::read(space, SQUID_TCP_SO_RCVBUF, table);
     if (result <= 0)
         return result;
 
-    rbuf.forceSize(rbuf.length() + result);
+    rbuf.rawAppendFinish(space, result);
     return result;
 }
 

--- a/src/tests/stub_SBuf.cc
+++ b/src/tests/stub_SBuf.cc
@@ -48,8 +48,8 @@ SBuf SBuf::consume(size_type) STUB_RETVAL(*this)
 const SBufStats& SBuf::GetStats() STUB_RETVAL(SBuf::stats)
 SBuf::size_type SBuf::copy(char *, size_type) const STUB_RETVAL(0)
 const char* SBuf::rawContent() const STUB_RETVAL(NULL)
-char *SBuf::rawSpace(size_type) STUB_RETVAL(NULL)
-void SBuf::forceSize(size_type) STUB
+char *SBuf::rawAppendStart(size_type) STUB_RETVAL(NULL)
+void SBuf::rawAppendFinish(const char *, size_type) STUB
 const char* SBuf::c_str() STUB_RETVAL("")
 void SBuf::reserveCapacity(size_type) STUB
 SBuf::size_type SBuf::reserve(const SBufReservationRequirements &) STUB_RETVAL(0)

--- a/src/tests/testSBuf.cc
+++ b/src/tests/testSBuf.cc
@@ -419,10 +419,9 @@ testSBuf::testRawSpace()
 {
     SBuf s1(literal);
     SBuf s2(fox1);
-    SBuf::size_type sz=s2.length();
-    char *rb=s2.rawSpace(strlen(fox2)+1);
+    char *rb=s2.rawAppendStart(strlen(fox2)+1);
     strcpy(rb,fox2);
-    s2.forceSize(sz+strlen(fox2));
+    s2.rawAppendFinish(rb, strlen(fox2));
     CPPUNIT_ASSERT_EQUAL(s1,s2);
 }
 


### PR DESCRIPTION
SBuf::forceSize() requires exclusive SBuf ownership but its precursor
SBuf::rawSpace() method does not guarantee exclusivity. The pair of
calls may result in SBuf::forceSize() throwing for no good reason.

New SBuf API provides a new pair of raw buffer appending calls that
reduces the number of false negatives.

This change may alleviate bug 4718 symptoms but does not address its
core problem (which is still unconfirmed).

This is a Measurement Factory project.