### PR TITLE
Fixed a dangerous lie in the dereferenceIdle() description

### DIFF
--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -233,6 +233,7 @@ Store::Controller::callback()
     return result;
 }
 
+/// update reference counters of the recently touched entry
 void
 Store::Controller::referenceBusy(StoreEntry &e)
 {
@@ -256,6 +257,8 @@ Store::Controller::referenceBusy(StoreEntry &e)
     }
 }
 
+/// dereference()s an idle entry
+/// \returns false if and only if the entry should be deleted
 bool
 Store::Controller::dereferenceIdle(StoreEntry &e, bool wantsLocalMemory)
 {

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -136,9 +136,7 @@ public:
 private:
     bool memoryCacheHasSpaceFor(const int pagesRequired) const;
 
-    /// update reference counters of the recently touched entry
     void referenceBusy(StoreEntry &e);
-    /// dereference() an idle entry and return true if the entry should be deleted
     bool dereferenceIdle(StoreEntry &, bool wantsLocalMemory);
 
     void allowSharing(StoreEntry &, const cache_key *);


### PR DESCRIPTION
Also moved private Controller method descriptions to .cc per convention.