### PR TITLE
Update systemd dependencies in squid.service

### DIFF
--- a/tools/systemd/squid.service
+++ b/tools/systemd/squid.service
@@ -8,7 +8,7 @@
 [Unit]
 Description=Squid Web Proxy Server
 Documentation=man:squid(8)
-After=network.target nss-lookup.target
+After=network.target network-online.target nss-lookup.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
The network.target is not sufficient to guarantee network
interfaces and IPs are assigned and available. Particularly when
systemd is not in charge of the IP assignment itself.

Use network-online.target as well, which should ensure network
is properly configured and online before starting Squid.