### PR TITLE
Backport uninitialised pointer fix in security/Handshake.cc

### DIFF
--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -546,8 +546,7 @@ Security::HandshakeParser::ParseCertificate(const SBuf &raw, Security::CertPoint
     Must(x509); // successfully parsed
     Must(x509Pos == x509Start + raw.length()); // no leftovers
 #else
-    // workaround GCC -O3 error with unused variables. see bug 4663.
-    (void)pCert;
+    pCert = nullptr;
     debugs(83, 2, "TLS parsing is not supported without OpenSSL. " << raw);
 #endif
 }


### PR DESCRIPTION
Backporting fix for src/security/Handhshake.cc uninitialised pointer from trunk to v4.0