### PR TITLE
v5 Sourceformat Enforcement

### DIFF
--- a/include/base64.h
+++ b/include/base64.h
@@ -169,3 +169,4 @@ base64_decode_final(struct base64_decode_ctx *ctx);
 #   define base64_encode_len(length) (BASE64_ENCODE_LENGTH(length)+BASE64_ENCODE_FINAL_LENGTH+1)
 
 #endif /* _SQUID_BASE64_H */
+

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -325,3 +325,4 @@ base64_encode_final(struct base64_encode_ctx *ctx,
 }
 
 #endif /* !HAVE_NETTLE_BASE64_H || !HAVE_NETTLE34_BASE64 */
+


### PR DESCRIPTION
Add some missing file termination CRLF after 1d11e9b3. These are necessary to avoid complaints from some code scanners (ie doxygen).