### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+compiler:
+ - gcc
+ - clang
+before_install:
+ - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+ - sudo apt-get -qq update
+ - sudo apt-get -qq build-dep squid
+ - sudo apt-get install --yes gcc-4.7
+script: ./bootstrap.sh && ./configure --enable-tests && make -j24 && make -j24 check && make -j24 distcheck && sudo make install


### PR DESCRIPTION
Travis CI spotted a few build errors in the past. Since it's free (as in beer) and the script is easy to maintain, you might want to add it to the existing set of CIs. [The script works](https://travis-ci.org/krichter722/squid/builds/280556273).