### PR TITLE
Security::HandshakeParser::parseServerCertificates builds cert list w…

### DIFF
--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -101,7 +101,7 @@ private:
     void parseV23Ciphers(const SBuf &raw);
 
     void parseServerCertificates(const SBuf &raw);
-    static void ParseCertificate(const SBuf &raw, CertPointer &cert);
+    static CertPointer ParseCertificate(const SBuf &raw);
 
     unsigned int currentContentType; ///< The current TLS/SSL record content type
 


### PR DESCRIPTION
…ith nils (#42)

... if squid does not compiled with OpenSSL support.
This patch fixes:
  * HandshakeParser::ParseCertificate() to return a Security::Pointer
  * HandshakeParser:: parseServerCertificates() to be a no-op if OpenSSL is
    not used
  * Fix compile error if squid compiled without openssl but with gnutls enabled

This is a Measurement Factory project