### PR TITLE
Fixed clientside_mark and client port logging in TPROXY mode

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1308,6 +1308,7 @@ getOutgoingAddress(HttpRequest * request, Comm::ConnectionPointer conn)
             else
 #endif
                 conn->local = request->client_addr;
+            conn->local.port(0); // let OS pick the source port to prevent address clashes
             // some flags need setting on the socket to use this address
             conn->flags |= COMM_DOBIND;
             conn->flags |= COMM_TRANSPARENT;

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -169,7 +169,6 @@ Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn, int)
     /* Trust the user configured properly. If not no harm done.
      * We will simply attempt a bind outgoing on our own IP.
      */
-    newConn->remote.port(0); // allow random outgoing port to prevent address clashes
     debugs(89, 5, HERE << "address TPROXY: " << newConn);
     return true;
 #else


### PR DESCRIPTION
The clientside_mark ACL was not working with TPROXY because a
conntrack query could not find connmark without a true client port.

Ip::Intercept::Lookup() must return true client address, but its
TproxyTransparent() component was reseting the client port. We should
use zero port when we compute the source address for the Squid-to-peer
connection instead.