### PR TITLE
Fix segmentation fault on -k parse

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3832,6 +3832,16 @@ parsePortCfg(AnyP::PortCfgPointer *head, const char *optionName)
         }
     }
 
+    if (s->secure.encryptTransport) {
+        // protocol requires TLS, that means cert= is a required parameter
+        if (s->secure.certs.empty()) {
+            debugs(3, DBG_CRITICAL, "FATAL: " << AnyP::UriScheme(s->transport.protocol) << "_port requires a cert= parameter");
+            self_destruct();
+            return;
+        }
+    }
+
+    // *_port line should now be fully valid so we can clone it if necessary
     if (Ip::EnableIpv6&IPV6_SPECIAL_SPLITSTACK && s->s.isAnyAddr()) {
         // clone the port options from *s to *(s->next)
         s->next = s->clone();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3833,7 +3833,6 @@ parsePortCfg(AnyP::PortCfgPointer *head, const char *optionName)
     }
 
     if (s->secure.encryptTransport) {
-        // protocol requires TLS, that means cert= is a required parameter
         if (s->secure.certs.empty()) {
             debugs(3, DBG_CRITICAL, "FATAL: " << AnyP::UriScheme(s->transport.protocol) << "_port requires a cert= parameter");
             self_destruct();

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -284,14 +284,9 @@ Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &port)
     // contexts are generated as needed. This method initializes the cert
     // and key pointers used to sign those contexts later.
 
-    const char *portType = AnyP::ProtocolType_str[port.transport.protocol];
-    if (certs.empty()) {
-        char buf[128];
-        fatalf("%s_port %s - missing cert= parameter", portType, port.s.toUrl(buf, sizeof(buf)));
-    }
-
     signingCa = certs.front();
 
+    const char *portType = AnyP::ProtocolType_str[port.transport.protocol];
     if (!signingCa.cert) {
         char buf[128];
         // XXX: we never actually checked that the cert is capable of signing!

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -284,6 +284,7 @@ Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &port)
     // contexts are generated as needed. This method initializes the cert
     // and key pointers used to sign those contexts later.
 
+    const char *portType = AnyP::ProtocolType_str[port.transport.protocol];
     if (certs.empty()) {
         char buf[128];
         fatalf("%s_port %s - missing cert= parameter", portType, port.s.toUrl(buf, sizeof(buf)));
@@ -291,7 +292,6 @@ Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &port)
 
     signingCa = certs.front();
 
-    const char *portType = AnyP::ProtocolType_str[port.transport.protocol];
     if (!signingCa.cert) {
         char buf[128];
         // XXX: we never actually checked that the cert is capable of signing!

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -284,6 +284,11 @@ Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &port)
     // contexts are generated as needed. This method initializes the cert
     // and key pointers used to sign those contexts later.
 
+    if (certs.empty()) {
+        char buf[128];
+        fatalf("%s_port %s - missing cert= parameter", portType, port.s.toUrl(buf, sizeof(buf)));
+    }
+
     signingCa = certs.front();
 
     const char *portType = AnyP::ProtocolType_str[port.transport.protocol];


### PR DESCRIPTION
When an HTTPS or SSL-Bump port is configured without a cert=
parameter it results in a segmentation fault. Detect that
occurance and add the required FATAL error message instead for
these configurations where cert= is a parameter rather than an
option.

Our project terminology for config settings is;

 "parameter"
 -  a required setting. Print a FATAL error message if missing.

 "option"
 -  an optional setting. Ignored or default value if missing.