### PR TITLE
GnuTLS implementation for TLS listening ports and client connections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1253,7 +1253,7 @@ if test "x$with_gnutls" != "xno"; then
     ## by testing for a 3.1.5+ function which we use
     AC_CHECK_LIB(gnutls,gnutls_certificate_verify_peers3,[LIBGNUTLS_LIBS="-lgnutls"])
   ])
-  AC_CHECK_HEADERS(gnutls/gnutls.h gnutls/x509.h)
+  AC_CHECK_HEADERS(gnutls/gnutls.h gnutls/x509.h gnutls/abstract.h)
 
   SQUID_STATE_ROLLBACK(squid_gnutls_state) #de-pollute LIBS
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -915,8 +915,8 @@ configDoConfigure(void)
     for (AnyP::PortCfgPointer s = HttpPortList; s != NULL; s = s->next) {
         if (!s->secure.encryptTransport)
             continue;
-        debugs(3, DBG_IMPORTANT, "Initializing " << AnyP::UriScheme(s->transport.protocol) << "_port " << s->s << " TLS context");
-        s->secure.createSigningContexts(*s);
+        debugs(3, DBG_IMPORTANT, "Initializing " << AnyP::UriScheme(s->transport.protocol) << "_port " << s->s << " TLS contexts");
+        s->secure.initServerContexts(*s);
     }
 
     // prevent infinite fetch loops in the request parser

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2223,12 +2223,20 @@ DOC_START
 
 	TLS / SSL Options:
 
-	   cert=	Path to SSL certificate (PEM format).
+	   tls-cert=	Path to TLS server certificate (PEM format).
 
-	   key=		Path to SSL private key file (PEM format)
-			if not specified, the certificate file is
-			assumed to be a combined certificate and
-			key file.
+			When OpenSSL or LibreSSL is used this file may also
+			contain a chain of intermediate certificates to send
+			in the TLS handshake.
+
+			When GnuTLS is used this option (and any paired
+			tls-key= option) may be repeated to load multiple
+			certificates for different domains.
+
+	   tls-key=	Path to TLS private key file (PEM format) for the
+			previous tls-cert= parameter.
+			If not specified, the previous certificate file is
+			assumed to be a combined certificate and key file.
 
 	   cipher=	Colon separated list of supported ciphers.
 			NOTE: some ciphers such as EDH ciphers depend on
@@ -2378,12 +2386,13 @@ DOC_START
 	over TLS or SSL connections. Commonly referred to as HTTPS.
 
 	This is most useful for situations where you are running squid in
-	accelerator mode and you want to do the TLS work at the accelerator level.
+	accelerator mode and you want to do the TLS work at the accelerator
+	level.
 
 	You may specify multiple socket addresses on multiple lines,
 	each with their own certificate and/or options.
 
-	The TLS cert= option is mandatory on HTTPS ports.
+	The tls-cert= option is mandatory on HTTPS ports.
 
 	See http_port for a list of modes and options.
 DOC_END

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2223,20 +2223,33 @@ DOC_START
 
 	TLS / SSL Options:
 
-	   tls-cert=	Path to TLS server certificate (PEM format).
+	   tls-cert=	Path to file containing an X.509 certificate (PEM format)
+			to be used in the TLS handshake ServerHello.
 
-			When OpenSSL or LibreSSL is used this file may also
-			contain a chain of intermediate certificates to send
-			in the TLS handshake.
+			If this certificate is constrained by KeyUsage TLS
+			feature it must allow HTTP server usage, along with
+			any additional restrictions imposed by your choice
+			of options= settings.
+
+			When OpenSSL is used this file may also contain a
+			chain of intermediate CA certificates to send in the
+			TLS handshake.
 
 			When GnuTLS is used this option (and any paired
 			tls-key= option) may be repeated to load multiple
 			certificates for different domains.
 
-	   tls-key=	Path to TLS private key file (PEM format) for the
-			previous tls-cert= parameter.
-			If not specified, the previous certificate file is
-			assumed to be a combined certificate and key file.
+			Also, when generate-host-certificates=on is configured
+			the first tls-cert= option must be a CA certificate
+			capable of signing the automatically generated
+			certificates.
+
+	   tls-key=	Path to a file containing private key file (PEM format)
+			for the previous tls-cert= option.
+
+			If tls-key= is not specified tls-cert= is assumed to
+			reference a PEM file containing both the certificate
+			and private key.
 
 	   cipher=	Colon separated list of supported ciphers.
 			NOTE: some ciphers such as EDH ciphers depend on
@@ -2380,7 +2393,7 @@ TYPE: PortCfg
 DEFAULT: none
 LOC: HttpPortList
 DOC_START
-	Usage:  [ip:]port [mode] cert=certificate.pem [options]
+	Usage:  [ip:]port [mode] tls-cert=certificate.pem [options]
 
 	The socket address where Squid will listen for client requests made
 	over TLS or SSL connections. Commonly referred to as HTTPS.
@@ -2803,12 +2816,14 @@ DOC_START
 	disable		Do not support https:// URLs.
 	
 	cert=/path/to/client/certificate
-			A client TLS certificate to use when connecting.
+			A client X.509 certificate to use when connecting.
 	
 	key=/path/to/client/private_key
-			The private TLS key corresponding to the cert= above.
-			If key= is not specified cert= is assumed to reference
-			a PEM file containing both the certificate and the key.
+			The private key corresponding to the cert= above.
+
+			If key= is not specified cert= is assumed to
+			reference a PEM file containing both the certificate
+			and private key.
 	
 	cipher=...	The list of valid TLS ciphers to use.
 
@@ -3577,14 +3592,15 @@ DOC_START
 	tls		Encrypt connections to this peer with TLS.
 	
 	sslcert=/path/to/ssl/certificate
-			A client SSL certificate to use when connecting to
+			A client X.509 certificate to use when connecting to
 			this peer.
 	
 	sslkey=/path/to/ssl/key
-			The private SSL key corresponding to sslcert above.
-			If 'sslkey' is not specified 'sslcert' is assumed to
-			reference a combined file containing both the
-			certificate and the key.
+			The private key corresponding to sslcert above.
+
+			If sslkey= is not specified sslcert= is assumed to
+			reference a PEM file containing both the certificate
+			and private key.
 	
 	sslcipher=...	The list of valid SSL ciphers to use when connecting
 			to this peer.
@@ -8983,14 +8999,16 @@ DOC_START
 	These options are used for Secure ICAP (icaps://....) services only.
 
 	tls-cert=/path/to/ssl/certificate
-			A client SSL certificate to use when connecting to
-			this icap server.
+			A client X.509 certificate to use when connecting to
+			this ICAP server.
 
 	tls-key=/path/to/ssl/key
-			The private TLS/SSL key corresponding to sslcert above.
-			If 'tls-key' is not specified 'tls-cert' is assumed to
-			reference a combined PEM format file containing both the
-			certificate and the key.
+			The private key corresponding to the previous
+			tls-cert= option.
+
+			If tls-key= is not specified tls-cert= is assumed to
+			reference a PEM file containing both the certificate
+			and private key.
 
 	tls-cipher=...	The list of valid TLS/SSL ciphers to use when connecting
 			to this icap server.

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2628,8 +2628,9 @@ clientNegotiateSSL(int fd, void *data)
     if (!tlsAttemptHandshake(conn, clientNegotiateSSL))
         return;
 
-#if USE_OPENSSL
     Security::SessionPointer session(fd_table[fd].ssl);
+
+#if USE_OPENSSL
     if (Security::SessionIsResumed(session)) {
         debugs(83, 2, "Session " << SSL_get_session(session.get()) <<
                " reused on FD " << fd << " (" << fd_table[fd].ipaddr <<

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2674,10 +2674,14 @@ clientNegotiateSSL(int fd, void *data)
                " on FD " << fd << " (" << fd_table[fd].ipaddr << ":" <<
                fd_table[fd].remote_port << ")");
     }
+#else
+    debugs(83, 2, "TLS session reuse not yet implemented.");
+#endif
 
     // Connection established. Retrieve TLS connection parameters for logging.
     conn->clientConnection->tlsNegotiations()->retrieveNegotiatedInfo(session);
 
+#if USE_OPENSSL
     X509 *client_cert = SSL_get_peer_certificate(session.get());
 
     if (client_cert) {
@@ -2689,10 +2693,10 @@ clientNegotiateSSL(int fd, void *data)
 
         X509_free(client_cert);
     } else {
-        debugs(83, 5, "FD " << fd << " has no certificate.");
+        debugs(83, 5, "FD " << fd << " has no client certificate.");
     }
 #else
-    debugs(1, DBG_CRITICAL, "ERROR: clientNegotiateSSL session logics not implemented.");
+    debugs(83, 2, "Client certificate requesting not yet implemented.");
 #endif
 
     conn->readSomeData();

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2611,8 +2611,9 @@ tlsAttemptHandshake(ConnStateData *conn, PF *callback)
     }
 
 #else
-    (void)session;
-    debugs(83, DBG_CRITICAL, "ERROR: HTTPS not supported by this Squid.");
+    // Performing TLS handshake should never be reachable without a TLS/SSL library.
+    (void)session; // avoid compiler and static analysis complaints
+    fatal("FATAL: HTTPS not supported by this Squid.");
 #endif
 
     conn->clientConnection->close();
@@ -2820,7 +2821,7 @@ ConnStateData::postHttpsAccept()
         HTTPMSGLOCK(acl_checklist->al->request);
         acl_checklist->nonBlockingCheck(httpsSslBumpAccessCheckDone, this);
 #else
-        debugs(33, DBG_CRITICAL, "ERROR: SSL-Bump requires --with-openssl");
+        fatal("FATAL: SSL-Bump requires --with-openssl");
 #endif
         return;
     } else {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2939,11 +2939,11 @@ void ConnStateData::buildSslCertGenerationParams(Ssl::CertificateProperties &cer
         certProperties.signWithX509.resetAndLock(port->secure.untrustedSigningCert.get());
         certProperties.signWithPkey.resetAndLock(port->secure.untrustedSignPkey.get());
     } else {
-        assert(port->secure.signingCert.get());
-        certProperties.signWithX509.resetAndLock(port->secure.signingCert.get());
+        assert(port->secure.signingCa.cert.get());
+        certProperties.signWithX509.resetAndLock(port->secure.signingCa.cert.get());
 
-        if (port->secure.signPkey)
-            certProperties.signWithPkey.resetAndLock(port->secure.signPkey.get());
+        if (port->secure.signingCa.pkey)
+            certProperties.signWithPkey.resetAndLock(port->secure.signingCa.pkey.get());
     }
     signAlgorithm = certProperties.signAlgorithm;
 
@@ -3282,7 +3282,7 @@ ConnStateData::startPeekAndSplice()
     }
 
     // will call httpsPeeked() with certificate and connection, eventually
-    Security::ContextPointer unConfiguredCTX(Ssl::createSSLContext(port->secure.signingCert, port->secure.signPkey, port->secure));
+    Security::ContextPointer unConfiguredCTX(Ssl::createSSLContext(port->secure.signingCa.cert, port->secure.signingCa.pkey, port->secure));
     fd_table[clientConnection->fd].dynamicTlsContext = unConfiguredCTX;
 
     if (!httpsCreate(clientConnection, unConfiguredCTX))

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2935,9 +2935,9 @@ void ConnStateData::buildSslCertGenerationParams(Ssl::CertificateProperties &cer
     assert(certProperties.signAlgorithm != Ssl::algSignEnd);
 
     if (certProperties.signAlgorithm == Ssl::algSignUntrusted) {
-        assert(port->secure.untrustedSigningCert);
-        certProperties.signWithX509.resetAndLock(port->secure.untrustedSigningCert.get());
-        certProperties.signWithPkey.resetAndLock(port->secure.untrustedSignPkey.get());
+        assert(port->secure.untrustedSigningCa.cert);
+        certProperties.signWithX509.resetAndLock(port->secure.untrustedSigningCa.cert.get());
+        certProperties.signWithPkey.resetAndLock(port->secure.untrustedSigningCa.pkey.get());
     } else {
         assert(port->secure.signingCa.cert.get());
         certProperties.signWithX509.resetAndLock(port->secure.signingCa.cert.get());

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -219,10 +219,10 @@ public:
     /// The caller assumes responsibility for connection closure detection.
     void stopPinnedConnectionMonitoring();
 
-#if USE_OPENSSL
     /// the second part of old httpsAccept, waiting for future HttpsServer home
     void postHttpsAccept();
 
+#if USE_OPENSSL
     /// Initializes and starts a peek-and-splice negotiation with the SSL client
     void startPeekAndSplice();
 

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 1996-2017 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "anyp/PortCfg.h"
+#include "fatal.h"
+#include "security/KeyData.h"
+#include "SquidConfig.h"
+#include "ssl/bio.h"
+
+/// verify that a private key and cert match
+static bool
+checkPrivateKey(Security::CertPointer &cert, Security::PrivateKeyPointer &pkey)
+{
+#if USE_OPENSSL
+    return X509_check_private_key(cert.get(), pkey.get());
+#elif USE_GNUTLS
+    return true; // TODO find GnuTLS equivalent check
+#else
+    return false;
+#endif
+}
+
+/**
+ * Read certificate from file.
+ * See also: Ssl::ReadX509Certificate function, gadgets.cc file
+ */
+bool
+Security::KeyData::loadX509CertFromFile()
+{
+#if USE_OPENSSL
+    const char *certFilename = certFile.c_str();
+    Ssl::BIO_Pointer bio(BIO_new(BIO_s_file()));
+    if (!bio || !BIO_read_filename(bio.get(), certFilename)) {
+        const auto x = ERR_get_error();
+        debugs(83, DBG_IMPORTANT, "ERROR: unable to load file '" << certFile << "': " << ErrorString(x));
+        return false;
+    }
+
+    X509 *certificate = PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr);
+
+#elif USE_GNUTLS
+    const char *certFilename = certFile.c_str();
+    gnutls_datum_t data;
+    Security::ErrorCode x = gnutls_load_file(certFilename, &data);
+    if (x != GNUTLS_E_SUCCESS) {
+        debugs(83, DBG_IMPORTANT, "ERROR: unable to load file '" << certFile << "': " << ErrorString(x));
+        return false;
+    }
+
+    gnutls_pcert_st pcrt;
+    x = gnutls_pcert_import_x509_raw(&pcrt, &data, GNUTLS_X509_FMT_PEM, 0);
+    if (x != GNUTLS_E_SUCCESS) {
+        debugs(83, DBG_IMPORTANT, "ERROR: unable to import certificate from '" << certFile << "': " << ErrorString(x));
+        return false;
+    }
+    gnutls_free(data.data);
+
+    gnutls_x509_crt_t certificate;
+    x = gnutls_pcert_export_x509(&pcrt, &certificate);
+    if (x != GNUTLS_E_SUCCESS) {
+        certificate = nullptr; // paranoid: just in case the *_t ptr is undefined after deinit.
+    }
+#else
+    // to simplify and prevent 'undefined variable errors' in the next code block
+    void *certificate = nullptr;
+#endif
+
+    if (certificate) {
+#if USE_OPENSSL
+        if (X509_check_issued(certificate, certificate) == X509_V_OK)
+            debugs(83, 5, "Certificate is self-signed, will not be chained");
+        else {
+            cert.resetWithoutLocking(certificate);
+            // and add to the chain any other certificate exist in the file
+            while (X509 *ca = PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr))
+                chain.emplace_front(Security::CertPointer(ca));
+        }
+#elif USE_GNUTLS
+        cert = Security::CertPointer(certificate, [](gnutls_x509_crt_t p) {
+                   debugs(83, 5, "gnutls_x509_crt_deinit cert=" << (void*)p);
+                   gnutls_x509_crt_deinit(p);
+               });
+        // XXX: do chain load and cert self-signed check like OpenSSL
+#endif
+
+    } else {
+        debugs(83, DBG_IMPORTANT, "ERROR: unable to load certificate from '" << certFile << "'");
+        cert.reset(); // paranoid: ensure cert is unset
+    }
+
+    return bool(cert);
+}
+
+void
+Security::KeyData::loadFromFiles(AnyP::PortCfg &port, const char *portType)
+{
+    char buf[128];
+    debugs(83, DBG_IMPORTANT, "Using certificate in " << certFile);
+
+    if (!loadX509CertFromFile()) {
+#if USE_OPENSSL
+        debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' missing certificate in '" << certFile << "'");
+#else
+        fatalf("Directive '%s_port %s' requires --with-openssl to load %s.", portType, port.s.toUrl(buf, sizeof(buf)), certFile.c_str());
+#endif
+        return;
+    }
+
+    const char *keyFilename = privateKeyFile.c_str();
+
+#if USE_OPENSSL
+    // XXX: Ssl::AskPasswordCb needs SSL_CTX_set_default_passwd_cb_userdata()
+    // so this may not fully work iff Config.Program.ssl_password is set.
+    pem_password_cb *cb = ::Config.Program.ssl_password ? &Ssl::AskPasswordCb : nullptr;
+    Ssl::ReadPrivateKeyFromFile(keyFilename, pkey, cb);
+
+#elif USE_GNUTLS
+    gnutls_datum_t data;
+    if (gnutls_load_file(keyFilename, &data) == GNUTLS_E_SUCCESS) {
+        gnutls_privkey_t key;
+        (void)gnutls_privkey_init(&key);
+        Security::ErrorCode x = gnutls_privkey_import_x509_raw(key, &data, GNUTLS_X509_FMT_PEM, nullptr, 0);
+        if (x == GNUTLS_E_SUCCESS) {
+            pkey = Security::PrivateKeyPointer(key, [](gnutls_privkey_t p) {
+                       debugs(83, 5, "gnutls_privkey_deinit pkey=" << (void*)p);
+                       gnutls_privkey_deinit(p);
+                   });
+        }
+    }
+    gnutls_free(data.data);
+#endif
+
+    if (!pkey) {
+        debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' missing private key in '" << keyFilename << "'");
+    } else if (!checkPrivateKey(cert, pkey)) {
+        debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' checkPrivateKey() failed");
+    } else
+        return; // everything is okay
+
+    pkey.reset();
+    cert.reset();
+}
+

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -58,7 +58,8 @@ Security::KeyData::loadX509CertFromFile()
     gnutls_x509_crt_t certificate;
     x = gnutls_pcert_export_x509(&pcrt, &certificate);
     if (x != GNUTLS_E_SUCCESS) {
-        certificate = nullptr; // paranoid: just in case the *_t ptr is undefined after deinit.
+        debugs(83, DBG_IMPORTANT, "ERROR: unable to X.509 convert certificate from '" << certFile << "': " << ErrorString(x));
+        return false;
     }
 
     if (certificate) {

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -149,4 +149,3 @@ Security::KeyData::loadFromFiles(const AnyP::PortCfg &port, const char *portType
     pkey.reset();
     cert.reset();
 }
-

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -14,8 +14,8 @@
 #include "ssl/bio.h"
 
 /// verify that a private key and cert match
-static bool
-checkPrivateKey(Security::CertPointer &cert, Security::PrivateKeyPointer &pkey)
+bool
+Security::KeyData::checkPrivateKey()
 {
 #if USE_OPENSSL
     return X509_check_private_key(cert.get(), pkey.get());
@@ -141,7 +141,7 @@ Security::KeyData::loadFromFiles(const AnyP::PortCfg &port, const char *portType
 
     if (!pkey) {
         debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' missing private key in '" << keyFilename << "'");
-    } else if (!checkPrivateKey(cert, pkey)) {
+    } else if (!checkPrivateKey()) {
         debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' checkPrivateKey() failed");
     } else
         return; // everything is okay

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -98,7 +98,7 @@ Security::KeyData::loadX509CertFromFile()
 }
 
 void
-Security::KeyData::loadFromFiles(AnyP::PortCfg &port, const char *portType)
+Security::KeyData::loadFromFiles(const AnyP::PortCfg &port, const char *portType)
 {
     char buf[128];
     debugs(83, DBG_IMPORTANT, "Using certificate in " << certFile);

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -87,6 +87,9 @@ Security::KeyData::loadX509CertFromFile()
                    gnutls_x509_crt_deinit(p);
                });
         // XXX: do chain load and cert self-signed check like OpenSSL
+    debugs(83, 2, "Loading certificate chain from PEM files not implemented in this Squid.");
+#else
+        // unreachable.
 #endif
 
     } else {
@@ -104,11 +107,7 @@ Security::KeyData::loadFromFiles(const AnyP::PortCfg &port, const char *portType
     debugs(83, DBG_IMPORTANT, "Using certificate in " << certFile);
 
     if (!loadX509CertFromFile()) {
-#if USE_OPENSSL
         debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' missing certificate in '" << certFile << "'");
-#else
-        fatalf("Directive '%s_port %s' requires --with-openssl to load %s.", portType, port.s.toUrl(buf, sizeof(buf)), certFile.c_str());
-#endif
         return;
     }
 
@@ -137,6 +136,9 @@ Security::KeyData::loadFromFiles(const AnyP::PortCfg &port, const char *portType
         }
     }
     gnutls_free(data.data);
+
+#else
+    debugs(83, 2, "Loading private key PEM files not implemented in this Squid.");
 #endif
 
     if (!pkey) {

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -127,9 +127,12 @@ Security::KeyData::loadFromFiles(const AnyP::PortCfg &port, const char *portType
         (void)gnutls_privkey_init(&key);
         Security::ErrorCode x = gnutls_privkey_import_x509_raw(key, &data, GNUTLS_X509_FMT_PEM, nullptr, 0);
         if (x == GNUTLS_E_SUCCESS) {
-            pkey = Security::PrivateKeyPointer(key, [](gnutls_privkey_t p) {
-                       debugs(83, 5, "gnutls_privkey_deinit pkey=" << (void*)p);
-                       gnutls_privkey_deinit(p);
+            gnutls_x509_privkey_t xkey;
+            gnutls_privkey_export_x509(key, &xkey);
+            gnutls_privkey_deinit(key);
+            pkey = Security::PrivateKeyPointer(xkey, [](gnutls_x509_privkey_t p) {
+                       debugs(83, 5, "gnutls_x509_privkey_deinit pkey=" << (void*)p);
+                       gnutls_x509_privkey_deinit(p);
                    });
         }
     }

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -135,7 +135,7 @@ Security::KeyData::loadX509ChainFromFile()
 /**
  * Read X.509 private key from file.
  */
-void
+bool
 Security::KeyData::loadX509PrivateKeyFromFile()
 {
     debugs(83, DBG_IMPORTANT, "Using key in " << privateKeyFile);
@@ -148,7 +148,7 @@ Security::KeyData::loadX509PrivateKeyFromFile()
     Ssl::ReadPrivateKeyFromFile(keyFilename, pkey, cb);
 
     if (pkey && !checkPrivateKey()) {
-        debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' checkPrivateKey() failed");
+        debugs(83, DBG_IMPORTANT, "WARNING: '" << privateKeyFile << "' checkPrivateKey() failed");
         pkey.reset();
     }
 
@@ -192,8 +192,8 @@ Security::KeyData::loadFromFiles(const AnyP::PortCfg &port, const char *portType
 
     // pkey is mandatory, not having it makes cert and chain pointless.
     if (!loadX509PrivateKeyFromFile()) {
-        debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' missing private key in '" << keyFilename << "'");
+        debugs(83, DBG_IMPORTANT, "WARNING: '" << portType << "_port " << port.s.toUrl(buf, sizeof(buf)) << "' missing private key in '" << privateKeyFile << "'");
         cert.reset();
-        chain.reset();
+        chain.clear();
     }
 }

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_SRC_SECURITY_KEYDATA_H
 #define SQUID_SRC_SECURITY_KEYDATA_H
 
+#include "anyp/forward.h"
 #include "sbuf/SBuf.h"
 #include "security/forward.h"
 
@@ -19,8 +20,22 @@ namespace Security
 class KeyData
 {
 public:
+    /// load the contents of certFile and privateKeyFile into memory cert, pkey and chain
+    void loadFromFiles(AnyP::PortCfg &, const char *portType);
+
+public:
     SBuf certFile;       ///< path of file containing PEM format X.509 certificate
     SBuf privateKeyFile; ///< path of file containing private key in PEM format
+
+    /// memory copy of the X.509 certificate from certFile
+    Security::CertPointer cert;
+    /// memory copy of the private key from privateKeyFile (which may be the same as certFile)
+    Security::PrivateKeyPointer pkey;
+    /// memory copy of any certificates which must be chained from cert
+    Security::CertList chain;
+
+private:
+    bool loadX509CertFromFile();
 };
 
 } // namespace Security

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -37,7 +37,7 @@ public:
 private:
     bool checkPrivateKey();
     bool loadX509CertFromFile();
-    bool loadX509ChainFromFile();
+    void loadX509ChainFromFile();
     bool loadX509PrivateKeyFromFile();
 };
 

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -37,6 +37,8 @@ public:
 private:
     bool checkPrivateKey();
     bool loadX509CertFromFile();
+    bool loadX509ChainFromFile();
+    bool loadX509PrivateKeyFromFile();
 };
 
 } // namespace Security

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -21,7 +21,7 @@ class KeyData
 {
 public:
     /// load the contents of certFile and privateKeyFile into memory cert, pkey and chain
-    void loadFromFiles(AnyP::PortCfg &, const char *portType);
+    void loadFromFiles(const AnyP::PortCfg &, const char *portType);
 
 public:
     SBuf certFile;       ///< path of file containing PEM format X.509 certificate

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -35,6 +35,7 @@ public:
     Security::CertList chain;
 
 private:
+    bool checkPrivateKey();
     bool loadX509CertFromFile();
 };
 

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -27,11 +27,11 @@ public:
     SBuf certFile;       ///< path of file containing PEM format X.509 certificate
     SBuf privateKeyFile; ///< path of file containing private key in PEM format
 
-    /// memory copy of the X.509 certificate from certFile
+    /// public X.509 certificate from certFile
     Security::CertPointer cert;
-    /// memory copy of the private key from privateKeyFile (which may be the same as certFile)
+    /// private key from privateKeyFile
     Security::PrivateKeyPointer pkey;
-    /// memory copy of any certificates which must be chained from cert
+    /// any certificates which must be chained from cert
     Security::CertList chain;
 
 private:

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -35,7 +35,6 @@ public:
     Security::CertList chain;
 
 private:
-    bool checkPrivateKey();
     bool loadX509CertFromFile();
     void loadX509ChainFromFile();
     bool loadX509PrivateKeyFromFile();

--- a/src/security/Makefile.am
+++ b/src/security/Makefile.am
@@ -22,6 +22,7 @@ libsecurity_la_SOURCES= \
 	Handshake.cc \
 	Handshake.h \
 	forward.h \
+	KeyData.cc \
 	KeyData.h \
 	LockingPointer.h \
 	NegotiationHistory.cc \

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -66,6 +66,7 @@ private:
     void parseOptions(); ///< parsed value of sslOptions
     long parseFlags();
     void loadCrlFile();
+    void loadKeysFile();
 
 public:
     SBuf sslOptions;     ///< library-specific options string

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -217,6 +217,14 @@ Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &port)
         if (!Ssl::InitServerContext(t, port))
             return false;
 #endif
+
+        updateContextCertChain(t);
+
+        if (!updateContextConfig(t)) {
+            debugs(83, DBG_CRITICAL, "ERROR: Configuring static TLS context");
+            return false;
+        }
+
         if (!loadClientCaFile())
             return false;
     }

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -45,9 +45,8 @@ Security::ServerOptions::operator =(const Security::ServerOptions &old) {
         staticContextSessionId = old.staticContextSessionId;
         generateHostCertificates = old.generateHostCertificates;
         signingCa = old.signingCa;
+        untrustedSigningCa = old.untrustedSigningCa;
         certsToChain = old.certsToChain;
-        untrustedSigningCert = old.untrustedSigningCert;
-        untrustedSignPkey = old.untrustedSignPkey;
         dynamicCertMemCacheSize = old.dynamicCertMemCacheSize;
     }
     return *this;
@@ -289,7 +288,7 @@ Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &port)
         debugs(3, DBG_IMPORTANT, "No TLS private key configured for  " << portType << "_port " << port.s);
 
 #if USE_OPENSSL
-    Ssl::generateUntrustedCert(untrustedSigningCert, untrustedSignPkey, signingCa.cert, signingCa.pkey);
+    Ssl::generateUntrustedCert(untrustedSigningCa.cert, untrustedSigningCa.pkey, signingCa.cert, signingCa.pkey);
 #elif USE_GNUTLS
     // TODO: implement for GnuTLS. Just a warning for now since generate is implicitly on for all crypto builds.
     signingCa.cert.reset();
@@ -301,7 +300,7 @@ Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &port)
     return;
 #endif
 
-    if (!untrustedSigningCert) {
+    if (!untrustedSigningCa.cert) {
         char buf[128];
         fatalf("Unable to generate signing certificate for untrusted sites for %s_port %s", portType, port.s.toUrl(buf, sizeof(buf)));
     }

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -56,9 +56,6 @@ public:
     /// update the context with a configured session ID (if any)
     void updateContextSessionId(Security::ContextPointer &);
 
-    /// Adds the certificates in certsToChain to the certificate chain of the given TLS context
-    void updateContextCertChain(Security::ContextPointer &);
-
     /// sync the various sources of CA files to be loaded
     void syncCaFiles();
 
@@ -82,8 +79,6 @@ public:
 
     Security::KeyData signingCa; ///< x509 certificate and key for signing generated certificates
     Security::KeyData untrustedSigningCa; ///< x509 certificate and key for signing untrusted generated certificates
-
-    Security::CertList certsToChain; ///<  x509 certificates to send with the generated cert
 
     /// max size of generated certificates memory cache (4 MB default)
     size_t dynamicCertMemCacheSize = 4*1024*1024;

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -69,8 +69,15 @@ public:
 
 #if USE_OPENSSL
     bool generateHostCertificates = true; ///< dynamically make host cert
-#elif USE_GNUTLS || 1 /* requires --with-openssl for now */
+#elif USE_GNUTLS
+    // TODO: GnuTLS does implement TLS server connections so the cert
+    // generate vs static choice can be reached in the code now.
+    // But this feature is not fully working implemented so must not
+    // be enabled by default for production installations.
     bool generateHostCertificates = false; ///< dynamically make host cert
+#else
+    // same as OpenSSL so config errors show up easily
+    bool generateHostCertificates = true; ///< dynamically make host cert
 #endif
 
     Security::KeyData signingCa; ///< x509 certificate and key for signing generated certificates

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -73,8 +73,8 @@ public:
     bool generateHostCertificates = false; ///< dynamically make host cert
 #endif
 
-    Security::CertPointer signingCert; ///< x509 certificate for signing generated certificates
-    Security::PrivateKeyPointer signPkey; ///< private key for signing generated certificates
+    Security::KeyData signingCa; ///< x509 certificate and key for signing generated certificates
+
     Security::CertList certsToChain; ///<  x509 certificates to send with the generated cert
     Security::CertPointer untrustedSigningCert; ///< x509 certificate for signing untrusted generated certificates
     Security::PrivateKeyPointer untrustedSignPkey; ///< private key for signing untrusted generated certificates

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -74,10 +74,9 @@ public:
 #endif
 
     Security::KeyData signingCa; ///< x509 certificate and key for signing generated certificates
+    Security::KeyData untrustedSigningCa; ///< x509 certificate and key for signing untrusted generated certificates
 
     Security::CertList certsToChain; ///<  x509 certificates to send with the generated cert
-    Security::CertPointer untrustedSigningCert; ///< x509 certificate for signing untrusted generated certificates
-    Security::PrivateKeyPointer untrustedSignPkey; ///< private key for signing untrusted generated certificates
 
     /// max size of generated certificates memory cache (4 MB default)
     size_t dynamicCertMemCacheSize = 4*1024*1024;
@@ -92,7 +91,7 @@ private:
     bool createStaticServerContext(AnyP::PortCfg &);
 
     /// initialize contexts for signing dynamic TLS certificates (if needed)
-    /// the resulting context is stored in signingCert, signPKey, untrustedSigningCert, untrustedSignPKey
+    /// the resulting keys are stored in signingCa and untrustedSigningCa
     void createSigningContexts(const AnyP::PortCfg &);
 
 private:

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -41,14 +41,8 @@ public:
     virtual Security::ContextPointer createBlankContext() const;
     virtual void dumpCfg(Packable *, const char *pfx) const;
 
-    /// generate a security server-context from these configured options
-    /// the resulting context is stored in staticContext
-    /// \returns true if a context could be created
-    bool createStaticServerContext(AnyP::PortCfg &);
-
-    /// initialize contexts for signing dynamic TLS certificates (if needed)
-    /// the resulting context is stored in signingCert, signPKey, untrustedSigningCert, untrustedSignPKey
-    void createSigningContexts(AnyP::PortCfg &);
+    /// initialize all server contexts as-needed
+    void initServerContexts(AnyP::PortCfg &);
 
     /// update the given TLS security context using squid.conf settings
     bool updateContextConfig(Security::ContextPointer &);
@@ -84,6 +78,15 @@ public:
 private:
     bool loadClientCaFile();
     void loadDhParams();
+
+    /// generate a security server-context from these configured options
+    /// the resulting context is stored in staticContext
+    /// \returns true if a context could be created
+    bool createStaticServerContext(AnyP::PortCfg &);
+
+    /// initialize contexts for signing dynamic TLS certificates (if needed)
+    /// the resulting context is stored in signingCert, signPKey, untrustedSigningCert, untrustedSignPKey
+    void createSigningContexts(const AnyP::PortCfg &);
 
 private:
     SBuf clientCaFile;  ///< name of file to load client CAs from

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -56,6 +56,9 @@ public:
     /// update the context with a configured session ID (if any)
     void updateContextSessionId(Security::ContextPointer &);
 
+    /// Adds the certificates in certsToChain to the certificate chain of the given TLS context
+    void updateContextCertChain(Security::ContextPointer &);
+
     /// sync the various sources of CA files to be loaded
     void syncCaFiles();
 

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -67,7 +67,11 @@ public:
     Security::ContextPointer staticContext;
     SBuf staticContextSessionId; ///< "session id context" for staticContext
 
+#if USE_OPENSSL
     bool generateHostCertificates = true; ///< dynamically make host cert
+#elif USE_GNUTLS || 1 /* requires --with-openssl for now */
+    bool generateHostCertificates = false; ///< dynamically make host cert
+#endif
 
     Security::CertPointer signingCert; ///< x509 certificate for signing generated certificates
     Security::PrivateKeyPointer signPkey; ///< private key for signing generated certificates

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -86,10 +86,9 @@ typedef CbDataList<Security::CertError> CertErrors;
 CtoCpp1(X509_free, X509 *)
 typedef Security::LockingPointer<X509, X509_free_cpp, HardFun<int, X509 *, X509_up_ref> > CertPointer;
 #elif USE_GNUTLS
-CtoCpp1(gnutls_x509_crt_deinit, gnutls_x509_crt_t)
-typedef Security::LockingPointer<struct gnutls_x509_crt_int, gnutls_x509_crt_deinit> CertPointer;
+typedef std::shared_ptr<struct gnutls_x509_crt_int> CertPointer;
 #else
-typedef void * CertPointer;
+typedef std::shared_ptr<void> CertPointer;
 #endif
 
 #if USE_OPENSSL
@@ -168,11 +167,9 @@ class PeerOptions;
 CtoCpp1(EVP_PKEY_free, EVP_PKEY *)
 typedef Security::LockingPointer<EVP_PKEY, EVP_PKEY_free_cpp, HardFun<int, EVP_PKEY *, EVP_PKEY_up_ref> > PrivateKeyPointer;
 #elif USE_GNUTLS
-CtoCpp1(gnutls_privkey_deinit, gnutls_privkey_t);
-typedef Security::LockingPointer<struct gnutls_privkey_st, gnutls_privkey_deinit> PrivateKeyPointer;
+typedef std::shared_ptr<struct gnutls_privkey_st> PrivateKeyPointer;
 #else
-// XXX: incompatible with the other PrivateKeyPointer declaration (lacks self-initialization)
-typedef void *PrivateKeyPointer;
+typedef std::shared_ptr<void> PrivateKeyPointer;
 #endif
 
 class ServerOptions;

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -13,8 +13,8 @@
 #include "security/Context.h"
 #include "security/Session.h"
 
-#if USE_GNUTLS && HAVE_GNUTLS_X509_H
-#include <gnutls/x509.h>
+#if USE_GNUTLS && HAVE_GNUTLS_ABSTRACT_H
+#include <gnutls/abstract.h>
 #endif
 #include <list>
 #if USE_OPENSSL && HAVE_OPENSSL_ERR_H
@@ -167,6 +167,9 @@ class PeerOptions;
 #if USE_OPENSSL
 CtoCpp1(EVP_PKEY_free, EVP_PKEY *)
 typedef Security::LockingPointer<EVP_PKEY, EVP_PKEY_free_cpp, HardFun<int, EVP_PKEY *, EVP_PKEY_up_ref> > PrivateKeyPointer;
+#elif USE_GNUTLS
+CtoCpp1(gnutls_privkey_deinit, gnutls_privkey_t);
+typedef Security::LockingPointer<struct gnutls_privkey_st, gnutls_privkey_deinit> PrivateKeyPointer;
 #else
 // XXX: incompatible with the other PrivateKeyPointer declaration (lacks self-initialization)
 typedef void *PrivateKeyPointer;

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -167,7 +167,7 @@ class PeerOptions;
 CtoCpp1(EVP_PKEY_free, EVP_PKEY *)
 typedef Security::LockingPointer<EVP_PKEY, EVP_PKEY_free_cpp, HardFun<int, EVP_PKEY *, EVP_PKEY_up_ref> > PrivateKeyPointer;
 #elif USE_GNUTLS
-typedef std::shared_ptr<struct gnutls_privkey_st> PrivateKeyPointer;
+typedef std::shared_ptr<struct gnutls_x509_privkey_int> PrivateKeyPointer;
 #else
 typedef std::shared_ptr<void> PrivateKeyPointer;
 #endif

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -42,14 +42,12 @@ Http::One::Server::start()
 {
     ConnStateData::start();
 
-#if USE_OPENSSL
     // XXX: Until we create an HttpsServer class, use this hack to allow old
     // client_side.cc code to manipulate ConnStateData object directly
     if (isHttpsServer) {
         postHttpsAccept();
         return;
     }
-#endif
 
     typedef CommCbMemFunT<Server, CommTimeoutCbParams> TimeoutDialer;
     AsyncCall::Pointer timeoutCall =  JobCallback(33, 5,

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -13,7 +13,9 @@
 
 #include "FadingCounter.h"
 #include "fd.h"
+#include "MemBuf.h"
 #include "security/Handshake.h"
+#include "ssl/support.h"
 
 #include <iosfwd>
 #include <list>

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -815,7 +815,7 @@ Ssl::chainCertificatesToSSLContext(Security::ContextPointer &ctx, Security::Serv
 {
     assert(ctx);
     // Add signing certificate to the certificates chain
-    X509 *signingCert = options.signingCert.get();
+    X509 *signingCert = options.signingCa.cert.get();
     if (SSL_CTX_add_extra_chain_cert(ctx.get(), signingCert)) {
         // increase the certificate lock
         X509_up_ref(signingCert);

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -525,13 +525,6 @@ Ssl::InitServerContext(Security::ContextPointer &ctx, AnyP::PortCfg &port)
         return false;
     }
 
-    port.secure.updateContextCertChain(ctx);
-
-    if (!port.secure.updateContextConfig(ctx)) {
-        debugs(83, DBG_CRITICAL, "ERROR: Configuring static SSL context");
-        return false;
-    }
-
     return true;
 }
 

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -511,20 +511,6 @@ Ssl::InitServerContext(Security::ContextPointer &ctx, AnyP::PortCfg &port)
     if (!ctx)
         return false;
 
-    if (!SSL_CTX_use_certificate(ctx.get(), port.secure.signingCert.get())) {
-        const int ssl_error = ERR_get_error();
-        const auto &keys = port.secure.certs.front();
-        debugs(83, DBG_CRITICAL, "ERROR: Failed to acquire TLS certificate '" << keys.certFile << "': " << Security::ErrorString(ssl_error));
-        return false;
-    }
-
-    if (!SSL_CTX_use_PrivateKey(ctx.get(), port.secure.signPkey.get())) {
-        const int ssl_error = ERR_get_error();
-        const auto &keys = port.secure.certs.front();
-        debugs(83, DBG_CRITICAL, "ERROR: Failed to acquire TLS private key '" << keys.privateKeyFile << "': " << Security::ErrorString(ssl_error));
-        return false;
-    }
-
     return true;
 }
 

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -270,12 +270,6 @@ bool configureSSLUsingPkeyAndCertFromMemory(SSL *ssl, const char *data, AnyP::Po
 
 /**
   \ingroup ServerProtocolSSLAPI
-  * Adds the certificates in certList to the certificate chain of the SSL context
- */
-void addChainToSslContext(Security::ContextPointer &, Security::CertList &);
-
-/**
-  \ingroup ServerProtocolSSLAPI
   * Configures sslContext to use squid untrusted certificates internal list
   * to complete certificate chains when verifies SSL servers certificates.
  */

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -67,6 +67,7 @@ namespace Ssl
 {
 
 /// callback for receiving password to access password secured PEM files
+/// XXX: Requires SSL_CTX_set_default_passwd_cb_userdata()!
 int AskPasswordCb(char *buf, int size, int rwflag, void *userdata);
 
 /// initialize the SSL library global state.

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -65,6 +65,10 @@ class MemMap;
 
 namespace Ssl
 {
+
+/// callback for receiving password to access password secured PEM files
+int AskPasswordCb(char *buf, int size, int rwflag, void *userdata);
+
 /// initialize the SSL library global state.
 /// call before generating any SSL context
 void Initialize();
@@ -276,15 +280,6 @@ void addChainToSslContext(Security::ContextPointer &, Security::CertList &);
   * to complete certificate chains when verifies SSL servers certificates.
  */
 void useSquidUntrusted(SSL_CTX *sslContext);
-
-/**
- \ingroup ServerProtocolSSLAPI
- *  Read certificate, private key and any certificates which must be chained from files.
- * See also: Ssl::readCertAndPrivateKeyFromFiles function,  defined in gadgets.h
- * \param certFilename name of file with certificate and certificates which must be chainned.
- * \param keyFilename name of file with private key.
- */
-void readCertChainAndPrivateKeyFromFiles(Security::CertPointer & cert, Security::PrivateKeyPointer & pkey, Security::CertList &chain, char const * certFilename, char const * keyFilename);
 
 /**
    \ingroup ServerProtocolSSLAPI

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -91,8 +91,9 @@ Security::ServerOptions &Security::ServerOptions::operator=(Security::ServerOpti
 void Security::ServerOptions::parse(const char *) STUB
 void Security::ServerOptions::dumpCfg(Packable *, const char *) const STUB
 Security::ContextPointer Security::ServerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer())
+void Security::ServerOptions::initServerContexts(AnyP::PortCfg&) STUB
 bool Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &) STUB_RETVAL(false)
-void Security::ServerOptions::createSigningContexts(AnyP::PortCfg &) STUB
+void Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &) STUB
 bool Security::ServerOptions::updateContextConfig(Security::ContextPointer &) STUB_RETVAL(false)
 void Security::ServerOptions::updateContextEecdh(Security::ContextPointer &) STUB
 void Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -31,6 +31,12 @@ std::ostream &Security::operator <<(std::ostream &os, const Security::EncryptorA
 Security::HandshakeParser::HandshakeParser() STUB
 bool Security::HandshakeParser::parseHello(const SBuf &) STUB_RETVAL(false)
 
+#include "security/KeyData.h"
+namespace Security
+{
+void KeyData::loadFromFiles(const AnyP::PortCfg &, const char *) STUB
+}
+
 #include "security/NegotiationHistory.h"
 Security::NegotiationHistory::NegotiationHistory() STUB
 void Security::NegotiationHistory::retrieveNegotiatedInfo(const Security::SessionPointer &) STUB
@@ -97,7 +103,6 @@ void Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &) STUB
 bool Security::ServerOptions::updateContextConfig(Security::ContextPointer &) STUB_RETVAL(false)
 void Security::ServerOptions::updateContextEecdh(Security::ContextPointer &) STUB
 void Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB
-void Security::ServerOptions::updateContextCertChain(Security::ContextPointer &) STUB
 void Security::ServerOptions::syncCaFiles() STUB
 void Security::ServerOptions::updateContextSessionId(Security::ContextPointer &) STUB
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -97,6 +97,7 @@ void Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &) STUB
 bool Security::ServerOptions::updateContextConfig(Security::ContextPointer &) STUB_RETVAL(false)
 void Security::ServerOptions::updateContextEecdh(Security::ContextPointer &) STUB
 void Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB
+void Security::ServerOptions::updateContextCertChain(Security::ContextPointer &) STUB
 void Security::ServerOptions::syncCaFiles() STUB
 void Security::ServerOptions::updateContextSessionId(Security::ContextPointer &) STUB
 

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -50,6 +50,7 @@ const String & Ssl::ErrorDetail::toString() const STUB_RETSTATREF(String)
 #include "ssl/support.h"
 namespace Ssl
 {
+int AskPasswordCb(char *, int, int, void *) STUB_RETVAL(0)
 bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &) STUB_RETVAL(false)
 bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, const char *) STUB_RETVAL(false)
 void SetupVerifyCallback(Security::ContextPointer &) STUB
@@ -71,7 +72,6 @@ Security::ContextPointer GenerateSslContext(CertificateProperties const &, Secur
 bool verifySslCertificate(Security::ContextPointer &, CertificateProperties const &) STUB_RETVAL(false)
 Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char *, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer())
 void addChainToSslContext(Security::ContextPointer &, STACK_OF(X509) *) STUB
-void readCertChainAndPrivateKeyFromFiles(Security::CertPointer &, Security::PrivateKeyPointer &, Security::CertList &, char const *, char const *) STUB
 int matchX509CommonNames(X509 *peer_cert, void *check_data, int (*check_func)(void *check_data,  ASN1_STRING *cn_data)) STUB_RETVAL(0)
 bool checkX509ServerValidity(X509 *cert, const char *server) STUB_RETVAL(false)
 int asn1timeToString(ASN1_TIME *tm, char *buf, int len) STUB_RETVAL(0)

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -71,7 +71,6 @@ bool generateUntrustedCert(Security::CertPointer &, Security::PrivateKeyPointer 
 Security::ContextPointer GenerateSslContext(CertificateProperties const &, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer())
 bool verifySslCertificate(Security::ContextPointer &, CertificateProperties const &) STUB_RETVAL(false)
 Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char *, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer())
-void addChainToSslContext(Security::ContextPointer &, STACK_OF(X509) *) STUB
 int matchX509CommonNames(X509 *peer_cert, void *check_data, int (*check_func)(void *check_data,  ASN1_STRING *cn_data)) STUB_RETVAL(0)
 bool checkX509ServerValidity(X509 *cert, const char *server) STUB_RETVAL(false)
 int asn1timeToString(ASN1_TIME *tm, char *buf, int len) STUB_RETVAL(0)


### PR DESCRIPTION
Move the http_port cert= and key= options logic to libsecurity and add GnuTLS implementation for PEM file loading. Also adds some extra debugging to clarify listening port initialization problems with the PEM files.

Enable most of the http(s)_port listening socket logic to always build except where OpenSSL-specific dependency still exists. It may seem reasonable to leave it optionally excluded for minimal builds, however a minimal proxy that does not support HTTPS in any way is increasingly useless in the modern web so preference is given to building the generic TLS related code. This also simplifies the required testing to detect code portability issues.

GnuTLS implementation is added for https_port configured with static cert=/key= parameters and the resulting TLS handshake behaviour. Squid built with GnuTLS can now act as useful parent proxies behind a SSL-Bump'ing frontend or for other clients which require a TLS explicit proxy.

Also fixes the definitions for the CertPointer and PrivateKeyPointer.