### PR TITLE
Fixed build on FreeBSD v11.2 (#266)

### DIFF
--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -1743,7 +1743,8 @@ wccp2AssignBuckets(void *)
 
         assignment_key = (struct assignment_key_t *) &wccp_packet[offset];
 
-        assignment_key->master_number = htonl(++service_list_ptr->change_num);
+        ++service_list_ptr->change_num;
+        assignment_key->master_number = htonl(service_list_ptr->change_num);
 
         offset += sizeof(struct assignment_key_t);
 


### PR DESCRIPTION
... and other platforms where htonl() is a macro that uses its argument
multiple times (GCC -Werror=sequence-point).