### PR TITLE
Fix %>ru logging of huge URLs

### DIFF
--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -117,3 +117,15 @@ AccessLogEntry::~AccessLogEntry()
 #endif
 }
 
+const SBuf *
+AccessLogEntry::effectiveVirginUrl() const
+{
+    const SBuf *effectiveUrl = request ? &request->url.absolute() : &virginUrlForMissingRequest_;
+    if (effectiveUrl && !effectiveUrl->isEmpty())
+        return effectiveUrl;
+    // We can not use ALE::url here because it may contain a request URI after
+    // adaptation/redirection. When the request is missing, a non-empty ALE::url
+    // means that we missed a setVirginUrlForMissingRequest() call somewhere.
+    return nullptr;
+}
+

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -228,6 +228,24 @@ public:
     }
     icap;
 #endif
+
+    /// Effective URI of the received client (or equivalent) HTTP request or,
+    /// in rare cases where that information was not collected, a nil pointer.
+    /// Receiving errors are represented by "error:..." URIs.
+    /// Adaptations and redirections do not affect this URI.
+    const SBuf *effectiveVirginUrl() const;
+
+    /// Remember Client URI (or equivalent) when there is no HttpRequest.
+    void setVirginUrlForMissingRequest(const SBuf &vu)
+    {
+        if (!request)
+            virginUrlForMissingRequest_ = vu;
+    }
+
+private:
+    /// Client URI (or equivalent) for effectiveVirginUrl() when HttpRequest is
+    /// missing. This member is ignored unless the request member is nil.
+    SBuf virginUrlForMissingRequest_;
 };
 
 class ACLChecklist;

--- a/src/Downloader.cc
+++ b/src/Downloader.cc
@@ -151,12 +151,10 @@ Downloader::buildRequest()
            "\n----------");
 
     ClientHttpRequest *const http = new ClientHttpRequest(nullptr);
-    http->request = request;
-    HTTPMSGLOCK(http->request);
+    http->initRequest(request);
     http->req_sz = 0;
     // XXX: performance regression. c_str() reallocates
     http->uri = xstrdup(url_.c_str());
-    setLogUri (http, urlCanonicalClean(request));
 
     context_ = new DownloaderContext(this, http);
     StoreIOBuffer tempBuffer;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1367,7 +1367,6 @@ tests_testCacheManager_SOURCES = \
 	tests/stub_SwapDir.cc \
 	MemStore.cc \
 	$(UNLINKDSOURCE) \
-	tests/stub_libanyp.cc \
 	urn.h \
 	urn.cc \
 	wccp2.h \
@@ -1799,7 +1798,6 @@ tests_testEvent_SOURCES = \
 	tests/stub_tunnel.cc \
 	MemStore.cc \
 	$(UNLINKDSOURCE) \
-	tests/stub_libanyp.cc \
 	urn.h \
 	urn.cc \
 	wccp2.h \
@@ -2033,7 +2031,6 @@ tests_testEventLoop_SOURCES = \
 	tests/stub_tunnel.cc \
 	MemStore.cc \
 	$(UNLINKDSOURCE) \
-	tests/stub_libanyp.cc \
 	urn.h \
 	urn.cc \
 	wccp2.h \
@@ -2262,7 +2259,6 @@ tests_test_http_range_SOURCES = \
 	tools.cc \
 	tests/stub_tunnel.cc \
 	$(UNLINKDSOURCE) \
-	tests/stub_libanyp.cc \
 	urn.h \
 	urn.cc \
 	wccp2.h \

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -179,7 +179,13 @@ operator <<(std::ostream &os, const AnyP::Uri &url)
 class HttpRequest;
 
 void urlInitialize(void);
-char *urlCanonicalClean(const HttpRequest *);
+/// \returns a pointer to a local static buffer containing request URI
+/// that honors strip_query_terms and %-encodes unsafe URI characters
+char *urlCanonicalClean(const HttpRequest &);
+/// call urlCanonicalClean() instead if you have HttpRequest
+/// \returns a pointer to a local static buffer containing request URI
+/// that honors strip_query_terms and %-encodes unsafe URI characters
+char *urlCanonicalCleanWithoutRequest(const SBuf &url, const HttpRequestMethod &, const AnyP::UriScheme &);
 const char *urlCanonicalFakeHttps(const HttpRequest * request);
 bool urlIsRelative(const char *);
 char *urlMakeAbsolute(const HttpRequest *, const char *);

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4417,19 +4417,42 @@ DOC_START
 
 	The <format specification> is a string with embedded % format codes
 
-	% format codes all follow the same basic structure where all but
-	the formatcode is optional. Output strings are automatically escaped
-	as required according to their context and the output format
-	modifiers are usually not needed, but can be specified if an explicit
-	output format is desired.
+	% format codes all follow the same basic structure where all
+	components but the formatcode are optional and usually unnecessary,
+	especially when dealing with common codes.
 
-		% ["|[|'|#|/] [-] [[0]width] [{arg}] formatcode [{arg}]
+		% [encoding] [-] [[0]width] [{arg}] formatcode [{arg}]
 
-		"	output in quoted string format
-		[	output in squid text log format as used by log_mime_hdrs
-		#	output in URL quoted format
-		/	output in shell \-escaped format
-		'	output as-is
+		encoding escapes or otherwise protects "special" characters:
+
+			"	Quoted string encoding where quote(") and
+				backslash(\) characters are \-escaped while
+				CR, LF, and TAB characters are encoded as \r,
+				\n, and \t two-character sequences.
+
+			[	Custom Squid encoding where percent(%), square
+				brackets([]), backslash(\) and characters with
+				codes outside of [32,126] range are %-encoded.
+				SP is not encoded. Used by log_mime_hdrs.
+
+			#	URL encoding (a.k.a. percent-encoding) where
+				all URL unsafe and control characters (per RFC
+				1738) are %-encoded.
+
+			/	Shell-like encoding where quote(") and
+				backslash(\) characters are \-escaped while CR
+				and LF characters are encoded as \r and \n
+				two-character sequences. Values containing SP
+				character(s) are surrounded by quotes(").
+
+			'	Raw/as-is encoding with no escaping/quoting.
+
+			Default encoding: When no explicit encoding is
+			specified, each %code determines its own encoding.
+			Most %codes use raw/as-is encoding, but some codes use
+			a so called "pass-through URL encoding" where all URL
+			unsafe and control characters (per RFC 1738) are
+			%-encoded, but the percent character(%) is left as is.
 
 		-	left aligned
 
@@ -4535,8 +4558,40 @@ DOC_START
 		[http::]rm	Request method (GET/POST etc)
 		[http::]>rm	Request method from client
 		[http::]<rm	Request method sent to server or peer
-		[http::]ru	Request URL from client (historic, filtered for logging)
-		[http::]>ru	Request URL from client
+
+		[http::]ru	Request URL received (or computed) and sanitized
+
+				Logs request URI received from the client, a
+				request adaptation service, or a request
+				redirector (whichever was applied last).
+
+				Computed URLs are URIs of internally generated
+				requests and various "error:..." URIs.
+
+				Honors strip_query_terms and uri_whitespace.
+
+				This field is not encoded by default. Encoding
+				this field using variants of %-encoding will
+				clash with uri_whitespace modifications that
+				also use %-encoding.
+
+		[http::]>ru	Request URL received from the client (or computed)
+
+				Computed URLs are URIs of internally generated
+				requests and various "error:..." URIs.
+
+				Unlike %ru, this request URI is not affected
+				by request adaptation, URL rewriting services,
+				and strip_query_terms.
+
+				Honors uri_whitespace.
+
+				This field is using pass-through URL encoding
+				by default. Encoding this field using other
+				variants of %-encoding will clash with
+				uri_whitespace modifications that also use
+				%-encoding.
+
 		[http::]<ru	Request URL sent to server or peer
 		[http::]>rs	Request URL scheme from client
 		[http::]<rs	Request URL scheme sent to server or peer

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -103,7 +103,6 @@
 #include "mime_header.h"
 #include "parser/Tokenizer.h"
 #include "profiler/Profiler.h"
-#include "rfc1738.h"
 #include "security/NegotiationHistory.h"
 #include "servers/forward.h"
 #include "SquidConfig.h"
@@ -474,10 +473,9 @@ void
 ClientHttpRequest::freeResources()
 {
     safe_free(uri);
-    safe_free(log_uri);
     safe_free(redirect.location);
     range_iter.boundary.clean();
-    HTTPMSGUNLOCK(request);
+    clearRequest();
 
     if (client_stream.tail)
         clientStreamAbort((clientStreamNode *)client_stream.tail->data, this);
@@ -1012,8 +1010,7 @@ ConnStateData::abortRequestParsing(const char *const uri)
 {
     ClientHttpRequest *http = new ClientHttpRequest(this);
     http->req_sz = inBuf.length();
-    http->uri = xstrdup(uri);
-    setLogUri (http, uri);
+    http->setErrorUri(uri);
     auto *context = new Http::Stream(clientConnection, http);
     StoreIOBuffer tempBuffer;
     tempBuffer.data = context->reqbuf;
@@ -1083,57 +1080,6 @@ findTrailingHTTPVersion(const char *uriAndHTTPVersion, const char *end)
     }
 
     return NULL;
-}
-
-void
-setLogUri(ClientHttpRequest * http, char const *uri, bool cleanUrl)
-{
-    safe_free(http->log_uri);
-
-    if (!cleanUrl)
-        // The uri is already clean just dump it.
-        http->log_uri = xstrndup(uri, MAX_URL);
-    else {
-        int flags = 0;
-        switch (Config.uri_whitespace) {
-        case URI_WHITESPACE_ALLOW:
-            flags |= RFC1738_ESCAPE_NOSPACE;
-
-        case URI_WHITESPACE_ENCODE:
-            flags |= RFC1738_ESCAPE_UNESCAPED;
-            http->log_uri = xstrndup(rfc1738_do_escape(uri, flags), MAX_URL);
-            break;
-
-        case URI_WHITESPACE_CHOP: {
-            flags |= RFC1738_ESCAPE_NOSPACE;
-            flags |= RFC1738_ESCAPE_UNESCAPED;
-            http->log_uri = xstrndup(rfc1738_do_escape(uri, flags), MAX_URL);
-            int pos = strcspn(http->log_uri, w_space);
-            http->log_uri[pos] = '\0';
-        }
-        break;
-
-        case URI_WHITESPACE_DENY:
-        case URI_WHITESPACE_STRIP:
-        default: {
-            const char *t;
-            char *tmp_uri = static_cast<char*>(xmalloc(strlen(uri) + 1));
-            char *q = tmp_uri;
-            t = uri;
-            while (*t) {
-                if (!xisspace(*t)) {
-                    *q = *t;
-                    ++q;
-                }
-                ++t;
-            }
-            *q = '\0';
-            http->log_uri = xstrndup(rfc1738_escape_unescaped(tmp_uri), MAX_URL);
-            xfree(tmp_uri);
-        }
-        break;
-        }
-    }
 }
 
 static void
@@ -1499,12 +1445,6 @@ bool ConnStateData::serveDelayedError(Http::Stream *context)
         debugs(33, 5, "Responding with delated error for " << http->uri);
         repContext->setReplyToStoreEntry(sslServerBump->entry, "delayed SslBump error");
 
-        // save the original request for logging purposes
-        if (!context->http->al->request) {
-            context->http->al->request = http->request;
-            HTTPMSGLOCK(context->http->al->request);
-        }
-
         // Get error details from the fake certificate-peeking request.
         http->request->detailError(sslServerBump->request->errType, sslServerBump->request->errDetail);
         context->pullData();
@@ -1547,11 +1487,6 @@ bool ConnStateData::serveDelayedError(Http::Stream *context)
                     SQUID_X509_V_ERR_DOMAIN_MISMATCH,
                     srvCert.get(), nullptr);
                 err->detail = errDetail;
-                // Save the original request for logging purposes.
-                if (!context->http->al->request) {
-                    context->http->al->request = request;
-                    HTTPMSGLOCK(context->http->al->request);
-                }
                 repContext->setReplyToError(request->method, err);
                 assert(context->http->out.offset == 0);
                 context->pullData();
@@ -1661,12 +1596,12 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
             request->url.host(internalHostname());
             request->url.port(getMyPort());
             http->flags.internal = true;
+            http->setLogUriToRequestUri();
         } else
             debugs(33, 2, "internal URL found: " << request->url.getScheme() << "://" << request->url.authority(true) << " (not this proxy)");
     }
 
     request->flags.internal = http->flags.internal;
-    setLogUri (http, urlCanonicalClean(request.getRaw()));
 
     if (!isFtp) {
         // XXX: for non-HTTP messages instantiate a different Http::Message child type
@@ -3469,8 +3404,7 @@ ConnStateData::buildFakeRequest(Http::MethodType const method, SBuf &useHost, un
     request->method = method;
     request->url.host(useHost.c_str());
     request->url.port(usePort);
-    http->request = request.getRaw();
-    HTTPMSGLOCK(http->request);
+    http->initRequest(request.getRaw());
 
     request->manager(this, http->al);
 
@@ -3486,7 +3420,6 @@ ConnStateData::buildFakeRequest(Http::MethodType const method, SBuf &useHost, un
     inBuf = payload;
     flags.readMore = false;
 
-    setLogUri(http, urlCanonicalClean(request.getRaw()));
     return http;
 }
 
@@ -4164,9 +4097,7 @@ ConnStateData::checkLogging()
     ClientHttpRequest http(this);
     http.req_sz = inBuf.length();
     // XXX: Or we died while waiting for the pinned connection to become idle.
-    char const *uri = "error:transaction-end-before-headers";
-    http.uri = xstrdup(uri);
-    setLogUri(&http, uri);
+    http.setErrorUri("error:transaction-end-before-headers");
 }
 
 bool

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -418,8 +418,6 @@ private:
     NotePairs::Pointer theNotes;
 };
 
-void setLogUri(ClientHttpRequest * http, char const *uri, bool cleanUrl = false);
-
 const char *findTrailingHTTPVersion(const char *uriAndHTTPVersion, const char *end = NULL);
 
 int varyEvaluateMatch(StoreEntry * entry, HttpRequest * req);

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2300,7 +2300,10 @@ clientReplyContext::createStoreEntry(const HttpRequestMethod& m, RequestFlags re
 
     if (http->request == NULL) {
         const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
-        http->request = new HttpRequest(m, AnyP::PROTO_NONE, "http", null_string, mx);
+        // XXX: These fake URI parameters shadow the real (or error:...) URI.
+        // TODO: Either always set the request earlier and assert here OR use
+        // http->uri (converted to Anyp::Uri) to create this catch-all request.
+        const_cast<HttpRequest *&>(http->request) =  new HttpRequest(m, AnyP::PROTO_NONE, "http", null_string, mx);
         HTTPMSGLOCK(http->request);
     }
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -264,6 +264,7 @@ logAcceptError(const Comm::ConnectionPointer &conn)
     AccessLogEntry::Pointer al = new AccessLogEntry;
     al->tcpClient = conn;
     al->url = "error:accept-client-connection";
+    al->setVirginUrlForMissingRequest(al->url);
     ACLFilledChecklist ch(nullptr, nullptr, nullptr);
     ch.src_addr = conn->remote;
     ch.my_addr = conn->local;

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -966,9 +966,8 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_CLIENT_REQ_URI:
-            // original client URI
-            if (al->request) {
-                sb = al->request->effectiveRequestUri();
+            if (const auto uri = al->effectiveVirginUrl()) {
+                sb = *uri;
                 out = sb.c_str();
                 quote = 1;
             }

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -278,6 +278,7 @@ htcpSyncAle(AccessLogEntryPointer &al, const Ip::Address &caddr, const int opcod
     al->cache.caddr = caddr;
     al->htcp.opcode = htcpOpcodeStr[opcode];
     al->url = url;
+    al->setVirginUrlForMissingRequest(al->url);
     // HTCP transactions do not wait
     al->cache.start_time = current_time;
     al->cache.trTime.tv_sec = 0;

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -80,6 +80,7 @@ icpSyncAle(AccessLogEntryPointer &al, const Ip::Address &caddr, const char *url,
     al->icp.opcode = ICP_QUERY;
     al->cache.caddr = caddr;
     al->url = url;
+    al->setVirginUrlForMissingRequest(al->url);
     // XXX: move to use icp.clientReply instead
     al->http.clientReplySz.payloadData = len;
     al->cache.start_time = current_time;

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -749,10 +749,9 @@ Ftp::Server::parseOneRequest()
     }
 
     ClientHttpRequest *const http = new ClientHttpRequest(this);
-    http->request = request;
-    HTTPMSGLOCK(http->request);
     http->req_sz = tok.parsedSize();
     http->uri = newUri;
+    http->initRequest(request);
 
     Http::Stream *const result =
         new Http::Stream(clientConnection, http);
@@ -1735,8 +1734,6 @@ Ftp::Server::setReply(const int code, const char *msg)
     assert(http->storeEntry() == NULL);
 
     HttpReply *const reply = Ftp::HttpReplyWrapper(code, msg, Http::scNoContent, 0);
-
-    setLogUri(http, urlCanonicalClean(http->request));
 
     clientStreamNode *const node = context->getClientReplyContext();
     clientReplyContext *const repContext =

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -118,8 +118,10 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
             // else use default ERR_INVALID_REQ set above.
             break;
         }
-        // setLogUri should called before repContext->setReplyToError
-        setLogUri(http, http->uri, true);
+        // setReplyToError() requires log_uri
+        // must be already initialized via ConnStateData::abortRequestParsing()
+        assert(http->log_uri);
+
         const char * requestErrorBytes = inBuf.c_str();
         if (!clientTunnelOnError(this, context, request, parser_->method(), errPage)) {
             setReplyError(context, request, parser_->method(), errPage, parser_->parseStatusCode, requestErrorBytes);
@@ -135,8 +137,8 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     mx->tcpClient = clientConnection;
     if ((request = HttpRequest::FromUrl(http->uri, mx, parser_->method())) == NULL) {
         debugs(33, 5, "Invalid URL: " << http->uri);
-        // setLogUri should called before repContext->setReplyToError
-        setLogUri(http, http->uri, true);
+        // setReplyToError() requires log_uri
+        http->setLogUriToRawUri(http->uri, parser_->method());
 
         const char * requestErrorBytes = inBuf.c_str();
         if (!clientTunnelOnError(this, context, request, parser_->method(), ERR_INVALID_URL)) {
@@ -154,8 +156,8 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
             (parser_->messageProtocol().major > 1) ) {
 
         debugs(33, 5, "Unsupported HTTP version discovered. :\n" << parser_->messageProtocol());
-        // setLogUri should called before repContext->setReplyToError
-        setLogUri(http, http->uri,  true);
+        // setReplyToError() requires log_uri
+        http->setLogUriToRawUri(http->uri, parser_->method());
 
         const char * requestErrorBytes = NULL; //HttpParserHdrBuf(parser_);
         if (!clientTunnelOnError(this, context, request, parser_->method(), ERR_UNSUP_HTTPVERSION)) {
@@ -168,8 +170,8 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     /* compile headers */
     if (parser_->messageProtocol().major >= 1 && !request->parseHeader(*parser_.getRaw())) {
         debugs(33, 5, "Failed to parse request headers:\n" << parser_->mimeHeader());
-        // setLogUri should called before repContext->setReplyToError
-        setLogUri(http, http->uri, true);
+        // setReplyToError() requires log_uri
+        http->setLogUriToRawUri(http->uri, parser_->method());
         const char * requestErrorBytes = NULL; //HttpParserHdrBuf(parser_);
         if (!clientTunnelOnError(this, context, request, parser_->method(), ERR_INVALID_REQ)) {
             setReplyError(context, request, parser_->method(), ERR_INVALID_REQ, Http::scBadRequest, requestErrorBytes);
@@ -195,8 +197,7 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
         request->notes()->append(notes().getRaw());
     }
 
-    http->request = request.getRaw();
-    HTTPMSGLOCK(http->request);
+    http->initRequest(request.getRaw());
 
     return true;
 }
@@ -242,8 +243,8 @@ Http::One::Server::processParsedRequest(Http::StreamPointer &context)
         if (!supportedExpect) {
             clientStreamNode *node = context->getClientReplyContext();
             quitAfterError(request.getRaw());
-            // setLogUri should called before repContext->setReplyToError
-            setLogUri(http, urlCanonicalClean(request.getRaw()));
+            // setReplyToError() requires log_uri
+            assert(http->log_uri);
             clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
             assert (repContext);
             repContext->setReplyToError(ERR_INVALID_REQ, Http::scExpectationFailed, request->method, http->uri,

--- a/src/tests/stub_client_side.cc
+++ b/src/tests/stub_client_side.cc
@@ -52,7 +52,6 @@ void ConnStateData::buildSslCertGenerationParams(Ssl::CertificateProperties &) S
 bool ConnStateData::serveDelayedError(Http::Stream *) STUB_RETVAL(false)
 #endif
 
-void setLogUri(ClientHttpRequest *, char const *, bool) STUB
 const char *findTrailingHTTPVersion(const char *, const char *) STUB_RETVAL(NULL)
 int varyEvaluateMatch(StoreEntry *, HttpRequest *) STUB_RETVAL(0)
 void clientOpenListenSockets(void) STUB

--- a/src/tests/stub_libanyp.cc
+++ b/src/tests/stub_libanyp.cc
@@ -31,7 +31,7 @@ const SBuf &AnyP::Uri::Asterisk()
 SBuf &AnyP::Uri::authority(bool) const STUB_RETVAL(nil)
 SBuf &AnyP::Uri::absolute() const STUB_RETVAL(nil)
 void urlInitialize() STUB
-char *urlCanonicalClean(const HttpRequest *) STUB_RETVAL(nullptr)
+char *urlCanonicalClean(const HttpRequest &) STUB_RETVAL(nullptr)
 const char *urlCanonicalFakeHttps(const HttpRequest *) STUB_RETVAL(nullptr)
 bool urlIsRelative(const char *) STUB_RETVAL(false)
 char *urlMakeAbsolute(const HttpRequest *, const char *)STUB_RETVAL(nullptr)


### PR DESCRIPTION
When dealing with an HTTP request header that Squid can parse but that
contains request URI length exceeding the 8K limit, Squid should log the
URL (prefix) instead of a dash. Logging the URL helps with triaging
these unusual requests. The older %ru (LFT_REQUEST_URI) was already
logging these huge URLs, but %>ru (LFT_CLIENT_REQ_URI) was logging a
dash. Now both log the URL (or its prefix).

As a side effect, %>ru now also logs error:request-too-large and other
Squid-specific pseudo-URLs, as appropriate.

Also refactored request- and URI-recording code to reduce chances of
similar inconsistencies reappearing in the future.

Also honor strip_query_terms in %ru for large URLs. Not stripping query
string in %ru was a security problem.

Also fixed a bug with "redirected" flag calculation in
ClientHttpRequest::handleAdaptedHeader(), which it could obtain a wrong
value because http->url and request->url differ semantically (the latter
is calculated from the former).

Also fixed a bug with possibly wrong %ru after redirection:
ClientHttpRequest::log_uri was not updated in this case.

Also initialize AccessLogEntry::request and AccessLogEntry::notes ASAP.
Before this change, these fields were initialized in
ClientHttpRequest::doCallouts(). It is better to initialize them just
after the request object is created so that ACLs, running before
doCallouts(), could have them at hand. There are at least three such
ACLs: force_request_body_continuation, spoof_client_ip and
spoof_client_ip.

Also synced %ru and %>ru documentation with the current code.