### PR TITLE
Fixed store.cc "!mem_obj" assertion via peerDigestRequest

### DIFF
--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -360,7 +360,7 @@ peerDigestRequest(PeerDigest * pd)
         debugs(72, 5, "peerDigestRequest: found old entry");
 
         old_e->lock("peerDigestRequest");
-        old_e->createMemObject(url, url, req->method);
+        old_e->ensureMemObject(url, url, req->method);
 
         fetch->old_sc = storeClientListAdd(old_e, fetch);
     }


### PR DESCRIPTION
Broken by commit 76d61119 (GitHub PR #50) which (correctly) made
createMeObject() assert but missed one case where the old code should
have been converted to call the new ensureMemObject() instead.

peerDigestRequest() is called every 5 minutes, triggered by the
peerDigestCheck event. Most calls find the old digest entry that has the
same method and URIs.