### PR TITLE
Bug 4829: Fix IPC memory leak when disker queue full

### DIFF
--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -372,6 +372,8 @@ IpcIoFile::push(IpcIoPendingRequest *const pending)
                dbName << " overflow: " <<
                SipcIo(KidIdentifier, ipcIo, diskId)); // TODO: report queue len
         // TODO: grow queue size
+        if (!pending->readRequest && ipcIo.page)
+            Ipc::Mem::PutPage(ipcIo.page); // Free the page if allocated
 
         pending->completeIo(NULL);
         delete pending;


### PR DESCRIPTION
https://bugs.squid-cache.org/show_bug.cgi?id=4829

When configured with rock only storage, after a long period of high load or a shorter period of extremely high load, we found disk IO dropped entirely. Even after giving Squid time to recover and then resuming a low load the diskers were just not doing anything.

We saw a lot of "run out of shared memory pages for IPC I/O" errors during the high load, which continues to remain on smaller loads after the recovery time. The only way we recovered from this was to restart Squid.

After some debugging we found that the shared memory pages were leaking when the disker queue was filling up. When freeing the shared memory page in the exception handling condition when the queue is full fixes the issue (see attached patches)
