### PR TITLE
Bug 3911: clang -fsanitize warnings

### DIFF
--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
@@ -26,8 +26,7 @@
 
 CBDATA_CLASS_INIT(DiskThreadsDiskFile);
 
-DiskThreadsDiskFile::DiskThreadsDiskFile(char const *aPath, DiskThreadsIOStrategy *anIO):fd(-1), errorOccured (false), IO(anIO),
-    inProgressIOs (0)
+DiskThreadsDiskFile::DiskThreadsDiskFile(char const *aPath)
 {
     assert(aPath);
     debugs(79, 3, "UFSFile::UFSFile: " << aPath);

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
@@ -21,7 +21,7 @@ class DiskThreadsDiskFile : public DiskFile
     CBDATA_CLASS(DiskThreadsDiskFile);
 
 public:
-    DiskThreadsDiskFile(char const *path, DiskThreadsIOStrategy *);
+    DiskThreadsDiskFile(char const *path);
     ~DiskThreadsDiskFile();
     virtual void open(int flags, mode_t mode, RefCount<IORequestor> callback);
     virtual void create(int flags, mode_t mode, RefCount<IORequestor> callback);
@@ -51,11 +51,10 @@ private:
     static DWCB WriteDone;
 #endif
 
-    int fd;
-    bool errorOccured;
-    char const *path_;
-    DiskThreadsIOStrategy *IO;
-    size_t inProgressIOs;
+    int fd = -1;
+    bool errorOccured = false;
+    char const *path_ = nullptr;
+    size_t inProgressIOs = 0;
     static AIOCB OpenDone;
     void openDone(int fd, const char *buf, int aio_return, int aio_errno);
     RefCount<IORequestor> ioRequestor;

--- a/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.cc
@@ -225,7 +225,7 @@ DiskThreadsIOStrategy::newFile (char const *path)
         return NULL;
     }
 
-    return new DiskThreadsDiskFile (path, this);
+    return new DiskThreadsDiskFile(path);
 }
 
 bool

--- a/src/store/LocalSearch.cc
+++ b/src/store/LocalSearch.cc
@@ -22,8 +22,6 @@ class LocalSearch : public StoreSearch
     CBDATA_CLASS(LocalSearch);
 
 public:
-    LocalSearch();
-
     /* StoreSearch API */
     virtual void next(void (callback)(void *cbdata), void *cbdata) override;
     virtual bool next() override;
@@ -33,10 +31,8 @@ public:
 
 private:
     void copyBucket();
-    void (*callback)(void *cbdata);
-    void *cbdata;
-    bool _done;
-    int bucket;
+    bool _done = false;
+    int bucket = 0;
     std::vector<StoreEntry *> entries;
 };
 
@@ -49,13 +45,6 @@ Store::NewLocalSearch()
 {
     return new LocalSearch;
 }
-
-Store::LocalSearch::LocalSearch() :
-    callback(NULL),
-    cbdata(NULL),
-    _done(false),
-    bucket(0)
-{}
 
 void
 Store::LocalSearch::next(void (aCallback)(void *), void *aCallbackData)

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -276,7 +276,8 @@ struct wccp2_router_id_element_t {
     uint32_t received_id;
 };
 
-static struct wccp2_router_id_element_t wccp2_router_id_element;
+// unused (for now)
+// static struct wccp2_router_id_element_t wccp2_router_id_element;
 
 /** \interface WCCPv2_Protocol
  * Sect 5.6.9 Capabilities Info Component
@@ -807,7 +808,7 @@ wccp2Init(void)
         wccp2_cache_view_header.cache_view_type = htons(WCCP2_WC_VIEW_INFO);
 
         wccp2_cache_view_header.cache_view_length = htons(sizeof(wccp2_cache_view_header) - 4 +
-                sizeof(wccp2_cache_view_info) + (wccp2_numrouters * sizeof(wccp2_router_id_element)));
+                sizeof(wccp2_cache_view_info) + (wccp2_numrouters * sizeof(wccp2_router_id_element_t)));
 
         wccp2_cache_view_header.cache_view_version = htonl(1);
 


### PR DESCRIPTION
Fixes warnings from clang when -fsanitize is used. Many of these are also part of the bug 4738 issues.

 * error: private field 'callback' is not used [-Werror,-Wunused-private-field]
 * error: private field 'cbdata' is not used [-Werror,-Wunused-private-field]
 * error: private field 'IO' is not used [-Werror,-Wunused-private-field]
 * error: variable 'wccp2_router_id_element' is not needed and
      will not be emitted [-Werror,-Wunneeded-internal-declaration]

We cannot set these warnings as default options yet because the STUB code intentionally does not use any private class members, so it would error on every unit test.