### PR TITLE
Bug 2821: Ignore Content-Range in non-206 responses

### DIFF
--- a/src/HttpHdrRange.cc
+++ b/src/HttpHdrRange.cc
@@ -372,8 +372,8 @@ HttpHdrRange::canonize(HttpReply *rep)
 {
     assert(rep);
 
-    if (rep->content_range)
-        clen = rep->content_range->elength;
+    if (rep->contentRange())
+        clen = rep->contentRange()->elength;
     else
         clen = rep->content_length;
 

--- a/src/HttpHdrRange.cc
+++ b/src/HttpHdrRange.cc
@@ -527,7 +527,7 @@ HttpHdrRange::offsetLimitExceeded(const int64_t limit) const
 }
 
 bool
-HttpHdrRange::contains(HttpHdrRangeSpec& r) const
+HttpHdrRange::contains(const HttpHdrRangeSpec& r) const
 {
     assert(r.length >= 0);
     HttpHdrRangeSpec::HttpRange rrange(r.offset, r.offset + r.length);

--- a/src/HttpHeaderRange.h
+++ b/src/HttpHeaderRange.h
@@ -78,7 +78,7 @@ public:
     int64_t firstOffset() const;
     int64_t lowestOffset(int64_t) const;
     bool offsetLimitExceeded(const int64_t limit) const;
-    bool contains(HttpHdrRangeSpec& r) const;
+    bool contains(const HttpHdrRangeSpec& r) const;
     std::vector<HttpHdrRangeSpec *> specs;
 
 private:

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -304,7 +304,7 @@ HttpReply::hdrCacheInit()
     date = header.getTime(Http::HdrType::DATE);
     last_modified = header.getTime(Http::HdrType::LAST_MODIFIED);
     surrogate_control = header.getSc();
-    if (sline.status() == Http::scPartialContent || sline.status() == Http::scRequestedRangeNotSatisfied)
+    if (sline.status() == Http::scPartialContent)
         content_range = header.getContRange();
     keep_alive = persistent() ? 1 : 0;
     const char *str = header.getStr(Http::HdrType::CONTENT_TYPE);

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -328,8 +328,7 @@ HttpReply::hdrCacheInit()
 const HttpHdrContRange *
 HttpReply::contentRange() const
 {
-    if (content_range)
-        assert(sline.status() == Http::scPartialContent);
+    assert(!content_range || sline.status() == Http::scPartialContent);
     return content_range;
 }
 

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -304,7 +304,7 @@ HttpReply::hdrCacheInit()
     date = header.getTime(Http::HdrType::DATE);
     last_modified = header.getTime(Http::HdrType::LAST_MODIFIED);
     surrogate_control = header.getSc();
-    if (sline.status() == Http::scPartialContent)
+    if (sline.status() == Http::scPartialContent || sline.status() == Http::scRequestedRangeNotSatisfied)
         content_range = header.getContRange();
     keep_alive = persistent() ? 1 : 0;
     const char *str = header.getStr(Http::HdrType::CONTENT_TYPE);

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -304,7 +304,8 @@ HttpReply::hdrCacheInit()
     date = header.getTime(Http::HdrType::DATE);
     last_modified = header.getTime(Http::HdrType::LAST_MODIFIED);
     surrogate_control = header.getSc();
-    content_range = header.getContRange();
+    if (sline.status() == Http::scPartialContent || sline.status() == Http::scRequestedRangeNotSatisfied)
+        content_range = header.getContRange();
     keep_alive = persistent() ? 1 : 0;
     const char *str = header.getStr(Http::HdrType::CONTENT_TYPE);
 

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -26,8 +26,8 @@
 #include "StrList.h"
 
 HttpReply::HttpReply() : Http::Message(hoReply), date (0), last_modified (0),
-    expires (0), surrogate_control (NULL), content_range (NULL), keep_alive (0),
-    protoPrefix("HTTP/"), bodySizeMax(-2)
+    expires (0), surrogate_control (NULL), keep_alive (0),
+    protoPrefix("HTTP/"), bodySizeMax(-2), content_range(nullptr)
 {
     init();
 }
@@ -297,6 +297,7 @@ HttpReply::hdrExpirationTime()
 void
 HttpReply::hdrCacheInit()
 {
+    hdrCacheClean();
     Http::Message::hdrCacheInit();
 
     http_ver = sline.version;
@@ -311,11 +312,17 @@ HttpReply::hdrCacheInit()
 
     if (str)
         content_type.limitInit(str, strcspn(str, ";\t "));
-    else
-        content_type = String();
 
     /* be sure to set expires after date and cache-control */
     expires = hdrExpirationTime();
+}
+
+HttpHdrContRange *
+HttpReply::contentRange() const
+{
+    if (content_range)
+        assert(sline.status() == Http::scPartialContent);
+    return content_range;
 }
 
 /* sync this routine when you update HttpReply struct */

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -25,9 +25,16 @@
 #include "Store.h"
 #include "StrList.h"
 
-HttpReply::HttpReply() : Http::Message(hoReply), date (0), last_modified (0),
-    expires(0), surrogate_control(nullptr), keep_alive(0),
-    protoPrefix("HTTP/"), bodySizeMax(-2), content_range(nullptr)
+HttpReply::HttpReply():
+    Http::Message(hoReply),
+    date(0),
+    last_modified(0),
+    expires(0),
+    surrogate_control(nullptr),
+    keep_alive(0),
+    protoPrefix("HTTP/"),
+    bodySizeMax(-2),
+    content_range(nullptr)
 {
     init();
 }

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -319,12 +319,10 @@ HttpReply::hdrCacheInit()
 }
 
 const HttpHdrContRange *
-HttpReply::contentRange(bool *unparsed) const
+HttpReply::contentRange() const
 {
     if (content_range)
         assert(sline.status() == Http::scPartialContent);
-    if (unparsed)
-        *unparsed = !content_range && header.has(Http::HdrType::CONTENT_RANGE);
     return content_range;
 }
 

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -52,8 +52,7 @@ public:
     HttpHdrSc *surrogate_control;
 
     /// \returns parsed Content-Range for a 206 response and nil for others
-    /// \param unparsed whether there is an unexpected, not parsed Content-Range
-    const HttpHdrContRange *contentRange(bool *unparsed = nullptr) const;
+    const HttpHdrContRange *contentRange() const;
 
     short int keep_alive;
 

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -51,7 +51,8 @@ public:
 
     HttpHdrSc *surrogate_control;
 
-    HttpHdrContRange *content_range;
+    /// \returns parsed Content-Range for a 206 response and nil for others
+    HttpHdrContRange *contentRange() const;
 
     short int keep_alive;
 
@@ -140,6 +141,8 @@ private:
     String removeStaleWarningValues(const String &value);
 
     mutable int64_t bodySizeMax; /**< cached result of calcMaxBodySize */
+
+    HttpHdrContRange *content_range; ///< parsed Content-Range; nil for non-206 responses!
 
 protected:
     virtual void packFirstLineInto(Packable * p, bool) const { sline.packInto(p); }

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -52,7 +52,8 @@ public:
     HttpHdrSc *surrogate_control;
 
     /// \returns parsed Content-Range for a 206 response and nil for others
-    HttpHdrContRange *contentRange() const;
+    /// \param unparsed whether there is an unexpected, not parsed Content-Range
+    const HttpHdrContRange *contentRange(bool *unparsed = nullptr) const;
 
     short int keep_alive;
 

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -507,7 +507,8 @@ Client::haveParsedReplyHeaders()
     maybePurgeOthers();
 
     // adaptation may overwrite old offset computed using the virgin response
-    currentOffset = theFinalReply->contentRange() ? theFinalReply->contentRange()->spec.offset : 0;
+    const bool partial = theFinalReply->contentRange();
+    currentOffset = partial ? theFinalReply->contentRange()->spec.offset : 0;
 }
 
 /// whether to prevent caching of an otherwise cachable response

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -507,9 +507,7 @@ Client::haveParsedReplyHeaders()
     maybePurgeOthers();
 
     // adaptation may overwrite old offset computed using the virgin response
-    const bool partial = theFinalReply->content_range &&
-                         theFinalReply->sline.status() == Http::scPartialContent;
-    currentOffset = partial ? theFinalReply->content_range->spec.offset : 0;
+    currentOffset = theFinalReply->contentRange() ? theFinalReply->contentRange()->spec.offset : 0;
 }
 
 /// whether to prevent caching of an otherwise cachable response

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -169,12 +169,12 @@ Http::Stream::getNextRangeOffset() const
             return start;
         }
 
-    } else if (reply && reply->content_range) {
+    } else if (reply && reply->contentRange()) {
         /* request does not have ranges, but reply does */
         /** \todo FIXME: should use range_iter_pos on reply, as soon as reply->content_range
          *        becomes HttpHdrRange rather than HttpHdrRangeSpec.
          */
-        return http->out.offset + reply->content_range->spec.offset;
+        return http->out.offset + reply->contentRange()->spec.offset;
     }
 
     return http->out.offset;
@@ -227,14 +227,14 @@ Http::Stream::socketState()
                 // we got everything we wanted from the store
                 return STREAM_COMPLETE;
             }
-        } else if (reply && reply->content_range) {
+        } else if (reply && reply->contentRange()) {
             /* reply has content-range, but Squid is not managing ranges */
             const int64_t &bytesSent = http->out.offset;
-            const int64_t &bytesExpected = reply->content_range->spec.length;
+            const int64_t &bytesExpected = reply->contentRange()->spec.length;
 
             debugs(33, 7, "body bytes sent vs. expected: " <<
                    bytesSent << " ? " << bytesExpected << " (+" <<
-                   reply->content_range->spec.offset << ")");
+                   reply->contentRange()->spec.offset << ")");
 
             // did we get at least what we expected, based on range specs?
 
@@ -428,14 +428,12 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
         range_err = "no [parse-able] reply";
     else if ((rep->sline.status() != Http::scOkay) && (rep->sline.status() != Http::scPartialContent))
         range_err = "wrong status code";
-    else if (hdr->has(Http::HdrType::CONTENT_RANGE)) {
-        if (rep->sline.status() == Http::scPartialContent)
-            range_err = "existing Content-Range in the 206 response";
-        else {
-            assert(rep->sline.status() == Http::scOkay);
-            range_err = "unexpected Content-Range in the 200 response";
-        }
-    }
+    else if (rep->sline.status() == Http::scPartialContent)
+        range_err = "too complex response"; // probably contains what the client needs
+    else if (rep->sline.status() != Http::scOkay)
+        range_err = "wrong status code";
+    else if (hdr->has(Http::HdrType::CONTENT_RANGE))
+        range_err = "meaningless response";
     else if (rep->content_length < 0)
         range_err = "unknown length";
     else if (rep->content_length != http->memObject()->getReply()->content_length)
@@ -471,8 +469,8 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
         // will (try-to) forward as-is.
         //TODO: we should cope with multirange request/responses
         // TODO: review, since rep->content_range is always nil here.
-        bool replyMatchRequest = rep->content_range != nullptr ?
-                                 request->range->contains(rep->content_range->spec) :
+        bool replyMatchRequest = rep->contentRange() != nullptr ?
+                                 request->range->contains(rep->contentRange()->spec) :
                                  true;
         const int spec_count = http->request->range->specs.size();
         int64_t actual_clen = -1;
@@ -483,12 +481,11 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
         /* append appropriate header(s) */
         if (spec_count == 1) {
             if (!replyMatchRequest) {
-                hdr->delById(Http::HdrType::CONTENT_RANGE);
-                hdr->putContRange(rep->content_range);
+                hdr->putContRange(rep->contentRange());
                 actual_clen = rep->content_length;
                 //http->range_iter.pos = rep->content_range->spec.begin();
-                (*http->range_iter.pos)->offset = rep->content_range->spec.offset;
-                (*http->range_iter.pos)->length = rep->content_range->spec.length;
+                (*http->range_iter.pos)->offset = rep->contentRange()->spec.offset;
+                (*http->range_iter.pos)->length = rep->contentRange()->spec.length;
 
             } else {
                 HttpHdrRange::iterator pos = http->request->range->begin();

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -418,20 +418,22 @@ void
 Http::Stream::buildRangeHeader(HttpReply *rep)
 {
     HttpHeader *hdr = rep ? &rep->header : nullptr;
-    const char *ignoreRangeReason = nullptr;
+    const char *range_err = nullptr;
     HttpRequest *request = http->request;
     assert(request->range);
     /* check if we still want to do ranges */
     int64_t roffLimit = request->getRangeOffsetLimit();
 
     if (!rep)
-        ignoreRangeReason = "no [parse-able] reply";
+        range_err = "no [parse-able] reply";
     else if ((rep->sline.status() != Http::scOkay) && (rep->sline.status() != Http::scPartialContent))
-        ignoreRangeReason = "wrong status code";
+        range_err = "wrong status code";
+    else if (hdr->has(Http::HdrType::CONTENT_RANGE))
+        range_err = "origin server does ranges";
     else if (rep->content_length < 0)
-        ignoreRangeReason = "unknown length";
+        range_err = "unknown length";
     else if (rep->content_length != http->memObject()->getReply()->content_length)
-        ignoreRangeReason = "INCONSISTENT length";  /* a bug? */
+        range_err = "INCONSISTENT length";  /* a bug? */
 
     /* hits only - upstream CachePeer determines correct behaviour on misses,
      * and client_side_reply determines hits candidates
@@ -439,29 +441,28 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
     else if (http->logType.isTcpHit() &&
              http->request->header.has(Http::HdrType::IF_RANGE) &&
              !clientIfRangeMatch(http, rep))
-        ignoreRangeReason = "If-Range match failed";
+        range_err = "If-Range match failed";
 
     else if (!http->request->range->canonize(rep))
-        ignoreRangeReason = "canonization failed";
+        range_err = "canonization failed";
     else if (http->request->range->isComplex())
-        ignoreRangeReason = "too complex range header";
+        range_err = "too complex range header";
     else if (!http->logType.isTcpHit() && http->request->range->offsetLimitExceeded(roffLimit))
-        ignoreRangeReason = "range outside range_offset_limit";
+        range_err = "range outside range_offset_limit";
 
     /* get rid of our range specs on error */
-    if (ignoreRangeReason) {
+    if (range_err) {
         /* XXX We do this here because we need canonisation etc. However, this current
          * code will lead to incorrect store offset requests - the store will have the
          * offset data, but we won't be requesting it.
          * So, we can either re-request, or generate an error
          */
-        http->request->ignoreRange(ignoreRangeReason);
+        http->request->ignoreRange(range_err);
     } else {
-        if (rep->sline.status() == Http::scOkay) {
-            rep->sline.set(rep->sline.version, Http::scPartialContent);
-            rep->content_range = rep->header.getContRange();
-        }
-        assert(rep->sline.status() == Http::scPartialContent);
+        /* XXX: TODO: Review, this unconditional set may be wrong. */
+        rep->sline.set(rep->sline.version, Http::scPartialContent);
+        // web server responded with a valid, but unexpected range.
+        // will (try-to) forward as-is.
         //TODO: we should cope with multirange request/responses
         bool replyMatchRequest = rep->content_range != nullptr ?
                                  request->range->contains(rep->content_range->spec) :
@@ -474,15 +475,30 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
         assert(spec_count > 0);
         /* append appropriate header(s) */
         if (spec_count == 1) {
-            HttpHdrRange::iterator pos = http->request->range->begin();
-            assert(*pos);
             if (!replyMatchRequest) {
+                hdr->delById(Http::HdrType::CONTENT_RANGE);
+                hdr->putContRange(rep->content_range);
+                actual_clen = rep->content_length;
                 //http->range_iter.pos = rep->content_range->spec.begin();
-                (*pos)->offset = rep->content_range->spec.offset;
-                (*pos)->length = rep->content_range->spec.length;
+                (*http->range_iter.pos)->offset = rep->content_range->spec.offset;
+                (*http->range_iter.pos)->length = rep->content_range->spec.length;
+
+            } else {
+                HttpHdrRange::iterator pos = http->request->range->begin();
+                assert(*pos);
+                /* append Content-Range */
+
+                if (!hdr->has(Http::HdrType::CONTENT_RANGE)) {
+                    /* No content range, so this was a full object we are
+                     * sending parts of.
+                     */
+                    httpHeaderAddContRange(hdr, **pos, rep->content_length);
+                }
+
+                /* set new Content-Length to the actual number of bytes
+                 * transmitted in the message-body */
+                actual_clen = (*pos)->length;
             }
-            httpHeaderAddContRange(hdr, **pos, rep->content_length);
-            actual_clen = (*pos)->length;
         } else {
             /* multipart! */
             /* generate boundary string */

--- a/src/tests/stub_HttpReply.cc
+++ b/src/tests/stub_HttpReply.cc
@@ -13,8 +13,8 @@
 #include "tests/STUB.h"
 
 HttpReply::HttpReply() : Http::Message(hoReply), date (0), last_modified (0),
-    expires (0), surrogate_control (NULL), content_range (NULL), keep_alive (0),
-    protoPrefix("HTTP/"), do_clean(false), bodySizeMax(-2)
+    expires(0), surrogate_control(nullptr), keep_alive(0),
+    protoPrefix("HTTP/"), do_clean(false), bodySizeMax(-2), content_range(nullptr)
 {STUB_NOP}
 HttpReply::~HttpReply() STUB
 void HttpReply::setHeaders(Http::StatusCode status, const char *reason, const char *ctype, int64_t clen, time_t lmt, time_t expires_) STUB
@@ -30,4 +30,5 @@ HttpReply * HttpReply::clone() const STUB_RETVAL(NULL)
 bool HttpReply::inheritProperties(const Http::Message *aMsg) STUB_RETVAL(false)
 bool HttpReply::updateOnNotModified(HttpReply const*) STUB_RETVAL(false)
 int64_t HttpReply::bodySize(const HttpRequestMethod&) const STUB_RETVAL(0)
+const HttpHdrContRange *HttpReply::contentRange() const STUB_RETVAL(nullptr)
 


### PR DESCRIPTION
Squid used to honor Content-Range header in HTTP 200 OK (and possibly
other non-206) responses, truncating (and possibly enlarging) some
response bodies. RFC 7233 declares Content-Range meaningless for
standard HTTP status codes other than 206 and 416. Squid now relays
meaningless Content-Range as is, without using its value.

Why not just strip a meaningless Content-Range header? Squid does not
really know whether it is the status code or the header that is "wrong".
Let the client figure it out while the server remains responsible.

Also ignore Content-Range in 416 (Range Not Satisfiable) responses
because that header does not apply to the response body.

Also fixed body corruption of (unlikely) multipart 206 responses to
single-part Range requests. Valid multipart responses carry no
Content-Range (in the primary header), which confused Squid.