### PR TITLE
Bug 4505: SMP caches sometimes do not purge entries (#46)

### DIFF
--- a/src/CollapsedForwarding.h
+++ b/src/CollapsedForwarding.h
@@ -13,6 +13,7 @@
 
 #include "ipc/forward.h"
 #include "ipc/Queue.h"
+#include "store/forward.h"
 
 #include <memory>
 
@@ -26,7 +27,11 @@ public:
     static void Init();
 
     /// notify other workers about changes in entry state (e.g., new data)
-    static void Broadcast(const StoreEntry &e);
+    static void Broadcast(const StoreEntry &e, const bool includingThisWorker = false);
+
+    /// notify other workers about state changes in Transient entry at the given xitTable.index
+    /// use Broadcast(StoreEntry) variant if you have a StoreEntry object
+    static void Broadcast(const sfileno index, const bool includingThisWorker);
 
     /// kick worker with empty IPC queue
     static void Notify(const int workerId);

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -99,7 +99,6 @@ MemObject::setUris(char const *aStoreId, char const *aLogUri, const HttpRequestM
 MemObject::MemObject() :
     inmem_lo(0),
     nclients(0),
-    smpCollapsed(false),
     request(nullptr),
     ping_reply_callback(nullptr),
     ircb_data(nullptr),
@@ -247,8 +246,6 @@ MemObject::stat(MemBuf * mb) const
         mb->appendf("\tmem-cache index: %d state: %d offset: %" PRId64 "\n", memCache.index, memCache.io, memCache.offset);
     if (object_sz >= 0)
         mb->appendf("\tobject_sz: %" PRId64 "\n", object_sz);
-    if (smpCollapsed)
-        mb->appendf("\tsmp-collapsed\n");
 
     StoreClientStats statsVisitor(mb);
 

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -16,6 +16,7 @@
 #include "sbuf/SBuf.h"
 #include "SquidString.h"
 #include "stmem.h"
+#include "store/forward.h"
 #include "StoreIOBuffer.h"
 #include "StoreIOState.h"
 #include "typedefs.h" //for IRCB
@@ -126,8 +127,12 @@ public:
 
     SwapOut swapout;
 
-    /// cache "I/O" direction and status
-    typedef enum { ioUndecided, ioWriting, ioReading, ioDone } Io;
+    /* TODO: Remove this change-minimizing hack */
+    using Io = Store::IoStatus;
+    static constexpr Io ioUndecided = Store::ioUndecided;
+    static constexpr Io ioReading = Store::ioReading;
+    static constexpr Io ioWriting = Store::ioWriting;
+    static constexpr Io ioDone = Store::ioDone;
 
     /// State of an entry with regards to the [shared] in-transit table.
     class XitTable
@@ -152,8 +157,6 @@ public:
         Io io; ///< current I/O state
     };
     MemCache memCache; ///< current [shared] memory caching state for the entry
-
-    bool smpCollapsed; ///< whether this entry gets data from another worker
 
     /* Read only - this reply must be preserved by store clients */
     /* The original reply. possibly with updated metadata. */

--- a/src/MemStore.h
+++ b/src/MemStore.h
@@ -59,10 +59,10 @@ public:
     virtual bool dereference(StoreEntry &e) override;
     virtual void updateHeaders(StoreEntry *e) override;
     virtual void maintain() override;
-    virtual bool anchorCollapsed(StoreEntry &e, bool &inSync) override;
-    virtual bool updateCollapsed(StoreEntry &e) override;
-    virtual void markForUnlink(StoreEntry &) override;
-    virtual void unlink(StoreEntry &e) override;
+    virtual bool anchorToCache(StoreEntry &e, bool &inSync) override;
+    virtual bool updateAnchored(StoreEntry &) override;
+    virtual void evictCached(StoreEntry &) override;
+    virtual void evictIfFound(const cache_key *) override;
     virtual bool smpAware() const override { return true; }
 
     static int64_t EntryLimit();
@@ -81,7 +81,7 @@ protected:
     void updateHeadersOrThrow(Ipc::StoreMapUpdate &update);
 
     void anchorEntry(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnchor &anchor);
-    bool updateCollapsedWith(StoreEntry &collapsed, const sfileno index, const Ipc::StoreMapAnchor &anchor);
+    bool updateAnchoredWith(StoreEntry &, const sfileno, const Ipc::StoreMapAnchor &);
 
     Ipc::Mem::PageId pageForSlice(Ipc::StoreMapSliceId sliceId);
     Ipc::StoreMap::Slice &nextAppendableSlice(const sfileno entryIndex, sfileno &sliceOffset);

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -2641,14 +2641,10 @@ Ftp::Gateway::haveParsedReplyHeaders()
 
     e->timestampsSet();
 
-    if (flags.authenticated) {
-        /*
-         * Authenticated requests can't be cached.
-         */
-        e->release();
-    } else if (!EBIT_TEST(e->flags, RELEASE_REQUEST) && !getCurrentOffset()) {
-        e->setPublicKey();
-    } else {
+    // makePublic() if allowed/possible or release() otherwise
+    if (flags.authenticated || // authenticated requests can't be cached
+            getCurrentOffset() ||
+            !e->makePublic()) {
         e->release();
     }
 }

--- a/src/enums.h
+++ b/src/enums.h
@@ -47,9 +47,16 @@ typedef enum {
     STORE_PENDING
 } store_status_t;
 
+/// StoreEntry relationship with a disk cache
 typedef enum {
+    /// StoreEntry is currently not associated with any disk store entry.
+    /// Does not guarantee (or preclude!) a matching disk store entry existence.
     SWAPOUT_NONE,
+    /// StoreEntry is being swapped out to the associated disk store entry.
+    /// Guarantees the disk store entry existence.
     SWAPOUT_WRITING,
+    /// StoreEntry is associated with a complete (i.e., fully swapped out) disk store entry.
+    /// Guarantees the disk store entry existence.
     SWAPOUT_DONE
 } swap_status_t;
 
@@ -69,7 +76,7 @@ enum {
     ENTRY_SPECIAL,
     ENTRY_REVALIDATE_ALWAYS,
     DELAY_SENDING,
-    RELEASE_REQUEST,
+    RELEASE_REQUEST, ///< prohibits making the key public
     REFRESH_REQUEST,
     ENTRY_REVALIDATE_STALE,
     ENTRY_DISPATCHED,

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -66,90 +66,68 @@ Rock::SwapDir::get(const cache_key *key)
 
     // create a brand new store entry and initialize it with stored basics
     StoreEntry *e = new StoreEntry();
+    e->createMemObject();
     anchorEntry(*e, filen, *slot);
-
-    e->hashInsert(key);
     trackReferences(*e);
-
     return e;
-    // the disk entry remains open for reading, protected from modifications
 }
 
 bool
-Rock::SwapDir::anchorCollapsed(StoreEntry &collapsed, bool &inSync)
+Rock::SwapDir::anchorToCache(StoreEntry &entry, bool &inSync)
 {
     if (!map || !theFile || !theFile->canRead())
         return false;
 
     sfileno filen;
     const Ipc::StoreMapAnchor *const slot = map->openForReading(
-            reinterpret_cast<cache_key*>(collapsed.key), filen);
+            reinterpret_cast<cache_key*>(entry.key), filen);
     if (!slot)
         return false;
 
-    anchorEntry(collapsed, filen, *slot);
-    inSync = updateCollapsedWith(collapsed, *slot);
+    anchorEntry(entry, filen, *slot);
+    inSync = updateAnchoredWith(entry, *slot);
     return true; // even if inSync is false
 }
 
 bool
-Rock::SwapDir::updateCollapsed(StoreEntry &collapsed)
+Rock::SwapDir::updateAnchored(StoreEntry &entry)
 {
     if (!map || !theFile || !theFile->canRead())
         return false;
 
-    if (collapsed.swap_filen < 0) // no longer using a disk cache
-        return true;
-    assert(collapsed.swap_dirn == index);
+    assert(entry.hasDisk(index));
 
-    const Ipc::StoreMapAnchor &s = map->readableEntry(collapsed.swap_filen);
-    return updateCollapsedWith(collapsed, s);
+    const Ipc::StoreMapAnchor &s = map->readableEntry(entry.swap_filen);
+    return updateAnchoredWith(entry, s);
 }
 
 bool
-Rock::SwapDir::updateCollapsedWith(StoreEntry &collapsed, const Ipc::StoreMapAnchor &anchor)
+Rock::SwapDir::updateAnchoredWith(StoreEntry &entry, const Ipc::StoreMapAnchor &anchor)
 {
-    collapsed.swap_file_sz = anchor.basics.swap_file_sz;
+    entry.swap_file_sz = anchor.basics.swap_file_sz;
     return true;
 }
 
 void
 Rock::SwapDir::anchorEntry(StoreEntry &e, const sfileno filen, const Ipc::StoreMapAnchor &anchor)
 {
-    const Ipc::StoreMapAnchor::Basics &basics = anchor.basics;
+    anchor.exportInto(e);
 
-    e.swap_file_sz = basics.swap_file_sz;
-    e.lastref = basics.lastref;
-    e.timestamp = basics.timestamp;
-    e.expires = basics.expires;
-    e.lastModified(basics.lastmod);
-    e.refcount = basics.refcount;
-    e.flags = basics.flags;
-
-    if (anchor.complete()) {
-        e.store_status = STORE_OK;
-        e.swap_status = SWAPOUT_DONE;
-    } else {
-        e.store_status = STORE_PENDING;
-        e.swap_status = SWAPOUT_WRITING; // even though another worker writes?
-    }
+    const bool complete = anchor.complete();
+    e.store_status = complete ? STORE_OK : STORE_PENDING;
+    // SWAPOUT_WRITING: even though another worker writes?
+    e.attachToDisk(index, filen, complete ? SWAPOUT_DONE : SWAPOUT_WRITING);
 
     e.ping_status = PING_NONE;
 
-    EBIT_CLR(e.flags, RELEASE_REQUEST);
-    e.clearPrivate();
     EBIT_SET(e.flags, ENTRY_VALIDATED);
-
-    e.swap_dirn = index;
-    e.swap_filen = filen;
 }
 
 void Rock::SwapDir::disconnect(StoreEntry &e)
 {
-    assert(e.swap_dirn == index);
-    assert(e.swap_filen >= 0);
-    // cannot have SWAPOUT_NONE entry with swap_filen >= 0
-    assert(e.swap_status != SWAPOUT_NONE);
+    assert(e.hasDisk(index));
+
+    ignoreReferences(e);
 
     // do not rely on e.swap_status here because there is an async delay
     // before it switches from SWAPOUT_WRITING to SWAPOUT_DONE.
@@ -161,16 +139,12 @@ void Rock::SwapDir::disconnect(StoreEntry &e)
     if (e.mem_obj && e.mem_obj->swapout.sio != NULL &&
             dynamic_cast<IoState&>(*e.mem_obj->swapout.sio).writeableAnchor_) {
         map->abortWriting(e.swap_filen);
-        e.swap_dirn = -1;
-        e.swap_filen = -1;
-        e.swap_status = SWAPOUT_NONE;
+        e.detachFromDisk();
         dynamic_cast<IoState&>(*e.mem_obj->swapout.sio).writeableAnchor_ = NULL;
-        Store::Root().transientsAbandon(e); // broadcasts after the change
+        Store::Root().stopSharing(e); // broadcasts after the change
     } else {
         map->closeForReading(e.swap_filen);
-        e.swap_dirn = -1;
-        e.swap_filen = -1;
-        e.swap_status = SWAPOUT_NONE;
+        e.detachFromDisk();
     }
 }
 
@@ -198,9 +172,16 @@ Rock::SwapDir::doReportStat() const
 }
 
 void
-Rock::SwapDir::swappedOut(const StoreEntry &)
+Rock::SwapDir::finalizeSwapoutSuccess(const StoreEntry &)
 {
-    // stats are not stored but computed when needed
+    // nothing to do
+}
+
+void
+Rock::SwapDir::finalizeSwapoutFailure(StoreEntry &entry)
+{
+    debugs(47, 5, entry);
+    disconnect(entry); // calls abortWriting() to free the disk entry
 }
 
 int64_t
@@ -771,7 +752,7 @@ Rock::SwapDir::openStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOS
         return NULL;
     }
 
-    if (e.swap_filen < 0) {
+    if (!e.hasDisk()) {
         debugs(47,4, HERE << e);
         return NULL;
     }
@@ -897,7 +878,7 @@ Rock::SwapDir::writeCompleted(int errflag, size_t, RefCount< ::WriteRequest> r)
 
         writeError(sio);
         sio.finishedWriting(errflag);
-        // and hope that Core will call disconnect() to close the map entry
+        // and wait for the finalizeSwapoutFailure() call to close the map entry
     }
 
     if (sio.touchingStoreEntry())
@@ -912,7 +893,7 @@ Rock::SwapDir::writeError(StoreIOState &sio)
     map->freeEntry(sio.swap_filen); // will mark as unusable, just in case
 
     if (sio.touchingStoreEntry())
-        Store::Root().transientsAbandon(*sio.e);
+        Store::Root().stopSharing(*sio.e);
     // else noop: a fresh entry update error does not affect stale entry readers
 
     // All callers must also call IoState callback, to propagate the error.
@@ -988,19 +969,24 @@ Rock::SwapDir::unlinkdUseful() const
 }
 
 void
-Rock::SwapDir::unlink(StoreEntry &e)
+Rock::SwapDir::evictIfFound(const cache_key *key)
 {
-    debugs(47, 5, HERE << e);
-    ignoreReferences(e);
-    map->freeEntry(e.swap_filen);
-    disconnect(e);
+    if (map)
+        map->freeEntryByKey(key); // may not be there
 }
 
 void
-Rock::SwapDir::markForUnlink(StoreEntry &e)
+Rock::SwapDir::evictCached(StoreEntry &e)
 {
     debugs(47, 5, e);
-    map->freeEntry(e.swap_filen);
+    if (e.hasDisk(index)) {
+        if (map->freeEntry(e.swap_filen))
+            CollapsedForwarding::Broadcast(e);
+        if (!e.locked())
+            disconnect(e);
+    } else if (const auto key = e.publicKey()) {
+        evictIfFound(key);
+    }
 }
 
 void
@@ -1080,6 +1066,12 @@ Rock::SwapDir::freeSlotsPath() const
     spacesPath = path;
     spacesPath.append("_spaces");
     return spacesPath.termedBuf();
+}
+
+bool
+Rock::SwapDir::hasReadableEntry(const StoreEntry &e) const
+{
+    return map->hasReadableEntry(reinterpret_cast<const cache_key*>(e.key));
 }
 
 namespace Rock

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -39,15 +39,18 @@ public:
     /* public ::SwapDir API */
     virtual void reconfigure();
     virtual StoreEntry *get(const cache_key *key);
-    virtual void markForUnlink(StoreEntry &e);
+    virtual void evictCached(StoreEntry &);
+    virtual void evictIfFound(const cache_key *);
     virtual void disconnect(StoreEntry &e);
     virtual uint64_t currentSize() const;
     virtual uint64_t currentCount() const;
     virtual bool doReportStat() const;
-    virtual void swappedOut(const StoreEntry &e);
+    virtual void finalizeSwapoutSuccess(const StoreEntry &);
+    virtual void finalizeSwapoutFailure(StoreEntry &);
     virtual void create();
     virtual void parse(int index, char *path);
     virtual bool smpAware() const { return true; }
+    virtual bool hasReadableEntry(const StoreEntry &) const;
 
     // temporary path to the shared memory map of first slots of cached entries
     SBuf inodeMapPath() const;
@@ -77,8 +80,8 @@ public:
 
 protected:
     /* Store API */
-    virtual bool anchorCollapsed(StoreEntry &collapsed, bool &inSync);
-    virtual bool updateCollapsed(StoreEntry &collapsed);
+    virtual bool anchorToCache(StoreEntry &entry, bool &inSync);
+    virtual bool updateAnchored(StoreEntry &);
 
     /* protected ::SwapDir API */
     virtual bool needsDiskStrand() const;
@@ -94,7 +97,6 @@ protected:
     virtual bool dereference(StoreEntry &e);
     virtual void updateHeaders(StoreEntry *e);
     virtual bool unlinkdUseful() const;
-    virtual void unlink(StoreEntry &e);
     virtual void statfs(StoreEntry &e) const;
 
     /* IORequestor API */
@@ -124,7 +126,7 @@ protected:
     StoreIOState::Pointer createUpdateIO(const Ipc::StoreMapUpdate &update, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *);
 
     void anchorEntry(StoreEntry &e, const sfileno filen, const Ipc::StoreMapAnchor &anchor);
-    bool updateCollapsedWith(StoreEntry &collapsed, const Ipc::StoreMapAnchor &anchor);
+    bool updateAnchoredWith(StoreEntry &, const Ipc::StoreMapAnchor &);
 
     friend class Rebuild;
     friend class IoState;

--- a/src/fs/ufs/RebuildState.h
+++ b/src/fs/ufs/RebuildState.h
@@ -33,7 +33,6 @@ public:
 
     virtual bool error() const;
     virtual bool isDone() const;
-    virtual StoreEntry *currentItem();
 
     RefCount<UFSSwapDir> sd;
     int n_read;
@@ -63,11 +62,17 @@ private:
     void rebuildFromDirectory();
     void rebuildFromSwapLog();
     void rebuildStep();
-    void undoAdd();
+    void addIfFresh(const cache_key *key,
+                    sfileno file_number,
+                    uint64_t swap_file_sz,
+                    time_t expires,
+                    time_t timestamp,
+                    time_t lastref,
+                    time_t lastmod,
+                    uint32_t refcount,
+                    uint16_t flags);
+    bool evictStaleAndContinue(const cache_key *candidateKey, const time_t maxRef, int &staleCount);
     int getNextFile(sfileno *, int *size);
-    StoreEntry *currentEntry() const;
-    void currentEntry(StoreEntry *);
-    StoreEntry *e;
     bool fromLog;
     bool _done;
     /// \bug (callback) should be hidden behind a proper human readable name

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -49,10 +49,10 @@ public:
     virtual void dump(StoreEntry &) const override;
     virtual bool doubleCheck(StoreEntry &) override;
     virtual bool unlinkdUseful() const override;
-    virtual void unlink(StoreEntry &) override;
     virtual void statfs(StoreEntry &) const override;
     virtual void maintain() override;
-    virtual void markForUnlink(StoreEntry &) override {}
+    virtual void evictCached(StoreEntry &) override;
+    virtual void evictIfFound(const cache_key *) override;
     virtual bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
     virtual void reference(StoreEntry &) override;
     virtual bool dereference(StoreEntry &) override;
@@ -67,11 +67,15 @@ public:
     virtual void reconfigure() override;
     virtual int callback() override;
     virtual void sync() override;
-    virtual void swappedOut(const StoreEntry &e) override;
+    virtual void finalizeSwapoutSuccess(const StoreEntry &) override;
+    virtual void finalizeSwapoutFailure(StoreEntry &) override;
     virtual uint64_t currentSize() const override { return cur_size; }
     virtual uint64_t currentCount() const override { return n_disk_objects; }
     virtual ConfigOption *getOptionTree() const override;
     virtual bool smpAware() const override { return false; }
+    /// as long as ufs relies on the global store_table to index entries,
+    /// it is wrong to ask individual ufs cache_dirs whether they have an entry
+    virtual bool hasReadableEntry(const StoreEntry &) const override { return false; }
 
     void unlinkFile(sfileno f);
     // move down when unlink is a virtual method
@@ -99,8 +103,6 @@ public:
                                uint32_t refcount,
                                uint16_t flags,
                                int clean);
-    /// Undo the effects of UFSSwapDir::addDiskRestore().
-    void undoAddDiskRestore(StoreEntry *e);
     int validFileno(sfileno filn, int flag) const;
     int mapBitAllocate();
 

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -922,7 +922,8 @@ gopherSendRequest(int, void *data)
                                          CommIoCbPtrFun(gopherSendComplete, gopherState));
     Comm::Write(gopherState->serverConn, &mb, call);
 
-    gopherState->entry->makePublic();
+    if (!gopherState->entry->makePublic())
+        gopherState->entry->makePrivate(true);
 }
 
 void

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -593,7 +593,7 @@ neighborsUdpPing(HttpRequest * request,
     if (Config.peers == NULL)
         return 0;
 
-    assert(entry->swap_status == SWAPOUT_NONE);
+    assert(!entry->hasDisk());
 
     mem->start_ping = current_time;
 
@@ -984,7 +984,7 @@ neighborsUdpAck(const cache_key * key, icp_common_t * header, const Ip::Address 
 
     debugs(15, 6, "neighborsUdpAck: opcode " << opcode << " '" << storeKeyText(key) << "'");
 
-    if (NULL != (entry = Store::Root().get(key)))
+    if ((entry = Store::Root().findCallback(key)))
         mem = entry->mem_obj;
 
     if ((p = whichPeer(from)))
@@ -1692,7 +1692,7 @@ dump_peers(StoreEntry * sentry, CachePeer * peers)
 void
 neighborsHtcpReply(const cache_key * key, HtcpReplyData * htcp, const Ip::Address &from)
 {
-    StoreEntry *e = Store::Root().get(key);
+    StoreEntry *e = Store::Root().findCallback(key);
     MemObject *mem = NULL;
     CachePeer *p;
     peer_t ntype = PEER_NONE;

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -953,7 +953,7 @@ peerAddFwdServer(ps_state *ps, CachePeer *peer, const hier_code code)
         // Non-PINNED destinations are uniquely identified by their CachePeer
         // (even though a DIRECT destination might match a cache_peer address).
         const bool duplicate = (server->code == PINNED) ?
-            (code == PINNED) : (server->_peer == peer);
+                               (code == PINNED) : (server->_peer == peer);
         if (duplicate) {
             debugs(44, 3, "skipping " << PeerSelectionDumper(ps, peer, code) <<
                    "; have " << PeerSelectionDumper(ps, server->_peer.get(), server->code));

--- a/src/security/cert_generators/file/security_file_certgen.cc
+++ b/src/security/cert_generators/file/security_file_certgen.cc
@@ -313,11 +313,11 @@ int main(int argc, char *argv[])
                 struct statvfs sfs;
 
                 if (xstatvfs(db_path.c_str(), &sfs)) {
-                   fs_block_size = 2048;
+                    fs_block_size = 2048;
                 } else {
-                   fs_block_size = sfs.f_frsize;
-                   // Sanity check; make sure we have a meaningful value.
-                   if (fs_block_size < 512)
+                    fs_block_size = sfs.f_frsize;
+                    // Sanity check; make sure we have a meaningful value.
+                    if (fs_block_size < 512)
                         fs_block_size = 2048;
                 }
             }

--- a/src/store/Controlled.h
+++ b/src/store/Controlled.h
@@ -18,6 +18,12 @@ namespace Store {
 class Controlled: public Storage
 {
 public:
+    /// \returns a possibly unlocked/unregistered stored entry with key (or nil)
+    /// The returned entry might not match the caller's Store ID or method. The
+    /// caller must abandon()/release() the entry or register it with Root().
+    /// This method must not trigger slow I/O operations (e.g., disk swap in).
+    virtual StoreEntry *get(const cache_key *) = 0;
+
     /// somebody needs this entry (many cache replacement policies need to know)
     virtual void reference(StoreEntry &e) = 0;
 
@@ -28,15 +34,15 @@ public:
     /// make stored metadata and HTTP headers the same as in the given entry
     virtual void updateHeaders(StoreEntry *) {}
 
-    /// If this storage cannot cache collapsed entries, return false.
+    /// If Transients entry cannot be attached to this storage, return false.
     /// If the entry is not found, return false. Otherwise, return true after
-    /// tying the entry to this cache and setting inSync to updateCollapsed().
-    virtual bool anchorCollapsed(StoreEntry &, bool &/*inSync*/) { return false; }
+    /// tying the entry to this cache and setting inSync to updateAnchored().
+    virtual bool anchorToCache(StoreEntry &, bool &/*inSync*/) { return false; }
 
-    /// Update a local collapsed entry with fresh info from this cache (if any).
-    /// Return true iff the cache supports collapsed entries and
-    /// the given local collapsed entry is now in sync with this storage.
-    virtual bool updateCollapsed(StoreEntry &) { return false; }
+    /// Update a local Transients entry with fresh info from this cache (if any).
+    /// Return true iff the cache supports Transients entries and
+    /// the given local Transients entry is now in sync with this storage.
+    virtual bool updateAnchored(StoreEntry &) { return false; }
 };
 
 } // namespace Store

--- a/src/store/Disk.cc
+++ b/src/store/Disk.cc
@@ -187,10 +187,10 @@ Store::Disk::canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) c
 bool
 Store::Disk::canLog(StoreEntry const &e)const
 {
-    if (e.swap_filen < 0)
+    if (e.hasDisk())
         return false;
 
-    if (e.swap_status != SWAPOUT_DONE)
+    if (!e.swappedOut())
         return false;
 
     if (e.swap_file_sz <= 0)

--- a/src/store/Disk.h
+++ b/src/store/Disk.h
@@ -69,8 +69,13 @@ public:
     /// called when the entry is about to forget its association with cache_dir
     virtual void disconnect(StoreEntry &) {}
 
-    /// called when entry swap out is complete
-    virtual void swappedOut(const StoreEntry &e) = 0;
+    /// finalize the successful swapout that has been already noticed by Store
+    virtual void finalizeSwapoutSuccess(const StoreEntry &) = 0;
+    /// abort the failed swapout that has been already noticed by Store
+    virtual void finalizeSwapoutFailure(StoreEntry &) = 0;
+
+    /// whether this cache dir has an entry with `e.key`
+    virtual bool hasReadableEntry(const StoreEntry &e) const = 0;
 
 protected:
     void parseOptions(int reconfiguring);

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -36,10 +36,10 @@ public:
     virtual bool dereference(StoreEntry &e) override;
     virtual void updateHeaders(StoreEntry *) override;
     virtual void maintain() override;
-    virtual bool anchorCollapsed(StoreEntry &e, bool &inSync) override;
-    virtual bool updateCollapsed(StoreEntry &e) override;
-    virtual void markForUnlink(StoreEntry &) override;
-    virtual void unlink(StoreEntry &) override;
+    virtual bool anchorToCache(StoreEntry &e, bool &inSync) override;
+    virtual bool updateAnchored(StoreEntry &) override;
+    virtual void evictCached(StoreEntry &) override;
+    virtual void evictIfFound(const cache_key *) override;
     virtual int callback() override;
 
     /// slowly calculate (and cache) hi/lo watermarks and similar limits
@@ -49,6 +49,8 @@ public:
     /// reduce the risk of selecting the wrong disk cache for the growing entry.
     int64_t accumulateMore(const StoreEntry&) const;
     virtual bool smpAware() const override;
+    /// whether any of disk caches has entry with e.key
+    bool hasReadableEntry(const StoreEntry &) const;
 
 private:
     /* migration logic */

--- a/src/store/forward.h
+++ b/src/store/forward.h
@@ -36,12 +36,16 @@ class Transients;
 
 namespace Store
 {
+/// cache "I/O" direction and status
+enum IoStatus { ioUndecided, ioWriting, ioReading, ioDone };
+
 class Storage;
 class Controller;
 class Controlled;
 class Disks;
 class Disk;
 class DiskConfig;
+class EntryGuard;
 
 typedef ::StoreEntry Entry;
 typedef ::MemStore Memory;

--- a/src/store_log.cc
+++ b/src/store_log.cc
@@ -57,6 +57,9 @@ storeLog(int tag, const StoreEntry * e)
 
         String ctype=(reply->content_type.size() ? reply->content_type.termedBuf() : str_unknown);
 
+        // mem_obj may still lack logging details; especially in RELEASE cases
+        const char *logUri = mem->hasUris() ? mem->logUri() : "?";
+
         logfileLineStart(storelog);
         logfilePrintf(storelog, "%9d.%03d %-7s %02d %08X %s %4d %9d %9d %9d " SQUIDSTRINGPH " %" PRId64 "/%" PRId64 " " SQUIDSBUFPH " %s\n",
                       (int) current_time.tv_sec,
@@ -73,7 +76,7 @@ storeLog(int tag, const StoreEntry * e)
                       reply->content_length,
                       e->contentLen(),
                       SQUIDSBUFPRINT(mem->method.image()),
-                      mem->logUri());
+                      logUri);
         logfileLineEnd(storelog);
     } else {
         /* no mem object. Most RELEASE cases */

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -75,7 +75,7 @@ storeCleanup(void *)
          * Calling StoreEntry->release() has no effect because we're
          * still in 'store_rebuilding' state
          */
-        if (e->swap_filen < 0)
+        if (!e->hasDisk())
             continue;
 
         if (opt_store_doublecheck)
@@ -354,51 +354,6 @@ storeRebuildParseEntry(MemBuf &buf, StoreEntry &tmpe, cache_key *key,
     if (EBIT_TEST(tmpe.flags, KEY_PRIVATE)) {
         ++ stats.badflags;
         return false;
-    }
-
-    return true;
-}
-
-bool
-storeRebuildKeepEntry(const StoreEntry &tmpe, const cache_key *key, StoreRebuildData &stats)
-{
-    /* this needs to become
-     * 1) unpack url
-     * 2) make synthetic request with headers ?? or otherwise search
-     * for a matching object in the store
-     * TODO FIXME change to new async api
-     * TODO FIXME I think there is a race condition here with the
-     * async api :
-     * store A reads in object foo, searchs for it, and finds nothing.
-     * store B reads in object foo, searchs for it, finds nothing.
-     * store A gets called back with nothing, so registers the object
-     * store B gets called back with nothing, so registers the object,
-     * which will conflict when the in core index gets around to scanning
-     * store B.
-     *
-     * this suggests that rather than searching for duplicates, the
-     * index rebuild should just assume its the most recent accurate
-     * store entry and whoever indexes the stores handles duplicates.
-     */
-    if (StoreEntry *e = Store::Root().get(key)) {
-
-        if (e->lastref >= tmpe.lastref) {
-            /* key already exists, old entry is newer */
-            /* keep old, ignore new */
-            ++stats.dupcount;
-
-            // For some stores, get() creates/unpacks a store entry. Signal
-            // such stores that we will no longer use the get() result:
-            e->lock("storeRebuildKeepEntry");
-            e->unlock("storeRebuildKeepEntry");
-
-            return false;
-        } else {
-            /* URL already exists, this swapfile not being used */
-            /* junk old, load new */
-            e->release();   /* release old entry */
-            ++stats.dupcount;
-        }
     }
 
     return true;

--- a/src/store_rebuild.h
+++ b/src/store_rebuild.h
@@ -42,8 +42,6 @@ void storeRebuildProgress(int sd_index, int total, int sofar);
 bool storeRebuildLoadEntry(int fd, int diskIndex, MemBuf &buf, StoreRebuildData &counts);
 /// parses entry buffer and validates entry metadata; fills e on success
 bool storeRebuildParseEntry(MemBuf &buf, StoreEntry &e, cache_key *key, StoreRebuildData &counts, uint64_t expectedSize);
-/// checks whether the loaded entry should be kept; updates counters
-bool storeRebuildKeepEntry(const StoreEntry &e, const cache_key *key, StoreRebuildData &counts);
 
 #endif /* SQUID_STORE_REBUILD_H_ */
 

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -31,22 +31,14 @@ storeSwapInStart(store_client * sc)
     if (e->mem_status != NOT_IN_MEMORY)
         debugs(20, 3, HERE << "already IN_MEMORY");
 
-    debugs(20, 3, "storeSwapInStart: called for : " << e->swap_dirn << " " <<
-           std::hex << std::setw(8) << std::setfill('0') << std::uppercase <<
-           e->swap_filen << " " <<  e->getMD5Text());
+    debugs(20, 3, *e << " " <<  e->getMD5Text());
 
-    if (e->swap_status != SWAPOUT_WRITING && e->swap_status != SWAPOUT_DONE) {
-        debugs(20, DBG_IMPORTANT, "storeSwapInStart: bad swap_status (" << swapStatusStr[e->swap_status] << ")");
-        return;
-    }
-
-    if (e->swap_filen < 0) {
-        debugs(20, DBG_IMPORTANT, "storeSwapInStart: swap_filen < 0");
+    if (!e->hasDisk()) {
+        debugs(20, DBG_IMPORTANT, "BUG: Attempt to swap in a not-stored entry " << *e << ". Salvaged.");
         return;
     }
 
     assert(e->mem_obj != NULL);
-    debugs(20, 3, "storeSwapInStart: Opening fileno " << std::hex << std::setw(8) << std::setfill('0') << std::uppercase << e->swap_filen);
     sc->swapin_sio = storeOpen(e, storeSwapInFileNotify, storeSwapInFileClosed, sc);
 }
 

--- a/src/tests/TestSwapDir.h
+++ b/src/tests/TestSwapDir.h
@@ -24,7 +24,8 @@ public:
     virtual uint64_t currentSize() const override;
     virtual uint64_t currentCount() const override;
     virtual void stat(StoreEntry &) const override;
-    virtual void swappedOut(const StoreEntry &e) override {}
+    virtual void finalizeSwapoutSuccess(const StoreEntry &) override {}
+    virtual void finalizeSwapoutFailure(StoreEntry &) override {}
     virtual void reconfigure() override;
     virtual void init() override;
     virtual bool unlinkdUseful() const override;
@@ -32,8 +33,9 @@ public:
     virtual StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
     virtual StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
     virtual void parse(int, char*) override;
-    virtual void markForUnlink(StoreEntry &) override {}
-    virtual void unlink(StoreEntry &) override {}
+    virtual void evictCached(StoreEntry &) override {}
+    virtual void evictIfFound(const cache_key *) override {}
+    virtual bool hasReadableEntry(const StoreEntry &) const override { return false; }
 };
 
 typedef RefCount<TestSwapDir> TestSwapDirPointer;

--- a/src/tests/stub_CollapsedForwarding.cc
+++ b/src/tests/stub_CollapsedForwarding.cc
@@ -12,5 +12,6 @@
 #define STUB_API "CollapsedForwarding.cc"
 #include "tests/STUB.h"
 
-void CollapsedForwarding::Broadcast(StoreEntry const&) STUB
+void CollapsedForwarding::Broadcast(StoreEntry const&, const bool) STUB
+void CollapsedForwarding::Broadcast(const sfileno, const bool) STUB
 

--- a/src/tests/stub_MemStore.cc
+++ b/src/tests/stub_MemStore.cc
@@ -19,7 +19,6 @@ MemStore::~MemStore() STUB
 bool MemStore::keepInLocalMemory(const StoreEntry &) const STUB_RETVAL(false)
 void MemStore::write(StoreEntry &e) STUB
 void MemStore::completeWriting(StoreEntry &e) STUB
-void MemStore::unlink(StoreEntry &e) STUB
 void MemStore::disconnect(StoreEntry &e) STUB
 void MemStore::reference(StoreEntry &) STUB
 void MemStore::updateHeaders(StoreEntry *) STUB
@@ -35,7 +34,8 @@ uint64_t MemStore::currentSize() const STUB_RETVAL(0)
 uint64_t MemStore::currentCount() const STUB_RETVAL(0)
 int64_t MemStore::maxObjectSize() const STUB_RETVAL(0)
 bool MemStore::dereference(StoreEntry &) STUB_RETVAL(false)
-void MemStore::markForUnlink(StoreEntry&) STUB
-bool MemStore::anchorCollapsed(StoreEntry&, bool&) STUB_RETVAL(false)
-bool MemStore::updateCollapsed(StoreEntry&) STUB_RETVAL(false)
+void MemStore::evictCached(StoreEntry&) STUB
+void MemStore::evictIfFound(const cache_key *) STUB
+bool MemStore::anchorToCache(StoreEntry&, bool&) STUB_RETVAL(false)
+bool MemStore::updateAnchored(StoreEntry&) STUB_RETVAL(false)
 

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -37,15 +37,14 @@ void StoreEntry::replaceHttpReply(HttpReply *, bool andStartWriting) STUB
 bool StoreEntry::mayStartSwapOut() STUB_RETVAL(false)
 void StoreEntry::trimMemory(const bool preserveSwappable) STUB
 void StoreEntry::abort() STUB
-void StoreEntry::makePublic(const KeyScope scope) STUB
+bool StoreEntry::makePublic(const KeyScope scope) STUB
 void StoreEntry::makePrivate(const bool shareable) STUB
-void StoreEntry::setPublicKey(const KeyScope scope) STUB
-void StoreEntry::setPrivateKey(const bool shareable) STUB
+bool StoreEntry::setPublicKey(const KeyScope scope) STUB
+void StoreEntry::setPrivateKey(const bool, const bool) STUB
 void StoreEntry::expireNow() STUB
 void StoreEntry::releaseRequest(const bool shareable) STUB
 void StoreEntry::negativeCache() STUB
-void StoreEntry::cacheNegatively() STUB
-void StoreEntry::purgeMem() STUB
+bool StoreEntry::cacheNegatively() STUB
 void StoreEntry::swapOut() STUB
 void StoreEntry::swapOutFileClose(int how) STUB
 const char *StoreEntry::url() const STUB_RETVAL(NULL)
@@ -83,7 +82,6 @@ void *StoreEntry::operator new(size_t byteCount)
     return new StoreEntry();
 }
 void StoreEntry::operator delete(void *address) STUB
-void StoreEntry::setReleaseFlag() STUB
 //#if USE_SQUID_ESI
 //ESIElement::Pointer StoreEntry::cachedESITree STUB_RETVAL(NULL)
 //#endif
@@ -112,6 +110,8 @@ void Store::Maintain(void *unused) STUB
 int Store::Controller::store_dirs_rebuilding = 0;
 StoreSearch *Store::Controller::search() STUB_RETVAL(NULL)
 void Store::Controller::maintain() STUB
+bool Store::Controller::markedForDeletion(const cache_key *) const STUB_RETVAL(false)
+void Store::Controller::freeMemorySpace(const int) STUB
 
 std::ostream &operator <<(std::ostream &os, const StoreEntry &)
 {
@@ -125,7 +125,7 @@ StoreEntry *storeGetPublic(const char *uri, const HttpRequestMethod& method) STU
 StoreEntry *storeGetPublicByRequest(HttpRequest * request, const KeyScope scope) STUB_RETVAL(NULL)
 StoreEntry *storeGetPublicByRequestMethod(HttpRequest * request, const HttpRequestMethod& method, const KeyScope scope) STUB_RETVAL(NULL)
 StoreEntry *storeCreateEntry(const char *, const char *, const RequestFlags &, const HttpRequestMethod&) STUB_RETVAL(NULL)
-StoreEntry *storeCreatePureEntry(const char *storeId, const char *logUrl, const RequestFlags &, const HttpRequestMethod&) STUB_RETVAL(NULL)
+StoreEntry *storeCreatePureEntry(const char *storeId, const char *logUrl, const HttpRequestMethod&) STUB_RETVAL(nullptr)
 void storeConfigure(void) STUB
 int expiresMoreThan(time_t, time_t) STUB_RETVAL(0)
 void storeAppendPrintf(StoreEntry *, const char *,...) STUB

--- a/src/tests/stub_store_rebuild.cc
+++ b/src/tests/stub_store_rebuild.cc
@@ -19,7 +19,6 @@
 #include "tests/STUB.h"
 
 void storeRebuildProgress(int sd_index, int total, int sofar) STUB
-bool storeRebuildKeepEntry(const StoreEntry &tmpe, const cache_key *key, StoreRebuildData &counts) STUB_RETVAL(false)
 bool storeRebuildParseEntry(MemBuf &, StoreEntry &, cache_key *, StoreRebuildData &, uint64_t) STUB_RETVAL(false)
 
 void storeRebuildComplete(StoreRebuildData *)

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -259,16 +259,28 @@ testRock::testRockSwapOut()
 
     // try to swap out entry to a used unlocked slot
     {
-        StoreEntry *const pe = addEntry(4);
+        // without marking the old entry as deleted
+        StoreEntry *const pe = addEntry(3);
 
-        CPPUNIT_ASSERT_EQUAL(SWAPOUT_WRITING, pe->swap_status);
-        CPPUNIT_ASSERT_EQUAL(0, pe->swap_dirn);
-        CPPUNIT_ASSERT(pe->swap_filen >= 0);
+        CPPUNIT_ASSERT_EQUAL(SWAPOUT_NONE, pe->swap_status);
+        CPPUNIT_ASSERT_EQUAL(-1, pe->swap_dirn);
+        CPPUNIT_ASSERT_EQUAL(-1, pe->swap_filen);
+        pe->unlock("testRock::testRockSwapOut e#3");
+
+        // after marking the old entry as deleted
+        StoreEntry *const pe2 = getEntry(4);
+        CPPUNIT_ASSERT(pe2 != nullptr);
+        pe2->release();
+
+        StoreEntry *const pe3 = addEntry(4);
+        CPPUNIT_ASSERT_EQUAL(SWAPOUT_WRITING, pe3->swap_status);
+        CPPUNIT_ASSERT_EQUAL(0, pe3->swap_dirn);
+        CPPUNIT_ASSERT(pe3->swap_filen >= 0);
 
         StockEventLoop loop;
         loop.run();
 
-        CPPUNIT_ASSERT_EQUAL(SWAPOUT_DONE, pe->swap_status);
+        CPPUNIT_ASSERT_EQUAL(SWAPOUT_DONE, pe3->swap_status);
 
         pe->unlock("testRock::testRockSwapOut e#4");
     }

--- a/src/tests/testStoreController.cc
+++ b/src/tests/testStoreController.cc
@@ -111,8 +111,6 @@ addedEntry(Store::Disk *aStore,
     e->expires = squid_curtime;
     e->lastModified(squid_curtime);
     e->refcount = 1;
-    EBIT_CLR(e->flags, RELEASE_REQUEST);
-    e->clearPrivate();
     e->ping_status = PING_NONE;
     EBIT_CLR(e->flags, ENTRY_VALIDATED);
     e->hashInsert((const cache_key *)name.termedBuf()); /* do it after we clear KEY_PRIVATE */

--- a/src/tests/testStoreHashIndex.cc
+++ b/src/tests/testStoreHashIndex.cc
@@ -89,8 +89,6 @@ addedEntry(Store::Disk *aStore,
     e->expires = squid_curtime;
     e->lastModified(squid_curtime);
     e->refcount = 1;
-    EBIT_CLR(e->flags, RELEASE_REQUEST);
-    e->clearPrivate();
     e->ping_status = PING_NONE;
     EBIT_CLR(e->flags, ENTRY_VALIDATED);
     e->hashInsert((const cache_key *)name.termedBuf()); /* do it after we clear KEY_PRIVATE */

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -158,7 +158,8 @@ WhoisState::readReply(const Comm::ConnectionPointer &conn, char *aBuffer, size_t
     entry->timestampsSet();
     entry->flush();
 
-    entry->makePublic();
+    if (!entry->makePublic())
+        entry->makePrivate(true);
 
     fwd->complete();
     debugs(75, 3, "whoisReadReply: Done: " << entry->url());


### PR DESCRIPTION
When Squid finds a requested entry in the memory cache, it does not
check whether the same entry is also stored in a cache_dir. The
StoreEntry object may become associated with its store entry in the
memory cache but not with its store entry on disk. This inconsistency
causes two known problems:

1. Squid may needlessly swap out the memory hit to disk, either
   overwriting an existing (and identical) disk entry or, worse,
   creating a duplicate entry on another disk. In the second case, the
   two disk entries are not synchronized and may eventually start to
   differ if one of them is removed or updated.

2. Squid may not delete a stale disk entry when needed, violating
   various HTTP MUSTs, and eventually serving stale [disk] cache entries
   to clients.

Another purging problem is not caused by the above inconsistency:

3. A DELETE request or equivalent may come for the entry which is still
   locked for writing. Squid fails to get a lock for such an entry (in
   order to purge it) and the entry remains in disk and/or memory cache.

To solve the first two problems:

* StoreEntry::mayStartSwapout() now avoids needless swapouts by checking
  whether StoreEntry was fully loaded, is being loaded, or could have
  been loaded from disk. To be able to reject swapouts in the last case,
  we now require that the newer (disk) entries explicitly delete their
  older variants instead of relying on the Store to overwrite the older
  (unlocked) variant. That explicit delete should already be happening
  in higher-level code (that knows which entry is newer and must mark
  any stale entries for deletion anyway).

To fix problem #3:

* A new Store::Controller::evictIfFound(key) method purges (or marks for
  deletion if purging is impossible) all the matching store entries,
  without loading the StoreEntry information from stores. Avoiding
  StoreEntry creation reduces waste of resources (the StoreEntry object
  would have to be deleted anyway) _and_ allows us to mark being-created
  entries (that are locked for writing and, hence, cannot be loaded into
  a StoreEntry object).

XXX: SMP cache purges may continue to malfunction when the Transients
table is missing. Currently, Transients are created only when the
collapsed_forwarding is on. After Squid bug 4579 is fixed, every public
StoreEntry will have the corresponding Transients entry and vice versa,
extending these fixes to all SMP environments.

Note that even if Squid properly avoids storing duplicate disk entries,
some cache_dir manipulations by humans and Squid crashes may lead to
such duplicates being present.  This patch leaves dealing with potential
duplicates out of scope except it guarantees that if an entry is
deleted, then all [possible] duplicates are deleted as well.

Fixing the above problems required (and/or benefited from) many related
improvements, including some Store API changes. It is impractical to
detail each change here, but several are highlighted below.

To propagate DELETEs across workers, every public StoreEntry now has a
Transients entry.

Prevented concurrent cache readers from aborting when their entry is
release()d. Unlike abort, release should not affect current readers.

Fixed store.log code to avoid "Bug: Missing MemObject::storeId value".

Removed Transients extras used to initialize MemObject StoreID/method in
StoreEntry objects created by Transients::get() for collapsed requests.
Controlled::get() and related Controller APIs do not _require_ setting
those MemObject details: get() methods for all cache stores return
StoreEntry objects without them (because entry basics lack Store ID and
request method). The caller is responsible for cache key collision
detection. Controlled::get() parameters could include Store ID and
request method for early cache key collision detection, but adding a
StoreQuery class and improving collision detection code is outside this
project scope (and requires many changes).

Found more cases where release() should not prevent sharing.
Remaining cases need further analysis as discussed in master 39fe14b2.

Greatly simplified UFS store rebuilding, possibly fixing subtle bug(s).

Clarified RELEASE_REQUEST flag meaning, becoming 'a private StoreEntry
which can't become public anymore'. Refactored the related code,
combining two related notions: 'a private entry' and 'an entry marked
for removal'.

Do not abort collapsed StoreEntries during syncing just because the
corresponding being stored shared entry was marked for deletion. Abort
them if the shared entry has been also aborted.

Added StoreEntry helper methods to prevent direct manipulation of
individual disk-related data members (swap_dirn, swap_filen, and
swap_status). These methods help keep these related data members in a
coherent state and minimize code duplication.
Conflicts:
	src/MemObject.cc