### PR TITLE
Do not update stored headers on HTTP 304 responses

### DIFF
--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -688,13 +688,9 @@ Store::Controller::updateOnNotModified(StoreEntry *old, const StoreEntry &newer)
     if (!old->timestampsSet() && !modified)
         return;
 
-    /* update stored image of the old entry */
-
-    if (sharedMemStore && old->mem_status == IN_MEMORY && !EBIT_TEST(old->flags, ENTRY_SPECIAL))
-        sharedMemStore->updateHeaders(old);
-
-    if (old->hasDisk())
-        swapDir->updateHeaders(old);
+    // XXX: Call memStore->updateHeaders(old) and swapDir->updateHeaders(old) to
+    // update stored headers, stored metadata, and in-transit metadata.
+    debugs(20, 3, *old << " headers were modified: " << modified);
 }
 
 bool


### PR DESCRIPTION
... until we learn how to synchronize stored and in-transit metadata.

This temporary disables a feature first introduced in commit abf396e.