### PR TITLE
Libressl support

### DIFF
--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -76,7 +76,11 @@ Ssl::Bio::Create(const int fd, Security::Io::Type type)
         BIO_meth_set_create(SquidMethods, squid_bio_create);
         BIO_meth_set_destroy(SquidMethods, squid_bio_destroy);
     }
+#if defined(LIBRESSL_VERSION_NUMBER)
+    BIO_METHOD *useMethod = SquidMethods;
+#elif !defined(LIBRESSL_VERSION_NUMBER)
     const BIO_METHOD *useMethod = SquidMethods;
+#endif
 #else
     BIO_METHOD *useMethod = &SquidMethods;
 #endif


### PR DESCRIPTION
Cannot build squid on alpine 3.8 without this fix. Latest version of
alpine linux use libressl instead of openssl