### PR TITLE
Bug 4829: IPC shared memory leaks when disker queue overflows

### DIFF
--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -372,8 +372,8 @@ IpcIoFile::push(IpcIoPendingRequest *const pending)
                dbName << " overflow: " <<
                SipcIo(KidIdentifier, ipcIo, diskId)); // TODO: report queue len
         // TODO: grow queue size
-        if (!pending->readRequest && ipcIo.page)
-            Ipc::Mem::PutPage(ipcIo.page); // Free the page if allocated
+        if (ipcIo.page)
+            Ipc::Mem::PutPage(ipcIo.page);
 
         pending->completeIo(NULL);
         delete pending;

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -372,6 +372,8 @@ IpcIoFile::push(IpcIoPendingRequest *const pending)
                dbName << " overflow: " <<
                SipcIo(KidIdentifier, ipcIo, diskId)); // TODO: report queue len
         // TODO: grow queue size
+        if (!pending->readRequest && ipcIo.page)
+            Ipc::Mem::PutPage(ipcIo.page); // Free the page if allocated
 
         pending->completeIo(NULL);
         delete pending;


### PR DESCRIPTION
The fixed leak was accompanied by these cache.log errors:

    ERROR: worker I/O push queue for ... overflow: ...

I/O queue overflows during disk read requests log the same error but do
not leak memory. Repeated overflows during disk write requests could
eventually exhaust IPC shared memory:

    ERROR: ... exception: run out of shared memory pages for IPC I/O

With IPC memory exhausted due to leaks, rock disk I/O stops forever.