### PR TITLE
Bug 4843 pt2: squidclient refactoring for GCC-8

### DIFF
--- a/tools/squidclient/Transport.cc
+++ b/tools/squidclient/Transport.cc
@@ -235,7 +235,7 @@ Transport::Connect()
 }
 
 ssize_t
-Transport::Write(void *buf, size_t len)
+Transport::Write(const void *buf, size_t len)
 {
     if (conn < 0)
         return -1;

--- a/tools/squidclient/Transport.h
+++ b/tools/squidclient/Transport.h
@@ -109,7 +109,7 @@ void ShutdownTls();
 
 /// write len bytes to the currently open connection.
 /// \return the number of bytes written, or -1 on errors
-ssize_t Write(void *buf, size_t len);
+ssize_t Write(const void *buf, size_t len);
 
 /// read up to len bytes from the currently open connection.
 /// \return the number of bytes read, or -1 on errors


### PR DESCRIPTION
Replace fixed size buffers for mime header block and additional
custom headers. This fixes long standing issues with buffer
overflow from large custom header values which have become a
hard error in GCC-8.

Also improve snprintf() URL buffer limit handling and const
correctness for Transport::Write().