### PR TITLE
Fix some compile errors from Windows MinGW

### DIFF
--- a/compat/assert.h
+++ b/compat/assert.h
@@ -9,7 +9,9 @@
 #ifndef SQUID_ASSERT_H
 #define SQUID_ASSERT_H
 
-#if defined(NODEBUG)
+#if PURIFY
+#define assert(EX) ((void)0)
+#elif defined(NODEBUG)
 #define assert(EX) ((void)0)
 #elif STDC_HEADERS
 #define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))

--- a/lib/sspwin32.cc
+++ b/lib/sspwin32.cc
@@ -492,12 +492,12 @@ const char * WINAPI SSP_MakeChallenge(PVOID PNegotiateBuf, int NegotiateLen)
         struct base64_encode_ctx ctx;
         base64_encode_init(&ctx);
         static char encoded[8192];
-        size_t dstLen = base64_encode_update(&ctx, encoded, cbOut, fResult);
+        size_t dstLen = base64_encode_update(&ctx, encoded, cbOut, reinterpret_cast<const uint8_t*>(fResult));
         assert(dstLen < sizeof(encoded));
         dstLen += base64_encode_final(&ctx, encoded+dstLen);
         assert(dstLen < sizeof(encoded));
         encoded[dstLen] = '\0';
-        return reinterpret_cast<char *>(encoded);
+        return encoded;
     }
     return NULL;
 }
@@ -558,12 +558,12 @@ const char * WINAPI SSP_MakeNegotiateBlob(PVOID PNegotiateBuf, int NegotiateLen,
         struct base64_encode_ctx ctx;
         base64_encode_init(&ctx);
         static char encoded[8192];
-        size_t dstLen = base64_encode_update(&ctx, encoded, cbOut, pServerBuf);
+        size_t dstLen = base64_encode_update(&ctx, encoded, cbOut, reinterpret_cast<const uint8_t*>(pServerBuf));
         assert(dstLen < sizeof(encoded));
         dstLen += base64_encode_final(&ctx, encoded+dstLen);
         assert(dstLen < sizeof(encoded));
         encoded[dstLen] = '\0';
-        return reinterpret_cast<char *>(encoded);
+        return encoded;
     }
     return NULL;
 }
@@ -593,12 +593,12 @@ const char * WINAPI SSP_ValidateNegotiateCredentials(PVOID PAutenticateBuf, int 
         struct base64_encode_ctx ctx;
         base64_encode_init(&ctx);
         static char encoded[8192];
-        size_t dstLen = base64_encode_update(&ctx, encoded, cbOut, pServerBuf);
+        size_t dstLen = base64_encode_update(&ctx, encoded, cbOut, reinterpret_cast<const uint8_t*>(pServerBuf));
         assert(dstLen < sizeof(encoded));
         dstLen += base64_encode_final(&ctx, encoded+dstLen);
         assert(dstLen < sizeof(encoded));
         encoded[dstLen] = '\0';
-        return reinterpret_cast<char *>(encoded);
+        return encoded;
     }
     return NULL;
 }

--- a/src/DiskIO/DiskThreads/aiops_win32.cc
+++ b/src/DiskIO/DiskThreads/aiops_win32.cc
@@ -279,7 +279,7 @@ squidaio_init(void)
     /* Create threads and get them to sit in their wait loop */
     squidaio_thread_pool = memPoolCreate("aio_thread", sizeof(squidaio_thread_t));
 
-    assert(NUMTHREADS);
+    assert(NUMTHREADS > 0);
 
     for (i = 0; i < NUMTHREADS; ++i) {
         threadp = (squidaio_thread_t *)squidaio_thread_pool->alloc();

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -657,7 +657,7 @@ urlMakeAbsolute(const HttpRequest * req, const char *relUrl)
 }
 
 int
-matchDomainName(const char *h, const char *d, uint8_t flags)
+matchDomainName(const char *h, const char *d, enum MatchDomainNameFlags flags)
 {
     int dl;
     int hl;

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -657,7 +657,7 @@ urlMakeAbsolute(const HttpRequest * req, const char *relUrl)
 }
 
 int
-matchDomainName(const char *h, const char *d, enum MatchDomainNameFlags flags)
+matchDomainName(const char *h, const char *d, MatchDomainNameFlags flags)
 {
     int dl;
     int hl;

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -231,7 +231,7 @@ enum MatchDomainNameFlags {
  * \retval 1 means the host is greater than the domain
  * \retval -1 means the host is less than the domain
  */
-int matchDomainName(const char *host, const char *domain, enum MatchDomainNameFlags flags = mdnNone);
+int matchDomainName(const char *host, const char *domain, MatchDomainNameFlags flags = mdnNone);
 int urlCheckRequest(const HttpRequest *);
 char *urlHostname(const char *url);
 void urlExtMethodConfigure(void);

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -231,7 +231,7 @@ enum MatchDomainNameFlags {
  * \retval 1 means the host is greater than the domain
  * \retval -1 means the host is less than the domain
  */
-int matchDomainName(const char *host, const char *domain, uint8_t flags = mdnNone);
+int matchDomainName(const char *host, const char *domain, enum MatchDomainNameFlags flags = mdnNone);
 int urlCheckRequest(const HttpRequest *);
 char *urlHostname(const char *url);
 void urlExtMethodConfigure(void);

--- a/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
+++ b/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
@@ -131,7 +131,7 @@ token_decode(size_t *decodedLen, uint8_t decoded[], const char *buf)
 {
     struct base64_decode_ctx ctx;
     base64_decode_init(&ctx);
-    if (!base64_decode_update(&ctx, decodedLen, decoded, strlen(buf), reinterpret_cast<const uint8_t*>(buf)) ||
+    if (!base64_decode_update(&ctx, decodedLen, decoded, strlen(buf), buf) ||
             !base64_decode_final(&ctx)) {
         SEND("BH base64 decode failed");
         fprintf(stderr, "ERROR: base64 decoding failed for: '%s'\n", buf);

--- a/src/auth/ntlm/SSPI/ntlm_sspi_auth.cc
+++ b/src/auth/ntlm/SSPI/ntlm_sspi_auth.cc
@@ -418,7 +418,7 @@ token_decode(size_t *decodedLen, uint8_t decoded[], const char *buf)
 {
     struct base64_decode_ctx ctx;
     base64_decode_init(&ctx);
-    if (!base64_decode_update(&ctx, decodedLen, decoded, strlen(buf), reinterpret_cast<const uint8_t*>(buf)) ||
+    if (!base64_decode_update(&ctx, decodedLen, decoded, strlen(buf), buf) ||
             !base64_decode_final(&ctx)) {
         SEND_BH("message=\"base64 decode failed\"");
         fprintf(stderr, "ERROR: base64 decoding failed for: '%s'\n", buf);

--- a/src/base/File.cc
+++ b/src/base/File.cc
@@ -173,7 +173,7 @@ File::open(const FileOpeningConfig &cfg)
     fd_ = CreateFile(TEXT(name_.c_str()), cfg.desiredAccess, cfg.shareMode, nullptr, cfg.creationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (fd_ == InvalidHandle) {
         const auto savedError = GetLastError();
-        throw TexcHere(sysCallFailure("CreateFile", WindowsErrorMessage(savedError).c_str()));
+        throw TexcHere(sysCallFailure("CreateFile", WindowsErrorMessage(savedError)));
     }
 #else
     mode_t oldCreationMask = 0;
@@ -216,12 +216,12 @@ File::truncate()
 #if _SQUID_WINDOWS_
     if (!SetFilePointer(fd_, 0, nullptr, FILE_BEGIN)) {
         const auto savedError = GetLastError();
-        throw TexcHere(sysCallFailure("SetFilePointer", WindowsErrorMessage(savedError).c_str()));
+        throw TexcHere(sysCallFailure("SetFilePointer", WindowsErrorMessage(savedError)));
     }
 
     if (!SetEndOfFile(fd_)) {
         const auto savedError = GetLastError();
-        throw TexcHere(sysCallFailure("SetEndOfFile", WindowsErrorMessage(savedError).c_str()));
+        throw TexcHere(sysCallFailure("SetEndOfFile", WindowsErrorMessage(savedError)));
     }
 #else
     if (::lseek(fd_, SEEK_SET, 0) < 0) {
@@ -246,7 +246,7 @@ File::readSmall(const SBuf::size_type minBytes, const SBuf::size_type maxBytes)
     DWORD result = 0;
     if (!ReadFile(fd_, rawBuf, readLimit, &result, nullptr)) {
         const auto savedError = GetLastError();
-        throw TexcHere(sysCallFailure("ReadFile", WindowsErrorMessage(savedError).c_str()));
+        throw TexcHere(sysCallFailure("ReadFile", WindowsErrorMessage(savedError)));
     }
 #else
     const auto result = ::read(fd_, rawBuf, readLimit);
@@ -261,12 +261,13 @@ File::readSmall(const SBuf::size_type minBytes, const SBuf::size_type maxBytes)
     buf.rawAppendFinish(rawBuf, bytesRead);
 
     if (buf.length() < minBytes) {
-        const auto failure = buf.length() ? "premature eof" : "empty file";
-        throw TexcHere(sysCallFailure("read", failure));
+        static const SBuf errPrematureEof("premature eof");
+        static const SBuf errEmptyFile("empty file");
+        throw TexcHere(sysCallFailure("read", buf.length() ? errPrematureEof : errEmptyFile));
     }
 
     if (buf.length() > maxBytes) {
-        const auto failure = "unreasonably large file";
+        static const SBuf failure("unreasonably large file");
         throw TexcHere(sysCallFailure("read", failure));
     }
 
@@ -281,7 +282,7 @@ File::writeAll(const SBuf &data)
     DWORD nBytesWritten = 0;
     if (!WriteFile(fd_, data.rawContent(), data.length(), &nBytesWritten, nullptr)) {
         const auto savedError = GetLastError();
-        throw TexcHere(sysCallFailure("WriteFile", WindowsErrorMessage(savedError).c_str()));
+        throw TexcHere(sysCallFailure("WriteFile", WindowsErrorMessage(savedError)));
     }
     const auto bytesWritten = static_cast<size_t>(nBytesWritten);
 #else
@@ -292,8 +293,10 @@ File::writeAll(const SBuf &data)
     }
     const auto bytesWritten = static_cast<size_t>(result);
 #endif
-    if (bytesWritten != data.length())
-        throw TexcHere(sysCallFailure("write", "partial write"));
+    if (bytesWritten != data.length()) {
+        static const SBuf failure("partial write");
+        throw TexcHere(sysCallFailure("write", failure));
+    }
 }
 
 void
@@ -302,7 +305,7 @@ File::synchronize()
 #if _SQUID_WINDOWS_
     if (!FlushFileBuffers(fd_)) {
         const auto savedError = GetLastError();
-        throw TexcHere(sysCallFailure("FlushFileBuffers", WindowsErrorMessage(savedError).c_str()));
+        throw TexcHere(sysCallFailure("FlushFileBuffers", WindowsErrorMessage(savedError)));
     }
 #else
     if (::fsync(fd_) != 0) {
@@ -340,7 +343,7 @@ File::lockOnce(const FileOpeningConfig &cfg)
 #if _SQUID_WINDOWS_
     if (!LockFileEx(fd_, cfg.lockFlags, 0, 0, 1, 0)) {
         const auto savedError = GetLastError();
-        throw TexcHere(sysCallFailure("LockFileEx", WindowsErrorMessage(savedError).c_str()));
+        throw TexcHere(sysCallFailure("LockFileEx", WindowsErrorMessage(savedError)));
     }
 #elif _SQUID_SOLARIS_
     if (fcntlLock(fd_, cfg.lockType) != 0) {
@@ -358,7 +361,7 @@ File::lockOnce(const FileOpeningConfig &cfg)
 
 /// \returns a description a system call-related failure
 SBuf
-File::sysCallFailure(const char *callName, const char *error) const
+File::sysCallFailure(const char *callName, const SBuf &error) const
 {
     return ToSBuf("failed to ", callName, ' ', name_, ": ", error);
 }
@@ -367,7 +370,7 @@ File::sysCallFailure(const char *callName, const char *error) const
 SBuf
 File::sysCallError(const char *callName, const int savedErrno) const
 {
-    return sysCallFailure(callName, xstrerr(savedErrno));
+    return sysCallFailure(callName, SBuf(xstrerr(savedErrno)));
 }
 
 #if _SQUID_WINDOWS_

--- a/src/base/File.cc
+++ b/src/base/File.cc
@@ -199,7 +199,7 @@ File::close()
 #if _SQUID_WINDOWS_
     if (!CloseHandle(fd_)) {
         const auto savedError = GetLastError();
-        debugs(54, DBG_IMPORTANT, sysCallFailure("CloseHandle", WindowsErrorMessage(savedError).c_str()));
+        debugs(54, DBG_IMPORTANT, sysCallFailure("CloseHandle", WindowsErrorMessage(savedError)));
     }
 #else
     if (::close(fd_) != 0) {

--- a/src/base/File.h
+++ b/src/base/File.h
@@ -105,7 +105,7 @@ protected:
     void close();
 
     /// \returns a description a system call-related failure
-    SBuf sysCallFailure(const char *callName, const char *error) const;
+    SBuf sysCallFailure(const char *callName, const SBuf &error) const;
     /// \returns a description of an errno-based system call failure
     SBuf sysCallError(const char *callName, const int savedErrno) const;
 

--- a/src/tests/stub_libanyp.cc
+++ b/src/tests/stub_libanyp.cc
@@ -36,7 +36,7 @@ bool urlIsRelative(const char *) STUB_RETVAL(false)
 char *urlMakeAbsolute(const HttpRequest *, const char *)STUB_RETVAL(nullptr)
 char *urlRInternal(const char *, unsigned short, const char *, const char *) STUB_RETVAL(nullptr)
 char *urlInternal(const char *, const char *) STUB_RETVAL(nullptr)
-int matchDomainName(const char *, const char *, uint) STUB_RETVAL(0)
+int matchDomainName(const char *, const char *, enum MatchDomainNameFlags) STUB_RETVAL(0)
 int urlCheckRequest(const HttpRequest *) STUB_RETVAL(0)
 char *urlHostname(const char *) STUB_RETVAL(nullptr)
 void urlExtMethodConfigure() STUB


### PR DESCRIPTION
MinGW compiler is a bit more limited than most GCC or Clang available.
The types used on Windows for some API declarations differ from those
commonly used on Linux/BSD systems.

TODO: There are additional compile issues to resolve.