### PR TITLE
Fixed Transient reader locking broken by 4310f8b

### DIFF
--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -886,7 +886,7 @@ MemStore::completeWriting(StoreEntry &e)
 
     e.mem_obj->memCache.index = -1;
     e.mem_obj->memCache.io = MemObject::ioDone;
-    map->closeForWriting(index, false);
+    map->closeForWriting(index);
 
     CollapsedForwarding::Broadcast(e); // before we close our transient entry!
     Store::Root().transientsCompleteWriting(e);

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -207,7 +207,7 @@ Transients::monitorIo(StoreEntry *e, const cache_key *key, const Store::IoStatus
     }
 }
 
-/// creates a new Transients entry or throws
+/// creates a new Transients entry
 void
 Transients::addEntry(StoreEntry *e, const cache_key *key, const Store::IoStatus direction)
 {
@@ -224,11 +224,12 @@ Transients::addEntry(StoreEntry *e, const cache_key *key, const Store::IoStatus 
     slot->set(*e, key);
     e->mem_obj->xitTable.index = index;
     if (direction == Store::ioWriting) {
-        // keep write lock; the caller will decide what to do with it
+        // allow reading and receive remote DELETE events, but do not switch to
+        // the reading lock because transientReaders() callers want true readers
         map->startAppending(e->mem_obj->xitTable.index);
     } else {
         // keep the entry locked (for reading) to receive remote DELETE events
-        map->closeForWriting(e->mem_obj->xitTable.index);
+        map->closeForWriting(e->mem_obj->xitTable.index, true);
     }
 }
 

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -229,7 +229,7 @@ Transients::addEntry(StoreEntry *e, const cache_key *key, const Store::IoStatus 
         map->startAppending(e->mem_obj->xitTable.index);
     } else {
         // keep the entry locked (for reading) to receive remote DELETE events
-        map->closeForWriting(e->mem_obj->xitTable.index, true);
+        map->switchWritingToReading(e->mem_obj->xitTable.index);
     }
 }
 
@@ -256,7 +256,7 @@ Transients::completeWriting(const StoreEntry &e)
 {
     assert(e.hasTransients());
     assert(isWriter(e));
-    map->closeForWriting(e.mem_obj->xitTable.index, true);
+    map->switchWritingToReading(e.mem_obj->xitTable.index);
     e.mem_obj->xitTable.io = Store::ioReading;
 }
 

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -491,7 +491,7 @@ Rock::Rebuild::finalizeOrThrow(const sfileno fileNo, LoadingEntry &le)
         anchor.basics.swap_file_sz = le.size;
     EBIT_SET(anchor.basics.flags, ENTRY_VALIDATED);
     le.state(LoadingEntry::leLoaded);
-    sd->map->closeForWriting(fileNo, false);
+    sd->map->closeForWriting(fileNo);
     ++counts.objcount;
 }
 

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -876,9 +876,8 @@ Rock::SwapDir::writeCompleted(int errflag, size_t, RefCount< ::WriteRequest> r)
             if (sio.touchingStoreEntry()) {
                 sio.e->swap_file_sz = sio.writeableAnchor_->basics.swap_file_sz =
                                           sio.offset_;
-
-                // close, the entry gets the read lock
-                map->closeForWriting(sio.swap_filen, true);
+                map->switchWritingToReading(sio.swap_filen);
+                // sio.e keeps the (now read) lock on the anchor
             }
             sio.writeableAnchor_ = NULL;
             sio.splicingPoint = request->sidCurrent;

--- a/src/ipc/MemMap.cc
+++ b/src/ipc/MemMap.cc
@@ -88,17 +88,25 @@ Ipc::MemMap::openForWritingAt(const sfileno fileno, bool overwriteExisting)
 }
 
 void
-Ipc::MemMap::closeForWriting(const sfileno fileno, bool lockForReading)
+Ipc::MemMap::closeForWriting(const sfileno fileno)
 {
-    debugs(54, 5, "closing slot at " << fileno << " for writing and "
-           "openning for reading in map [" << path << ']');
+    debugs(54, 5, "stop writing slot at " << fileno <<
+           " in map [" << path << ']');
     assert(valid(fileno));
     Slot &s = shared->slots[fileno];
     assert(s.writing());
-    if (lockForReading)
-        s.lock.switchExclusiveToShared();
-    else
-        s.lock.unlockExclusive();
+    s.lock.unlockExclusive();
+}
+
+void
+Ipc::MemMap::switchWritingToReading(const sfileno fileno)
+{
+    debugs(54, 5, "switching writing slot at " << fileno <<
+           " to reading in map [" << path << ']');
+    assert(valid(fileno));
+    Slot &s = shared->slots[fileno];
+    assert(s.writing());
+    s.lock.switchExclusiveToShared();
 }
 
 /// terminate writing the entry, freeing its slot for others to use

--- a/src/ipc/MemMap.h
+++ b/src/ipc/MemMap.h
@@ -90,7 +90,10 @@ public:
     Slot *openForWritingAt(sfileno fileno, bool overwriteExisting = true);
 
     /// successfully finish writing the entry
-    void closeForWriting(const sfileno fileno, bool lockForReading = false);
+    void closeForWriting(const sfileno fileno);
+
+    /// stop writing the locked entry and start reading it
+    void switchWritingToReading(const sfileno fileno);
 
     /// only works on locked entries; returns nil unless the slot is readable
     const Slot *peekAtReader(const sfileno fileno) const;

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -155,20 +155,24 @@ Ipc::StoreMap::startAppending(const sfileno fileno)
 }
 
 void
-Ipc::StoreMap::closeForWriting(const sfileno fileno, bool lockForReading)
+Ipc::StoreMap::closeForWriting(const sfileno fileno)
 {
     Anchor &s = anchorAt(fileno);
     assert(s.writing());
-    if (lockForReading) {
-        s.lock.switchExclusiveToShared();
-        debugs(54, 5, "switched entry " << fileno <<
-               " from writing to reading " << path);
-        assert(s.complete());
-    } else {
-        s.lock.unlockExclusive();
-        debugs(54, 5, "closed entry " << fileno << " for writing " << path);
-        // cannot assert completeness here because we have no lock
-    }
+    // TODO: assert(!s.empty()); // i.e., unlocked s becomes s.complete()
+    s.lock.unlockExclusive();
+    debugs(54, 5, "closed entry " << fileno << " for writing " << path);
+    // cannot assert completeness here because we have no lock
+}
+
+void
+Ipc::StoreMap::switchWritingToReading(const sfileno fileno)
+{
+    debugs(54, 5, "switching entry " << fileno << " from writing to reading " << path);
+    Anchor &s = anchorAt(fileno);
+    assert(s.writing());
+    s.lock.switchExclusiveToShared();
+    assert(s.complete());
 }
 
 Ipc::StoreMap::Slice &

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -233,7 +233,9 @@ public:
     /// restrict opened for writing entry to appending operations; allow reads
     void startAppending(const sfileno fileno);
     /// successfully finish creating or updating the entry at fileno pos
-    void closeForWriting(const sfileno fileno, bool lockForReading = false);
+    void closeForWriting(const sfileno fileno);
+    /// stop writing (or updating) the locked entry and start reading it
+    void switchWritingToReading(const sfileno fileno);
     /// unlock and "forget" openForWriting entry, making it Empty again
     /// this call does not free entry slices so the caller has to do that
     void forgetWritingEntry(const sfileno fileno);


### PR DESCRIPTION
The closeForWriting() call comment is correct -- we must keep the lock,
but the optional argument was accidentally lost (when undoing the failed
attempt to remove all long-term transient locks in the feature branch).

Also polished stale comments (which led to the above bug discovery!).

Also polished addEntry() aspects that I have missed in 4310f8b.