### PR TITLE
Bug 4679: User names not sent to url_rewrite_program

### DIFF
--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -70,6 +70,30 @@ AccessLogEntry::syncNotes(HttpRequest *req)
         assert(notes == req->notes());
 }
 
+const char *
+AccessLogEntry::getClientIdent() const
+{
+    if (tcpClient)
+        return tcpClient->rfc931;
+
+    if (cache.rfc931 && *cache.rfc931)
+        return cache.rfc931;
+
+    return nullptr;
+}
+
+const char *
+AccessLogEntry::getExtUser() const
+{
+    if (request->extacl_user.size())
+        return request->extacl_user.termedBuf();
+
+    if (cache.extuser && *cache.extuser)
+        return cache.extuser;
+
+    return nullptr;
+}
+
 AccessLogEntry::~AccessLogEntry()
 {
     safe_free(headers.request);

--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -85,7 +85,7 @@ AccessLogEntry::getClientIdent() const
 const char *
 AccessLogEntry::getExtUser() const
 {
-    if (request->extacl_user.size())
+    if (request && request->extacl_user.size())
         return request->extacl_user.termedBuf();
 
     if (cache.extuser && *cache.extuser)

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -49,6 +49,12 @@ public:
     /// including indirect forwarded-for IP if configured to log that
     void getLogClientIp(char *buf, size_t bufsz) const;
 
+    /// Fetch the client IDENT string, or nil if none is available.
+    const char *getClientIdent() const;
+
+    /// Fetch the external ACL provided 'user=' string, or nil if none is available.
+    const char *getExtUser() const;
+
     /// Fetch the transaction method string (ICP opcode, HTCP opcode or HTTP method)
     SBuf getLogMethod() const;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -416,9 +416,6 @@ ClientHttpRequest::logRequest()
     if (request)
         prepareLogWithRequestDetails(request, al);
 
-    if (getConn() != NULL && getConn()->clientConnection != NULL && getConn()->clientConnection->rfc931[0])
-        al->cache.rfc931 = getConn()->clientConnection->rfc931;
-
 #if USE_OPENSSL && 0
 
     /* This is broken. Fails if the connection has been closed. Needs

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -873,13 +873,13 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
                     out = t;
             }
             if (!out)
-                out = strOrNull(al->cache.extuser);
+                out = strOrNull(al->getExtUser());
 #if USE_OPENSSL
             if (!out)
                 out = strOrNull(al->cache.ssluser);
 #endif
             if (!out)
-                out = strOrNull(al->cache.rfc931);
+                out = strOrNull(al->getClientIdent());
             break;
 
         case LFT_USER_LOGIN:
@@ -890,17 +890,11 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_USER_IDENT:
-            out = strOrNull(al->cache.rfc931);
+            out = strOrNull(al->getClientIdent());
             break;
 
         case LFT_USER_EXTERNAL:
-            if (al->request && al->request->extacl_user.size()) {
-                if (const char *t = al->request->extacl_user.termedBuf())
-                    out = t;
-            }
-
-            if (!out)
-                out = strOrNull(al->cache.extuser);
+            out = strOrNull(al->getExtUser());
             break;
 
         /* case LFT_USER_REALM: */

--- a/src/log/FormatHttpdCombined.cc
+++ b/src/log/FormatHttpdCombined.cc
@@ -22,7 +22,7 @@
 void
 Log::Format::HttpdCombined(const AccessLogEntry::Pointer &al, Logfile * logfile)
 {
-    const char *user_ident = ::Format::QuoteUrlEncodeUsername(al->cache.rfc931);
+    const char *user_ident = ::Format::QuoteUrlEncodeUsername(al->getClientIdent());
     const char *user_auth = NULL;
     const char *referer = NULL;
     const char *agent = NULL;

--- a/src/log/FormatHttpdCommon.cc
+++ b/src/log/FormatHttpdCommon.cc
@@ -27,7 +27,7 @@ Log::Format::HttpdCommon(const AccessLogEntry::Pointer &al, Logfile * logfile)
     if (al->request && al->request->auth_user_request != NULL)
         user_auth = ::Format::QuoteUrlEncodeUsername(al->request->auth_user_request->username());
 #endif
-    const char *user_ident = ::Format::QuoteUrlEncodeUsername(al->cache.rfc931);
+    const char *user_ident = ::Format::QuoteUrlEncodeUsername(al->getClientIdent());
 
     char clientip[MAX_IPSTRLEN];
     al->getLogClientIp(clientip, MAX_IPSTRLEN);

--- a/src/log/FormatSquidIcap.cc
+++ b/src/log/FormatSquidIcap.cc
@@ -43,7 +43,7 @@ Log::Format::SquidIcap(const AccessLogEntry::Pointer &al, Logfile * logfile)
 #endif
 
     if (!user)
-        user = ::Format::QuoteUrlEncodeUsername(al->cache.extuser);
+        user = ::Format::QuoteUrlEncodeUsername(al->getExtUser());
 
 #if USE_OPENSSL
     if (!user)
@@ -51,7 +51,7 @@ Log::Format::SquidIcap(const AccessLogEntry::Pointer &al, Logfile * logfile)
 #endif
 
     if (!user)
-        user = ::Format::QuoteUrlEncodeUsername(al->cache.rfc931);
+        user = ::Format::QuoteUrlEncodeUsername(al->getClientIdent());
 
     if (user && !*user)
         safe_free(user);

--- a/src/log/FormatSquidNative.cc
+++ b/src/log/FormatSquidNative.cc
@@ -32,7 +32,7 @@ Log::Format::SquidNative(const AccessLogEntry::Pointer &al, Logfile * logfile)
 #endif
 
     if (!user)
-        user = ::Format::QuoteUrlEncodeUsername(al->cache.extuser);
+        user = ::Format::QuoteUrlEncodeUsername(al->getExtUser());
 
 #if USE_OPENSSL
     if (!user)
@@ -40,7 +40,7 @@ Log::Format::SquidNative(const AccessLogEntry::Pointer &al, Logfile * logfile)
 #endif
 
     if (!user)
-        user = ::Format::QuoteUrlEncodeUsername(al->cache.rfc931);
+        user = ::Format::QuoteUrlEncodeUsername(al->getClientIdent());
 
     if (user && !*user)
         safe_free(user);


### PR DESCRIPTION
Add accessors to AccessLogEntry for retrieving IDENT and External ACL user
labels in a consistent way. Use these ascessors for all log and logformat
outputs.

NP: does not hide/remove the original cache.* members due to direct use
    remaining in some code locations that cannot yet be avoided.