### PR TITLE
Fixed %ssl::<cert_issuer documentation typo in e2e33ac

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4552,7 +4552,7 @@ DOC_START
 				not available. Consider encoding the logged
 				value because Subject often has spaces.
 
-		ssl::>cert_issuer
+		ssl::<cert_issuer
 				The Issuer field of the received server
 				TLS certificate or a dash ('-') if this is
 				not available. Consider encoding the logged


### PR DESCRIPTION
TODO: Migrate from plain text to structured cf.data.pre.