### PR TITLE
Cleanup: storeAppendPrintf removal script

### DIFF
--- a/src/CacheDigest.cc
+++ b/src/CacheDigest.cc
@@ -229,26 +229,26 @@ cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * se
     assert(tot_count == hit_count + miss_count);    /* paranoid */
 
     if (!tot_count) {
-        storeAppendPrintf(sentry, "no guess stats for " SQUIDSBUFPH " available\n", SQUIDSBUFPRINT(label));
+        sentry->appendf("no guess stats for " SQUIDSBUFPH " available\n", SQUIDSBUFPRINT(label));
         return;
     }
 
-    storeAppendPrintf(sentry, "Digest guesses stats for " SQUIDSBUFPH ":\n", SQUIDSBUFPRINT(label));
-    storeAppendPrintf(sentry, "guess\t hit\t\t miss\t\t total\t\t\n");
-    storeAppendPrintf(sentry, " \t #\t %%\t #\t %%\t #\t %%\t\n");
-    storeAppendPrintf(sentry, "true\t %d\t %.2f\t %d\t %.2f\t %d\t %.2f\n",
+    sentry->appendf("Digest guesses stats for " SQUIDSBUFPH ":\n", SQUIDSBUFPRINT(label));
+    sentry->appendf("guess\t hit\t\t miss\t\t total\t\t\n");
+    sentry->appendf(" \t #\t %%\t #\t %%\t #\t %%\t\n");
+    sentry->appendf("true\t %d\t %.2f\t %d\t %.2f\t %d\t %.2f\n",
                       stats->trueHits, xpercent(stats->trueHits, tot_count),
                       stats->trueMisses, xpercent(stats->trueMisses, tot_count),
                       true_count, xpercent(true_count, tot_count));
-    storeAppendPrintf(sentry, "false\t %d\t %.2f\t %d\t %.2f\t %d\t %.2f\n",
+    sentry->appendf("false\t %d\t %.2f\t %d\t %.2f\t %d\t %.2f\n",
                       stats->falseHits, xpercent(stats->falseHits, tot_count),
                       stats->falseMisses, xpercent(stats->falseMisses, tot_count),
                       false_count, xpercent(false_count, tot_count));
-    storeAppendPrintf(sentry, "all\t %d\t %.2f\t %d\t %.2f\t %d\t %.2f\n",
+    sentry->appendf("all\t %d\t %.2f\t %d\t %.2f\t %d\t %.2f\n",
                       hit_count, xpercent(hit_count, tot_count),
                       miss_count, xpercent(miss_count, tot_count),
                       tot_count, xpercent(tot_count, tot_count));
-    storeAppendPrintf(sentry, "\tclose_hits: %d ( %d%%) /* cd said hit, doc was in the peer cache, but we got a miss */\n",
+    sentry->appendf("\tclose_hits: %d ( %d%%) /* cd said hit, doc was in the peer cache, but we got a miss */\n",
                       stats->closeHits, xpercentInt(stats->closeHits, stats->falseHits));
 }
 
@@ -258,23 +258,23 @@ cacheDigestReport(CacheDigest * cd, const SBuf &label, StoreEntry * e)
     CacheDigestStats stats;
     assert(cd && e);
     cacheDigestStats(cd, &stats);
-    storeAppendPrintf(e, SQUIDSBUFPH " digest: size: %d bytes\n",
+    e->appendf(SQUIDSBUFPH " digest: size: %d bytes\n",
                       SQUIDSBUFPRINT(label), stats.bit_count / 8
                      );
-    storeAppendPrintf(e, "\t entries: count: %" PRIu64 " capacity: %" PRIu64 " util: %d%%\n",
+    e->appendf("\t entries: count: %" PRIu64 " capacity: %" PRIu64 " util: %d%%\n",
                       cd->count,
                       cd->capacity,
                       xpercentInt(cd->count, cd->capacity)
                      );
-    storeAppendPrintf(e, "\t deletion attempts: %" PRIu64 "\n",
+    e->appendf("\t deletion attempts: %" PRIu64 "\n",
                       cd->del_count
                      );
-    storeAppendPrintf(e, "\t bits: per entry: %d on: %d capacity: %d util: %d%%\n",
+    e->appendf("\t bits: per entry: %d on: %d capacity: %d util: %d%%\n",
                       cd->bits_per_entry,
                       stats.bit_on_count, stats.bit_count,
                       xpercentInt(stats.bit_on_count, stats.bit_count)
                      );
-    storeAppendPrintf(e, "\t bit-seq: count: %d avg.len: %.2f\n",
+    e->appendf("\t bit-seq: count: %d avg.len: %.2f\n",
                       stats.bseq_count,
                       xdiv(stats.bseq_len_sum, stats.bseq_count)
                      );

--- a/src/ClientDelayConfig.cc
+++ b/src/ClientDelayConfig.cc
@@ -25,8 +25,8 @@ void ClientDelayPool::dump(StoreEntry * entry, unsigned int poolNumberMinusOne) 
     LOCAL_ARRAY(char, nom, 32);
     snprintf(nom, 32, "client_delay_access %d", poolNumberMinusOne + 1);
     dump_acl_access(entry, nom, access);
-    storeAppendPrintf(entry, "client_delay_parameters %d %d %" PRId64 "\n", poolNumberMinusOne + 1, rate,highwatermark);
-    storeAppendPrintf(entry, "\n");
+    entry->appendf("client_delay_parameters %d %d %" PRId64 "\n", poolNumberMinusOne + 1, rate,highwatermark);
+    entry->appendf("\n");
 }
 
 ClientDelayPools *
@@ -58,7 +58,7 @@ void ClientDelayConfig::dumpPoolCount(StoreEntry * entry, const char *name) cons
 {
     const auto &pools_ = ClientDelayPools::Instance()->pools;
     if (pools_.size()) {
-        storeAppendPrintf(entry, "%s %d\n", name, static_cast<int>(pools_.size()));
+        entry->appendf("%s %d\n", name, static_cast<int>(pools_.size()));
         for (unsigned int i = 0; i < pools_.size(); ++i)
             pools_[i]->dump(entry, i);
     }

--- a/src/DelayBucket.cc
+++ b/src/DelayBucket.cc
@@ -19,7 +19,7 @@
 void
 DelayBucket::stats(StoreEntry *entry)const
 {
-    storeAppendPrintf(entry, "%d", level());
+    entry->appendf("%d", level());
 }
 
 void

--- a/src/DelayConfig.cc
+++ b/src/DelayConfig.cc
@@ -102,11 +102,11 @@ DelayConfig::dumpPoolCount(StoreEntry * entry, const char *name) const
     int i;
 
     if (!DelayPools::pools()) {
-        storeAppendPrintf(entry, "%s 0\n", name);
+        entry->appendf("%s 0\n", name);
         return;
     }
 
-    storeAppendPrintf(entry, "%s %d\n", name, DelayPools::pools());
+    entry->appendf("%s %d\n", name, DelayPools::pools());
 
     for (i = 0; i < DelayPools::pools(); ++i)
         DelayPools::delay_data[i].dump (entry, i);

--- a/src/DelayPool.cc
+++ b/src/DelayPool.cc
@@ -44,7 +44,7 @@ DelayPool::dump(StoreEntry *entry, unsigned int i) const
     if (theComposite() == NULL)
         return;
 
-    storeAppendPrintf(entry, "delay_class %d %s\n", i + 1, pool->theClassTypeLabel());
+    entry->appendf("delay_class %d %s\n", i + 1, pool->theClassTypeLabel());
 
     LOCAL_ARRAY(char, nom, 32);
 
@@ -52,11 +52,11 @@ DelayPool::dump(StoreEntry *entry, unsigned int i) const
 
     dump_acl_access(entry, nom, access);
 
-    storeAppendPrintf(entry, "delay_parameters %d", i + 1);
+    entry->appendf("delay_parameters %d", i + 1);
 
     theComposite()->dump (entry);
 
-    storeAppendPrintf(entry, "\n");
+    entry->appendf("\n");
 }
 
 void

--- a/src/DelaySpec.cc
+++ b/src/DelaySpec.cc
@@ -23,19 +23,19 @@ void
 DelaySpec::stats (StoreEntry * sentry, char const *label) const
 {
     if (restore_bps == -1) {
-        storeAppendPrintf(sentry, "\t%s:\n\t\tDisabled.\n\n", label);
+        sentry->appendf("\t%s:\n\t\tDisabled.\n\n", label);
         return;
     }
 
-    storeAppendPrintf(sentry, "\t%s:\n", label);
-    storeAppendPrintf(sentry, "\t\tMax: %" PRId64 "\n", max_bytes);
-    storeAppendPrintf(sentry, "\t\tRestore: %d\n", restore_bps);
+    sentry->appendf("\t%s:\n", label);
+    sentry->appendf("\t\tMax: %" PRId64 "\n", max_bytes);
+    sentry->appendf("\t\tRestore: %d\n", restore_bps);
 }
 
 void
 DelaySpec::dump (StoreEntry *entry) const
 {
-    storeAppendPrintf(entry, " %d/%" PRId64 "", restore_bps, max_bytes);
+    entry->appendf(" %d/%" PRId64 "", restore_bps, max_bytes);
 }
 
 void

--- a/src/DelayTagged.cc
+++ b/src/DelayTagged.cc
@@ -58,16 +58,16 @@ DelayTagged::stats(StoreEntry * sentry)
     if (spec.restore_bps == -1)
         return;
 
-    storeAppendPrintf(sentry, "\t\tCurrent: ");
+    sentry->appendf("\t\tCurrent: ");
 
     if (buckets.empty()) {
-        storeAppendPrintf (sentry, "Not used yet.\n\n");
+        sentry->appendf("Not used yet.\n\n");
         return;
     }
 
     DelayTaggedStatsVisitor visitor(sentry);
     buckets.visit(visitor);
-    storeAppendPrintf(sentry, "\n\n");
+    sentry->appendf("\n\n");
 }
 
 void
@@ -137,7 +137,7 @@ DelayTaggedBucket::~DelayTaggedBucket()
 void
 DelayTaggedBucket::stats(StoreEntry *entry) const
 {
-    storeAppendPrintf(entry, " " SQUIDSTRINGPH ":", SQUIDSTRINGPRINT(tag));
+    entry->appendf(" " SQUIDSTRINGPH ":", SQUIDSTRINGPRINT(tag));
     theBucket.stats(entry);
 }
 

--- a/src/DelayUser.cc
+++ b/src/DelayUser.cc
@@ -70,16 +70,16 @@ DelayUser::stats(StoreEntry * sentry)
     if (spec.restore_bps == -1)
         return;
 
-    storeAppendPrintf(sentry, "\t\tCurrent: ");
+    sentry->appendf("\t\tCurrent: ");
 
     if (buckets.empty()) {
-        storeAppendPrintf (sentry, "Not used yet.\n\n");
+        sentry->appendf("Not used yet.\n\n");
         return;
     }
 
     DelayUserStatsVisitor visitor(sentry);
     buckets.visit(visitor);
-    storeAppendPrintf(sentry, "\n\n");
+    sentry->appendf("\n\n");
 }
 
 void
@@ -149,7 +149,7 @@ DelayUserBucket::~DelayUserBucket()
 void
 DelayUserBucket::stats (StoreEntry *entry) const
 {
-    storeAppendPrintf(entry, " %s:", authUser->username());
+    entry->appendf(" %s:", authUser->username());
     theBucket.stats(entry);
 }
 

--- a/src/DiskIO/DiskDaemon/DiskdAction.cc
+++ b/src/DiskIO/DiskDaemon/DiskdAction.cc
@@ -116,24 +116,24 @@ DiskdAction::dump(StoreEntry* entry)
 {
     debugs(79, 5, HERE);
     Must(entry != NULL);
-    storeAppendPrintf(entry, "sent_count: %.0f\n", data.sent_count);
-    storeAppendPrintf(entry, "recv_count: %.0f\n", data.recv_count);
-    storeAppendPrintf(entry, "max_away: %.0f\n", data.max_away);
-    storeAppendPrintf(entry, "max_shmuse: %.0f\n", data.max_shmuse);
-    storeAppendPrintf(entry, "open_fail_queue_len: %.0f\n", data.open_fail_queue_len);
-    storeAppendPrintf(entry, "block_queue_len: %.0f\n", data.block_queue_len);
-    storeAppendPrintf(entry, "\n              OPS   SUCCESS    FAIL\n");
-    storeAppendPrintf(entry, "%7s %9.0f %9.0f %7.0f\n",
+    entry->appendf("sent_count: %.0f\n", data.sent_count);
+    entry->appendf("recv_count: %.0f\n", data.recv_count);
+    entry->appendf("max_away: %.0f\n", data.max_away);
+    entry->appendf("max_shmuse: %.0f\n", data.max_shmuse);
+    entry->appendf("open_fail_queue_len: %.0f\n", data.open_fail_queue_len);
+    entry->appendf("block_queue_len: %.0f\n", data.block_queue_len);
+    entry->appendf("\n              OPS   SUCCESS    FAIL\n");
+    entry->appendf("%7s %9.0f %9.0f %7.0f\n",
                       "open", data.open_ops, data.open_success, data.open_fail);
-    storeAppendPrintf(entry, "%7s %9.0f %9.0f %7.0f\n",
+    entry->appendf("%7s %9.0f %9.0f %7.0f\n",
                       "create", data.create_ops, data.create_success, data.create_fail);
-    storeAppendPrintf(entry, "%7s %9.0f %9.0f %7.0f\n",
+    entry->appendf("%7s %9.0f %9.0f %7.0f\n",
                       "close", data.close_ops, data.close_success, data.close_fail);
-    storeAppendPrintf(entry, "%7s %9.0f %9.0f %7.0f\n",
+    entry->appendf("%7s %9.0f %9.0f %7.0f\n",
                       "unlink", data.unlink_ops, data.unlink_success, data.unlink_fail);
-    storeAppendPrintf(entry, "%7s %9.0f %9.0f %7.0f\n",
+    entry->appendf("%7s %9.0f %9.0f %7.0f\n",
                       "read", data.read_ops, data.read_success, data.read_fail);
-    storeAppendPrintf(entry, "%7s %9.0f %9.0f %7.0f\n",
+    entry->appendf("%7s %9.0f %9.0f %7.0f\n",
                       "write", data.write_ops, data.write_success, data.write_fail);
 }
 

--- a/src/DiskIO/DiskDaemon/DiskdIOStrategy.cc
+++ b/src/DiskIO/DiskDaemon/DiskdIOStrategy.cc
@@ -464,7 +464,7 @@ DiskdIOStrategy::optionQ1Parse(const char *name, const char *value, int isaRecon
 void
 DiskdIOStrategy::optionQ1Dump(StoreEntry * e) const
 {
-    storeAppendPrintf(e, " Q1=%d", magic1);
+    e->appendf(" Q1=%d", magic1);
 }
 
 bool
@@ -496,7 +496,7 @@ DiskdIOStrategy::optionQ2Parse(const char *name, const char *value, int isaRecon
 void
 DiskdIOStrategy::optionQ2Dump(StoreEntry * e) const
 {
-    storeAppendPrintf(e, " Q2=%d", magic2);
+    e->appendf(" Q2=%d", magic2);
 }
 
 /*
@@ -572,6 +572,6 @@ DiskdIOStrategy::callback()
 void
 DiskdIOStrategy::statfs(StoreEntry & sentry)const
 {
-    storeAppendPrintf(&sentry, "Pending operations: %d\n", away);
+    sentry.appendf("Pending operations: %d\n", away);
 }
 

--- a/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.cc
@@ -168,17 +168,17 @@ DiskThreadsIOStrategy::DiskThreadsIOStrategy() :
 void
 DiskThreadsIOStrategy::aioStats(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "ASYNC IO Counters:\n");
-    storeAppendPrintf(sentry, "  Operation\t# Requests\tNumber serviced\n");
-    storeAppendPrintf(sentry, "  open\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.open_start, squidaio_counts.open_finish);
-    storeAppendPrintf(sentry, "  close\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.close_start, squidaio_counts.close_finish);
-    storeAppendPrintf(sentry, "  cancel\t%" PRIu64 "\t-\n", squidaio_counts.cancel);
-    storeAppendPrintf(sentry, "  write\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.write_start, squidaio_counts.write_finish);
-    storeAppendPrintf(sentry, "  read\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.read_start, squidaio_counts.read_finish);
-    storeAppendPrintf(sentry, "  stat\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.stat_start, squidaio_counts.stat_finish);
-    storeAppendPrintf(sentry, "  unlink\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.unlink_start, squidaio_counts.unlink_finish);
-    storeAppendPrintf(sentry, "  check_callback\t%" PRIu64 "\t-\n", squidaio_counts.check_callback);
-    storeAppendPrintf(sentry, "  queue\t%d\t-\n", squidaio_get_queue_len());
+    sentry->appendf("ASYNC IO Counters:\n");
+    sentry->appendf("  Operation\t# Requests\tNumber serviced\n");
+    sentry->appendf("  open\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.open_start, squidaio_counts.open_finish);
+    sentry->appendf("  close\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.close_start, squidaio_counts.close_finish);
+    sentry->appendf("  cancel\t%" PRIu64 "\t-\n", squidaio_counts.cancel);
+    sentry->appendf("  write\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.write_start, squidaio_counts.write_finish);
+    sentry->appendf("  read\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.read_start, squidaio_counts.read_finish);
+    sentry->appendf("  stat\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.stat_start, squidaio_counts.stat_finish);
+    sentry->appendf("  unlink\t%" PRIu64 "\t%" PRIu64 "\n", squidaio_counts.unlink_start, squidaio_counts.unlink_finish);
+    sentry->appendf("  check_callback\t%" PRIu64 "\t-\n", squidaio_counts.check_callback);
+    sentry->appendf("  queue\t%d\t-\n", squidaio_get_queue_len());
     squidaio_stats(sentry);
 }
 

--- a/src/DiskIO/DiskThreads/aiops.cc
+++ b/src/DiskIO/DiskThreads/aiops.cc
@@ -1008,14 +1008,14 @@ squidaio_stats(StoreEntry * sentry)
     if (!squidaio_initialised)
         return;
 
-    storeAppendPrintf(sentry, "\n\nThreads Status:\n");
+    sentry->appendf("\n\nThreads Status:\n");
 
-    storeAppendPrintf(sentry, "#\tID\t# Requests\n");
+    sentry->appendf("#\tID\t# Requests\n");
 
     threadp = threads;
 
     for (i = 0; i < NUMTHREADS; ++i) {
-        storeAppendPrintf(sentry, "%i\t0x%lx\t%ld\n", i + 1, (unsigned long)threadp->thread, threadp->requests);
+        sentry->appendf("%i\t0x%lx\t%ld\n", i + 1, (unsigned long)threadp->thread, threadp->requests);
         threadp = threadp->next;
     }
 }

--- a/src/DiskIO/DiskThreads/aiops_win32.cc
+++ b/src/DiskIO/DiskThreads/aiops_win32.cc
@@ -1110,14 +1110,14 @@ squidaio_stats(StoreEntry * sentry)
     if (!squidaio_initialised)
         return;
 
-    storeAppendPrintf(sentry, "\n\nThreads Status:\n");
+    sentry->appendf("\n\nThreads Status:\n");
 
-    storeAppendPrintf(sentry, "#\tID\t# Requests\n");
+    sentry->appendf("#\tID\t# Requests\n");
 
     threadp = threads;
 
     for (i = 0; i < NUMTHREADS; ++i) {
-        storeAppendPrintf(sentry, "%i\t0x%lx\t%ld\n", i + 1, threadp->dwThreadId, threadp->requests);
+        sentry->appendf("%i\t0x%lx\t%ld\n", i + 1, threadp->dwThreadId, threadp->requests);
         threadp = threadp->next;
     }
 }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1271,25 +1271,25 @@ fwdStats(StoreEntry * s)
 {
     int i;
     int j;
-    storeAppendPrintf(s, "Status");
+    s->appendf("Status");
 
     for (j = 1; j < MAX_FWD_STATS_IDX; ++j) {
-        storeAppendPrintf(s, "\ttry#%d", j);
+        s->appendf("\ttry#%d", j);
     }
 
-    storeAppendPrintf(s, "\n");
+    s->appendf("\n");
 
     for (i = 0; i <= (int) Http::scInvalidHeader; ++i) {
         if (FwdReplyCodes[0][i] == 0)
             continue;
 
-        storeAppendPrintf(s, "%3d", i);
+        s->appendf("%3d", i);
 
         for (j = 0; j <= MAX_FWD_STATS_IDX; ++j) {
-            storeAppendPrintf(s, "\t%d", FwdReplyCodes[j][i]);
+            s->appendf("\t%d", FwdReplyCodes[j][i]);
         }
 
-        storeAppendPrintf(s, "\n");
+        s->appendf("\n");
     }
 }
 

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -335,7 +335,7 @@ httpHdrCcStatDumper(StoreEntry * sentry, int, double val, double, int count)
     const char *name = valid_id ? CcAttrs[id].name : "INVALID";
 
     if (count || valid_id)
-        storeAppendPrintf(sentry, "%2d\t %-20s\t %5d\t %6.2f\n",
+        sentry->appendf("%2d\t %-20s\t %5d\t %6.2f\n",
                           id, name, count, xdiv(count, dump_stat->ccParsedCount));
 }
 

--- a/src/HttpHdrSc.cc
+++ b/src/HttpHdrSc.cc
@@ -293,7 +293,7 @@ httpHdrScTargetStatDumper(StoreEntry * sentry, int, double val, double, int coun
     const char *name = valid_id ? ScAttrs[id].name : "INVALID";
 
     if (count || valid_id)
-        storeAppendPrintf(sentry, "%2d\t %-20s\t %5d\t %6.2f\n",
+        sentry->appendf("%2d\t %-20s\t %5d\t %6.2f\n",
                           id, name, count, xdiv(count, dump_stat->scParsedCount));
 }
 
@@ -306,7 +306,7 @@ httpHdrScStatDumper(StoreEntry * sentry, int, double val, double, int count)
     const char *name = valid_id ? ScAttrs[id].name : "INVALID";
 
     if (count || valid_id)
-        storeAppendPrintf(sentry, "%2d\t %-20s\t %5d\t %6.2f\n",
+        sentry->appendf("%2d\t %-20s\t %5d\t %6.2f\n",
                           id, name, count, xdiv(count, dump_stat->scParsedCount));
 }
 

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1580,7 +1580,7 @@ httpHeaderFieldStatDumper(StoreEntry * sentry, int, double val, double, int coun
         visible = CBIT_TEST(*dump_stat->owner_mask, id);
 
     if (visible)
-        storeAppendPrintf(sentry, "%2d\t %-20s\t %5d\t %6.2f\n",
+        sentry->appendf("%2d\t %-20s\t %5d\t %6.2f\n",
                           id, name, count, xdiv(count, dump_stat->busyDestroyedCount));
 }
 
@@ -1588,7 +1588,7 @@ static void
 httpHeaderFldsPerHdrDumper(StoreEntry * sentry, int idx, double val, double, int count)
 {
     if (count)
-        storeAppendPrintf(sentry, "%2d\t %5d\t %5d\t %6.2f\n",
+        sentry->appendf("%2d\t %5d\t %5d\t %6.2f\n",
                           idx, (int) val, count,
                           xpercent(count, dump_stat->destroyedCount));
 }
@@ -1600,24 +1600,24 @@ httpHeaderStatDump(const HttpHeaderStat * hs, StoreEntry * e)
     assert(e);
 
     dump_stat = hs;
-    storeAppendPrintf(e, "\nHeader Stats: %s\n", hs->label);
-    storeAppendPrintf(e, "\nField type distribution\n");
-    storeAppendPrintf(e, "%2s\t %-20s\t %5s\t %6s\n",
+    e->appendf("\nHeader Stats: %s\n", hs->label);
+    e->appendf("\nField type distribution\n");
+    e->appendf("%2s\t %-20s\t %5s\t %6s\n",
                       "id", "name", "count", "#/header");
     hs->fieldTypeDistr.dump(e, httpHeaderFieldStatDumper);
-    storeAppendPrintf(e, "\nCache-control directives distribution\n");
-    storeAppendPrintf(e, "%2s\t %-20s\t %5s\t %6s\n",
+    e->appendf("\nCache-control directives distribution\n");
+    e->appendf("%2s\t %-20s\t %5s\t %6s\n",
                       "id", "name", "count", "#/cc_field");
     hs->ccTypeDistr.dump(e, httpHdrCcStatDumper);
-    storeAppendPrintf(e, "\nSurrogate-control directives distribution\n");
-    storeAppendPrintf(e, "%2s\t %-20s\t %5s\t %6s\n",
+    e->appendf("\nSurrogate-control directives distribution\n");
+    e->appendf("%2s\t %-20s\t %5s\t %6s\n",
                       "id", "name", "count", "#/sc_field");
     hs->scTypeDistr.dump(e, httpHdrScStatDumper);
-    storeAppendPrintf(e, "\nNumber of fields per header distribution\n");
-    storeAppendPrintf(e, "%2s\t %-5s\t %5s\t %6s\n",
+    e->appendf("\nNumber of fields per header distribution\n");
+    e->appendf("%2s\t %-5s\t %5s\t %6s\n",
                       "id", "#flds", "count", "%total");
     hs->hdrUCountDistr.dump(e, httpHeaderFldsPerHdrDumper);
-    storeAppendPrintf(e, "\n");
+    e->appendf("\n");
     dump_stat = NULL;
 }
 
@@ -1641,15 +1641,15 @@ httpHeaderStoreReport(StoreEntry * e)
     }
 
     /* field stats for all messages */
-    storeAppendPrintf(e, "\nHttp Fields Stats (replies and requests)\n");
+    e->appendf("\nHttp Fields Stats (replies and requests)\n");
 
-    storeAppendPrintf(e, "%2s\t %-25s\t %5s\t %6s\t %6s\n",
+    e->appendf("%2s\t %-25s\t %5s\t %6s\t %6s\n",
                       "id", "name", "#alive", "%err", "%repeat");
 
     // scan heaaderTable and output
     for (auto h : WholeEnum<Http::HdrType>()) {
         auto stats = headerStatsTable[h];
-        storeAppendPrintf(e, "%2d\t %-25s\t %5d\t %6.3f\t %6.3f\n",
+        e->appendf("%2d\t %-25s\t %5d\t %6.3f\t %6.3f\n",
                           Http::HeaderLookupTable.lookup(h).id,
                           Http::HeaderLookupTable.lookup(h).name,
                           stats.aliveCount,
@@ -1657,11 +1657,11 @@ httpHeaderStoreReport(StoreEntry * e)
                           xpercent(stats.repCount, stats.seenCount));
     }
 
-    storeAppendPrintf(e, "Headers Parsed: %d + %d = %d\n",
+    e->appendf("Headers Parsed: %d + %d = %d\n",
                       HttpHeaderStats[hoRequest].parsedCount,
                       HttpHeaderStats[hoReply].parsedCount,
                       HttpHeaderStats[0].parsedCount);
-    storeAppendPrintf(e, "Hdr Fields Parsed: %d\n", HeaderEntryParsedCount);
+    e->appendf("Hdr Fields Parsed: %d\n", HeaderEntryParsedCount);
 }
 
 int

--- a/src/HttpHeaderTools.cc
+++ b/src/HttpHeaderTools.cc
@@ -371,7 +371,7 @@ void header_mangler_dump_access(StoreEntry * entry, const char *option,
                                 const headerMangler &m, const char *name)
 {
     if (m.access_list != NULL) {
-        storeAppendPrintf(entry, "%s ", option);
+        entry->appendf("%s ", option);
         dump_acl_access(entry, name, m.access_list);
     }
 }
@@ -381,7 +381,7 @@ void header_mangler_dump_replacement(StoreEntry * entry, const char *option,
                                      const headerMangler &m, const char *name)
 {
     if (m.replacement)
-        storeAppendPrintf(entry, "%s %s %s\n", option, name, m.replacement);
+        entry->appendf("%s %s %s\n", option, name, m.replacement);
 }
 
 HeaderManglers::HeaderManglers()

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -214,29 +214,29 @@ MemStore::getStats(StoreInfoStats &stats) const
 void
 MemStore::stat(StoreEntry &e) const
 {
-    storeAppendPrintf(&e, "\n\nShared Memory Cache\n");
+    e.appendf("\n\nShared Memory Cache\n");
 
-    storeAppendPrintf(&e, "Maximum Size: %.0f KB\n", maxSize()/1024.0);
-    storeAppendPrintf(&e, "Current Size: %.2f KB %.2f%%\n",
+    e.appendf("Maximum Size: %.0f KB\n", maxSize()/1024.0);
+    e.appendf("Current Size: %.2f KB %.2f%%\n",
                       currentSize() / 1024.0,
                       Math::doublePercent(currentSize(), maxSize()));
 
     if (map) {
         const int entryLimit = map->entryLimit();
         const int slotLimit = map->sliceLimit();
-        storeAppendPrintf(&e, "Maximum entries: %9d\n", entryLimit);
+        e.appendf("Maximum entries: %9d\n", entryLimit);
         if (entryLimit > 0) {
-            storeAppendPrintf(&e, "Current entries: %" PRId64 " %.2f%%\n",
+            e.appendf("Current entries: %" PRId64 " %.2f%%\n",
                               currentCount(), (100.0 * currentCount() / entryLimit));
         }
 
-        storeAppendPrintf(&e, "Maximum slots:   %9d\n", slotLimit);
+        e.appendf("Maximum slots:   %9d\n", slotLimit);
         if (slotLimit > 0) {
             const unsigned int slotsFree =
                 Ipc::Mem::PagesAvailable(Ipc::Mem::PageId::cachePage);
             if (slotsFree <= static_cast<const unsigned int>(slotLimit)) {
                 const int usedSlots = slotLimit - static_cast<const int>(slotsFree);
-                storeAppendPrintf(&e, "Used slots:      %9d %.2f%%\n",
+                e.appendf("Used slots:      %9d %.2f%%\n",
                                   usedSlots, (100.0 * usedSlots / slotLimit));
             }
 

--- a/src/MessageDelayPools.cc
+++ b/src/MessageDelayPools.cc
@@ -102,9 +102,9 @@ MessageDelayPool::dump(StoreEntry *entry) const
     SBuf name("response_delay_pool_access ");
     name.append(poolName);
     dump_acl_access(entry, name.c_str(), access);
-    storeAppendPrintf(entry, "response_delay_pool parameters %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %d\n",
+    entry->appendf("response_delay_pool parameters %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %d\n",
                       individualRestore, individualMaximum, aggregateRestore, aggregateMaximum, initialBucketLevel);
-    storeAppendPrintf(entry, "\n");
+    entry->appendf("\n");
 }
 
 MessageBucket::Pointer

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -108,10 +108,10 @@ void
 Note::dump(StoreEntry *entry, const char *k)
 {
     for (auto v: values) {
-        storeAppendPrintf(entry, "%s %.*s %s",
+        entry->appendf("%s %.*s %s",
                           k, key().length(), key().rawContent(), ConfigParser::QuoteString(SBufToString(v->value())));
         dump_acl_list(entry, v->aclList);
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 

--- a/src/ProfStats.cc
+++ b/src/ProfStats.cc
@@ -120,9 +120,9 @@ xprof_summary_item(StoreEntry * sentry, char const *descr, TimersArray * list)
 
     time_frame = (double) show->delta / (double) xprof_average_delta;
 
-    storeAppendPrintf(sentry, "\n%s:", descr);
+    sentry->appendf("\n%s:", descr);
 
-    storeAppendPrintf(sentry, " (Cumulated time: %" PRIu64 ", %.2f sec)\n",
+    sentry->appendf(" (Cumulated time: %" PRIu64 ", %.2f sec)\n",
                       show->delta,
                       time_frame
                      );
@@ -212,12 +212,12 @@ xprof_summary(StoreEntry * sentry)
 {
     hrtime_t now = get_tick();
 
-    storeAppendPrintf(sentry, "CPU Profiling Statistics:\n");
+    sentry->appendf("CPU Profiling Statistics:\n");
     storeAppendPrintf(sentry,
                       "  (CPU times are in arbitrary units, most probably in CPU clock ticks)\n");
     storeAppendPrintf(sentry,
                       "Probe Name\t Event Count\t last Interval \t Avg Interval \t since squid start \t (since system boot) \n");
-    storeAppendPrintf(sentry, "Total\t %lu\t %" PRIu64 " \t %" PRIu64 " \t %" PRIu64 " \t %" PRIu64 "\n",
+    sentry->appendf("Total\t %lu\t %" PRIu64 " \t %" PRIu64 " \t %" PRIu64 " \t %" PRIu64 "\n",
                       (long unsigned) xprof_events,
                       xprof_delta,
                       xprof_average_delta,

--- a/src/ProfStats.cc
+++ b/src/ProfStats.cc
@@ -91,8 +91,7 @@ static double time_frame;
 static void
 xprof_show_item(StoreEntry * sentry, const char *name, xprof_stats_data * hist)
 {
-    storeAppendPrintf(sentry,
-                      "%s\t %" PRIu64 "\t %" PRIu64 "\t %" PRIu64 "\t %" PRIu64 "\t %" PRIu64 "\t %.2f\t %6.3f\t\n",
+    sentry->appendf("%s\t %" PRIu64 "\t %" PRIu64 "\t %" PRIu64 "\t %" PRIu64 "\t %" PRIu64 "\t %.2f\t %6.3f\t\n",
                       name,
                       hist->count,
                       hist->summ,
@@ -127,8 +126,7 @@ xprof_summary_item(StoreEntry * sentry, char const *descr, TimersArray * list)
                       time_frame
                      );
 
-    storeAppendPrintf(sentry,
-                      "Probe Name\t  Events\t cumulated time \t best case \t average \t worst case\t Rate / sec \t %% in int\n");
+    sentry->appendf("Probe Name\t  Events\t cumulated time \t best case \t average \t worst case\t Rate / sec \t %% in int\n");
 
     for (i = 0; i < XPROF_LAST; ++i) {
         if (!hist[i]->name)
@@ -213,10 +211,8 @@ xprof_summary(StoreEntry * sentry)
     hrtime_t now = get_tick();
 
     sentry->appendf("CPU Profiling Statistics:\n");
-    storeAppendPrintf(sentry,
-                      "  (CPU times are in arbitrary units, most probably in CPU clock ticks)\n");
-    storeAppendPrintf(sentry,
-                      "Probe Name\t Event Count\t last Interval \t Avg Interval \t since squid start \t (since system boot) \n");
+    sentry->appendf("  (CPU times are in arbitrary units, most probably in CPU clock ticks)\n");
+    sentry->appendf("Probe Name\t Event Count\t last Interval \t Avg Interval \t since squid start \t (since system boot) \n");
     sentry->appendf("Total\t %lu\t %" PRIu64 " \t %" PRIu64 " \t %" PRIu64 " \t %" PRIu64 "\n",
                       (long unsigned) xprof_events,
                       xprof_delta,

--- a/src/SBufStatsAction.cc
+++ b/src/SBufStatsAction.cc
@@ -47,7 +47,7 @@ statHistSBufDumper(StoreEntry * sentry, int, double val, double size, int count)
 {
     if (count == 0)
         return;
-    storeAppendPrintf(sentry, "\t%d-%d\t%d\n", static_cast<int>(val), static_cast<int>(val+size), count);
+    sentry->appendf("\t%d-%d\t%d\n", static_cast<int>(val), static_cast<int>(val+size), count);
 }
 
 void

--- a/src/StatHist.cc
+++ b/src/StatHist.cc
@@ -165,7 +165,7 @@ static void
 statHistBinDumper(StoreEntry * sentry, int idx, double val, double size, int count)
 {
     if (count)
-        storeAppendPrintf(sentry, "\t%3d/%f\t%d\t%f\n",
+        sentry->appendf("\t%3d/%f\t%d\t%f\n",
                           idx, val, count, count / size);
 }
 
@@ -243,7 +243,7 @@ void
 statHistEnumDumper(StoreEntry * sentry, int idx, double val, double, int count)
 {
     if (count)
-        storeAppendPrintf(sentry, "%2d\t %5d\t %5d\n",
+        sentry->appendf("%2d\t %5d\t %5d\n",
                           idx, (int) val, count);
 }
 
@@ -251,6 +251,6 @@ void
 statHistIntDumper(StoreEntry * sentry, int, double val, double, int count)
 {
     if (count)
-        storeAppendPrintf(sentry, "%9d\t%9d\n", (int) val, count);
+        sentry->appendf("%9d\t%9d\n", (int) val, count);
 }
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -422,9 +422,6 @@ void storeFreeMemory(void);
 int expiresMoreThan(time_t, time_t);
 
 /// \ingroup StoreAPI
-void storeAppendPrintf(StoreEntry *, const char *,...) PRINTF_FORMAT_ARG2;
-
-/// \ingroup StoreAPI
 int storeTooManyDiskFilesOpen(void);
 
 /// \ingroup StoreAPI

--- a/src/Store.h
+++ b/src/Store.h
@@ -425,9 +425,6 @@ int expiresMoreThan(time_t, time_t);
 void storeAppendPrintf(StoreEntry *, const char *,...) PRINTF_FORMAT_ARG2;
 
 /// \ingroup StoreAPI
-void storeAppendVPrintf(StoreEntry *, const char *, va_list ap);
-
-/// \ingroup StoreAPI
 int storeTooManyDiskFilesOpen(void);
 
 /// \ingroup StoreAPI

--- a/src/String.cc
+++ b/src/String.cc
@@ -319,7 +319,7 @@ String::caseCmp(char const *aString, String::size_type count) const
 void
 String::stat(StoreEntry *entry) const
 {
-    storeAppendPrintf(entry, "%p : %d/%d \"%.*s\"\n",this,len_, size_, size(), rawBuf());
+    entry->appendf("%p : %d/%d \"%.*s\"\n",this,len_, size_, size(), rawBuf());
 }
 
 StringRegistry &
@@ -362,7 +362,7 @@ String::size_type memStringCount();
 void
 StringRegistry::Stat(StoreEntry *entry)
 {
-    storeAppendPrintf(entry, "%lu entries, %lu reported from MemPool\n", (unsigned long) Instance().entries.elements, (unsigned long) memStringCount());
+    entry->appendf("%lu entries, %lu reported from MemPool\n", (unsigned long) Instance().entries.elements, (unsigned long) memStringCount());
     Instance().entries.head->walk(Stater, entry);
 }
 

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -70,18 +70,18 @@ Transients::getStats(StoreInfoStats &stats) const
 void
 Transients::stat(StoreEntry &e) const
 {
-    storeAppendPrintf(&e, "\n\nTransient Objects\n");
+    e.appendf("\n\nTransient Objects\n");
 
-    storeAppendPrintf(&e, "Maximum Size: %.0f KB\n", maxSize()/1024.0);
-    storeAppendPrintf(&e, "Current Size: %.2f KB %.2f%%\n",
+    e.appendf("Maximum Size: %.0f KB\n", maxSize()/1024.0);
+    e.appendf("Current Size: %.2f KB %.2f%%\n",
                       currentSize() / 1024.0,
                       Math::doublePercent(currentSize(), maxSize()));
 
     if (map) {
         const int limit = map->entryLimit();
-        storeAppendPrintf(&e, "Maximum entries: %9d\n", limit);
+        e.appendf("Maximum entries: %9d\n", limit);
         if (limit > 0) {
-            storeAppendPrintf(&e, "Current entries: %" PRId64 " %.2f%%\n",
+            e.appendf("Current entries: %" PRId64 " %.2f%%\n",
                               currentCount(), (100.0 * currentCount() / limit));
         }
     }

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -217,7 +217,7 @@ asnFreeMemory(void)
 static void
 asnStats(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "Address    \tAS Numbers\n");
+    sentry->appendf("Address    \tAS Numbers\n");
     squid_rn_walktree(AS_tree_head, printRadixNode, sentry);
 }
 
@@ -504,16 +504,16 @@ printRadixNode(struct squid_radix_node *rn, void *_sentry)
     assert(e->e_info);
     addr = e->e_addr.addr;
     mask = e->e_mask.addr;
-    storeAppendPrintf(sentry, "%s/%d\t",
+    sentry->appendf("%s/%d\t",
                       addr.toStr(buf, MAX_IPSTRLEN),
                       mask.cidr() );
     asinfo = e->e_info;
     assert(asinfo->as_number);
 
     for (q = asinfo->as_number; q; q = q->next)
-        storeAppendPrintf(sentry, " %d", q->element);
+        sentry->appendf(" %d", q->element);
 
-    storeAppendPrintf(sentry, "\n");
+    sentry->appendf("\n");
 
     return 0;
 }

--- a/src/adaptation/Config.cc
+++ b/src/adaptation/Config.cc
@@ -168,7 +168,7 @@ Adaptation::Config::dumpService(StoreEntry *entry, const char *name) const
         else if (isIcap && !cfg.secure.encryptTransport && cfg.connectionEncryption)
             optConnectionEncryption = " connection-encryption=on";
 
-        storeAppendPrintf(entry, "%s " SQUIDSTRINGPH " %s_%s %d " SQUIDSTRINGPH "%s\n",
+        entry->appendf("%s " SQUIDSTRINGPH " %s_%s %d " SQUIDSTRINGPH "%s\n",
                           name,
                           SQUIDSTRINGPRINT(cfg.key),
                           cfg.methodStr(), cfg.vectPointStr(), cfg.bypass,
@@ -269,7 +269,7 @@ Adaptation::Config::DumpServiceGroups(StoreEntry *entry, const char *name)
 {
     typedef Groups::iterator GI;
     for (GI i = AllGroups().begin(); i != AllGroups().end(); ++i)
-        storeAppendPrintf(entry, "%s " SQUIDSTRINGPH "\n", name, SQUIDSTRINGPRINT((*i)->id));
+        entry->appendf("%s " SQUIDSTRINGPH "\n", name, SQUIDSTRINGPRINT((*i)->id));
 }
 
 void

--- a/src/auth/SchemeConfig.cc
+++ b/src/auth/SchemeConfig.cc
@@ -145,28 +145,28 @@ Auth::SchemeConfig::dump(StoreEntry *entry, const char *name, Auth::SchemeConfig
     const char *schemeType = scheme->type();
 
     wordlist *list = authenticateProgram;
-    storeAppendPrintf(entry, "%s %s", name, schemeType);
+    entry->appendf("%s %s", name, schemeType);
     while (list != NULL) {
-        storeAppendPrintf(entry, " %s", list->key);
+        entry->appendf(" %s", list->key);
         list = list->next;
     }
-    storeAppendPrintf(entry, "\n");
+    entry->appendf("\n");
 
-    storeAppendPrintf(entry, "%s %s realm " SQUIDSBUFPH "\n", name, schemeType, SQUIDSBUFPRINT(realm));
+    entry->appendf("%s %s realm " SQUIDSBUFPH "\n", name, schemeType, SQUIDSBUFPRINT(realm));
 
-    storeAppendPrintf(entry, "%s %s children %d startup=%d idle=%d concurrency=%d\n",
+    entry->appendf("%s %s children %d startup=%d idle=%d concurrency=%d\n",
                       name, schemeType,
                       authenticateChildren.n_max, authenticateChildren.n_startup,
                       authenticateChildren.n_idle, authenticateChildren.concurrency);
 
     if (keyExtrasLine.size() > 0) // default is none
-        storeAppendPrintf(entry, "%s %s key_extras \"%s\"\n", name, schemeType, keyExtrasLine.termedBuf());
+        entry->appendf("%s %s key_extras \"%s\"\n", name, schemeType, keyExtrasLine.termedBuf());
 
     if (!keep_alive) // default is on
-        storeAppendPrintf(entry, "%s %s keep_alive off\n", name, schemeType);
+        entry->appendf("%s %s keep_alive off\n", name, schemeType);
 
     if (utf8) // default is off
-        storeAppendPrintf(entry, "%s %s utf8 on\n", name, schemeType);
+        entry->appendf("%s %s utf8 on\n", name, schemeType);
 
     return true;
 }

--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -244,16 +244,16 @@ void
 Auth::User::CredentialsCacheStats(StoreEntry *output)
 {
     auto userlist = authenticateCachedUsersList();
-    storeAppendPrintf(output, "Cached Usernames: %d", static_cast<int32_t>(userlist.size()));
-    storeAppendPrintf(output, "\n%-15s %-9s %-9s %-9s %s\t%s\n",
+    output->appendf("Cached Usernames: %d", static_cast<int32_t>(userlist.size()));
+    output->appendf("\n%-15s %-9s %-9s %-9s %s\t%s\n",
                       "Type",
                       "State",
                       "Check TTL",
                       "Cache TTL",
                       "Username", "Key");
-    storeAppendPrintf(output, "--------------- --------- --------- --------- ------------------------------\n");
+    output->appendf("--------------- --------- --------- --------- ------------------------------\n");
     for ( auto auth_user : userlist ) {
-        storeAppendPrintf(output, "%-15s %-9s %-9d %-9d %s\t" SQUIDSBUFPH "\n",
+        output->appendf("%-15s %-9s %-9d %-9d %s\t" SQUIDSBUFPH "\n",
                           Auth::Type_str[auth_user->auth_type],
                           CredentialState_str[auth_user->credentials()],
                           auth_user->ttl(),

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -123,8 +123,8 @@ Auth::Basic::Config::dump(StoreEntry * entry, const char *name, Auth::SchemeConf
     if (!Auth::SchemeConfig::dump(entry, name, scheme))
         return false; // not configured
 
-    storeAppendPrintf(entry, "%s basic credentialsttl %d seconds\n", name, (int) credentialsTTL);
-    storeAppendPrintf(entry, "%s basic casesensitive %s\n", name, casesensitive ? "on" : "off");
+    entry->appendf("%s basic credentialsttl %d seconds\n", name, (int) credentialsTTL);
+    entry->appendf("%s basic casesensitive %s\n", name, casesensitive ? "on" : "off");
     return true;
 }
 

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -473,7 +473,7 @@ Auth::Digest::Config::dump(StoreEntry * entry, const char *name, Auth::SchemeCon
     if (!Auth::SchemeConfig::dump(entry, name, scheme))
         return false;
 
-    storeAppendPrintf(entry, "%s %s nonce_max_count %d\n%s %s nonce_max_duration %d seconds\n%s %s nonce_garbage_interval %d seconds\n",
+    entry->appendf("%s %s nonce_max_count %d\n%s %s nonce_max_duration %d seconds\n%s %s nonce_garbage_interval %d seconds\n",
                       name, "digest", noncemaxuses,
                       name, "digest", (int) noncemaxduration,
                       name, "digest", (int) nonceGCInterval);

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1422,7 +1422,7 @@ dump_acl(StoreEntry * entry, const char *name, ACL * ae)
 {
     while (ae != NULL) {
         debugs(3, 3, "dump_acl: " << name << " " << ae->name);
-        storeAppendPrintf(entry, "%s %s %s ",
+        entry->appendf("%s %s %s ",
                           name,
                           ae->name,
                           ae->typeString());
@@ -1475,7 +1475,7 @@ static void
 dump_address(StoreEntry * entry, const char *name, Ip::Address &addr)
 {
     char buf[MAX_IPSTRLEN];
-    storeAppendPrintf(entry, "%s %s\n", name, addr.toStr(buf,MAX_IPSTRLEN) );
+    entry->appendf("%s %s\n", name, addr.toStr(buf,MAX_IPSTRLEN) );
 }
 
 static void
@@ -1515,13 +1515,13 @@ dump_acl_address(StoreEntry * entry, const char *name, Acl::Address * head)
 
     for (Acl::Address *l = head; l; l = l->next) {
         if (!l->addr.isAnyAddr())
-            storeAppendPrintf(entry, "%s %s", name, l->addr.toStr(buf,MAX_IPSTRLEN));
+            entry->appendf("%s %s", name, l->addr.toStr(buf,MAX_IPSTRLEN));
         else
-            storeAppendPrintf(entry, "%s autoselect", name);
+            entry->appendf("%s autoselect", name);
 
         dump_acl_list(entry, l->aclList);
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -1553,13 +1553,13 @@ dump_acl_tos(StoreEntry * entry, const char *name, acl_tos * head)
 
     for (l = head; l; l = l->next) {
         if (l->tos > 0)
-            storeAppendPrintf(entry, "%s 0x%02X", name, l->tos);
+            entry->appendf("%s 0x%02X", name, l->tos);
         else
-            storeAppendPrintf(entry, "%s none", name);
+            entry->appendf("%s none", name);
 
         dump_acl_list(entry, l->aclList);
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -1611,11 +1611,11 @@ static void
 dump_acl_nfmark(StoreEntry * entry, const char *name, acl_nfmark * head)
 {
     for (acl_nfmark *l = head; l; l = l->next) {
-        storeAppendPrintf(entry, "%s %s", name, ToSBuf(l->markConfig).c_str());
+        entry->appendf("%s %s", name, ToSBuf(l->markConfig).c_str());
 
         dump_acl_list(entry, l->aclList);
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -1655,13 +1655,13 @@ dump_acl_b_size_t(StoreEntry * entry, const char *name, AclSizeLimit * head)
 {
     for (AclSizeLimit *l = head; l; l = l->next) {
         if (l->size != -1)
-            storeAppendPrintf(entry, "%s %d %s\n", name, (int) l->size, B_BYTES_STR);
+            entry->appendf("%s %d %s\n", name, (int) l->size, B_BYTES_STR);
         else
-            storeAppendPrintf(entry, "%s none", name);
+            entry->appendf("%s none", name);
 
         dump_acl_list(entry, l->aclList);
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -1860,9 +1860,9 @@ dump_cachedir(StoreEntry * entry, const char *name, const Store::DiskConfig &swa
     for (i = 0; i < swap.n_configured; ++i) {
         s = dynamic_cast<SwapDir *>(swap.swapDirs[i].getRaw());
         if (!s) continue;
-        storeAppendPrintf(entry, "%s %s %s", name, s->type(), s->path);
+        entry->appendf("%s %s %s", name, s->type(), s->path);
         s->dump(*entry);
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -2095,7 +2095,7 @@ dump_peer(StoreEntry * entry, const char *name, CachePeer * p)
     LOCAL_ARRAY(char, xname, 128);
 
     while (p != NULL) {
-        storeAppendPrintf(entry, "%s %s %s %d %d name=%s",
+        entry->appendf("%s %s %s %d %d name=%s",
                           name,
                           p->host,
                           neighborTypeStr(p),
@@ -2110,7 +2110,7 @@ dump_peer(StoreEntry * entry, const char *name, CachePeer * p)
         }
 
         for (t = p->typelist; t; t = t->next) {
-            storeAppendPrintf(entry, "neighbor_type_domain %s %s %s\n",
+            entry->appendf("neighbor_type_domain %s %s %s\n",
                               p->host,
                               peer_type_str(t->type),
                               t->domain);
@@ -2445,14 +2445,14 @@ dump_cachemgrpasswd(StoreEntry * entry, const char *name, Mgr::ActionPasswordLis
 {
     while (list) {
         if (strcmp(list->passwd, "none") && strcmp(list->passwd, "disable"))
-            storeAppendPrintf(entry, "%s XXXXXXXXXX", name);
+            entry->appendf("%s XXXXXXXXXX", name);
         else
-            storeAppendPrintf(entry, "%s %s", name, list->passwd);
+            entry->appendf("%s %s", name, list->passwd);
 
         for (auto w : list->actions)
             entry->appendf(" " SQUIDSBUFPH, SQUIDSBUFPRINT(w));
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
         list = list->next;
     }
 }
@@ -2503,12 +2503,12 @@ static void
 dump_denyinfo(StoreEntry * entry, const char *name, AclDenyInfoList * var)
 {
     while (var != NULL) {
-        storeAppendPrintf(entry, "%s %s", name, var->err_page_name);
+        entry->appendf("%s %s", name, var->err_page_name);
 
         for (const auto &aclName: var->acl_list)
-            storeAppendPrintf(entry, " " SQUIDSBUFPH, SQUIDSBUFPRINT(aclName));
+            entry->appendf(" " SQUIDSBUFPH, SQUIDSBUFPRINT(aclName));
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
 
         var = var->next;
     }
@@ -2583,7 +2583,7 @@ parse_hostdomaintype(void)
 static void
 dump_int(StoreEntry * entry, const char *name, int var)
 {
-    storeAppendPrintf(entry, "%s %d\n", name, var);
+    entry->appendf("%s %d\n", name, var);
 }
 
 void
@@ -2603,7 +2603,7 @@ free_int(int *var)
 static void
 dump_int64_t(StoreEntry * entry, const char *name, int64_t var)
 {
-    storeAppendPrintf(entry, "%s %" PRId64 "\n", name, var);
+    entry->appendf("%s %" PRId64 "\n", name, var);
 }
 
 void
@@ -2623,7 +2623,7 @@ free_int64_t(int64_t *var)
 static void
 dump_onoff(StoreEntry * entry, const char *name, int var)
 {
-    storeAppendPrintf(entry, "%s %s\n", name, var ? "on" : "off");
+    entry->appendf("%s %s\n", name, var ? "on" : "off");
 }
 
 void
@@ -2665,7 +2665,7 @@ dump_tristate(StoreEntry * entry, const char *name, int var)
     else
         state = "off";
 
-    storeAppendPrintf(entry, "%s %s\n", name, state);
+    entry->appendf("%s %s\n", name, state);
 }
 
 static void
@@ -2727,7 +2727,7 @@ static void
 dump_refreshpattern(StoreEntry * entry, const char *name, RefreshPattern * head)
 {
     while (head != NULL) {
-        storeAppendPrintf(entry, "%s%s %s %d %d%% %d",
+        entry->appendf("%s%s %s %d %d%% %d",
                           name,
                           head->pattern.flags&REG_ICASE ? " -i" : null_string,
                           head->pattern.c_str(),
@@ -2736,36 +2736,36 @@ dump_refreshpattern(StoreEntry * entry, const char *name, RefreshPattern * head)
                           (int) head->max / 60);
 
         if (head->max_stale >= 0)
-            storeAppendPrintf(entry, " max-stale=%d", head->max_stale);
+            entry->appendf(" max-stale=%d", head->max_stale);
 
         if (head->flags.refresh_ims)
-            storeAppendPrintf(entry, " refresh-ims");
+            entry->appendf(" refresh-ims");
 
         if (head->flags.store_stale)
-            storeAppendPrintf(entry, " store-stale");
+            entry->appendf(" store-stale");
 
 #if USE_HTTP_VIOLATIONS
 
         if (head->flags.override_expire)
-            storeAppendPrintf(entry, " override-expire");
+            entry->appendf(" override-expire");
 
         if (head->flags.override_lastmod)
-            storeAppendPrintf(entry, " override-lastmod");
+            entry->appendf(" override-lastmod");
 
         if (head->flags.reload_into_ims)
-            storeAppendPrintf(entry, " reload-into-ims");
+            entry->appendf(" reload-into-ims");
 
         if (head->flags.ignore_reload)
-            storeAppendPrintf(entry, " ignore-reload");
+            entry->appendf(" ignore-reload");
 
         if (head->flags.ignore_no_store)
-            storeAppendPrintf(entry, " ignore-no-store");
+            entry->appendf(" ignore-no-store");
 
         if (head->flags.ignore_private)
-            storeAppendPrintf(entry, " ignore-private");
+            entry->appendf(" ignore-private");
 #endif
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
 
         head = head->next;
     }
@@ -2959,7 +2959,7 @@ static void
 dump_string(StoreEntry * entry, const char *name, char *var)
 {
     if (var != NULL)
-        storeAppendPrintf(entry, "%s %s\n", name, var);
+        entry->appendf("%s %s\n", name, var);
 }
 
 static void
@@ -3032,7 +3032,7 @@ parse_TokenOrQuotedString(char **var)
 static void
 dump_time_t(StoreEntry * entry, const char *name, time_t var)
 {
-    storeAppendPrintf(entry, "%s %d seconds\n", name, (int) var);
+    entry->appendf("%s %d seconds\n", name, (int) var);
 }
 
 void
@@ -3055,9 +3055,9 @@ static void
 dump_time_msec(StoreEntry * entry, const char *name, time_msec_t var)
 {
     if (var % 1000)
-        storeAppendPrintf(entry, "%s %" PRId64 " milliseconds\n", name, var);
+        entry->appendf("%s %" PRId64 " milliseconds\n", name, var);
     else
-        storeAppendPrintf(entry, "%s %d seconds\n", name, (int)(var/1000) );
+        entry->appendf("%s %d seconds\n", name, (int)(var/1000) );
 }
 
 void
@@ -3076,7 +3076,7 @@ static void
 dump_time_nanoseconds(StoreEntry *entry, const char *name, const std::chrono::nanoseconds &var)
 {
     // std::chrono::nanoseconds::rep is unknown a priori so we cast to (and print) the largest supported integer
-    storeAppendPrintf(entry, "%s %jd nanoseconds\n", name, static_cast<intmax_t>(var.count()));
+    entry->appendf("%s %jd nanoseconds\n", name, static_cast<intmax_t>(var.count()));
 }
 
 static void
@@ -3095,40 +3095,40 @@ free_time_nanoseconds(std::chrono::nanoseconds *var)
 static void
 dump_size_t(StoreEntry * entry, const char *name, size_t var)
 {
-    storeAppendPrintf(entry, "%s %d\n", name, (int) var);
+    entry->appendf("%s %d\n", name, (int) var);
 }
 #endif
 
 static void
 dump_b_size_t(StoreEntry * entry, const char *name, size_t var)
 {
-    storeAppendPrintf(entry, "%s %d %s\n", name, (int) var, B_BYTES_STR);
+    entry->appendf("%s %d %s\n", name, (int) var, B_BYTES_STR);
 }
 
 static void
 dump_b_ssize_t(StoreEntry * entry, const char *name, ssize_t var)
 {
-    storeAppendPrintf(entry, "%s %d %s\n", name, (int) var, B_BYTES_STR);
+    entry->appendf("%s %d %s\n", name, (int) var, B_BYTES_STR);
 }
 
 #if UNUSED_CODE
 static void
 dump_kb_size_t(StoreEntry * entry, const char *name, size_t var)
 {
-    storeAppendPrintf(entry, "%s %d %s\n", name, (int) var, B_KBYTES_STR);
+    entry->appendf("%s %d %s\n", name, (int) var, B_KBYTES_STR);
 }
 #endif
 
 static void
 dump_b_int64_t(StoreEntry * entry, const char *name, int64_t var)
 {
-    storeAppendPrintf(entry, "%s %" PRId64 " %s\n", name, var, B_BYTES_STR);
+    entry->appendf("%s %" PRId64 " %s\n", name, var, B_BYTES_STR);
 }
 
 static void
 dump_kb_int64_t(StoreEntry * entry, const char *name, int64_t var)
 {
-    storeAppendPrintf(entry, "%s %" PRId64 " %s\n", name, var, B_KBYTES_STR);
+    entry->appendf("%s %" PRId64 " %s\n", name, var, B_KBYTES_STR);
 }
 
 #if UNUSED_CODE
@@ -3201,7 +3201,7 @@ free_b_int64_t(int64_t * var)
 static void
 dump_u_short(StoreEntry * entry, const char *name, unsigned short var)
 {
-    storeAppendPrintf(entry, "%s %d\n", name, var);
+    entry->appendf("%s %d\n", name, var);
 }
 
 static void
@@ -3239,7 +3239,7 @@ static void
 dump_wordlist(StoreEntry * entry, const char *name, wordlist * list)
 {
     while (list != NULL) {
-        storeAppendPrintf(entry, "%s %s\n", name, list->key);
+        entry->appendf("%s %s\n", name, list->key);
         list = list->next;
     }
 }
@@ -3317,7 +3317,7 @@ dump_uri_whitespace(StoreEntry * entry, const char *name, int var)
     else
         s = "strip";
 
-    storeAppendPrintf(entry, "%s %s\n", name, s);
+    entry->appendf("%s %s\n", name, s);
 }
 
 static void
@@ -3352,15 +3352,15 @@ static void
 dump_removalpolicy(StoreEntry * entry, const char *name, RemovalPolicySettings * settings)
 {
     wordlist *args;
-    storeAppendPrintf(entry, "%s %s", name, settings->type);
+    entry->appendf("%s %s", name, settings->type);
     args = settings->args;
 
     while (args) {
-        storeAppendPrintf(entry, " %s", args->key);
+        entry->appendf(" %s", args->key);
         args = args->next;
     }
 
-    storeAppendPrintf(entry, "\n");
+    entry->appendf("\n");
 }
 
 inline void
@@ -3416,16 +3416,16 @@ parse_memcachemode(SquidConfig *)
 static void
 dump_memcachemode(StoreEntry * entry, const char *name, SquidConfig &)
 {
-    storeAppendPrintf(entry, "%s ", name);
+    entry->appendf("%s ", name);
     if (Config.onoff.memory_cache_first && Config.onoff.memory_cache_disk)
-        storeAppendPrintf(entry, "always");
+        entry->appendf("always");
     else if (!Config.onoff.memory_cache_first && Config.onoff.memory_cache_disk)
-        storeAppendPrintf(entry, "disk");
+        entry->appendf("disk");
     else if (Config.onoff.memory_cache_first && !Config.onoff.memory_cache_disk)
-        storeAppendPrintf(entry, "network");
+        entry->appendf("network");
     else if (!Config.onoff.memory_cache_first && !Config.onoff.memory_cache_disk)
-        storeAppendPrintf(entry, "none");
-    storeAppendPrintf(entry, "\n");
+        entry->appendf("none");
+    entry->appendf("\n");
 }
 
 #include "cf_parser.cci"
@@ -3484,7 +3484,7 @@ dump_IpAddress_list(StoreEntry * e, const char *n, const Ip::Address_list * s)
     char ntoabuf[MAX_IPSTRLEN];
 
     while (s) {
-        storeAppendPrintf(e, "%s %s\n",
+        e->appendf("%s %s\n",
                           n,
                           s->s.toStr(ntoabuf,MAX_IPSTRLEN));
         s = s->next;
@@ -3944,60 +3944,60 @@ dump_generic_port(StoreEntry * e, const char *n, const AnyP::PortCfgPointer &s)
 {
     char buf[MAX_IPSTRLEN];
 
-    storeAppendPrintf(e, "%s %s",
+    e->appendf("%s %s",
                       n,
                       s->s.toUrl(buf,MAX_IPSTRLEN));
 
     // MODES and specific sub-options.
     if (s->flags.natIntercept)
-        storeAppendPrintf(e, " intercept");
+        e->appendf(" intercept");
 
     else if (s->flags.tproxyIntercept)
-        storeAppendPrintf(e, " tproxy");
+        e->appendf(" tproxy");
 
     else if (s->flags.proxySurrogate)
-        storeAppendPrintf(e, " require-proxy-header");
+        e->appendf(" require-proxy-header");
 
     else if (s->flags.accelSurrogate) {
-        storeAppendPrintf(e, " accel");
+        e->appendf(" accel");
 
         if (s->vhost)
-            storeAppendPrintf(e, " vhost");
+            e->appendf(" vhost");
 
         if (s->vport < 0)
-            storeAppendPrintf(e, " vport");
+            e->appendf(" vport");
         else if (s->vport > 0)
-            storeAppendPrintf(e, " vport=%d", s->vport);
+            e->appendf(" vport=%d", s->vport);
 
         if (s->defaultsite)
-            storeAppendPrintf(e, " defaultsite=%s", s->defaultsite);
+            e->appendf(" defaultsite=%s", s->defaultsite);
 
         // TODO: compare against prefix of 'n' instead of assuming http_port
         if (s->transport.protocol != AnyP::PROTO_HTTP)
-            storeAppendPrintf(e, " protocol=%s", AnyP::ProtocolType_str[s->transport.protocol]);
+            e->appendf(" protocol=%s", AnyP::ProtocolType_str[s->transport.protocol]);
 
         if (s->allow_direct)
-            storeAppendPrintf(e, " allow-direct");
+            e->appendf(" allow-direct");
 
         if (s->ignore_cc)
-            storeAppendPrintf(e, " ignore-cc");
+            e->appendf(" ignore-cc");
 
     }
 
     // Generic independent options
 
     if (s->name)
-        storeAppendPrintf(e, " name=%s", s->name);
+        e->appendf(" name=%s", s->name);
 
 #if USE_HTTP_VIOLATIONS
     if (!s->flags.accelSurrogate && s->ignore_cc)
-        storeAppendPrintf(e, " ignore-cc");
+        e->appendf(" ignore-cc");
 #endif
 
     if (s->connection_auth_disabled)
-        storeAppendPrintf(e, " connection-auth=off");
+        e->appendf(" connection-auth=off");
     else
-        storeAppendPrintf(e, " connection-auth=on");
+        e->appendf(" connection-auth=on");
 
     if (s->disable_pmtu_discovery != DISABLE_PMTU_OFF) {
         const char *pmtu;
@@ -4007,23 +4007,23 @@ dump_generic_port(StoreEntry * e, const char *n, const AnyP::PortCfgPointer &s)
         else
             pmtu = "transparent";
 
-        storeAppendPrintf(e, " disable-pmtu-discovery=%s", pmtu);
+        e->appendf(" disable-pmtu-discovery=%s", pmtu);
     }
 
     if (s->s.isAnyAddr() && !s->s.isIPv6())
-        storeAppendPrintf(e, " ipv4");
+        e->appendf(" ipv4");
 
     if (s->tcp_keepalive.enabled) {
         if (s->tcp_keepalive.idle || s->tcp_keepalive.interval || s->tcp_keepalive.timeout) {
-            storeAppendPrintf(e, " tcpkeepalive=%d,%d,%d", s->tcp_keepalive.idle, s->tcp_keepalive.interval, s->tcp_keepalive.timeout);
+            e->appendf(" tcpkeepalive=%d,%d,%d", s->tcp_keepalive.idle, s->tcp_keepalive.interval, s->tcp_keepalive.timeout);
         } else {
-            storeAppendPrintf(e, " tcpkeepalive");
+            e->appendf(" tcpkeepalive");
         }
     }
 
 #if USE_OPENSSL
     if (s->flags.tunnelSslBumping)
-        storeAppendPrintf(e, " ssl-bump");
+        e->appendf(" ssl-bump");
 #endif
 
     s->secure.dumpCfg(e, "tls-");
@@ -4034,7 +4034,7 @@ dump_PortCfg(StoreEntry * e, const char *n, const AnyP::PortCfgPointer &s)
 {
     for (AnyP::PortCfgPointer p = s; p != NULL; p = p->next) {
         dump_generic_port(e, n, p);
-        storeAppendPrintf(e, "\n");
+        e->appendf("\n");
     }
 }
 
@@ -4252,42 +4252,42 @@ dump_access_log(StoreEntry * entry, const char *name, CustomLog * logs)
     CustomLog *log;
 
     for (log = logs; log; log = log->next) {
-        storeAppendPrintf(entry, "%s ", name);
+        entry->appendf("%s ", name);
 
         switch (log->type) {
 
         case Log::Format::CLF_CUSTOM:
-            storeAppendPrintf(entry, "%s logformat=%s", log->filename, log->logFormat->name);
+            entry->appendf("%s logformat=%s", log->filename, log->logFormat->name);
             break;
 
         case Log::Format::CLF_NONE:
-            storeAppendPrintf(entry, "logformat=none");
+            entry->appendf("logformat=none");
             break;
 
         case Log::Format::CLF_SQUID:
             // this is the default, no need to add to the dump
-            //storeAppendPrintf(entry, "%s logformat=squid", log->filename);
+            //entry->appendf("%s logformat=squid", log->filename);
             break;
 
         case Log::Format::CLF_COMBINED:
-            storeAppendPrintf(entry, "%s logformat=combined", log->filename);
+            entry->appendf("%s logformat=combined", log->filename);
             break;
 
         case Log::Format::CLF_COMMON:
-            storeAppendPrintf(entry, "%s logformat=common", log->filename);
+            entry->appendf("%s logformat=common", log->filename);
             break;
 
 #if ICAP_CLIENT
         case Log::Format::CLF_ICAP_SQUID:
-            storeAppendPrintf(entry, "%s logformat=icap_squid", log->filename);
+            entry->appendf("%s logformat=icap_squid", log->filename);
             break;
 #endif
         case Log::Format::CLF_USERAGENT:
-            storeAppendPrintf(entry, "%s logformat=useragent", log->filename);
+            entry->appendf("%s logformat=useragent", log->filename);
             break;
 
         case Log::Format::CLF_REFERER:
-            storeAppendPrintf(entry, "%s logformat=referrer", log->filename);
+            entry->appendf("%s logformat=referrer", log->filename);
             break;
 
         case Log::Format::CLF_UNKNOWN:
@@ -4296,19 +4296,19 @@ dump_access_log(StoreEntry * entry, const char *name, CustomLog * logs)
 
         // default is on-error=die
         if (!log->fatal)
-            storeAppendPrintf(entry, " on-error=drop");
+            entry->appendf(" on-error=drop");
 
         // default: 64KB
         if (log->bufferSize != 64*1024)
-            storeAppendPrintf(entry, " buffer-size=%" PRIuSIZE, log->bufferSize);
+            entry->appendf(" buffer-size=%" PRIuSIZE, log->bufferSize);
 
         if (log->rotateCount >= 0)
-            storeAppendPrintf(entry, " rotate=%d", log->rotateCount);
+            entry->appendf(" rotate=%d", log->rotateCount);
 
         if (log->aclList)
             dump_acl_list(entry, log->aclList);
 
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -4390,17 +4390,17 @@ static void
 dump_CpuAffinityMap(StoreEntry *const entry, const char *const name, const CpuAffinityMap *const cpuAffinityMap)
 {
     if (cpuAffinityMap) {
-        storeAppendPrintf(entry, "%s process_numbers=", name);
+        entry->appendf("%s process_numbers=", name);
         for (size_t i = 0; i < cpuAffinityMap->processes().size(); ++i) {
-            storeAppendPrintf(entry, "%s%i", (i ? "," : ""),
+            entry->appendf("%s%i", (i ? "," : ""),
                               cpuAffinityMap->processes()[i]);
         }
-        storeAppendPrintf(entry, " cores=");
+        entry->appendf(" cores=");
         for (size_t i = 0; i < cpuAffinityMap->cores().size(); ++i) {
-            storeAppendPrintf(entry, "%s%i", (i ? "," : ""),
+            entry->appendf("%s%i", (i ? "," : ""),
                               cpuAffinityMap->cores()[i]);
         }
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -4512,11 +4512,11 @@ static void parse_icap_service_failure_limit(Adaptation::Icap::Config *cfg)
 
 static void dump_icap_service_failure_limit(StoreEntry *entry, const char *name, const Adaptation::Icap::Config &cfg)
 {
-    storeAppendPrintf(entry, "%s %d", name, cfg.service_failure_limit);
+    entry->appendf("%s %d", name, cfg.service_failure_limit);
     if (cfg.oldest_service_failure > 0) {
-        storeAppendPrintf(entry, " in %d seconds", (int)cfg.oldest_service_failure);
+        entry->appendf(" in %d seconds", (int)cfg.oldest_service_failure);
     }
-    storeAppendPrintf(entry, "\n");
+    entry->appendf("\n");
 }
 
 static void free_icap_service_failure_limit(Adaptation::Icap::Config *cfg)
@@ -4587,11 +4587,11 @@ static void parse_sslproxy_cert_adapt(sslproxy_cert_adapt **cert_adapt)
 static void dump_sslproxy_cert_adapt(StoreEntry *entry, const char *name, sslproxy_cert_adapt *cert_adapt)
 {
     for (sslproxy_cert_adapt *ca = cert_adapt; ca != NULL; ca = ca->next) {
-        storeAppendPrintf(entry, "%s ", name);
-        storeAppendPrintf(entry, "%s{%s} ", Ssl::sslCertAdaptAlgoritm(ca->alg), ca->param);
+        entry->appendf("%s ", name);
+        entry->appendf("%s{%s} ", Ssl::sslCertAdaptAlgoritm(ca->alg), ca->param);
         if (ca->aclList)
             dump_acl_list(entry, ca->aclList);
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -4644,11 +4644,11 @@ static void dump_sslproxy_cert_sign(StoreEntry *entry, const char *name, sslprox
 {
     sslproxy_cert_sign *cs;
     for (cs = cert_sign; cs != NULL; cs = cs->next) {
-        storeAppendPrintf(entry, "%s ", name);
-        storeAppendPrintf(entry, "%s ", Ssl::certSignAlgorithm(cs->alg));
+        entry->appendf("%s ", name);
+        entry->appendf("%s ", Ssl::certSignAlgorithm(cs->alg));
         if (cs->aclList)
             dump_acl_list(entry, cs->aclList);
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -4800,10 +4800,10 @@ static void dump_HeaderWithAclList(StoreEntry * entry, const char *name, HeaderW
         return;
 
     for (HeaderWithAclList::iterator hwa = headers->begin(); hwa != headers->end(); ++hwa) {
-        storeAppendPrintf(entry, "%s %s %s", name, hwa->fieldName.c_str(), hwa->fieldValue.c_str());
+        entry->appendf("%s %s %s", name, hwa->fieldName.c_str(), hwa->fieldValue.c_str());
         if (hwa->aclList)
             dump_acl_list(entry, hwa->aclList);
-        storeAppendPrintf(entry, "\n");
+        entry->appendf("\n");
     }
 }
 
@@ -5022,12 +5022,12 @@ dump_UrlHelperTimeout(StoreEntry *entry, const char *name, SquidConfig::UrlHelpe
     assert(config.action >= 0 && config.action <= toutActUseConfiguredResponse);
 
     dump_time_t(entry, name, Config.Timeout.urlRewrite);
-    storeAppendPrintf(entry, " on_timeout=%s", onTimedOutActions[config.action]);
+    entry->appendf(" on_timeout=%s", onTimedOutActions[config.action]);
 
     if (config.response)
-        storeAppendPrintf(entry, " response=\"%s\"", config.response);
+        entry->appendf(" response=\"%s\"", config.response);
 
-    storeAppendPrintf(entry, "\n");
+    entry->appendf("\n");
 }
 
 static void

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -224,7 +224,7 @@ carpCachemgr(StoreEntry * sentry)
 {
     CachePeer *p;
     int sumfetches = 0;
-    storeAppendPrintf(sentry, "%24s %10s %10s %10s %10s\n",
+    sentry->appendf("%24s %10s %10s %10s %10s\n",
                       "Hostname",
                       "Hash",
                       "Multiplier",
@@ -235,7 +235,7 @@ carpCachemgr(StoreEntry * sentry)
         sumfetches += p->stats.fetches;
 
     for (p = Config.peers; p; p = p->next) {
-        storeAppendPrintf(sentry, "%24s %10x %10f %10f %10f\n",
+        sentry->appendf("%24s %10x %10f %10f %10f\n",
                           p->name, p->carp.hash,
                           p->carp.load_multiplier,
                           p->carp.load_factor,

--- a/src/cbdata.cc
+++ b/src/cbdata.cc
@@ -467,7 +467,7 @@ cbdata::dump(StoreEntry *sentry) const
 #else
     void *p = (void *)&data;
 #endif
-    storeAppendPrintf(sentry, "%c%p\t%d\t%d\t%20s:%-5d\n", valid ? ' ' :
+    sentry->appendf("%c%p\t%d\t%d\t%20s:%-5d\n", valid ? ' ' :
                       '!', p, type, locks, file, line);
 }
 
@@ -486,14 +486,14 @@ struct CBDataDumper : public unary_function<cbdata, void> {
 static void
 cbdataDump(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "%d cbdata entries\n", cbdataCount);
+    sentry->appendf("%d cbdata entries\n", cbdataCount);
 #if USE_CBDATA_DEBUG
 
-    storeAppendPrintf(sentry, "Pointer\tType\tLocks\tAllocated by\n");
+    sentry->appendf("Pointer\tType\tLocks\tAllocated by\n");
     CBDataDumper dumper(sentry);
     for_each (cbdataEntries, dumper);
-    storeAppendPrintf(sentry, "\n");
-    storeAppendPrintf(sentry, "types\tsize\tallocated\ttotal\n");
+    sentry->appendf("\n");
+    sentry->appendf("types\tsize\tallocated\ttotal\n");
 
     for (int i = 1; i < cbdata_types; ++i) {
         MemAllocator *pool = cbdata_index[i].pool;
@@ -504,16 +504,16 @@ cbdataDump(StoreEntry * sentry)
 #else
             int obj_size = pool->objectSize() - cbdata::Offset;
 #endif
-            storeAppendPrintf(sentry, "%s\t%d\t%ld\t%ld\n", pool->objectType() + 7, obj_size, (long int)pool->getMeter().inuse.currentLevel(), (long int)obj_size * pool->getMeter().inuse.currentLevel());
+            sentry->appendf("%s\t%d\t%ld\t%ld\n", pool->objectType() + 7, obj_size, (long int)pool->getMeter().inuse.currentLevel(), (long int)obj_size * pool->getMeter().inuse.currentLevel());
         }
     }
 
 #else
-    storeAppendPrintf(sentry, "detailed allocation information only available when compiled with --enable-debug-cbdata\n");
+    sentry->appendf("detailed allocation information only available when compiled with --enable-debug-cbdata\n");
 
 #endif
 
-    storeAppendPrintf(sentry, "\nsee also \"Memory utilization\" for detailed per type statistics\n");
+    sentry->appendf("\nsee also \"Memory utilization\" for detailed per type statistics\n");
 }
 
 CallbackData &
@@ -535,7 +535,7 @@ struct CBDataCallDumper : public unary_function<CBDataCall, void> {
     CBDataCallDumper (StoreEntry *anEntry):where(anEntry) {}
 
     void operator()(CBDataCall * const &x) {
-        storeAppendPrintf(where, "%s\t%s\t%d\n", x->label, x->file, x->line);
+        where->appendf("%s\t%s\t%d\n", x->label, x->file, x->line);
     }
 
     StoreEntry *where;
@@ -546,10 +546,10 @@ struct CBDataHistoryDumper : public CBDataDumper {
 
     void operator()(cbdata const &x) {
         CBDataDumper::operator()(x);
-        storeAppendPrintf(where, "\n");
-        storeAppendPrintf(where, "Action\tFile\tLine\n");
+        where->appendf("\n");
+        where->appendf("Action\tFile\tLine\n");
         std::for_each (x.calls.begin(), x.calls.end(), callDumper);
-        storeAppendPrintf(where, "\n");
+        where->appendf("\n");
     }
 
     StoreEntry *where;
@@ -559,8 +559,8 @@ struct CBDataHistoryDumper : public CBDataDumper {
 void
 cbdataDumpHistory(StoreEntry *sentry)
 {
-    storeAppendPrintf(sentry, "%d cbdata entries\n", cbdataCount);
-    storeAppendPrintf(sentry, "Pointer\tType\tLocks\tAllocated by\n");
+    sentry->appendf("%d cbdata entries\n", cbdataCount);
+    sentry->appendf("Pointer\tType\tLocks\tAllocated by\n");
     CBDataHistoryDumper dumper(sentry);
     for_each (cbdataEntries, dumper);
 }

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -272,18 +272,18 @@ clientdbDump(StoreEntry * sentry)
     int icp_hits = 0;
     int http_total = 0;
     int http_hits = 0;
-    storeAppendPrintf(sentry, "Cache Clients:\n");
+    sentry->appendf("Cache Clients:\n");
     hash_first(client_table);
 
     while (hash_link *hash = hash_next(client_table)) {
         const ClientInfo *c = static_cast<const ClientInfo *>(hash);
-        storeAppendPrintf(sentry, "Address: %s\n", hashKeyStr(hash));
+        sentry->appendf("Address: %s\n", hashKeyStr(hash));
         if ( (name = fqdncache_gethostbyaddr(c->addr, 0)) ) {
-            storeAppendPrintf(sentry, "Name:    %s\n", name);
+            sentry->appendf("Name:    %s\n", name);
         }
-        storeAppendPrintf(sentry, "Currently established connections: %d\n",
+        sentry->appendf("Currently established connections: %d\n",
                           c->n_established);
-        storeAppendPrintf(sentry, "    ICP  Requests %d\n",
+        sentry->appendf("    ICP  Requests %d\n",
                           c->Icp.n_requests);
 
         for (LogTags_ot l = LOG_TAG_NONE; l < LOG_TYPE_MAX; ++l) {
@@ -295,10 +295,10 @@ clientdbDump(StoreEntry * sentry)
             if (LOG_UDP_HIT == l)
                 icp_hits += c->Icp.result_hist[l];
 
-            storeAppendPrintf(sentry, "        %-20.20s %7d %3d%%\n", LogTags(l).c_str(), c->Icp.result_hist[l], Math::intPercent(c->Icp.result_hist[l], c->Icp.n_requests));
+            sentry->appendf("        %-20.20s %7d %3d%%\n", LogTags(l).c_str(), c->Icp.result_hist[l], Math::intPercent(c->Icp.result_hist[l], c->Icp.n_requests));
         }
 
-        storeAppendPrintf(sentry, "    HTTP Requests %d\n", c->Http.n_requests);
+        sentry->appendf("    HTTP Requests %d\n", c->Http.n_requests);
 
         for (LogTags_ot l = LOG_TAG_NONE; l < LOG_TYPE_MAX; ++l) {
             if (c->Http.result_hist[l] == 0)
@@ -316,13 +316,13 @@ clientdbDump(StoreEntry * sentry)
                               Math::intPercent(c->Http.result_hist[l], c->Http.n_requests));
         }
 
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
     }
 
-    storeAppendPrintf(sentry, "TOTALS\n");
-    storeAppendPrintf(sentry, "ICP : %d Queries, %d Hits (%3d%%)\n",
+    sentry->appendf("TOTALS\n");
+    sentry->appendf("ICP : %d Queries, %d Hits (%3d%%)\n",
                       icp_total, icp_hits, Math::intPercent(icp_hits, icp_total));
-    storeAppendPrintf(sentry, "HTTP: %d Requests, %d Hits (%3d%%)\n",
+    sentry->appendf("HTTP: %d Requests, %d Hits (%3d%%)\n",
                       http_total, http_hits, Math::intPercent(http_hits, http_total));
 }
 

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -309,8 +309,7 @@ clientdbDump(StoreEntry * sentry)
             if (LogTags(l).isTcpHit())
                 http_hits += c->Http.result_hist[l];
 
-            storeAppendPrintf(sentry,
-                              "        %-20.20s %7d %3d%%\n",
+            sentry->appendf("        %-20.20s %7d %3d%%\n",
                               LogTags(l).c_str(),
                               c->Http.result_hist[l],
                               Math::intPercent(c->Http.result_hist[l], c->Http.n_requests));

--- a/src/comm/ModDevPoll.cc
+++ b/src/comm/ModDevPoll.cc
@@ -151,8 +151,8 @@ comm_update_fd(int fd, int events)
 
 static void commIncomingStats(StoreEntry *sentry)
 {
-    storeAppendPrintf(sentry, "Total number of devpoll loops: %ld\n", statCounter.select_loops);
-    storeAppendPrintf(sentry, "Histogram of returned filedescriptors\n");
+    sentry->appendf("Total number of devpoll loops: %ld\n", statCounter.select_loops);
+    sentry->appendf("Histogram of returned filedescriptors\n");
     statCounter.select_fds_hist.dump(sentry, statHistIntDumper);
 }
 

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -201,8 +201,8 @@ static void
 commIncomingStats(StoreEntry * sentry)
 {
     StatCounters *f = &statCounter;
-    storeAppendPrintf(sentry, "Total number of epoll(2) loops: %ld\n", statCounter.select_loops);
-    storeAppendPrintf(sentry, "Histogram of returned filedescriptors\n");
+    sentry->appendf("Total number of epoll(2) loops: %ld\n", statCounter.select_loops);
+    sentry->appendf("Histogram of returned filedescriptors\n");
     f->select_fds_hist.dump(sentry, statHistIntDumper);
 }
 

--- a/src/comm/ModPoll.cc
+++ b/src/comm/ModPoll.cc
@@ -620,19 +620,19 @@ Comm::SelectLoopInit(void)
 static void
 commIncomingStats(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "Current incoming_udp_interval: %d\n",
+    sentry->appendf("Current incoming_udp_interval: %d\n",
                       incoming_udp_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "Current incoming_dns_interval: %d\n",
+    sentry->appendf("Current incoming_dns_interval: %d\n",
                       incoming_dns_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "Current incoming_tcp_interval: %d\n",
+    sentry->appendf("Current incoming_tcp_interval: %d\n",
                       incoming_tcp_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "\n");
-    storeAppendPrintf(sentry, "Histogram of events per incoming socket type\n");
-    storeAppendPrintf(sentry, "ICP Messages handled per comm_poll_udp_incoming() call:\n");
+    sentry->appendf("\n");
+    sentry->appendf("Histogram of events per incoming socket type\n");
+    sentry->appendf("ICP Messages handled per comm_poll_udp_incoming() call:\n");
     statCounter.comm_udp_incoming.dump(sentry, statHistIntDumper);
-    storeAppendPrintf(sentry, "DNS Messages handled per comm_poll_dns_incoming() call:\n");
+    sentry->appendf("DNS Messages handled per comm_poll_dns_incoming() call:\n");
     statCounter.comm_dns_incoming.dump(sentry, statHistIntDumper);
-    storeAppendPrintf(sentry, "HTTP Messages handled per comm_poll_tcp_incoming() call:\n");
+    sentry->appendf("HTTP Messages handled per comm_poll_tcp_incoming() call:\n");
     statCounter.comm_tcp_incoming.dump(sentry, statHistIntDumper);
 }
 

--- a/src/comm/ModSelect.cc
+++ b/src/comm/ModSelect.cc
@@ -739,19 +739,19 @@ examine_select(fd_set * readfds, fd_set * writefds)
 static void
 commIncomingStats(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "Current incoming_udp_interval: %d\n",
+    sentry->appendf("Current incoming_udp_interval: %d\n",
                       incoming_udp_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "Current incoming_dns_interval: %d\n",
+    sentry->appendf("Current incoming_dns_interval: %d\n",
                       incoming_dns_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "Current incoming_tcp_interval: %d\n",
+    sentry->appendf("Current incoming_tcp_interval: %d\n",
                       incoming_tcp_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "\n");
-    storeAppendPrintf(sentry, "Histogram of events per incoming socket type\n");
-    storeAppendPrintf(sentry, "ICP Messages handled per comm_select_udp_incoming() call:\n");
+    sentry->appendf("\n");
+    sentry->appendf("Histogram of events per incoming socket type\n");
+    sentry->appendf("ICP Messages handled per comm_select_udp_incoming() call:\n");
     statCounter.comm_udp_incoming.dump(sentry, statHistIntDumper);
-    storeAppendPrintf(sentry, "DNS Messages handled per comm_select_dns_incoming() call:\n");
+    sentry->appendf("DNS Messages handled per comm_select_dns_incoming() call:\n");
     statCounter.comm_dns_incoming.dump(sentry, statHistIntDumper);
-    storeAppendPrintf(sentry, "HTTP Messages handled per comm_select_tcp_incoming() call:\n");
+    sentry->appendf("HTTP Messages handled per comm_select_tcp_incoming() call:\n");
     statCounter.comm_tcp_incoming.dump(sentry, statHistIntDumper);
 }
 

--- a/src/comm/ModSelectWin32.cc
+++ b/src/comm/ModSelectWin32.cc
@@ -750,19 +750,19 @@ examine_select(fd_set * readfds, fd_set * writefds)
 static void
 commIncomingStats(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "Current incoming_udp_interval: %d\n",
+    sentry->appendf("Current incoming_udp_interval: %d\n",
                       incoming_udp_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "Current incoming_dns_interval: %d\n",
+    sentry->appendf("Current incoming_dns_interval: %d\n",
                       incoming_dns_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "Current incoming_tcp_interval: %d\n",
+    sentry->appendf("Current incoming_tcp_interval: %d\n",
                       incoming_tcp_interval >> INCOMING_FACTOR);
-    storeAppendPrintf(sentry, "\n");
-    storeAppendPrintf(sentry, "Histogram of events per incoming socket type\n");
-    storeAppendPrintf(sentry, "ICP Messages handled per comm_select_udp_incoming() call:\n");
+    sentry->appendf("\n");
+    sentry->appendf("Histogram of events per incoming socket type\n");
+    sentry->appendf("ICP Messages handled per comm_select_udp_incoming() call:\n");
     statCounter.comm_udp_incoming.dump(sentry, statHistIntDumper);
-    storeAppendPrintf(sentry, "DNS Messages handled per comm_select_dns_incoming() call:\n");
+    sentry->appendf("DNS Messages handled per comm_select_dns_incoming() call:\n");
     statCounter.comm_dns_incoming.dump(sentry, statHistIntDumper);
-    storeAppendPrintf(sentry, "HTTP Messages handled per comm_select_tcp_incoming() call:\n");
+    sentry->appendf("HTTP Messages handled per comm_select_tcp_incoming() call:\n");
     statCounter.comm_tcp_incoming.dump(sentry, statHistIntDumper);
 }
 

--- a/src/delay_pools.cc
+++ b/src/delay_pools.cc
@@ -326,7 +326,7 @@ ClassCBucket::stats(StoreEntry *sentry)const
 {
     for (unsigned int j = 0; j < individuals.size(); ++j) {
         assert (individualUsed (j));
-        storeAppendPrintf(sentry, " %d:",individuals.key_map[j]);
+        sentry->appendf(" %d:",individuals.key_map[j]);
         individuals.values[j].stats (sentry);
     }
 }
@@ -394,11 +394,11 @@ Aggregate::stats(StoreEntry * sentry)
     if (rate()->restore_bps == -1)
         return;
 
-    storeAppendPrintf(sentry, "\t\tCurrent: ");
+    sentry->appendf("\t\tCurrent: ");
 
     theBucket.stats(sentry);
 
-    storeAppendPrintf(sentry, "\n\n");
+    sentry->appendf("\n\n");
 }
 
 void
@@ -540,14 +540,14 @@ std::vector<Updateable *> DelayPools::toUpdate;
 void
 DelayPools::Stats(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "Delay pools configured: %d\n\n", DelayPools::pools());
+    sentry->appendf("Delay pools configured: %d\n\n", DelayPools::pools());
 
     for (unsigned short i = 0; i < DelayPools::pools(); ++i) {
         if (DelayPools::delay_data[i].theComposite().getRaw()) {
-            storeAppendPrintf(sentry, "Pool: %d\n\tClass: %s\n\n", i + 1, DelayPools::delay_data[i].pool->theClassTypeLabel());
+            sentry->appendf("Pool: %d\n\tClass: %s\n\n", i + 1, DelayPools::delay_data[i].pool->theClassTypeLabel());
             DelayPools::delay_data[i].theComposite()->stats (sentry);
         } else
-            storeAppendPrintf(sentry, "\tMisconfigured pool.\n\n");
+            sentry->appendf("\tMisconfigured pool.\n\n");
     }
 }
 
@@ -621,21 +621,21 @@ VectorPool::stats(StoreEntry * sentry)
     rate()->stats (sentry, label());
 
     if (rate()->restore_bps == -1) {
-        storeAppendPrintf(sentry, "\n\n");
+        sentry->appendf("\n\n");
         return;
     }
 
-    storeAppendPrintf(sentry, "\t\tCurrent:");
+    sentry->appendf("\t\tCurrent:");
 
     for (unsigned int i = 0; i < buckets.size(); ++i) {
-        storeAppendPrintf(sentry, " %d:", buckets.key_map[i]);
+        sentry->appendf(" %d:", buckets.key_map[i]);
         buckets.values[i].stats(sentry);
     }
 
     if (!buckets.size())
-        storeAppendPrintf(sentry, " Not used yet.");
+        sentry->appendf(" Not used yet.");
 
-    storeAppendPrintf(sentry, "\n\n");
+    sentry->appendf("\n\n");
 }
 
 void
@@ -766,20 +766,20 @@ ClassCHostPool::stats(StoreEntry * sentry)
     rate()->stats (sentry, label());
 
     if (rate()->restore_bps == -1) {
-        storeAppendPrintf(sentry, "\n\n");
+        sentry->appendf("\n\n");
         return;
     }
 
     for (unsigned int index = 0; index < buckets.size(); ++index) {
-        storeAppendPrintf(sentry, "\t\tCurrent [Network %d]:", buckets.key_map[index]);
+        sentry->appendf("\t\tCurrent [Network %d]:", buckets.key_map[index]);
         buckets.values[index].stats (sentry);
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
     }
 
     if (!buckets.size())
-        storeAppendPrintf(sentry, "\t\tCurrent [All networks]: Not used yet.\n");
+        sentry->appendf("\t\tCurrent [All networks]: Not used yet.\n");
 
-    storeAppendPrintf(sentry, "\n\n");
+    sentry->appendf("\n\n");
 }
 
 void

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -712,15 +712,15 @@ idnsStats(StoreEntry * sentry)
     int i;
     int j;
     char buf[MAX_IPSTRLEN];
-    storeAppendPrintf(sentry, "Internal DNS Statistics:\n");
-    storeAppendPrintf(sentry, "\nThe Queue:\n");
-    storeAppendPrintf(sentry, "                       DELAY SINCE\n");
-    storeAppendPrintf(sentry, "  ID   SIZE SENDS FIRST SEND LAST SEND M FQDN\n");
-    storeAppendPrintf(sentry, "------ ---- ----- ---------- --------- - ----\n");
+    sentry->appendf("Internal DNS Statistics:\n");
+    sentry->appendf("\nThe Queue:\n");
+    sentry->appendf("                       DELAY SINCE\n");
+    sentry->appendf("  ID   SIZE SENDS FIRST SEND LAST SEND M FQDN\n");
+    sentry->appendf("------ ---- ----- ---------- --------- - ----\n");
 
     for (n = lru_list.head; n; n = n->next) {
         q = (idns_query *)n->data;
-        storeAppendPrintf(sentry, "%#06x %4d %5d %10.3f %9.3f %c %s\n",
+        sentry->appendf("%#06x %4d %5d %10.3f %9.3f %c %s\n",
                           (int) q->query_id, (int) q->sz, q->nsends,
                           tvSubDsec(q->start_t, current_time),
                           tvSubDsec(q->sent_t, current_time),
@@ -729,49 +729,49 @@ idnsStats(StoreEntry * sentry)
     }
 
     if (Config.dns.packet_max > 0)
-        storeAppendPrintf(sentry, "\nDNS jumbo-grams: %zd Bytes\n", Config.dns.packet_max);
+        sentry->appendf("\nDNS jumbo-grams: %zd Bytes\n", Config.dns.packet_max);
     else
-        storeAppendPrintf(sentry, "\nDNS jumbo-grams: not working\n");
+        sentry->appendf("\nDNS jumbo-grams: not working\n");
 
-    storeAppendPrintf(sentry, "\nNameservers:\n");
-    storeAppendPrintf(sentry, "IP ADDRESS                                     # QUERIES # REPLIES Type\n");
-    storeAppendPrintf(sentry, "---------------------------------------------- --------- --------- --------\n");
+    sentry->appendf("\nNameservers:\n");
+    sentry->appendf("IP ADDRESS                                     # QUERIES # REPLIES Type\n");
+    sentry->appendf("---------------------------------------------- --------- --------- --------\n");
 
     for (const auto &server : nameservers) {
-        storeAppendPrintf(sentry, "%-45s %9d %9d %s\n",  /* Let's take the maximum: (15 IPv4/45 IPv6) */
+        sentry->appendf("%-45s %9d %9d %s\n",  /* Let's take the maximum: (15 IPv4/45 IPv6) */
                           server.S.toStr(buf,MAX_IPSTRLEN),
                           server.nqueries,
                           server.nreplies,
                           server.mDNSResolver?"multicast":"recurse");
     }
 
-    storeAppendPrintf(sentry, "\nRcode Matrix:\n");
-    storeAppendPrintf(sentry, "RCODE");
+    sentry->appendf("\nRcode Matrix:\n");
+    sentry->appendf("RCODE");
 
     for (i = 0; i < MAX_ATTEMPT; ++i)
-        storeAppendPrintf(sentry, " ATTEMPT%d", i + 1);
+        sentry->appendf(" ATTEMPT%d", i + 1);
 
-    storeAppendPrintf(sentry, " PROBLEM\n");
+    sentry->appendf(" PROBLEM\n");
 
     for (j = 0; j < MAX_RCODE; ++j) {
         if (j > 10 && j < 16)
             continue; // unassigned by IANA.
 
-        storeAppendPrintf(sentry, "%5d", j);
+        sentry->appendf("%5d", j);
 
         for (i = 0; i < MAX_ATTEMPT; ++i)
-            storeAppendPrintf(sentry, " %8d", RcodeMatrix[j][i]);
+            sentry->appendf(" %8d", RcodeMatrix[j][i]);
 
-        storeAppendPrintf(sentry, " : %s\n",Rcodes[j]);
+        sentry->appendf(" : %s\n",Rcodes[j]);
     }
 
     if (npc) {
-        storeAppendPrintf(sentry, "\nSearch list:\n");
+        sentry->appendf("\nSearch list:\n");
 
         for (i=0; i < npc; ++i)
-            storeAppendPrintf(sentry, "%s\n", searchpath[i].domain);
+            sentry->appendf("%s\n", searchpath[i].domain);
 
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
     }
 }
 

--- a/src/event.cc
+++ b/src/event.cc
@@ -277,16 +277,16 @@ EventScheduler::dump(StoreEntry * sentry)
     ev_entry *e = tasks;
 
     if (last_event_ran)
-        storeAppendPrintf(sentry, "Last event to run: %s\n\n", last_event_ran);
+        sentry->appendf("Last event to run: %s\n\n", last_event_ran);
 
-    storeAppendPrintf(sentry, "%-25s\t%-15s\t%s\t%s\n",
+    sentry->appendf("%-25s\t%-15s\t%s\t%s\n",
                       "Operation",
                       "Next Execution",
                       "Weight",
                       "Callback Valid?");
 
     while (e != NULL) {
-        storeAppendPrintf(sentry, "%-25s\t%0.3f sec\t%5d\t %s\n",
+        sentry->appendf("%-25s\t%0.3f sec\t%5d\t %s\n",
                           e->name, e->when ? e->when - current_dtime : 0, e->weight,
                           (e->arg && e->cbdata) ? cbdataReferenceValid(e->arg) ? "yes" : "no" : "N/A");
         e = e->next;

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -378,46 +378,46 @@ dump_externalAclHelper(StoreEntry * sentry, const char *name, const external_acl
     const wordlist *word;
 
     for (node = list; node; node = node->next) {
-        storeAppendPrintf(sentry, "%s %s", name, node->name);
+        sentry->appendf("%s %s", name, node->name);
 
         if (!node->local_addr.isIPv6())
-            storeAppendPrintf(sentry, " ipv4");
+            sentry->appendf(" ipv4");
         else
-            storeAppendPrintf(sentry, " ipv6");
+            sentry->appendf(" ipv6");
 
         if (node->ttl != DEFAULT_EXTERNAL_ACL_TTL)
-            storeAppendPrintf(sentry, " ttl=%d", node->ttl);
+            sentry->appendf(" ttl=%d", node->ttl);
 
         if (node->negative_ttl != node->ttl)
-            storeAppendPrintf(sentry, " negative_ttl=%d", node->negative_ttl);
+            sentry->appendf(" negative_ttl=%d", node->negative_ttl);
 
         if (node->grace)
-            storeAppendPrintf(sentry, " grace=%d", node->grace);
+            sentry->appendf(" grace=%d", node->grace);
 
         if (node->children.n_max != DEFAULT_EXTERNAL_ACL_CHILDREN)
-            storeAppendPrintf(sentry, " children-max=%d", node->children.n_max);
+            sentry->appendf(" children-max=%d", node->children.n_max);
 
         if (node->children.n_startup != 0) // sync with helper/ChildConfig.cc default
-            storeAppendPrintf(sentry, " children-startup=%d", node->children.n_startup);
+            sentry->appendf(" children-startup=%d", node->children.n_startup);
 
         if (node->children.n_idle != 1) // sync with helper/ChildConfig.cc default
-            storeAppendPrintf(sentry, " children-idle=%d", node->children.n_idle);
+            sentry->appendf(" children-idle=%d", node->children.n_idle);
 
         if (node->children.concurrency != 0)
-            storeAppendPrintf(sentry, " concurrency=%d", node->children.concurrency);
+            sentry->appendf(" concurrency=%d", node->children.concurrency);
 
         if (node->cache)
-            storeAppendPrintf(sentry, " cache=%d", node->cache_size);
+            sentry->appendf(" cache=%d", node->cache_size);
 
         if (node->quote == Format::LOG_QUOTE_SHELL)
-            storeAppendPrintf(sentry, " protocol=2.5");
+            sentry->appendf(" protocol=2.5");
 
         node->format.dump(sentry, NULL, false);
 
         for (word = node->cmdline; word; word = word->next)
-            storeAppendPrintf(sentry, " %s", word->key);
+            sentry->appendf(" %s", word->key);
 
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
     }
 }
 
@@ -1090,11 +1090,11 @@ static void
 externalAclStats(StoreEntry * sentry)
 {
     for (external_acl *p = Config.externalAclHelperList; p; p = p->next) {
-        storeAppendPrintf(sentry, "External ACL Statistics: %s\n", p->name);
-        storeAppendPrintf(sentry, "Cache size: %d\n", p->cache->count);
+        sentry->appendf("External ACL Statistics: %s\n", p->name);
+        sentry->appendf("Cache size: %d\n", p->cache->count);
         assert(p->theHelper);
         p->theHelper->packStatsInto(sentry);
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
     }
 }
 

--- a/src/fde.cc
+++ b/src/fde.cc
@@ -76,11 +76,11 @@ fde::dumpStats(StoreEntry &dumpEntry, int fdNumber) const
         return;
 
 #if _SQUID_WINDOWS_
-    storeAppendPrintf(&dumpEntry, "%4d 0x%-8lX %-6.6s %4d %7" PRId64 "%c %7" PRId64 "%c %-21s %s\n",
+    dumpEntry.appendf("%4d 0x%-8lX %-6.6s %4d %7" PRId64 "%c %7" PRId64 "%c %-21s %s\n",
                       fdNumber,
                       win32.handle,
 #else
-    storeAppendPrintf(&dumpEntry, "%4d %-6.6s %4d %7" PRId64 "%c %7" PRId64 "%c %-21s %s\n",
+    dumpEntry.appendf("%4d %-6.6s %4d %7" PRId64 "%c %7" PRId64 "%c %-21s %s\n",
                       fdNumber,
 #endif
                       fdTypeStr[type],
@@ -96,13 +96,13 @@ fde::dumpStats(StoreEntry &dumpEntry, int fdNumber) const
 void
 fde::DumpStats(StoreEntry *dumpEntry)
 {
-    storeAppendPrintf(dumpEntry, "Active file descriptors:\n");
+    dumpEntry->appendf("Active file descriptors:\n");
 #if _SQUID_WINDOWS_
-    storeAppendPrintf(dumpEntry, "%-4s %-10s %-6s %-4s %-7s* %-7s* %-21s %s\n",
+    dumpEntry->appendf("%-4s %-10s %-6s %-4s %-7s* %-7s* %-21s %s\n",
                       "File",
                       "Handle",
 #else
-    storeAppendPrintf(dumpEntry, "%-4s %-6s %-4s %-7s* %-7s* %-21s %s\n",
+    dumpEntry->appendf("%-4s %-6s %-4s %-7s* %-7s* %-21s %s\n",
                       "File",
 #endif
                       "Type",
@@ -112,9 +112,9 @@ fde::DumpStats(StoreEntry *dumpEntry)
                       "Remote Address",
                       "Description");
 #if _SQUID_WINDOWS_
-    storeAppendPrintf(dumpEntry, "---- ---------- ------ ---- -------- -------- --------------------- ------------------------------\n");
+    dumpEntry->appendf("---- ---------- ------ ---- -------- -------- --------------------- ------------------------------\n");
 #else
-    storeAppendPrintf(dumpEntry, "---- ------ ---- -------- -------- --------------------- ------------------------------\n");
+    dumpEntry->appendf("---- ------ ---- -------- -------- --------------------- ------------------------------\n");
 #endif
 
     for (int i = 0; i < Squid_MaxFD; ++i) {

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -122,11 +122,11 @@ Format::Format::dump(StoreEntry * entry, const char *directiveName, bool eol) co
     for (const Format *fmt = this; fmt; fmt = fmt->next) {
         debugs(46, 3, HERE << "Dumping format definition for " << fmt->name);
         if (directiveName)
-            storeAppendPrintf(entry, "%s %s ", directiveName, fmt->name);
+            entry->appendf("%s %s ", directiveName, fmt->name);
 
         for (Token *t = fmt->format; t; t = t->next) {
             if (t->type == LFT_STRING)
-                storeAppendPrintf(entry, "%s", t->data.string);
+                entry->appendf("%s", t->data.string);
             else {
                 char argbuf[256];
                 char *arg = NULL;
@@ -267,15 +267,15 @@ Format::Format::dump(StoreEntry * entry, const char *directiveName, bool eol) co
                     entry->append("0", 1);
 
                 if (t->widthMin >= 0)
-                    storeAppendPrintf(entry, "%d", t->widthMin);
+                    entry->appendf("%d", t->widthMin);
 
                 if (t->widthMax >= 0)
-                    storeAppendPrintf(entry, ".%d", t->widthMax);
+                    entry->appendf(".%d", t->widthMax);
 
                 if (arg)
-                    storeAppendPrintf(entry, "{%s}", arg);
+                    entry->appendf("{%s}", arg);
 
-                storeAppendPrintf(entry, "%s", t->label);
+                entry->appendf("%s", t->label);
 
                 if (t->space)
                     entry->append(" ", 1);

--- a/src/fqdncache.cc
+++ b/src/fqdncache.cc
@@ -532,36 +532,36 @@ fqdnStats(StoreEntry * sentry)
     if (fqdn_table == NULL)
         return;
 
-    storeAppendPrintf(sentry, "FQDN Cache Statistics:\n");
+    sentry->appendf("FQDN Cache Statistics:\n");
 
-    storeAppendPrintf(sentry, "FQDNcache Entries In Use: %d\n",
+    sentry->appendf("FQDNcache Entries In Use: %d\n",
                       fqdncache_entry::UseCount());
 
-    storeAppendPrintf(sentry, "FQDNcache Entries Cached: %d\n",
+    sentry->appendf("FQDNcache Entries Cached: %d\n",
                       fqdncacheCount());
 
-    storeAppendPrintf(sentry, "FQDNcache Requests: %d\n",
+    sentry->appendf("FQDNcache Requests: %d\n",
                       FqdncacheStats.requests);
 
-    storeAppendPrintf(sentry, "FQDNcache Hits: %d\n",
+    sentry->appendf("FQDNcache Hits: %d\n",
                       FqdncacheStats.hits);
 
-    storeAppendPrintf(sentry, "FQDNcache Negative Hits: %d\n",
+    sentry->appendf("FQDNcache Negative Hits: %d\n",
                       FqdncacheStats.negative_hits);
 
-    storeAppendPrintf(sentry, "FQDNcache Misses: %d\n",
+    sentry->appendf("FQDNcache Misses: %d\n",
                       FqdncacheStats.misses);
 
-    storeAppendPrintf(sentry, "FQDN Cache Contents:\n\n");
+    sentry->appendf("FQDN Cache Contents:\n\n");
 
-    storeAppendPrintf(sentry, "%-45.45s %3s %3s %3s %s\n",
+    sentry->appendf("%-45.45s %3s %3s %3s %s\n",
                       "Address", "Flg", "TTL", "Cnt", "Hostnames");
 
     hash_first(fqdn_table);
 
     while ((f = (fqdncache_entry *) hash_next(fqdn_table))) {
         ttl = (f->flags.fromhosts ? -1 : (f->expires - squid_curtime));
-        storeAppendPrintf(sentry, "%-45.45s  %c%c %3.3d % 3d",
+        sentry->appendf("%-45.45s  %c%c %3.3d % 3d",
                           hashKeyStr(&f->hash),
                           f->flags.negcached ? 'N' : ' ',
                           f->flags.fromhosts ? 'H' : ' ',
@@ -569,9 +569,9 @@ fqdnStats(StoreEntry * sentry)
                           (int) f->name_count);
 
         for (k = 0; k < (int) f->name_count; ++k)
-            storeAppendPrintf(sentry, " %s", f->names[k]);
+            sentry->appendf(" %s", f->names[k]);
 
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
     }
 }
 

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -442,7 +442,7 @@ void
 Rock::SwapDir::dumpTimeOption(StoreEntry * e) const
 {
     if (fileConfig.ioTimeout)
-        storeAppendPrintf(e, " swap-timeout=%" PRId64,
+        e->appendf(" swap-timeout=%" PRId64,
                           static_cast<int64_t>(fileConfig.ioTimeout));
 }
 
@@ -493,7 +493,7 @@ void
 Rock::SwapDir::dumpRateOption(StoreEntry * e) const
 {
     if (fileConfig.ioRate >= 0)
-        storeAppendPrintf(e, " max-swap-rate=%d", fileConfig.ioRate);
+        e->appendf(" max-swap-rate=%d", fileConfig.ioRate);
 }
 
 /// parses size-specific options; mimics ::SwapDir::optionObjectSizeParse()
@@ -540,7 +540,7 @@ Rock::SwapDir::parseSizeOption(char const *option, const char *value, int reconf
 void
 Rock::SwapDir::dumpSizeOption(StoreEntry * e) const
 {
-    storeAppendPrintf(e, " slot-size=%" PRId64, slotSize);
+    e->appendf(" slot-size=%" PRId64, slotSize);
 }
 
 /// check the results of the configuration; only level-0 debugging works here
@@ -1053,27 +1053,27 @@ Rock::SwapDir::ignoreReferences(StoreEntry &e)
 void
 Rock::SwapDir::statfs(StoreEntry &e) const
 {
-    storeAppendPrintf(&e, "\n");
-    storeAppendPrintf(&e, "Maximum Size: %" PRIu64 " KB\n", maxSize() >> 10);
-    storeAppendPrintf(&e, "Current Size: %.2f KB %.2f%%\n",
+    e.appendf("\n");
+    e.appendf("Maximum Size: %" PRIu64 " KB\n", maxSize() >> 10);
+    e.appendf("Current Size: %.2f KB %.2f%%\n",
                       currentSize() / 1024.0,
                       Math::doublePercent(currentSize(), maxSize()));
 
     const int entryLimit = entryLimitActual();
     const int slotLimit = slotLimitActual();
-    storeAppendPrintf(&e, "Maximum entries: %9d\n", entryLimit);
+    e.appendf("Maximum entries: %9d\n", entryLimit);
     if (map && entryLimit > 0) {
         const int entryCount = map->entryCount();
-        storeAppendPrintf(&e, "Current entries: %9d %.2f%%\n",
+        e.appendf("Current entries: %9d %.2f%%\n",
                           entryCount, (100.0 * entryCount / entryLimit));
     }
 
-    storeAppendPrintf(&e, "Maximum slots:   %9d\n", slotLimit);
+    e.appendf("Maximum slots:   %9d\n", slotLimit);
     if (map && slotLimit > 0) {
         const unsigned int slotsFree = !freeSlots ? 0 : freeSlots->size();
         if (slotsFree <= static_cast<const unsigned int>(slotLimit)) {
             const int usedSlots = slotLimit - static_cast<const int>(slotsFree);
-            storeAppendPrintf(&e, "Used slots:      %9d %.2f%%\n",
+            e.appendf("Used slots:      %9d %.2f%%\n",
                               usedSlots, (100.0 * usedSlots / slotLimit));
         }
         if (slotLimit < 100) { // XXX: otherwise too expensive to count
@@ -1083,18 +1083,18 @@ Rock::SwapDir::statfs(StoreEntry &e) const
         }
     }
 
-    storeAppendPrintf(&e, "Pending operations: %d out of %d\n",
+    e.appendf("Pending operations: %d out of %d\n",
                       store_open_disk_fd, Config.max_open_disk_fds);
 
-    storeAppendPrintf(&e, "Flags:");
+    e.appendf("Flags:");
 
     if (flags.selected)
-        storeAppendPrintf(&e, " SELECTED");
+        e.appendf(" SELECTED");
 
     if (flags.read_only)
-        storeAppendPrintf(&e, " READ-ONLY");
+        e.appendf(" READ-ONLY");
 
-    storeAppendPrintf(&e, "\n");
+    e.appendf("\n");
 
 }
 

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -244,7 +244,7 @@ Fs::Ufs::UFSSwapDir::optionIOParse(char const *option, const char *value, int is
 void
 Fs::Ufs::UFSSwapDir::optionIODump(StoreEntry * e) const
 {
-    storeAppendPrintf(e, " IOEngine=%s", ioType);
+    e->appendf(" IOEngine=%s", ioType);
 }
 
 ConfigOption *
@@ -376,37 +376,37 @@ Fs::Ufs::UFSSwapDir::statfs(StoreEntry & sentry) const
     int totl_in = 0;
     int free_in = 0;
     int x;
-    storeAppendPrintf(&sentry, "First level subdirectories: %d\n", l1);
-    storeAppendPrintf(&sentry, "Second level subdirectories: %d\n", l2);
-    storeAppendPrintf(&sentry, "Maximum Size: %" PRIu64 " KB\n", maxSize() >> 10);
-    storeAppendPrintf(&sentry, "Current Size: %.2f KB\n", currentSize() / 1024.0);
-    storeAppendPrintf(&sentry, "Percent Used: %0.2f%%\n",
+    sentry.appendf("First level subdirectories: %d\n", l1);
+    sentry.appendf("Second level subdirectories: %d\n", l2);
+    sentry.appendf("Maximum Size: %" PRIu64 " KB\n", maxSize() >> 10);
+    sentry.appendf("Current Size: %.2f KB\n", currentSize() / 1024.0);
+    sentry.appendf("Percent Used: %0.2f%%\n",
                       Math::doublePercent(currentSize(), maxSize()));
-    storeAppendPrintf(&sentry, "Filemap bits in use: %d of %d (%d%%)\n",
+    sentry.appendf("Filemap bits in use: %d of %d (%d%%)\n",
                       map->numFilesInMap(), map->capacity(),
                       Math::intPercent(map->numFilesInMap(), map->capacity()));
     x = fsStats(path, &totl_kb, &free_kb, &totl_in, &free_in);
 
     if (0 == x) {
-        storeAppendPrintf(&sentry, "Filesystem Space in use: %d/%d KB (%d%%)\n",
+        sentry.appendf("Filesystem Space in use: %d/%d KB (%d%%)\n",
                           totl_kb - free_kb,
                           totl_kb,
                           Math::intPercent(totl_kb - free_kb, totl_kb));
-        storeAppendPrintf(&sentry, "Filesystem Inodes in use: %d/%d (%d%%)\n",
+        sentry.appendf("Filesystem Inodes in use: %d/%d (%d%%)\n",
                           totl_in - free_in,
                           totl_in,
                           Math::intPercent(totl_in - free_in, totl_in));
     }
 
-    storeAppendPrintf(&sentry, "Flags:");
+    sentry.appendf("Flags:");
 
     if (flags.selected)
-        storeAppendPrintf(&sentry, " SELECTED");
+        sentry.appendf(" SELECTED");
 
     if (flags.read_only)
-        storeAppendPrintf(&sentry, " READ-ONLY");
+        sentry.appendf(" READ-ONLY");
 
-    storeAppendPrintf(&sentry, "\n");
+    sentry.appendf("\n");
 
     IO->statfs(sentry);
 }
@@ -1231,7 +1231,7 @@ Fs::Ufs::UFSSwapDir::replacementRemove(StoreEntry * e)
 void
 Fs::Ufs::UFSSwapDir::dump(StoreEntry & entry) const
 {
-    storeAppendPrintf(&entry, " %" PRIu64 " %d %d", maxSize() >> 20, l1, l2);
+    entry.appendf(" %" PRIu64 " %d %d", maxSize() >> 20, l1, l2);
     dumpOptions(&entry);
 }
 

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -389,8 +389,7 @@ gopherToHTML(GopherStateData * gopherState, char *inbuf, int len)
     if (gopherState->conversion == GopherStateData::HTML_INDEX_PAGE) {
         char *html_url = html_quote(entry->url());
         gopherHTMLHeader(entry, "Gopher Index %s", html_url);
-        storeAppendPrintf(entry,
-                          "<p>This is a searchable Gopher index. Use the search\n"
+        entry->appendf("<p>This is a searchable Gopher index. Use the search\n"
                           "function of your browser to enter search terms.\n"
                           "<ISINDEX>\n");
         gopherHTMLFooter(entry);
@@ -404,8 +403,7 @@ gopherToHTML(GopherStateData * gopherState, char *inbuf, int len)
     if (gopherState->conversion == GopherStateData::HTML_CSO_PAGE) {
         char *html_url = html_quote(entry->url());
         gopherHTMLHeader(entry, "CSO Search of %s", html_url);
-        storeAppendPrintf(entry,
-                          "<P>A CSO database usually contains a phonebook or\n"
+        entry->appendf("<P>A CSO database usually contains a phonebook or\n"
                           "directory.  Use the search function of your browser to enter\n"
                           "search terms.</P><ISINDEX>\n");
         gopherHTMLFooter(entry);

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -322,26 +322,26 @@ gopherCachable(const HttpRequest * req)
 static void
 gopherHTMLHeader(StoreEntry * e, const char *title, const char *substring)
 {
-    storeAppendPrintf(e, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n");
-    storeAppendPrintf(e, "<HTML><HEAD><TITLE>");
-    storeAppendPrintf(e, title, substring);
-    storeAppendPrintf(e, "</TITLE>");
-    storeAppendPrintf(e, "<STYLE type=\"text/css\"><!--BODY{background-color:#ffffff;font-family:verdana,sans-serif}--></STYLE>\n");
-    storeAppendPrintf(e, "</HEAD>\n<BODY><H1>");
-    storeAppendPrintf(e, title, substring);
-    storeAppendPrintf(e, "</H1>\n");
+    e->appendf("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n");
+    e->appendf("<HTML><HEAD><TITLE>");
+    e->appendf(title, substring);
+    e->appendf("</TITLE>");
+    e->appendf("<STYLE type=\"text/css\"><!--BODY{background-color:#ffffff;font-family:verdana,sans-serif}--></STYLE>\n");
+    e->appendf("</HEAD>\n<BODY><H1>");
+    e->appendf(title, substring);
+    e->appendf("</H1>\n");
 }
 
 static void
 gopherHTMLFooter(StoreEntry * e)
 {
-    storeAppendPrintf(e, "<HR noshade size=\"1px\">\n");
-    storeAppendPrintf(e, "<ADDRESS>\n");
-    storeAppendPrintf(e, "Generated %s by %s (%s)\n",
+    e->appendf("<HR noshade size=\"1px\">\n");
+    e->appendf("<ADDRESS>\n");
+    e->appendf("Generated %s by %s (%s)\n",
                       mkrfc1123(squid_curtime),
                       getMyHostname(),
                       visible_appname_string);
-    storeAppendPrintf(e, "</ADDRESS></BODY></HTML>\n");
+    e->appendf("</ADDRESS></BODY></HTML>\n");
 }
 
 static void
@@ -351,9 +351,9 @@ gopherEndHTML(GopherStateData * gopherState)
 
     if (!gopherState->HTML_header_added) {
         gopherHTMLHeader(e, "Server Return Nothing", NULL);
-        storeAppendPrintf(e, "<P>The Gopher query resulted in a blank response</P>");
+        e->appendf("<P>The Gopher query resulted in a blank response</P>");
     } else if (gopherState->HTML_pre) {
-        storeAppendPrintf(e, "</PRE>\n");
+        e->appendf("</PRE>\n");
     }
 
     gopherHTMLFooter(e);

--- a/src/helper/ChildConfig.h
+++ b/src/helper/ChildConfig.h
@@ -113,7 +113,7 @@ public:
 
 /* Legacy parser interface */
 #define parse_HelperChildConfig(c)     (c)->parseConfig()
-#define dump_HelperChildConfig(e,n,c)  storeAppendPrintf((e), "\n%s %d startup=%d idle=%d concurrency=%d\n", (n), (c).n_max, (c).n_startup, (c).n_idle, (c).concurrency)
+#define dump_HelperChildConfig(e,n,c)  (e)->appendf("\n%s %d startup=%d idle=%d concurrency=%d\n", (n), (c).n_max, (c).n_startup, (c).n_idle, (c).concurrency)
 #define free_HelperChildConfig(dummy)  // NO.
 
 #endif /* _SQUID_SRC_HELPER_CHILDCONFIG_H */

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -976,8 +976,8 @@ netdbDump(StoreEntry * sentry)
     int i;
     int j;
     net_db_peer *p;
-    storeAppendPrintf(sentry, "Network DB Statistics:\n");
-    storeAppendPrintf(sentry, "%-46.46s %9s %7s %5s %s\n",  /* Max between 16 (IPv4) or 46 (IPv6)   */
+    sentry->appendf("Network DB Statistics:\n");
+    sentry->appendf("%-46.46s %9s %7s %5s %s\n",  /* Max between 16 (IPv4) or 46 (IPv6)   */
                       "Network",
                       "recv/sent",
                       "RTT",
@@ -1003,7 +1003,7 @@ netdbDump(StoreEntry * sentry)
 
     for (k = 0; k < i; ++k) {
         n = *(list + k);
-        storeAppendPrintf(sentry, "%-46.46s %4d/%4d %7.1f %5.1f", /* Max between 16 (IPv4) or 46 (IPv6)   */
+        sentry->appendf("%-46.46s %4d/%4d %7.1f %5.1f", /* Max between 16 (IPv4) or 46 (IPv6)   */
                           n->network,
                           n->pings_recv,
                           n->pings_sent,
@@ -1011,14 +1011,14 @@ netdbDump(StoreEntry * sentry)
                           n->hops);
 
         for (x = n->hosts; x; x = x->next)
-            storeAppendPrintf(sentry, " %s", hashKeyStr(x));
+            sentry->appendf(" %s", hashKeyStr(x));
 
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
 
         p = n->peers;
 
         for (j = 0; j < n->n_peers; ++j, ++p) {
-            storeAppendPrintf(sentry, "    %-22.22s %7.1f %5.1f\n",
+            sentry->appendf("    %-22.22s %7.1f %5.1f\n",
                               p->peername,
                               p->rtt,
                               p->hops);
@@ -1028,7 +1028,7 @@ netdbDump(StoreEntry * sentry)
     xfree(list);
 #else
 
-    storeAppendPrintf(sentry,"NETDB support not compiled into this Squid cache.\n");
+    sentry->appendf("NETDB support not compiled into this Squid cache.\n");
 #endif
 }
 
@@ -1259,7 +1259,7 @@ netdbBinaryExchange(StoreEntry * s)
 
     reply->setHeaders(Http::scBadRequest, "Bad Request", NULL, -1, squid_curtime, -2);
     s->replaceHttpReply(reply);
-    storeAppendPrintf(s, "NETDB support not compiled into this Squid cache.\n");
+    s->appendf("NETDB support not compiled into this Squid cache.\n");
 #endif
 
     s->complete();

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -244,7 +244,7 @@ extern Config TheConfig;
 #define dump_QosConfig(e,n,X) do { \
         char temp[256]; /* random number. change as needed. max config line length. */ \
         (X).dumpConfigLine(temp,n); \
-            storeAppendPrintf(e, "%s", temp); \
+            e->appendf("%s", temp); \
     } while(0);
 
 } // namespace Qos

--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -144,24 +144,24 @@ Ipc::ReadWriteLockStats::ReadWriteLockStats()
 void
 Ipc::ReadWriteLockStats::dump(StoreEntry &e) const
 {
-    storeAppendPrintf(&e, "Available locks: %9d\n", count);
+    e.appendf("Available locks: %9d\n", count);
 
     if (!count)
         return;
 
-    storeAppendPrintf(&e, "Reading: %9d %6.2f%%\n",
+    e.appendf("Reading: %9d %6.2f%%\n",
                       readable, (100.0 * readable / count));
-    storeAppendPrintf(&e, "Writing: %9d %6.2f%%\n",
+    e.appendf("Writing: %9d %6.2f%%\n",
                       writeable, (100.0 * writeable / count));
-    storeAppendPrintf(&e, "Idle:    %9d %6.2f%%\n",
+    e.appendf("Idle:    %9d %6.2f%%\n",
                       idle, (100.0 * idle / count));
 
     if (readers || writers) {
         const int locked = readers + writers;
-        storeAppendPrintf(&e, "Readers:         %9d %6.2f%%\n",
+        e.appendf("Readers:         %9d %6.2f%%\n",
                           readers, (100.0 * readers / locked));
         const double appPerc = writers ? (100.0 * appenders / writers) : 0.0;
-        storeAppendPrintf(&e, "Writers:         %9d %6.2f%% including Appenders: %9d %6.2f%%\n",
+        e.appendf("Writers:         %9d %6.2f%% including Appenders: %9d %6.2f%%\n",
                           writers, (100.0 * writers / locked),
                           appenders, appPerc);
     }

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -769,11 +769,11 @@ ipcacheStatPrint(ipcache_entry * i, StoreEntry * sentry)
 
     if (!i) {
         debugs(14, DBG_CRITICAL, HERE << "CRITICAL: ipcache_entry is NULL!");
-        storeAppendPrintf(sentry, "CRITICAL ERROR\n");
+        sentry->appendf("CRITICAL ERROR\n");
         return;
     }
 
-    storeAppendPrintf(sentry, " %-32.32s %c%c %6d %6d %2d(%2d)",
+    sentry->appendf(" %-32.32s %c%c %6d %6d %2d(%2d)",
                       hashKeyStr(&i->hash),
                       i->flags.fromhosts ? 'H' : ' ',
                       i->flags.negcached ? 'N' : ' ',
@@ -785,7 +785,7 @@ ipcacheStatPrint(ipcache_entry * i, StoreEntry * sentry)
     /** \par
      * Negative-cached entries have no IPs listed. */
     if (i->flags.negcached) {
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
         return;
     }
 
@@ -795,7 +795,7 @@ ipcacheStatPrint(ipcache_entry * i, StoreEntry * sentry)
     for (const auto &addr: i->addrs.raw()) {
         /* Display tidy-up: IPv6 are so big make the list vertical */
         const char *indent = firstLine ? "" : "                                                         ";
-        storeAppendPrintf(sentry, "%s %45.45s-%3s\n",
+        sentry->appendf("%s %45.45s-%3s\n",
                           indent,
                           addr.ip.toStr(buf, MAX_IPSTRLEN),
                           addr.bad() ? "BAD" : "OK ");
@@ -813,32 +813,32 @@ stat_ipcache_get(StoreEntry * sentry)
 {
     dlink_node *m;
     assert(ip_table != NULL);
-    storeAppendPrintf(sentry, "IP Cache Statistics:\n");
-    storeAppendPrintf(sentry, "IPcache Entries Cached:  %d\n",
+    sentry->appendf("IP Cache Statistics:\n");
+    sentry->appendf("IPcache Entries Cached:  %d\n",
                       ipcacheCount());
-    storeAppendPrintf(sentry, "IPcache Requests: %d\n",
+    sentry->appendf("IPcache Requests: %d\n",
                       IpcacheStats.requests);
-    storeAppendPrintf(sentry, "IPcache Hits:            %d\n",
+    sentry->appendf("IPcache Hits:            %d\n",
                       IpcacheStats.hits);
-    storeAppendPrintf(sentry, "IPcache Negative Hits:       %d\n",
+    sentry->appendf("IPcache Negative Hits:       %d\n",
                       IpcacheStats.negative_hits);
-    storeAppendPrintf(sentry, "IPcache Numeric Hits:        %d\n",
+    sentry->appendf("IPcache Numeric Hits:        %d\n",
                       IpcacheStats.numeric_hits);
-    storeAppendPrintf(sentry, "IPcache Misses:          %d\n",
+    sentry->appendf("IPcache Misses:          %d\n",
                       IpcacheStats.misses);
-    storeAppendPrintf(sentry, "IPcache Retrieved A:     %d\n",
+    sentry->appendf("IPcache Retrieved A:     %d\n",
                       IpcacheStats.rr_a);
-    storeAppendPrintf(sentry, "IPcache Retrieved AAAA:  %d\n",
+    sentry->appendf("IPcache Retrieved AAAA:  %d\n",
                       IpcacheStats.rr_aaaa);
-    storeAppendPrintf(sentry, "IPcache Retrieved CNAME: %d\n",
+    sentry->appendf("IPcache Retrieved CNAME: %d\n",
                       IpcacheStats.rr_cname);
-    storeAppendPrintf(sentry, "IPcache CNAME-Only Response: %d\n",
+    sentry->appendf("IPcache CNAME-Only Response: %d\n",
                       IpcacheStats.cname_only);
-    storeAppendPrintf(sentry, "IPcache Invalid Request: %d\n",
+    sentry->appendf("IPcache Invalid Request: %d\n",
                       IpcacheStats.invalid);
-    storeAppendPrintf(sentry, "\n\n");
-    storeAppendPrintf(sentry, "IP Cache Contents:\n\n");
-    storeAppendPrintf(sentry, " %-31.31s %3s %6s %6s  %4s\n",
+    sentry->appendf("\n\n");
+    sentry->appendf("IP Cache Contents:\n\n");
+    sentry->appendf(" %-31.31s %3s %6s %6s  %4s\n",
                       "Hostname",
                       "Flg",
                       "lstref",

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -503,7 +503,7 @@ fvdbDumpTable(StoreEntry * e, hash_table * hash)
 
     while ((h = hash_next(hash))) {
         fv = (fvdb_entry *) h;
-        storeAppendPrintf(e, "%9d %s\n", fv->n, hashKeyStr(&fv->hash));
+        e->appendf("%9d %s\n", fv->n, hashKeyStr(&fv->hash));
     }
 }
 

--- a/src/mgr/BasicActions.cc
+++ b/src/mgr/BasicActions.cc
@@ -57,7 +57,7 @@ Mgr::MenuAction::dump(StoreEntry* entry)
     const CacheManager::Menu& menu = CacheManager::GetInstance()->menu();
 
     for (Iterator a = menu.begin(); a != menu.end(); ++a) {
-        storeAppendPrintf(entry, " %-22s\t%-32s\t%s\n",
+        entry->appendf(" %-22s\t%-32s\t%s\n",
                           (*a)->name, (*a)->desc,
                           CacheManager::GetInstance()->ActionProtection(*a));
     }
@@ -97,7 +97,7 @@ void
 Mgr::ReconfigureAction::dump(StoreEntry* entry)
 {
     debugs(16, DBG_IMPORTANT, "Reconfigure by Cache Manager command.");
-    storeAppendPrintf(entry, "Reconfiguring Squid Process ....");
+    entry->appendf("Reconfiguring Squid Process ....");
     reconfigure(SIGHUP);
 }
 
@@ -116,7 +116,7 @@ void
 Mgr::RotateAction::dump(StoreEntry* entry)
 {
     debugs(16, DBG_IMPORTANT, "Rotate Logs by Cache Manager command.");
-    storeAppendPrintf(entry, "Rotating Squid Process Logs ....");
+    entry->appendf("Rotating Squid Process Logs ....");
 #if defined(_SQUID_LINUX_THREADS_)
     rotate_logs(SIGQUIT);
 #else
@@ -142,7 +142,7 @@ Mgr::OfflineToggleAction::dump(StoreEntry* entry)
     Config.onoff.offline = !Config.onoff.offline;
     debugs(16, DBG_IMPORTANT, "offline_mode now " << (Config.onoff.offline ? "ON" : "OFF") << " by Cache Manager request.");
 
-    storeAppendPrintf(entry, "offline_mode is now %s\n",
+    entry->appendf("offline_mode is now %s\n",
                       Config.onoff.offline ? "ON" : "OFF");
 }
 

--- a/src/mgr/FunAction.cc
+++ b/src/mgr/FunAction.cc
@@ -49,9 +49,9 @@ Mgr::FunAction::dump(StoreEntry* entry)
     debugs(16, 5, HERE);
     Must(entry != NULL);
     if (UsingSmp())
-        storeAppendPrintf(entry, "by kid%d {\n", KidIdentifier);
+        entry->appendf("by kid%d {\n", KidIdentifier);
     handler(entry);
     if (atomic() && UsingSmp())
-        storeAppendPrintf(entry, "} by kid%d\n\n", KidIdentifier);
+        entry->appendf("} by kid%d\n\n", KidIdentifier);
 }
 

--- a/src/mgr/InfoAction.cc
+++ b/src/mgr/InfoAction.cc
@@ -144,10 +144,10 @@ Mgr::InfoAction::dump(StoreEntry* entry)
 
 #if XMALLOC_STATISTICS
     if (UsingSmp())
-        storeAppendPrintf(entry, "by kid%d {\n", KidIdentifier);
+        entry->appendf("by kid%d {\n", KidIdentifier);
     DumpMallocStatistics(entry);
     if (UsingSmp())
-        storeAppendPrintf(entry, "} by kid%d\n\n", KidIdentifier);
+        entry->appendf("} by kid%d\n\n", KidIdentifier);
 #endif
     if (IamPrimaryProcess())
         DumpInfo(data, entry);

--- a/src/mgr/StoreIoAction.cc
+++ b/src/mgr/StoreIoAction.cc
@@ -65,11 +65,11 @@ Mgr::StoreIoAction::dump(StoreEntry* entry)
 {
     debugs(16, 5, HERE);
     Must(entry != NULL);
-    storeAppendPrintf(entry, "Store IO Interface Stats\n");
-    storeAppendPrintf(entry, "create.calls %.0f\n", data.create_calls);
-    storeAppendPrintf(entry, "create.select_fail %.0f\n", data.create_select_fail);
-    storeAppendPrintf(entry, "create.create_fail %.0f\n", data.create_create_fail);
-    storeAppendPrintf(entry, "create.success %.0f\n", data.create_success);
+    entry->appendf("Store IO Interface Stats\n");
+    entry->appendf("create.calls %.0f\n", data.create_calls);
+    entry->appendf("create.select_fail %.0f\n", data.create_select_fail);
+    entry->appendf("create.create_fail %.0f\n", data.create_create_fail);
+    entry->appendf("create.success %.0f\n", data.create_success);
 }
 
 void

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1518,70 +1518,70 @@ void
 dump_peer_options(StoreEntry * sentry, CachePeer * p)
 {
     if (p->options.proxy_only)
-        storeAppendPrintf(sentry, " proxy-only");
+        sentry->appendf(" proxy-only");
 
     if (p->options.no_query)
-        storeAppendPrintf(sentry, " no-query");
+        sentry->appendf(" no-query");
 
     if (p->options.background_ping)
-        storeAppendPrintf(sentry, " background-ping");
+        sentry->appendf(" background-ping");
 
     if (p->options.no_digest)
-        storeAppendPrintf(sentry, " no-digest");
+        sentry->appendf(" no-digest");
 
     if (p->options.default_parent)
-        storeAppendPrintf(sentry, " default");
+        sentry->appendf(" default");
 
     if (p->options.roundrobin)
-        storeAppendPrintf(sentry, " round-robin");
+        sentry->appendf(" round-robin");
 
     if (p->options.carp)
-        storeAppendPrintf(sentry, " carp");
+        sentry->appendf(" carp");
 
 #if USE_AUTH
     if (p->options.userhash)
-        storeAppendPrintf(sentry, " userhash");
+        sentry->appendf(" userhash");
 #endif
 
     if (p->options.sourcehash)
-        storeAppendPrintf(sentry, " sourcehash");
+        sentry->appendf(" sourcehash");
 
     if (p->options.weighted_roundrobin)
-        storeAppendPrintf(sentry, " weighted-round-robin");
+        sentry->appendf(" weighted-round-robin");
 
     if (p->options.mcast_responder)
-        storeAppendPrintf(sentry, " multicast-responder");
+        sentry->appendf(" multicast-responder");
 
 #if PEER_MULTICAST_SIBLINGS
     if (p->options.mcast_siblings)
-        storeAppendPrintf(sentry, " multicast-siblings");
+        sentry->appendf(" multicast-siblings");
 #endif
 
     if (p->weight != 1)
-        storeAppendPrintf(sentry, " weight=%d", p->weight);
+        sentry->appendf(" weight=%d", p->weight);
 
     if (p->options.closest_only)
-        storeAppendPrintf(sentry, " closest-only");
+        sentry->appendf(" closest-only");
 
 #if USE_HTCP
     if (p->options.htcp) {
-        storeAppendPrintf(sentry, " htcp");
+        sentry->appendf(" htcp");
         if (p->options.htcp_oldsquid || p->options.htcp_no_clr || p->options.htcp_no_purge_clr || p->options.htcp_only_clr) {
             bool doneopts = false;
             if (p->options.htcp_oldsquid) {
-                storeAppendPrintf(sentry, "oldsquid");
+                sentry->appendf("oldsquid");
                 doneopts = true;
             }
             if (p->options.htcp_no_clr) {
-                storeAppendPrintf(sentry, "%sno-clr",(doneopts?",":"="));
+                sentry->appendf("%sno-clr",(doneopts?",":"="));
                 doneopts = true;
             }
             if (p->options.htcp_no_purge_clr) {
-                storeAppendPrintf(sentry, "%sno-purge-clr",(doneopts?",":"="));
+                sentry->appendf("%sno-purge-clr",(doneopts?",":"="));
                 doneopts = true;
             }
             if (p->options.htcp_only_clr) {
-                storeAppendPrintf(sentry, "%sonly-clr",(doneopts?",":"="));
+                sentry->appendf("%sonly-clr",(doneopts?",":"="));
                 //doneopts = true; // uncomment if more opts are added
             }
         }
@@ -1589,58 +1589,58 @@ dump_peer_options(StoreEntry * sentry, CachePeer * p)
 #endif
 
     if (p->options.no_netdb_exchange)
-        storeAppendPrintf(sentry, " no-netdb-exchange");
+        sentry->appendf(" no-netdb-exchange");
 
 #if USE_DELAY_POOLS
     if (p->options.no_delay)
-        storeAppendPrintf(sentry, " no-delay");
+        sentry->appendf(" no-delay");
 #endif
 
     if (p->login)
-        storeAppendPrintf(sentry, " login=%s", p->login);
+        sentry->appendf(" login=%s", p->login);
 
     if (p->mcast.ttl > 0)
-        storeAppendPrintf(sentry, " ttl=%d", p->mcast.ttl);
+        sentry->appendf(" ttl=%d", p->mcast.ttl);
 
     if (p->connect_timeout_raw > 0)
-        storeAppendPrintf(sentry, " connect-timeout=%d", (int)p->connect_timeout_raw);
+        sentry->appendf(" connect-timeout=%d", (int)p->connect_timeout_raw);
 
     if (p->connect_fail_limit != PEER_TCP_MAGIC_COUNT)
-        storeAppendPrintf(sentry, " connect-fail-limit=%d", p->connect_fail_limit);
+        sentry->appendf(" connect-fail-limit=%d", p->connect_fail_limit);
 
 #if USE_CACHE_DIGESTS
 
     if (p->digest_url)
-        storeAppendPrintf(sentry, " digest-url=%s", p->digest_url);
+        sentry->appendf(" digest-url=%s", p->digest_url);
 
 #endif
 
     if (p->options.allow_miss)
-        storeAppendPrintf(sentry, " allow-miss");
+        sentry->appendf(" allow-miss");
 
     if (p->options.no_tproxy)
-        storeAppendPrintf(sentry, " no-tproxy");
+        sentry->appendf(" no-tproxy");
 
     if (p->max_conn > 0)
-        storeAppendPrintf(sentry, " max-conn=%d", p->max_conn);
+        sentry->appendf(" max-conn=%d", p->max_conn);
     if (p->standby.limit > 0)
-        storeAppendPrintf(sentry, " standby=%d", p->standby.limit);
+        sentry->appendf(" standby=%d", p->standby.limit);
 
     if (p->options.originserver)
-        storeAppendPrintf(sentry, " originserver");
+        sentry->appendf(" originserver");
 
     if (p->domain)
-        storeAppendPrintf(sentry, " forceddomain=%s", p->domain);
+        sentry->appendf(" forceddomain=%s", p->domain);
 
     if (p->connection_auth == 0)
-        storeAppendPrintf(sentry, " connection-auth=off");
+        sentry->appendf(" connection-auth=off");
     else if (p->connection_auth == 1)
-        storeAppendPrintf(sentry, " connection-auth=on");
+        sentry->appendf(" connection-auth=on");
     else if (p->connection_auth == 2)
-        storeAppendPrintf(sentry, " connection-auth=auto");
+        sentry->appendf(" connection-auth=auto");
 
     p->secure.dumpCfg(sentry,"tls-");
-    storeAppendPrintf(sentry, "\n");
+    sentry->appendf("\n");
 }
 
 static void
@@ -1650,59 +1650,59 @@ dump_peers(StoreEntry * sentry, CachePeer * peers)
     int i;
 
     if (peers == NULL)
-        storeAppendPrintf(sentry, "There are no neighbors installed.\n");
+        sentry->appendf("There are no neighbors installed.\n");
 
     for (CachePeer *e = peers; e; e = e->next) {
         assert(e->host != NULL);
-        storeAppendPrintf(sentry, "\n%-11.11s: %s\n",
+        sentry->appendf("\n%-11.11s: %s\n",
                           neighborTypeStr(e),
                           e->name);
-        storeAppendPrintf(sentry, "Host       : %s/%d/%d\n",
+        sentry->appendf("Host       : %s/%d/%d\n",
                           e->host,
                           e->http_port,
                           e->icp.port);
-        storeAppendPrintf(sentry, "Flags      :");
+        sentry->appendf("Flags      :");
         dump_peer_options(sentry, e);
 
         for (i = 0; i < e->n_addresses; ++i) {
-            storeAppendPrintf(sentry, "Address[%d] : %s\n", i,
+            sentry->appendf("Address[%d] : %s\n", i,
                               e->addresses[i].toStr(ntoabuf,MAX_IPSTRLEN) );
         }
 
-        storeAppendPrintf(sentry, "Status     : %s\n",
+        sentry->appendf("Status     : %s\n",
                           neighborUp(e) ? "Up" : "Down");
-        storeAppendPrintf(sentry, "FETCHES    : %d\n", e->stats.fetches);
-        storeAppendPrintf(sentry, "OPEN CONNS : %d\n", e->stats.conn_open);
-        storeAppendPrintf(sentry, "AVG RTT    : %d msec\n", e->stats.rtt);
+        sentry->appendf("FETCHES    : %d\n", e->stats.fetches);
+        sentry->appendf("OPEN CONNS : %d\n", e->stats.conn_open);
+        sentry->appendf("AVG RTT    : %d msec\n", e->stats.rtt);
 
         if (!e->options.no_query) {
-            storeAppendPrintf(sentry, "LAST QUERY : %8d seconds ago\n",
+            sentry->appendf("LAST QUERY : %8d seconds ago\n",
                               (int) (squid_curtime - e->stats.last_query));
 
             if (e->stats.last_reply > 0)
-                storeAppendPrintf(sentry, "LAST REPLY : %8d seconds ago\n",
+                sentry->appendf("LAST REPLY : %8d seconds ago\n",
                                   (int) (squid_curtime - e->stats.last_reply));
             else
-                storeAppendPrintf(sentry, "LAST REPLY : none received\n");
+                sentry->appendf("LAST REPLY : none received\n");
 
-            storeAppendPrintf(sentry, "PINGS SENT : %8d\n", e->stats.pings_sent);
+            sentry->appendf("PINGS SENT : %8d\n", e->stats.pings_sent);
 
-            storeAppendPrintf(sentry, "PINGS ACKED: %8d %3d%%\n",
+            sentry->appendf("PINGS ACKED: %8d %3d%%\n",
                               e->stats.pings_acked,
                               Math::intPercent(e->stats.pings_acked, e->stats.pings_sent));
         }
 
-        storeAppendPrintf(sentry, "IGNORED    : %8d %3d%%\n", e->stats.ignored_replies, Math::intPercent(e->stats.ignored_replies, e->stats.pings_acked));
+        sentry->appendf("IGNORED    : %8d %3d%%\n", e->stats.ignored_replies, Math::intPercent(e->stats.ignored_replies, e->stats.pings_acked));
 
         if (!e->options.no_query) {
-            storeAppendPrintf(sentry, "Histogram of PINGS ACKED:\n");
+            sentry->appendf("Histogram of PINGS ACKED:\n");
 #if USE_HTCP
 
             if (e->options.htcp) {
-                storeAppendPrintf(sentry, "\tMisses\t%8d %3d%%\n",
+                sentry->appendf("\tMisses\t%8d %3d%%\n",
                                   e->htcp.counts[0],
                                   Math::intPercent(e->htcp.counts[0], e->stats.pings_acked));
-                storeAppendPrintf(sentry, "\tHits\t%8d %3d%%\n",
+                sentry->appendf("\tHits\t%8d %3d%%\n",
                                   e->htcp.counts[1],
                                   Math::intPercent(e->htcp.counts[1], e->stats.pings_acked));
             } else {
@@ -1712,7 +1712,7 @@ dump_peers(StoreEntry * sentry, CachePeer * peers)
                     if (e->icp.counts[op] == 0)
                         continue;
 
-                    storeAppendPrintf(sentry, "    %12.12s : %8d %3d%%\n",
+                    sentry->appendf("    %12.12s : %8d %3d%%\n",
                                       icp_opcode_str[op],
                                       e->icp.counts[op],
                                       Math::intPercent(e->icp.counts[op], e->stats.pings_acked));
@@ -1727,11 +1727,11 @@ dump_peers(StoreEntry * sentry, CachePeer * peers)
         }
 
         if (e->stats.last_connect_failure) {
-            storeAppendPrintf(sentry, "Last failed connect() at: %s\n",
+            sentry->appendf("Last failed connect() at: %s\n",
                               Time::FormatHttpd(e->stats.last_connect_failure));
         }
 
-        storeAppendPrintf(sentry, "keep-alive ratio: %d%%\n", Math::intPercent(e->stats.n_keepalives_recv, e->stats.n_keepalives_sent));
+        sentry->appendf("keep-alive ratio: %d%%\n", Math::intPercent(e->stats.n_keepalives_recv, e->stats.n_keepalives_sent));
     }
 }
 

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -350,8 +350,7 @@ PconnPool::key(const Comm::ConnectionPointer &destLink, const char *domain)
 void
 PconnPool::dumpHist(StoreEntry * e) const
 {
-    storeAppendPrintf(e,
-                      "%s persistent connection counts:\n"
+    e->appendf("%s persistent connection counts:\n"
                       "\n"
                       "\t Requests\t Connection Count\n"
                       "\t --------\t ----------------\n",

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -361,7 +361,7 @@ PconnPool::dumpHist(StoreEntry * e) const
         if (hist[i] == 0)
             continue;
 
-        storeAppendPrintf(e, "\t%d\t%d\n", i, hist[i]);
+        e->appendf("\t%d\t%d\n", i, hist[i]);
     }
 }
 
@@ -373,7 +373,7 @@ PconnPool::dumpHash(StoreEntry *e) const
 
     int i = 0;
     for (hash_link *walker = hash_next(hid); walker; walker = hash_next(hid)) {
-        storeAppendPrintf(e, "\t item %d:\t%s\n", i, (char *)(walker->key));
+        e->appendf("\t item %d:\t%s\n", i, (char *)(walker->key));
         ++i;
     }
 }
@@ -588,9 +588,9 @@ PconnModule::dump(StoreEntry *e)
     int i = 0; // TODO: Why number pools if they all have names?
     for (PCI p = pools.begin(); p != pools.end(); ++p, ++i) {
         // TODO: Let each pool dump itself the way it wants to.
-        storeAppendPrintf(e, "\n Pool %d Stats\n", i);
+        e->appendf("\n Pool %d Stats\n", i);
         (*p)->dumpHist(e);
-        storeAppendPrintf(e, "\n Pool %d Hash Table\n",i);
+        e->appendf("\n Pool %d Hash Table\n",i);
         (*p)->dumpHash(e);
     }
 }

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -1044,7 +1044,7 @@ void
 peerDigestStatsReport(const PeerDigest * pd, StoreEntry * e)
 {
 #define f2s(flag) (pd->flags.flag ? "yes" : "no")
-#define appendTime(tm) storeAppendPrintf(e, "%s\t %10ld\t %+d\t %+d\n", \
+#define appendTime(tm) e->appendf("%s\t %10ld\t %+d\t %+d\n", \
     ""#tm, (long int)pd->times.tm, \
     saneDiff(pd->times.tm - squid_curtime), \
     saneDiff(pd->times.tm - pd->times.initialized))
@@ -1052,39 +1052,39 @@ peerDigestStatsReport(const PeerDigest * pd, StoreEntry * e)
     assert(pd);
 
     auto host = pd->host;
-    storeAppendPrintf(e, "\npeer digest from " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(host));
+    e->appendf("\npeer digest from " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(host));
 
     cacheDigestGuessStatsReport(&pd->stats.guess, e, host);
 
-    storeAppendPrintf(e, "\nevent\t timestamp\t secs from now\t secs from init\n");
+    e->appendf("\nevent\t timestamp\t secs from now\t secs from init\n");
     appendTime(initialized);
     appendTime(needed);
     appendTime(requested);
     appendTime(received);
     appendTime(next_check);
 
-    storeAppendPrintf(e, "peer digest state:\n");
-    storeAppendPrintf(e, "\tneeded: %3s, usable: %3s, requested: %3s\n",
+    e->appendf("peer digest state:\n");
+    e->appendf("\tneeded: %3s, usable: %3s, requested: %3s\n",
                       f2s(needed), f2s(usable), f2s(requested));
-    storeAppendPrintf(e, "\n\tlast retry delay: %d secs\n",
+    e->appendf("\n\tlast retry delay: %d secs\n",
                       (int) pd->times.retry_delay);
-    storeAppendPrintf(e, "\tlast request response time: %d secs\n",
+    e->appendf("\tlast request response time: %d secs\n",
                       (int) pd->times.req_delay);
-    storeAppendPrintf(e, "\tlast request result: %s\n",
+    e->appendf("\tlast request result: %s\n",
                       pd->req_result ? pd->req_result : "(none)");
 
-    storeAppendPrintf(e, "\npeer digest traffic:\n");
-    storeAppendPrintf(e, "\trequests sent: %d, volume: %d KB\n",
+    e->appendf("\npeer digest traffic:\n");
+    e->appendf("\trequests sent: %d, volume: %d KB\n",
                       pd->stats.sent.msgs, (int) pd->stats.sent.kbytes.kb);
-    storeAppendPrintf(e, "\treplies recv:  %d, volume: %d KB\n",
+    e->appendf("\treplies recv:  %d, volume: %d KB\n",
                       pd->stats.recv.msgs, (int) pd->stats.recv.kbytes.kb);
 
-    storeAppendPrintf(e, "\npeer digest structure:\n");
+    e->appendf("\npeer digest structure:\n");
 
     if (pd->cd)
         cacheDigestReport(pd->cd, host, e);
     else
-        storeAppendPrintf(e, "\tno in-memory copy\n");
+        e->appendf("\tno in-memory copy\n");
 }
 
 #endif

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -196,7 +196,7 @@ peerSourceHashCachemgr(StoreEntry * sentry)
 {
     CachePeer *p;
     int sumfetches = 0;
-    storeAppendPrintf(sentry, "%24s %10s %10s %10s %10s\n",
+    sentry->appendf("%24s %10s %10s %10s %10s\n",
                       "Hostname",
                       "Hash",
                       "Multiplier",
@@ -207,7 +207,7 @@ peerSourceHashCachemgr(StoreEntry * sentry)
         sumfetches += p->stats.fetches;
 
     for (p = Config.peers; p; p = p->next) {
-        storeAppendPrintf(sentry, "%24s %10x %10f %10f %10f\n",
+        sentry->appendf("%24s %10x %10f %10f %10f\n",
                           p->name, p->sourcehash.hash,
                           p->sourcehash.load_multiplier,
                           p->sourcehash.load_factor,

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -204,7 +204,7 @@ peerUserHashCachemgr(StoreEntry * sentry)
 {
     CachePeer *p;
     int sumfetches = 0;
-    storeAppendPrintf(sentry, "%24s %10s %10s %10s %10s\n",
+    sentry->appendf("%24s %10s %10s %10s %10s\n",
                       "Hostname",
                       "Hash",
                       "Multiplier",
@@ -215,7 +215,7 @@ peerUserHashCachemgr(StoreEntry * sentry)
         sumfetches += p->stats.fetches;
 
     for (p = Config.peers; p; p = p->next) {
-        storeAppendPrintf(sentry, "%24s %10x %10f %10f %10f\n",
+        sentry->appendf("%24s %10x %10f %10f %10f\n",
                           p->name, p->userhash.hash,
                           p->userhash.load_multiplier,
                           p->userhash.load_factor,

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -196,14 +196,14 @@ static void
 redirectStats(StoreEntry * sentry)
 {
     if (redirectors == NULL) {
-        storeAppendPrintf(sentry, "No redirectors defined\n");
+        sentry->appendf("No redirectors defined\n");
         return;
     }
 
     redirectors->packStatsInto(sentry, "Redirector Statistics");
 
     if (Config.onoff.redirector_bypass)
-        storeAppendPrintf(sentry, "\nNumber of requests bypassed "
+        sentry->appendf("\nNumber of requests bypassed "
                           "because all redirectors were busy: %d\n", redirectorBypassed);
 }
 
@@ -211,14 +211,14 @@ static void
 storeIdStats(StoreEntry * sentry)
 {
     if (storeIds == NULL) {
-        storeAppendPrintf(sentry, "No StoreId helpers defined\n");
+        sentry->appendf("No StoreId helpers defined\n");
         return;
     }
 
     storeIds->packStatsInto(sentry, "StoreId helper Statistics");
 
     if (Config.onoff.store_id_bypass)
-        storeAppendPrintf(sentry, "\nNumber of requests bypassed "
+        sentry->appendf("\nNumber of requests bypassed "
                           "because all StoreId helpers were busy: %d\n", storeIdBypassed);
 }
 

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -653,7 +653,7 @@ getMaxAge(const char *url)
 static int
 refreshCountsStatsEntry(StoreEntry * sentry, struct RefreshCounts &rc, int code, const char *desc)
 {
-    storeAppendPrintf(sentry, "%6d\t%6.2f\t%s\n", rc.status[code], xpercent(rc.status[code], rc.total), desc);
+    sentry->appendf("%6d\t%6.2f\t%s\n", rc.status[code], xpercent(rc.status[code], rc.total), desc);
     return rc.status[code];
 }
 
@@ -663,8 +663,8 @@ refreshCountsStats(StoreEntry * sentry, struct RefreshCounts &rc)
     if (!rc.total)
         return;
 
-    storeAppendPrintf(sentry, "\n\n%s histogram:\n", rc.proto);
-    storeAppendPrintf(sentry, "Count\t%%Total\tCategory\n");
+    sentry->appendf("\n\n%s histogram:\n", rc.proto);
+    sentry->appendf("Count\t%%Total\tCategory\n");
 
     int sum = 0;
     sum += refreshCountsStatsEntry(sentry, rc, FRESH_REQUEST_MAX_STALE_ALL, "Fresh: request max-stale wildcard");
@@ -682,17 +682,17 @@ refreshCountsStats(StoreEntry * sentry, struct RefreshCounts &rc)
     sum += refreshCountsStatsEntry(sentry, rc, STALE_MAX_RULE, "Stale: refresh_pattern max age rule");
     sum += refreshCountsStatsEntry(sentry, rc, STALE_LMFACTOR_RULE, "Stale: refresh_pattern last-mod factor percentage");
     sum += refreshCountsStatsEntry(sentry, rc, STALE_DEFAULT, "Stale: by default");
-    storeAppendPrintf(sentry, "\n");
+    sentry->appendf("\n");
 }
 
 static void
 refreshStats(StoreEntry * sentry)
 {
     // display per-rule counts of usage and tests
-    storeAppendPrintf(sentry, "\nRefresh pattern usage:\n\n");
-    storeAppendPrintf(sentry, "  Used      \tChecks    \t%% Matches\tPattern\n");
+    sentry->appendf("\nRefresh pattern usage:\n\n");
+    sentry->appendf("  Used      \tChecks    \t%% Matches\tPattern\n");
     for (const RefreshPattern *R = Config.Refresh; R; R = R->next) {
-        storeAppendPrintf(sentry, "  %10" PRIu64 "\t%10" PRIu64 "\t%6.2f\t%s%s\n",
+        sentry->appendf("  %10" PRIu64 "\t%10" PRIu64 "\t%6.2f\t%s%s\n",
                           R->stats.matchCount,
                           R->stats.matchTests,
                           xpercent(R->stats.matchCount, R->stats.matchTests),
@@ -709,18 +709,18 @@ refreshStats(StoreEntry * sentry)
         total += refreshCounts[i].total;
 
     /* protocol usage histogram */
-    storeAppendPrintf(sentry, "\nRefreshCheck calls per protocol\n\n");
+    sentry->appendf("\nRefreshCheck calls per protocol\n\n");
 
-    storeAppendPrintf(sentry, "Protocol\t#Calls\t%%Calls\n");
+    sentry->appendf("Protocol\t#Calls\t%%Calls\n");
 
     for (i = 0; i < rcCount; ++i)
-        storeAppendPrintf(sentry, "%10s\t%6d\t%6.2f\n",
+        sentry->appendf("%10s\t%6d\t%6.2f\n",
                           refreshCounts[i].proto,
                           refreshCounts[i].total,
                           xpercent(refreshCounts[i].total, total));
 
     /* per protocol histograms */
-    storeAppendPrintf(sentry, "\n\nRefreshCheck histograms for various protocols\n");
+    sentry->appendf("\n\nRefreshCheck histograms for various protocols\n");
 
     for (i = 0; i < rcCount; ++i)
         refreshCountsStats(sentry, refreshCounts[i]);

--- a/src/repl/lru/store_repl_lru.cc
+++ b/src/repl/lru/store_repl_lru.cc
@@ -281,7 +281,7 @@ again:
             goto again;
         }
 
-        storeAppendPrintf(sentry, "LRU reference age: %.2f days\n", (double) (squid_curtime - entry->lastref) / (double) (24 * 60 * 60));
+        sentry->appendf("LRU reference age: %.2f days\n", (double) (squid_curtime - entry->lastref) / (double) (24 * 60 * 60));
     }
 }
 

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -129,63 +129,63 @@ extern unsigned int mem_pool_free_calls;
 static void
 statUtilization(StoreEntry * e)
 {
-    storeAppendPrintf(e, "Cache Utilisation:\n");
-    storeAppendPrintf(e, "\n");
-    storeAppendPrintf(e, "Last 5 minutes:\n");
+    e->appendf("Cache Utilisation:\n");
+    e->appendf("\n");
+    e->appendf("Last 5 minutes:\n");
 
     if (NCountHist >= 5)
         statAvgDump(e, 5, 0);
     else
-        storeAppendPrintf(e, "(no values recorded yet)\n");
+        e->appendf("(no values recorded yet)\n");
 
-    storeAppendPrintf(e, "\n");
+    e->appendf("\n");
 
-    storeAppendPrintf(e, "Last 15 minutes:\n");
+    e->appendf("Last 15 minutes:\n");
 
     if (NCountHist >= 15)
         statAvgDump(e, 15, 0);
     else
-        storeAppendPrintf(e, "(no values recorded yet)\n");
+        e->appendf("(no values recorded yet)\n");
 
-    storeAppendPrintf(e, "\n");
+    e->appendf("\n");
 
-    storeAppendPrintf(e, "Last hour:\n");
+    e->appendf("Last hour:\n");
 
     if (NCountHist >= 60)
         statAvgDump(e, 60, 0);
     else
-        storeAppendPrintf(e, "(no values recorded yet)\n");
+        e->appendf("(no values recorded yet)\n");
 
-    storeAppendPrintf(e, "\n");
+    e->appendf("\n");
 
-    storeAppendPrintf(e, "Last 8 hours:\n");
+    e->appendf("Last 8 hours:\n");
 
     if (NCountHourHist >= 8)
         statAvgDump(e, 0, 8);
     else
-        storeAppendPrintf(e, "(no values recorded yet)\n");
+        e->appendf("(no values recorded yet)\n");
 
-    storeAppendPrintf(e, "\n");
+    e->appendf("\n");
 
-    storeAppendPrintf(e, "Last day:\n");
+    e->appendf("Last day:\n");
 
     if (NCountHourHist >= 24)
         statAvgDump(e, 0, 24);
     else
-        storeAppendPrintf(e, "(no values recorded yet)\n");
+        e->appendf("(no values recorded yet)\n");
 
-    storeAppendPrintf(e, "\n");
+    e->appendf("\n");
 
-    storeAppendPrintf(e, "Last 3 days:\n");
+    e->appendf("Last 3 days:\n");
 
     if (NCountHourHist >= 72)
         statAvgDump(e, 0, 72);
     else
-        storeAppendPrintf(e, "(no values recorded yet)\n");
+        e->appendf("(no values recorded yet)\n");
 
-    storeAppendPrintf(e, "\n");
+    e->appendf("\n");
 
-    storeAppendPrintf(e, "Totals since cache startup:\n");
+    e->appendf("Totals since cache startup:\n");
 
     statCountersDump(e);
 }
@@ -219,45 +219,45 @@ DumpIoStats(Mgr::IoActionData& stats, StoreEntry* sentry)
 {
     int i;
 
-    storeAppendPrintf(sentry, "HTTP I/O\n");
-    storeAppendPrintf(sentry, "number of reads: %.0f\n", stats.http_reads);
-    storeAppendPrintf(sentry, "Read Histogram:\n");
+    sentry->appendf("HTTP I/O\n");
+    sentry->appendf("number of reads: %.0f\n", stats.http_reads);
+    sentry->appendf("Read Histogram:\n");
 
     for (i = 0; i < IoStats::histSize; ++i) {
-        storeAppendPrintf(sentry, "%5d-%5d: %9.0f %2.0f%%\n",
+        sentry->appendf("%5d-%5d: %9.0f %2.0f%%\n",
                           i ? (1 << (i - 1)) + 1 : 1,
                           1 << i,
                           stats.http_read_hist[i],
                           Math::doublePercent(stats.http_read_hist[i], stats.http_reads));
     }
 
-    storeAppendPrintf(sentry, "\n");
-    storeAppendPrintf(sentry, "FTP I/O\n");
-    storeAppendPrintf(sentry, "number of reads: %.0f\n", stats.ftp_reads);
-    storeAppendPrintf(sentry, "Read Histogram:\n");
+    sentry->appendf("\n");
+    sentry->appendf("FTP I/O\n");
+    sentry->appendf("number of reads: %.0f\n", stats.ftp_reads);
+    sentry->appendf("Read Histogram:\n");
 
     for (i = 0; i < IoStats::histSize; ++i) {
-        storeAppendPrintf(sentry, "%5d-%5d: %9.0f %2.0f%%\n",
+        sentry->appendf("%5d-%5d: %9.0f %2.0f%%\n",
                           i ? (1 << (i - 1)) + 1 : 1,
                           1 << i,
                           stats.ftp_read_hist[i],
                           Math::doublePercent(stats.ftp_read_hist[i], stats.ftp_reads));
     }
 
-    storeAppendPrintf(sentry, "\n");
-    storeAppendPrintf(sentry, "Gopher I/O\n");
-    storeAppendPrintf(sentry, "number of reads: %.0f\n", stats.gopher_reads);
-    storeAppendPrintf(sentry, "Read Histogram:\n");
+    sentry->appendf("\n");
+    sentry->appendf("Gopher I/O\n");
+    sentry->appendf("number of reads: %.0f\n", stats.gopher_reads);
+    sentry->appendf("Read Histogram:\n");
 
     for (i = 0; i < IoStats::histSize; ++i) {
-        storeAppendPrintf(sentry, "%5d-%5d: %9.0f %2.0f%%\n",
+        sentry->appendf("%5d-%5d: %9.0f %2.0f%%\n",
                           i ? (1 << (i - 1)) + 1 : 1,
                           1 << i,
                           stats.gopher_read_hist[i],
                           Math::doublePercent(stats.gopher_read_hist[i], stats.gopher_reads));
     }
 
-    storeAppendPrintf(sentry, "\n");
+    sentry->appendf("\n");
 }
 
 static const char *
@@ -448,7 +448,7 @@ info_get_mallstat(int size, int number, int oldnum, void *data)
 
 // format: "%12s %15s %6s %12s\n","Alloc Size","Count","Delta","Alloc/sec"
     if (number > 0)
-        storeAppendPrintf(sentry, "%12d %15d %6d %.1f\n", size, number, number - oldnum, xdiv((number - oldnum), xm_deltat));
+        sentry->appendf("%12d %15d %6d %.1f\n", size, number, number - oldnum, xdiv((number - oldnum), xm_deltat));
 }
 
 #endif
@@ -580,210 +580,210 @@ GetInfo(Mgr::InfoActionData& stats)
 void
 DumpInfo(Mgr::InfoActionData& stats, StoreEntry* sentry)
 {
-    storeAppendPrintf(sentry, "Squid Object Cache: Version %s\n",
+    sentry->appendf("Squid Object Cache: Version %s\n",
                       version_string);
 
-    storeAppendPrintf(sentry, "Build Info: " SQUID_BUILD_INFO "\n");
+    sentry->appendf("Build Info: " SQUID_BUILD_INFO "\n");
 
 #if _SQUID_WINDOWS_
     if (WIN32_run_mode == _WIN_SQUID_RUN_MODE_SERVICE) {
-        storeAppendPrintf(sentry,"\nRunning as " SQUIDSBUFPH " Windows System Service on %s\n",
+        sentry->appendf("\nRunning as " SQUIDSBUFPH " Windows System Service on %s\n",
                           SQUIDSBUFPRINT(service_name), WIN32_OS_string);
-        storeAppendPrintf(sentry,"Service command line is: %s\n", WIN32_Service_Command_Line);
+        sentry->appendf("Service command line is: %s\n", WIN32_Service_Command_Line);
     } else
-        storeAppendPrintf(sentry,"Running on %s\n",WIN32_OS_string);
+        sentry->appendf("Running on %s\n",WIN32_OS_string);
 #else
-    storeAppendPrintf(sentry,"Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
+    sentry->appendf("Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
 #endif
 
-    storeAppendPrintf(sentry, "Start Time:\t%s\n",
+    sentry->appendf("Start Time:\t%s\n",
                       mkrfc1123(stats.squid_start.tv_sec));
 
-    storeAppendPrintf(sentry, "Current Time:\t%s\n",
+    sentry->appendf("Current Time:\t%s\n",
                       mkrfc1123(stats.current_time.tv_sec));
 
-    storeAppendPrintf(sentry, "Connection information for %s:\n",APP_SHORTNAME);
+    sentry->appendf("Connection information for %s:\n",APP_SHORTNAME);
 
     if (Config.onoff.client_db)
-        storeAppendPrintf(sentry, "\tNumber of clients accessing cache:\t%.0f\n", stats.client_http_clients);
+        sentry->appendf("\tNumber of clients accessing cache:\t%.0f\n", stats.client_http_clients);
     else
         sentry->append("\tNumber of clients accessing cache:\t(client_db off)\n", 52);
 
-    storeAppendPrintf(sentry, "\tNumber of HTTP requests received:\t%.0f\n",
+    sentry->appendf("\tNumber of HTTP requests received:\t%.0f\n",
                       stats.client_http_requests);
 
-    storeAppendPrintf(sentry, "\tNumber of ICP messages received:\t%.0f\n",
+    sentry->appendf("\tNumber of ICP messages received:\t%.0f\n",
                       stats.icp_pkts_recv);
 
-    storeAppendPrintf(sentry, "\tNumber of ICP messages sent:\t%.0f\n",
+    sentry->appendf("\tNumber of ICP messages sent:\t%.0f\n",
                       stats.icp_pkts_sent);
 
-    storeAppendPrintf(sentry, "\tNumber of queued ICP replies:\t%.0f\n",
+    sentry->appendf("\tNumber of queued ICP replies:\t%.0f\n",
                       stats.icp_replies_queued);
 
 #if USE_HTCP
 
-    storeAppendPrintf(sentry, "\tNumber of HTCP messages received:\t%.0f\n",
+    sentry->appendf("\tNumber of HTCP messages received:\t%.0f\n",
                       stats.htcp_pkts_recv);
 
-    storeAppendPrintf(sentry, "\tNumber of HTCP messages sent:\t%.0f\n",
+    sentry->appendf("\tNumber of HTCP messages sent:\t%.0f\n",
                       stats.htcp_pkts_sent);
 
 #endif
 
     double fct = stats.count > 1 ? stats.count : 1.0;
-    storeAppendPrintf(sentry, "\tRequest failure ratio:\t%5.2f\n",
+    sentry->appendf("\tRequest failure ratio:\t%5.2f\n",
                       stats.request_failure_ratio / fct);
 
-    storeAppendPrintf(sentry, "\tAverage HTTP requests per minute since start:\t%.1f\n",
+    sentry->appendf("\tAverage HTTP requests per minute since start:\t%.1f\n",
                       stats.avg_client_http_requests);
 
-    storeAppendPrintf(sentry, "\tAverage ICP messages per minute since start:\t%.1f\n",
+    sentry->appendf("\tAverage ICP messages per minute since start:\t%.1f\n",
                       stats.avg_icp_messages);
 
-    storeAppendPrintf(sentry, "\tSelect loop called: %.0f times, %0.3f ms avg\n",
+    sentry->appendf("\tSelect loop called: %.0f times, %0.3f ms avg\n",
                       stats.select_loops, stats.avg_loop_time / fct);
 
-    storeAppendPrintf(sentry, "Cache information for %s:\n",APP_SHORTNAME);
+    sentry->appendf("Cache information for %s:\n",APP_SHORTNAME);
 
-    storeAppendPrintf(sentry, "\tHits as %% of all requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
+    sentry->appendf("\tHits as %% of all requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
                       stats.request_hit_ratio5 / fct,
                       stats.request_hit_ratio60 / fct);
 
-    storeAppendPrintf(sentry, "\tHits as %% of bytes sent:\t5min: %3.1f%%, 60min: %3.1f%%\n",
+    sentry->appendf("\tHits as %% of bytes sent:\t5min: %3.1f%%, 60min: %3.1f%%\n",
                       stats.byte_hit_ratio5 / fct,
                       stats.byte_hit_ratio60 / fct);
 
-    storeAppendPrintf(sentry, "\tMemory hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
+    sentry->appendf("\tMemory hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
                       stats.request_hit_mem_ratio5 / fct,
                       stats.request_hit_mem_ratio60 / fct);
 
-    storeAppendPrintf(sentry, "\tDisk hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
+    sentry->appendf("\tDisk hits as %% of hit requests:\t5min: %3.1f%%, 60min: %3.1f%%\n",
                       stats.request_hit_disk_ratio5 / fct,
                       stats.request_hit_disk_ratio60 / fct);
 
-    storeAppendPrintf(sentry, "\tStorage Swap size:\t%.0f KB\n",
+    sentry->appendf("\tStorage Swap size:\t%.0f KB\n",
                       stats.store.swap.size / 1024);
 
-    storeAppendPrintf(sentry, "\tStorage Swap capacity:\t%4.1f%% used, %4.1f%% free\n",
+    sentry->appendf("\tStorage Swap capacity:\t%4.1f%% used, %4.1f%% free\n",
                       Math::doublePercent(stats.store.swap.size, stats.store.swap.capacity),
                       Math::doublePercent(stats.store.swap.available(), stats.store.swap.capacity));
 
-    storeAppendPrintf(sentry, "\tStorage Mem size:\t%.0f KB\n",
+    sentry->appendf("\tStorage Mem size:\t%.0f KB\n",
                       stats.store.mem.size / 1024);
 
-    storeAppendPrintf(sentry, "\tStorage Mem capacity:\t%4.1f%% used, %4.1f%% free\n",
+    sentry->appendf("\tStorage Mem capacity:\t%4.1f%% used, %4.1f%% free\n",
                       Math::doublePercent(stats.store.mem.size, stats.store.mem.capacity),
                       Math::doublePercent(stats.store.mem.available(), stats.store.mem.capacity));
 
-    storeAppendPrintf(sentry, "\tMean Object Size:\t%0.2f KB\n",
+    sentry->appendf("\tMean Object Size:\t%0.2f KB\n",
                       stats.store.swap.meanObjectSize() / 1024);
 
-    storeAppendPrintf(sentry, "\tRequests given to unlinkd:\t%.0f\n",
+    sentry->appendf("\tRequests given to unlinkd:\t%.0f\n",
                       stats.unlink_requests);
 
-    storeAppendPrintf(sentry, "Median Service Times (seconds)  5 min    60 min:\n");
+    sentry->appendf("Median Service Times (seconds)  5 min    60 min:\n");
 
     fct = stats.count > 1 ? stats.count * 1000.0 : 1000.0;
-    storeAppendPrintf(sentry, "\tHTTP Requests (All):  %8.5f %8.5f\n",
+    sentry->appendf("\tHTTP Requests (All):  %8.5f %8.5f\n",
                       stats.http_requests5 / fct,
                       stats.http_requests60 / fct);
 
-    storeAppendPrintf(sentry, "\tCache Misses:         %8.5f %8.5f\n",
+    sentry->appendf("\tCache Misses:         %8.5f %8.5f\n",
                       stats.cache_misses5 / fct,
                       stats.cache_misses60 / fct);
 
-    storeAppendPrintf(sentry, "\tCache Hits:           %8.5f %8.5f\n",
+    sentry->appendf("\tCache Hits:           %8.5f %8.5f\n",
                       stats.cache_hits5 / fct,
                       stats.cache_hits60 / fct);
 
-    storeAppendPrintf(sentry, "\tNear Hits:            %8.5f %8.5f\n",
+    sentry->appendf("\tNear Hits:            %8.5f %8.5f\n",
                       stats.near_hits5 / fct,
                       stats.near_hits60 / fct);
 
-    storeAppendPrintf(sentry, "\tNot-Modified Replies: %8.5f %8.5f\n",
+    sentry->appendf("\tNot-Modified Replies: %8.5f %8.5f\n",
                       stats.not_modified_replies5 / fct,
                       stats.not_modified_replies60 / fct);
 
-    storeAppendPrintf(sentry, "\tDNS Lookups:          %8.5f %8.5f\n",
+    sentry->appendf("\tDNS Lookups:          %8.5f %8.5f\n",
                       stats.dns_lookups5 / fct,
                       stats.dns_lookups60 / fct);
 
     fct = stats.count > 1 ? stats.count * 1000000.0 : 1000000.0;
-    storeAppendPrintf(sentry, "\tICP Queries:          %8.5f %8.5f\n",
+    sentry->appendf("\tICP Queries:          %8.5f %8.5f\n",
                       stats.icp_queries5 / fct,
                       stats.icp_queries60 / fct);
 
-    storeAppendPrintf(sentry, "Resource usage for %s:\n", APP_SHORTNAME);
+    sentry->appendf("Resource usage for %s:\n", APP_SHORTNAME);
 
-    storeAppendPrintf(sentry, "\tUP Time:\t%.3f seconds\n", stats.up_time);
+    sentry->appendf("\tUP Time:\t%.3f seconds\n", stats.up_time);
 
-    storeAppendPrintf(sentry, "\tCPU Time:\t%.3f seconds\n", stats.cpu_time);
+    sentry->appendf("\tCPU Time:\t%.3f seconds\n", stats.cpu_time);
 
-    storeAppendPrintf(sentry, "\tCPU Usage:\t%.2f%%\n",
+    sentry->appendf("\tCPU Usage:\t%.2f%%\n",
                       stats.cpu_usage);
 
-    storeAppendPrintf(sentry, "\tCPU Usage, 5 minute avg:\t%.2f%%\n",
+    sentry->appendf("\tCPU Usage, 5 minute avg:\t%.2f%%\n",
                       stats.cpu_usage5);
 
-    storeAppendPrintf(sentry, "\tCPU Usage, 60 minute avg:\t%.2f%%\n",
+    sentry->appendf("\tCPU Usage, 60 minute avg:\t%.2f%%\n",
                       stats.cpu_usage60);
 
-    storeAppendPrintf(sentry, "\tMaximum Resident Size: %.0f KB\n",
+    sentry->appendf("\tMaximum Resident Size: %.0f KB\n",
                       stats.maxrss);
 
-    storeAppendPrintf(sentry, "\tPage faults with physical i/o: %.0f\n",
+    sentry->appendf("\tPage faults with physical i/o: %.0f\n",
                       stats.page_faults);
 
 #if HAVE_MSTATS && HAVE_GNUMALLOC_H
 
-    storeAppendPrintf(sentry, "Memory usage for %s via mstats():\n",APP_SHORTNAME);
+    sentry->appendf("Memory usage for %s via mstats():\n",APP_SHORTNAME);
 
-    storeAppendPrintf(sentry, "\tTotal space in arena:  %6.0f KB\n",
+    sentry->appendf("\tTotal space in arena:  %6.0f KB\n",
                       stats.ms_bytes_total / 1024);
 
-    storeAppendPrintf(sentry, "\tTotal free:            %6.0f KB %.0f%%\n",
+    sentry->appendf("\tTotal free:            %6.0f KB %.0f%%\n",
                       stats.ms_bytes_free / 1024,
                       Math::doublePercent(stats.ms_bytes_free, stats.ms_bytes_total));
 
 #endif
 
-    storeAppendPrintf(sentry, "Memory accounted for:\n");
-    storeAppendPrintf(sentry, "\tTotal accounted:       %6.0f KB\n",
+    sentry->appendf("Memory accounted for:\n");
+    sentry->appendf("\tTotal accounted:       %6.0f KB\n",
                       stats.total_accounted / 1024);
     {
         MemPoolGlobalStats mp_stats;
         memPoolGetGlobalStats(&mp_stats);
-        storeAppendPrintf(sentry, "\tmemPoolAlloc calls: %9.0f\n",
+        sentry->appendf("\tmemPoolAlloc calls: %9.0f\n",
                           stats.gb_saved_count);
-        storeAppendPrintf(sentry, "\tmemPoolFree calls:  %9.0f\n",
+        sentry->appendf("\tmemPoolFree calls:  %9.0f\n",
                           stats.gb_freed_count);
     }
 
-    storeAppendPrintf(sentry, "File descriptor usage for %s:\n", APP_SHORTNAME);
-    storeAppendPrintf(sentry, "\tMaximum number of file descriptors:   %4.0f\n",
+    sentry->appendf("File descriptor usage for %s:\n", APP_SHORTNAME);
+    sentry->appendf("\tMaximum number of file descriptors:   %4.0f\n",
                       stats.max_fd);
-    storeAppendPrintf(sentry, "\tLargest file desc currently in use:   %4.0f\n",
+    sentry->appendf("\tLargest file desc currently in use:   %4.0f\n",
                       stats.biggest_fd);
-    storeAppendPrintf(sentry, "\tNumber of file desc currently in use: %4.0f\n",
+    sentry->appendf("\tNumber of file desc currently in use: %4.0f\n",
                       stats.number_fd);
-    storeAppendPrintf(sentry, "\tFiles queued for open:                %4.0f\n",
+    sentry->appendf("\tFiles queued for open:                %4.0f\n",
                       stats.opening_fd);
-    storeAppendPrintf(sentry, "\tAvailable number of file descriptors: %4.0f\n",
+    sentry->appendf("\tAvailable number of file descriptors: %4.0f\n",
                       stats.num_fd_free);
-    storeAppendPrintf(sentry, "\tReserved number of file descriptors:  %4.0f\n",
+    sentry->appendf("\tReserved number of file descriptors:  %4.0f\n",
                       stats.reserved_fd);
-    storeAppendPrintf(sentry, "\tStore Disk files open:                %4.0f\n",
+    sentry->appendf("\tStore Disk files open:                %4.0f\n",
                       stats.store.swap.open_disk_fd);
 
-    storeAppendPrintf(sentry, "Internal Data Structures:\n");
-    storeAppendPrintf(sentry, "\t%6.0f StoreEntries\n",
+    sentry->appendf("Internal Data Structures:\n");
+    sentry->appendf("\t%6.0f StoreEntries\n",
                       stats.store.store_entry_count);
-    storeAppendPrintf(sentry, "\t%6.0f StoreEntries with MemObjects\n",
+    sentry->appendf("\t%6.0f StoreEntries with MemObjects\n",
                       stats.store.mem_object_count);
-    storeAppendPrintf(sentry, "\t%6.0f Hot Object Cache Items\n",
+    sentry->appendf("\t%6.0f Hot Object Cache Items\n",
                       stats.store.mem.count);
-    storeAppendPrintf(sentry, "\t%6.0f on-disk objects\n",
+    sentry->appendf("\t%6.0f on-disk objects\n",
                       stats.store.swap.count);
 }
 
@@ -793,8 +793,8 @@ DumpMallocStatistics(StoreEntry* sentry)
 #if XMALLOC_STATISTICS
     xm_deltat = current_dtime - xm_time;
     xm_time = current_dtime;
-    storeAppendPrintf(sentry, "\nMemory allocation statistics\n");
-    storeAppendPrintf(sentry, "%12s %15s %6s %12s\n","Alloc Size","Count","Delta","Alloc/sec");
+    sentry->appendf("\nMemory allocation statistics\n");
+    sentry->appendf("%12s %15s %6s %12s\n","Alloc Size","Count","Delta","Alloc/sec");
     malloc_statistics(info_get_mallstat, sentry);
 #endif
 }
@@ -830,47 +830,47 @@ GetServiceTimesStats(Mgr::ServiceTimesActionData& stats)
 void
 DumpServiceTimesStats(Mgr::ServiceTimesActionData& stats, StoreEntry* sentry)
 {
-    storeAppendPrintf(sentry, "Service Time Percentiles            5 min    60 min:\n");
+    sentry->appendf("Service Time Percentiles            5 min    60 min:\n");
     double fct = stats.count > 1 ? stats.count * 1000.0 : 1000.0;
     for (int i = 0; i < Mgr::ServiceTimesActionData::seriesSize; ++i) {
-        storeAppendPrintf(sentry, "\tHTTP Requests (All):  %2d%%  %8.5f %8.5f\n",
+        sentry->appendf("\tHTTP Requests (All):  %2d%%  %8.5f %8.5f\n",
                           (i + 1) * 5,
                           stats.http_requests5[i] / fct,
                           stats.http_requests60[i] / fct);
     }
     for (int i = 0; i < Mgr::ServiceTimesActionData::seriesSize; ++i) {
-        storeAppendPrintf(sentry, "\tCache Misses:         %2d%%  %8.5f %8.5f\n",
+        sentry->appendf("\tCache Misses:         %2d%%  %8.5f %8.5f\n",
                           (i + 1) * 5,
                           stats.cache_misses5[i] / fct,
                           stats.cache_misses60[i] / fct);
     }
     for (int i = 0; i < Mgr::ServiceTimesActionData::seriesSize; ++i) {
-        storeAppendPrintf(sentry, "\tCache Hits:           %2d%%  %8.5f %8.5f\n",
+        sentry->appendf("\tCache Hits:           %2d%%  %8.5f %8.5f\n",
                           (i + 1) * 5,
                           stats.cache_hits5[i] / fct,
                           stats.cache_hits60[i] / fct);
     }
     for (int i = 0; i < Mgr::ServiceTimesActionData::seriesSize; ++i) {
-        storeAppendPrintf(sentry, "\tNear Hits:            %2d%%  %8.5f %8.5f\n",
+        sentry->appendf("\tNear Hits:            %2d%%  %8.5f %8.5f\n",
                           (i + 1) * 5,
                           stats.near_hits5[i] / fct,
                           stats.near_hits60[i] / fct);
     }
     for (int i = 0; i < Mgr::ServiceTimesActionData::seriesSize; ++i) {
-        storeAppendPrintf(sentry, "\tNot-Modified Replies: %2d%%  %8.5f %8.5f\n",
+        sentry->appendf("\tNot-Modified Replies: %2d%%  %8.5f %8.5f\n",
                           (i + 1) * 5,
                           stats.not_modified_replies5[i] / fct,
                           stats.not_modified_replies60[i] / fct);
     }
     for (int i = 0; i < Mgr::ServiceTimesActionData::seriesSize; ++i) {
-        storeAppendPrintf(sentry, "\tDNS Lookups:          %2d%%  %8.5f %8.5f\n",
+        sentry->appendf("\tDNS Lookups:          %2d%%  %8.5f %8.5f\n",
                           (i + 1) * 5,
                           stats.dns_lookups5[i] / fct,
                           stats.dns_lookups60[i] / fct);
     }
     fct = stats.count > 1 ? stats.count * 1000000.0 : 1000000.0;
     for (int i = 0; i < Mgr::ServiceTimesActionData::seriesSize; ++i) {
-        storeAppendPrintf(sentry, "\tICP Queries:          %2d%%  %8.5f %8.5f\n",
+        sentry->appendf("\tICP Queries:          %2d%%  %8.5f %8.5f\n",
                           (i + 1) * 5,
                           stats.icp_queries5[i] / fct,
                           stats.icp_queries60[i] / fct);
@@ -1025,165 +1025,165 @@ GetAvgStat(Mgr::IntervalActionData& stats, int minutes, int hours)
 void
 DumpAvgStat(Mgr::IntervalActionData& stats, StoreEntry* sentry)
 {
-    storeAppendPrintf(sentry, "sample_start_time = %d.%d (%s)\n",
+    sentry->appendf("sample_start_time = %d.%d (%s)\n",
                       (int)stats.sample_start_time.tv_sec,
                       (int)stats.sample_start_time.tv_usec,
                       mkrfc1123(stats.sample_start_time.tv_sec));
-    storeAppendPrintf(sentry, "sample_end_time = %d.%d (%s)\n",
+    sentry->appendf("sample_end_time = %d.%d (%s)\n",
                       (int)stats.sample_end_time.tv_sec,
                       (int)stats.sample_end_time.tv_usec,
                       mkrfc1123(stats.sample_end_time.tv_sec));
 
-    storeAppendPrintf(sentry, "client_http.requests = %f/sec\n",
+    sentry->appendf("client_http.requests = %f/sec\n",
                       stats.client_http_requests);
-    storeAppendPrintf(sentry, "client_http.hits = %f/sec\n",
+    sentry->appendf("client_http.hits = %f/sec\n",
                       stats.client_http_hits);
-    storeAppendPrintf(sentry, "client_http.errors = %f/sec\n",
+    sentry->appendf("client_http.errors = %f/sec\n",
                       stats.client_http_errors);
-    storeAppendPrintf(sentry, "client_http.kbytes_in = %f/sec\n",
+    sentry->appendf("client_http.kbytes_in = %f/sec\n",
                       stats.client_http_kbytes_in);
-    storeAppendPrintf(sentry, "client_http.kbytes_out = %f/sec\n",
+    sentry->appendf("client_http.kbytes_out = %f/sec\n",
                       stats.client_http_kbytes_out);
 
     double fct = stats.count > 1 ? stats.count : 1.0;
-    storeAppendPrintf(sentry, "client_http.all_median_svc_time = %f seconds\n",
+    sentry->appendf("client_http.all_median_svc_time = %f seconds\n",
                       stats.client_http_all_median_svc_time / fct);
-    storeAppendPrintf(sentry, "client_http.miss_median_svc_time = %f seconds\n",
+    sentry->appendf("client_http.miss_median_svc_time = %f seconds\n",
                       stats.client_http_miss_median_svc_time / fct);
-    storeAppendPrintf(sentry, "client_http.nm_median_svc_time = %f seconds\n",
+    sentry->appendf("client_http.nm_median_svc_time = %f seconds\n",
                       stats.client_http_nm_median_svc_time / fct);
-    storeAppendPrintf(sentry, "client_http.nh_median_svc_time = %f seconds\n",
+    sentry->appendf("client_http.nh_median_svc_time = %f seconds\n",
                       stats.client_http_nh_median_svc_time / fct);
-    storeAppendPrintf(sentry, "client_http.hit_median_svc_time = %f seconds\n",
+    sentry->appendf("client_http.hit_median_svc_time = %f seconds\n",
                       stats.client_http_hit_median_svc_time / fct);
 
-    storeAppendPrintf(sentry, "server.all.requests = %f/sec\n",
+    sentry->appendf("server.all.requests = %f/sec\n",
                       stats.server_all_requests);
-    storeAppendPrintf(sentry, "server.all.errors = %f/sec\n",
+    sentry->appendf("server.all.errors = %f/sec\n",
                       stats.server_all_errors);
-    storeAppendPrintf(sentry, "server.all.kbytes_in = %f/sec\n",
+    sentry->appendf("server.all.kbytes_in = %f/sec\n",
                       stats.server_all_kbytes_in);
-    storeAppendPrintf(sentry, "server.all.kbytes_out = %f/sec\n",
+    sentry->appendf("server.all.kbytes_out = %f/sec\n",
                       stats.server_all_kbytes_out);
 
-    storeAppendPrintf(sentry, "server.http.requests = %f/sec\n",
+    sentry->appendf("server.http.requests = %f/sec\n",
                       stats.server_http_requests);
-    storeAppendPrintf(sentry, "server.http.errors = %f/sec\n",
+    sentry->appendf("server.http.errors = %f/sec\n",
                       stats.server_http_errors);
-    storeAppendPrintf(sentry, "server.http.kbytes_in = %f/sec\n",
+    sentry->appendf("server.http.kbytes_in = %f/sec\n",
                       stats.server_http_kbytes_in);
-    storeAppendPrintf(sentry, "server.http.kbytes_out = %f/sec\n",
+    sentry->appendf("server.http.kbytes_out = %f/sec\n",
                       stats.server_http_kbytes_out);
 
-    storeAppendPrintf(sentry, "server.ftp.requests = %f/sec\n",
+    sentry->appendf("server.ftp.requests = %f/sec\n",
                       stats.server_ftp_requests);
-    storeAppendPrintf(sentry, "server.ftp.errors = %f/sec\n",
+    sentry->appendf("server.ftp.errors = %f/sec\n",
                       stats.server_ftp_errors);
-    storeAppendPrintf(sentry, "server.ftp.kbytes_in = %f/sec\n",
+    sentry->appendf("server.ftp.kbytes_in = %f/sec\n",
                       stats.server_ftp_kbytes_in);
-    storeAppendPrintf(sentry, "server.ftp.kbytes_out = %f/sec\n",
+    sentry->appendf("server.ftp.kbytes_out = %f/sec\n",
                       stats.server_ftp_kbytes_out);
 
-    storeAppendPrintf(sentry, "server.other.requests = %f/sec\n",
+    sentry->appendf("server.other.requests = %f/sec\n",
                       stats.server_other_requests);
-    storeAppendPrintf(sentry, "server.other.errors = %f/sec\n",
+    sentry->appendf("server.other.errors = %f/sec\n",
                       stats.server_other_errors);
-    storeAppendPrintf(sentry, "server.other.kbytes_in = %f/sec\n",
+    sentry->appendf("server.other.kbytes_in = %f/sec\n",
                       stats.server_other_kbytes_in);
-    storeAppendPrintf(sentry, "server.other.kbytes_out = %f/sec\n",
+    sentry->appendf("server.other.kbytes_out = %f/sec\n",
                       stats.server_other_kbytes_out);
 
-    storeAppendPrintf(sentry, "icp.pkts_sent = %f/sec\n",
+    sentry->appendf("icp.pkts_sent = %f/sec\n",
                       stats.icp_pkts_sent);
-    storeAppendPrintf(sentry, "icp.pkts_recv = %f/sec\n",
+    sentry->appendf("icp.pkts_recv = %f/sec\n",
                       stats.icp_pkts_recv);
-    storeAppendPrintf(sentry, "icp.queries_sent = %f/sec\n",
+    sentry->appendf("icp.queries_sent = %f/sec\n",
                       stats.icp_queries_sent);
-    storeAppendPrintf(sentry, "icp.replies_sent = %f/sec\n",
+    sentry->appendf("icp.replies_sent = %f/sec\n",
                       stats.icp_replies_sent);
-    storeAppendPrintf(sentry, "icp.queries_recv = %f/sec\n",
+    sentry->appendf("icp.queries_recv = %f/sec\n",
                       stats.icp_queries_recv);
-    storeAppendPrintf(sentry, "icp.replies_recv = %f/sec\n",
+    sentry->appendf("icp.replies_recv = %f/sec\n",
                       stats.icp_replies_recv);
-    storeAppendPrintf(sentry, "icp.replies_queued = %f/sec\n",
+    sentry->appendf("icp.replies_queued = %f/sec\n",
                       stats.icp_replies_queued);
-    storeAppendPrintf(sentry, "icp.query_timeouts = %f/sec\n",
+    sentry->appendf("icp.query_timeouts = %f/sec\n",
                       stats.icp_query_timeouts);
-    storeAppendPrintf(sentry, "icp.kbytes_sent = %f/sec\n",
+    sentry->appendf("icp.kbytes_sent = %f/sec\n",
                       stats.icp_kbytes_sent);
-    storeAppendPrintf(sentry, "icp.kbytes_recv = %f/sec\n",
+    sentry->appendf("icp.kbytes_recv = %f/sec\n",
                       stats.icp_kbytes_recv);
-    storeAppendPrintf(sentry, "icp.q_kbytes_sent = %f/sec\n",
+    sentry->appendf("icp.q_kbytes_sent = %f/sec\n",
                       stats.icp_q_kbytes_sent);
-    storeAppendPrintf(sentry, "icp.r_kbytes_sent = %f/sec\n",
+    sentry->appendf("icp.r_kbytes_sent = %f/sec\n",
                       stats.icp_r_kbytes_sent);
-    storeAppendPrintf(sentry, "icp.q_kbytes_recv = %f/sec\n",
+    sentry->appendf("icp.q_kbytes_recv = %f/sec\n",
                       stats.icp_q_kbytes_recv);
-    storeAppendPrintf(sentry, "icp.r_kbytes_recv = %f/sec\n",
+    sentry->appendf("icp.r_kbytes_recv = %f/sec\n",
                       stats.icp_r_kbytes_recv);
-    storeAppendPrintf(sentry, "icp.query_median_svc_time = %f seconds\n",
+    sentry->appendf("icp.query_median_svc_time = %f seconds\n",
                       stats.icp_query_median_svc_time / fct);
-    storeAppendPrintf(sentry, "icp.reply_median_svc_time = %f seconds\n",
+    sentry->appendf("icp.reply_median_svc_time = %f seconds\n",
                       stats.icp_reply_median_svc_time / fct);
-    storeAppendPrintf(sentry, "dns.median_svc_time = %f seconds\n",
+    sentry->appendf("dns.median_svc_time = %f seconds\n",
                       stats.dns_median_svc_time / fct);
-    storeAppendPrintf(sentry, "unlink.requests = %f/sec\n",
+    sentry->appendf("unlink.requests = %f/sec\n",
                       stats.unlink_requests);
-    storeAppendPrintf(sentry, "page_faults = %f/sec\n",
+    sentry->appendf("page_faults = %f/sec\n",
                       stats.page_faults);
-    storeAppendPrintf(sentry, "select_loops = %f/sec\n",
+    sentry->appendf("select_loops = %f/sec\n",
                       stats.select_loops);
-    storeAppendPrintf(sentry, "select_fds = %f/sec\n",
+    sentry->appendf("select_fds = %f/sec\n",
                       stats.select_fds);
-    storeAppendPrintf(sentry, "average_select_fd_period = %f/fd\n",
+    sentry->appendf("average_select_fd_period = %f/fd\n",
                       stats.average_select_fd_period / fct);
-    storeAppendPrintf(sentry, "median_select_fds = %f\n",
+    sentry->appendf("median_select_fds = %f\n",
                       stats.median_select_fds / fct);
-    storeAppendPrintf(sentry, "swap.outs = %f/sec\n",
+    sentry->appendf("swap.outs = %f/sec\n",
                       stats.swap_outs);
-    storeAppendPrintf(sentry, "swap.ins = %f/sec\n",
+    sentry->appendf("swap.ins = %f/sec\n",
                       stats.swap_ins);
-    storeAppendPrintf(sentry, "swap.files_cleaned = %f/sec\n",
+    sentry->appendf("swap.files_cleaned = %f/sec\n",
                       stats.swap_files_cleaned);
-    storeAppendPrintf(sentry, "aborted_requests = %f/sec\n",
+    sentry->appendf("aborted_requests = %f/sec\n",
                       stats.aborted_requests);
 
-    storeAppendPrintf(sentry, "hit_validation.attempts = %f/sec\n",
+    sentry->appendf("hit_validation.attempts = %f/sec\n",
                       stats.hitValidationAttempts);
-    storeAppendPrintf(sentry, "hit_validation.refusals.due_to_locking = %f/sec\n",
+    sentry->appendf("hit_validation.refusals.due_to_locking = %f/sec\n",
                       stats.hitValidationRefusalsDueToLocking);
-    storeAppendPrintf(sentry, "hit_validation.refusals.due_to_zeroSize = %f/sec\n",
+    sentry->appendf("hit_validation.refusals.due_to_zeroSize = %f/sec\n",
                       stats.hitValidationRefusalsDueToZeroSize);
-    storeAppendPrintf(sentry, "hit_validation.refusals.due_to_timeLimit = %f/sec\n",
+    sentry->appendf("hit_validation.refusals.due_to_timeLimit = %f/sec\n",
                       stats.hitValidationRefusalsDueToTimeLimit);
-    storeAppendPrintf(sentry, "hit_validation.failures = %f/sec\n",
+    sentry->appendf("hit_validation.failures = %f/sec\n",
                       stats.hitValidationFailures);
 
 #if USE_POLL
-    storeAppendPrintf(sentry, "syscalls.polls = %f/sec\n", stats.syscalls_selects);
+    sentry->appendf("syscalls.polls = %f/sec\n", stats.syscalls_selects);
 #elif defined(USE_SELECT) || defined(USE_SELECT_WIN32)
-    storeAppendPrintf(sentry, "syscalls.selects = %f/sec\n", stats.syscalls_selects);
+    sentry->appendf("syscalls.selects = %f/sec\n", stats.syscalls_selects);
 #endif
 
-    storeAppendPrintf(sentry, "syscalls.disk.opens = %f/sec\n", stats.syscalls_disk_opens);
-    storeAppendPrintf(sentry, "syscalls.disk.closes = %f/sec\n", stats.syscalls_disk_closes);
-    storeAppendPrintf(sentry, "syscalls.disk.reads = %f/sec\n", stats.syscalls_disk_reads);
-    storeAppendPrintf(sentry, "syscalls.disk.writes = %f/sec\n", stats.syscalls_disk_writes);
-    storeAppendPrintf(sentry, "syscalls.disk.seeks = %f/sec\n", stats.syscalls_disk_seeks);
-    storeAppendPrintf(sentry, "syscalls.disk.unlinks = %f/sec\n", stats.syscalls_disk_unlinks);
-    storeAppendPrintf(sentry, "syscalls.sock.accepts = %f/sec\n", stats.syscalls_sock_accepts);
-    storeAppendPrintf(sentry, "syscalls.sock.sockets = %f/sec\n", stats.syscalls_sock_sockets);
-    storeAppendPrintf(sentry, "syscalls.sock.connects = %f/sec\n", stats.syscalls_sock_connects);
-    storeAppendPrintf(sentry, "syscalls.sock.binds = %f/sec\n", stats.syscalls_sock_binds);
-    storeAppendPrintf(sentry, "syscalls.sock.closes = %f/sec\n", stats.syscalls_sock_closes);
-    storeAppendPrintf(sentry, "syscalls.sock.reads = %f/sec\n", stats.syscalls_sock_reads);
-    storeAppendPrintf(sentry, "syscalls.sock.writes = %f/sec\n", stats.syscalls_sock_writes);
-    storeAppendPrintf(sentry, "syscalls.sock.recvfroms = %f/sec\n", stats.syscalls_sock_recvfroms);
-    storeAppendPrintf(sentry, "syscalls.sock.sendtos = %f/sec\n", stats.syscalls_sock_sendtos);
+    sentry->appendf("syscalls.disk.opens = %f/sec\n", stats.syscalls_disk_opens);
+    sentry->appendf("syscalls.disk.closes = %f/sec\n", stats.syscalls_disk_closes);
+    sentry->appendf("syscalls.disk.reads = %f/sec\n", stats.syscalls_disk_reads);
+    sentry->appendf("syscalls.disk.writes = %f/sec\n", stats.syscalls_disk_writes);
+    sentry->appendf("syscalls.disk.seeks = %f/sec\n", stats.syscalls_disk_seeks);
+    sentry->appendf("syscalls.disk.unlinks = %f/sec\n", stats.syscalls_disk_unlinks);
+    sentry->appendf("syscalls.sock.accepts = %f/sec\n", stats.syscalls_sock_accepts);
+    sentry->appendf("syscalls.sock.sockets = %f/sec\n", stats.syscalls_sock_sockets);
+    sentry->appendf("syscalls.sock.connects = %f/sec\n", stats.syscalls_sock_connects);
+    sentry->appendf("syscalls.sock.binds = %f/sec\n", stats.syscalls_sock_binds);
+    sentry->appendf("syscalls.sock.closes = %f/sec\n", stats.syscalls_sock_closes);
+    sentry->appendf("syscalls.sock.reads = %f/sec\n", stats.syscalls_sock_reads);
+    sentry->appendf("syscalls.sock.writes = %f/sec\n", stats.syscalls_sock_writes);
+    sentry->appendf("syscalls.sock.recvfroms = %f/sec\n", stats.syscalls_sock_recvfroms);
+    sentry->appendf("syscalls.sock.sendtos = %f/sec\n", stats.syscalls_sock_sendtos);
 
-    storeAppendPrintf(sentry, "cpu_time = %f seconds\n", stats.cpu_time);
-    storeAppendPrintf(sentry, "wall_time = %f seconds\n", stats.wall_time);
-    storeAppendPrintf(sentry, "cpu_usage = %f%%\n", Math::doublePercent(stats.cpu_time, stats.wall_time));
+    sentry->appendf("cpu_time = %f seconds\n", stats.cpu_time);
+    sentry->appendf("wall_time = %f seconds\n", stats.wall_time);
+    sentry->appendf("cpu_usage = %f%%\n", Math::doublePercent(stats.cpu_time, stats.wall_time));
 }
 
 static void
@@ -1351,23 +1351,23 @@ statAvgTick(void *)
 static void
 statCountersHistograms(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "client_http.allSvcTime histogram:\n");
+    sentry->appendf("client_http.allSvcTime histogram:\n");
     statCounter.client_http.allSvcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "client_http.missSvcTime histogram:\n");
+    sentry->appendf("client_http.missSvcTime histogram:\n");
     statCounter.client_http.missSvcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "client_http.nearMissSvcTime histogram:\n");
+    sentry->appendf("client_http.nearMissSvcTime histogram:\n");
     statCounter.client_http.nearMissSvcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "client_http.nearHitSvcTime histogram:\n");
+    sentry->appendf("client_http.nearHitSvcTime histogram:\n");
     statCounter.client_http.nearHitSvcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "client_http.hitSvcTime histogram:\n");
+    sentry->appendf("client_http.hitSvcTime histogram:\n");
     statCounter.client_http.hitSvcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "icp.querySvcTime histogram:\n");
+    sentry->appendf("icp.querySvcTime histogram:\n");
     statCounter.icp.querySvcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "icp.replySvcTime histogram:\n");
+    sentry->appendf("icp.replySvcTime histogram:\n");
     statCounter.icp.replySvcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "dns.svc_time histogram:\n");
+    sentry->appendf("dns.svc_time histogram:\n");
     statCounter.dns.svcTime.dump(sentry, NULL);
-    storeAppendPrintf(sentry, "select_fds_hist histogram:\n");
+    sentry->appendf("select_fds_hist histogram:\n");
     statCounter.select_fds_hist.dump(sentry, NULL);
 }
 
@@ -1464,136 +1464,136 @@ GetCountersStats(Mgr::CountersActionData& stats)
 void
 DumpCountersStats(Mgr::CountersActionData& stats, StoreEntry* sentry)
 {
-    storeAppendPrintf(sentry, "sample_time = %d.%d (%s)\n",
+    sentry->appendf("sample_time = %d.%d (%s)\n",
                       (int) stats.sample_time.tv_sec,
                       (int) stats.sample_time.tv_usec,
                       mkrfc1123(stats.sample_time.tv_sec));
-    storeAppendPrintf(sentry, "client_http.requests = %.0f\n",
+    sentry->appendf("client_http.requests = %.0f\n",
                       stats.client_http_requests);
-    storeAppendPrintf(sentry, "client_http.hits = %.0f\n",
+    sentry->appendf("client_http.hits = %.0f\n",
                       stats.client_http_hits);
-    storeAppendPrintf(sentry, "client_http.errors = %.0f\n",
+    sentry->appendf("client_http.errors = %.0f\n",
                       stats.client_http_errors);
-    storeAppendPrintf(sentry, "client_http.kbytes_in = %.0f\n",
+    sentry->appendf("client_http.kbytes_in = %.0f\n",
                       stats.client_http_kbytes_in);
-    storeAppendPrintf(sentry, "client_http.kbytes_out = %.0f\n",
+    sentry->appendf("client_http.kbytes_out = %.0f\n",
                       stats.client_http_kbytes_out);
-    storeAppendPrintf(sentry, "client_http.hit_kbytes_out = %.0f\n",
+    sentry->appendf("client_http.hit_kbytes_out = %.0f\n",
                       stats.client_http_hit_kbytes_out);
 
-    storeAppendPrintf(sentry, "server.all.requests = %.0f\n",
+    sentry->appendf("server.all.requests = %.0f\n",
                       stats.server_all_requests);
-    storeAppendPrintf(sentry, "server.all.errors = %.0f\n",
+    sentry->appendf("server.all.errors = %.0f\n",
                       stats.server_all_errors);
-    storeAppendPrintf(sentry, "server.all.kbytes_in = %.0f\n",
+    sentry->appendf("server.all.kbytes_in = %.0f\n",
                       stats.server_all_kbytes_in);
-    storeAppendPrintf(sentry, "server.all.kbytes_out = %.0f\n",
+    sentry->appendf("server.all.kbytes_out = %.0f\n",
                       stats.server_all_kbytes_out);
 
-    storeAppendPrintf(sentry, "server.http.requests = %.0f\n",
+    sentry->appendf("server.http.requests = %.0f\n",
                       stats.server_http_requests);
-    storeAppendPrintf(sentry, "server.http.errors = %.0f\n",
+    sentry->appendf("server.http.errors = %.0f\n",
                       stats.server_http_errors);
-    storeAppendPrintf(sentry, "server.http.kbytes_in = %.0f\n",
+    sentry->appendf("server.http.kbytes_in = %.0f\n",
                       stats.server_http_kbytes_in);
-    storeAppendPrintf(sentry, "server.http.kbytes_out = %.0f\n",
+    sentry->appendf("server.http.kbytes_out = %.0f\n",
                       stats.server_http_kbytes_out);
 
-    storeAppendPrintf(sentry, "server.ftp.requests = %.0f\n",
+    sentry->appendf("server.ftp.requests = %.0f\n",
                       stats.server_ftp_requests);
-    storeAppendPrintf(sentry, "server.ftp.errors = %.0f\n",
+    sentry->appendf("server.ftp.errors = %.0f\n",
                       stats.server_ftp_errors);
-    storeAppendPrintf(sentry, "server.ftp.kbytes_in = %.0f\n",
+    sentry->appendf("server.ftp.kbytes_in = %.0f\n",
                       stats.server_ftp_kbytes_in);
-    storeAppendPrintf(sentry, "server.ftp.kbytes_out = %.0f\n",
+    sentry->appendf("server.ftp.kbytes_out = %.0f\n",
                       stats.server_ftp_kbytes_out);
 
-    storeAppendPrintf(sentry, "server.other.requests = %.0f\n",
+    sentry->appendf("server.other.requests = %.0f\n",
                       stats.server_other_requests);
-    storeAppendPrintf(sentry, "server.other.errors = %.0f\n",
+    sentry->appendf("server.other.errors = %.0f\n",
                       stats.server_other_errors);
-    storeAppendPrintf(sentry, "server.other.kbytes_in = %.0f\n",
+    sentry->appendf("server.other.kbytes_in = %.0f\n",
                       stats.server_other_kbytes_in);
-    storeAppendPrintf(sentry, "server.other.kbytes_out = %.0f\n",
+    sentry->appendf("server.other.kbytes_out = %.0f\n",
                       stats.server_other_kbytes_out);
 
-    storeAppendPrintf(sentry, "icp.pkts_sent = %.0f\n",
+    sentry->appendf("icp.pkts_sent = %.0f\n",
                       stats.icp_pkts_sent);
-    storeAppendPrintf(sentry, "icp.pkts_recv = %.0f\n",
+    sentry->appendf("icp.pkts_recv = %.0f\n",
                       stats.icp_pkts_recv);
-    storeAppendPrintf(sentry, "icp.queries_sent = %.0f\n",
+    sentry->appendf("icp.queries_sent = %.0f\n",
                       stats.icp_queries_sent);
-    storeAppendPrintf(sentry, "icp.replies_sent = %.0f\n",
+    sentry->appendf("icp.replies_sent = %.0f\n",
                       stats.icp_replies_sent);
-    storeAppendPrintf(sentry, "icp.queries_recv = %.0f\n",
+    sentry->appendf("icp.queries_recv = %.0f\n",
                       stats.icp_queries_recv);
-    storeAppendPrintf(sentry, "icp.replies_recv = %.0f\n",
+    sentry->appendf("icp.replies_recv = %.0f\n",
                       stats.icp_replies_recv);
-    storeAppendPrintf(sentry, "icp.query_timeouts = %.0f\n",
+    sentry->appendf("icp.query_timeouts = %.0f\n",
                       stats.icp_query_timeouts);
-    storeAppendPrintf(sentry, "icp.replies_queued = %.0f\n",
+    sentry->appendf("icp.replies_queued = %.0f\n",
                       stats.icp_replies_queued);
-    storeAppendPrintf(sentry, "icp.kbytes_sent = %.0f\n",
+    sentry->appendf("icp.kbytes_sent = %.0f\n",
                       stats.icp_kbytes_sent);
-    storeAppendPrintf(sentry, "icp.kbytes_recv = %.0f\n",
+    sentry->appendf("icp.kbytes_recv = %.0f\n",
                       stats.icp_kbytes_recv);
-    storeAppendPrintf(sentry, "icp.q_kbytes_sent = %.0f\n",
+    sentry->appendf("icp.q_kbytes_sent = %.0f\n",
                       stats.icp_q_kbytes_sent);
-    storeAppendPrintf(sentry, "icp.r_kbytes_sent = %.0f\n",
+    sentry->appendf("icp.r_kbytes_sent = %.0f\n",
                       stats.icp_r_kbytes_sent);
-    storeAppendPrintf(sentry, "icp.q_kbytes_recv = %.0f\n",
+    sentry->appendf("icp.q_kbytes_recv = %.0f\n",
                       stats.icp_q_kbytes_recv);
-    storeAppendPrintf(sentry, "icp.r_kbytes_recv = %.0f\n",
+    sentry->appendf("icp.r_kbytes_recv = %.0f\n",
                       stats.icp_r_kbytes_recv);
 
 #if USE_CACHE_DIGESTS
 
-    storeAppendPrintf(sentry, "icp.times_used = %.0f\n",
+    sentry->appendf("icp.times_used = %.0f\n",
                       stats.icp_times_used);
-    storeAppendPrintf(sentry, "cd.times_used = %.0f\n",
+    sentry->appendf("cd.times_used = %.0f\n",
                       stats.cd_times_used);
-    storeAppendPrintf(sentry, "cd.msgs_sent = %.0f\n",
+    sentry->appendf("cd.msgs_sent = %.0f\n",
                       stats.cd_msgs_sent);
-    storeAppendPrintf(sentry, "cd.msgs_recv = %.0f\n",
+    sentry->appendf("cd.msgs_recv = %.0f\n",
                       stats.cd_msgs_recv);
-    storeAppendPrintf(sentry, "cd.memory = %.0f\n",
+    sentry->appendf("cd.memory = %.0f\n",
                       stats.cd_memory);
-    storeAppendPrintf(sentry, "cd.local_memory = %.0f\n",
+    sentry->appendf("cd.local_memory = %.0f\n",
                       stats.cd_local_memory);
-    storeAppendPrintf(sentry, "cd.kbytes_sent = %.0f\n",
+    sentry->appendf("cd.kbytes_sent = %.0f\n",
                       stats.cd_kbytes_sent);
-    storeAppendPrintf(sentry, "cd.kbytes_recv = %.0f\n",
+    sentry->appendf("cd.kbytes_recv = %.0f\n",
                       stats.cd_kbytes_recv);
 #endif
 
-    storeAppendPrintf(sentry, "unlink.requests = %.0f\n",
+    sentry->appendf("unlink.requests = %.0f\n",
                       stats.unlink_requests);
-    storeAppendPrintf(sentry, "page_faults = %.0f\n",
+    sentry->appendf("page_faults = %.0f\n",
                       stats.page_faults);
-    storeAppendPrintf(sentry, "select_loops = %.0f\n",
+    sentry->appendf("select_loops = %.0f\n",
                       stats.select_loops);
-    storeAppendPrintf(sentry, "cpu_time = %f\n",
+    sentry->appendf("cpu_time = %f\n",
                       stats.cpu_time);
-    storeAppendPrintf(sentry, "wall_time = %f\n",
+    sentry->appendf("wall_time = %f\n",
                       stats.wall_time);
-    storeAppendPrintf(sentry, "swap.outs = %.0f\n",
+    sentry->appendf("swap.outs = %.0f\n",
                       stats.swap_outs);
-    storeAppendPrintf(sentry, "swap.ins = %.0f\n",
+    sentry->appendf("swap.ins = %.0f\n",
                       stats.swap_ins);
-    storeAppendPrintf(sentry, "swap.files_cleaned = %.0f\n",
+    sentry->appendf("swap.files_cleaned = %.0f\n",
                       stats.swap_files_cleaned);
-    storeAppendPrintf(sentry, "aborted_requests = %.0f\n",
+    sentry->appendf("aborted_requests = %.0f\n",
                       stats.aborted_requests);
 
-    storeAppendPrintf(sentry, "hit_validation.attempts = %.0f\n",
+    sentry->appendf("hit_validation.attempts = %.0f\n",
                       stats.hitValidationAttempts);
-    storeAppendPrintf(sentry, "hit_validation.refusals.due_to_locking = %.0f\n",
+    sentry->appendf("hit_validation.refusals.due_to_locking = %.0f\n",
                       stats.hitValidationRefusalsDueToLocking);
-    storeAppendPrintf(sentry, "hit_validation.refusals.due_to_zeroSize = %.0f\n",
+    sentry->appendf("hit_validation.refusals.due_to_zeroSize = %.0f\n",
                       stats.hitValidationRefusalsDueToZeroSize);
-    storeAppendPrintf(sentry, "hit_validation.refusals.due_to_timeLimit = %.0f\n",
+    sentry->appendf("hit_validation.refusals.due_to_timeLimit = %.0f\n",
                       stats.hitValidationRefusalsDueToTimeLimit);
-    storeAppendPrintf(sentry, "hit_validation.failures = %.0f\n",
+    sentry->appendf("hit_validation.failures = %.0f\n",
                       stats.hitValidationFailures);
 }
 
@@ -1620,42 +1620,42 @@ statPeerSelect(StoreEntry * sentry)
     static const SBuf label("all peers");
     cacheDigestGuessStatsReport(&f->cd.guess, sentry, label);
     /* per-peer */
-    storeAppendPrintf(sentry, "\nPer-peer statistics:\n");
+    sentry->appendf("\nPer-peer statistics:\n");
 
     for (peer = getFirstPeer(); peer; peer = getNextPeer(peer)) {
         if (peer->digest)
             peerDigestStatsReport(peer->digest, sentry);
         else
-            storeAppendPrintf(sentry, "\nNo peer digest from %s\n", peer->host);
+            sentry->appendf("\nNo peer digest from %s\n", peer->host);
 
-        storeAppendPrintf(sentry, "\n");
+        sentry->appendf("\n");
     }
 
-    storeAppendPrintf(sentry, "\nAlgorithm usage:\n");
-    storeAppendPrintf(sentry, "Cache Digest: %7d (%3d%%)\n",
+    sentry->appendf("\nAlgorithm usage:\n");
+    sentry->appendf("Cache Digest: %7d (%3d%%)\n",
                       f->cd.times_used, xpercentInt(f->cd.times_used, tot_used));
-    storeAppendPrintf(sentry, "Icp:          %7d (%3d%%)\n",
+    sentry->appendf("Icp:          %7d (%3d%%)\n",
                       f->icp.times_used, xpercentInt(f->icp.times_used, tot_used));
-    storeAppendPrintf(sentry, "Total:        %7d (%3d%%)\n",
+    sentry->appendf("Total:        %7d (%3d%%)\n",
                       tot_used, xpercentInt(tot_used, tot_used));
 #else
 
-    storeAppendPrintf(sentry, "peer digests are disabled; no stats is available.\n");
+    sentry->appendf("peer digests are disabled; no stats is available.\n");
 #endif
 }
 
 static void
 statDigestBlob(StoreEntry * sentry)
 {
-    storeAppendPrintf(sentry, "\nCounters:\n");
+    sentry->appendf("\nCounters:\n");
     statCountersDump(sentry);
-    storeAppendPrintf(sentry, "\n5 Min Averages:\n");
+    sentry->appendf("\n5 Min Averages:\n");
     statAvgDump(sentry, 5, 0);
-    storeAppendPrintf(sentry, "\nHistograms:\n");
+    sentry->appendf("\nHistograms:\n");
     statCountersHistograms(sentry);
-    storeAppendPrintf(sentry, "\nPeer Digests:\n");
+    sentry->appendf("\nPeer Digests:\n");
     statPeerSelect(sentry);
-    storeAppendPrintf(sentry, "\nLocal Digest:\n");
+    sentry->appendf("\nLocal Digest:\n");
     storeDigestReport(sentry);
 }
 
@@ -1816,30 +1816,30 @@ statClientRequests(StoreEntry * s)
         http = static_cast<ClientHttpRequest *>(i->data);
         assert(http);
         ConnStateData * conn = http->getConn();
-        storeAppendPrintf(s, "Connection: %p\n", conn);
+        s->appendf("Connection: %p\n", conn);
 
         if (conn != NULL) {
             const int fd = conn->clientConnection->fd;
-            storeAppendPrintf(s, "\tFD %d, read %" PRId64 ", wrote %" PRId64 "\n", fd,
+            s->appendf("\tFD %d, read %" PRId64 ", wrote %" PRId64 "\n", fd,
                               fd_table[fd].bytes_read, fd_table[fd].bytes_written);
-            storeAppendPrintf(s, "\tFD desc: %s\n", fd_table[fd].desc);
-            storeAppendPrintf(s, "\tin: buf %p, used %ld, free %ld\n",
+            s->appendf("\tFD desc: %s\n", fd_table[fd].desc);
+            s->appendf("\tin: buf %p, used %ld, free %ld\n",
                               conn->inBuf.rawContent(), (long int) conn->inBuf.length(), (long int) conn->inBuf.spaceSize());
-            storeAppendPrintf(s, "\tremote: %s\n",
+            s->appendf("\tremote: %s\n",
                               conn->clientConnection->remote.toUrl(buf,MAX_IPSTRLEN));
-            storeAppendPrintf(s, "\tlocal: %s\n",
+            s->appendf("\tlocal: %s\n",
                               conn->clientConnection->local.toUrl(buf,MAX_IPSTRLEN));
-            storeAppendPrintf(s, "\tnrequests: %u\n", conn->pipeline.nrequests);
+            s->appendf("\tnrequests: %u\n", conn->pipeline.nrequests);
         }
 
-        storeAppendPrintf(s, "uri %s\n", http->uri);
-        storeAppendPrintf(s, "logType %s\n", http->logType.c_str());
-        storeAppendPrintf(s, "out.offset %ld, out.size %lu\n",
+        s->appendf("uri %s\n", http->uri);
+        s->appendf("logType %s\n", http->logType.c_str());
+        s->appendf("out.offset %ld, out.size %lu\n",
                           (long int) http->out.offset, (unsigned long int) http->out.size);
-        storeAppendPrintf(s, "req_sz %ld\n", (long int) http->req_sz);
+        s->appendf("req_sz %ld\n", (long int) http->req_sz);
         e = http->storeEntry();
-        storeAppendPrintf(s, "entry %p/%s\n", e, e ? e->getMD5Text() : "N/A");
-        storeAppendPrintf(s, "start %ld.%06d (%f seconds ago)\n",
+        s->appendf("entry %p/%s\n", e, e ? e->getMD5Text() : "N/A");
+        s->appendf("start %ld.%06d (%f seconds ago)\n",
                           (long int) http->al->cache.start_time.tv_sec,
                           (int) http->al->cache.start_time.tv_usec,
                           tvSubDsec(http->al->cache.start_time, current_time));
@@ -1863,13 +1863,13 @@ statClientRequests(StoreEntry * s)
         if (!p)
             p = dash_str;
 
-        storeAppendPrintf(s, "username %s\n", p);
+        s->appendf("username %s\n", p);
 
 #if USE_DELAY_POOLS
-        storeAppendPrintf(s, "delay_pool %d\n", DelayId::DelayClient(http).pool());
+        s->appendf("delay_pool %d\n", DelayId::DelayClient(http).pool());
 #endif
 
-        storeAppendPrintf(s, "\n");
+        s->appendf("\n");
     }
 }
 
@@ -1883,7 +1883,7 @@ statClientRequests(StoreEntry * s)
     dt = tvSubDsec(CountHist[i+1].timestamp, CountHist[i].timestamp); \
     if (dt <= 0.0) \
         break; \
-    storeAppendPrintf(e, "%lu,%0.2f:", \
+    e->appendf("%lu,%0.2f:", \
         CountHist[i].timestamp.tv_sec, \
         ((CountHist[i].Y - CountHist[i+1].Y) / dt)); \
     }
@@ -1893,13 +1893,13 @@ statClientRequests(StoreEntry * s)
     dt = tvSubDsec(CountHourHist[i+1].timestamp, CountHourHist[i].timestamp); \
     if (dt <= 0.0) \
         break; \
-    storeAppendPrintf(e, "%lu,%0.2f:", \
+    e->appendf("%lu,%0.2f:", \
         CountHourHist[i].timestamp.tv_sec, \
         ((CountHourHist[i].Y - CountHourHist[i+1].Y) / dt)); \
     }
 
-#define GRAPH_TITLE(X,Y) storeAppendPrintf(e,"%s\t%s\t",X,Y);
-#define GRAPH_END storeAppendPrintf(e,"\n");
+#define GRAPH_TITLE(X,Y) e->appendf("%s\t%s\t",X,Y);
+#define GRAPH_END e->appendf("\n");
 
 #define GENGRAPH(X,Y,Z) \
     GRAPH_TITLE(Y,Z) \

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -351,7 +351,7 @@ statObjects(void *data)
 
     if (state->theSearch->isDone()) {
         if (UsingSmp())
-            storeAppendPrintf(state->sentry, "} by kid%d\n\n", KidIdentifier);
+            state->sentry->appendf("} by kid%d\n\n", KidIdentifier);
         state->sentry->complete();
         state->sentry->unlock("statObjects+isDone");
         delete state;

--- a/src/store.cc
+++ b/src/store.cc
@@ -1009,33 +1009,33 @@ StoreEntry::checkCachable()
 void
 storeCheckCachableStats(StoreEntry *sentry)
 {
-    storeAppendPrintf(sentry, "Category\t Count\n");
+    sentry->appendf("Category\t Count\n");
 
 #if CACHE_ALL_METHODS
 
-    storeAppendPrintf(sentry, "no.non_get\t%d\n",
+    sentry->appendf("no.non_get\t%d\n",
                       store_check_cachable_hist.no.non_get);
 #endif
 
-    storeAppendPrintf(sentry, "no.not_entry_cachable\t%d\n",
+    sentry->appendf("no.not_entry_cachable\t%d\n",
                       store_check_cachable_hist.no.not_entry_cachable);
-    storeAppendPrintf(sentry, "no.wrong_content_length\t%d\n",
+    sentry->appendf("no.wrong_content_length\t%d\n",
                       store_check_cachable_hist.no.wrong_content_length);
-    storeAppendPrintf(sentry, "no.negative_cached\t%d\n",
+    sentry->appendf("no.negative_cached\t%d\n",
                       0); // TODO: Remove this backward compatibility hack.
-    storeAppendPrintf(sentry, "no.missing_parts\t%d\n",
+    sentry->appendf("no.missing_parts\t%d\n",
                       store_check_cachable_hist.no.missing_parts);
-    storeAppendPrintf(sentry, "no.too_big\t%d\n",
+    sentry->appendf("no.too_big\t%d\n",
                       store_check_cachable_hist.no.too_big);
-    storeAppendPrintf(sentry, "no.too_small\t%d\n",
+    sentry->appendf("no.too_small\t%d\n",
                       store_check_cachable_hist.no.too_small);
-    storeAppendPrintf(sentry, "no.private_key\t%d\n",
+    sentry->appendf("no.private_key\t%d\n",
                       store_check_cachable_hist.no.private_key);
-    storeAppendPrintf(sentry, "no.too_many_open_files\t%d\n",
+    sentry->appendf("no.too_many_open_files\t%d\n",
                       store_check_cachable_hist.no.too_many_open_files);
-    storeAppendPrintf(sentry, "no.too_many_open_fds\t%d\n",
+    sentry->appendf("no.too_many_open_fds\t%d\n",
                       store_check_cachable_hist.no.too_many_open_fds);
-    storeAppendPrintf(sentry, "yes.default\t%d\n",
+    sentry->appendf("yes.default\t%d\n",
                       store_check_cachable_hist.yes.Default);
 }
 

--- a/src/store.cc
+++ b/src/store.cc
@@ -876,16 +876,6 @@ StoreEntry::vappendf(const char *fmt, va_list vargs)
     delete[] buf2;
 }
 
-// deprecated. use StoreEntry::appendf() instead.
-void
-storeAppendPrintf(StoreEntry * e, const char *fmt,...)
-{
-    va_list args;
-    va_start(args, fmt);
-    e->vappendf(fmt, args);
-    va_end(args);
-}
-
 struct _store_check_cachable_hist {
 
     struct {

--- a/src/store.cc
+++ b/src/store.cc
@@ -886,13 +886,6 @@ storeAppendPrintf(StoreEntry * e, const char *fmt,...)
     va_end(args);
 }
 
-// deprecated. use StoreEntry::appendf() instead.
-void
-storeAppendVPrintf(StoreEntry * e, const char *fmt, va_list vargs)
-{
-    e->vappendf(fmt, vargs);
-}
-
 struct _store_check_cachable_hist {
 
     struct {

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -140,14 +140,14 @@ Store::Controller::getStats(StoreInfoStats &stats) const
 void
 Store::Controller::stat(StoreEntry &output) const
 {
-    storeAppendPrintf(&output, "Store Directory Statistics:\n");
-    storeAppendPrintf(&output, "Store Entries          : %lu\n",
+    output.appendf("Store Directory Statistics:\n");
+    output.appendf("Store Entries          : %lu\n",
                       (unsigned long int)StoreEntry::inUseCount());
-    storeAppendPrintf(&output, "Maximum Swap Size      : %" PRIu64 " KB\n",
+    output.appendf("Maximum Swap Size      : %" PRIu64 " KB\n",
                       maxSize() >> 10);
-    storeAppendPrintf(&output, "Current Store Swap Size: %.2f KB\n",
+    output.appendf("Current Store Swap Size: %.2f KB\n",
                       currentSize() / 1024.0);
-    storeAppendPrintf(&output, "Current Capacity       : %.2f%% used, %.2f%% free\n",
+    output.appendf("Current Capacity       : %.2f%% used, %.2f%% free\n",
                       Math::doublePercent(currentSize(), maxSize()),
                       Math::doublePercent((maxSize() - currentSize()), maxSize()));
 

--- a/src/store/Disk.cc
+++ b/src/store/Disk.cc
@@ -65,14 +65,14 @@ Store::Disk::stat(StoreEntry &output) const
     if (!doReportStat())
         return;
 
-    storeAppendPrintf(&output, "Store Directory #%d (%s): %s\n", index, type(),
+    output.appendf("Store Directory #%d (%s): %s\n", index, type(),
                       path);
-    storeAppendPrintf(&output, "FS Block Size %d Bytes\n",
+    output.appendf("FS Block Size %d Bytes\n",
                       fs.blksize);
     statfs(output);
 
     if (repl) {
-        storeAppendPrintf(&output, "Removal policy: %s\n", repl->_type);
+        output.appendf("Removal policy: %s\n", repl->_type);
 
         if (repl->Stats)
             repl->Stats(repl, &output);
@@ -340,7 +340,7 @@ void
 Store::Disk::optionReadOnlyDump(StoreEntry * e) const
 {
     if (flags.read_only)
-        storeAppendPrintf(e, " no-store");
+        e->appendf(" no-store");
 }
 
 bool
@@ -382,10 +382,10 @@ void
 Store::Disk::optionObjectSizeDump(StoreEntry * e) const
 {
     if (min_objsize != -1)
-        storeAppendPrintf(e, " min-size=%" PRId64, min_objsize);
+        e->appendf(" min-size=%" PRId64, min_objsize);
 
     if (max_objsize != -1)
-        storeAppendPrintf(e, " max-size=%" PRId64, max_objsize);
+        e->appendf(" max-size=%" PRId64, max_objsize);
 }
 
 // some SwapDirs may maintain their indexes and be able to lookup an entry key

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -439,7 +439,7 @@ Store::Disks::stat(StoreEntry & output) const
     /* Now go through each store, calling its stat routine */
 
     for (i = 0; i < Config.cacheSwap.n_configured; ++i) {
-        storeAppendPrintf(&output, "\n");
+        output.appendf("\n");
         store(i)->stat(output);
     }
 }

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -200,16 +200,16 @@ storeDigestReport(StoreEntry * e)
     if (store_digest) {
         static const SBuf label("store");
         cacheDigestReport(store_digest, label, e);
-        storeAppendPrintf(e, "\t added: %d rejected: %d ( %.2f %%) del-ed: %d\n",
+        e->appendf("\t added: %d rejected: %d ( %.2f %%) del-ed: %d\n",
                           sd_stats.add_count,
                           sd_stats.rej_count,
                           xpercent(sd_stats.rej_count, sd_stats.rej_count + sd_stats.add_count),
                           sd_stats.del_count);
-        storeAppendPrintf(e, "\t collisions: on add: %.2f %% on rej: %.2f %%\n",
+        e->appendf("\t collisions: on add: %.2f %% on rej: %.2f %%\n",
                           xpercent(sd_stats.add_coll_count, sd_stats.add_count),
                           xpercent(sd_stats.rej_coll_count, sd_stats.rej_count));
     } else {
-        storeAppendPrintf(e, "store digest: disabled.\n");
+        e->appendf("store digest: disabled.\n");
     }
 
 #endif //USE_CACHE_DIGESTS

--- a/src/store_log.cc
+++ b/src/store_log.cc
@@ -137,7 +137,7 @@ storeLogTagsHist(StoreEntry *e)
 {
     int tag;
     for (tag = 0; tag <= STORE_LOG_SWAPOUTFAIL; ++tag) {
-        storeAppendPrintf(e, "%s %d\n",
+        e->appendf("%s %d\n",
                           storeLogTags[tag],
                           storeLogTagsCounts[tag]);
     }

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -110,7 +110,6 @@ StoreEntry *storeCreateEntry(const char *, const char *, const RequestFlags &, c
 StoreEntry *storeCreatePureEntry(const char *storeId, const char *logUrl, const HttpRequestMethod&) STUB_RETVAL(nullptr)
 void storeConfigure(void) STUB
 int expiresMoreThan(time_t, time_t) STUB_RETVAL(0)
-void storeAppendPrintf(StoreEntry *, const char *,...) STUB
 int storeTooManyDiskFilesOpen(void) STUB_RETVAL(0)
 void storeHeapPositionUpdate(StoreEntry *, SwapDir *) STUB
 void storeSwapFileNumberSet(StoreEntry * e, sfileno filn) STUB

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -111,7 +111,6 @@ StoreEntry *storeCreatePureEntry(const char *storeId, const char *logUrl, const 
 void storeConfigure(void) STUB
 int expiresMoreThan(time_t, time_t) STUB_RETVAL(0)
 void storeAppendPrintf(StoreEntry *, const char *,...) STUB
-void storeAppendVPrintf(StoreEntry *, const char *, va_list ap) STUB
 int storeTooManyDiskFilesOpen(void) STUB_RETVAL(0)
 void storeHeapPositionUpdate(StoreEntry *, SwapDir *) STUB
 void storeSwapFileNumberSet(StoreEntry * e, sfileno filn) STUB

--- a/src/ufsdump.cc
+++ b/src/ufsdump.cc
@@ -34,17 +34,6 @@ eventAdd(const char *name, EVH * func, void *arg, double when, int, bool cbdata)
 const char *urlCanonical(HttpRequest *) { assert(false); return NULL; }
 
 void
-storeAppendPrintf(StoreEntry * e, const char *fmt,...)
-{
-    va_list args;
-    va_start(args, fmt);
-
-    assert(false);
-
-    va_end(args);
-}
-
-void
 Mgr::RegisterAction(char const * action, char const * desc, OBJH * handler, int pw_req_flag, int atomic) {}
 
 /* MinGW needs also a stub of death() */

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -2023,10 +2023,10 @@ dump_wccp2_method(StoreEntry * e, const char *label, int v)
 {
     switch (v) {
     case WCCP2_METHOD_GRE:
-        storeAppendPrintf(e, "%s gre\n", label);
+        e->appendf("%s gre\n", label);
         break;
     case WCCP2_METHOD_L2:
-        storeAppendPrintf(e, "%s l2\n", label);
+        e->appendf("%s l2\n", label);
         break;
     default:
         debugs(80, DBG_CRITICAL, "FATAL: WCCPv2 configured method (" << v << ") is not valid.");
@@ -2071,10 +2071,10 @@ dump_wccp2_amethod(StoreEntry * e, const char *label, int v)
 {
     switch (v) {
     case WCCP2_ASSIGNMENT_METHOD_HASH:
-        storeAppendPrintf(e, "%s hash\n", label);
+        e->appendf("%s hash\n", label);
         break;
     case WCCP2_ASSIGNMENT_METHOD_MASK:
-        storeAppendPrintf(e, "%s mask\n", label);
+        e->appendf("%s mask\n", label);
         break;
     default:
         debugs(80, DBG_CRITICAL, "FATAL: WCCPv2 configured " << label << " (" << v << ") is not valid.");
@@ -2153,15 +2153,15 @@ dump_wccp2_service(StoreEntry * e, const char *label, void *)
 
     while (srv != NULL) {
         debugs(80, 3, "dump_wccp2_service: id " << srv->info.service_id << ", type " << srv->info.service);
-        storeAppendPrintf(e, "%s %s %d", label,
+        e->appendf("%s %s %d", label,
                           (srv->info.service == WCCP2_SERVICE_DYNAMIC) ? "dynamic" : "standard",
                           srv->info.service_id);
 
         if (srv->wccp2_security_type == WCCP2_MD5_SECURITY) {
-            storeAppendPrintf(e, " %s", srv->wccp_password);
+            e->appendf(" %s", srv->wccp_password);
         }
 
-        storeAppendPrintf(e, "\n");
+        e->appendf("\n");
 
         srv = srv->next;
     }
@@ -2371,65 +2371,65 @@ dump_wccp2_service_info(StoreEntry * e, const char *label, void *)
             continue;
         }
 
-        storeAppendPrintf(e, "%s %d", label, srv->info.service_id);
+        e->appendf("%s %d", label, srv->info.service_id);
 
         /* priority */
-        storeAppendPrintf(e, " priority=%d", srv->info.service_priority);
+        e->appendf(" priority=%d", srv->info.service_priority);
 
         /* flags */
         flags = ntohl(srv->info.service_flags);
 
         bool comma = false;
         if (flags != 0) {
-            storeAppendPrintf(e, " flags=");
+            e->appendf(" flags=");
 
             if (flags & WCCP2_SERVICE_SRC_IP_HASH) {
-                storeAppendPrintf(e, "src_ip_hash");
+                e->appendf("src_ip_hash");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_DST_IP_HASH) {
-                storeAppendPrintf(e, "%sdst_ip_hash", comma ? "," : "");
+                e->appendf("%sdst_ip_hash", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_SRC_PORT_HASH) {
-                storeAppendPrintf(e, "%ssource_port_hash", comma ? "," : "");
+                e->appendf("%ssource_port_hash", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_DST_PORT_HASH) {
-                storeAppendPrintf(e, "%sdst_port_hash", comma ? "," : "");
+                e->appendf("%sdst_port_hash", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_PORTS_DEFINED) {
-                storeAppendPrintf(e, "%sports_defined", comma ? "," : "");
+                e->appendf("%sports_defined", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_PORTS_SOURCE) {
-                storeAppendPrintf(e, "%sports_source", comma ? "," : "");
+                e->appendf("%sports_source", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_SRC_IP_ALT_HASH) {
-                storeAppendPrintf(e, "%ssrc_ip_alt_hash", comma ? "," : "");
+                e->appendf("%ssrc_ip_alt_hash", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_DST_IP_ALT_HASH) {
-                storeAppendPrintf(e, "%ssrc_ip_alt_hash", comma ? "," : "");
+                e->appendf("%ssrc_ip_alt_hash", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_SRC_PORT_ALT_HASH) {
-                storeAppendPrintf(e, "%ssrc_port_alt_hash", comma ? "," : "");
+                e->appendf("%ssrc_port_alt_hash", comma ? "," : "");
                 comma = true;
             }
 
             if (flags & WCCP2_SERVICE_DST_PORT_ALT_HASH) {
-                storeAppendPrintf(e, "%sdst_port_alt_hash", comma ? "," : "");
+                e->appendf("%sdst_port_alt_hash", comma ? "," : "");
                 //comma = true; // uncomment if more options added
             }
         }
@@ -2438,49 +2438,49 @@ dump_wccp2_service_info(StoreEntry * e, const char *label, void *)
         comma = false;
 
         if (srv->info.port0 != 0) {
-            storeAppendPrintf(e, " ports=%d", ntohs(srv->info.port0));
+            e->appendf(" ports=%d", ntohs(srv->info.port0));
             comma = true;
         }
 
         if (srv->info.port1 != 0) {
-            storeAppendPrintf(e, "%s%d", comma ? "," : "ports=", ntohs(srv->info.port1));
+            e->appendf("%s%d", comma ? "," : "ports=", ntohs(srv->info.port1));
             comma = true;
         }
 
         if (srv->info.port2 != 0) {
-            storeAppendPrintf(e, "%s%d", comma ? "," : "ports=", ntohs(srv->info.port2));
+            e->appendf("%s%d", comma ? "," : "ports=", ntohs(srv->info.port2));
             comma = true;
         }
 
         if (srv->info.port3 != 0) {
-            storeAppendPrintf(e, "%s%d", comma ? "," : "ports=", ntohs(srv->info.port3));
+            e->appendf("%s%d", comma ? "," : "ports=", ntohs(srv->info.port3));
             comma = true;
         }
 
         if (srv->info.port4 != 0) {
-            storeAppendPrintf(e, "%s%d", comma ? "," : "ports=", ntohs(srv->info.port4));
+            e->appendf("%s%d", comma ? "," : "ports=", ntohs(srv->info.port4));
             comma = true;
         }
 
         if (srv->info.port5 != 0) {
-            storeAppendPrintf(e, "%s%d", comma ? "," : "ports=", ntohs(srv->info.port5));
+            e->appendf("%s%d", comma ? "," : "ports=", ntohs(srv->info.port5));
             comma = true;
         }
 
         if (srv->info.port6 != 0) {
-            storeAppendPrintf(e, "%s%d", comma ? "," : "ports=", ntohs(srv->info.port6));
+            e->appendf("%s%d", comma ? "," : "ports=", ntohs(srv->info.port6));
             comma = true;
         }
 
         if (srv->info.port7 != 0) {
-            storeAppendPrintf(e, "%s%d", comma ? "," : "ports=", ntohs(srv->info.port7));
+            e->appendf("%s%d", comma ? "," : "ports=", ntohs(srv->info.port7));
             // comma = true; // uncomment if more options are added
         }
 
         /* protocol */
-        storeAppendPrintf(e, " protocol=%s", (srv->info.service_protocol == IPPROTO_TCP) ? "tcp" : "udp");
+        e->appendf(" protocol=%s", (srv->info.service_protocol == IPPROTO_TCP) ? "tcp" : "udp");
 
-        storeAppendPrintf(e, "\n");
+        e->appendf("\n");
 
         srv = srv->next;
     }


### PR DESCRIPTION
Automatically convert deprecated uses of storeAppendPrintf()
to use the Packable API method.

The store API definitions and some difficult to auto-remove
uses remain for future manual removal once all developer
branches have been updated by this script.