### PR TITLE
Fix sys/file.h includes

### DIFF
--- a/src/base/File.cc
+++ b/src/base/File.cc
@@ -18,9 +18,6 @@
 #if HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
-#if HAVE_SYS_FILE_H
-#include <sys/file.h>
-#endif
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif

--- a/src/base/File.h
+++ b/src/base/File.h
@@ -11,6 +11,10 @@
 
 #include "sbuf/SBuf.h"
 
+#if HAVE_SYS_FILE_H
+#include <sys/file.h>
+#endif
+
 /// How should a file be opened/created? Should it be locked?
 class FileOpeningConfig
 {

--- a/src/security/cert_generators/file/certificate_db.cc
+++ b/src/security/cert_generators/file/certificate_db.cc
@@ -17,11 +17,11 @@
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
-#if HAVE_SYS_FILE_H
-#include <sys/file.h>
-#endif
 #if HAVE_FCNTL_H
 #include <fcntl.h>
+#endif
+#if HAVE_SYS_FILE_H
+#include <sys/file.h>
 #endif
 
 #define HERE "(security_file_certgen) " << __FILE__ << ':' << __LINE__ << ": "


### PR DESCRIPTION
LOCK_UN definition in base/File.h requires sys/file.h which was not being included until later in the .cc

This should fix compile errors on GNU/Hurd.