### PR TITLE
Bug 4822: Build failure (-Wformat) where time_t is not long int

### DIFF
--- a/src/ipc/Kid.cc
+++ b/src/ipc/Kid.cc
@@ -90,7 +90,9 @@ Kid::reportStopped() const
     if (hopeless() && Config.hopelessKidRevivalDelay) {
         syslog(LOG_NOTICE, "Squid Parent: %s process %d will not be restarted for %ld "
                "seconds due to repeated, frequent failures",
-               theName.termedBuf(), pid, Config.hopelessKidRevivalDelay);
+               theName.termedBuf(),
+               pid,
+               static_cast<long int>(Config.hopelessKidRevivalDelay));
     }
 }
 


### PR DESCRIPTION
There is no good way to printf() time_t. AFAICT, Squid usually just
casts to (long) int. TODO: Use C++ streams (with manipulators) instead.