### PR TITLE
Skip ssl_bump ACL checks for internal requests

### DIFF
--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1419,6 +1419,11 @@ ClientRequestContext::checkNoCacheDone(const allow_t &answer)
 bool
 ClientRequestContext::sslBumpAccessCheck()
 {
+    if (!http->getConn()) {
+        http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
+        return false;
+    }
+
     // If SSL connection tunneling or bumping decision has been made, obey it.
     const Ssl::BumpMode bumpMode = http->getConn()->sslBumpMode;
     if (bumpMode != Ssl::bumpEnd) {


### PR DESCRIPTION
getConn() for internal requests can produce NULL.