### PR TITLE
Supply AccessLogEntry (ALE) for more fast ACL checks.

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -331,6 +331,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
          * we do NOT want the indirect client address to be tested here.
          */
         ACLFilledChecklist ch(Config.accessList.miss, request, NULL);
+        ch.al = al;
         ch.src_addr = request->client_addr;
         if (ch.fastCheck().denied()) {
             err_type page_id;
@@ -1218,6 +1219,7 @@ FwdState::pconnPop(const Comm::ConnectionPointer &dest, const char *domain)
     bool retriable = checkRetriable();
     if (!retriable && Config.accessList.serverPconnForNonretriable) {
         ACLFilledChecklist ch(Config.accessList.serverPconnForNonretriable, request, NULL);
+        ch.al = al;
         retriable = ch.fastCheck().allowed();
     }
     // always call shared pool first because we need to close an idle

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -28,6 +28,7 @@ typedef void STMCB (void *data, StoreIOBuffer wroteBuffer);
 typedef void STABH(void *);
 
 class store_client;
+class PeerSelector;
 
 class MemObject
 {
@@ -161,7 +162,7 @@ public:
 
     struct timeval start_ping;
     IRCB *ping_reply_callback;
-    void *ircb_data;
+    PeerSelector *ircb_data;
 
     struct {
         STABH *callback;

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -69,6 +69,7 @@ bool
 Note::match(HttpRequest *request, HttpReply *reply, const AccessLogEntry::Pointer &al, SBuf &matched)
 {
     ACLFilledChecklist ch(nullptr, request, nullptr);
+    ch.al = al;
     ch.reply = reply;
     if (reply)
         HTTPMSGLOCK(ch.reply);

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -141,7 +141,7 @@ ACL::matches(ACLChecklist *checklist) const
     } else {
         // make sure the ALE has as much data as possible
         if (requiresAle())
-            checklist->syncAle();
+            checklist->syncAle(true);
 
         // have to cast because old match() API is missing const
         result = const_cast<ACL*>(this)->match(checklist);

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -76,6 +76,9 @@ ACLChecklist::preCheck(const char *what)
 
     AclMatchedName = NULL;
     finished_ = false;
+
+    if (hasAle())
+        syncAle();
 }
 
 bool

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -164,7 +164,7 @@ public:
     virtual bool hasRequest() const = 0;
     virtual bool hasReply() const = 0;
     virtual bool hasAle() const = 0;
-    virtual void syncAle() const = 0;
+    virtual void syncAle(const bool warnUnsync = false) const = 0;
 
     /// change the current ACL list
     /// \return a pointer to the old list value (may be nullptr)

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -79,45 +79,51 @@ showDebugWarning(const char *msg)
 }
 
 void
-ACLFilledChecklist::syncAle() const
+ACLFilledChecklist::syncAle(const bool warnUnsync) const
 {
     // make sure the ALE fields used by Format::assemble to
     // fill the old external_acl_type codes are set if any
     // data on them exists in the Checklist
 
     if (!al->cache.port && conn()) {
-        showDebugWarning("listening port");
+        if (warnUnsync)
+            showDebugWarning("listening port");
         al->cache.port = conn()->port;
     }
 
     if (request) {
         if (!al->request) {
-            showDebugWarning("HttpRequest object");
+            if (warnUnsync)
+                showDebugWarning("HttpRequest object");
             al->request = request;
             HTTPMSGLOCK(al->request);
         }
 
         if (!al->adapted_request) {
-            showDebugWarning("adapted HttpRequest object");
+            if (warnUnsync)
+                showDebugWarning("adapted HttpRequest object");
             al->adapted_request = request;
             HTTPMSGLOCK(al->adapted_request);
         }
 
         if (al->url.isEmpty()) {
-            showDebugWarning("URL");
+            if (warnUnsync)
+                showDebugWarning("URL");
             al->url = request->url.absolute();
         }
     }
 
     if (reply && !al->reply) {
-        showDebugWarning("HttpReply object");
+        if (warnUnsync)
+            showDebugWarning("HttpReply object");
         al->reply = reply;
         HTTPMSGLOCK(al->reply);
     }
 
 #if USE_IDENT
     if (*rfc931 && !al->cache.rfc931) {
-        showDebugWarning("IDENT");
+        if (warnUnsync)
+            showDebugWarning("IDENT");
         al->cache.rfc931 = xstrdup(rfc931);
     }
 #endif

--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -61,7 +61,7 @@ public:
     virtual bool hasRequest() const { return request != NULL; }
     virtual bool hasReply() const { return reply != NULL; }
     virtual bool hasAle() const { return al != NULL; }
-    virtual void syncAle() const;
+    virtual void syncAle(const bool warnUnsync = false) const;
 
 public:
     Ip::Address src_addr;

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -13,6 +13,7 @@
 #include "HttpRequest.h"
 #include "mgr/Registration.h"
 #include "neighbors.h"
+#include "PeerSelectState.h"
 #include "SquidConfig.h"
 #include "Store.h"
 #include "URL.h"
@@ -143,8 +144,11 @@ carpInit(void)
 }
 
 CachePeer *
-carpSelectParent(HttpRequest * request)
+carpSelectParent(PeerSelector *ps)
 {
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     int k;
     CachePeer *p = NULL;
     CachePeer *tp;
@@ -204,7 +208,7 @@ carpSelectParent(HttpRequest * request)
         debugs(39, 3, "carpSelectParent: key=" << key << " name=" << tp->name << " combined_hash=" << combined_hash  <<
                " score=" << std::setprecision(0) << score);
 
-        if ((score > high_score) && peerHTTPOkay(tp, request)) {
+        if ((score > high_score) && peerHTTPOkay(tp, ps)) {
             p = tp;
             high_score = score;
         }

--- a/src/carp.h
+++ b/src/carp.h
@@ -12,10 +12,10 @@
 #define SQUID_CARP_H_
 
 class CachePeer;
-class HttpRequest;
+class PeerSelector;
 
 void carpInit(void);
-CachePeer *carpSelectParent(HttpRequest *);
+CachePeer *carpSelectParent(PeerSelector *);
 
 #endif /* SQUID_CARP_H_ */
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -452,6 +452,7 @@ ClientHttpRequest::logRequest()
     bool updatePerformanceCounters = true;
     if (Config.accessList.stats_collection) {
         ACLFilledChecklist statsCheck(Config.accessList.stats_collection, request, NULL);
+        statsCheck.al = al;
         if (al->reply) {
             statsCheck.reply = al->reply;
             HTTPMSGLOCK(statsCheck.reply);
@@ -1521,6 +1522,7 @@ bool ConnStateData::serveDelayedError(Http::Stream *context)
             bool allowDomainMismatch = false;
             if (Config.ssl_client.cert_error) {
                 ACLFilledChecklist check(Config.ssl_client.cert_error, request, dash_str);
+                check.al = http->al;
                 check.sslErrors = new Security::CertErrors(Security::CertError(SQUID_X509_V_ERR_DOMAIN_MISMATCH, srvCert));
                 allowDomainMismatch = check.fastCheck().allowed();
                 delete check.sslErrors;
@@ -1569,6 +1571,7 @@ clientTunnelOnError(ConnStateData *conn, Http::StreamPointer &context, HttpReque
 {
     if (conn->mayTunnelUnsupportedProto()) {
         ACLFilledChecklist checklist(Config.accessList.on_unsupported_protocol, request.getRaw(), nullptr);
+        checklist.al = (context && context->http) ? context->http->al : nullptr;
         checklist.requestErrorType = requestError;
         checklist.src_addr = conn->clientConnection->remote;
         checklist.my_addr = conn->clientConnection->local;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1780,6 +1780,7 @@ ClientHttpRequest::doCallouts()
         calloutContext->tosToClientDone = true;
         if (getConn() != NULL && Comm::IsConnOpen(getConn()->clientConnection)) {
             ACLFilledChecklist ch(NULL, request, NULL);
+            ch.al = calloutContext->http->al;
             ch.src_addr = request->client_addr;
             ch.my_addr = request->my_addr;
             tos_t tos = aclMapTOS(Ip::Qos::TheConfig.tosToClient, &ch);
@@ -1792,6 +1793,7 @@ ClientHttpRequest::doCallouts()
         calloutContext->nfmarkToClientDone = true;
         if (getConn() != NULL && Comm::IsConnOpen(getConn()->clientConnection)) {
             ACLFilledChecklist ch(NULL, request, NULL);
+            ch.al = calloutContext->http->al;
             ch.src_addr = request->client_addr;
             ch.my_addr = request->my_addr;
             nfmark_t mark = aclMapNfmark(Ip::Qos::TheConfig.nfmarkToClient, &ch);

--- a/src/http.cc
+++ b/src/http.cc
@@ -801,6 +801,7 @@ HttpStateData::handle1xx(HttpReply *reply)
     // check whether the 1xx response forwarding is allowed by squid.conf
     if (Config.accessList.reply) {
         ACLFilledChecklist ch(Config.accessList.reply, originalRequest().getRaw());
+        ch.al = fwd->al;
         ch.reply = reply;
         HTTPMSGLOCK(ch.reply);
         if (!ch.fastCheck().allowed()) { // TODO: support slow lookups?
@@ -2334,6 +2335,7 @@ HttpStateData::finishingBrokenPost()
     }
 
     ACLFilledChecklist ch(Config.accessList.brokenPosts, originalRequest().getRaw());
+    ch.al = fwd->al;
     if (!ch.fastCheck().allowed()) {
         debugs(11, 5, HERE << "didn't match brokenPosts");
         return false;

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -32,6 +32,7 @@
 #include "mgr/Registration.h"
 #include "mime_header.h"
 #include "neighbors.h"
+#include "PeerSelectState.h"
 #include "SquidConfig.h"
 #include "SquidTime.h"
 #include "Store.h"
@@ -1304,9 +1305,12 @@ netdbExchangeStart(void *data)
 }
 
 CachePeer *
-netdbClosestParent(HttpRequest * request)
+netdbClosestParent(PeerSelector *ps)
 {
 #if USE_ICMP
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     CachePeer *p = NULL;
     netdbEntry *n;
     const ipcache_addrs *ia;
@@ -1350,7 +1354,7 @@ netdbClosestParent(HttpRequest * request)
         if (neighborType(p, request->url) != PEER_PARENT)
             continue;
 
-        if (!peerHTTPOkay(p, request))  /* not allowed */
+        if (!peerHTTPOkay(p, ps))  /* not allowed */
             continue;
 
         return p;

--- a/src/icmp/net_db.h
+++ b/src/icmp/net_db.h
@@ -16,6 +16,7 @@
 class CachePeer;
 class HttpRequest;
 class netdbEntry;
+class PeerSelector;
 class StoreEntry;
 class URL;
 
@@ -80,7 +81,7 @@ void netdbBinaryExchange(StoreEntry *);
 void netdbExchangeStart(void *);
 
 void netdbExchangeUpdatePeer(Ip::Address &, CachePeer *, double, double);
-CachePeer *netdbClosestParent(HttpRequest *);
+CachePeer *netdbClosestParent(PeerSelector *);
 void netdbHostData(const char *host, int *samp, int *rtt, int *hops);
 
 #endif /* ICMP_NET_DB_H */

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -49,8 +49,8 @@
 /* count mcast group peers every 15 minutes */
 #define MCAST_COUNT_RATE 900
 
-bool peerAllowedToUse(const CachePeer *, HttpRequest *);
-static int peerWouldBePinged(const CachePeer *, HttpRequest *);
+bool peerAllowedToUse(const CachePeer *, PeerSelector *);
+static int peerWouldBePinged(const CachePeer *, PeerSelector *);
 static void neighborRemove(CachePeer *);
 static void neighborAlive(CachePeer *, const MemObject *, const icp_common_t *);
 #if USE_HTCP
@@ -134,9 +134,10 @@ neighborType(const CachePeer * p, const URL &url)
  * \return Whether it is appropriate to fetch REQUEST from PEER.
  */
 bool
-peerAllowedToUse(const CachePeer * p, HttpRequest * request)
+peerAllowedToUse(const CachePeer * p, PeerSelector * ps)
 {
-
+    assert(ps);
+    HttpRequest *request = ps->request;
     assert(request != NULL);
 
     if (neighborType(p, request->url) == PEER_SIBLING) {
@@ -167,14 +168,17 @@ peerAllowedToUse(const CachePeer * p, HttpRequest * request)
         return true;
 
     ACLFilledChecklist checklist(p->access, request, NULL);
-
+    checklist.al = ps->al;
     return checklist.fastCheck().allowed();
 }
 
 /* Return TRUE if it is okay to send an ICP request to this CachePeer.   */
 static int
-peerWouldBePinged(const CachePeer * p, HttpRequest * request)
+peerWouldBePinged(const CachePeer * p, PeerSelector * ps)
 {
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     if (p->icp.port == 0)
         return 0;
 
@@ -196,7 +200,7 @@ peerWouldBePinged(const CachePeer * p, HttpRequest * request)
         if (!request->flags.hierarchical)
             return 0;
 
-    if (!peerAllowedToUse(p, request))
+    if (!peerAllowedToUse(p, ps))
         return 0;
 
     /* Ping dead peers every timeout interval */
@@ -245,12 +249,12 @@ peerConnClosed(CachePeer *p)
 
 /* Return TRUE if it is okay to send an HTTP request to this CachePeer. */
 int
-peerHTTPOkay(const CachePeer * p, HttpRequest * request)
+peerHTTPOkay(const CachePeer * p, PeerSelector * ps)
 {
     if (!peerCanOpenMore(p) && !peerHasConnAvailable(p))
         return 0;
 
-    if (!peerAllowedToUse(p, request))
+    if (!peerAllowedToUse(p, ps))
         return 0;
 
     if (!neighborUp(p))
@@ -260,13 +264,13 @@ peerHTTPOkay(const CachePeer * p, HttpRequest * request)
 }
 
 int
-neighborsCount(HttpRequest * request)
+neighborsCount(PeerSelector *ps)
 {
     CachePeer *p = NULL;
     int count = 0;
 
     for (p = Config.peers; p; p = p->next)
-        if (peerWouldBePinged(p, request))
+        if (peerWouldBePinged(p, ps))
             ++count;
 
     debugs(15, 3, "neighborsCount: " << count);
@@ -275,8 +279,11 @@ neighborsCount(HttpRequest * request)
 }
 
 CachePeer *
-getFirstUpParent(HttpRequest * request)
+getFirstUpParent(PeerSelector *ps)
 {
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     CachePeer *p = NULL;
 
     for (p = Config.peers; p; p = p->next) {
@@ -286,7 +293,7 @@ getFirstUpParent(HttpRequest * request)
         if (neighborType(p, request->url) != PEER_PARENT)
             continue;
 
-        if (!peerHTTPOkay(p, request))
+        if (!peerHTTPOkay(p, ps))
             continue;
 
         break;
@@ -297,8 +304,11 @@ getFirstUpParent(HttpRequest * request)
 }
 
 CachePeer *
-getRoundRobinParent(HttpRequest * request)
+getRoundRobinParent(PeerSelector *ps)
 {
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     CachePeer *p;
     CachePeer *q = NULL;
 
@@ -309,7 +319,7 @@ getRoundRobinParent(HttpRequest * request)
         if (neighborType(p, request->url) != PEER_PARENT)
             continue;
 
-        if (!peerHTTPOkay(p, request))
+        if (!peerHTTPOkay(p, ps))
             continue;
 
         if (p->weight == 0)
@@ -336,8 +346,11 @@ getRoundRobinParent(HttpRequest * request)
 }
 
 CachePeer *
-getWeightedRoundRobinParent(HttpRequest * request)
+getWeightedRoundRobinParent(PeerSelector *ps)
 {
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     CachePeer *p;
     CachePeer *q = NULL;
     int weighted_rtt;
@@ -349,7 +362,7 @@ getWeightedRoundRobinParent(HttpRequest * request)
         if (neighborType(p, request->url) != PEER_PARENT)
             continue;
 
-        if (!peerHTTPOkay(p, request))
+        if (!peerHTTPOkay(p, ps))
             continue;
 
         if (q && q->rr_count < p->rr_count)
@@ -451,8 +464,11 @@ peerAlive(CachePeer *p)
 }
 
 CachePeer *
-getDefaultParent(HttpRequest * request)
+getDefaultParent(PeerSelector *ps)
 {
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     CachePeer *p = NULL;
 
     for (p = Config.peers; p; p = p->next) {
@@ -462,7 +478,7 @@ getDefaultParent(HttpRequest * request)
         if (!p->options.default_parent)
             continue;
 
-        if (!peerHTTPOkay(p, request))
+        if (!peerHTTPOkay(p, ps))
             continue;
 
         debugs(15, 3, "getDefaultParent: returning " << p->host);
@@ -573,7 +589,7 @@ int
 neighborsUdpPing(HttpRequest * request,
                  StoreEntry * entry,
                  IRCB * callback,
-                 void *callback_data,
+                 PeerSelector *ps,
                  int *exprep,
                  int *timeout)
 {
@@ -599,7 +615,7 @@ neighborsUdpPing(HttpRequest * request,
 
     mem->ping_reply_callback = callback;
 
-    mem->ircb_data = callback_data;
+    mem->ircb_data = ps;
 
     reqnum = icpSetCacheKey((const cache_key *)entry->key);
 
@@ -609,7 +625,7 @@ neighborsUdpPing(HttpRequest * request,
 
         debugs(15, 5, "neighborsUdpPing: Peer " << p->host);
 
-        if (!peerWouldBePinged(p, request))
+        if (!peerWouldBePinged(p, ps))
             continue;       /* next CachePeer */
 
         ++peers_pinged;
@@ -734,9 +750,11 @@ neighborsUdpPing(HttpRequest * request,
 
 /* lookup the digest of a given CachePeer */
 lookup_t
-peerDigestLookup(CachePeer * p, HttpRequest * request)
+peerDigestLookup(CachePeer * p, PeerSelector * ps)
 {
 #if USE_CACHE_DIGESTS
+    assert(ps);
+    HttpRequest *request = ps->request;
     const cache_key *key = request ? storeKeyPublicByRequest(request) : NULL;
     assert(p);
     assert(request);
@@ -746,7 +764,7 @@ peerDigestLookup(CachePeer * p, HttpRequest * request)
     if (!p->digest) {
         debugs(15, 5, "peerDigestLookup: gone!");
         return LOOKUP_NONE;
-    } else if (!peerHTTPOkay(p, request)) {
+    } else if (!peerHTTPOkay(p, ps)) {
         debugs(15, 5, "peerDigestLookup: !peerHTTPOkay");
         return LOOKUP_NONE;
     } else if (!p->digest->flags.needed) {
@@ -776,10 +794,12 @@ peerDigestLookup(CachePeer * p, HttpRequest * request)
 
 /* select best CachePeer based on cache digests */
 CachePeer *
-neighborsDigestSelect(HttpRequest * request)
+neighborsDigestSelect(PeerSelector *ps)
 {
     CachePeer *best_p = NULL;
 #if USE_CACHE_DIGESTS
+    assert(ps);
+    HttpRequest *request = ps->request;
 
     int best_rtt = 0;
     int choice_count = 0;
@@ -802,7 +822,7 @@ neighborsDigestSelect(HttpRequest * request)
         if (i == 1)
             first_ping = p;
 
-        lookup = peerDigestLookup(p, request);
+        lookup = peerDigestLookup(p, ps);
 
         if (lookup == LOOKUP_NONE)
             continue;
@@ -952,7 +972,7 @@ neighborIgnoreNonPeer(const Ip::Address &from, icp_opcode opcode)
  * * from being used
  */
 static int
-ignoreMulticastReply(CachePeer * p, MemObject * mem)
+ignoreMulticastReply(CachePeer * p, PeerSelector * ps)
 {
     if (p == NULL)
         return 0;
@@ -960,7 +980,7 @@ ignoreMulticastReply(CachePeer * p, MemObject * mem)
     if (!p->options.mcast_responder)
         return 0;
 
-    if (peerHTTPOkay(p, mem->request.getRaw()))
+    if (peerHTTPOkay(p, ps))
         return 0;
 
     return 1;
@@ -1031,13 +1051,19 @@ neighborsUdpAck(const cache_key * key, icp_common_t * header, const Ip::Address 
         return;
     }
 
+    if (!mem->ircb_data) {
+        debugs(12, DBG_IMPORTANT, "BUG: missing ICP callback data for " << *entry);
+        neighborCountIgnored(p);
+        return;
+    }
+
     debugs(15, 3, "neighborsUdpAck: " << opcode_d << " for '" << storeKeyText(key) << "' from " << (p ? p->host : "source") << " ");
 
     if (p) {
         ntype = neighborType(p, mem->request->url);
     }
 
-    if (ignoreMulticastReply(p, mem)) {
+    if (ignoreMulticastReply(p, mem->ircb_data)) {
         neighborCountIgnored(p);
     } else if (opcode == ICP_MISS) {
         if (p == NULL) {
@@ -1741,12 +1767,18 @@ neighborsHtcpReply(const cache_key * key, HtcpReplyData * htcp, const Ip::Addres
         return;
     }
 
+    if (!mem->ircb_data) {
+        debugs(12, DBG_IMPORTANT, "BUG: missing HTCP callback data for " << *e);
+        neighborCountIgnored(p);
+        return;
+    }
+
     if (p) {
         ntype = neighborType(p, mem->request->url);
         neighborUpdateRtt(p, mem);
     }
 
-    if (ignoreMulticastReply(p, mem)) {
+    if (ignoreMulticastReply(p, mem->ircb_data)) {
         neighborCountIgnored(p);
         return;
     }

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -21,16 +21,17 @@ class HttpRequestMethod;
 class CachePeer;
 class StoreEntry;
 class URL;
+class PeerSelector;
 
 CachePeer *getFirstPeer(void);
-CachePeer *getFirstUpParent(HttpRequest *);
+CachePeer *getFirstUpParent(PeerSelector *);
 CachePeer *getNextPeer(CachePeer *);
-CachePeer *getSingleParent(HttpRequest *);
-int neighborsCount(HttpRequest *);
+CachePeer *getSingleParent(PeerSelector *);
+int neighborsCount(PeerSelector *);
 int neighborsUdpPing(HttpRequest *,
                      StoreEntry *,
                      IRCB * callback,
-                     void *data,
+                     PeerSelector *ps,
                      int *exprep,
                      int *timeout);
 void neighborAddAcl(const char *, const char *);
@@ -43,13 +44,13 @@ void neighborsHtcpClear(StoreEntry *, const char *, HttpRequest *, const HttpReq
 #endif
 CachePeer *peerFindByName(const char *);
 CachePeer *peerFindByNameAndPort(const char *, unsigned short);
-CachePeer *getDefaultParent(HttpRequest * request);
-CachePeer *getRoundRobinParent(HttpRequest * request);
-CachePeer *getWeightedRoundRobinParent(HttpRequest * request);
+CachePeer *getDefaultParent(PeerSelector*);
+CachePeer *getRoundRobinParent(PeerSelector*);
+CachePeer *getWeightedRoundRobinParent(PeerSelector*);
 void peerClearRRStart(void);
 void peerClearRR(void);
-lookup_t peerDigestLookup(CachePeer * p, HttpRequest * request);
-CachePeer *neighborsDigestSelect(HttpRequest * request);
+lookup_t peerDigestLookup(CachePeer * p, PeerSelector *);
+CachePeer *neighborsDigestSelect(PeerSelector *);
 void peerNoteDigestLookup(HttpRequest * request, CachePeer * p, lookup_t lookup);
 void peerNoteDigestGone(CachePeer * p);
 int neighborUp(const CachePeer * e);
@@ -58,7 +59,7 @@ peer_t neighborType(const CachePeer *, const URL &);
 void peerConnectFailed(CachePeer *);
 void peerConnectSucceded(CachePeer *);
 void dump_peer_options(StoreEntry *, CachePeer *);
-int peerHTTPOkay(const CachePeer *, HttpRequest *);
+int peerHTTPOkay(const CachePeer *, PeerSelector *);
 
 // TODO: Consider moving this method to CachePeer class.
 /// \returns the effective connect timeout for the given peer

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -134,8 +134,11 @@ PeerSelector::~PeerSelector()
 }
 
 static int
-peerSelectIcpPing(HttpRequest * request, int direct, StoreEntry * entry)
+peerSelectIcpPing(PeerSelector *ps, int direct, StoreEntry * entry)
 {
+    assert(ps);
+    HttpRequest *request = ps->request;
+
     int n;
     assert(entry);
     assert(entry->ping_status == PING_NONE);
@@ -149,7 +152,7 @@ peerSelectIcpPing(HttpRequest * request, int direct, StoreEntry * entry)
         if (direct != DIRECT_NO)
             return 0;
 
-    n = neighborsCount(request);
+    n = neighborsCount(ps);
 
     debugs(44, 3, "counted " << n << " neighbors");
 
@@ -539,7 +542,7 @@ PeerSelector::selectMore()
     resolveSelected();
 }
 
-bool peerAllowedToUse(const CachePeer * p, HttpRequest * request);
+bool peerAllowedToUse(const CachePeer *, PeerSelector*);
 
 /// Selects a pinned connection if it exists, is valid, and is allowed.
 void
@@ -550,7 +553,7 @@ PeerSelector::selectPinned()
         return;
     CachePeer *pear = request->pinnedConnection()->pinnedPeer();
     if (Comm::IsConnOpen(request->pinnedConnection()->validatePinnedConnection(request, pear))) {
-        const bool usePinned = pear ? peerAllowedToUse(pear, request) : (direct != DIRECT_NO);
+        const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
         if (usePinned) {
             addSelection(pear, PINNED);
             if (entry)
@@ -582,16 +585,16 @@ PeerSelector::selectSomeNeighbor()
     }
 
 #if USE_CACHE_DIGESTS
-    if ((p = neighborsDigestSelect(request))) {
+    if ((p = neighborsDigestSelect(ps))) {
         if (neighborType(p, request->url) == PEER_PARENT)
             code = CD_PARENT_HIT;
         else
             code = CD_SIBLING_HIT;
     } else
 #endif
-        if ((p = netdbClosestParent(request))) {
+        if ((p = netdbClosestParent(this))) {
             code = CLOSEST_PARENT;
-        } else if (peerSelectIcpPing(request, direct, entry)) {
+        } else if (peerSelectIcpPing(this, direct, entry)) {
             debugs(44, 3, "Doing ICP pings");
             ping.start = current_time;
             ping.n_sent = neighborsUdpPing(request,
@@ -681,21 +684,21 @@ PeerSelector::selectSomeParent()
     if (direct == DIRECT_YES)
         return;
 
-    if ((p = peerSourceHashSelectParent(request))) {
+    if ((p = peerSourceHashSelectParent(this))) {
         code = SOURCEHASH_PARENT;
 #if USE_AUTH
-    } else if ((p = peerUserHashSelectParent(request))) {
+    } else if ((p = peerUserHashSelectParent(this))) {
         code = USERHASH_PARENT;
 #endif
-    } else if ((p = carpSelectParent(request))) {
+    } else if ((p = carpSelectParent(this))) {
         code = CARP;
-    } else if ((p = getRoundRobinParent(request))) {
+    } else if ((p = getRoundRobinParent(this))) {
         code = ROUNDROBIN_PARENT;
-    } else if ((p = getWeightedRoundRobinParent(request))) {
+    } else if ((p = getWeightedRoundRobinParent(this))) {
         code = ROUNDROBIN_PARENT;
-    } else if ((p = getFirstUpParent(request))) {
+    } else if ((p = getFirstUpParent(this))) {
         code = FIRSTUP_PARENT;
-    } else if ((p = getDefaultParent(request))) {
+    } else if ((p = getDefaultParent(this))) {
         code = DEFAULT_PARENT;
     }
 
@@ -719,7 +722,7 @@ PeerSelector::selectAllParents()
         if (neighborType(p, request->url) != PEER_PARENT)
             continue;
 
-        if (!peerHTTPOkay(p, request))
+        if (!peerHTTPOkay(p, this))
             continue;
 
         addSelection(p, ANY_OLD_PARENT);
@@ -730,7 +733,7 @@ PeerSelector::selectAllParents()
      * simply are not configured to handle the request.
      */
     /* Add default parent as a last resort */
-    if ((p = getDefaultParent(request))) {
+    if ((p = getDefaultParent(this))) {
         addSelection(p, DEFAULT_PARENT);
     }
 }
@@ -814,7 +817,7 @@ PeerSelector::handleIcpReply(CachePeer *p, const peer_t type, icp_common_t *head
 
     if (p && request)
         peerNoteDigestLookup(request, p,
-                             peerDigestLookup(p, request, entry));
+                             peerDigestLookup(p, this));
 
 #endif
 

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -13,6 +13,7 @@
 #include "HttpRequest.h"
 #include "mgr/Registration.h"
 #include "neighbors.h"
+#include "PeerSelectState.h"
 #include "SquidConfig.h"
 #include "Store.h"
 
@@ -141,7 +142,7 @@ peerSourceHashRegisterWithCacheManager(void)
 }
 
 CachePeer *
-peerSourceHashSelectParent(HttpRequest * request)
+peerSourceHashSelectParent(PeerSelector *ps)
 {
     int k;
     const char *c;
@@ -156,6 +157,9 @@ peerSourceHashSelectParent(HttpRequest * request)
 
     if (n_sourcehash_peers == 0)
         return NULL;
+
+    assert(ps);
+    HttpRequest *request = ps->request;
 
     key = request->client_addr.toStr(ntoabuf, sizeof(ntoabuf));
 
@@ -175,7 +179,7 @@ peerSourceHashSelectParent(HttpRequest * request)
         debugs(39, 3, "peerSourceHashSelectParent: " << tp->name << " combined_hash " << combined_hash  <<
                " score " << std::setprecision(0) << score);
 
-        if ((score > high_score) && peerHTTPOkay(tp, request)) {
+        if ((score > high_score) && peerHTTPOkay(tp, ps)) {
             p = tp;
             high_score = score;
         }

--- a/src/peer_sourcehash.h
+++ b/src/peer_sourcehash.h
@@ -12,10 +12,10 @@
 #define SQUID_PEER_SOURCEHASH_H_
 
 class CachePeer;
-class HttpRequest;
+class PeerSelector;
 
 void peerSourceHashInit(void);
-CachePeer * peerSourceHashSelectParent(HttpRequest * request);
+CachePeer * peerSourceHashSelectParent(PeerSelector*);
 
 #endif /* SQUID_PEER_SOURCEHASH_H_ */
 

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -18,6 +18,7 @@
 #include "HttpRequest.h"
 #include "mgr/Registration.h"
 #include "neighbors.h"
+#include "PeerSelectState.h"
 #include "SquidConfig.h"
 #include "Store.h"
 
@@ -146,7 +147,7 @@ peerUserHashRegisterWithCacheManager(void)
 }
 
 CachePeer *
-peerUserHashSelectParent(HttpRequest * request)
+peerUserHashSelectParent(PeerSelector *ps)
 {
     int k;
     const char *c;
@@ -160,6 +161,9 @@ peerUserHashSelectParent(HttpRequest * request)
 
     if (n_userhash_peers == 0)
         return NULL;
+
+    assert(ps);
+    HttpRequest *request = ps->request;
 
     if (request->auth_user_request != NULL)
         key = request->auth_user_request->username();
@@ -183,7 +187,7 @@ peerUserHashSelectParent(HttpRequest * request)
         debugs(39, 3, "peerUserHashSelectParent: " << tp->name << " combined_hash " << combined_hash  <<
                " score " << std::setprecision(0) << score);
 
-        if ((score > high_score) && peerHTTPOkay(tp, request)) {
+        if ((score > high_score) && peerHTTPOkay(tp, ps)) {
             p = tp;
             high_score = score;
         }

--- a/src/peer_userhash.h
+++ b/src/peer_userhash.h
@@ -12,10 +12,11 @@
 #define SQUID_PEER_USERHASH_H_
 
 class CachePeer;
+class PeerSelector;
 class HttpRequest;
 
 void peerUserHashInit(void);
-CachePeer * peerUserHashSelectParent(HttpRequest * request);
+CachePeer * peerUserHashSelectParent(PeerSelector*);
 
 #endif /* SQUID_PEER_USERHASH_H_ */
 

--- a/src/tests/stub_carp.cc
+++ b/src/tests/stub_carp.cc
@@ -12,8 +12,8 @@
 #include "tests/STUB.h"
 
 class CachePeer;
-class HttpRequest;
+class PeerSelector;
 
 void carpInit(void) STUB
-CachePeer * carpSelectParent(HttpRequest *) STUB_RETVAL(NULL)
+CachePeer *carpSelectParent(PeerSelector *ps) STUB_RETVAL(NULL)
 

--- a/src/tests/stub_libicmp.cc
+++ b/src/tests/stub_libicmp.cc
@@ -35,6 +35,6 @@ void netdbDeleteAddrNetwork(Ip::Address &addr) STUB
 void netdbBinaryExchange(StoreEntry *) STUB
 void netdbExchangeStart(void *) STUB
 void netdbExchangeUpdatePeer(Ip::Address &, CachePeer *, double, double) STUB
-CachePeer *netdbClosestParent(HttpRequest *) STUB_RETVAL(NULL)
+CachePeer *netdbClosestParent(PeerSelector *) STUB_RETVAL(NULL)
 void netdbHostData(const char *host, int *samp, int *rtt, int *hops) STUB
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1102,6 +1102,7 @@ tunnelStart(ClientHttpRequest * http)
          * default is to allow.
          */
         ACLFilledChecklist ch(Config.accessList.miss, request, NULL);
+        ch.al = http->al;
         ch.src_addr = request->client_addr;
         ch.my_addr = request->my_addr;
         if (ch.fastCheck().denied()) {


### PR DESCRIPTION
Supplying ALE for fast ACL checks allows those checks to use ACLs that
assemble values from logformat %codes. Today, such ACLs are limited to
misplaced external ACLs (that should not be used with "fast"
directives!), but it is likely that fast ACLs like annotate_client will
eventually require ALE.

The "has" ACL documentation promises ALE for every transaction, but our
code does not deliver on that promise. This change fixes a dozen of
easy cases where ALE was available nearby. Also a non-trivial
cache_peer_access case was fixed, which proved to be more complex
because of the significant call depth of the peerAllowedToUse() check,
which is a known design problem of its own.

More cases need fixing, and the whole concept of ALE probably needs to
be revised because logformat %code expansion is needed in the
increasing number of contexts that have nothing to do with access
logging.

Also fixed triggering of (probably pointless) level-1 warnings:

* ALE missing adapted HttpRequest object
* ALE missing URL

With fix applied, any ACLChecklist with ALE synchronizes it at
'pre-check' stage without logging level-1 warnings. Warnings are
triggered only if for some reason this 'pre-check' synchronization was
bypassed.
