### PR TITLE
Update debug Ctx mechanism with stdlib containers

### DIFF
--- a/src/Debug.h
+++ b/src/Debug.h
@@ -23,6 +23,8 @@
 #undef assert
 #endif
 
+#include <string>
+
 #if PURIFY
 #define assert(EX) ((void)0)
 #elif defined(NODEBUG)
@@ -35,7 +37,7 @@
 
 /* context-based debugging, the actual type is subject to change */
 typedef int Ctx;
-Ctx ctx_enter(const char *descr);
+Ctx ctx_enter(const std::string &descr);
 void ctx_exit(Ctx ctx);
 
 /* defined debug section limits */

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -106,7 +106,8 @@ MemObject::MemObject()
 MemObject::~MemObject()
 {
     debugs(20, 3, "MemObject destructed, this=" << this);
-    const Ctx ctx = ctx_enter(hasUris() ? urlXXX() : "[unknown_ctx]");
+    static const std::string unknownCtx("[unknown_ctx]");
+    const Ctx ctx = ctx_enter(hasUris() ? std::string(urlXXX()) : unknownCtx);
 
 #if URL_CHECKSUM_DEBUG
     checkUrlChecksum();

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -704,8 +704,6 @@ static int Ctx_Valid_Level = -1;
 static int Ctx_Current_Level = -1;
 /* saved descriptions (stack) */
 static std::deque<const char *> Ctx_Descrs;
-/* "safe" get secription */
-static const char *ctx_get_descr(Ctx ctx);
 
 Ctx
 ctx_enter(const char *descr)
@@ -736,6 +734,16 @@ ctx_exit(Ctx ctx)
 
     if (Ctx_Valid_Level > Ctx_Current_Level)
         Ctx_Valid_Level = Ctx_Current_Level;
+}
+
+/* checks for nulls and overflows */
+static const char *
+ctx_get_descr(Ctx ctx)
+{
+    if (ctx < 0 || ctx > CTX_MAX_LEVEL)
+        return "<lost>";
+
+    return Ctx_Descrs[ctx] ? Ctx_Descrs[ctx] : "<null>";
 }
 
 /*
@@ -773,16 +781,6 @@ ctx_print(void)
 
     /* unlock */
     Ctx_Lock.store(false);
-}
-
-/* checks for nulls and overflows */
-static const char *
-ctx_get_descr(Ctx ctx)
-{
-    if (ctx < 0 || ctx > CTX_MAX_LEVEL)
-        return "<lost>";
-
-    return Ctx_Descrs[ctx] ? Ctx_Descrs[ctx] : "<null>";
 }
 
 Debug::Context *Debug::Current = nullptr;

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -693,11 +693,6 @@ xassert(const char *msg, const char *file, int line)
 
 #define CTX_MAX_LEVEL 255
 
-/*
- * produce a warning when nesting reaches this level and then double
- * the level
- */
-static int Ctx_Warn_Level = 32;
 /* all descriptions has been printed up to this level */
 static int Ctx_Reported_Level = -1;
 /* descriptions are still valid or active up to this level */
@@ -717,6 +712,7 @@ ctx_enter(const char *descr)
     if (Ctx_Current_Level <= CTX_MAX_LEVEL)
         Ctx_Descrs[Ctx_Current_Level] = descr;
 
+    static int Ctx_Warn_Level = 32;
     if (Ctx_Current_Level == Ctx_Warn_Level) {
         debugs(0, DBG_CRITICAL, "# ctx: suspiciously deep (" << Ctx_Warn_Level << ") nesting:");
         Ctx_Warn_Level *= 2;

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -755,9 +755,13 @@ static void
 ctx_print(void)
 {
     /* lock to prevent recursive calls, eg from _db_print */
-    static std::atomic_bool Ctx_Lock;
-    if (Ctx_Lock.exchange(true))
+    // TODO: make this ctx_*() code thread safe
+    static int Ctx_Lock = 0;
+    ++Ctx_Lock;
+    if (Ctx_Lock > 1) {
+        --Ctx_Lock;
         return;
+    }
 
     /* all descriptions has been printed up to this level */
     static int Ctx_Reported_Level = -1;
@@ -785,7 +789,7 @@ ctx_print(void)
     }
 
     /* unlock */
-    Ctx_Lock.store(false);
+    --Ctx_Lock;
 }
 
 Debug::Context *Debug::Current = nullptr;

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -691,7 +691,9 @@ xassert(const char *msg, const char *file, int line)
  * have a bug if your nesting goes that deep.
  */
 
+#if !defined(CTX_MAX_LEVEL)
 #define CTX_MAX_LEVEL 255
+#endif
 
 /* all descriptions has been printed up to this level */
 static int Ctx_Reported_Level = -1;

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -696,8 +696,6 @@ xassert(const char *msg, const char *file, int line)
 #define CTX_MAX_LEVEL 255
 #endif
 
-/* all descriptions has been printed up to this level */
-static int Ctx_Reported_Level = -1;
 /* descriptions are still valid or active up to this level */
 static int Ctx_Valid_Level = -1;
 /* current level, the number of nested ctx_enter() calls */
@@ -760,6 +758,9 @@ ctx_print(void)
     static std::atomic_bool Ctx_Lock;
     if (Ctx_Lock.exchange(true))
         return;
+
+    /* all descriptions has been printed up to this level */
+    static int Ctx_Reported_Level = -1;
 
     /* ok, user saw [0,Ctx_Reported_Level] descriptions */
     /* first inform about entries popped since user saw them */

--- a/src/http.cc
+++ b/src/http.cc
@@ -663,7 +663,7 @@ HttpStateData::processReplyHeader()
     /** Creates a blank header. If this routine is made incremental, this will not do */
 
     /* NP: all exit points to this function MUST call ctx_exit(ctx) */
-    Ctx ctx = ctx_enter(entry->mem_obj->urlXXX());
+    Ctx ctx = ctx_enter(std::string(entry->mem_obj->urlXXX()));
 
     debugs(11, 3, "processReplyHeader: key '" << entry->getMD5Text() << "'");
 
@@ -897,7 +897,7 @@ HttpStateData::haveParsedReplyHeaders()
 {
     Client::haveParsedReplyHeaders();
 
-    Ctx ctx = ctx_enter(entry->mem_obj->urlXXX());
+    Ctx ctx = ctx_enter(std::string(entry->mem_obj->urlXXX()));
     HttpReply *rep = finalReply();
     const Http::StatusCode statusCode = rep->sline.status();
 

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -38,7 +38,7 @@ DebugStream()
 }
 
 Ctx
-ctx_enter(const char *)
+ctx_enter(const std::string &)
 {
     return -1;
 }


### PR DESCRIPTION
The ctx_*() mechanism functions inside debug.cc are used to
store URLs. We can improve memory management and exceptinon
safety by updating it to use C++ types.

Replace the locking with proper std::atomic. Not strictly
necessary, but can avoid complications with exception handling
and signal interrupts racing the current check-then-increment
actions.

Replace the custom almost-stack internal storage with a
std::deque. We cannot use a std::stack due to requiring indexed
access to stored values. An array or vector could be used, but
deque has faster add/remove for the stack-like actions at the
tail of the container.

Replacing the c-string inputs from callers with std::string.
Resolving any issues related to caller objects being tied to the
context stored values by ownership of the context description.

Also, enable build-time control of CTX_MAX_LEVEL via
./configure variable parameter rather than patching.