### PR TITLE
Bug 4691: balance_on_multiple_ip config option docs

### DIFF
--- a/doc/release-notes/release-3.2.sgml
+++ b/doc/release-notes/release-3.2.sgml
@@ -744,6 +744,10 @@ This section gives a thorough account of those changes in three categories:
 <sect1>Removed tags<label id="removedtags">
 <p>
 <descrip>
+	<tag>balance_on_multiple_ip</tag>
+	<p>Obsolete. The behaviour controlled by this directive is no longer possible
+	   with DNS parallel lookup and connection features (aka 'Happy Eyeballs').
+
 	<tag>chunked_request_body_max_size</tag>
 	<p>Obsolete. Squid is now HTTP/1.1 with support for streaming chunked encoded requests.
 

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -315,7 +315,6 @@ public:
         int surrogate_is_remote;
         int request_entities;
         int detect_broken_server_pconns;
-        int balance_on_multiple_ip;
         int relaxed_header_parser;
         int check_hostnames;
         int allow_underscore;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -252,6 +252,12 @@ DOC_START
 DOC_END
 
 # Options Removed in 3.2
+NAME: balance_on_multiple_ip
+TYPE: obsolete
+DOC_START
+	Remove this line. Squid performs a 'Happy Eyeballs' algorithm, this multiple-IP algorithm is not longer relevant.
+DOC_END
+
 NAME: chunked_request_body_max_size
 TYPE: obsolete
 DOC_START
@@ -10184,22 +10190,6 @@ DOC_START
 	privileges after initializing.  This means, for example, if you
 	use a HTTP port less than 1024 and try to reconfigure, you may
 	get an error saying that Squid can not open the port.
-DOC_END
-
-NAME: balance_on_multiple_ip
-TYPE: onoff
-LOC: Config.onoff.balance_on_multiple_ip
-DEFAULT: off
-DOC_START
-	Modern IP resolvers in squid sort lookup results by preferred access.
-	By default squid will use these IP in order and only rotates to
-	the next listed when the most preffered fails.
-
-	Some load balancing servers based on round robin DNS have been
-	found not to preserve user session state across requests
-	to different IP addresses.
-
-	Enabling this directive Squid rotates IP's per request.
 DOC_END
 
 NAME: pipeline_prefetch


### PR DESCRIPTION
Add missing balance_on_multiple_ip removal documentation
after the active code was removed by 3.2 TCP connection
server selection changes.