### PR TITLE
Do not assign nil values in ACLFilledChecklist::syncAle()

### DIFF
--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -132,11 +132,11 @@ ACLFilledChecklist::syncAle(HttpRequest *adaptedRequest, const char *logUri) con
 {
     if (!al)
         return;
-    if (!al->adapted_request) {
+    if (!al->adapted_request && adaptedRequest) {
         al->adapted_request = adaptedRequest;
         HTTPMSGLOCK(al->adapted_request);
     }
-    if (al->url.isEmpty())
+    if (al->url.isEmpty() && logUri)
         al->url = logUri;
 }
 

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -132,11 +132,11 @@ ACLFilledChecklist::syncAle(HttpRequest *adaptedRequest, const char *logUri) con
 {
     if (!al)
         return;
-    if (!al->adapted_request && adaptedRequest) {
+    if (adaptedRequest && !al->adapted_request) {
         al->adapted_request = adaptedRequest;
         HTTPMSGLOCK(al->adapted_request);
     }
-    if (al->url.isEmpty() && logUri)
+    if (logUri && al->url.isEmpty())
         al->url = logUri;
 }
 


### PR DESCRIPTION
Being explicit about nil parameters protects (future) code from
dereferencing them.