### PR TITLE
Support masked marks in the clientside_mark directive

### DIFF
--- a/src/ConnMarkConfig.cc
+++ b/src/ConnMarkConfig.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 1996-2018 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#include "ConnMarkConfig.h"
+#include "parser/Tokenizer.h"
+#include "sbuf/Stream.h"
+
+#include <limits>
+
+static nfmark_t
+getNfmark(Parser::Tokenizer &tokenizer, const SBuf &token)
+{
+    int64_t number;
+    if (!tokenizer.int64(number, 0, false))
+        throw TexcHere(ToSBuf("ConnMarkConfig: invalid value '", tokenizer.buf(), "' in '", token, "'"));
+
+    if (number > std::numeric_limits<nfmark_t>::max())
+        throw TexcHere(ToSBuf("ConnMarkConfig: number, ", number, "in '", token, "' is too big"));
+
+    return static_cast<nfmark_t>(number);
+}
+
+ConnMarkConfig
+ConnMarkConfig::Parse(const SBuf &token)
+{
+    Parser::Tokenizer tokenizer(token);
+
+    const nfmark_t mark = getNfmark(tokenizer, token);
+    const nfmark_t mask = tokenizer.skip('/') ? getNfmark(tokenizer, token) : 0xffffffff;
+
+    if (!tokenizer.atEnd())
+        throw TexcHere(ToSBuf("ConnMarkConfig: trailing garbage in '", token, "'"));
+
+    return {mark, mask};
+}
+
+std::ostream &
+operator <<(std::ostream &os, const ConnMarkConfig c)
+{
+    os << asHex(c.nfmark);
+
+    if (c.nfmask != 0xffffffff)
+        os << '/' << asHex(c.nfmask);
+
+    return os;
+}

--- a/src/ConnMarkConfig.h
+++ b/src/ConnMarkConfig.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 1996-2018 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_CONNMARKCONFIG_H
+#define SQUID_CONNMARKCONFIG_H
+
+#include "ip/forward.h"
+#include "sbuf/SBuf.h"
+
+/// a netfilter connection mark/mask pair (a.k.a. connmark)
+class ConnMarkConfig
+{
+public:
+    /// expects a "mark[/mask]" format
+    static ConnMarkConfig Parse(const SBuf &token);
+    /// whether the connection 'mark' matches the configured mark/mask
+    bool matches(const nfmark_t mark) const { return (mark & nfmask) == nfmark; }
+
+    nfmark_t nfmark;
+    nfmark_t nfmask;
+};
+
+std::ostream &operator <<(std::ostream &os, const ConnMarkConfig connmark);
+
+#endif // SQUID_CONNMARKCONFIG_H

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1278,15 +1278,15 @@ aclMapTOS(acl_tos * head, ACLChecklist * ch)
 }
 
 /// Checks for a netfilter mark value to apply depending on the ACL
-nfmark_t
+acl_nfmark *
 aclMapNfmark(acl_nfmark * head, ACLChecklist * ch)
 {
     for (acl_nfmark *l = head; l; l = l->next) {
         if (!l->aclList || ch->fastCheck(l->aclList).allowed())
-            return l->nfmark;
+            return l;
     }
 
-    return 0;
+    return nullptr;
 }
 
 void
@@ -1352,7 +1352,10 @@ nfmark_t
 GetNfmarkToServer(HttpRequest * request)
 {
     ACLFilledChecklist ch(NULL, request, NULL);
-    return aclMapNfmark(Ip::Qos::TheConfig.nfmarkToServer, &ch);
+    if (const auto mc = aclMapNfmark(Ip::Qos::TheConfig.nfmarkToServer, &ch))
+        return mc->connMark.nfmark;
+
+    return 0;
 }
 
 void

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -262,6 +262,8 @@ squid_SOURCES = \
 	ConfigOption.cc \
 	ConfigParser.cc \
 	ConfigParser.h \
+	ConnMarkConfig.cc \
+	ConnMarkConfig.h \
 	CpuAffinity.cc \
 	CpuAffinity.h \
 	CpuAffinityMap.cc \
@@ -1234,6 +1236,8 @@ tests_testCacheManager_SOURCES = \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \
 	ConfigParser.cc \
+	ConnMarkConfig.cc \
+	ConnMarkConfig.h \
 	CpuAffinityMap.cc \
 	CpuAffinityMap.h \
 	CpuAffinitySet.cc \
@@ -1647,6 +1651,8 @@ tests_testEvent_SOURCES = \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \
 	ConfigParser.cc \
+	ConnMarkConfig.cc \
+	ConnMarkConfig.h \
 	CpuAffinityMap.cc \
 	CpuAffinityMap.h \
 	CpuAffinitySet.cc \
@@ -1882,6 +1888,8 @@ tests_testEventLoop_SOURCES = \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \
 	ConfigParser.cc \
+	ConnMarkConfig.cc \
+	ConnMarkConfig.h \
 	CpuAffinityMap.cc \
 	CpuAffinityMap.h \
 	CpuAffinitySet.cc \
@@ -2115,6 +2123,8 @@ tests_test_http_range_SOURCES = \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \
 	ConfigParser.cc \
+	ConnMarkConfig.cc \
+	ConnMarkConfig.h \
 	CpuAffinityMap.cc \
 	CpuAffinityMap.h \
 	CpuAffinitySet.cc \
@@ -2392,6 +2402,8 @@ tests_testHttp1Parser_LDFLAGS = $(LIBADD_DL)
 ## Tests of the HttpRequest module.
 tests_testHttpRequest_SOURCES = \
 	AccessLogEntry.cc \
+	ConnMarkConfig.cc \
+	ConnMarkConfig.h \
 	RequestFlags.h \
 	RequestFlags.cc \
 	HttpRequest.cc \
@@ -3273,6 +3285,8 @@ tests_testURL_SOURCES = \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \
 	ConfigParser.cc \
+	ConnMarkConfig.cc \
+	ConnMarkConfig.h \
 	CpuAffinityMap.cc \
 	CpuAffinityMap.h \
 	CpuAffinitySet.cc \

--- a/src/acl/ConnMark.cc
+++ b/src/acl/ConnMark.cc
@@ -22,47 +22,15 @@ Acl::ConnMark::empty() const
     return false;
 }
 
-static std::ostream &
-operator <<(std::ostream &os, const Acl::ConnMark::ConnMarkQuery connmark)
-{
-    os << asHex(connmark.first);
-    if (connmark.second != 0xffffffff) {
-        os << '/' << asHex(connmark.second);
-    }
-    return os;
-}
-
-nfmark_t
-Acl::ConnMark::getNumber(Parser::Tokenizer &tokenizer, const SBuf &token) const
-{
-    int64_t number;
-    if (!tokenizer.int64(number, 0, false)) {
-        throw TexcHere(ToSBuf("acl ", typeString(), ": invalid value '", tokenizer.buf(), "' in ", token));
-    }
-
-    if (number > std::numeric_limits<nfmark_t>::max()) {
-        throw TexcHere(ToSBuf("acl ", typeString(), ": number ", number, " in ", token, " is too big"));
-    }
-    return static_cast<nfmark_t>(number);
-}
-
 void
 Acl::ConnMark::parse()
 {
     while (const char *t = ConfigParser::strtokFile()) {
         SBuf token(t);
         Parser::Tokenizer tokenizer(token);
-
-        const auto mark = getNumber(tokenizer, token);
-        const auto mask = tokenizer.skip('/') ? getNumber(tokenizer, token) : 0xffffffff;
-
-        if (!tokenizer.atEnd()) {
-            throw TexcHere(ToSBuf("acl ", typeString(), ": trailing garbage in ", token));
-        }
-
-        const ConnMarkQuery connmark(mark, mask);
-        marks.push_back(connmark);
-        debugs(28, 7, "added " << connmark);
+        const auto cm = ConnMarkConfig::Parse(token);
+        marks.push_back(cm);
+        debugs(28, 7, "added " << cm);
     }
 
     if (marks.empty()) {
@@ -77,7 +45,7 @@ Acl::ConnMark::match(ACLChecklist *cl)
     const auto connmark = checklist->conn()->clientConnection->nfmark;
 
     for (const auto &m : marks) {
-        if ((connmark & m.second) == m.first) {
+        if (m.matches(connmark)) {
             debugs(28, 5, "found " << m << " matching " << asHex(connmark));
             return 1;
         }

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -12,6 +12,7 @@
 #include "acl/Acl.h"
 #include "ip/forward.h"
 #include "parser/Tokenizer.h"
+#include "ConnMarkConfig.h"
 
 #include <vector>
 
@@ -29,12 +30,8 @@ public:
     virtual SBufList dump() const override;
     virtual bool empty() const override;
 
-    /// a mark/mask pair for matching CONNMARKs
-    typedef std::pair<nfmark_t, nfmark_t> ConnMarkQuery;
-
 private:
-    nfmark_t getNumber(Parser::Tokenizer &tokenizer, const SBuf &token) const;
-    std::vector<ConnMarkQuery> marks; ///< mark/mask pairs in configured order
+    std::vector<ConnMarkConfig> marks; ///< marks/masks in configured order
 };
 
 } // namespace Acl

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2570,7 +2570,23 @@ DOC_START
 	Allows you to apply a Netfilter mark value to packets being transmitted
 	on the client-side, based on an ACL.
 
-	clientside_mark mark-value [!]aclname ...
+	clientside_mark mark[/mask] [!]aclname ...
+
+	Mark and mask are unsigned integers (hex, octal, or decimal).
+	The mask may be used to preserve marking previously set by other agents
+	(e.g., iptables).
+
+	A matching rule replaces the original packet mark value with the configured mark.
+	If a mask is also specified, then the masked bits of the original value are
+	zeroed, and the configured mark is ORed with that adjusted value. For example,
+	setting a 0xAB/0xF mark for a packet with a 0x5F mark, results in a
+	0xFB mark (rather than a 0xAB or 0x5B mark).
+
+	This directive semantics is similar to iptables --set-mark rather than
+	--set-xmark functionality.
+
+	The directive rules are evaluated in the configuration order. The first
+	matching rule wins.
 
 	Example where normal_service_net uses the mark value 0x00
 	and good_service_net uses 0x20

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -537,7 +537,7 @@ Ip::Qos::Config::isAclNfmarkActive() const
     for (int i=0; i<2; ++i) {
         while (nfmarkAcls[i]) {
             acl_nfmark *l = nfmarkAcls[i];
-            if (l->nfmark > 0)
+            if (l->connMark.nfmark > 0)
                 return true;
             nfmarkAcls[i] = l->next;
         }

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -10,6 +10,7 @@
 #define SQUID_QOSCONFIG_H
 
 #include "acl/forward.h"
+#include "ConnMarkConfig.h"
 #include "hier_code.h"
 #include "ip/forward.h"
 
@@ -43,12 +44,12 @@ class acl_nfmark
     CBDATA_CLASS(acl_nfmark);
 
 public:
-    acl_nfmark() : next(NULL), aclList(NULL), nfmark(0) {}
+    acl_nfmark() : next(NULL), aclList(NULL) {}
     ~acl_nfmark();
 
     acl_nfmark *next;
     ACLList *aclList;
-    nfmark_t nfmark;
+    ConnMarkConfig connMark;
 };
 
 namespace Ip


### PR DESCRIPTION
... to preserve existing mark bits when adding Squid connmarks.

No functionality changes expected until the /mask is configured.

The masking implementation is based on iptables --set-mark rather than
--set-xmark principles. TODO: Add support for the latter if needed.