### PR TITLE
Bug 4716: Blank lines in cachemgr.conf are not skipped

### DIFF
--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -294,7 +294,8 @@ auth_html(const char *host, int port, const char *user_name)
 
         while (fgets(config_line, BUFSIZ, fp)) {
             char *server, *comment;
-            strtok(config_line, "\r\n");
+            if (strtok(config_line, "\r\n") == nullptr)
+                continue;
 
             if (config_line[0] == '#')
                 continue;


### PR DESCRIPTION
The default cachemgr.conf contains three lines other than
comments. Two of them are blank, the third is "localhost".
These blank lines show up in the "Cache Server" list in the
CGI output.