### PR TITLE
Do not link to OpenSSL licensing terms from squid -v

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -666,8 +666,7 @@ mainParseOptions(int argc, char *argv[])
             if (strlen(SQUID_BUILD_INFO))
                 printf("%s\n",SQUID_BUILD_INFO);
 #if USE_OPENSSL
-            printf("\nThis binary uses %s. ", SSLeay_version(SSLEAY_VERSION));
-            printf("For legal restrictions on distribution see https://www.openssl.org/source/license.html\n\n");
+            printf("\nThis binary uses %s.\n", SSLeay_version(SSLEAY_VERSION));
 #endif
             printf( "configure options: %s\n", SQUID_CONFIGURE_OPTIONS);
 


### PR DESCRIPTION
The link is unnecessary and may be unstable. The accompanying text is
unnecessary scary. All libraries used by Squid come with "legal
restrictions on distribution". There is no reason to single OpenSSL out.