### PR TITLE
Avoid native FTP deaths from one of the unhandled "reply" exceptions

### DIFF
--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1126,10 +1126,12 @@ Ftp::Server::writeErrorReply(const HttpReply *reply, const int scode)
     }
 #endif
 
-    Must(reply);
-    const char *reason = reply->header.has(Http::HdrType::FTP_REASON) ?
-                         reply->header.getStr(Http::HdrType::FTP_REASON):
-                         reply->sline.reason();
+    const char *reason = "Lost Error";
+    if (reply) {
+        reason = reply->header.has(Http::HdrType::FTP_REASON) ?
+                 reply->header.getStr(Http::HdrType::FTP_REASON):
+                 reply->sline.reason();
+    }
 
     mb.appendf("%i %s\r\n", scode, reason); // error terminating line
 


### PR DESCRIPTION
There is no reason to kill the client-Squid transaction (not to mention
whole Squid!) when the server-to-Squid reply structure is missing in
Ftp::Server::writeErrorReply(). Some errors might not even have that
structure?

The symptom of this bug is the following cache.log message:

  FATAL: Dying from an exception handling failure; exception: reply

There are currently three Must(reply) exceptions. This change addresses
one likely (and easy to fix) case.

This is a Measurement Factory project.