### PR TITLE
Convert Acl::InnerNode to C++11 for-each loop

### DIFF
--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -21,7 +21,8 @@
 void
 Acl::InnerNode::prepareForUse()
 {
-    std::for_each(nodes.begin(), nodes.end(), std::mem_fun(&ACL::prepareForUse));
+    for (auto &node : nodes)
+        node->prepareForUse();
 }
 
 bool

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -21,7 +21,7 @@
 void
 Acl::InnerNode::prepareForUse()
 {
-    for (auto &node : nodes)
+    for (auto node : nodes)
         node->prepareForUse();
 }
 


### PR DESCRIPTION
This also fixes a bug in some STL implementations where passing for_each &ACL::prepareForUse
results in the ACL class nil-method explicitly running instead of the child ACL class
virtual method.