### PR TITLE
Avoid ssl/helper.cc "ssl_crtd" assertions on reconfiguration

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3024,7 +3024,7 @@ ConnStateData::getSslContextStart()
             request_message.setCode(Ssl::CrtdMessage::code_new_certificate);
             request_message.composeRequest(certProperties);
             debugs(33, 5, HERE << "SSL crtd request: " << request_message.compose().c_str());
-            Ssl::Helper::GetInstance()->sslSubmit(request_message, sslCrtdHandleReplyWrapper, this);
+            Ssl::Helper::Submit(request_message, sslCrtdHandleReplyWrapper, this);
             return;
         } catch (const std::exception &e) {
             debugs(33, DBG_IMPORTANT, "ERROR: Failed to compose ssl_crtd " <<

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -991,6 +991,9 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
         entryData.password = label;
 #endif
 
+    // XXX: Accessing the state->def->queue without cbdataReferenceValid check.
+    // It will work because the state->def may not cbdata valid but still its
+    // memory is accessible.
     dlinkDelete(&state->list, &state->def->queue);
 
     ExternalACLEntryPointer entry;

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -991,9 +991,8 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
         entryData.password = label;
 #endif
 
-    // XXX: Accessing the state->def->queue without cbdataReferenceValid check.
-    // It will work because the state->def may not cbdata valid but still its
-    // memory is accessible.
+    // XXX: This state->def access conflicts with the cbdata validity check
+    // below.
     dlinkDelete(&state->list, &state->def->queue);
 
     ExternalACLEntryPointer entry;

--- a/src/main.cc
+++ b/src/main.cc
@@ -880,15 +880,9 @@ mainReconfigureStart(void)
 #if USE_HTCP
     htcpClosePorts();
 #endif
-#if USE_SSL_CRTD
-    Ssl::Helper::GetInstance()->Shutdown();
-#endif
 #if USE_OPENSSL
-    if (Ssl::CertValidationHelper::GetInstance())
-        Ssl::CertValidationHelper::GetInstance()->Shutdown();
     Ssl::TheGlobalContextStorage.reconfigureStart();
 #endif
-    redirectShutdown();
 #if USE_AUTH
     authenticateReset();
 #endif
@@ -976,14 +970,13 @@ mainReconfigureFinish(void *)
     storeLogOpen();
     Dns::Init();
 #if USE_SSL_CRTD
-    Ssl::Helper::GetInstance()->Init();
+    Ssl::Helper::Reconfigure();
 #endif
 #if USE_OPENSSL
-    if (Ssl::CertValidationHelper::GetInstance())
-        Ssl::CertValidationHelper::GetInstance()->Init();
+    Ssl::CertValidationHelper::Reconfigure();
 #endif
 
-    redirectInit();
+    redirectReconfigure();
 #if USE_AUTH
     authenticateInit(&Auth::TheConfig.schemes);
 #endif
@@ -1186,12 +1179,11 @@ mainInitialize(void)
     Dns::Init();
 
 #if USE_SSL_CRTD
-    Ssl::Helper::GetInstance()->Init();
+    Ssl::Helper::Init();
 #endif
 
 #if USE_OPENSSL
-    if (Ssl::CertValidationHelper::GetInstance())
-        Ssl::CertValidationHelper::GetInstance()->Init();
+    Ssl::CertValidationHelper::Init();
 #endif
 
     redirectInit();
@@ -2063,11 +2055,10 @@ SquidShutdown()
 
     debugs(1, DBG_IMPORTANT, "Shutting down...");
 #if USE_SSL_CRTD
-    Ssl::Helper::GetInstance()->Shutdown();
+    Ssl::Helper::Shutdown();
 #endif
 #if USE_OPENSSL
-    if (Ssl::CertValidationHelper::GetInstance())
-        Ssl::CertValidationHelper::GetInstance()->Shutdown();
+    Ssl::CertValidationHelper::Shutdown();
 #endif
     redirectShutdown();
     externalAclShutdown();

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -434,3 +434,9 @@ redirectShutdown(void)
     storeIdExtrasFmt = NULL;
 }
 
+void
+redirectReconfigure()
+{
+    redirectShutdown();
+    redirectInit();
+}

--- a/src/redirect.h
+++ b/src/redirect.h
@@ -19,6 +19,7 @@ class ClientHttpRequest;
 
 void redirectInit(void);
 void redirectShutdown(void);
+void redirectReconfigure();
 void redirectStart(ClientHttpRequest *, HLPCB *, void *);
 void storeIdStart(ClientHttpRequest *, HLPCB *, void *);
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -241,7 +241,7 @@ Security::PeerConnector::sslFinalized()
         try {
             debugs(83, 5, "Sending SSL certificate for validation to ssl_crtvd.");
             AsyncCall::Pointer call = asyncCall(83,5, "Security::PeerConnector::sslCrtvdHandleReply", Ssl::CertValidationHelper::CbDialer(this, &Security::PeerConnector::sslCrtvdHandleReply, nullptr));
-            Ssl::CertValidationHelper::GetInstance()->sslSubmit(validationRequest, call);
+            Ssl::CertValidationHelper::Submit(validationRequest, call);
             return false;
         } catch (const std::exception &e) {
             debugs(83, DBG_IMPORTANT, "ERROR: Failed to compose ssl_crtvd " <<

--- a/src/ssl/helper.h
+++ b/src/ssl/helper.h
@@ -22,23 +22,19 @@ namespace Ssl
 {
 #if USE_SSL_CRTD
 /**
- * Set of thread for ssl_crtd. This class is singleton. Use this class only
- * over GetIntance() static method. This class use helper structure
- * for threads management.
+ * Set of thread for ssl_crtd. This class is singleton.
+ * This class use helper structure for threads management.
  */
 class Helper
 {
 public:
-    static Helper * GetInstance(); ///< Instance class.
-    void Init(); ///< Init helper structure.
-    void Shutdown(); ///< Shutdown helper structure.
+    static void Init(); ///< Init helper structure.
+    static void Shutdown(); ///< Shutdown helper structure.
+    static void Reconfigure(); ///< Reconfigure helper structure.
     /// Submit crtd message to external crtd server.
-    void sslSubmit(CrtdMessage const & message, HLPCB * callback, void *data);
+    static void Submit(CrtdMessage const & message, HLPCB * callback, void *data);
 private:
-    Helper();
-    ~Helper();
-
-    helper * ssl_crtd; ///< helper for management of ssl_crtd.
+    static helper * ssl_crtd; ///< helper for management of ssl_crtd.
 };
 #endif
 
@@ -50,16 +46,13 @@ public:
     typedef UnaryMemFunT<Security::PeerConnector, CertValidationResponse::Pointer> CbDialer;
 
     typedef void CVHCB(void *, Ssl::CertValidationResponse const &);
-    static CertValidationHelper * GetInstance(); ///< Instance class.
-    void Init(); ///< Init helper structure.
-    void Shutdown(); ///< Shutdown helper structure.
+    static void Init(); ///< Init helper structure.
+    static void Shutdown(); ///< Shutdown helper structure.
+    static void Reconfigure(); ///< Reconfigure helper structure
     /// Submit crtd request message to external crtd server.
-    void sslSubmit(Ssl::CertValidationRequest const & request, AsyncCall::Pointer &);
+    static void Submit(Ssl::CertValidationRequest const & request, AsyncCall::Pointer &);
 private:
-    CertValidationHelper();
-    ~CertValidationHelper();
-
-    helper * ssl_crt_validator; ///< helper for management of ssl_crtd.
+    static helper * ssl_crt_validator; ///< helper for management of ssl_crtd.
 public:
     typedef LruMap<SBuf, Ssl::CertValidationResponse::Pointer, sizeof(Ssl::CertValidationResponse::Pointer) + sizeof(Ssl::CertValidationResponse)> LruCache;
     static LruCache *HelperCache; ///< cache for cert validation helper

--- a/src/ssl/stub_libsslutil.cc
+++ b/src/ssl/stub_libsslutil.cc
@@ -37,8 +37,7 @@ void Ssl::readCertAndPrivateKeyFromFiles(Security::CertPointer &, Security::Priv
 bool Ssl::sslDateIsInTheFuture(char const *) STUB_RETVAL(false)
 
 #include "ssl/helper.h"
-Ssl::Helper * Ssl::Helper::GetInstance() STUB_RETVAL(NULL)
 void Ssl::Helper::Init() STUB
 void Ssl::Helper::Shutdown() STUB
-void Ssl::Helper::sslSubmit(Ssl::CrtdMessage const & message, HLPCB * callback, void *data) STUB
+void Ssl::Helper::Submit(Ssl::CrtdMessage const & message, HLPCB * callback, void *data) STUB
 


### PR DESCRIPTION
Reconfiguration process consists of mainReconfigureStart() and
mainReconfigureFinish() steps separated by at least one main loop
iteration. Clearing a Squid global variable in mainReconfigureStart()
creates two problems for transactions that were started before
reconfiguration:

1. Transactions accessing that global _during_ reconfiguration loop
   iteration(s) may be confused by the variable sudden disappearance.

2. Transactions accessing that global _after_ mainReconfigureFinish()
   may be confused by the variable disappearance if reconfiguration
   resulted in the global variable becoming nil.

To remove the first problem for ssl_crtd, external_acl, and redirecting
helpers, all of them are now reconfigured "instantly", during
mainReconfigureFinish().

To prevent crashes due to the second problem, Squid now generates helper
errors if the disappeared ssl_crtd or external_acl helpers are accessed
after reconfiguration. The admin is warned about such problems via
level-1 cache.log ERROR messages.

The second problem cannot be fully solved without storing (refcounted)
configuration globals inside each transaction that uses them. Such
serious changes are outside this small assertion-fixing project scope.

This is a Measurement Factory project.