### PR TITLE
New function to find Local listening IP and add new %A macro

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -754,3 +754,15 @@ FindListeningPortAddress(const HttpRequest *request, const bool derive_ips, cons
     return localip;
 }
 
+const Ip::Address *FindListeningPortAddress(const HttpRequestPointer &request)
+{
+    return FindListeningPortAddress(request.getRaw(), true, nullptr, nullptr);
+}
+
+const Ip::Address *FindListeningPortAddress(const AccessLogEntryPointer &al)
+{
+    return FindListeningPortAddress(al->request, false,
+                    al->cache.port ? &(al->cache.port->s) : nullptr,
+                    al->tcpClient ? &(al->tcpClient->local) : nullptr);
+}
+

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -743,7 +743,7 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
 static const Ip::Address *
 FindListeningPortAddressInAddress(const Ip::Address *ip)
 {
-    // FindListeningPortAddress() callers do not want "any" addresses
+    // FindListeningPortAddress() callers do not want INADDR_ANY addresses
     return (ip && !ip->isAnyAddr()) ? ip : nullptr;
 }
 
@@ -776,10 +776,12 @@ FindListeningPortAddress(const HttpRequest *callerRequest, const AccessLogEntry 
     const Ip::Address *ip = nullptr;
 
     if (request->flags.interceptTproxy || request->flags.intercepted) {
-        if (!ip)
-            ip = FindListeningPortAddressInPort(request->masterXaction->squidPort);
+        ip = FindListeningPortAddressInPort(request->masterXaction->squidPort);
         if (!ip && ale)
             ip = FindListeningPortAddressInPort(ale->cache.port);
+        if (ip)
+            return ip;
+
         // XXX: tcpClient contains client destination rather than Squid
         // listening address for intercepted and PROXY clients, but here we fall
         // through as if it does not.
@@ -787,8 +789,7 @@ FindListeningPortAddress(const HttpRequest *callerRequest, const AccessLogEntry 
 
     /* handle intercepted-without-port-info and all non-intercepted cases */
 
-    if (!ip)
-        ip = FindListeningPortAddressInConn(request->masterXaction->tcpClient);
+    ip = FindListeningPortAddressInConn(request->masterXaction->tcpClient);
     if (!ip && ale)
         ip = FindListeningPortAddressInConn(ale->tcpClient);
 

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -738,10 +738,9 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
     }
 }
 
-/// \returns a pointer to known *_port address where the request was accepted
-/// \returns nil for nil requests and when the port address info was not available
-/// cacheIp and localIp are useful when such information may not be available in request
-const Ip::Address *
+/// cacheIp and localIp are useful when required information may not be available in request
+/// \see const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const AccessLogEntry *al)
+static const Ip::Address *
 FindListeningPortAddress(const HttpRequest *request, const Ip::Address *cacheIp, const Ip::Address *localIp)
 {
     if (request) {

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -791,6 +791,9 @@ FindListeningPortAddress(const HttpRequest *callerRequest, const AccessLogEntry 
     if (!ip && ale)
         ip = FindListeningPortAddressInConn(ale->tcpClient);
 
+    // XXX: should we check request->my_addr as well?
+    // if yes then when? before checking tcpClient or before intercepion checks?
+
     return ip; // may still be nil
 }
 

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -792,9 +792,6 @@ FindListeningPortAddress(const HttpRequest *callerRequest, const AccessLogEntry 
     if (!ip && ale)
         ip = FindListeningPortAddressInConn(ale->tcpClient);
 
-    // XXX: should we check request->my_addr as well?
-    // if yes then when? before checking tcpClient or before intercepion checks?
-
     return ip; // may still be nil
 }
 

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -781,7 +781,7 @@ FindListeningPortAddress(const HttpRequest *callerRequest, const AccessLogEntry 
     if (ip || request->flags.interceptTproxy || request->flags.intercepted)
         return ip;
 
-    /* handle non-intercepted cases */
+    /* handle non-intercepted cases that were not handled above */
     ip = FindListeningPortAddressInConn(request->masterXaction->tcpClient);
     if (!ip && ale)
         ip = FindListeningPortAddressInConn(ale->tcpClient);

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -740,21 +740,27 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
 
 /// \returns a pointer to known *_port address where the request was accepted
 /// \returns nil for nil requests and when the port address info was not available
-/// cacheIp and localIp are useful when such information should not be derived from request
-/// if cacheIp or localIp is nil and deriveIps is set, then it tries to derive them from request
+/// cacheIp and localIp are useful when such information may not be available in request
 const Ip::Address *
-FindListeningPortAddress(const HttpRequest *request, const bool deriveIps, const Ip::Address *cacheIp, const Ip::Address *localIp)
+FindListeningPortAddress(const HttpRequest *request, const Ip::Address *cacheIp, const Ip::Address *localIp)
 {
     if (request) {
         if (request->flags.interceptTproxy || request->flags.intercepted) {
-            if (!cacheIp && deriveIps && request->masterXaction->squidPort)
-                cacheIp = &(request->masterXaction->squidPort->s);
+            if (request->masterXaction->squidPort) {
+                if (!request->masterXaction->squidPort->s.isAnyAddr())
+                    return &(request->masterXaction->squidPort->s);
+                else if (!cacheIp)
+                    return nullptr;
+            }
             if (cacheIp)
                 return (cacheIp->isAnyAddr() ? nullptr : cacheIp);
+	    // XXX: is it correct to return localIp if cacheIp didn't have info?
         }
-        if (!localIp && deriveIps && request->masterXaction->tcpClient)
-            return &(request->masterXaction->tcpClient->local);
+        // XXX: do we need to check isAnyAddr() here?
+        if (request->masterXaction->tcpClient)
+            localIp = &(request->masterXaction->tcpClient->local);
     }
+    // XXX: do we need to check isAnyAddr() here?
     return localIp;
 }
 
@@ -762,9 +768,10 @@ const Ip::Address *
 FindListeningPortAddress(const HttpRequest *request, const AccessLogEntry *al)
 {
     if (al)
-        return FindListeningPortAddress(al->request, false,
+        return FindListeningPortAddress(
+                    request ? request : al->request, // use request if specifically given
                     al->cache.port ? &(al->cache.port->s) : nullptr,
                     al->tcpClient ? &(al->tcpClient->local) : nullptr);
-    return (request ? FindListeningPortAddress(request, true, nullptr, nullptr) : nullptr);
+    return FindListeningPortAddress(request, nullptr, nullptr);
 }
 

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -739,16 +739,16 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
 }
 
 const Ip::Address *
-FindListeningPortAddress(const HttpRequest *request, const Ip::Address *cacheip, const Ip::Address *localip)
+FindListeningPortAddress(const HttpRequest *request, const bool derive_ips, const Ip::Address *cacheip, const Ip::Address *localip)
 {
     if (request) {
         if (request->flags.interceptTproxy || request->flags.intercepted) {
-            if (!cacheip && request->masterXaction->squidPort)
+            if (!cacheip && derive_ips && request->masterXaction->squidPort)
                 cacheip = &(request->masterXaction->squidPort->s);
             if (cacheip)
                 return (cacheip->isAnyAddr() ? nullptr : cacheip);
         }
-        if (!localip && request->masterXaction->tcpClient)
+        if (!localip && derive_ips && request->masterXaction->tcpClient)
             return &(request->masterXaction->tcpClient->local);
     }
     return localip;

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -776,6 +776,8 @@ FindListeningPortAddress(const HttpRequest *callerRequest, const AccessLogEntry 
     const Ip::Address *ip = FindListeningPortAddressInPort(request->masterXaction->squidPort);
     if (!ip && ale)
         ip = FindListeningPortAddressInPort(ale->cache.port);
+
+    // XXX: also handle PROXY protocol here when we have a flag to identify such request
     if (ip || request->flags.interceptTproxy || request->flags.intercepted)
         return ip;
 

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -738,3 +738,19 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
     }
 }
 
+const Ip::Address *
+FindListeningPortAddress(const HttpRequest *request, const Ip::Address *cacheip, const Ip::Address *localip)
+{
+    if (request) {
+        if (request->flags.interceptTproxy || request->flags.intercepted) {
+            if (!cacheip && request->masterXaction->squidPort)
+                cacheip = &(request->masterXaction->squidPort->s);
+            if (cacheip)
+                return (cacheip->isAnyAddr() ? nullptr : cacheip);
+        }
+        if (!localip && request->masterXaction->tcpClient)
+            return &(request->masterXaction->tcpClient->local);
+    }
+    return localip;
+}
+

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -759,12 +759,12 @@ FindListeningPortAddress(const HttpRequest *request, const bool deriveIps, const
 }
 
 const Ip::Address *
-FindListeningPortAddress(const HttpRequestPointer &request, const AccessLogEntryPointer &al)
+FindListeningPortAddress(const HttpRequest *request, const AccessLogEntry *al)
 {
     if (al)
         return FindListeningPortAddress(al->request, false,
                     al->cache.port ? &(al->cache.port->s) : nullptr,
                     al->tcpClient ? &(al->tcpClient->local) : nullptr);
-    return (request ? FindListeningPortAddress(request.getRaw(), true, nullptr, nullptr) : nullptr);
+    return (request ? FindListeningPortAddress(request, true, nullptr, nullptr) : nullptr);
 }
 

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -254,12 +254,8 @@ class ConnStateData;
  */
 void UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs const &notes);
 
-/**
- * The listening IP address from squid.conf *_port which the transaction client was connected to.
- * May be [::] or 0.0.0.0.
- * \retval * object with IP address details.
- * \retval nullptr no IP was found.
- **/
+/// \returns listening/*_port address used by the client connection (or nil)
+/// nil parameter(s) indicate missing caller information and are handled safely
 const Ip::Address *FindListeningPortAddress(const HttpRequest *, const AccessLogEntry *);
 
 #endif /* SQUID_HTTPREQUEST_H */

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -254,5 +254,11 @@ class ConnStateData;
  */
 void UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs const &notes);
 
+/// \returns a pointer to known *_port address where the request was accepted
+/// \returns nil for nil requests and when the port address info was not available
+/// cacheip and localip are useful when ALE has necessary info (cache.port->s / tcpClient->local)
+/// if cacheip or localip is nil, then it tries to derive them from request
+const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const Ip::Address *cacheip = nullptr, const Ip::Address *localip = nullptr);
+
 #endif /* SQUID_HTTPREQUEST_H */
 

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -254,9 +254,13 @@ class ConnStateData;
  */
 void UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs const &notes);
 
-/// \returns a pointer to known *_port address where the request was accepted
-/// \returns nil for nil requests and when the port address info was not available
-const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const AccessLogEntry *al);
+/**
+ * The listening IP address from squid.conf *_port which the transaction client was connected to.
+ * May be [::] or 0.0.0.0.
+ * \retval * object with IP address details.
+ * \retval nullptr no IP was found.
+ **/
+const Ip::Address *FindListeningPortAddress(const HttpRequest *, const AccessLogEntry *);
 
 #endif /* SQUID_HTTPREQUEST_H */
 

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -256,7 +256,7 @@ void UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs cons
 
 /// \returns a pointer to known *_port address where the request was accepted
 /// \returns nil for nil requests and when the port address info was not available
-const Ip::Address *FindListeningPortAddress(const HttpRequestPointer &request, const AccessLogEntryPointer &al);
+const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const AccessLogEntry *al);
 
 #endif /* SQUID_HTTPREQUEST_H */
 

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -257,8 +257,8 @@ void UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs cons
 /// \returns a pointer to known *_port address where the request was accepted
 /// \returns nil for nil requests and when the port address info was not available
 /// cacheip and localip are useful when ALE has necessary info (cache.port->s / tcpClient->local)
-/// if cacheip or localip is nil, then it tries to derive them from request
-const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const Ip::Address *cacheip = nullptr, const Ip::Address *localip = nullptr);
+/// if cacheip or localip is nil and derive_ips is set, then it tries to derive them from request
+const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const bool derive_ips = false, const Ip::Address *cacheip = nullptr, const Ip::Address *localip = nullptr);
 
 #endif /* SQUID_HTTPREQUEST_H */
 

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -256,11 +256,7 @@ void UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs cons
 
 /// \returns a pointer to known *_port address where the request was accepted
 /// \returns nil for nil requests and when the port address info was not available
-/// cacheip and localip are useful when ALE has necessary info (cache.port->s / tcpClient->local)
-/// if cacheip or localip is nil and derive_ips is set, then it tries to derive them from request
-const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const bool derive_ips, const Ip::Address *cacheip, const Ip::Address *localip);
-const Ip::Address *FindListeningPortAddress(const HttpRequestPointer &request);
-const Ip::Address *FindListeningPortAddress(const AccessLogEntryPointer &al);
+const Ip::Address *FindListeningPortAddress(const HttpRequestPointer &request, const AccessLogEntryPointer &al);
 
 #endif /* SQUID_HTTPREQUEST_H */
 

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -258,7 +258,9 @@ void UpdateRequestNotes(ConnStateData *csd, HttpRequest &request, NotePairs cons
 /// \returns nil for nil requests and when the port address info was not available
 /// cacheip and localip are useful when ALE has necessary info (cache.port->s / tcpClient->local)
 /// if cacheip or localip is nil and derive_ips is set, then it tries to derive them from request
-const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const bool derive_ips = false, const Ip::Address *cacheip = nullptr, const Ip::Address *localip = nullptr);
+const Ip::Address *FindListeningPortAddress(const HttpRequest *request, const bool derive_ips, const Ip::Address *cacheip, const Ip::Address *localip);
+const Ip::Address *FindListeningPortAddress(const HttpRequestPointer &request);
+const Ip::Address *FindListeningPortAddress(const AccessLogEntryPointer &al);
 
 #endif /* SQUID_HTTPREQUEST_H */
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -8451,6 +8451,7 @@ DOC_START
 
 	URL FORMAT TAGS:
 		%a	- username (if available. Password NOT included)
+		%A	- Local listening IP address the client connection was connected to
 		%B	- FTP path URL
 		%e	- Error number
 		%E	- Error description

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -759,7 +759,7 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
         break;
 
     case 'A':
-        // TODO: When/if we get ALE here, pass al as well (request is ignored if al is passed)
+        // TODO: When/if we get ALE here, pass it as well
         if (const auto addr = FindListeningPortAddress(request.getRaw(), nullptr))
             mb.appendf("%s", addr->toStr(ntoabuf, MAX_IPSTRLEN));
         else

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -698,7 +698,7 @@ ErrorState::Dump(MemBuf * mb)
     str.appendf("TimeStamp: %s\r\n\r\n", mkrfc1123(squid_curtime));
 
     /* - IP stuff */
-    str.appendf("ClientIP: %s\r\n", src_addr.toStr(ntoabuf, MAX_IPSTRLEN));
+    str.appendf("ClientIP: %s\r\n", src_addr.toStr(ntoabuf,MAX_IPSTRLEN));
 
     if (request && request->hier.host[0] != '\0') {
         str.appendf("ServerIP: %s\r\n", request->hier.host);
@@ -760,7 +760,7 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
 
     case 'A':
         // TODO: When/if we get ALE here, use al->cache.port->s and al->tcpClient->local as well
-        if (const auto addr = FindListeningPortAddress(request.getRaw()))
+        if (const auto addr = FindListeningPortAddress(request.getRaw(), true))
             mb.appendf("%s", addr->toStr(ntoabuf, MAX_IPSTRLEN));
         else
             p = "-";
@@ -859,12 +859,12 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
         break;
 
     case 'i':
-        mb.appendf("%s", src_addr.toStr(ntoabuf, MAX_IPSTRLEN));
+        mb.appendf("%s", src_addr.toStr(ntoabuf,MAX_IPSTRLEN));
         break;
 
     case 'I':
         if (request && request->hier.tcpServer)
-            p = request->hier.tcpServer->remote.toStr(ntoabuf, MAX_IPSTRLEN);
+            p = request->hier.tcpServer->remote.toStr(ntoabuf,MAX_IPSTRLEN);
         else if (!building_deny_info_url)
             p = "[unknown]";
         break;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -759,8 +759,8 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
         break;
 
     case 'A':
-        // TODO: When/if we get ALE here, use FindListeningPortAddress(al) as well
-        if (const auto addr = FindListeningPortAddress(request))
+        // TODO: When/if we get ALE here, pass al as well (request is ignored if al is passed)
+        if (const auto addr = FindListeningPortAddress(request, nullptr))
             mb.appendf("%s", addr->toStr(ntoabuf, MAX_IPSTRLEN));
         else
             p = "-";

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -698,7 +698,7 @@ ErrorState::Dump(MemBuf * mb)
     str.appendf("TimeStamp: %s\r\n\r\n", mkrfc1123(squid_curtime));
 
     /* - IP stuff */
-    str.appendf("ClientIP: %s\r\n", src_addr.toStr(ntoabuf,MAX_IPSTRLEN));
+    str.appendf("ClientIP: %s\r\n", src_addr.toStr(ntoabuf, MAX_IPSTRLEN));
 
     if (request && request->hier.host[0] != '\0') {
         str.appendf("ServerIP: %s\r\n", request->hier.host);
@@ -755,6 +755,14 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
             p = request->auth_user_request->username();
         if (!p)
 #endif
+            p = "-";
+        break;
+
+    case 'A':
+        // TODO: When/if we get ALE here, use al->cache.port->s and al->tcpClient->local as well
+        if (const auto addr = FindListeningPortAddress(request.getRaw()))
+            mb.appendf("%s", addr->toStr(ntoabuf, MAX_IPSTRLEN));
+        else
             p = "-";
         break;
 
@@ -851,12 +859,12 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
         break;
 
     case 'i':
-        mb.appendf("%s", src_addr.toStr(ntoabuf,MAX_IPSTRLEN));
+        mb.appendf("%s", src_addr.toStr(ntoabuf, MAX_IPSTRLEN));
         break;
 
     case 'I':
         if (request && request->hier.tcpServer)
-            p = request->hier.tcpServer->remote.toStr(ntoabuf,MAX_IPSTRLEN);
+            p = request->hier.tcpServer->remote.toStr(ntoabuf, MAX_IPSTRLEN);
         else if (!building_deny_info_url)
             p = "[unknown]";
         break;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -759,8 +759,8 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
         break;
 
     case 'A':
-        // TODO: When/if we get ALE here, use al->cache.port->s and al->tcpClient->local as well
-        if (const auto addr = FindListeningPortAddress(request.getRaw(), true))
+        // TODO: When/if we get ALE here, use FindListeningPortAddress(al) as well
+        if (const auto addr = FindListeningPortAddress(request))
             mb.appendf("%s", addr->toStr(ntoabuf, MAX_IPSTRLEN));
         else
             p = "-";

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -760,7 +760,7 @@ ErrorState::Convert(char token, bool building_deny_info_url, bool allowRecursion
 
     case 'A':
         // TODO: When/if we get ALE here, pass al as well (request is ignored if al is passed)
-        if (const auto addr = FindListeningPortAddress(request, nullptr))
+        if (const auto addr = FindListeningPortAddress(request.getRaw(), nullptr))
             mb.appendf("%s", addr->toStr(ntoabuf, MAX_IPSTRLEN));
         else
             p = "-";

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -35,6 +35,7 @@ typedef void ERCB(int fd, void *, size_t);
  *
  \verbatim
    a - User identity                            x
+   A - Local listening IP address               x
    B - URL with FTP %2f hack                    x
    c - Squid error code                         x
    d - seconds elapsed since request received   x

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -471,7 +471,6 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_LOCAL_LISTENING_IP:
-            // avoid logging a dash if we have reliable info
             if (const auto addr = FindListeningPortAddress(nullptr, al.getRaw()))
                 out = addr->toStr(tmp, sizeof(tmp));
             break;

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -496,8 +496,8 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
 
         case LFT_LOCAL_LISTENING_PORT:
             // XXX: Out of sync with LFT_LOCAL_LISTENING_IP
-            if (al->cache.port) {
-                outint = al->cache.port->s.port();
+            if (const auto addr = FindListeningPortAddress(nullptr, al.getRaw())) {
+                outint = addr->port();
                 doint = 1;
             } else if (al->request) {
                 outint = al->request->my_addr.port();

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -470,20 +470,14 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             }
             break;
 
-        case LFT_LOCAL_LISTENING_IP: {
+        case LFT_LOCAL_LISTENING_IP:
             // avoid logging a dash if we have reliable info
-            const bool interceptedAtKnownPort = al->request ?
-                                                (al->request->flags.interceptTproxy ||
-                                                 al->request->flags.intercepted) && al->cache.port :
-                                                false;
-            if (interceptedAtKnownPort) {
-                const bool portAddressConfigured = !al->cache.port->s.isAnyAddr();
-                if (portAddressConfigured)
-                    out = al->cache.port->s.toStr(tmp, sizeof(tmp));
-            } else if (al->tcpClient)
-                out = al->tcpClient->local.toStr(tmp, sizeof(tmp));
-        }
-        break;
+            if (const auto addr = FindListeningPortAddress(
+                                    al->request,
+                                    al->cache.port ? &(al->cache.port->s) : nullptr,
+                                    al->tcpClient ? &(al->tcpClient->local) : nullptr))
+                out = addr->toStr(tmp, sizeof(tmp));
+            break;
 
         case LFT_CLIENT_LOCAL_IP:
             if (al->tcpClient)

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -473,7 +473,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
         case LFT_LOCAL_LISTENING_IP:
             // avoid logging a dash if we have reliable info
             if (const auto addr = FindListeningPortAddress(
-                                    al->request,
+                                    al->request, false,
                                     al->cache.port ? &(al->cache.port->s) : nullptr,
                                     al->tcpClient ? &(al->tcpClient->local) : nullptr))
                 out = addr->toStr(tmp, sizeof(tmp));

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -495,6 +495,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_LOCAL_LISTENING_PORT:
+            // XXX: Out of sync with LFT_LOCAL_LISTENING_IP
             if (al->cache.port) {
                 outint = al->cache.port->s.port();
                 doint = 1;

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -472,10 +472,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
 
         case LFT_LOCAL_LISTENING_IP:
             // avoid logging a dash if we have reliable info
-            if (const auto addr = FindListeningPortAddress(
-                                    al->request, false,
-                                    al->cache.port ? &(al->cache.port->s) : nullptr,
-                                    al->tcpClient ? &(al->tcpClient->local) : nullptr))
+            if (const auto addr = FindListeningPortAddress(al))
                 out = addr->toStr(tmp, sizeof(tmp));
             break;
 

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -472,7 +472,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
 
         case LFT_LOCAL_LISTENING_IP:
             // avoid logging a dash if we have reliable info
-            if (const auto addr = FindListeningPortAddress(al))
+            if (const auto addr = FindListeningPortAddress(nullptr, al))
                 out = addr->toStr(tmp, sizeof(tmp));
             break;
 

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -495,12 +495,8 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_LOCAL_LISTENING_PORT:
-            // XXX: Out of sync with LFT_LOCAL_LISTENING_IP
             if (const auto addr = FindListeningPortAddress(nullptr, al.getRaw())) {
                 outint = addr->port();
-                doint = 1;
-            } else if (al->request) {
-                outint = al->request->my_addr.port();
                 doint = 1;
             }
             break;

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -472,7 +472,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
 
         case LFT_LOCAL_LISTENING_IP:
             // avoid logging a dash if we have reliable info
-            if (const auto addr = FindListeningPortAddress(nullptr, al))
+            if (const auto addr = FindListeningPortAddress(nullptr, al.getRaw()))
                 out = addr->toStr(tmp, sizeof(tmp));
             break;
 


### PR DESCRIPTION
Implemented a new function to find local listening IP:Port in a
consistent way and added support for %A macro in error pages and
deny_info URL using the same function.