### PR TITLE
Fix --with-netfilter-conntrack error message

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2310,7 +2310,7 @@ case "$with_netfilter_conntrack" in
     ;;
   *)
     if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--without-netfilter-conntrack path does not point to a directory])
+      AC_MSG_ERROR([--with-netfilter-conntrack path does not point to a directory])
     fi
     squid_opt_netfilterconntrackpath=$withval
     LDFLAGS="-L$squid_opt_netfilterconntrackpath/lib $LDFLAGS"


### PR DESCRIPTION
Typo: The nonexistent directory error should say --with, not --without.