### PR TITLE
Optimization: Do not create/configure ACLFilledChecklist in vain

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2464,10 +2464,11 @@ ConnStateData::whenClientIpKnown()
 #if USE_DELAY_POOLS
     fd_table[clientConnection->fd].clientInfo = NULL;
 
-    if (Config.onoff.client_db) {
-        /* it was said several times that client write limiter does not work if client_db is disabled */
+    if (!Config.onoff.client_db)
+        return; // client delay pools require client_db
 
-        auto &pools = ClientDelayPools::Instance()->pools;
+    const auto &pools = ClientDelayPools::Instance()->pools;
+    if (pools.size()) {
         ACLFilledChecklist ch(NULL, NULL, NULL);
 
         // TODO: we check early to limit error response bandwith but we


### PR DESCRIPTION
While client_db is required for client-side pools to work, it may be
enabled for other reasons, without any client-side pools configured. We
should not create and configure useless ACLFilledChecklist objects
because those operations are already not trivial today and have a
a tendency of becoming more expensive with time.