### PR TITLE
Restored Squid ability to serve pure hits broken by d816577.

### DIFF
--- a/src/store.cc
+++ b/src/store.cc
@@ -1554,9 +1554,8 @@ StoreEntry::timestampsSet()
     // compensate for Squid-to-server and server-to-Squid delays
     if (mem_obj && mem_obj->request) {
         struct timeval responseTime;
-        if (mem_obj->request->hier.peerResponseTime(responseTime) &&
-                responseTime.tv_sec < squid_curtime)
-            served_date -= (squid_curtime - responseTime.tv_sec);
+        if (mem_obj->request->hier.peerResponseTime(responseTime))
+            served_date -= responseTime.tv_sec;
     }
 
     time_t exp = 0;


### PR DESCRIPTION
Since PR #79, most incoming objects got wrong served_date, becoming immediately stale and usually requiring revalidation.