### PR TITLE
Moved peer*(ps_state) functions into ps_state renamed PeerSelector

### DIFF
--- a/src/ICP.h
+++ b/src/ICP.h
@@ -24,13 +24,12 @@
 class HttpRequest;
 
 /**
- \ingroup ServerProtocolICPAPI
- *
- * This struct is the wire-level header.
- * DO NOT add more move fields on pain of breakage.
+ * Wire-level ICP header.
+ * DO NOT add or move fields.
  * DO NOT add virtual methods.
  */
-struct _icp_common_t {
+class icp_common_t {
+public:
     /** opcode */
     unsigned char opcode;
     /** version number */
@@ -44,21 +43,15 @@ struct _icp_common_t {
     /** sender host id */
     uint32_t shostid;
 
-/// \todo I don't believe this header is included in non-c++ code anywhere
-///     the struct should become a public POD class and kill these ifdef.
-#ifdef __cplusplus
-
-    _icp_common_t();
-    _icp_common_t(char *buf, unsigned int len);
+    icp_common_t();
+    icp_common_t(char *buf, unsigned int len);
 
     void handleReply(char *buf, Ip::Address &from);
-    static _icp_common_t *createMessage(icp_opcode opcode, int flags, const char *url, int reqnum, int pad);
+    static icp_common_t *createMessage(icp_opcode opcode, int flags, const char *url, int reqnum, int pad);
     icp_opcode getOpCode() const;
-#endif
 };
-typedef struct _icp_common_t icp_common_t;
-
-#ifdef __cplusplus
+// TODO: Remove after fixing remaining users.
+#define _icp_common_t icp_common_t
 
 /**
  \ingroup ServerProtocolICPAPI
@@ -77,8 +70,6 @@ public:
     Ip::Address from;
     char *url;
 };
-
-#endif
 
 /// \ingroup ServerProtocolICPAPI
 struct icpUdpData {

--- a/src/ICP.h
+++ b/src/ICP.h
@@ -47,11 +47,11 @@ public:
     icp_common_t(char *buf, unsigned int len);
 
     void handleReply(char *buf, Ip::Address &from);
-    static icp_common_t *createMessage(icp_opcode opcode, int flags, const char *url, int reqnum, int pad);
     icp_opcode getOpCode() const;
+
+    /// \returns newly allocated buffer with an ICP message, including header
+    static icp_common_t *CreateMessage(icp_opcode opcode, int flags, const char *url, int reqnum, int pad);
 };
-// TODO: Remove after fixing remaining users.
-#define _icp_common_t icp_common_t
 
 /**
  \ingroup ServerProtocolICPAPI

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -60,7 +60,7 @@ class PeerSelector: public Dns::IpReceiver
     CBDATA_CHILD(PeerSelector);
 
 public:
-    explicit PeerSelector(PeerSelectionInitiator *initiator);
+    explicit PeerSelector(PeerSelectionInitiator*);
     virtual ~PeerSelector() override;
 
     /* Dns::IpReceiver API */

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -127,9 +127,7 @@ private:
     allow_t always_direct;
     allow_t never_direct;
     int direct;   // TODO: fold always_direct/never_direct/prefer_direct into this now that ACL can do a multi-state result.
-
     size_t foundPaths = 0; ///< number of unique destinations identified so far
-
     ErrorState *lastError;
 
     FwdServer *servers; ///< a linked list of (unresolved) selected peers
@@ -151,7 +149,6 @@ private:
      */
     CachePeer *hit;
     peer_t hit_type;
-
     ACLChecklist *acl_checklist;
 
     typedef CbcPointer<PeerSelectionInitiator> Initiator;

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -19,11 +19,11 @@
 #include "mem/forward.h"
 #include "PingData.h"
 
-class HttpRequest;
-class StoreEntry;
 class ErrorState;
-class icp_common_t;
 class HtcpReplyData;
+class HttpRequest;
+class icp_common_t;
+class StoreEntry;
 
 void peerSelectInit(void);
 

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -22,6 +22,8 @@
 class HttpRequest;
 class StoreEntry;
 class ErrorState;
+class icp_common_t;
+class HtcpReplyData;
 
 void peerSelectInit(void);
 
@@ -51,13 +53,15 @@ public:
 
 class FwdServer;
 
-class ps_state: public Dns::IpReceiver
+/// Finds peer (including origin server) IPs for forwarding a single request.
+/// Gives PeerSelectionInitiator each found destination, in the right order.
+class PeerSelector: public Dns::IpReceiver
 {
-    CBDATA_CHILD(ps_state);
+    CBDATA_CHILD(PeerSelector);
 
 public:
-    explicit ps_state(PeerSelectionInitiator *initiator);
-    virtual ~ps_state() override;
+    explicit PeerSelector(PeerSelectionInitiator *initiator);
+    virtual ~PeerSelector() override;
 
     /* Dns::IpReceiver API */
     virtual void noteIp(const Ip::Address &ip) override;
@@ -77,17 +81,58 @@ public:
     /// processes a newly discovered/finalized path
     void handlePath(Comm::ConnectionPointer &path, FwdServer &fs);
 
+    /// a single selection loop iteration: attempts to add more destinations
+    void selectMore();
+
     HttpRequest *request;
     AccessLogEntry::Pointer al; ///< info for the future access.log entry
     StoreEntry *entry;
+
+    void *peerCountMcastPeerXXX = nullptr; ///< a hack to help peerCountMcastPeersStart()
+
+    ping_data ping;
+
+protected:
+    bool selectionAborted();
+
+    void handlePingTimeout();
+    void handleIcpReply(CachePeer*, const peer_t, icp_common_t *header);
+    void handleIcpParentMiss(CachePeer*, icp_common_t*);
+#if USE_HTCP
+    void handleHtcpParentMiss(CachePeer*, HtcpReplyData*);
+    void handleHtcpReply(CachePeer*, const peer_t, HtcpReplyData*);
+#endif
+
+    int checkNetdbDirect();
+    void checkAlwaysDirectDone(const allow_t answer);
+    void checkNeverDirectDone(const allow_t answer);
+
+    void selectSomeNeighbor();
+    void selectSomeNeighborReplies();
+    void selectSomeDirect();
+    void selectSomeParent();
+    void selectAllParents();
+    void selectPinned();
+
+    void addSelection(CachePeer*, const hier_code);
+
+    void resolveSelected();
+
+    static IRCB HandlePingReply;
+    static ACLCB CheckAlwaysDirectDone;
+    static ACLCB CheckNeverDirectDone;
+    static EVH HandlePingTimeout;
+
+private:
     allow_t always_direct;
     allow_t never_direct;
     int direct;   // TODO: fold always_direct/never_direct/prefer_direct into this now that ACL can do a multi-state result.
+
     size_t foundPaths = 0; ///< number of unique destinations identified so far
-    void *peerCountMcastPeerXXX = nullptr; ///< a hack to help peerCountMcastPeersStart()
+
     ErrorState *lastError;
 
-    FwdServer *servers;    ///< temporary linked list of peers we will pass back.
+    FwdServer *servers; ///< a linked list of (unresolved) selected peers
 
     /*
      * Why are these Ip::Address instead of CachePeer *?  Because a
@@ -106,15 +151,13 @@ public:
      */
     CachePeer *hit;
     peer_t hit_type;
-    ping_data ping;
+
     ACLChecklist *acl_checklist;
-
-    const InstanceId<ps_state> id; ///< unique identification in worker log
-
-private:
 
     typedef CbcPointer<PeerSelectionInitiator> Initiator;
     Initiator initiator_; ///< recipient of the destinations we select; use interestedInitiator() to access
+
+    const InstanceId<PeerSelector> id; ///< unique identification in worker log
 };
 
 #endif /* SQUID_PEERSELECTSTATE_H */

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -73,15 +73,15 @@ Comm::ConnectionPointer icpIncomingConn = NULL;
 Comm::ConnectionPointer icpOutgoingConn = NULL;
 
 /* icp_common_t */
-_icp_common_t::_icp_common_t() :
+icp_common_t::icp_common_t() :
     opcode(ICP_INVALID), version(0), length(0), reqnum(0),
     flags(0), pad(0), shostid(0)
 {}
 
-_icp_common_t::_icp_common_t(char *buf, unsigned int len) :
+icp_common_t::icp_common_t(char *buf, unsigned int len) :
     opcode(ICP_INVALID), version(0), reqnum(0), flags(0), pad(0), shostid(0)
 {
-    if (len < sizeof(_icp_common_t)) {
+    if (len < sizeof(icp_common_t)) {
         /* mark as invalid */
         length = len + 1;
         return;
@@ -98,7 +98,7 @@ _icp_common_t::_icp_common_t(char *buf, unsigned int len) :
 }
 
 icp_opcode
-_icp_common_t::getOpCode() const
+icp_common_t::getOpCode() const
 {
     if (opcode > static_cast<char>(icp_opcode::ICP_END))
         return ICP_INVALID;
@@ -228,8 +228,8 @@ icpUdpSendQueue(int fd, void *)
     }
 }
 
-_icp_common_t *
-_icp_common_t::createMessage(
+icp_common_t *
+icp_common_t::CreateMessage(
     icp_opcode opcode,
     int flags,
     const char *url,
@@ -387,7 +387,7 @@ icpLogFromICPCode(icp_opcode opcode)
 void
 icpCreateAndSend(icp_opcode opcode, int flags, char const *url, int reqnum, int pad, int fd, const Ip::Address &from)
 {
-    icp_common_t *reply = _icp_common_t::createMessage(opcode, flags, url, reqnum, pad);
+    icp_common_t *reply = icp_common_t::CreateMessage(opcode, flags, url, reqnum, pad);
     icpUdpSend(fd, from, reply, icpLogFromICPCode(opcode), 0);
 }
 
@@ -493,7 +493,7 @@ doV2Query(int fd, Ip::Address &from, char *buf, icp_common_t header)
 }
 
 void
-_icp_common_t::handleReply(char *buf, Ip::Address &from)
+icp_common_t::handleReply(char *buf, Ip::Address &from)
 {
     if (neighbors_do_private_keys && reqnum == 0) {
         debugs(12, DBG_CRITICAL, "icpHandleIcpV2: Neighbor " << from << " returned reqnum = 0");

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -643,7 +643,7 @@ neighborsUdpPing(HttpRequest * request,
 
                 if (p->icp.port == echo_port) {
                     debugs(15, 4, "neighborsUdpPing: Looks like a dumb cache, send DECHO ping");
-                    query = _icp_common_t::createMessage(ICP_DECHO, 0, url, reqnum, 0);
+                    query = icp_common_t::CreateMessage(ICP_DECHO, 0, url, reqnum, 0);
                     icpUdpSend(icpOutgoingConn->fd, p->in_addr, query, LOG_ICP_QUERY, 0);
                 } else {
                     flags = 0;
@@ -652,7 +652,7 @@ neighborsUdpPing(HttpRequest * request,
                         if (p->icp.version == ICP_VERSION_2)
                             flags |= ICP_FLAG_SRC_RTT;
 
-                    query = _icp_common_t::createMessage(ICP_QUERY, flags, url, reqnum, 0);
+                    query = icp_common_t::CreateMessage(ICP_QUERY, flags, url, reqnum, 0);
 
                     icpUdpSend(icpOutgoingConn->fd, p->in_addr, query, LOG_ICP_QUERY, 0.0);
                 }
@@ -1403,7 +1403,7 @@ peerCountMcastPeersStart(void *data)
     mcastSetTtl(icpOutgoingConn->fd, p->mcast.ttl);
     p->mcast.id = mem->id;
     reqnum = icpSetCacheKey((const cache_key *)fake->key);
-    query = _icp_common_t::createMessage(ICP_QUERY, 0, url, reqnum, 0);
+    query = icp_common_t::CreateMessage(ICP_QUERY, 0, url, reqnum, 0);
     icpUdpSend(icpOutgoingConn->fd, p->in_addr, query, LOG_ICP_QUERY, 0);
     fake->ping_status = PING_WAITING;
     eventAdd("peerCountMcastPeersDone",

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1375,7 +1375,6 @@ peerCountMcastPeersStart(void *data)
     // XXX: Do not create lots of complex fake objects (while abusing their
     // APIs) to pass around a few basic data points like start_ping and ping!
     CachePeer *p = (CachePeer *)data;
-    ps_state *psstate;
     MemObject *mem;
     icp_common_t *query;
     int reqnum;
@@ -1390,7 +1389,7 @@ peerCountMcastPeersStart(void *data)
     HttpRequest *req = HttpRequest::FromUrl(url, mx);
     assert(req != nullptr);
     StoreEntry *fake = storeCreateEntry(url, url, RequestFlags(), Http::METHOD_GET);
-    psstate = new ps_state(nullptr);
+    auto psstate = new PeerSelector(nullptr);
     psstate->request = req;
     HTTPMSGLOCK(psstate->request);
     psstate->entry = fake;
@@ -1418,7 +1417,7 @@ peerCountMcastPeersStart(void *data)
 static void
 peerCountMcastPeersDone(void *data)
 {
-    ps_state *psstate = (ps_state *)data;
+    auto psstate = static_cast<PeerSelector*>(data);
     StoreEntry *fake = psstate->entry;
 
     if (cbdataReferenceValid(psstate->peerCountMcastPeerXXX)) {
@@ -1442,7 +1441,7 @@ peerCountMcastPeersDone(void *data)
 static void
 peerCountHandleIcpReply(CachePeer * p, peer_t, AnyP::ProtocolType proto, void *, void *data)
 {
-    ps_state *psstate = (ps_state *)data;
+    auto psstate = static_cast<PeerSelector*>(data);
     StoreEntry *fake = psstate->entry;
     assert(fake);
     MemObject *mem = fake->mem_obj;

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1389,7 +1389,7 @@ peerCountMcastPeersStart(void *data)
     HttpRequest *req = HttpRequest::FromUrl(url, mx);
     assert(req != nullptr);
     StoreEntry *fake = storeCreateEntry(url, url, RequestFlags(), Http::METHOD_GET);
-    auto psstate = new PeerSelector(nullptr);
+    const auto psstate = new PeerSelector(nullptr);
     psstate->request = req;
     HTTPMSGLOCK(psstate->request);
     psstate->entry = fake;
@@ -1417,7 +1417,7 @@ peerCountMcastPeersStart(void *data)
 static void
 peerCountMcastPeersDone(void *data)
 {
-    auto psstate = static_cast<PeerSelector*>(data);
+    const auto psstate = static_cast<PeerSelector*>(data);
     StoreEntry *fake = psstate->entry;
 
     if (cbdataReferenceValid(psstate->peerCountMcastPeerXXX)) {
@@ -1441,7 +1441,7 @@ peerCountMcastPeersDone(void *data)
 static void
 peerCountHandleIcpReply(CachePeer * p, peer_t, AnyP::ProtocolType proto, void *, void *data)
 {
-    auto psstate = static_cast<PeerSelector*>(data);
+    const auto psstate = static_cast<PeerSelector*>(data);
     StoreEntry *fake = psstate->entry;
     assert(fake);
     MemObject *mem = fake->mem_obj;

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -251,7 +251,6 @@ PeerSelector::CheckAlwaysDirectDone(allow_t answer, void *data)
     static_cast<PeerSelector*>(data)->checkAlwaysDirectDone(answer);
 }
 
-
 /// \returns true (after destroying "this") if the peer initiator is gone
 /// \returns false (without side effects) otherwise
 bool
@@ -596,11 +595,11 @@ PeerSelector::selectSomeNeighbor()
             debugs(44, 3, "Doing ICP pings");
             ping.start = current_time;
             ping.n_sent = neighborsUdpPing(request,
-                                               entry,
-                                               HandlePingReply,
-                                               this,
-                                               &ping.n_replies_expected,
-                                               &ping.timeout);
+                                           entry,
+                                           HandlePingReply,
+                                           this,
+                                           &ping.n_replies_expected,
+                                           &ping.timeout);
 
             if (ping.n_sent == 0)
                 debugs(44, DBG_CRITICAL, "WARNING: neighborsUdpPing returned 0");
@@ -928,7 +927,7 @@ PeerSelector::addSelection(CachePeer *peer, const hier_code code)
         // Non-PINNED destinations are uniquely identified by their CachePeer
         // (even though a DIRECT destination might match a cache_peer address).
         const bool duplicate = (server->code == PINNED) ?
-            (code == PINNED) : (server->_peer == peer);
+                               (code == PINNED) : (server->_peer == peer);
         if (duplicate) {
             debugs(44, 3, "skipping " << PeerSelectionDumper(this, peer, code) <<
                    "; have " << PeerSelectionDumper(this, server->_peer.get(), server->code));

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -140,7 +140,7 @@ peerSelectIcpPing(HttpRequest * request, int direct, StoreEntry * entry)
     assert(entry);
     assert(entry->ping_status == PING_NONE);
     assert(direct != DIRECT_YES);
-    debugs(44, 3, "peerSelectIcpPing: " << entry->url());
+    debugs(44, 3, entry->url());
 
     if (!request->flags.hierarchical && direct != DIRECT_NO)
         return 0;
@@ -151,7 +151,7 @@ peerSelectIcpPing(HttpRequest * request, int direct, StoreEntry * entry)
 
     n = neighborsCount(request);
 
-    debugs(44, 3, "peerSelectIcpPing: counted " << n << " neighbors");
+    debugs(44, 3, "counted " << n << " neighbors");
 
     return n;
 }
@@ -199,13 +199,13 @@ void
 PeerSelector::checkNeverDirectDone(const allow_t answer)
 {
     acl_checklist = nullptr;
-    debugs(44, 3, "peerCheckNeverDirectDone: " << answer);
+    debugs(44, 3, answer);
     never_direct = answer;
     switch (answer) {
     case ACCESS_ALLOWED:
         /** if never_direct says YES, do that. */
         direct = DIRECT_NO;
-        debugs(44, 3, HERE << "direct = " << DirectStr[direct] << " (never_direct allow)");
+        debugs(44, 3, "direct = " << DirectStr[direct] << " (never_direct allow)");
         break;
     case ACCESS_DENIED: // not relevant.
     case ACCESS_DUNNO:  // not relevant.
@@ -227,13 +227,13 @@ void
 PeerSelector::checkAlwaysDirectDone(const allow_t answer)
 {
     acl_checklist = nullptr;
-    debugs(44, 3, "peerCheckAlwaysDirectDone: " << answer);
+    debugs(44, 3, answer);
     always_direct = answer;
     switch (answer) {
     case ACCESS_ALLOWED:
         /** if always_direct says YES, do that. */
         direct = DIRECT_YES;
-        debugs(44, 3, HERE << "direct = " << DirectStr[direct] << " (always_direct allow)");
+        debugs(44, 3, "direct = " << DirectStr[direct] << " (always_direct allow)");
         break;
     case ACCESS_DENIED: // not relevant.
     case ACCESS_DUNNO:  // not relevant.
@@ -429,8 +429,8 @@ PeerSelector::checkNetdbDirect()
 
     myhops = netdbHostHops(request->url.host());
 
-    debugs(44, 3, "peerCheckNetdbDirect: MY hops = " << myhops);
-    debugs(44, 3, "peerCheckNetdbDirect: minimum_direct_hops = " << Config.minDirectHops);
+    debugs(44, 3, "MY hops = " << myhops);
+    debugs(44, 3, "minimum_direct_hops = " << Config.minDirectHops);
 
     if (myhops && myhops <= Config.minDirectHops)
         return 1;
@@ -440,7 +440,7 @@ PeerSelector::checkNetdbDirect()
     if (p == NULL)
         return 0;
 
-    debugs(44, 3, "peerCheckNetdbDirect: closest_parent_miss RTT = " << ping.p_rtt << " msec");
+    debugs(44, 3, "closest_parent_miss RTT = " << ping.p_rtt << " msec");
 
     if (myrtt && myrtt <= ping.p_rtt)
         return 1;
@@ -461,7 +461,7 @@ PeerSelector::selectMore()
     /** If we don't know whether DIRECT is permitted ... */
     if (direct == DIRECT_UNKNOWN) {
         if (always_direct == ACCESS_DUNNO) {
-            debugs(44, 3, "peerSelectFoo: direct = " << DirectStr[direct] << " (always_direct to be checked)");
+            debugs(44, 3, "direct = " << DirectStr[direct] << " (always_direct to be checked)");
             /** check always_direct; */
             ACLFilledChecklist *ch = new ACLFilledChecklist(Config.accessList.AlwaysDirect, request, NULL);
             ch->al = al;
@@ -469,7 +469,7 @@ PeerSelector::selectMore()
             acl_checklist->nonBlockingCheck(CheckAlwaysDirectDone, this);
             return;
         } else if (never_direct == ACCESS_DUNNO) {
-            debugs(44, 3, "peerSelectFoo: direct = " << DirectStr[direct] << " (never_direct to be checked)");
+            debugs(44, 3, "direct = " << DirectStr[direct] << " (never_direct to be checked)");
             /** check never_direct; */
             ACLFilledChecklist *ch = new ACLFilledChecklist(Config.accessList.NeverDirect, request, NULL);
             ch->al = al;
@@ -479,20 +479,20 @@ PeerSelector::selectMore()
         } else if (request->flags.noDirect) {
             /** if we are accelerating, direct is not an option. */
             direct = DIRECT_NO;
-            debugs(44, 3, "peerSelectFoo: direct = " << DirectStr[direct] << " (forced non-direct)");
+            debugs(44, 3, "direct = " << DirectStr[direct] << " (forced non-direct)");
         } else if (request->flags.loopDetected) {
             /** if we are in a forwarding-loop, direct is not an option. */
             direct = DIRECT_YES;
-            debugs(44, 3, "peerSelectFoo: direct = " << DirectStr[direct] << " (forwarding loop detected)");
+            debugs(44, 3, "direct = " << DirectStr[direct] << " (forwarding loop detected)");
         } else if (checkNetdbDirect()) {
             direct = DIRECT_YES;
-            debugs(44, 3, "peerSelectFoo: direct = " << DirectStr[direct] << " (checkNetdbDirect)");
+            debugs(44, 3, "direct = " << DirectStr[direct] << " (checkNetdbDirect)");
         } else {
             direct = DIRECT_MAYBE;
-            debugs(44, 3, "peerSelectFoo: direct = " << DirectStr[direct] << " (default)");
+            debugs(44, 3, "direct = " << DirectStr[direct] << " (default)");
         }
 
-        debugs(44, 3, "peerSelectFoo: direct = " << DirectStr[direct]);
+        debugs(44, 3, "direct = " << DirectStr[direct]);
     }
 
     if (!entry || entry->ping_status == PING_NONE)
@@ -593,7 +593,7 @@ PeerSelector::selectSomeNeighbor()
         if ((p = netdbClosestParent(request))) {
             code = CLOSEST_PARENT;
         } else if (peerSelectIcpPing(request, direct, entry)) {
-            debugs(44, 3, "peerSelect: Doing ICP pings");
+            debugs(44, 3, "Doing ICP pings");
             ping.start = current_time;
             ping.n_sent = neighborsUdpPing(request,
                                                entry,
@@ -604,7 +604,7 @@ PeerSelector::selectSomeNeighbor()
 
             if (ping.n_sent == 0)
                 debugs(44, DBG_CRITICAL, "WARNING: neighborsUdpPing returned 0");
-            debugs(44, 3, "peerSelect: " << ping.n_replies_expected <<
+            debugs(44, 3, ping.n_replies_expected <<
                    " ICP replies expected, RTT " << ping.timeout <<
                    " msec");
 
@@ -809,7 +809,7 @@ void
 PeerSelector::handleIcpReply(CachePeer *p, const peer_t type, icp_common_t *header)
 {
     icp_opcode op = header->getOpCode();
-    debugs(44, 3, "peerHandleIcpReply: " << icp_opcode_str[op] << " " << url()  );
+    debugs(44, 3, icp_opcode_str[op] << ' ' << url());
 #if USE_CACHE_DIGESTS && 0
     /* do cd lookup to count false misses */
 
@@ -841,7 +841,7 @@ PeerSelector::handleIcpReply(CachePeer *p, const peer_t type, icp_common_t *head
 void
 PeerSelector::handleHtcpReply(CachePeer *p, const peer_t type, HtcpReplyData *htcp)
 {
-    debugs(44, 3, "" << (htcp->hit ? "HIT" : "MISS") << " " << url());
+    debugs(44, 3, (htcp->hit ? "HIT" : "MISS") << ' ' << url());
     ++ping.n_recv;
 
     if (htcp->hit) {

--- a/src/tests/stub_icp.cc
+++ b/src/tests/stub_icp.cc
@@ -13,15 +13,13 @@
 #define STUB_API "icp_*.cc"
 #include "tests/STUB.h"
 
-#ifdef __cplusplus
-_icp_common_t::_icp_common_t() STUB
-_icp_common_t::_icp_common_t(char *buf, unsigned int len) STUB
-void _icp_common_t::handleReply(char *buf, Ip::Address &from) STUB
-_icp_common_t *_icp_common_t::createMessage(icp_opcode opcode, int flags, const char *url, int reqnum, int pad) STUB_RETVAL(NULL)
-icp_opcode _icp_common_t::getOpCode() const STUB_RETVAL(ICP_INVALID)
+icp_common_t::icp_common_t() STUB
+icp_common_t::icp_common_t(char *buf, unsigned int len) STUB
+void icp_common_t::handleReply(char *buf, Ip::Address &from) STUB
+icp_common_t *icp_common_t::CreateMessage(icp_opcode opcode, int flags, const char *url, int reqnum, int pad) STUB_RETVAL(nullptr)
+icp_opcode icp_common_t::getOpCode() const STUB_RETVAL(ICP_INVALID)
 ICPState::ICPState(icp_common_t &aHeader, HttpRequest *aRequest) STUB
 ICPState::~ICPState() STUB
-#endif
 
 Comm::ConnectionPointer icpIncomingConn;
 Comm::ConnectionPointer icpOutgoingConn;


### PR DESCRIPTION
No functionality changes intended (other than debug message variations).

Also polished related documentation and debug messages.

Also converted "struct _icp_common_t" into an icp_common_t class, to
make its forward declarations simple. As a side effect, removed
__cplusplus ifdefs, addressing an old TODO.