### PR TITLE
Feature detect cpu_set_t

### DIFF
--- a/compat/cpu.h
+++ b/compat/cpu.h
@@ -18,7 +18,7 @@
 
 #if !HAVE_CPU_AFFINITY
 /* failing replacements to minimize the number of if-HAVE_CPU_AFFINITYs */
-#if !defined(__cpu_set_t_defined)
+#if !HAVE_CPU_SET_T
 typedef struct {
     int bits;
 } cpu_set_t;

--- a/configure.ac
+++ b/configure.ac
@@ -2989,6 +2989,10 @@ AC_CHECK_TYPE(mtyp_t,AC_DEFINE(HAVE_MTYP_T,1,
 #include <sys/ipc.h>
 #include <sys/msg.h>])
 
+AC_CHECK_TYPE(cpu_set_t,
+   AC_DEFINE(HAVE_CPU_SET_T,1,[cpu_set_t is defined by the system headers]),
+   ,[#include <sched.h>])
+
 # check for compiler support of %zu printf macro
 AH_TEMPLATE(PRIuSIZE,[Compiler supports %zu printf macro])
 AC_MSG_CHECKING([for compiler %zu support])

--- a/configure.ac
+++ b/configure.ac
@@ -2990,8 +2990,11 @@ AC_CHECK_TYPE(mtyp_t,AC_DEFINE(HAVE_MTYP_T,1,
 #include <sys/msg.h>])
 
 AC_CHECK_TYPE(cpu_set_t,
-   AC_DEFINE(HAVE_CPU_SET_T,1,[cpu_set_t is defined by the system headers]),
-   ,[#include <sched.h>])
+   AC_DEFINE(HAVE_CPU_SET_T,1,[cpu_set_t is defined by the system headers]),,[
+#if HAVE_SCHED_H
+#include <sched.h>
+#endif
+])
 
 # check for compiler support of %zu printf macro
 AH_TEMPLATE(PRIuSIZE,[Compiler supports %zu printf macro])


### PR DESCRIPTION
Some OS define this type but do not define __cpu_set_t_defined.
Use proper feature detection instead of relying on the macro.