### PR TITLE
Do not abuse argv[0] to supply roles and IDs to SMP kids

### DIFF
--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -101,7 +101,7 @@ CommandLine::nextOption(int &optId) const
         assert(optind > 0 && static_cast<unsigned int>(optind) < argv_.size());
         SBuf errMsg;
         errMsg.Printf("'%s': %s", argv_[optind - 1],  optId == '?' ?
-                "unrecognized option or missing required argument" : "missing required argument");
+                      "unrecognized option or missing required argument" : "missing required argument");
         throw TexcHere(errMsg);
     }
     return optId != -1;

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -8,438 +8,108 @@
 
 #include "squid.h"
 
-#include "cache_cf.h"
 #include "CommandLine.h"
-#include "fatal.h"
-#include "globals.h"
-#include "parser/Tokenizer.h"
-#include "tools.h"
-
-#if USE_OPENSSL
-#include "ssl/context_storage.h"
-#endif
-
-#include <algorithm>
-#include <getopt.h>
-
-static char *opt_syslog_facility = NULL;
 
 static void
-usage(void)
+ResetGetopt(const bool allowStderrWarnings)
 {
-    fprintf(stderr,
-            "Usage: %s [-cdzCFNRVYX] [-n name] [-s | -l facility] [-f config-file] [-[au] port] [-k signal]"
-#if USE_WIN32_SERVICE
-            "[-ir] [-O CommandLine]"
-#endif
-            "\n"
-            "    -h | --help       Print help message.\n"
-            "    -v | --version    Print version details.\n"
-            "\n"
-            "       -a port   Specify HTTP port number (default: %d).\n"
-            "       -d level  Write debugging to stderr also.\n"
-            "       -f file   Use given config-file instead of\n"
-            "                 %s\n"
-#if USE_WIN32_SERVICE
-            "       -i        Installs as a Windows Service (see -n option).\n"
-#endif
-            "       -k reconfigure|rotate|shutdown|"
-#ifdef SIGTTIN
-            "restart|"
-#endif
-            "interrupt|kill|debug|check|parse\n"
-            "                 Parse configuration file, then send signal to \n"
-            "                 running copy (except -k parse) and exit.\n"
-            "       -n name   Specify service name to use for service operations\n"
-            "                 default is: " APP_SHORTNAME ".\n"
-#if USE_WIN32_SERVICE
-            "       -r        Removes a Windows Service (see -n option).\n"
-#endif
-            "       -s | -l facility\n"
-            "                 Enable logging to syslog.\n"
-            "       -u port   Specify ICP port number (default: %d), disable with 0.\n"
-            "       -z        Create missing swap directories and then exit.\n"
-            "       -C        Do not catch fatal signals.\n"
-            "       -D        OBSOLETE. Scheduled for removal.\n"
-            "       -F        Don't serve any requests until store is rebuilt.\n"
-            "       -N        Master process runs in foreground and is a worker. No kids.\n"
-            "       --foreground\n"
-            "                 Master process runs in foreground and creates worker kids.\n"
-            "       --kid\n"
-            "                 A kid name passed to a worker Squid process.\n"
-            "                 Warning: do not use it directly since it is an internal option.\n"
-#if USE_WIN32_SERVICE
-            "       -O options\n"
-            "                 Set Windows Service Command line options in Registry.\n"
-#endif
-            "       -R        Do not set REUSEADDR on port.\n"
-            "       -S        Double-check swap during rebuild.\n"
-            "       -X        Force full debugging.\n"
-            "       -Y        Only return UDP_HIT or UDP_MISS_NOFETCH during fast reload.\n",
-            APP_SHORTNAME, CACHE_HTTP_PORT, DefaultConfigFile, CACHE_ICP_PORT);
-    exit(EXIT_FAILURE);
+    opterr = allowStderrWarnings ? 1 : 0;
+    // getopt(3) uses global state but resets it if optind is zero
+    // getopt(3) always skips argv[0], even if optind is zero
+    optind = 0;
 }
 
-CommandLine::CommandLine(const int anArgc, char *anArgv[])
-    : execFile_(anArgv[0])
+CommandLine::CommandLine(int argC, char *argV[], const char *shortRules, const struct option *longRules):
+    argv_(),
+    shortOptions_(xstrdup(shortRules)),
+    longOptions_()
 {
-    parse(anArgc, anArgv);
-}
+    assert(argC > 0); // C++ main() requirement that makes our arg0() safe
 
-void
-CommandLine::parse(int anArgc, char *anArgv[])
-{
-    int optIndex = 0;
+    /* copy argV items */
+    argv_.reserve(argC+1);
+    for (int i = 0; i < argC; ++i)
+        argv_.push_back(xstrdup(argV[i]));
+    argv_.push_back(nullptr); // POSIX argv "must be terminated by a null pointer"
 
-    // short options
-    const char *shortOpStr =
-#if USE_WIN32_SERVICE
-        "O:Vir"
-#endif
-        "CDFNRSYXa:d:f:hk:m::n:sl:u:vz?";
-
-    // long options
-    static struct option squidOptions[] = {
-        {"foreground", no_argument, 0,  ForegroundCode},
-        {"kid",        required_argument, 0, KidCode},
-        {"help",       no_argument, 0, 'h'},
-        {"version",    no_argument, 0, 'v'},
-        {0, 0, 0, 0}
-    };
-
-    int c;
-
-    while ((c = getopt_long(anArgc, anArgv, shortOpStr, squidOptions, &optIndex)) != -1) {
-        if (c == '?' || c == 'h') {
-            usage();
-            // unreacheable
+    /* copy grammar rules for the long options */
+    for (auto longOption = longRules; longOption; ++longOption) {
+        longOptions_.push_back(*longOption);
+        if (!longOption->name)
             break;
+    }
+}
+
+CommandLine::CommandLine(const CommandLine &them):
+    CommandLine(them.argc(), them.argv(), them.shortOptions_, them.longOptions())
+{
+}
+
+CommandLine &
+CommandLine::operator =(CommandLine them) // not a reference so that we can swap
+{
+    // cannot just swap(*this, them): std::swap(T,T) may call this assignment op
+    std::swap(argv_, them.argv_);
+    std::swap(shortOptions_, them.shortOptions_);
+    std::swap(longOptions_, them.longOptions_);
+    return *this;
+}
+
+CommandLine::~CommandLine()
+{
+    for (auto arg: argv_)
+        xfree(arg);
+
+    xfree(shortOptions_);
+}
+
+bool
+CommandLine::hasOption(const int optIdToFind, const char **optValue) const
+{
+    ResetGetopt(false); // avoid duped warnings; forEachOption() will complain
+    int optId = 0;
+    while (nextOption(optId)) {
+        if (optId == optIdToFind) {
+            if (optValue)
+                *optValue = optarg;
+            return true;
         }
-        options.push_back(std::make_pair(c, optarg ? SBuf(optarg) : SBuf()));
     }
-
-    // reserve space for --kid option (with argument) and nil termination pointer
-    argv_.clear();
-    argv_.reserve(anArgc + 3);
-    for (int i = 0; i < anArgc; ++i)
-        argv_.push_back(anArgv[i]);
-}
-
-const char **
-CommandLine::argv(const char *argv0, const char *kid)
-{
-    argv_[0] = argv0;
-
-    auto kidPos = std::find_if(argv_.begin(), argv_.end(), [](const char *opt)
-            { return strcmp(opt, "--kid") == 0; });
-    // not expected to happen because kids do not create kids
-    if (kidPos != argv_.end()) {
-        assert(++kidPos != argv_.end());
-        *kidPos = xstrdup(kid);
-    } else {
-        argv_.push_back("--kid");
-        argv_.push_back(xstrdup(kid));
-    }
-    argv_.push_back(nullptr);
-    return &argv_[0];
-}
-
-SBuf
-CommandLine::kidName() const
-{
-    auto kidOpt = std::find_if(options.begin(), options.end(), [](const OptionsPair &p)
-             { return p.first == KidCode; });
-    if (kidOpt == options.end())
-        return SBuf();
-    return kidOpt->second;
+    return false;
 }
 
 void
-CommandLine::processOptions()
+CommandLine::forEachOption(Visitor visitor) const
 {
-    std::for_each(options.begin(), options.end(), [this](OptionsPair &opt)
-            { processOption(opt.first, opt.second.isEmpty() ? nullptr : opt.second.c_str()); });
+    ResetGetopt(true);
+    int optId = 0;
+    while (nextOption(optId))
+        visitor(optId, optarg);
 }
 
-// apply a single option
+/// extracts the next option (if any)
+/// \returns whether the option was extracted
+bool
+CommandLine::nextOption(int &optId) const
+{
+    optId = getopt_long(argc(), argv(), shortOptions_, longOptions(), nullptr);
+    // TODO: if (optId == '?'), then throw an error instead of relying on opterr
+    return optId != -1;
+}
+
 void
-CommandLine::processOption(const char optCode, const char *optArg)
+CommandLine::resetArg0(const char *programName)
 {
-    // XXX: use optArg instead
-    optarg = const_cast<char *>(optArg);
-    switch (optCode) {
-
-        case 'C':
-            /** \par C
-             * Unset/disabel global option for catchign signals. opt_catch_signals */
-            opt_catch_signals = 0;
-            break;
-
-        case 'D':
-            /** \par D
-             * OBSOLETE: WAS: override to prevent optional startup DNS tests. */
-            debugs(1,DBG_CRITICAL, "WARNING: -D command-line option is obsolete.");
-            break;
-
-        case 'F':
-            /** \par F
-             * Set global option for foreground rebuild. opt_foreground_rebuild */
-            opt_foreground_rebuild = 1;
-            break;
-
-        case 'N':
-            /** \par N
-             * Set global option for 'no_daemon' mode. opt_no_daemon */
-            opt_no_daemon = 1;
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'O':
-            /** \par O
-             * Set global option. opt_command_lin and WIN32_Command_Line */
-            opt_command_line = 1;
-            WIN32_Command_Line = xstrdup(optarg);
-            break;
-#endif
-
-        case 'R':
-            /** \par R
-             * Unset/disable global option opt_reuseaddr */
-            opt_reuseaddr = 0;
-            break;
-
-        case 'S':
-            /** \par S
-             * Set global option opt_store_doublecheck */
-            opt_store_doublecheck = 1;
-            break;
-
-        case 'X':
-            /** \par X
-             * Force full debugging */
-            Debug::parseOptions("rotate=0 ALL,9");
-            Debug::override_X = 1;
-            sigusr2_handle(SIGUSR2);
-            break;
-
-        case 'Y':
-            /** \par Y
-             * Set global option opt_reload_hit_only */
-            opt_reload_hit_only = 1;
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'i':
-            /** \par i
-             * Set global option opt_install_service (to TRUE) */
-            opt_install_service = TRUE;
-            break;
-#endif
-
-        case 'a':
-            {
-                /** \par a
-                 * Add optional HTTP port as given following the option */
-                char *portOpt = xstrdup(optarg);
-                add_http_port(portOpt);
-                xfree(portOpt);
-                break;
-            }
-
-        case 'd':
-            /** \par d
-             * Set global option Debug::log_stderr to the number given following the option */
-            Debug::log_stderr = atoi(optarg);
-            break;
-
-        case 'f':
-            /** \par f
-             * Load the file given instead of the default squid.conf. */
-            xfree(ConfigFile);
-            ConfigFile = xstrdup(optarg);
-            break;
-
-        case 'k':
-            /** \par k
-             * Run the administrative action given following the option */
-
-            /** \li When it is missing or an unknown option display the usage help. */
-            if (!optarg || strlen(optarg) < 1)
-                usage();
-
-            else if (!strncmp(optarg, "reconfigure", strlen(optarg)))
-                /** \li On reconfigure send SIGHUP. */
-                opt_send_signal = SIGHUP;
-            else if (!strncmp(optarg, "rotate", strlen(optarg)))
-                /** \li On rotate send SIGQUIT or SIGUSR1. */
-#if defined(_SQUID_LINUX_THREADS_)
-                opt_send_signal = SIGQUIT;
-#else
-                opt_send_signal = SIGUSR1;
-#endif
-
-            else if (!strncmp(optarg, "debug", strlen(optarg)))
-                /** \li On debug send SIGTRAP or SIGUSR2. */
-#if defined(_SQUID_LINUX_THREADS_)
-                opt_send_signal = SIGTRAP;
-#else
-                opt_send_signal = SIGUSR2;
-#endif
-
-            else if (!strncmp(optarg, "shutdown", strlen(optarg)))
-                /** \li On shutdown send SIGTERM. */
-                opt_send_signal = SIGTERM;
-            else if (!strncmp(optarg, "interrupt", strlen(optarg)))
-                /** \li On interrupt send SIGINT. */
-                opt_send_signal = SIGINT;
-            else if (!strncmp(optarg, "kill", strlen(optarg)))
-                /** \li On kill send SIGKILL. */
-                opt_send_signal = SIGKILL;
-
-#ifdef SIGTTIN
-
-            else if (!strncmp(optarg, "restart", strlen(optarg)))
-                /** \li On restart send SIGTTIN. (exit and restart by parent) */
-                opt_send_signal = SIGTTIN;
-
-#endif
-
-            else if (!strncmp(optarg, "check", strlen(optarg)))
-                /** \li On check send 0 / SIGNULL. */
-                opt_send_signal = 0;    /* SIGNULL */
-            else if (!strncmp(optarg, "parse", strlen(optarg)))
-                /** \li On parse set global flag to re-parse the config file only. */
-                opt_parse_cfg_only = 1;
-            else
-                usage();
-
-            break;
-
-        case 'm':
-            /** \par m
-             * Set global malloc_debug_level to the value given following the option.
-             * if none is given it toggles the xmalloc_trace option on/off */
-            if (optarg) {
-#if MALLOC_DBG
-                malloc_debug_level = atoi(optarg);
-#else
-                fatal("Need to add -DMALLOC_DBG when compiling to use -mX option");
-#endif
-
-            }
-            break;
-
-        case 'n':
-            /** \par n
-             * Set global option opt_signal_service (to true).
-             * Stores the additional parameter given in global service_name */
-            if (optarg && *optarg != '\0') {
-                const SBuf t(optarg);
-                ::Parser::Tokenizer tok(t);
-                const CharacterSet chr = CharacterSet::ALPHA+CharacterSet::DIGIT;
-                if (!tok.prefix(service_name, chr))
-                    fatalf("Expected alphanumeric service name for the -n option but got: %s", optarg);
-                if (!tok.atEnd())
-                    fatalf("Garbage after alphanumeric service name in the -n option value: %s", optarg);
-                if (service_name.length() > 32)
-                    fatalf("Service name (-n option) must be limited to 32 characters but got %u", service_name.length());
-                opt_signal_service = true;
-            } else {
-                fatal("A service name is required for the -n option");
-            }
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'r':
-            /** \par r
-             * Set global option opt_remove_service (to TRUE) */
-            opt_remove_service = TRUE;
-
-            break;
-
-#endif
-
-        case 'l':
-            /** \par l
-             * Stores the syslog facility name in global opt_syslog_facility
-             * then performs actions for -s option. */
-            xfree(opt_syslog_facility); // ignore any previous options sent
-            opt_syslog_facility = xstrdup(optarg);
-
-        case 's':
-            /** \par s
-             * Initialize the syslog for output */
-#if HAVE_SYSLOG
-
-            _db_set_syslog(opt_syslog_facility);
-
-            break;
-
-#else
-
-            fatal("Logging to syslog not available on this platform");
-
-            /* NOTREACHED */
-#endif
-
-        case 'u':
-            /** \par u
-             * Store the ICP port number given in global option icpPortNumOverride
-             * ensuring its a positive number. */
-            icpPortNumOverride = atoi(optarg);
-
-            if (icpPortNumOverride < 0)
-                icpPortNumOverride = 0;
-
-            break;
-
-        case 'v':
-            /** \par v
-             * Display squid version and build information. Then exit. */
-            printf("Squid Cache: Version %s\n",version_string);
-            printf("Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
-            if (strlen(SQUID_BUILD_INFO))
-                printf("%s\n",SQUID_BUILD_INFO);
-#if USE_OPENSSL
-            printf("\nThis binary uses %s. ", SSLeay_version(SSLEAY_VERSION));
-            printf("For legal restrictions on distribution see https://www.openssl.org/source/license.html\n\n");
-#endif
-            printf( "configure options: %s\n", SQUID_CONFIGURE_OPTIONS);
-
-#if USE_WIN32_SERVICE
-
-            printf("Compiled as Windows System Service.\n");
-
-#endif
-
-            exit(EXIT_SUCCESS);
-
-        /* NOTREACHED */
-
-        case 'z':
-            /** \par z
-             * Set global option Debug::log_stderr and opt_create_swap_dirs */
-            Debug::log_stderr = 1;
-            opt_create_swap_dirs = 1;
-            break;
-
-        case ForegroundCode:
-            /** \par --foreground
-             * Set global option opt_foreground */
-            opt_foreground = 1;
-            break;
-
-        case KidCode:
-            // \par --kid
-            // expected to be already applied in SquidMain()
-            break;
-
-        default:
-            fatalf("Unexpected option with code %d", optCode);
-            break;
-    }
+    assert(programName);
+    xfree(argv_[0]);
+    argv_[0] = xstrdup(programName);
 }
 
+void
+CommandLine::addOption(const char *name, const char *value)
+{
+    assert(name);
+    argv_.push_back(xstrdup(name));
+    if (value)
+        argv_.push_back(xstrdup(value));
+}

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -8,8 +8,8 @@
 
 #include "squid.h"
 
-#include "CommandLine.h"
 #include "cache_cf.h"
+#include "CommandLine.h"
 #include "fatal.h"
 #include "globals.h"
 #include "parser/Tokenizer.h"
@@ -135,10 +135,10 @@ CommandLine::argv(const char *argv0, const char *kid)
     // not expected to happen because kids do not create kids
     if (kidPos != argv_.end()) {
         assert(++kidPos != argv_.end());
-        *kidPos = strdup(kid);
+        *kidPos = xstrdup(kid);
     } else {
         argv_.push_back("--kid");
-        argv_.push_back(strdup(kid));
+        argv_.push_back(xstrdup(kid));
     }
     argv_.push_back(nullptr);
     return &argv_[0];

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -1,0 +1,445 @@
+/*
+ * Copyright (C) 1996-2018 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#include "CommandLine.h"
+#include "cache_cf.h"
+#include "fatal.h"
+#include "globals.h"
+#include "parser/Tokenizer.h"
+#include "tools.h"
+
+#if USE_OPENSSL
+#include "ssl/context_storage.h"
+#endif
+
+#include <algorithm>
+#include <getopt.h>
+
+static char *opt_syslog_facility = NULL;
+
+static void
+usage(void)
+{
+    fprintf(stderr,
+            "Usage: %s [-cdzCFNRVYX] [-n name] [-s | -l facility] [-f config-file] [-[au] port] [-k signal]"
+#if USE_WIN32_SERVICE
+            "[-ir] [-O CommandLine]"
+#endif
+            "\n"
+            "    -h | --help       Print help message.\n"
+            "    -v | --version    Print version details.\n"
+            "\n"
+            "       -a port   Specify HTTP port number (default: %d).\n"
+            "       -d level  Write debugging to stderr also.\n"
+            "       -f file   Use given config-file instead of\n"
+            "                 %s\n"
+#if USE_WIN32_SERVICE
+            "       -i        Installs as a Windows Service (see -n option).\n"
+#endif
+            "       -k reconfigure|rotate|shutdown|"
+#ifdef SIGTTIN
+            "restart|"
+#endif
+            "interrupt|kill|debug|check|parse\n"
+            "                 Parse configuration file, then send signal to \n"
+            "                 running copy (except -k parse) and exit.\n"
+            "       -n name   Specify service name to use for service operations\n"
+            "                 default is: " APP_SHORTNAME ".\n"
+#if USE_WIN32_SERVICE
+            "       -r        Removes a Windows Service (see -n option).\n"
+#endif
+            "       -s | -l facility\n"
+            "                 Enable logging to syslog.\n"
+            "       -u port   Specify ICP port number (default: %d), disable with 0.\n"
+            "       -z        Create missing swap directories and then exit.\n"
+            "       -C        Do not catch fatal signals.\n"
+            "       -D        OBSOLETE. Scheduled for removal.\n"
+            "       -F        Don't serve any requests until store is rebuilt.\n"
+            "       -N        Master process runs in foreground and is a worker. No kids.\n"
+            "       --foreground\n"
+            "                 Master process runs in foreground and creates worker kids.\n"
+            "       --kid\n"
+            "                 A kid name passed to a worker Squid process.\n"
+            "                 Warning: do not use it directly since it is an internal option.\n"
+#if USE_WIN32_SERVICE
+            "       -O options\n"
+            "                 Set Windows Service Command line options in Registry.\n"
+#endif
+            "       -R        Do not set REUSEADDR on port.\n"
+            "       -S        Double-check swap during rebuild.\n"
+            "       -X        Force full debugging.\n"
+            "       -Y        Only return UDP_HIT or UDP_MISS_NOFETCH during fast reload.\n",
+            APP_SHORTNAME, CACHE_HTTP_PORT, DefaultConfigFile, CACHE_ICP_PORT);
+    exit(EXIT_FAILURE);
+}
+
+CommandLine::CommandLine(const int anArgc, char *anArgv[])
+    : execFile_(anArgv[0])
+{
+    parse(anArgc, anArgv);
+}
+
+void
+CommandLine::parse(int anArgc, char *anArgv[])
+{
+    int optIndex = 0;
+
+    // short options
+    const char *shortOpStr =
+#if USE_WIN32_SERVICE
+        "O:Vir"
+#endif
+        "CDFNRSYXa:d:f:hk:m::n:sl:u:vz?";
+
+    // long options
+    static struct option squidOptions[] = {
+        {"foreground", no_argument, 0,  ForegroundCode},
+        {"kid",        required_argument, 0, KidCode},
+        {"help",       no_argument, 0, 'h'},
+        {"version",    no_argument, 0, 'v'},
+        {0, 0, 0, 0}
+    };
+
+    int c;
+
+    while ((c = getopt_long(anArgc, anArgv, shortOpStr, squidOptions, &optIndex)) != -1) {
+        if (c == '?' || c == 'h') {
+            usage();
+            // unreacheable
+            break;
+        }
+        options.push_back(std::make_pair(c, optarg ? SBuf(optarg) : SBuf()));
+    }
+
+    // reserve space for --kid option (with argument) and nil termination pointer
+    argv_.clear();
+    argv_.reserve(anArgc + 3);
+    for (int i = 0; i < anArgc; ++i)
+        argv_.push_back(anArgv[i]);
+}
+
+const char **
+CommandLine::argv(const char *argv0, const char *kid)
+{
+    argv_[0] = argv0;
+
+    auto kidPos = std::find_if(argv_.begin(), argv_.end(), [](const char *opt)
+            { return strcmp(opt, "--kid") == 0; });
+    // not expected to happen because kids do not create kids
+    if (kidPos != argv_.end()) {
+        assert(++kidPos != argv_.end());
+        *kidPos = strdup(kid);
+    } else {
+        argv_.push_back("--kid");
+        argv_.push_back(strdup(kid));
+    }
+    argv_.push_back(nullptr);
+    return &argv_[0];
+}
+
+SBuf
+CommandLine::kidName() const
+{
+    auto kidOpt = std::find_if(options.begin(), options.end(), [](const OptionsPair &p)
+             { return p.first == KidCode; });
+    if (kidOpt == options.end())
+        return SBuf();
+    return kidOpt->second;
+}
+
+void
+CommandLine::processOptions()
+{
+    std::for_each(options.begin(), options.end(), [this](OptionsPair &opt)
+            { processOption(opt.first, opt.second.isEmpty() ? nullptr : opt.second.c_str()); });
+}
+
+// apply a single option
+void
+CommandLine::processOption(const char optCode, const char *optArg)
+{
+    // XXX: use optArg instead
+    optarg = const_cast<char *>(optArg);
+    switch (optCode) {
+
+        case 'C':
+            /** \par C
+             * Unset/disabel global option for catchign signals. opt_catch_signals */
+            opt_catch_signals = 0;
+            break;
+
+        case 'D':
+            /** \par D
+             * OBSOLETE: WAS: override to prevent optional startup DNS tests. */
+            debugs(1,DBG_CRITICAL, "WARNING: -D command-line option is obsolete.");
+            break;
+
+        case 'F':
+            /** \par F
+             * Set global option for foreground rebuild. opt_foreground_rebuild */
+            opt_foreground_rebuild = 1;
+            break;
+
+        case 'N':
+            /** \par N
+             * Set global option for 'no_daemon' mode. opt_no_daemon */
+            opt_no_daemon = 1;
+            break;
+
+#if USE_WIN32_SERVICE
+
+        case 'O':
+            /** \par O
+             * Set global option. opt_command_lin and WIN32_Command_Line */
+            opt_command_line = 1;
+            WIN32_Command_Line = xstrdup(optarg);
+            break;
+#endif
+
+        case 'R':
+            /** \par R
+             * Unset/disable global option opt_reuseaddr */
+            opt_reuseaddr = 0;
+            break;
+
+        case 'S':
+            /** \par S
+             * Set global option opt_store_doublecheck */
+            opt_store_doublecheck = 1;
+            break;
+
+        case 'X':
+            /** \par X
+             * Force full debugging */
+            Debug::parseOptions("rotate=0 ALL,9");
+            Debug::override_X = 1;
+            sigusr2_handle(SIGUSR2);
+            break;
+
+        case 'Y':
+            /** \par Y
+             * Set global option opt_reload_hit_only */
+            opt_reload_hit_only = 1;
+            break;
+
+#if USE_WIN32_SERVICE
+
+        case 'i':
+            /** \par i
+             * Set global option opt_install_service (to TRUE) */
+            opt_install_service = TRUE;
+            break;
+#endif
+
+        case 'a':
+            {
+                /** \par a
+                 * Add optional HTTP port as given following the option */
+                char *portOpt = xstrdup(optarg);
+                add_http_port(portOpt);
+                xfree(portOpt);
+                break;
+            }
+
+        case 'd':
+            /** \par d
+             * Set global option Debug::log_stderr to the number given following the option */
+            Debug::log_stderr = atoi(optarg);
+            break;
+
+        case 'f':
+            /** \par f
+             * Load the file given instead of the default squid.conf. */
+            xfree(ConfigFile);
+            ConfigFile = xstrdup(optarg);
+            break;
+
+        case 'k':
+            /** \par k
+             * Run the administrative action given following the option */
+
+            /** \li When it is missing or an unknown option display the usage help. */
+            if (!optarg || strlen(optarg) < 1)
+                usage();
+
+            else if (!strncmp(optarg, "reconfigure", strlen(optarg)))
+                /** \li On reconfigure send SIGHUP. */
+                opt_send_signal = SIGHUP;
+            else if (!strncmp(optarg, "rotate", strlen(optarg)))
+                /** \li On rotate send SIGQUIT or SIGUSR1. */
+#if defined(_SQUID_LINUX_THREADS_)
+                opt_send_signal = SIGQUIT;
+#else
+                opt_send_signal = SIGUSR1;
+#endif
+
+            else if (!strncmp(optarg, "debug", strlen(optarg)))
+                /** \li On debug send SIGTRAP or SIGUSR2. */
+#if defined(_SQUID_LINUX_THREADS_)
+                opt_send_signal = SIGTRAP;
+#else
+                opt_send_signal = SIGUSR2;
+#endif
+
+            else if (!strncmp(optarg, "shutdown", strlen(optarg)))
+                /** \li On shutdown send SIGTERM. */
+                opt_send_signal = SIGTERM;
+            else if (!strncmp(optarg, "interrupt", strlen(optarg)))
+                /** \li On interrupt send SIGINT. */
+                opt_send_signal = SIGINT;
+            else if (!strncmp(optarg, "kill", strlen(optarg)))
+                /** \li On kill send SIGKILL. */
+                opt_send_signal = SIGKILL;
+
+#ifdef SIGTTIN
+
+            else if (!strncmp(optarg, "restart", strlen(optarg)))
+                /** \li On restart send SIGTTIN. (exit and restart by parent) */
+                opt_send_signal = SIGTTIN;
+
+#endif
+
+            else if (!strncmp(optarg, "check", strlen(optarg)))
+                /** \li On check send 0 / SIGNULL. */
+                opt_send_signal = 0;    /* SIGNULL */
+            else if (!strncmp(optarg, "parse", strlen(optarg)))
+                /** \li On parse set global flag to re-parse the config file only. */
+                opt_parse_cfg_only = 1;
+            else
+                usage();
+
+            break;
+
+        case 'm':
+            /** \par m
+             * Set global malloc_debug_level to the value given following the option.
+             * if none is given it toggles the xmalloc_trace option on/off */
+            if (optarg) {
+#if MALLOC_DBG
+                malloc_debug_level = atoi(optarg);
+#else
+                fatal("Need to add -DMALLOC_DBG when compiling to use -mX option");
+#endif
+
+            }
+            break;
+
+        case 'n':
+            /** \par n
+             * Set global option opt_signal_service (to true).
+             * Stores the additional parameter given in global service_name */
+            if (optarg && *optarg != '\0') {
+                const SBuf t(optarg);
+                ::Parser::Tokenizer tok(t);
+                const CharacterSet chr = CharacterSet::ALPHA+CharacterSet::DIGIT;
+                if (!tok.prefix(service_name, chr))
+                    fatalf("Expected alphanumeric service name for the -n option but got: %s", optarg);
+                if (!tok.atEnd())
+                    fatalf("Garbage after alphanumeric service name in the -n option value: %s", optarg);
+                if (service_name.length() > 32)
+                    fatalf("Service name (-n option) must be limited to 32 characters but got %u", service_name.length());
+                opt_signal_service = true;
+            } else {
+                fatal("A service name is required for the -n option");
+            }
+            break;
+
+#if USE_WIN32_SERVICE
+
+        case 'r':
+            /** \par r
+             * Set global option opt_remove_service (to TRUE) */
+            opt_remove_service = TRUE;
+
+            break;
+
+#endif
+
+        case 'l':
+            /** \par l
+             * Stores the syslog facility name in global opt_syslog_facility
+             * then performs actions for -s option. */
+            xfree(opt_syslog_facility); // ignore any previous options sent
+            opt_syslog_facility = xstrdup(optarg);
+
+        case 's':
+            /** \par s
+             * Initialize the syslog for output */
+#if HAVE_SYSLOG
+
+            _db_set_syslog(opt_syslog_facility);
+
+            break;
+
+#else
+
+            fatal("Logging to syslog not available on this platform");
+
+            /* NOTREACHED */
+#endif
+
+        case 'u':
+            /** \par u
+             * Store the ICP port number given in global option icpPortNumOverride
+             * ensuring its a positive number. */
+            icpPortNumOverride = atoi(optarg);
+
+            if (icpPortNumOverride < 0)
+                icpPortNumOverride = 0;
+
+            break;
+
+        case 'v':
+            /** \par v
+             * Display squid version and build information. Then exit. */
+            printf("Squid Cache: Version %s\n",version_string);
+            printf("Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
+            if (strlen(SQUID_BUILD_INFO))
+                printf("%s\n",SQUID_BUILD_INFO);
+#if USE_OPENSSL
+            printf("\nThis binary uses %s. ", SSLeay_version(SSLEAY_VERSION));
+            printf("For legal restrictions on distribution see https://www.openssl.org/source/license.html\n\n");
+#endif
+            printf( "configure options: %s\n", SQUID_CONFIGURE_OPTIONS);
+
+#if USE_WIN32_SERVICE
+
+            printf("Compiled as Windows System Service.\n");
+
+#endif
+
+            exit(EXIT_SUCCESS);
+
+        /* NOTREACHED */
+
+        case 'z':
+            /** \par z
+             * Set global option Debug::log_stderr and opt_create_swap_dirs */
+            Debug::log_stderr = 1;
+            opt_create_swap_dirs = 1;
+            break;
+
+        case ForegroundCode:
+            /** \par --foreground
+             * Set global option opt_foreground */
+            opt_foreground = 1;
+            break;
+
+        case KidCode:
+            // \par --kid
+            // expected to be already applied in SquidMain()
+            break;
+
+        default:
+            fatalf("Unexpected option with code %d", optCode);
+            break;
+    }
+}
+

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -74,8 +74,11 @@ CommandLine::hasOption(const int optIdToFind, const char **optValue) const
     int optId = 0;
     while (nextOption(optId)) {
         if (optId == optIdToFind) {
-            if (optValue)
+            if (optValue) {
+                // do not need to copy the optarg string because it is a pointer into the original
+                // argv array (https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html)
                 *optValue = optarg;
+            }
             return true;
         }
     }
@@ -130,7 +133,8 @@ LongOption::LongOption() :
 {
 }
 
-LongOption::LongOption(const RawLongOption &opt)
+LongOption::LongOption(const RawLongOption &opt) :
+    option({nullptr, 0, nullptr, 0})
 {
     copy(opt);
 }
@@ -148,16 +152,15 @@ LongOption::~LongOption()
 LongOption &
 LongOption::operator =(const LongOption &opt)
 {
-    if (this != &opt) {
-        xfree(name);
+    if (this != &opt)
         copy(static_cast<const RawLongOption &>(opt));
-    }
     return *this;
 }
 
 void
 LongOption::copy(const RawLongOption &opt)
 {
+    xfree(name);
     name = opt.name ? xstrdup(opt.name) : nullptr;
     has_arg = opt.has_arg;
     flag = opt.flag;

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -21,12 +21,13 @@ ResetGetopt(const bool allowStderrWarnings)
     optind = 0;
 }
 
-CommandLine::CommandLine(int argC, char *argV[], const char &shortRules, const LongOption *longRules):
+CommandLine::CommandLine(int argC, char *argV[], const char *shortRules, const RawLongOption *longRules):
     argv_(),
-    shortOptions_(xstrdup(&shortRules)),
+    shortOptions_(shortRules ? xstrdup(shortRules) : ""),
     longOptions_()
 {
     assert(argC > 0); // C++ main() requirement that makes our arg0() safe
+    assert(shortRules);
 
     /* copy argV items */
     argv_.reserve(argC+1);
@@ -43,7 +44,7 @@ CommandLine::CommandLine(int argC, char *argV[], const char &shortRules, const L
 }
 
 CommandLine::CommandLine(const CommandLine &them):
-    CommandLine(them.argc(), them.argv(), *them.shortOptions_, them.longOptions())
+    CommandLine(them.argc(), them.argv(), them.shortOptions_, them.longOptions())
 {
 }
 
@@ -124,36 +125,38 @@ CommandLine::pushFrontOption(const char *name, const char *value)
         argv_.insert(argv_.begin() + 2, xstrdup(value));
 }
 
-Option::Option() :
+LongOption::LongOption() :
     option({nullptr, 0, nullptr, 0})
 {
 }
 
-Option::Option(const LongOption &opt)
+LongOption::LongOption(const RawLongOption &opt)
 {
     copy(opt);
 }
 
-Option::Option(const Option &opt):
-    Option(static_cast<const LongOption &>(opt))
+LongOption::LongOption(const LongOption &opt):
+    LongOption(static_cast<const RawLongOption &>(opt))
 {
 }
 
-Option::~Option()
+LongOption::~LongOption()
 {
     xfree(name);
 }
 
-Option &
-Option::operator =(const Option &opt)
+LongOption &
+LongOption::operator =(const LongOption &opt)
 {
-    xfree(name);
-    copy(static_cast<const LongOption &>(opt));
+    if (this != &opt) {
+        xfree(name);
+        copy(static_cast<const RawLongOption &>(opt));
+    }
     return *this;
 }
 
 void
-Option::copy(const LongOption &opt)
+LongOption::copy(const RawLongOption &opt)
 {
     name = opt.name ? xstrdup(opt.name) : nullptr;
     has_arg = opt.has_arg;

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -116,7 +116,7 @@ CommandLine::resetArg0(const char *programName)
 }
 
 void
-CommandLine::addOption(const char *name, const char *value)
+CommandLine::pushFrontOption(const char *name, const char *value)
 {
     assert(name);
     argv_.insert(argv_.begin() + 1, xstrdup(name));

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -37,8 +37,8 @@ CommandLine::CommandLine(int argC, char *argV[], const char &shortRules, const L
     /* copy grammar rules for the long options */
     if (longRules) {
         for (auto longOption = longRules; longOption->name; ++longOption)
-            longOptions_.push_back(Option(*longOption));
-        longOptions_.push_back(Option());
+            longOptions_.emplace_back(*longOption);
+        longOptions_.emplace_back();
     }
 }
 
@@ -48,7 +48,7 @@ CommandLine::CommandLine(const CommandLine &them):
 }
 
 CommandLine &
-CommandLine::operator =(const CommandLine &them) // not a reference so that we can swap
+CommandLine::operator =(const CommandLine &them)
 {
     // cannot just swap(*this, them): std::swap(T,T) may call this assignment op
     CommandLine tmp(them);

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -14,20 +14,20 @@
 #endif
 #include <vector>
 
-typedef struct option LongOption;
+typedef struct option RawLongOption;
 
 /// A struct option C++ wrapper, helps with option::name copying/freeing.
-class Option : public LongOption
+class LongOption : public RawLongOption
 {
 public:
-    Option();
-    explicit Option(const LongOption &);
-    Option(const Option&);
-    Option &operator =(const Option &);
-    ~Option();
+    LongOption();
+    explicit LongOption(const RawLongOption &);
+    LongOption(const LongOption&);
+    LongOption &operator =(const LongOption &);
+    ~LongOption();
 
 private:
-    void copy(const LongOption &);
+    void copy(const RawLongOption &);
 };
 
 /// Manages arguments passed to a program (i.e., main(argc, argv) parameters).
@@ -35,7 +35,7 @@ class CommandLine
 {
 public:
     /// expects main() input plus getopt_long(3) grammar rules for parsing argv
-    CommandLine(int argc, char *argv[], const char &shortRules, const LongOption *longRules);
+    CommandLine(int argc, char *argv[], const char *shortRules, const RawLongOption *longRules);
     CommandLine(const CommandLine &them);
     ~CommandLine();
 
@@ -70,7 +70,7 @@ public:
     void pushFrontOption(const char *name, const char *value = nullptr);
 
 private:
-    const LongOption *longOptions() const { return longOptions_.size() ? longOptions_.data() : nullptr; }
+    const RawLongOption *longOptions() const { return longOptions_.size() ? longOptions_.data() : nullptr; }
     bool nextOption(int &optId) const;
 
     /// raw main() parameters, including argv[0] and a nil argv[argc]
@@ -78,7 +78,7 @@ private:
 
     /* getopt_long() grammar rules */
     const char *shortOptions_; ///< single-dash, single-letter (-x) option rules
-    std::vector<Option> longOptions_; ///< long --option rules
+    std::vector<LongOption> longOptions_; ///< long --option rules
 };
 
 #endif /* SQUID_COMMANDLINE_H */

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -46,7 +46,7 @@ public:
     bool hasOption(const int optId, const char **optValue = nullptr) const;
 
     /// A callback function for forEachOption(); receives parsed options.
-    /// Must not call addOption(), hasOption() or forEachOption() -- getopt(3) uses globals!
+    /// Must not call pushFrontOption(), hasOption() or forEachOption() -- getopt(3) uses globals!
     typedef void Visitor(const int optId, const char *optValue);
 
     /// calls Visitor for each of the configured command line option
@@ -64,8 +64,8 @@ public:
     /// replaces argv[0] with the new value
     void resetArg0(const char *programName);
 
-    /// inserts a (possibly duplicated) option at the position 1 (just after argv[0])
-    void addOption(const char *name, const char *value = nullptr);
+    /// inserts a (possibly duplicated) option at the beginning of options (just after argv[0])
+    void pushFrontOption(const char *name, const char *value = nullptr);
 
 private:
     const LongOption *longOptions() const { return longOptions_.size() ? longOptions_.data() : nullptr; }

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -17,15 +17,15 @@ typedef struct option LongOption;
 /// A struct option C++ wrapper, helps with option::name copying/freeing.
 class Option : public LongOption
 {
-    public:
-        Option();
-        explicit Option(const LongOption &);
-        Option(const Option&);
-        Option &operator =(const Option &);
-        ~Option();
+public:
+    Option();
+    explicit Option(const LongOption &);
+    Option(const Option&);
+    Option &operator =(const Option &);
+    ~Option();
 
-    private:
-        void copy(const LongOption &);
+private:
+    void copy(const LongOption &);
 };
 
 /// Manages arguments passed to a program (i.e., main(argc, argv) parameters).

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 1996-2018 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef COMMANDLINE_H
+#define COMMANDLINE_H
+
+#include "sbuf/SBuf.h"
+#include <vector>
+
+/// Manages arguments passed to the program, including the program name.
+/// The same info is passed to main() as argc and argv[] parameters.
+class CommandLine
+{
+    public:
+        // codes for options without short option characters
+        enum LongCodes {
+            ForegroundCode = 1,
+            KidCode = 2
+        };
+
+        typedef std::pair<char, SBuf> OptionsPair;
+        typedef std::list<OptionsPair> Options;
+
+        CommandLine(int argc, char *argv[]);
+
+        /// \returns parsed kid option argument or an empty string
+        SBuf kidName() const;
+
+        /// apply all available command line options
+        void processOptions();
+
+        /// generate a new argument list from the parsed one,
+        /// supstituting argv[0] and adding/substituting kid option
+        const char **argv(const char *argv0, const char *kidName);
+
+        /// \returns Squid executable file name
+        SBuf execFile() const { return execFile_; }
+
+    private:
+        void processOption(const char, const char *);
+        void parse(int argc, char *argv[]);
+
+        SBuf execFile_;
+        std::vector<const char *> argv_;
+        Options options;
+};
+
+#endif
+

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -9,7 +9,9 @@
 #ifndef SQUID_COMMANDLINE_H
 #define SQUID_COMMANDLINE_H
 
+#if HAVE_GETOPT_H
 #include <getopt.h>
+#endif
 #include <vector>
 
 typedef struct option LongOption;

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -16,38 +16,38 @@
 /// The same info is passed to main() as argc and argv[] parameters.
 class CommandLine
 {
-    public:
-        // codes for options without short option characters
-        enum LongCodes {
-            ForegroundCode = 1,
-            KidCode = 2
-        };
+public:
+    // codes for options without short option characters
+    enum LongCodes {
+        ForegroundCode = 1,
+        KidCode = 2
+    };
 
-        typedef std::pair<char, SBuf> OptionsPair;
-        typedef std::list<OptionsPair> Options;
+    typedef std::pair<char, SBuf> OptionsPair;
+    typedef std::list<OptionsPair> Options;
 
-        CommandLine(int argc, char *argv[]);
+    CommandLine(int argc, char *argv[]);
 
-        /// \returns parsed kid option argument or an empty string
-        SBuf kidName() const;
+    /// \returns parsed kid option argument or an empty string
+    SBuf kidName() const;
 
-        /// apply all available command line options
-        void processOptions();
+    /// apply all available command line options
+    void processOptions();
 
-        /// generate a new argument list from the parsed one,
-        /// supstituting argv[0] and adding/substituting kid option
-        const char **argv(const char *argv0, const char *kidName);
+    /// generate a new argument list from the parsed one,
+    /// supstituting argv[0] and adding/substituting kid option
+    const char **argv(const char *argv0, const char *kidName);
 
-        /// \returns Squid executable file name
-        SBuf execFile() const { return execFile_; }
+    /// \returns Squid executable file name
+    SBuf execFile() const { return execFile_; }
 
-    private:
-        void processOption(const char, const char *);
-        void parse(int argc, char *argv[]);
+private:
+    void processOption(const char, const char *);
+    void parse(int argc, char *argv[]);
 
-        SBuf execFile_;
-        std::vector<const char *> argv_;
-        Options options;
+    SBuf execFile_;
+    std::vector<const char *> argv_;
+    Options options;
 };
 
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -256,10 +256,10 @@ squid_SOURCES = \
 	clientStreamForward.h \
 	CollapsedForwarding.cc \
 	CollapsedForwarding.h \
-	CompletionDispatcher.cc \
-	CompletionDispatcher.h \
 	CommandLine.cc \
 	CommandLine.h \
+	CompletionDispatcher.cc \
+	CompletionDispatcher.h \
 	CommRead.h \
 	ConfigOption.cc \
 	ConfigParser.cc \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -258,6 +258,8 @@ squid_SOURCES = \
 	CollapsedForwarding.h \
 	CompletionDispatcher.cc \
 	CompletionDispatcher.h \
+	CommandLine.cc \
+	CommandLine.h \
 	CommRead.h \
 	ConfigOption.cc \
 	ConfigParser.cc \

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -338,7 +338,7 @@ static void
 ProcessMacros(char*& line, int& len)
 {
     SubstituteMacro(line, len, "${service_name}", service_name.c_str());
-    SubstituteMacro(line, len, "${process_name}", TheKidName);
+    SubstituteMacro(line, len, "${process_name}", TheKidName.c_str());
     SubstituteMacro(line, len, "${process_number}", xitoa(KidIdentifier));
 }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -116,9 +116,5 @@ extern int opt_parse_cfg_only; /* 0 */
 /// Zero for SMP-unaware code and in no-SMP mode.
 extern int KidIdentifier; /* 0 */
 
-extern int opt_signal_service; /* 0 */
-/// Want to detect "-u 0"
-extern int icpPortNumOverride; /* 1 */
-
 #endif /* SQUID_GLOBALS_H */
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -116,5 +116,9 @@ extern int opt_parse_cfg_only; /* 0 */
 /// Zero for SMP-unaware code and in no-SMP mode.
 extern int KidIdentifier; /* 0 */
 
+extern int opt_signal_service; /* 0 */
+/// Want to detect "-u 0"
+extern int icpPortNumOverride; /* 1 */
+
 #endif /* SQUID_GLOBALS_H */
 

--- a/src/ipc/Kid.cc
+++ b/src/ipc/Kid.cc
@@ -175,6 +175,15 @@ const String& Kid::name() const
     return theName;
 }
 
+String Kid::pureName() const
+{
+    if (theName.size() > 2 && theName[0] == '(') {
+        assert(theName[theName.size() - 1] == ')');
+        return theName.substr(1, theName.size() - 1);
+    }
+    return theName;
+}
+
 time_t
 Kid::deathDuration() const
 {

--- a/src/ipc/Kid.cc
+++ b/src/ipc/Kid.cc
@@ -20,25 +20,13 @@
 
 int TheProcessKind = pkOther;
 
-Kid::Kid():
-    processRole(),
-    processId(0),
-    badFailures(0),
-    pid(-1),
-    startTime(0),
-    isRunning(false),
-    status(0)
+Kid::Kid()
 {
 }
 
 Kid::Kid(const char *aRole, const int anId):
     processRole(aRole),
-    processId(anId),
-    badFailures(0),
-    pid(-1),
-    startTime(0),
-    isRunning(false),
-    status(0)
+    processId(anId)
 {
 }
 

--- a/src/ipc/Kid.cc
+++ b/src/ipc/Kid.cc
@@ -170,13 +170,14 @@ bool Kid::signaled(int sgnl) const
 }
 
 /// returns kid name
-const String& Kid::name() const
+const String& Kid::processName() const
 {
     return theName;
 }
 
-String Kid::pureName() const
+String Kid::gist() const
 {
+    // TODO: Assemble both processName() and gist() from role and ID instead.
     if (theName.size() > 2 && theName[0] == '(') {
         assert(theName[theName.size() - 1] == ')');
         return theName.substr(1, theName.size() - 1);

--- a/src/ipc/Kid.h
+++ b/src/ipc/Kid.h
@@ -92,7 +92,7 @@ private:
     pid_t  pid = -1; ///< current (for a running kid) or last (for stopped kid) PID
     time_t startTime = 0; ///< last start time
     time_t stopTime = 0; ///< last termination time
-    bool   isRunning = false; ///< whether the kid is assumed to be alive
+    bool isRunning = false; ///< whether the kid is assumed to be alive
     PidStatus status = 0; ///< exit status of a stopped kid
 };
 

--- a/src/ipc/Kid.h
+++ b/src/ipc/Kid.h
@@ -77,6 +77,9 @@ public:
     /// returns kid name
     const String& name() const;
 
+    /// \returns kid name without parenthesis
+    String pureName() const;
+
 private:
     void reportStopped() const;
 

--- a/src/ipc/Kid.h
+++ b/src/ipc/Kid.h
@@ -74,11 +74,11 @@ public:
     /// whether the process was terminated by a given signal
     bool signaled(int sgnl) const;
 
-    /// returns kid name
-    const String& name() const;
+    /// \returns kid's role and ID formatted for use as a process name
+    const String& processName() const;
 
-    /// \returns kid name without parenthesis
-    String pureName() const;
+    /// \returns kid's role and ID summary; usable as a --kid parameter value
+    String gist() const;
 
 private:
     void reportStopped() const;

--- a/src/ipc/Kid.h
+++ b/src/ipc/Kid.h
@@ -85,15 +85,15 @@ private:
 
     // Information preserved across restarts
     SBuf processRole;
-    int processId;
-    int badFailures; ///< number of "repeated frequent" failures
+    int processId = 0;
+    int badFailures = 0; ///< number of "repeated frequent" failures
 
     // Information specific to a running or stopped kid
-    pid_t  pid; ///< current (for a running kid) or last (for stopped kid) PID
-    time_t startTime; ///< last start time
+    pid_t  pid = -1; ///< current (for a running kid) or last (for stopped kid) PID
+    time_t startTime = 0; ///< last start time
     time_t stopTime = 0; ///< last termination time
-    bool   isRunning; ///< whether the kid is assumed to be alive
-    PidStatus status; ///< exit status of a stopped kid
+    bool   isRunning = false; ///< whether the kid is assumed to be alive
+    PidStatus status = 0; ///< exit status of a stopped kid
 };
 
 // TODO: processes may not be kids; is there a better place to put this?

--- a/src/ipc/Kid.h
+++ b/src/ipc/Kid.h
@@ -27,7 +27,7 @@ public:
 public:
     Kid();
 
-    Kid(const String& kid_name);
+    Kid(const char *role, const int id);
 
     /// called when this kid got started, records PID
     void start(pid_t cpid);
@@ -75,16 +75,17 @@ public:
     bool signaled(int sgnl) const;
 
     /// \returns kid's role and ID formatted for use as a process name
-    const String& processName() const;
+    SBuf processName() const;
 
     /// \returns kid's role and ID summary; usable as a --kid parameter value
-    String gist() const;
+    SBuf gist() const;
 
 private:
     void reportStopped() const;
 
     // Information preserved across restarts
-    String theName; ///< process name
+    SBuf processRole;
+    int processId;
     int badFailures; ///< number of "repeated frequent" failures
 
     // Information specific to a running or stopped kid

--- a/src/ipc/Kids.cc
+++ b/src/ipc/Kids.cc
@@ -16,7 +16,7 @@
 #include "tools.h"
 
 Kids TheKids;
-KidName TheKidName;
+SBuf TheKidName;
 
 Kids::Kids()
 {

--- a/src/ipc/Kids.cc
+++ b/src/ipc/Kids.cc
@@ -30,15 +30,15 @@ void Kids::init()
     storage.reserve(NumberOfKids());
 
     for (int i = 0; i < Config.workers; ++i)
-        storage.push_back(Kid("squid", storage.size() + 1));
+        storage.emplace_back("squid", storage.size() + 1);
 
     // add Kid records for all disk processes
     for (int i = 0; i < Config.cacheSwap.n_strands; ++i)
-        storage.push_back(Kid("squid-disk", storage.size() + 1));
+        storage.emplace_back("squid-disk", storage.size() + 1);
 
     // if coordination is needed, add a Kid record for Coordinator
     if (storage.size() > 1)
-        storage.push_back(Kid("squid-coord", storage.size() + 1));
+        storage.emplace_back("squid-coord", storage.size() + 1);
 
     Must(storage.size() == static_cast<size_t>(NumberOfKids()));
 }

--- a/src/ipc/Kids.cc
+++ b/src/ipc/Kids.cc
@@ -29,25 +29,16 @@ void Kids::init()
 
     storage.reserve(NumberOfKids());
 
-    char kid_name[32];
-
-    // add Kid records for all workers
-    for (int i = 0; i < Config.workers; ++i) {
-        snprintf(kid_name, sizeof(kid_name), "(squid-%d)", (int)(storage.size()+1));
-        storage.push_back(Kid(kid_name));
-    }
+    for (int i = 0; i < Config.workers; ++i)
+        storage.push_back(Kid("squid", storage.size() + 1));
 
     // add Kid records for all disk processes
-    for (int i = 0; i < Config.cacheSwap.n_strands; ++i) {
-        snprintf(kid_name, sizeof(kid_name), "(squid-disk-%d)", (int)(storage.size()+1));
-        storage.push_back(Kid(kid_name));
-    }
+    for (int i = 0; i < Config.cacheSwap.n_strands; ++i)
+        storage.push_back(Kid("squid-disk", storage.size() + 1));
 
     // if coordination is needed, add a Kid record for Coordinator
-    if (storage.size() > 1) {
-        snprintf(kid_name, sizeof(kid_name), "(squid-coord-%d)", (int)(storage.size()+1));
-        storage.push_back(Kid(kid_name));
-    }
+    if (storage.size() > 1)
+        storage.push_back(Kid("squid-coord", storage.size() + 1));
 
     Must(storage.size() == static_cast<size_t>(NumberOfKids()));
 }

--- a/src/ipc/Kids.h
+++ b/src/ipc/Kids.h
@@ -64,7 +64,7 @@ private:
 
 extern Kids TheKids; ///< All kids being maintained
 
-typedef char KidName[64]; ///< Squid process name (e.g., "squid-coord")
+typedef SBuf KidName; ///< Squid process name (e.g., "squid-coord")
 extern KidName TheKidName; ///< current Squid process name
 
 #endif /* SQUID_IPC_KIDS_H */

--- a/src/ipc/Kids.h
+++ b/src/ipc/Kids.h
@@ -64,8 +64,7 @@ private:
 
 extern Kids TheKids; ///< All kids being maintained
 
-typedef SBuf KidName; ///< Squid process name (e.g., "squid-coord")
-extern KidName TheKidName; ///< current Squid process name
+extern SBuf TheKidName; ///< current Squid process name (e.g., "squid-coord")
 
 #endif /* SQUID_IPC_KIDS_H */
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -417,23 +417,23 @@ enum {
     optKid
 };
 
-    // short options
-    // TODO: consider prefixing with ':' for better logging
-    // (distinguish missing required argument cases)
-    const char *shortOpStr =
+// short options
+// TODO: consider prefixing with ':' for better logging
+// (distinguish missing required argument cases)
+const char *shortOpStr =
 #if USE_WIN32_SERVICE
-        "O:Vir"
+    "O:Vir"
 #endif
-        "CDFNRSYXa:d:f:hk:m::n:sl:u:vz?";
+    "CDFNRSYXa:d:f:hk:m::n:sl:u:vz?";
 
-    // long options
-    static struct option squidOptions[] = {
-        {"foreground", no_argument, 0,  optForeground},
-        {"kid",        required_argument, 0, optKid},
-        {"help",       no_argument, 0, 'h'},
-        {"version",    no_argument, 0, 'v'},
-        {0, 0, 0, 0}
-    };
+// long options
+static struct option squidOptions[] = {
+    {"foreground", no_argument, 0,  optForeground},
+    {"kid",        required_argument, 0, optKid},
+    {"help",       no_argument, 0, 'h'},
+    {"version",    no_argument, 0, 'v'},
+    {0, 0, 0, 0}
+};
 
 // handle a command line parameter
 static void
@@ -441,283 +441,283 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
 {
     switch (optId) {
 
-        case 'C':
-            /** \par C
-             * Unset/disabel global option for catchign signals. opt_catch_signals */
-            opt_catch_signals = 0;
-            break;
+    case 'C':
+        /** \par C
+         * Unset/disabel global option for catchign signals. opt_catch_signals */
+        opt_catch_signals = 0;
+        break;
 
-        case 'D':
-            /** \par D
-             * OBSOLETE: WAS: override to prevent optional startup DNS tests. */
-            debugs(1,DBG_CRITICAL, "WARNING: -D command-line option is obsolete.");
-            break;
+    case 'D':
+        /** \par D
+         * OBSOLETE: WAS: override to prevent optional startup DNS tests. */
+        debugs(1,DBG_CRITICAL, "WARNING: -D command-line option is obsolete.");
+        break;
 
-        case 'F':
-            /** \par F
-             * Set global option for foreground rebuild. opt_foreground_rebuild */
-            opt_foreground_rebuild = 1;
-            break;
+    case 'F':
+        /** \par F
+         * Set global option for foreground rebuild. opt_foreground_rebuild */
+        opt_foreground_rebuild = 1;
+        break;
 
-        case 'N':
-            /** \par N
-             * Set global option for 'no_daemon' mode. opt_no_daemon */
-            opt_no_daemon = 1;
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'O':
-            /** \par O
-             * Set global option. opt_command_lin and WIN32_Command_Line */
-            opt_command_line = 1;
-            WIN32_Command_Line = xstrdup(optValue);
-            break;
-#endif
-
-        case 'R':
-            /** \par R
-             * Unset/disable global option opt_reuseaddr */
-            opt_reuseaddr = 0;
-            break;
-
-        case 'S':
-            /** \par S
-             * Set global option opt_store_doublecheck */
-            opt_store_doublecheck = 1;
-            break;
-
-        case 'X':
-            /** \par X
-             * Force full debugging */
-            Debug::parseOptions("rotate=0 ALL,9");
-            Debug::override_X = 1;
-            sigusr2_handle(SIGUSR2);
-            break;
-
-        case 'Y':
-            /** \par Y
-             * Set global option opt_reload_hit_only */
-            opt_reload_hit_only = 1;
-            break;
+    case 'N':
+        /** \par N
+         * Set global option for 'no_daemon' mode. opt_no_daemon */
+        opt_no_daemon = 1;
+        break;
 
 #if USE_WIN32_SERVICE
 
-        case 'i':
-            /** \par i
-             * Set global option opt_install_service (to TRUE) */
-            opt_install_service = TRUE;
-            break;
+    case 'O':
+        /** \par O
+         * Set global option. opt_command_lin and WIN32_Command_Line */
+        opt_command_line = 1;
+        WIN32_Command_Line = xstrdup(optValue);
+        break;
 #endif
 
-        case 'a':
-            {
-                /** \par a
-                 * Add optional HTTP port as given following the option */
-                char *port = xstrdup(optValue);
-                add_http_port(port);
-                xfree(port);
-                break;
-            }
+    case 'R':
+        /** \par R
+         * Unset/disable global option opt_reuseaddr */
+        opt_reuseaddr = 0;
+        break;
 
-        case 'd':
-            /** \par d
-             * Set global option Debug::log_stderr to the number given following the option */
-            Debug::log_stderr = atoi(optValue);
-            break;
+    case 'S':
+        /** \par S
+         * Set global option opt_store_doublecheck */
+        opt_store_doublecheck = 1;
+        break;
 
-        case 'f':
-            /** \par f
-             * Load the file given instead of the default squid.conf. */
-            xfree(ConfigFile);
-            ConfigFile = xstrdup(optValue);
-            break;
+    case 'X':
+        /** \par X
+         * Force full debugging */
+        Debug::parseOptions("rotate=0 ALL,9");
+        Debug::override_X = 1;
+        sigusr2_handle(SIGUSR2);
+        break;
 
-        case 'k':
-            /** \par k
-             * Run the administrative action given following the option */
+    case 'Y':
+        /** \par Y
+         * Set global option opt_reload_hit_only */
+        opt_reload_hit_only = 1;
+        break;
 
-            /** \li When it is missing or an unknown option display the usage help. */
-            if (!optValue || strlen(optValue) < 1)
-                usage();
+#if USE_WIN32_SERVICE
 
-            else if (!strncmp(optValue, "reconfigure", strlen(optValue)))
-                /** \li On reconfigure send SIGHUP. */
-                opt_send_signal = SIGHUP;
-            else if (!strncmp(optValue, "rotate", strlen(optValue)))
-                /** \li On rotate send SIGQUIT or SIGUSR1. */
+    case 'i':
+        /** \par i
+         * Set global option opt_install_service (to TRUE) */
+        opt_install_service = TRUE;
+        break;
+#endif
+
+    case 'a':
+    {
+        /** \par a
+         * Add optional HTTP port as given following the option */
+        char *port = xstrdup(optValue);
+        add_http_port(port);
+        xfree(port);
+        break;
+    }
+
+    case 'd':
+        /** \par d
+         * Set global option Debug::log_stderr to the number given following the option */
+        Debug::log_stderr = atoi(optValue);
+        break;
+
+    case 'f':
+        /** \par f
+         * Load the file given instead of the default squid.conf. */
+        xfree(ConfigFile);
+        ConfigFile = xstrdup(optValue);
+        break;
+
+    case 'k':
+        /** \par k
+         * Run the administrative action given following the option */
+
+        /** \li When it is missing or an unknown option display the usage help. */
+        if (!optValue || strlen(optValue) < 1)
+            usage();
+
+        else if (!strncmp(optValue, "reconfigure", strlen(optValue)))
+            /** \li On reconfigure send SIGHUP. */
+            opt_send_signal = SIGHUP;
+        else if (!strncmp(optValue, "rotate", strlen(optValue)))
+            /** \li On rotate send SIGQUIT or SIGUSR1. */
 #if defined(_SQUID_LINUX_THREADS_)
-                opt_send_signal = SIGQUIT;
+            opt_send_signal = SIGQUIT;
 #else
-                opt_send_signal = SIGUSR1;
+            opt_send_signal = SIGUSR1;
 #endif
 
-            else if (!strncmp(optValue, "debug", strlen(optValue)))
-                /** \li On debug send SIGTRAP or SIGUSR2. */
+        else if (!strncmp(optValue, "debug", strlen(optValue)))
+            /** \li On debug send SIGTRAP or SIGUSR2. */
 #if defined(_SQUID_LINUX_THREADS_)
-                opt_send_signal = SIGTRAP;
+            opt_send_signal = SIGTRAP;
 #else
-                opt_send_signal = SIGUSR2;
+            opt_send_signal = SIGUSR2;
 #endif
 
-            else if (!strncmp(optValue, "shutdown", strlen(optValue)))
-                /** \li On shutdown send SIGTERM. */
-                opt_send_signal = SIGTERM;
-            else if (!strncmp(optValue, "interrupt", strlen(optValue)))
-                /** \li On interrupt send SIGINT. */
-                opt_send_signal = SIGINT;
-            else if (!strncmp(optValue, "kill", strlen(optValue)))
-                /** \li On kill send SIGKILL. */
-                opt_send_signal = SIGKILL;
+        else if (!strncmp(optValue, "shutdown", strlen(optValue)))
+            /** \li On shutdown send SIGTERM. */
+            opt_send_signal = SIGTERM;
+        else if (!strncmp(optValue, "interrupt", strlen(optValue)))
+            /** \li On interrupt send SIGINT. */
+            opt_send_signal = SIGINT;
+        else if (!strncmp(optValue, "kill", strlen(optValue)))
+            /** \li On kill send SIGKILL. */
+            opt_send_signal = SIGKILL;
 
 #ifdef SIGTTIN
 
-            else if (!strncmp(optValue, "restart", strlen(optValue)))
-                /** \li On restart send SIGTTIN. (exit and restart by parent) */
-                opt_send_signal = SIGTTIN;
+        else if (!strncmp(optValue, "restart", strlen(optValue)))
+            /** \li On restart send SIGTTIN. (exit and restart by parent) */
+            opt_send_signal = SIGTTIN;
 
 #endif
 
-            else if (!strncmp(optValue, "check", strlen(optValue)))
-                /** \li On check send 0 / SIGNULL. */
-                opt_send_signal = 0;    /* SIGNULL */
-            else if (!strncmp(optValue, "parse", strlen(optValue)))
-                /** \li On parse set global flag to re-parse the config file only. */
-                opt_parse_cfg_only = 1;
-            else
-                usage();
-
-            break;
-
-        case 'm':
-            /** \par m
-             * Set global malloc_debug_level to the value given following the option.
-             * if none is given it toggles the xmalloc_trace option on/off */
-            if (optValue) {
-#if MALLOC_DBG
-                malloc_debug_level = atoi(optValue);
-#else
-                fatal("Need to add -DMALLOC_DBG when compiling to use -mX option");
-#endif
-
-            }
-            break;
-
-        case 'n':
-            /** \par n
-             * Set global option opt_signal_service (to true).
-             * Stores the additional parameter given in global service_name */
-            if (optValue && *optValue != '\0') {
-                const SBuf t(optValue);
-                ::Parser::Tokenizer tok(t);
-                const CharacterSet chr = CharacterSet::ALPHA+CharacterSet::DIGIT;
-                if (!tok.prefix(service_name, chr))
-                    fatalf("Expected alphanumeric service name for the -n option but got: %s", optValue);
-                if (!tok.atEnd())
-                    fatalf("Garbage after alphanumeric service name in the -n option value: %s", optValue);
-                if (service_name.length() > 32)
-                    fatalf("Service name (-n option) must be limited to 32 characters but got %u", service_name.length());
-                opt_signal_service = true;
-            } else {
-                fatal("A service name is required for the -n option");
-            }
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'r':
-            /** \par r
-             * Set global option opt_remove_service (to TRUE) */
-            opt_remove_service = TRUE;
-
-            break;
-
-#endif
-
-        case 'l':
-            /** \par l
-             * Stores the syslog facility name in global opt_syslog_facility
-             * then performs actions for -s option. */
-            xfree(opt_syslog_facility); // ignore any previous options sent
-            opt_syslog_facility = xstrdup(optValue);
-
-        case 's':
-            /** \par s
-             * Initialize the syslog for output */
-#if HAVE_SYSLOG
-
-            _db_set_syslog(opt_syslog_facility);
-
-            break;
-
-#else
-
-            fatal("Logging to syslog not available on this platform");
-
-            /* NOTREACHED */
-#endif
-
-        case 'u':
-            /** \par u
-             * Store the ICP port number given in global option icpPortNumOverride
-             * ensuring its a positive number. */
-            icpPortNumOverride = atoi(optValue);
-
-            if (icpPortNumOverride < 0)
-                icpPortNumOverride = 0;
-
-            break;
-
-        case 'v':
-            /** \par v
-             * Display squid version and build information. Then exit. */
-            printf("Squid Cache: Version %s\n",version_string);
-            printf("Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
-            if (strlen(SQUID_BUILD_INFO))
-                printf("%s\n",SQUID_BUILD_INFO);
-#if USE_OPENSSL
-            printf("\nThis binary uses %s. ", SSLeay_version(SSLEAY_VERSION));
-            printf("For legal restrictions on distribution see https://www.openssl.org/source/license.html\n\n");
-#endif
-            printf( "configure options: %s\n", SQUID_CONFIGURE_OPTIONS);
-
-#if USE_WIN32_SERVICE
-
-            printf("Compiled as Windows System Service.\n");
-
-#endif
-
-            exit(EXIT_SUCCESS);
-
-        /* NOTREACHED */
-
-        case 'z':
-            /** \par z
-             * Set global option Debug::log_stderr and opt_create_swap_dirs */
-            Debug::log_stderr = 1;
-            opt_create_swap_dirs = 1;
-            break;
-
-        case optForeground:
-            /** \par --foreground
-             * Set global option opt_foreground */
-            opt_foreground = 1;
-            break;
-
-        case optKid:
-            // already processed in ConfigureCurrentKid()
-            break;
-
-        case 'h':
-
-        case '?':
-
-        default:
-            /** \par h,?, or unknown
-             * \copydoc usage() */
+        else if (!strncmp(optValue, "check", strlen(optValue)))
+            /** \li On check send 0 / SIGNULL. */
+            opt_send_signal = 0;    /* SIGNULL */
+        else if (!strncmp(optValue, "parse", strlen(optValue)))
+            /** \li On parse set global flag to re-parse the config file only. */
+            opt_parse_cfg_only = 1;
+        else
             usage();
 
-            break;
+        break;
+
+    case 'm':
+        /** \par m
+         * Set global malloc_debug_level to the value given following the option.
+         * if none is given it toggles the xmalloc_trace option on/off */
+        if (optValue) {
+#if MALLOC_DBG
+            malloc_debug_level = atoi(optValue);
+#else
+            fatal("Need to add -DMALLOC_DBG when compiling to use -mX option");
+#endif
+
+        }
+        break;
+
+    case 'n':
+        /** \par n
+         * Set global option opt_signal_service (to true).
+         * Stores the additional parameter given in global service_name */
+        if (optValue && *optValue != '\0') {
+            const SBuf t(optValue);
+            ::Parser::Tokenizer tok(t);
+            const CharacterSet chr = CharacterSet::ALPHA+CharacterSet::DIGIT;
+            if (!tok.prefix(service_name, chr))
+                fatalf("Expected alphanumeric service name for the -n option but got: %s", optValue);
+            if (!tok.atEnd())
+                fatalf("Garbage after alphanumeric service name in the -n option value: %s", optValue);
+            if (service_name.length() > 32)
+                fatalf("Service name (-n option) must be limited to 32 characters but got %u", service_name.length());
+            opt_signal_service = true;
+        } else {
+            fatal("A service name is required for the -n option");
+        }
+        break;
+
+#if USE_WIN32_SERVICE
+
+    case 'r':
+        /** \par r
+         * Set global option opt_remove_service (to TRUE) */
+        opt_remove_service = TRUE;
+
+        break;
+
+#endif
+
+    case 'l':
+        /** \par l
+         * Stores the syslog facility name in global opt_syslog_facility
+         * then performs actions for -s option. */
+        xfree(opt_syslog_facility); // ignore any previous options sent
+        opt_syslog_facility = xstrdup(optValue);
+
+    case 's':
+        /** \par s
+         * Initialize the syslog for output */
+#if HAVE_SYSLOG
+
+        _db_set_syslog(opt_syslog_facility);
+
+        break;
+
+#else
+
+        fatal("Logging to syslog not available on this platform");
+
+        /* NOTREACHED */
+#endif
+
+    case 'u':
+        /** \par u
+         * Store the ICP port number given in global option icpPortNumOverride
+         * ensuring its a positive number. */
+        icpPortNumOverride = atoi(optValue);
+
+        if (icpPortNumOverride < 0)
+            icpPortNumOverride = 0;
+
+        break;
+
+    case 'v':
+        /** \par v
+         * Display squid version and build information. Then exit. */
+        printf("Squid Cache: Version %s\n",version_string);
+        printf("Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
+        if (strlen(SQUID_BUILD_INFO))
+            printf("%s\n",SQUID_BUILD_INFO);
+#if USE_OPENSSL
+        printf("\nThis binary uses %s. ", SSLeay_version(SSLEAY_VERSION));
+        printf("For legal restrictions on distribution see https://www.openssl.org/source/license.html\n\n");
+#endif
+        printf( "configure options: %s\n", SQUID_CONFIGURE_OPTIONS);
+
+#if USE_WIN32_SERVICE
+
+        printf("Compiled as Windows System Service.\n");
+
+#endif
+
+        exit(EXIT_SUCCESS);
+
+    /* NOTREACHED */
+
+    case 'z':
+        /** \par z
+         * Set global option Debug::log_stderr and opt_create_swap_dirs */
+        Debug::log_stderr = 1;
+        opt_create_swap_dirs = 1;
+        break;
+
+    case optForeground:
+        /** \par --foreground
+         * Set global option opt_foreground */
+        opt_foreground = 1;
+        break;
+
+    case optKid:
+        // already processed in ConfigureCurrentKid()
+        break;
+
+    case 'h':
+
+    case '?':
+
+    default:
+        /** \par h,?, or unknown
+         * \copydoc usage() */
+        usage();
+
+        break;
     }
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -59,6 +59,7 @@
 #include "mime.h"
 #include "neighbors.h"
 #include "parser/Tokenizer.h"
+#include "Parsing.h"
 #include "pconn.h"
 #include "peer_sourcehash.h"
 #include "peer_userhash.h"
@@ -420,7 +421,7 @@ enum {
 // short options
 // TODO: consider prefixing with ':' for better logging
 // (distinguish missing required argument cases)
-const char *shortOpStr =
+static const char *shortOpStr =
 #if USE_WIN32_SERVICE
     "O:Vir"
 #endif
@@ -515,6 +516,7 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
         /** \par a
          * Add optional HTTP port as given following the option */
         char *port = xstrdup(optValue);
+        // use a copy to avoid optValue modification
         add_http_port(port);
         xfree(port);
         break;
@@ -523,7 +525,7 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
     case 'd':
         /** \par d
          * Set global option Debug::log_stderr to the number given following the option */
-        Debug::log_stderr = atoi(optValue);
+        Debug::log_stderr = xatoi(optValue);
         break;
 
     case 'f':
@@ -595,7 +597,7 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
          * if none is given it toggles the xmalloc_trace option on/off */
         if (optValue) {
 #if MALLOC_DBG
-            malloc_debug_level = atoi(optValue);
+            malloc_debug_level = xatoi(optValue);
 #else
             fatal("Need to add -DMALLOC_DBG when compiling to use -mX option");
 #endif
@@ -1431,7 +1433,7 @@ ConfigureCurrentKid(const CommandLine &cmdLine)
         SBuf kidId;
         Parser::Tokenizer tok(processName);
         tok.suffix(kidId, CharacterSet::DIGIT);
-        KidIdentifier = atoi(kidId.c_str());
+        KidIdentifier = xatoi(kidId.c_str());
         tok.skipSuffix(SBuf("-"));
         TheKidName = tok.remaining();
         if (TheKidName.cmp("squid-coord") == 0)
@@ -1457,7 +1459,7 @@ static void StartUsingConfig()
 int
 SquidMain(int argc, char **argv)
 {
-    const CommandLine cmdLine(argc, argv, *shortOpStr, squidOptions);
+    const CommandLine cmdLine(argc, argv, shortOpStr, squidOptions);
 
     ConfigureCurrentKid(cmdLine);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -58,6 +58,7 @@
 #include "ipcache.h"
 #include "mime.h"
 #include "neighbors.h"
+#include "parser/Tokenizer.h"
 #include "pconn.h"
 #include "peer_sourcehash.h"
 #include "peer_userhash.h"
@@ -66,7 +67,6 @@
 #include "redirect.h"
 #include "refresh.h"
 #include "sbuf/Stream.h"
-#include "sbuf/StringConvert.h"
 #include "SBufStatsAction.h"
 #include "send-announce.h"
 #include "SquidConfig.h"
@@ -144,6 +144,9 @@ void WIN32_svcstatusupdate(DWORD, DWORD);
 void WINAPI WIN32_svcHandler(DWORD);
 #endif
 
+static int opt_signal_service = FALSE;
+static char *opt_syslog_facility = NULL;
+static int icpPortNumOverride = 1;  /* Want to detect "-u 0" */
 static int configured_once = 0;
 #if MALLOC_DBG
 static int malloc_debug_level = 0;
@@ -164,10 +167,12 @@ static void mainRotate(void);
 static void mainReconfigureStart(void);
 static void mainReconfigureFinish(void*);
 static void mainInitialize(void);
+static void usage(void);
+static void mainHandleCommandLineOption(const int optId, const char *optValue);
 static void sendSignal(void);
 static void serverConnectionsOpen(void);
 static void serverConnectionsClose(void);
-static void watch_child(CommandLine &);
+static void watch_child(const CommandLine &);
 static void setEffectiveUser(void);
 static void SquidShutdown(void);
 static void mainSetCwd(void);
@@ -345,6 +350,369 @@ SignalEngine::handleStoppedChild()
     while (pid > 0 || (pid < 0 && errno == EINTR));
 #endif
 #endif
+}
+
+static void
+usage(void)
+{
+    fprintf(stderr,
+            "Usage: %s [-cdzCFNRVYX] [-n name] [-s | -l facility] [-f config-file] [-[au] port] [-k signal]"
+#if USE_WIN32_SERVICE
+            "[-ir] [-O CommandLine]"
+#endif
+            "\n"
+            "    -h | --help       Print help message.\n"
+            "    -v | --version    Print version details.\n"
+            "\n"
+            "       -a port   Specify HTTP port number (default: %d).\n"
+            "       -d level  Write debugging to stderr also.\n"
+            "       -f file   Use given config-file instead of\n"
+            "                 %s\n"
+#if USE_WIN32_SERVICE
+            "       -i        Installs as a Windows Service (see -n option).\n"
+#endif
+            "       -k reconfigure|rotate|shutdown|"
+#ifdef SIGTTIN
+            "restart|"
+#endif
+            "interrupt|kill|debug|check|parse\n"
+            "                 Parse configuration file, then send signal to \n"
+            "                 running copy (except -k parse) and exit.\n"
+            "       -n name   Specify service name to use for service operations\n"
+            "                 default is: " APP_SHORTNAME ".\n"
+#if USE_WIN32_SERVICE
+            "       -r        Removes a Windows Service (see -n option).\n"
+#endif
+            "       -s | -l facility\n"
+            "                 Enable logging to syslog.\n"
+            "       -u port   Specify ICP port number (default: %d), disable with 0.\n"
+            "       -z        Create missing swap directories and then exit.\n"
+            "       -C        Do not catch fatal signals.\n"
+            "       -D        OBSOLETE. Scheduled for removal.\n"
+            "       -F        Don't serve any requests until store is rebuilt.\n"
+            "       -N        Master process runs in foreground and is a worker. No kids.\n"
+            "       --foreground\n"
+            "                 Master process runs in foreground and creates worker kids.\n"
+            "       --kid role-ID\n"
+            "                 Play a given SMP kid process role, with a given ID. Do not use\n"
+            "                 this option. It is meant for the master process use only.\n"
+#if USE_WIN32_SERVICE
+            "       -O options\n"
+            "                 Set Windows Service Command line options in Registry.\n"
+#endif
+            "       -R        Do not set REUSEADDR on port.\n"
+            "       -S        Double-check swap during rebuild.\n"
+            "       -X        Force full debugging.\n"
+            "       -Y        Only return UDP_HIT or UDP_MISS_NOFETCH during fast reload.\n",
+            APP_SHORTNAME, CACHE_HTTP_PORT, DefaultConfigFile, CACHE_ICP_PORT);
+    exit(EXIT_FAILURE);
+}
+
+/// CommandLine option IDs for --long options that lack a short (-x) equivalent
+enum {
+    // The absolute values do not matter except that the following values should
+    // not be used: Values below 2 are for special getopt_long(3) use cases, and
+    // values in the [33,126] range are reserved for short options (-x).
+    optForeground = 2,
+    optKid
+};
+
+    // short options
+    const char *shortOpStr =
+#if USE_WIN32_SERVICE
+        "O:Vir"
+#endif
+        "CDFNRSYXa:d:f:hk:m::n:sl:u:vz?";
+
+    // long options
+    static struct option squidOptions[] = {
+        {"foreground", no_argument, 0,  optForeground},
+        {"kid",        required_argument, 0, optKid},
+        {"help",       no_argument, 0, 'h'},
+        {"version",    no_argument, 0, 'v'},
+        {0, 0, 0, 0}
+    };
+
+// handle a command line parameter
+static void
+mainHandleCommandLineOption(const int optId, const char *optValue)
+{
+    // XXX: Remove these diff-minimizing hacks and reformat.
+    const auto c = optId;
+    #define optarg optValue
+
+        switch (c) {
+
+        case 'C':
+            /** \par C
+             * Unset/disabel global option for catchign signals. opt_catch_signals */
+            opt_catch_signals = 0;
+            break;
+
+        case 'D':
+            /** \par D
+             * OBSOLETE: WAS: override to prevent optional startup DNS tests. */
+            debugs(1,DBG_CRITICAL, "WARNING: -D command-line option is obsolete.");
+            break;
+
+        case 'F':
+            /** \par F
+             * Set global option for foreground rebuild. opt_foreground_rebuild */
+            opt_foreground_rebuild = 1;
+            break;
+
+        case 'N':
+            /** \par N
+             * Set global option for 'no_daemon' mode. opt_no_daemon */
+            opt_no_daemon = 1;
+            break;
+
+#if USE_WIN32_SERVICE
+
+        case 'O':
+            /** \par O
+             * Set global option. opt_command_lin and WIN32_Command_Line */
+            opt_command_line = 1;
+            WIN32_Command_Line = xstrdup(optarg);
+            break;
+#endif
+
+        case 'R':
+            /** \par R
+             * Unset/disable global option opt_reuseaddr */
+            opt_reuseaddr = 0;
+            break;
+
+        case 'S':
+            /** \par S
+             * Set global option opt_store_doublecheck */
+            opt_store_doublecheck = 1;
+            break;
+
+        case 'X':
+            /** \par X
+             * Force full debugging */
+            Debug::parseOptions("rotate=0 ALL,9");
+            Debug::override_X = 1;
+            sigusr2_handle(SIGUSR2);
+            break;
+
+        case 'Y':
+            /** \par Y
+             * Set global option opt_reload_hit_only */
+            opt_reload_hit_only = 1;
+            break;
+
+#if USE_WIN32_SERVICE
+
+        case 'i':
+            /** \par i
+             * Set global option opt_install_service (to TRUE) */
+            opt_install_service = TRUE;
+            break;
+#endif
+
+        case 'a':
+            /** \par a
+             * Add optional HTTP port as given following the option */
+            add_http_port(const_cast<char*>(optarg)); // XXX: Remove cast.
+            break;
+
+        case 'd':
+            /** \par d
+             * Set global option Debug::log_stderr to the number given following the option */
+            Debug::log_stderr = atoi(optarg);
+            break;
+
+        case 'f':
+            /** \par f
+             * Load the file given instead of the default squid.conf. */
+            xfree(ConfigFile);
+            ConfigFile = xstrdup(optarg);
+            break;
+
+        case 'k':
+            /** \par k
+             * Run the administrative action given following the option */
+
+            /** \li When it is missing or an unknown option display the usage help. */
+            if (!optarg || strlen(optarg) < 1)
+                usage();
+
+            else if (!strncmp(optarg, "reconfigure", strlen(optarg)))
+                /** \li On reconfigure send SIGHUP. */
+                opt_send_signal = SIGHUP;
+            else if (!strncmp(optarg, "rotate", strlen(optarg)))
+                /** \li On rotate send SIGQUIT or SIGUSR1. */
+#if defined(_SQUID_LINUX_THREADS_)
+                opt_send_signal = SIGQUIT;
+#else
+                opt_send_signal = SIGUSR1;
+#endif
+
+            else if (!strncmp(optarg, "debug", strlen(optarg)))
+                /** \li On debug send SIGTRAP or SIGUSR2. */
+#if defined(_SQUID_LINUX_THREADS_)
+                opt_send_signal = SIGTRAP;
+#else
+                opt_send_signal = SIGUSR2;
+#endif
+
+            else if (!strncmp(optarg, "shutdown", strlen(optarg)))
+                /** \li On shutdown send SIGTERM. */
+                opt_send_signal = SIGTERM;
+            else if (!strncmp(optarg, "interrupt", strlen(optarg)))
+                /** \li On interrupt send SIGINT. */
+                opt_send_signal = SIGINT;
+            else if (!strncmp(optarg, "kill", strlen(optarg)))
+                /** \li On kill send SIGKILL. */
+                opt_send_signal = SIGKILL;
+
+#ifdef SIGTTIN
+
+            else if (!strncmp(optarg, "restart", strlen(optarg)))
+                /** \li On restart send SIGTTIN. (exit and restart by parent) */
+                opt_send_signal = SIGTTIN;
+
+#endif
+
+            else if (!strncmp(optarg, "check", strlen(optarg)))
+                /** \li On check send 0 / SIGNULL. */
+                opt_send_signal = 0;    /* SIGNULL */
+            else if (!strncmp(optarg, "parse", strlen(optarg)))
+                /** \li On parse set global flag to re-parse the config file only. */
+                opt_parse_cfg_only = 1;
+            else
+                usage();
+
+            break;
+
+        case 'm':
+            /** \par m
+             * Set global malloc_debug_level to the value given following the option.
+             * if none is given it toggles the xmalloc_trace option on/off */
+            if (optarg) {
+#if MALLOC_DBG
+                malloc_debug_level = atoi(optarg);
+#else
+                fatal("Need to add -DMALLOC_DBG when compiling to use -mX option");
+#endif
+
+            }
+            break;
+
+        case 'n':
+            /** \par n
+             * Set global option opt_signal_service (to true).
+             * Stores the additional parameter given in global service_name */
+            if (optarg && *optarg != '\0') {
+                const SBuf t(optarg);
+                ::Parser::Tokenizer tok(t);
+                const CharacterSet chr = CharacterSet::ALPHA+CharacterSet::DIGIT;
+                if (!tok.prefix(service_name, chr))
+                    fatalf("Expected alphanumeric service name for the -n option but got: %s", optarg);
+                if (!tok.atEnd())
+                    fatalf("Garbage after alphanumeric service name in the -n option value: %s", optarg);
+                if (service_name.length() > 32)
+                    fatalf("Service name (-n option) must be limited to 32 characters but got %u", service_name.length());
+                opt_signal_service = true;
+            } else {
+                fatal("A service name is required for the -n option");
+            }
+            break;
+
+#if USE_WIN32_SERVICE
+
+        case 'r':
+            /** \par r
+             * Set global option opt_remove_service (to TRUE) */
+            opt_remove_service = TRUE;
+
+            break;
+
+#endif
+
+        case 'l':
+            /** \par l
+             * Stores the syslog facility name in global opt_syslog_facility
+             * then performs actions for -s option. */
+            xfree(opt_syslog_facility); // ignore any previous options sent
+            opt_syslog_facility = xstrdup(optarg);
+
+        case 's':
+            /** \par s
+             * Initialize the syslog for output */
+#if HAVE_SYSLOG
+
+            _db_set_syslog(opt_syslog_facility);
+
+            break;
+
+#else
+
+            fatal("Logging to syslog not available on this platform");
+
+            /* NOTREACHED */
+#endif
+
+        case 'u':
+            /** \par u
+             * Store the ICP port number given in global option icpPortNumOverride
+             * ensuring its a positive number. */
+            icpPortNumOverride = atoi(optarg);
+
+            if (icpPortNumOverride < 0)
+                icpPortNumOverride = 0;
+
+            break;
+
+        case 'v':
+            /** \par v
+             * Display squid version and build information. Then exit. */
+            printf("Squid Cache: Version %s\n",version_string);
+            printf("Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
+            if (strlen(SQUID_BUILD_INFO))
+                printf("%s\n",SQUID_BUILD_INFO);
+#if USE_OPENSSL
+            printf("\nThis binary uses %s. ", SSLeay_version(SSLEAY_VERSION));
+            printf("For legal restrictions on distribution see https://www.openssl.org/source/license.html\n\n");
+#endif
+            printf( "configure options: %s\n", SQUID_CONFIGURE_OPTIONS);
+
+#if USE_WIN32_SERVICE
+
+            printf("Compiled as Windows System Service.\n");
+
+#endif
+
+            exit(EXIT_SUCCESS);
+
+        /* NOTREACHED */
+
+        case 'z':
+            /** \par z
+             * Set global option Debug::log_stderr and opt_create_swap_dirs */
+            Debug::log_stderr = 1;
+            opt_create_swap_dirs = 1;
+            break;
+
+        case 1:
+            /** \par --foreground
+             * Set global option opt_foreground */
+            opt_foreground = 1;
+            break;
+
+        case 'h':
+
+        case '?':
+
+        default:
+            /** \par h,?, or unknown
+             * \copydoc usage() */
+            usage();
+
+            break;
+        }
 }
 
 /* ARGSUSED */
@@ -1051,9 +1419,10 @@ SquidMainSafe(int argc, char **argv)
 static void
 ConfigureCurrentKid(const CommandLine &cmdLine)
 {
-    if (!cmdLine.kidName().isEmpty()) {
-        // TODO: parse directly SBuf instead
-        char *processName = xstrdup(cmdLine.kidName().c_str());
+    const char *kidParams = nullptr;
+    if (cmdLine.hasOption(optKid, &kidParams)) {
+        // TODO: Use Tokenizer to parse kidParams.
+        char *processName = xstrdup(kidParams);
         if (const char *idStart = strrchr(processName, '-')) {
             KidIdentifier = atoi(idStart + 1);
             const size_t nameLen = idStart - processName;
@@ -1084,7 +1453,7 @@ static void StartUsingConfig()
 int
 SquidMain(int argc, char **argv)
 {
-    CommandLine cmdLine(argc, argv);
+    const CommandLine cmdLine(argc, argv, shortOpStr, squidOptions);
 
     ConfigureCurrentKid(cmdLine);
 
@@ -1133,7 +1502,7 @@ SquidMain(int argc, char **argv)
 
 #endif
 
-    cmdLine.processOptions();
+    cmdLine.forEachOption(mainHandleCommandLineOption);
 
     if (opt_foreground && opt_no_daemon) {
         debugs(1, DBG_CRITICAL, "WARNING: --foreground command-line option has no effect with -N.");
@@ -1522,7 +1891,7 @@ masterExit()
 #endif /* !_SQUID_WINDOWS_ */
 
 static void
-watch_child(CommandLine &cmdLine)
+watch_child(const CommandLine &masterCommand)
 {
 #if !_SQUID_WINDOWS_
     pid_t pid;
@@ -1628,22 +1997,27 @@ watch_child(CommandLine &cmdLine)
                 continue;
 
             if (!mainStartScriptCalled) {
-                mainStartScript(cmdLine.execFile().c_str());
+                mainStartScript(masterCommand.arg0());
                 mainStartScriptCalled = true;
             }
+
+            // These are only needed by the forked child below, but let's keep
+            // them out of that "no man's land" between fork() and execvp().
+            auto kidCommand = masterCommand;
+            kidCommand.resetArg0(kid.processName().termedBuf());
+            kidCommand.addOption("--kid", kid.gist().termedBuf());
 
             if ((pid = fork()) == 0) {
                 /* child */
                 openlog(APP_SHORTNAME, LOG_PID | LOG_NDELAY | LOG_CONS, LOG_LOCAL4);
-                const auto argv = cmdLine.argv(kid.name().termedBuf(), kid.pureName().termedBuf());
-                execvp(cmdLine.execFile().c_str(), const_cast<char * const *>(argv));
+                (void)execvp(masterCommand.arg0(), kidCommand.argv());
                 int xerrno = errno;
                 syslog(LOG_ALERT, "execvp failed: %s", xstrerr(xerrno));
             }
 
             kid.start(pid);
             syslog(LOG_NOTICE, "Squid Parent: %s process %d started",
-                   kid.name().termedBuf(), pid);
+                   kid.processName().termedBuf(), pid);
         }
 
         /* parent */

--- a/src/main.cc
+++ b/src/main.cc
@@ -1053,7 +1053,7 @@ ConfigureCurrentKid(const CommandLine &cmdLine)
 {
     if (!cmdLine.kidName().isEmpty()) {
         // TODO: parse directly SBuf instead
-        char *processName = strdup(cmdLine.kidName().c_str());
+        char *processName = xstrdup(cmdLine.kidName().c_str());
         if (const char *idStart = strrchr(processName, '-')) {
             KidIdentifier = atoi(idStart + 1);
             const size_t nameLen = idStart - processName;
@@ -1068,7 +1068,7 @@ ConfigureCurrentKid(const CommandLine &cmdLine)
             else
                 TheProcessKind = pkOther; // including coordinator
         }
-        free(processName);
+        xfree(processName);
     } else {
         xstrncpy(TheKidName, APP_SHORTNAME, sizeof(TheKidName));
         KidIdentifier = 0;

--- a/src/main.cc
+++ b/src/main.cc
@@ -26,6 +26,7 @@
 #include "client_db.h"
 #include "client_side.h"
 #include "comm.h"
+#include "CommandLine.h"
 #include "ConfigParser.h"
 #include "CpuAffinity.h"
 #include "DiskIO/DiskIOModule.h"
@@ -57,7 +58,6 @@
 #include "ipcache.h"
 #include "mime.h"
 #include "neighbors.h"
-#include "parser/Tokenizer.h"
 #include "pconn.h"
 #include "peer_sourcehash.h"
 #include "peer_userhash.h"
@@ -66,6 +66,7 @@
 #include "redirect.h"
 #include "refresh.h"
 #include "sbuf/Stream.h"
+#include "sbuf/StringConvert.h"
 #include "SBufStatsAction.h"
 #include "send-announce.h"
 #include "SquidConfig.h"
@@ -143,9 +144,6 @@ void WIN32_svcstatusupdate(DWORD, DWORD);
 void WINAPI WIN32_svcHandler(DWORD);
 #endif
 
-static int opt_signal_service = FALSE;
-static char *opt_syslog_facility = NULL;
-static int icpPortNumOverride = 1;  /* Want to detect "-u 0" */
 static int configured_once = 0;
 #if MALLOC_DBG
 static int malloc_debug_level = 0;
@@ -166,11 +164,10 @@ static void mainRotate(void);
 static void mainReconfigureStart(void);
 static void mainReconfigureFinish(void*);
 static void mainInitialize(void);
-static void usage(void);
 static void sendSignal(void);
 static void serverConnectionsOpen(void);
 static void serverConnectionsClose(void);
-static void watch_child(int, char **);
+static void watch_child(CommandLine &);
 static void setEffectiveUser(void);
 static void SquidShutdown(void);
 static void mainSetCwd(void);
@@ -249,379 +246,6 @@ SignalEngine::checkEvents(int)
         handleStoppedChild();
     PROF_stop(SignalEngine_checkEvents);
     return EVENT_IDLE;
-}
-
-class OptParser
-{
-    public:
-        typedef std::map<char, std::string> Options;
-        typedef Options::iterator OptionsIterator;
-
-        OptParser(int argc, char *argv[]);
-
-        void processOptions();
-        void processOption(const char shortOpt);
-        std::string getOption(const char shortOpt);
-
-    private:
-
-        OptionsIterator processOption(OptionsIterator);
-        void parse(int argc, char *argv[]);
-
-        Options options;
-};
-
-OptParser::OptParser(int argc, char *argv[])
-{
-    parse(argc, argv);
-}
-
-void
-OptParser::parse(int argc, char *argv[])
-{
-    int optIndex = 0;
-
-    static std::string shortOptions = std::string(
-    #if USE_WIN32_SERVICE
-            "O:Vir"
-    #endif
-            "CDFK:NRSYXa:d:f:hk:m::n:sl:u:vz?"
-            );
-
-    // long options
-    static struct option squidOptions[] = {
-        {"foreground", no_argument, 0,  1 },
-        {"help",       no_argument, 0, 'h'},
-        {"version",    no_argument, 0, 'v'},
-        {"kid",        required_argument, 0, 'K'},
-        {0, 0, 0, 0}
-    };
-
-    int c;
-
-
-    while ((c = getopt_long(argc, argv, shortOptions.c_str(), squidOptions, &optIndex)) != -1) {
-        const auto optPos = shortOptions.find(c);
-        if (optPos == std::string::npos) {
-            usage();
-            break;
-        }
-        options.insert(std::make_pair(c, std::string(optarg ? optarg : "")));
-    }
-}
-
-std::string
-OptParser::getOption(const char shortOpt)
-{
-    auto opt = options.find(shortOpt);
-    if (opt == options.end())
-        return std::string();
-    const std::string value = opt->second;
-    options.erase(opt);
-    return value;
-}
-
-void
-OptParser::processOptions()
-{
-    for (OptionsIterator it = options.begin(); it != options.end();)
-        it = processOption(it);
-}
-
-/**
- * Parse the parameters received via command line interface.
- *
- * \param argc   Number of options received on command line
- * \param argv   List of parameters received on command line
- */
-void
-OptParser::processOption(const char shortOpt)
-{
-    auto opt = options.find(shortOpt);
-    printf("shortopt=%c\n", shortOpt);
-    assert(opt != options.end());
-    processOption(opt);
-}
-
-OptParser::OptionsIterator
-OptParser::processOption(OptionsIterator opt)
-{
-        const char *optValue = opt->second.empty() ? nullptr : opt->second.c_str();
-
-        switch (opt->first) {
-
-        case 'C':
-            /** \par C
-             * Unset/disabel global option for catchign signals. opt_catch_signals */
-            opt_catch_signals = 0;
-            break;
-
-        case 'D':
-            /** \par D
-             * OBSOLETE: WAS: override to prevent optional startup DNS tests. */
-            debugs(1,DBG_CRITICAL, "WARNING: -D command-line option is obsolete.");
-            break;
-
-        case 'F':
-            /** \par F
-             * Set global option for foreground rebuild. opt_foreground_rebuild */
-            opt_foreground_rebuild = 1;
-            break;
-
-        case 'N':
-            /** \par N
-             * Set global option for 'no_daemon' mode. opt_no_daemon */
-            opt_no_daemon = 1;
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'O':
-            /** \par O
-             * Set global option. opt_command_lin and WIN32_Command_Line */
-            opt_command_line = 1;
-            WIN32_Command_Line = xstrdup(optValue);
-            break;
-#endif
-
-        case 'R':
-            /** \par R
-             * Unset/disable global option opt_reuseaddr */
-            opt_reuseaddr = 0;
-            break;
-
-        case 'S':
-            /** \par S
-             * Set global option opt_store_doublecheck */
-            opt_store_doublecheck = 1;
-            break;
-
-        case 'X':
-            /** \par X
-             * Force full debugging */
-            Debug::parseOptions("rotate=0 ALL,9");
-            Debug::override_X = 1;
-            sigusr2_handle(SIGUSR2);
-            break;
-
-        case 'Y':
-            /** \par Y
-             * Set global option opt_reload_hit_only */
-            opt_reload_hit_only = 1;
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'i':
-            /** \par i
-             * Set global option opt_install_service (to TRUE) */
-            opt_install_service = TRUE;
-            break;
-#endif
-
-        case 'a':
-            /** \par a
-             * Add optional HTTP port as given following the option */
-            add_http_port(const_cast<char*>(optValue));
-            break;
-
-        case 'd':
-            /** \par d
-             * Set global option Debug::log_stderr to the number given following the option */
-            Debug::log_stderr = atoi(optValue);
-            break;
-
-        case 'f':
-            /** \par f
-             * Load the file given instead of the default squid.conf. */
-            xfree(ConfigFile);
-            ConfigFile = xstrdup(optValue);
-            break;
-
-        case 'K': {
-            fatal("Must parse --kid option before other options");
-            break;
-          }
-
-        case 'k':
-            /** \par k
-             * Run the administrative action given following the option */
-
-            /** \li When it is missing or an unknown option display the usage help. */
-            if (!optValue || strlen(optValue) < 1)
-                usage();
-
-            else if (!strncmp(optValue, "reconfigure", strlen(optValue)))
-                /** \li On reconfigure send SIGHUP. */
-                opt_send_signal = SIGHUP;
-            else if (!strncmp(optValue, "rotate", strlen(optValue)))
-                /** \li On rotate send SIGQUIT or SIGUSR1. */
-#if defined(_SQUID_LINUX_THREADS_)
-                opt_send_signal = SIGQUIT;
-#else
-                opt_send_signal = SIGUSR1;
-#endif
-
-            else if (!strncmp(optValue, "debug", strlen(optValue)))
-                /** \li On debug send SIGTRAP or SIGUSR2. */
-#if defined(_SQUID_LINUX_THREADS_)
-                opt_send_signal = SIGTRAP;
-#else
-                opt_send_signal = SIGUSR2;
-#endif
-
-            else if (!strncmp(optValue, "shutdown", strlen(optValue)))
-                /** \li On shutdown send SIGTERM. */
-                opt_send_signal = SIGTERM;
-            else if (!strncmp(optValue, "interrupt", strlen(optValue)))
-                /** \li On interrupt send SIGINT. */
-                opt_send_signal = SIGINT;
-            else if (!strncmp(optValue, "kill", strlen(optValue)))
-                /** \li On kill send SIGKILL. */
-                opt_send_signal = SIGKILL;
-
-#ifdef SIGTTIN
-
-            else if (!strncmp(optValue, "restart", strlen(optValue)))
-                /** \li On restart send SIGTTIN. (exit and restart by parent) */
-                opt_send_signal = SIGTTIN;
-
-#endif
-
-            else if (!strncmp(optValue, "check", strlen(optValue)))
-                /** \li On check send 0 / SIGNULL. */
-                opt_send_signal = 0;    /* SIGNULL */
-            else if (!strncmp(optValue, "parse", strlen(optValue)))
-                /** \li On parse set global flag to re-parse the config file only. */
-                opt_parse_cfg_only = 1;
-            else
-                usage();
-
-            break;
-
-        case 'm':
-            /** \par m
-             * Set global malloc_debug_level to the value given following the option.
-             * if none is given it toggles the xmalloc_trace option on/off */
-            if (optValue) {
-#if MALLOC_DBG
-                malloc_debug_level = atoi(optValue);
-#else
-                fatal("Need to add -DMALLOC_DBG when compiling to use -mX option");
-#endif
-
-            }
-            break;
-
-        case 'n':
-            /** \par n
-             * Set global option opt_signal_service (to true).
-             * Stores the additional parameter given in global service_name */
-            if (optValue && *optValue != '\0') {
-                const SBuf t(optValue);
-                ::Parser::Tokenizer tok(t);
-                const CharacterSet chr = CharacterSet::ALPHA+CharacterSet::DIGIT;
-                if (!tok.prefix(service_name, chr))
-                    fatalf("Expected alphanumeric service name for the -n option but got: %s", optValue);
-                if (!tok.atEnd())
-                    fatalf("Garbage after alphanumeric service name in the -n option value: %s", optValue);
-                if (service_name.length() > 32)
-                    fatalf("Service name (-n option) must be limited to 32 characters but got %u", service_name.length());
-                opt_signal_service = true;
-            } else {
-                fatal("A service name is required for the -n option");
-            }
-            break;
-
-#if USE_WIN32_SERVICE
-
-        case 'r':
-            /** \par r
-             * Set global option opt_remove_service (to TRUE) */
-            opt_remove_service = TRUE;
-
-            break;
-
-#endif
-
-        case 'l':
-            /** \par l
-             * Stores the syslog facility name in global opt_syslog_facility
-             * then performs actions for -s option. */
-            xfree(opt_syslog_facility); // ignore any previous options sent
-            opt_syslog_facility = xstrdup(optValue);
-
-        case 's':
-            /** \par s
-             * Initialize the syslog for output */
-#if HAVE_SYSLOG
-
-            _db_set_syslog(opt_syslog_facility);
-
-            break;
-
-#else
-
-            fatal("Logging to syslog not available on this platform");
-
-            /* NOTREACHED */
-#endif
-
-        case 'u':
-            /** \par u
-             * Store the ICP port number given in global option icpPortNumOverride
-             * ensuring its a positive number. */
-            icpPortNumOverride = atoi(optValue);
-
-            if (icpPortNumOverride < 0)
-                icpPortNumOverride = 0;
-
-            break;
-
-        case 'v':
-            /** \par v
-             * Display squid version and build information. Then exit. */
-            printf("Squid Cache: Version %s\n",version_string);
-            printf("Service Name: " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(service_name));
-            if (strlen(SQUID_BUILD_INFO))
-                printf("%s\n",SQUID_BUILD_INFO);
-#if USE_OPENSSL
-            printf("\nThis binary uses %s. ", SSLeay_version(SSLEAY_VERSION));
-            printf("For legal restrictions on distribution see https://www.openssl.org/source/license.html\n\n");
-#endif
-            printf( "configure options: %s\n", SQUID_CONFIGURE_OPTIONS);
-
-#if USE_WIN32_SERVICE
-
-            printf("Compiled as Windows System Service.\n");
-
-#endif
-
-            exit(EXIT_SUCCESS);
-
-        /* NOTREACHED */
-
-        case 'z':
-            /** \par z
-             * Set global option Debug::log_stderr and opt_create_swap_dirs */
-            Debug::log_stderr = 1;
-            opt_create_swap_dirs = 1;
-            break;
-
-        case 1:
-            /** \par --foreground
-             * Set global option opt_foreground */
-            opt_foreground = 1;
-            break;
-
-        case 'h':
-        case '?':
-        default:
-            usage();
-            break;
-        }
-
-        return options.erase(opt);
 }
 
 /// Decides whether the signal-controlled action X should be delayed, canceled,
@@ -721,59 +345,6 @@ SignalEngine::handleStoppedChild()
     while (pid > 0 || (pid < 0 && errno == EINTR));
 #endif
 #endif
-}
-
-static void
-usage(void)
-{
-    fprintf(stderr,
-            "Usage: %s [-cdzCFNRVYX] [-n name] [-s | -l facility] [-f config-file] [-[au] port] [-k signal]"
-#if USE_WIN32_SERVICE
-            "[-ir] [-O CommandLine]"
-#endif
-            "\n"
-            "    -h | --help       Print help message.\n"
-            "    -v | --version    Print version details.\n"
-            "\n"
-            "       -a port   Specify HTTP port number (default: %d).\n"
-            "       -d level  Write debugging to stderr also.\n"
-            "       -f file   Use given config-file instead of\n"
-            "                 %s\n"
-#if USE_WIN32_SERVICE
-            "       -i        Installs as a Windows Service (see -n option).\n"
-#endif
-            "       -k reconfigure|rotate|shutdown|"
-#ifdef SIGTTIN
-            "restart|"
-#endif
-            "interrupt|kill|debug|check|parse\n"
-            "                 Parse configuration file, then send signal to \n"
-            "                 running copy (except -k parse) and exit.\n"
-            "       -n name   Specify service name to use for service operations\n"
-            "                 default is: " APP_SHORTNAME ".\n"
-#if USE_WIN32_SERVICE
-            "       -r        Removes a Windows Service (see -n option).\n"
-#endif
-            "       -s | -l facility\n"
-            "                 Enable logging to syslog.\n"
-            "       -u port   Specify ICP port number (default: %d), disable with 0.\n"
-            "       -z        Create missing swap directories and then exit.\n"
-            "       -C        Do not catch fatal signals.\n"
-            "       -D        OBSOLETE. Scheduled for removal.\n"
-            "       -F        Don't serve any requests until store is rebuilt.\n"
-            "       -N        Master process runs in foreground and is a worker. No kids.\n"
-            "       --foreground\n"
-            "                 Master process runs in foreground and creates worker kids.\n"
-#if USE_WIN32_SERVICE
-            "       -O options\n"
-            "                 Set Windows Service Command line options in Registry.\n"
-#endif
-            "       -R        Do not set REUSEADDR on port.\n"
-            "       -S        Double-check swap during rebuild.\n"
-            "       -X        Force full debugging.\n"
-            "       -Y        Only return UDP_HIT or UDP_MISS_NOFETCH during fast reload.\n",
-            APP_SHORTNAME, CACHE_HTTP_PORT, DefaultConfigFile, CACHE_ICP_PORT);
-    exit(EXIT_FAILURE);
 }
 
 /* ARGSUSED */
@@ -1478,18 +1049,16 @@ SquidMainSafe(int argc, char **argv)
 
 /// computes name and ID for the current kid process
 static void
-ConfigureCurrentKid(OptParser &optParser)
+ConfigureCurrentKid(const CommandLine &cmdLine)
 {
-    const auto optValue = optParser.getOption('K');
-    // kids are marked with parenthesis around their process names
-    if (!optValue.empty() && optValue[0] == '(') {
-        const char *processName = optValue.c_str();
-        printf("process name = %s\n", processName);
+    if (!cmdLine.kidName().isEmpty()) {
+        // TODO: parse directly SBuf instead
+        char *processName = strdup(cmdLine.kidName().c_str());
         if (const char *idStart = strrchr(processName, '-')) {
             KidIdentifier = atoi(idStart + 1);
-            const size_t nameLen = idStart - (processName + 1);
+            const size_t nameLen = idStart - processName;
             assert(nameLen < sizeof(TheKidName));
-            xstrncpy(TheKidName, processName + 1, nameLen + 1);
+            xstrncpy(TheKidName, processName, nameLen);
             if (!strcmp(TheKidName, "squid-coord"))
                 TheProcessKind = pkCoordinator;
             else if (!strcmp(TheKidName, "squid"))
@@ -1499,6 +1068,7 @@ ConfigureCurrentKid(OptParser &optParser)
             else
                 TheProcessKind = pkOther; // including coordinator
         }
+        free(processName);
     } else {
         xstrncpy(TheKidName, APP_SHORTNAME, sizeof(TheKidName));
         KidIdentifier = 0;
@@ -1514,9 +1084,9 @@ static void StartUsingConfig()
 int
 SquidMain(int argc, char **argv)
 {
-    OptParser optParser(argc, argv);
-    // configure current kid
-    ConfigureCurrentKid(optParser);
+    CommandLine cmdLine(argc, argv);
+
+    ConfigureCurrentKid(cmdLine);
 
     Debug::parseOptions(NULL);
 
@@ -1563,7 +1133,7 @@ SquidMain(int argc, char **argv)
 
 #endif
 
-    optParser.processOptions();
+    cmdLine.processOptions();
 
     if (opt_foreground && opt_no_daemon) {
         debugs(1, DBG_CRITICAL, "WARNING: --foreground command-line option has no effect with -N.");
@@ -1679,7 +1249,7 @@ SquidMain(int argc, char **argv)
 
     if (IamMasterProcess()) {
         if (InDaemonMode()) {
-            watch_child(argc, argv);
+            watch_child(cmdLine);
             // NOTREACHED
         } else {
             Instance::WriteOurPid();
@@ -1952,10 +1522,9 @@ masterExit()
 #endif /* !_SQUID_WINDOWS_ */
 
 static void
-watch_child(int argc, char *argv[])
+watch_child(CommandLine &cmdLine)
 {
 #if !_SQUID_WINDOWS_
-    char *prog;
     pid_t pid;
 #ifdef TIOCNOTTY
 
@@ -2059,23 +1628,15 @@ watch_child(int argc, char *argv[])
                 continue;
 
             if (!mainStartScriptCalled) {
-                mainStartScript(argv[0]);
+                mainStartScript(cmdLine.execFile().c_str());
                 mainStartScriptCalled = true;
             }
 
             if ((pid = fork()) == 0) {
                 /* child */
                 openlog(APP_SHORTNAME, LOG_PID | LOG_NDELAY | LOG_CONS, LOG_LOCAL4);
-                prog = argv[0];
-
-                char **newArgv = (char **)malloc(sizeof(char *) * (argc + 3));
-                for (int j = 1; j < argc; j++)
-                    newArgv[j] = strdup(argv[j]);
-                newArgv[0] = const_cast<char*>(kid.name().termedBuf());
-                newArgv[argc] = strdup("--kid");
-                newArgv[argc + 1] = newArgv[0];
-                newArgv[argc + 2] = nullptr;
-                execvp(prog, newArgv);
+                const auto argv = cmdLine.argv(kid.name().termedBuf(), kid.pureName().termedBuf());
+                execvp(cmdLine.execFile().c_str(), const_cast<char * const *>(argv));
                 int xerrno = errno;
                 syslog(LOG_ALERT, "execvp failed: %s", xstrerr(xerrno));
             }

--- a/src/main.cc
+++ b/src/main.cc
@@ -2010,7 +2010,7 @@ watch_child(const CommandLine &masterCommand)
             auto kidCommand = masterCommand;
             kidCommand.resetArg0(kid.processName().c_str());
             assert(!kidCommand.hasOption(optKid));
-            kidCommand.addOption("--kid", kid.gist().c_str());
+            kidCommand.pushFrontOption("--kid", kid.gist().c_str());
 
             if ((pid = fork()) == 0) {
                 /* child */

--- a/src/squid.8.in
+++ b/src/squid.8.in
@@ -124,6 +124,11 @@ Parent process does not exit until its children have finished. It has no effect 
 which does not fork/exit at startup.
 .
 .if !'po4a'hide' .TP
+.if !'po4a'hide' .B "\--kid roleID"
+Play a given SMP kid process role, with a given ID. Do not use
+this option. It is meant for the master process use only.
+.
+.if !'po4a'hide' .TP
 .if !'po4a'hide' .B "\-O options"
 Set Windows Service Command line options in Registry.
 .


### PR DESCRIPTION
Use a newly added "--kid role-ID" command line option instead. Just like
argv[0], the new option is not meant for direct/human use.

This change allows exec(3)-wrapping tools like Valgrind to work with SMP
Squid: When launching kid processes, Valgrind does not pass Squid-formed
argv[0] to kid processes, breaking old kid role and ID detection code.

This change does not alter argv[0] of Squid processes. There is nothing
wrong with Squid-formed argv[0] values for Squid kids.
    
Also added a CommandLine class to support command line parsing without
code duplication. Squid needs to handle the new --kid option way before
the old mainParseOptions() handles the other options. The new class also
encapsulates argv manipulations, reducing main.cc pollution.