### PR TITLE
Documentation for several ACL types

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1030,17 +1030,20 @@ DOC_START
 	acl aclname dst [-n] ip-address/mask ...	# URL host's IP address [slow]
 	acl aclname localip ip-address/mask ... # IP address the client connected to [fast]
 
-	acl aclname arp      mac-address ... (xx:xx:xx:xx:xx:xx notation)
+	acl aclname arp      mac-address ...
+	acl aclname eui64    eui64-address ...
 	  # [fast]
+	  # MAC (EUI-48) and EUI-64 addresses use xx:xx:xx:xx:xx:xx notation.
+	  #
 	  # The 'arp' ACL code is not portable to all operating systems.
 	  # It works on Linux, Solaris, Windows, FreeBSD, and some other
 	  # BSD variants.
 	  #
-	  # NOTE: Squid can only determine the MAC/EUI address for IPv4
+	  # Squid can only determine the MAC/EUI address for IPv4
 	  # clients that are on the same subnet. If the client is on a
 	  # different subnet, then Squid cannot find out its address.
 	  #
-	  # NOTE 2: IPv6 protocol does not contain ARP. MAC/EUI is either
+	  # IPv6 protocol does not contain ARP. MAC/EUI is either
 	  # encoded directly in the IPv6 address or not available.
 
 	acl aclname clientside_mark mark[/mask] ...
@@ -1089,6 +1092,7 @@ DOC_START
 	  # cache_peer_access mycache_mydomain.net deny all
 
 	acl aclname peername myPeer ...
+	acl aclname peername_regex [-i] regex-pattern ...
 	  # [fast]
 	  # match against a named cache_peer entry
 	  # set unique name= on cache_peer lines for reliable use.


### PR DESCRIPTION
These ACL types have been available for some time but have not
yet had a mention in the squid.conf docs.