### PR TITLE
Bug 4828: Use feature detection for IPFilter API/ABI checks

### DIFF
--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -912,4 +912,41 @@ AC_DEFUN([SQUID_CHECK_BROKEN_SOLARIS_IPFILTER],[
 #define IPFILTER_VERSION        5000004
 #endif
   ])
+
+## Solaris 10+ backported IPv6 NAT to their IPFilter v4.1 instead of using v5
+  AC_CHECK_MEMBERS([
+    struct natlookup.nl_inipaddr.in6,
+    struct natlookup.nl_realipaddr.in6
+  ],,,[
+#if USE_SOLARIS_IPFILTER_MINOR_T_HACK
+#define minor_t fubar
+#endif
+#if HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#if HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#if HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
+#if HAVE_SYS_IOCCOM_H
+#include <sys/ioccom.h>
+#endif
+#if USE_SOLARIS_IPFILTER_MINOR_T_HACK
+#undef minor_t
+#endif
+#if HAVE_IP_COMPAT_H
+#include <ip_compat.h>
+#elif HAVE_NETINET_IP_COMPAT_H
+#include <netinet/ip_compat.h>
+#endif
+#if HAVE_IP_FIL_H
+#include <ip_fil.h>
+#elif HAVE_NETINET_IP_FIL_H
+#include <netinet/ip_fil.h>
+#endif
+#include <ip_nat.h>
+  ])
+
 ])

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -205,15 +205,6 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
     // for NAT lookup set local and remote IP:port's
     if (newConn->remote.isIPv6()) {
 #if HAVE_NATLOOKUP_NL_INIPADDR_IN6
-        // warn once every 10 at critical level, then push down a level each repeated event
-        static int warningLevel = DBG_CRITICAL;
-        debugs(89, warningLevel, "IPF (IPFilter v4) NAT does not support IPv6. Please upgrade to IPFilter v5.1");
-        warningLevel = (warningLevel + 1) % 10;
-        return false;
-    }
-    newConn->local.getInAddr(natLookup.nl_inip);
-    newConn->remote.getInAddr(natLookup.nl_outip);
-#else
         natLookup.nl_v = 6;
         newConn->local.getInAddr(natLookup.nl_inipaddr.in6);
         newConn->remote.getInAddr(natLookup.nl_outipaddr.in6);
@@ -223,6 +214,15 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
         newConn->local.getInAddr(natLookup.nl_inipaddr.in4);
         newConn->remote.getInAddr(natLookup.nl_outipaddr.in4);
     }
+#else
+        // warn once every 10 at critical level, then push down a level each repeated event
+        static int warningLevel = DBG_CRITICAL;
+        debugs(89, warningLevel, "IPF (IPFilter v4) NAT does not support IPv6. Please upgrade to IPFilter v5.1");
+        warningLevel = (warningLevel + 1) % 10;
+        return false;
+    }
+    newConn->local.getInAddr(natLookup.nl_inip);
+    newConn->remote.getInAddr(natLookup.nl_outip);
 #endif
     natLookup.nl_inport = htons(newConn->local.port());
     natLookup.nl_outport = htons(newConn->remote.port());

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -204,7 +204,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
     memset(&natLookup, 0, sizeof(natLookup));
     // for NAT lookup set local and remote IP:port's
     if (newConn->remote.isIPv6()) {
-#if IPFILTER_VERSION < 5000003
+#if HAVE_NATLOOKUP_NL_INIPADDR_IN6
         // warn once every 10 at critical level, then push down a level each repeated event
         static int warningLevel = DBG_CRITICAL;
         debugs(89, warningLevel, "IPF (IPFilter v4) NAT does not support IPv6. Please upgrade to IPFilter v5.1");
@@ -292,13 +292,13 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
         debugs(89, 9, HERE << "address: " << newConn);
         return false;
     } else {
-#if IPFILTER_VERSION < 5000003
-        newConn->local = natLookup.nl_realip;
-#else
+#if HAVE_NATLOOKUP_NL_REALIPADDR_IN6
         if (newConn->remote.isIPv6())
             newConn->local = natLookup.nl_realipaddr.in6;
         else
             newConn->local = natLookup.nl_realipaddr.in4;
+#else
+        newConn->local = natLookup.nl_realip;
 #endif
         newConn->local.port(ntohs(natLookup.nl_realport));
         debugs(89, 5, HERE << "address NAT: " << newConn);

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -217,7 +217,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
 #else
         // warn once every 10 at critical level, then push down a level each repeated event
         static int warningLevel = DBG_CRITICAL;
-        debugs(89, warningLevel, "IPF (IPFilter v4) NAT does not support IPv6. Please upgrade to IPFilter v5.1");
+        debugs(89, warningLevel, "Your IPF (IPFilter) NAT does not support IPv6. Please upgrade it.");
         warningLevel = (warningLevel + 1) % 10;
         return false;
     }


### PR DESCRIPTION
Solaris 10+ backported IPFiter v5 features to their v4.1.9 which breaks
the IPFilterv4 logic when IPv6 is received. Resulting in crashes when
IPFilver version detection builds for IPv4-only code.

Fix by switching to feature detection of the relevant library symbols
instead of library version.