### PR TITLE
Fixed localnet ACL definition in recommended/default squid.conf

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1538,7 +1538,7 @@ NOCOMMENT_START
 acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
 acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
 acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
-acl localhet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
 acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
 acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
 acl localnet src fc00::/7       	# RFC 4193 local private network range


### PR DESCRIPTION
... it was lacking 169.254.0.0/16 subnet due to a typo in fe204e1d.