### PR TITLE
Fixed Ip::Address copying

### DIFF
--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -349,13 +349,6 @@ Ip::Address::getReverseString(char buf[MAX_IPSTRLEN], int show_type) const
     return false;
 }
 
-Ip::Address&
-Ip::Address::operator =(const Ip::Address &s)
-{
-    memmove(&mSocketAddr_, &s.mSocketAddr_, sizeof(struct sockaddr_in6));
-    return *this;
-};
-
 Ip::Address::Address(const char*s)
 {
     setEmpty();
@@ -490,12 +483,6 @@ Ip::Address::operator =(struct in6_addr const &s)
 
     return *this;
 };
-
-Ip::Address::Address(const Ip::Address &s)
-{
-    setEmpty();
-    operator=(s);
-}
 
 Ip::Address::Address(const struct hostent &s)
 {

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -352,7 +352,7 @@ Ip::Address::getReverseString(char buf[MAX_IPSTRLEN], int show_type) const
 Ip::Address&
 Ip::Address::operator =(const Ip::Address &s)
 {
-    memcpy(this, &s, sizeof(Ip::Address));
+    memmove(&mSocketAddr_, &s.mSocketAddr_, sizeof(struct sockaddr_in6));
     return *this;
 };
 
@@ -440,7 +440,7 @@ Ip::Address::operator =(const struct sockaddr_storage &s)
 {
     /* some AF_* magic to tell socket types apart and what we need to do */
     if (s.ss_family == AF_INET6) {
-        memcpy(&mSocketAddr_, &s, sizeof(struct sockaddr_in6));
+        memmove(&mSocketAddr_, &s, sizeof(struct sockaddr_in6));
     } else { // convert it to our storage mapping.
         struct sockaddr_in *sin = (struct sockaddr_in*)&s;
         mSocketAddr_.sin6_port = sin->sin_port;
@@ -458,8 +458,7 @@ Ip::Address::Address(struct sockaddr_in6 const &s)
 Ip::Address &
 Ip::Address::operator =(struct sockaddr_in6 const &s)
 {
-    memcpy(&mSocketAddr_, &s, sizeof(struct sockaddr_in6));
-
+    memmove(&mSocketAddr_, &s, sizeof(struct sockaddr_in6));
     return *this;
 };
 
@@ -486,8 +485,7 @@ Ip::Address::Address(struct in6_addr const &s)
 Ip::Address &
 Ip::Address::operator =(struct in6_addr const &s)
 {
-
-    memcpy(&mSocketAddr_.sin6_addr, &s, sizeof(struct in6_addr));
+    memmove(&mSocketAddr_.sin6_addr, &s, sizeof(struct in6_addr));
     mSocketAddr_.sin6_family = AF_INET6;
 
     return *this;
@@ -983,7 +981,7 @@ Ip::Address::getSockAddr(struct sockaddr_in &buf) const
 void
 Ip::Address::getSockAddr(struct sockaddr_in6 &buf) const
 {
-    memcpy(&buf, &mSocketAddr_, sizeof(struct sockaddr_in6));
+    memmove(&buf, &mSocketAddr_, sizeof(struct sockaddr_in6));
     /* maintain address family. It may have changed inside us. */
     buf.sin6_family = AF_INET6;
 
@@ -1031,7 +1029,7 @@ Ip::Address::map6to4(const struct in6_addr &in, struct in_addr &out) const
 void
 Ip::Address::getInAddr(struct in6_addr &buf) const
 {
-    memcpy(&buf, &mSocketAddr_.sin6_addr, sizeof(struct in6_addr));
+    memmove(&buf, &mSocketAddr_.sin6_addr, sizeof(struct in6_addr));
 }
 
 bool

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -44,7 +44,6 @@ public:
     /** @name Constructors and Destructor */
     /*@{*/
     Address() { setEmpty(); }
-    Address(const Ip::Address &);
     Address(const struct in_addr &);
     Address(const struct sockaddr_in &);
     Address(const struct in6_addr &);
@@ -57,7 +56,6 @@ public:
 
     /** @name Assignment Operators */
     /*@{*/
-    Address& operator =(const Address &s);
     Address& operator =(struct sockaddr_in const &s);
     Address& operator =(struct sockaddr_storage const &s);
     Address& operator =(struct in_addr const &s);


### PR DESCRIPTION
Explicit copy construction was slow and unnecessary.
Explicit copy assignment mishandled self copying and was unnecessary.
The remaining memcpy() calls mishandled self copying.

There are no known cases of Ip::Address self copying.