### PR TITLE
added initial .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,26 @@
+before_script:
+    - sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"
+        # avoid `Picking 'squid3' as source package instead of 'squid' E: Unable to find a source package for squid3`
+    - apt-get update
+    - apt-get build-dep --yes squid
+    - export MAKEFLAGS=-j$((`grep -c ^processor /proc/cpuinfo`*2))
+
+ubuntu-17.04:
+    image: ubuntu:zesty
+    script:
+        - ./bootstrap.sh && ./configure && make && make check && make install
+
+ubuntu-16.04:
+    image: ubuntu:xenial
+    script:
+        - ./bootstrap.sh && ./configure && make && make check && make install
+
+ubuntu-14.04:
+    image: ubuntu:trusty
+    script:
+        - ./bootstrap.sh && ./configure && make && make check && make install
+
+ubuntu-17.10:
+    image: ubuntu:artful
+    script:
+        - ./bootstrap.sh && ./configure && make && make check && make install


### PR DESCRIPTION
GitLab support CI with arbitrary Docker images meaning arbitrary OS, currently Ubuntu 14.04, 16.04, 17.04 and 17.10. It might make sense to mirror to gitlab.com or use an existing GitLab instance. [The script works](https://gitlab.com/krichter/squid/pipelines/12217089).

Reproducing the build instructions including unit and integration tests and packaging  as well as an installation on different reference platforms (list is extendable) allows to track commits breaking the build as early as possible without much interfering with the workflow without CI.