### PR TITLE
Bug 4707: purge tool does not obey --sysconfdir= build option

### DIFF
--- a/src/Common.am
+++ b/src/Common.am
@@ -36,6 +36,11 @@ AM_CFLAGS = $(SQUID_CFLAGS)
 AM_CXXFLAGS = $(SQUID_CXXFLAGS)
 DEFS = @DEFS@
 
+# Make ./configure location settings above available to the code
+DEFS += -DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
+	-DDEFAULT_SQUID_DATA_DIR=\"$(datadir)\" \
+	-DDEFAULT_SQUID_CONFIG_DIR=\"$(sysconfdir)\"
+
 ## so that others can always use += for these variables
 CLEANFILES =
 check_PROGRAMS = 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -729,9 +729,6 @@ EXTRA_DIST = \
 	mib.txt \
 	mime.conf.default
 
-# Make location configure settings available to the code
-DEFS += -DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" -DDEFAULT_SQUID_DATA_DIR=\"$(datadir)\" -DDEFAULT_SQUID_CONFIG_DIR=\"$(sysconfdir)\"
-
 snmp_core.o snmp_agent.o: ../lib/snmplib/libsnmplib.la $(top_srcdir)/include/cache_snmp.h
 
 globals.cc: globals.h mk-globals-c.awk

--- a/src/WinSvc.cc
+++ b/src/WinSvc.cc
@@ -517,7 +517,7 @@ int WIN32_Subsystem_Init(int * argc, char *** argv)
                 ConfigFile = static_cast<char *>(xmalloc(Size));
                 RegQueryValueEx(hndKey, CONFIGFILE, NULL, &Type, (unsigned char *)ConfigFile, &Size);
             } else
-                ConfigFile = xstrdup(DefaultConfigFile);
+                ConfigFile = xstrdup(DEFAULT_CONFIG_FILE);
 
             Size = 0;
 
@@ -533,7 +533,7 @@ int WIN32_Subsystem_Init(int * argc, char *** argv)
 
             RegCloseKey(hndKey);
         } else {
-            ConfigFile = xstrdup(DefaultConfigFile);
+            ConfigFile = xstrdup(DEFAULT_CONFIG_FILE);
             WIN32_Service_Command_Line = xstrdup("");
         }
 
@@ -778,7 +778,7 @@ WIN32_InstallService()
             /* Now store the config file location in the registry */
 
             if (!ConfigFile)
-                ConfigFile = xstrdup(DefaultConfigFile);
+                ConfigFile = xstrdup(DEFAULT_CONFIG_FILE);
 
             WIN32_StoreKey(CONFIGFILE, REG_SZ, (unsigned char *) ConfigFile, strlen(ConfigFile) + 1);
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -24,7 +24,6 @@ extern char ThisCache2[RFC2181_MAXHOSTNAMELEN << 1];
 extern char config_input_line[BUFSIZ];
 /// During parsing, the name of the current squid.conf directive being parsed.
 extern const char *cfg_directive; /* NULL */
-extern const char *DefaultConfigFile;   /* DEFAULT_CONFIG_FILE */
 extern const char *cfg_filename;    /* NULL */
 extern const char *dash_str;    /* "-" */
 extern const char *null_string; /* "" */

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -8,11 +8,6 @@
 include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/src/TestHeaders.am
 
-# TODO: get rid of this when config filename is no longer a global constant.
-#      its only here so the pinger globals.cc will link.
-DEFS += -DDEFAULT_CONFIG_FILE=NULL
-
-
 # ICMP Specific Configurations
 
 if ENABLE_PINGER

--- a/src/main.cc
+++ b/src/main.cc
@@ -405,7 +405,7 @@ usage(void)
             "       -S        Double-check swap during rebuild.\n"
             "       -X        Force full debugging.\n"
             "       -Y        Only return UDP_HIT or UDP_MISS_NOFETCH during fast reload.\n",
-            APP_SHORTNAME, CACHE_HTTP_PORT, DefaultConfigFile, CACHE_ICP_PORT);
+            APP_SHORTNAME, CACHE_HTTP_PORT, DEFAULT_CONFIG_FILE, CACHE_ICP_PORT);
     exit(EXIT_FAILURE);
 }
 
@@ -1535,7 +1535,7 @@ SquidMain(int argc, char **argv)
         int parse_err;
 
         if (!ConfigFile)
-            ConfigFile = xstrdup(DefaultConfigFile);
+            ConfigFile = xstrdup(DEFAULT_CONFIG_FILE);
 
         assert(!configured_once);
 

--- a/tools/purge/conffile.hh
+++ b/tools/purge/conffile.hh
@@ -55,11 +55,6 @@ typedef int bool;
 #endif
 #endif /* __cplusplus */
 
-
-#if !defined(DEFAULT_CONFIG_FILE)
-#error Missing -DDEFAULT_CONFIG_FILE= compile option for squid.conf location
-#endif
-
 #include <vector>
 
 struct CacheDir {

--- a/tools/purge/conffile.hh
+++ b/tools/purge/conffile.hh
@@ -56,8 +56,8 @@ typedef int bool;
 #endif /* __cplusplus */
 
 
-#if !defined(DEFAULT_SQUID_CONF)
-#define DEFAULT_SQUID_CONF "/usr/local/squid/etc/squid.conf"
+#if !defined(DEFAULT_CONFIG_FILE)
+#error Missing -DDEFAULT_CONFIG_FILE= compile option for squid.conf location
 #endif
 
 #include <vector>
@@ -75,7 +75,7 @@ typedef std::vector<CacheDir> CacheDirVector;
 
 int
 readConfigFile( CacheDirVector& cachedir, 
-		const char* fn = DEFAULT_SQUID_CONF, 
+		const char* fn,
 		FILE* debug = 0 );
   // purpose: read squid.conf file and extract cache_dir entries
   // paramtr: cachedir (OUT): vector with an entry for each cache_dir found

--- a/tools/purge/purge.cc
+++ b/tools/purge/purge.cc
@@ -615,7 +615,7 @@ helpMe( void )
         "\t0 and 1 are recommended - slow rebuild your cache with other modes.\n"
         " -s\tshow all options after option parsing, but before really starting.\n"
         " -v\tshow more information about the file, e.g. MD5, timestamps and flags.\n"
-        "\n", DEFAULT_SQUID_CONF, DEFAULTHOST, DEFAULTPORT );
+        "\n", DEFAULT_CONFIG_FILE, DEFAULTHOST, DEFAULTPORT );
 
 }
 
@@ -890,7 +890,7 @@ main( int argc, char* argv[] )
 {
     // setup variables
     REList* list = 0;
-    char* conffile = xstrdup( DEFAULT_SQUID_CONF );
+    char* conffile = xstrdup(DEFAULT_CONFIG_FILE);
     serverPort = htons(DEFAULTPORT);
     if ( convertHostname(DEFAULTHOST,serverHost) == -1 ) {
         fprintf( stderr, "unable to resolve host %s!\n", DEFAULTHOST );


### PR DESCRIPTION
The purge tool was still using DEFAULT_SQUID_CONF macro from
before it was bundled with Squid, which had no connection to our
./configure script.

Update it to the DEFAULT_CONFIG_FILE macro used by other Squid
binaries and fix some existing issues with that macro's use by
binaries outside 'squid'.