### PR TITLE
Add Cache Manager support for Accept header

### DIFF
--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -228,6 +228,8 @@ CacheManager::ParseHeaders(const HttpRequest * request, Mgr::ActionParams &param
 
     params.httpMethod = request->method.id();
     params.httpFlags = request->flags;
+    if (request->header.has(Http::HdrType::ACCEPT))
+        params.httpAccept = request->header.getStrOrList(Http::HdrType::ACCEPT);
 
 #if HAVE_AUTH_MODULE_BASIC
     // TODO: use the authentication system decode to retrieve these details properly.

--- a/src/mgr/Action.h
+++ b/src/mgr/Action.h
@@ -15,6 +15,7 @@
 #include "mgr/forward.h"
 
 class StoreEntry;
+class String;
 
 namespace Mgr
 {

--- a/src/mgr/ActionParams.cc
+++ b/src/mgr/ActionParams.cc
@@ -28,6 +28,7 @@ Mgr::ActionParams::ActionParams(const Ipc::TypedMsgHdr &msg)
 
     msg.getPod(httpFlags);
     msg.getString(httpOrigin);
+    msg.getString(httpAccept);
 
     msg.getString(actionName);
     msg.getString(userName);
@@ -43,6 +44,7 @@ Mgr::ActionParams::pack(Ipc::TypedMsgHdr &msg) const
     msg.putString(foo);
     msg.putPod(httpFlags);
     msg.putString(httpOrigin);
+    msg.putString(httpAccept);
 
     msg.putString(actionName);
     msg.putString(userName);

--- a/src/mgr/ActionParams.h
+++ b/src/mgr/ActionParams.h
@@ -34,6 +34,7 @@ public:
     HttpRequestMethod httpMethod; ///< HTTP request method
     RequestFlags httpFlags; ///< HTTP request flags
     String httpOrigin;       ///< HTTP Origin: header (if any)
+    String httpAccept; ///< HTTP Accept: header (if any)
 
     /* action parameters extracted from the client HTTP request */
     String actionName; ///< action name (and credentials realm)


### PR DESCRIPTION
This completes the support in cachemgr Action classes for
incremental addition of report formats other than text/plain
(historic cachemgr.cgi accepted syntax).

Reporters (class Action children) can now determine their
content-type support dynamically based on request
Accept header.