### PR TITLE
Bump minimum required GnuTLS version to 3.4.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1245,13 +1245,13 @@ if test "x$with_gnutls" != "xno"; then
   LIBS="$LIBS $LIBGNUTLS_PATH"
 
   # auto-detect using pkg-config
-  PKG_CHECK_MODULES([LIBGNUTLS],[gnutls >= 3.1.5],[
+  PKG_CHECK_MODULES([LIBGNUTLS],[gnutls >= 3.4.0],[
     CPPFLAGS="$CPPFLAGS $LIBGNUTLS_CFLAGS"
     ],[
     ## find the package without pkg-config
     ## check that the library is actually new enough.
-    ## by testing for a 3.1.5+ function which we use
-    AC_CHECK_LIB(gnutls,gnutls_certificate_verify_peers3,[LIBGNUTLS_LIBS="-lgnutls"])
+    ## by testing for a 3.4.0+ function which we use
+    AC_CHECK_LIB(gnutls,gnutls_pcert_export_x509,[LIBGNUTLS_LIBS="-lgnutls"])
   ])
   AC_CHECK_HEADERS(gnutls/gnutls.h gnutls/x509.h gnutls/abstract.h)
 


### PR DESCRIPTION
Commit 51e09c0 (GitHub PR #81) added GnuTLS functions available starting
with GnuTLS v3.4.0 but did not bump the ./configure check accordingly.