### PR TITLE
Bug 4852: regression in deny_info %R macro

### DIFF
--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -925,8 +925,8 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
     case 'R':
         if (building_deny_info_url) {
             if (request != NULL) {
-                SBuf tmp = request->url.path();
-                p = tmp.c_str();
+                const SBuf &tmp = request->url.path();
+                mb.append(tmp.rawContent(), tmp.length());
                 no_urlescape = 1;
             } else
                 p = "[no request]";


### PR DESCRIPTION
SBuf:c_str() produces a temporary c-string which is not
guaranteed to survive does not survive as long as required to
print the deny_info URL. The HttpRequest::url path SBuf has a
much longer lifetime, so use a const reference to it instead.