### PR TITLE
Bug 4805: add missing include for stdexcept

### DIFF
--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -11,7 +11,7 @@
 
 #include "base/Here.h"
 
-#include <exception>
+#include <stdexcept>
 
 class SBuf;
 


### PR DESCRIPTION
Now that TextException inherits from runtime_error we have to include the definitions from stdexcept.

The exception include only defines std::exception base class.