### PR TITLE
Update URI parser to use SBuf parsing APIs

### DIFF
--- a/src/Downloader.cc
+++ b/src/Downloader.cc
@@ -129,7 +129,7 @@ Downloader::buildRequest()
     const HttpRequestMethod method = Http::METHOD_GET;
 
     const MasterXaction::Pointer mx = new MasterXaction(initiator_);
-    HttpRequest *const request = HttpRequest::FromUrl(url_.c_str(), mx, method);
+    auto * const request = HttpRequest::FromUrl(url_, mx, method);
     if (!request) {
         debugs(33, 5, "Invalid URI: " << url_);
         return false; //earlyError(...)

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -329,9 +329,7 @@ HttpRequest::parseFirstLine(const char *start, const char *end)
     if (end < start)   // missing URI
         return false;
 
-    const bool ret = url.parse(method, SBuf(start, size_t(end-start)));
-
-    return ret;
+    return url.parse(method, SBuf(start, size_t(end-start)));
 }
 
 /* swaps out request using httpRequestPack */

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -329,13 +329,7 @@ HttpRequest::parseFirstLine(const char *start, const char *end)
     if (end < start)   // missing URI
         return false;
 
-    char save = *end;
-
-    * (char *) end = '\0';     // temp terminate URI, XXX dangerous?
-
-    const bool ret = url.parse(method, SBuf(start));
-
-    * (char *) end = save;
+    const bool ret = url.parse(method, SBuf(start, size_t(end-start)));
 
     return ret;
 }

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -532,14 +532,20 @@ HttpRequest::expectingBody(const HttpRequestMethod &, int64_t &theSize) const
  * If the request cannot be created cleanly, NULL is returned
  */
 HttpRequest *
-HttpRequest::FromUrl(const char * url, const MasterXaction::Pointer &mx, const HttpRequestMethod& method)
+HttpRequest::FromUrl(const SBuf &url, const MasterXaction::Pointer &mx, const HttpRequestMethod& method)
 {
     std::unique_ptr<HttpRequest> req(new HttpRequest(mx));
-    if (req->url.parse(method, SBuf(url))) {
+    if (req->url.parse(method, url)) {
         req->method = method;
         return req.release();
     }
     return nullptr;
+}
+
+HttpRequest *
+HttpRequest::FromUrlXXX(const char * url, const MasterXaction::Pointer &mx, const HttpRequestMethod& method)
+{
+    return FromUrl(SBuf(url), mx, method);
 }
 
 /**

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -333,7 +333,7 @@ HttpRequest::parseFirstLine(const char *start, const char *end)
 
     * (char *) end = '\0';     // temp terminate URI, XXX dangerous?
 
-    const bool ret = url.parse(method, start);
+    const bool ret = url.parse(method, SBuf(start));
 
     * (char *) end = save;
 
@@ -543,7 +543,7 @@ HttpRequest *
 HttpRequest::FromUrl(const char * url, const MasterXaction::Pointer &mx, const HttpRequestMethod& method)
 {
     std::unique_ptr<HttpRequest> req(new HttpRequest(mx));
-    if (req->url.parse(method, url)) {
+    if (req->url.parse(method, SBuf(url))) {
         req->method = method;
         return req.release();
     }

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -211,7 +211,10 @@ public:
 
     static void httpRequestPack(void *obj, Packable *p);
 
-    static HttpRequest * FromUrl(const char * url, const MasterXaction::Pointer &, const HttpRequestMethod &method = Http::METHOD_GET);
+    static HttpRequest * FromUrl(const SBuf &url, const MasterXaction::Pointer &, const HttpRequestMethod &method = Http::METHOD_GET);
+
+    /// \deprecated use SBuf variant instead
+    static HttpRequest * FromUrlXXX(const char * url, const MasterXaction::Pointer &, const HttpRequestMethod &method = Http::METHOD_GET);
 
     ConnStateData *pinnedConnection();
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1013,6 +1013,7 @@ tests_testURL_LDADD = \
 	libsquid.la \
 	proxyp/libproxyp.la \
 	anyp/libanyp.la \
+	parser/libparser.la \
 	base/libbase.la \
 	ip/libip.la \
 	sbuf/libsbuf.la \

--- a/src/anyp/ProtocolType.h
+++ b/src/anyp/ProtocolType.h
@@ -14,6 +14,7 @@
 namespace AnyP
 {
 
+// TODO order by current protocol popularity (eg HTTPS before FTP)
 /**
  * List of all protocols known and supported.
  * This is a combined list. It is used as type-codes where needed and

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -499,7 +499,7 @@ AnyP::Uri::parseUrn(Parser::Tokenizer &tok)
     if (!alphanum[*nid.begin()])
         throw TextException("NID prefix is not alphanumeric", Here());
 
-    if (!alphanum[*nid.end()])
+    if (!alphanum[*nid.rbegin()])
         throw TextException("NID suffix is not alphanumeric", Here());
 
     setScheme(AnyP::PROTO_URN, nullptr);

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -205,22 +205,14 @@ urlAppendDomain(char *host)
 /*
  * Parse a URI/URL.
  *
- * Stores parsed values in the `request` argument.
- *
- * This abuses HttpRequest as a way of representing the parsed url
- * and its components.
- * method is used to switch parsers and to init the HttpRequest.
- * If method is Http::METHOD_CONNECT, then rather than a URL a hostname:port is
- * looked for.
- * The url is non const so that if its too long we can NULL-terminate it in place.
- */
-
-/*
- * This routine parses a URL. Its assumed that the URL is complete -
+ * It is assumed that the URL is complete -
  * ie, the end of the string is the end of the URL. Don't pass a partial
  * URL here as this routine doesn't have any way of knowing whether
- * its partial or not (ie, it handles the case of no trailing slash as
+ * it is partial or not (ie, it handles the case of no trailing slash as
  * being "end of host with implied path of /".
+ *
+ * method is used to switch parsers. If method is Http::METHOD_CONNECT,
+ * then rather than a URL a hostname:port is looked for.
  */
 bool
 AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf str)

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -127,10 +127,9 @@ urlInitialize(void)
 }
 
 /**
- * Parse the URI scheme details from tokenizer.
+ * Extract the URI scheme and ':' delimiter from the given input buffer.
  *
- * Schemes up to 16 characters are accepted, and a ':' delimiter
- * is expected.
+ * Schemes up to 16 characters are accepted.
  *
  * Governed by RFC 3986 section 3.1
  */
@@ -251,11 +250,10 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf &rawUrl)
         if (scheme == AnyP::PROTO_NONE)
             return false; // invalid scheme
 
-        // URN have a different schema from URL
         if (scheme == AnyP::PROTO_URN)
             return parseUrn(tok);
 
-        // URL then have "//"
+        // URLs then have "//"
         static const SBuf doubleSlash("//");
         if (!tok.skip(doubleSlash))
             return false;
@@ -460,7 +458,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf &rawUrl)
     return true;
 
     } catch (...) {
-        debugs(23, 2, "URI parse error: " << CurrentException);
+        debugs(23, 2, "error: " << CurrentException << Raw("rawUrl", rawUrl.rawContent(), rawUrl.length()).minLevel(DBG_DATA));
         return false;
     }
 }

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -462,7 +462,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf &rawUrl)
     return true;
 
     } catch (...) {
-        debugs(23, 2, "error: " << CurrentException << Raw("rawUrl", rawUrl.rawContent(), rawUrl.length()).minLevel(DBG_DATA));
+        debugs(23, 2, "error: " << CurrentException << " " << Raw("rawUrl", rawUrl.rawContent(), rawUrl.length()));
         return false;
     }
 }

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -148,7 +148,7 @@ uriParseScheme(Parser::Tokenizer &tok)
 
     SBuf str;
     if (tok.prefix(str, schemeChars, 16) && tok.skip(':') && CharacterSet::ALPHA[str.at(0)]) {
-        auto protocol = AnyP::UriScheme::FindProtocolType(str);
+        const auto protocol = AnyP::UriScheme::FindProtocolType(str);
         return AnyP::UriScheme(protocol, str.c_str());
     }
 
@@ -256,7 +256,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf &rawUrl)
             return parseUrn(tok);
 
         // URL then have "//"
-        static SBuf doubleSlash("//");
+        static const SBuf doubleSlash("//");
         if (!tok.skip(doubleSlash))
             return false;
 

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -144,7 +144,7 @@ uriParseScheme(Parser::Tokenizer &tok)
      * letter and followed by any combination of letters, digits, plus
      * ("+"), period ("."), or hyphen ("-").
      */
-    static const CharacterSet schemeChars = CharacterSet("scheme", "+.-") + CharacterSet::ALPHA + CharacterSet::DIGIT;
+    static const auto schemeChars = CharacterSet("scheme", "+.-") + CharacterSet::ALPHA + CharacterSet::DIGIT;
 
     AnyP::UriScheme result;
     SBuf str;
@@ -477,7 +477,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
 bool
 AnyP::Uri::parseUrn(Parser::Tokenizer &tok)
 {
-    static const CharacterSet nidChars = CharacterSet("NID","-") + CharacterSet::ALPHANUM;
+    static const auto nidChars = CharacterSet("NID","-") + CharacterSet::ALPHANUM;
     SBuf nid;
     if (tok.prefix(nid, nidChars, 32) && tok.skip(':')) {
         debugs(23, 3, "Split URI into proto='urn', nid='" << nid << "', path='" << tok.remaining() << "'");

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -192,7 +192,7 @@ urlAppendDomain(char *host)
  * then rather than a URL a hostname:port is looked for.
  */
 bool
-AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
+AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf &rawUrl)
 {
     try {
 
@@ -208,13 +208,13 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
     char *dst;
     foundHost[0] = urlpath[0] = login[0] = '\0';
 
-    if ((l = urlStr.length()) + Config.appendDomainLen > (MAX_URL - 1)) {
+    if ((l = rawUrl.length()) + Config.appendDomainLen > (MAX_URL - 1)) {
         debugs(23, DBG_IMPORTANT, MYNAME << "URL too large (" << l << " bytes)");
         return false;
     }
 
     if ((method == Http::METHOD_OPTIONS || method == Http::METHOD_TRACE) &&
-               Asterisk().cmp(urlStr) == 0) {
+               Asterisk().cmp(rawUrl) == 0) {
         // XXX: these methods might also occur in HTTPS traffic. Handle this better.
         setScheme(AnyP::PROTO_HTTP, nullptr);
         port(getScheme().defaultPort());
@@ -222,7 +222,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
         return true;
     }
 
-    Parser::Tokenizer tok(urlStr);
+    Parser::Tokenizer tok(rawUrl);
     AnyP::UriScheme scheme;
 
     if (method == Http::METHOD_CONNECT) {
@@ -383,7 +383,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
         }
     }
 
-    debugs(23, 3, "Split URL '" << urlStr << "' into proto='" << scheme.image() << "', host='" << foundHost << "', port='" << foundPort << "', path='" << urlpath << "'");
+    debugs(23, 3, "Split URL '" << rawUrl << "' into proto='" << scheme.image() << "', host='" << foundHost << "', port='" << foundPort << "', path='" << urlpath << "'");
 
     if (Config.onoff.check_hostnames &&
             strspn(foundHost, Config.onoff.allow_underscore ? valid_hostname_chars_u : valid_hostname_chars) != strlen(foundHost)) {
@@ -419,7 +419,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
 #endif
 
     if (stringHasWhitespace(urlpath)) {
-        debugs(23, 2, "URI has whitespace: {" << urlStr << "}");
+        debugs(23, 2, "URI has whitespace: {" << rawUrl << "}");
 
         switch (Config.uri_whitespace) {
 

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -265,7 +265,9 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf str)
 
     } else if ((method == Http::METHOD_OPTIONS || method == Http::METHOD_TRACE) &&
                AnyP::Uri::Asterisk().cmp(url) == 0) {
-        parseFinish(AnyP::PROTO_HTTP, nullptr, url, foundHost, SBuf(), 80 /* HTTP default port */);
+        setScheme(AnyP::PROTO_HTTP, nullptr);
+        path(Asterisk());
+        port(getScheme().defaultPort());
         return true;
     } else if (strncmp(url, "urn:", 4) == 0) {
         debugs(23, 3, "Split URI '" << url << "' into proto='urn', path='" << (url+4) << "'");
@@ -477,24 +479,12 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf str)
         }
     }
 
-    parseFinish(protocol, proto, urlpath, foundHost, SBuf(login), foundPort);
+    setScheme(protocol, proto);
+    path(urlpath);
+    host(foundHost);
+    userInfo(SBuf(login));
+    port(foundPort);
     return true;
-}
-
-/// Update the URL object with parsed URI data.
-void
-AnyP::Uri::parseFinish(const AnyP::ProtocolType protocol,
-                       const char *const protoStr, // for unknown protocols
-                       const char *const aUrlPath,
-                       const char *const aHost,
-                       const SBuf &aLogin,
-                       const int aPort)
-{
-    setScheme(protocol, protoStr);
-    path(aUrlPath);
-    host(aHost);
-    userInfo(aLogin);
-    port(aPort);
 }
 
 void

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -502,12 +502,11 @@ AnyP::Uri::parseUrn(Parser::Tokenizer &tok)
     if (!alphanum[*nid.end()])
         throw TextException("NID suffix is not alphanumeric", Here());
 
-    debugs(23, 3, "Split URI into proto='urn', nid='" << nid << "', path='" << Raw("tok",tok.remaining().rawContent(),tok.remaining().length()) << "'");
-
     setScheme(AnyP::PROTO_URN, nullptr);
     host(nid.c_str());
     // TODO validate path characters
     path(tok.remaining());
+    debugs(23, 3, "Split URI into proto=urn, nid=" << nid << ", " << Raw("path",path().rawContent(),path().length()));
 }
 
 void

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -138,6 +138,8 @@ static AnyP::UriScheme
 uriParseScheme(Parser::Tokenizer &tok)
 {
     /*
+     * RFC 3986 section 3.1 paragraph 2:
+     *
      * Scheme names consist of a sequence of characters beginning with a
      * letter and followed by any combination of letters, digits, plus
      * ("+"), period ("."), or hyphen ("-").
@@ -214,7 +216,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
 
     if ((method == Http::METHOD_OPTIONS || method == Http::METHOD_TRACE) &&
                Asterisk().cmp(urlStr) == 0) {
-        // XXX: these methods might also occur in HTTPS traffic. Handle this batter.
+        // XXX: these methods might also occur in HTTPS traffic. Handle this better.
         setScheme(AnyP::PROTO_HTTP, nullptr);
         port(getScheme().defaultPort());
         path(Asterisk());
@@ -247,6 +249,9 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
 
         // first the "scheme:" part
         scheme = uriParseScheme(tok);
+
+        if (scheme == AnyP::PROTO_NONE)
+            return false; // invalid scheme
 
         // URN have a different schema from URL
         if (scheme == AnyP::PROTO_URN) {

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -148,11 +148,14 @@ uriParseScheme(Parser::Tokenizer &tok)
 
     AnyP::UriScheme result;
     SBuf str;
-    if (CharacterSet::ALPHA[tok.buf().at(0)] &&
-        tok.prefix(str, schemeChars, 16) && tok.skip(':')) {
-
+    auto saved = tok.remaining();
+    if (tok.prefix(str, schemeChars, 16) && tok.skip(':') && CharacterSet::ALPHA[str.at(0)]) {
         auto protocol = AnyP::UriScheme::FindProtocolType(str);
         result = AnyP::UriScheme(protocol, str.c_str());
+    } else {
+        // TODO: ideally we would use throw mechanism, but we still
+        //     have old code using URL parse for ad-hoc processing.
+        tok.reset(saved);
     }
 
     return result;

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -148,7 +148,9 @@ uriParseScheme(Parser::Tokenizer &tok)
     SBuf str;
     if (tok.prefix(str, schemeChars, 16) && tok.skip(':') && CharacterSet::ALPHA[str.at(0)]) {
         const auto protocol = AnyP::UriScheme::FindProtocolType(str);
-        return AnyP::UriScheme(protocol, str.c_str());
+        if (protocol == AnyP::PROTO_UNKNOWN)
+            return AnyP::UriScheme(protocol, str.c_str());
+        return AnyP::UriScheme(protocol, nullptr);
     }
 
     throw TextException("invalid URI scheme", Here());

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -306,7 +306,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf &rawUrl)
         }
         *dst = '\0';
 
-        foundPort = scheme.defaultPort();
+        foundPort = scheme.defaultPort(); // may be reset later
 
         /* Is there any login information? (we should eventually parse it above) */
         t = strrchr(foundHost, '@');

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -493,8 +493,6 @@ AnyP::Uri::parseUrn(Parser::Tokenizer &tok)
     if (!tok.skip(':'))
         throw TextException("NID too long or missing ':' delimiter", Here());
 
-    debugs(23, 3, "Split URI into proto='urn', nid='" << nid << "', path='" << tok.remaining() << "'");
-
     if (nid.length() < 2)
         throw TextException("NID too short", Here());
 
@@ -502,7 +500,9 @@ AnyP::Uri::parseUrn(Parser::Tokenizer &tok)
         throw TextException("NID prefix is not alphanumeric", Here());
 
     if (!alphanum[*nid.end()])
-        throw TextException("NID suffixis not alphanumeric", Here());
+        throw TextException("NID suffix is not alphanumeric", Here());
+
+    debugs(23, 3, "Split URI into proto='urn', nid='" << nid << "', path='" << Raw("tok",tok.remaining().rawContent(),tok.remaining().length()) << "'");
 
     setScheme(AnyP::PROTO_URN, nullptr);
     host(nid.c_str());

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -247,7 +247,6 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf urlStr)
 
     } else {
 
-        // first the "scheme:" part
         scheme = uriParseScheme(tok);
 
         if (scheme == AnyP::PROTO_NONE)

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -59,7 +59,7 @@ public:
     }
     void touch(); ///< clear the cached URI display forms
 
-    bool parse(const HttpRequestMethod &, const char *url);
+    bool parse(const HttpRequestMethod &, const SBuf url);
 
     /// \return a new URI that honors uri_whitespace
     static char *cleanup(const char *uri);

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -126,7 +126,7 @@ public:
     SBuf &absolute() const;
 
 private:
-    bool parseUrn(Parser::Tokenizer&);
+    void parseUrn(Parser::Tokenizer&);
 
     /**
      \par

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -122,8 +122,6 @@ public:
     SBuf &absolute() const;
 
 private:
-    void parseFinish(const AnyP::ProtocolType, const char *const, const char *const, const char *const, const SBuf &, const int);
-
     /**
      \par
      * The scheme of this URL. This has the 'type code' smell about it.

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -126,6 +126,8 @@ public:
     SBuf &absolute() const;
 
 private:
+    bool parseUrn(Parser::Tokenizer&);
+
     /**
      \par
      * The scheme of this URL. This has the 'type code' smell about it.

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -59,7 +59,7 @@ public:
     }
     void touch(); ///< clear the cached URI display forms
 
-    bool parse(const HttpRequestMethod &, const SBuf url);
+    bool parse(const HttpRequestMethod &, const SBuf &url);
 
     /// \return a new URI that honors uri_whitespace
     static char *cleanup(const char *uri);

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -71,6 +71,10 @@ public:
         scheme_ = AnyP::UriScheme(p, str);
         touch();
     }
+    void setScheme(const AnyP::UriScheme &s) {
+        scheme_ = s;
+        touch();
+    }
 
     void userInfo(const SBuf &s) {userInfo_=s; touch();}
     const SBuf &userInfo() const {return userInfo_;}

--- a/src/anyp/UriScheme.cc
+++ b/src/anyp/UriScheme.cc
@@ -56,7 +56,7 @@ AnyP::UriScheme::FindProtocolType(const SBuf &scheme)
 
     Init();
 
-    SBuf img = scheme;
+    auto img = scheme;
     img.toLower();
     // TODO: use base/EnumIterator.h if possible
     for (int i = AnyP::PROTO_NONE + 1; i < AnyP::PROTO_UNKNOWN; ++i) {

--- a/src/anyp/UriScheme.cc
+++ b/src/anyp/UriScheme.cc
@@ -48,6 +48,25 @@ AnyP::UriScheme::Init()
     }
 }
 
+const AnyP::ProtocolType
+AnyP::UriScheme::FindProtocolType(const SBuf &str)
+{
+    if (str.isEmpty())
+        return AnyP::PROTO_NONE;
+
+    Init();
+
+    SBuf img = str;
+    img.toLower();
+    // TODO: use base/EnumIterator.h if possible
+    for (int i = AnyP::PROTO_NONE + 1; i < AnyP::PROTO_UNKNOWN; ++i) {
+        if (LowercaseSchemeNames_.at(i) == img)
+            return AnyP::ProtocolType(i);
+    }
+
+    return AnyP::PROTO_UNKNOWN;
+}
+
 unsigned short
 AnyP::UriScheme::defaultPort() const
 {

--- a/src/anyp/UriScheme.cc
+++ b/src/anyp/UriScheme.cc
@@ -49,14 +49,14 @@ AnyP::UriScheme::Init()
 }
 
 const AnyP::ProtocolType
-AnyP::UriScheme::FindProtocolType(const SBuf &str)
+AnyP::UriScheme::FindProtocolType(const SBuf &scheme)
 {
-    if (str.isEmpty())
+    if (scheme.isEmpty())
         return AnyP::PROTO_NONE;
 
     Init();
 
-    SBuf img = str;
+    SBuf img = scheme;
     img.toLower();
     // TODO: use base/EnumIterator.h if possible
     for (int i = AnyP::PROTO_NONE + 1; i < AnyP::PROTO_UNKNOWN; ++i) {

--- a/src/anyp/UriScheme.h
+++ b/src/anyp/UriScheme.h
@@ -54,7 +54,7 @@ public:
     /// initializes down-cased protocol scheme names array
     static void Init();
 
-    /// produce the ProtocolType code for names scheme, or PROTO_UNKNOWN
+    /// \returns ProtocolType for the given scheme name or PROTO_UNKNOWN
     static const AnyP::ProtocolType FindProtocolType(const SBuf &);
 
 private:

--- a/src/anyp/UriScheme.h
+++ b/src/anyp/UriScheme.h
@@ -54,6 +54,9 @@ public:
     /// initializes down-cased protocol scheme names array
     static void Init();
 
+    /// produce the ProtocolType code for names scheme, or PROTO_UNKNOWN
+    static const AnyP::ProtocolType FindProtocolType(const SBuf &);
+
 private:
     /// optimization: stores down-cased protocol scheme names, copied from
     /// AnyP::ProtocolType_str

--- a/src/base/CharacterSet.cc
+++ b/src/base/CharacterSet.cc
@@ -152,3 +152,4 @@ CharacterSet::ETAGC("ETAGC", {{0x21,0x21},{0x23,0x7e},{0x80,0xff}}),
 // RFC 7235
 CharacterSet::TOKEN68C("TOKEN68C","-._~+/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 ;
+

--- a/src/base/CharacterSet.cc
+++ b/src/base/CharacterSet.cc
@@ -150,6 +150,7 @@ CharacterSet::OBSTEXT("OBSTEXT",0x80,0xff),
 // RFC 7232
 CharacterSet::ETAGC("ETAGC", {{0x21,0x21},{0x23,0x7e},{0x80,0xff}}),
 // RFC 7235
-CharacterSet::TOKEN68C("TOKEN68C","-._~+/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+CharacterSet::TOKEN68C("TOKEN68C","-._~+/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+// RFC 8141
+CharacterSet::ALPHANUM("alphanum","0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 ;
-

--- a/src/base/CharacterSet.cc
+++ b/src/base/CharacterSet.cc
@@ -150,7 +150,5 @@ CharacterSet::OBSTEXT("OBSTEXT",0x80,0xff),
 // RFC 7232
 CharacterSet::ETAGC("ETAGC", {{0x21,0x21},{0x23,0x7e},{0x80,0xff}}),
 // RFC 7235
-CharacterSet::TOKEN68C("TOKEN68C","-._~+/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-// RFC 8141
-CharacterSet::ALPHANUM("alphanum","0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+CharacterSet::TOKEN68C("TOKEN68C","-._~+/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 ;

--- a/src/base/CharacterSet.h
+++ b/src/base/CharacterSet.h
@@ -115,6 +115,10 @@ public:
     // token68 (internal charaters only, excludes '=' terminator)
     static const CharacterSet TOKEN68C;
 
+    // URN character set, RFC 8141
+    // alphanum
+    static const CharacterSet ALPHANUM;
+
 private:
     /** index of characters in this set
      *

--- a/src/base/CharacterSet.h
+++ b/src/base/CharacterSet.h
@@ -115,10 +115,6 @@ public:
     // token68 (internal charaters only, excludes '=' terminator)
     static const CharacterSet TOKEN68C;
 
-    // URN character set, RFC 8141
-    // alphanum
-    static const CharacterSet ALPHANUM;
-
 private:
     /** index of characters in this set
      *

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -347,7 +347,8 @@ clientBeginRequest(const HttpRequestMethod& method, char const *url, CSCB * stre
     http->uri = (char *)xcalloc(url_sz, 1);
     strcpy(http->uri, url); // XXX: polluting http->uri before parser validation
 
-    if ((request = HttpRequest::FromUrl(http->uri, mx, method)) == NULL) {
+    request = HttpRequest::FromUrlXXX(http->uri, mx, method);
+    if (!request) {
         debugs(85, 5, "Invalid URL: " << http->uri);
         return -1;
     }

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1269,7 +1269,7 @@ ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
             // prevent broken helpers causing too much damage. If old URL == new URL skip the re-write.
             if (urlNote != NULL && strcmp(urlNote, http->uri)) {
                 AnyP::Uri tmpUrl;
-                if (tmpUrl.parse(old_request->method, urlNote)) {
+                if (tmpUrl.parse(old_request->method, SBuf(urlNote))) {
                     HttpRequest *new_request = old_request->clone();
                     new_request->url = tmpUrl;
                     debugs(61, 2, "URL-rewriter diverts URL from " << old_request->effectiveRequestUri() << " to " << new_request->effectiveRequestUri());

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -695,7 +695,7 @@ htcpUnpackSpecifier(char *buf, int sz)
     method.HttpRequestMethodXXX(s->method);
 
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initHtcp);
-    s->request = HttpRequest::FromUrl(s->uri, mx, method == Http::METHOD_NONE ? HttpRequestMethod(Http::METHOD_GET) : method);
+    s->request = HttpRequest::FromUrlXXX(s->uri, mx, method == Http::METHOD_NONE ? HttpRequestMethod(Http::METHOD_GET) : method);
     if (!s->request) {
         debugs(31, 3, "failed to create request. Invalid URI?");
         return nil;

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -1275,7 +1275,7 @@ netdbExchangeStart(void *data)
     char *uri = internalRemoteUri(p->secure.encryptTransport, p->host, p->http_port, "/squid-internal-dynamic/", netDB);
     debugs(38, 3, "Requesting '" << uri << "'");
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initIcmp);
-    HttpRequestPointer req(HttpRequest::FromUrl(uri, mx));
+    HttpRequestPointer req(HttpRequest::FromUrlXXX(uri, mx));
 
     if (!req) {
         debugs(38, DBG_IMPORTANT, MYNAME << ": Bad URI " << uri);

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -495,9 +495,9 @@ icpGetRequest(char *url, int reqnum, int fd, Ip::Address &from)
         return NULL;
     }
 
-    HttpRequest *result;
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initIcp);
-    if ((result = HttpRequest::FromUrl(url, mx)) == NULL)
+    auto *result = HttpRequest::FromUrlXXX(url, mx);
+    if (!result)
         icpCreateAndSend(ICP_ERR, 0, url, reqnum, 0, fd, from, nullptr);
 
     return result;

--- a/src/mgr/Inquirer.cc
+++ b/src/mgr/Inquirer.cc
@@ -77,7 +77,7 @@ Mgr::Inquirer::start()
     if (strands.empty()) {
         const char *url = aggrAction->command().params.httpUri.termedBuf();
         const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initIpc);
-        HttpRequest *req = HttpRequest::FromUrl(url, mx);
+        auto *req = HttpRequest::FromUrlXXX(url, mx);
         ErrorState err(ERR_INVALID_URL, Http::scNotFound, req, nullptr);
         std::unique_ptr<HttpReply> reply(err.BuildHttpReply());
         replyBuf.reset(reply->pack());

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -404,7 +404,7 @@ MimeIcon::created(StoreEntry *newEntry)
     /* fill `e` with a canned 2xx response object */
 
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initIcon);
-    HttpRequestPointer r(HttpRequest::FromUrl(url_, mx));
+    HttpRequestPointer r(HttpRequest::FromUrlXXX(url_, mx));
     if (!r)
         fatalf("mimeLoadIcon: cannot parse internal URL: %s", url_);
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1403,7 +1403,7 @@ peerCountMcastPeersStart(void *data)
     p->in_addr.toUrl(url+7, MAX_URL -8 );
     strcat(url, "/");
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initPeerMcast);
-    HttpRequest *req = HttpRequest::FromUrl(url, mx);
+    auto *req = HttpRequest::FromUrlXXX(url, mx);
     assert(req != nullptr);
     StoreEntry *fake = storeCreateEntry(url, url, RequestFlags(), Http::METHOD_GET);
     const auto psstate = new PeerSelector(nullptr);

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -327,7 +327,7 @@ peerDigestRequest(PeerDigest * pd)
     debugs(72, 2, url);
 
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initCacheDigest);
-    req = HttpRequest::FromUrl(url, mx);
+    req = HttpRequest::FromUrlXXX(url, mx);
 
     assert(req);
 

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -726,7 +726,7 @@ Ftp::Server::parseOneRequest()
     calcUri(path);
     MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
     mx->tcpClient = clientConnection;
-    HttpRequest *const request = HttpRequest::FromUrl(uri.c_str(), mx, method);
+    auto * const request = HttpRequest::FromUrl(uri, mx, method);
     if (!request) {
         debugs(33, 5, "Invalid FTP URL: " << uri);
         uri.clear();

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -139,7 +139,8 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     // TODO: move URL parse into Http Parser and INVALID_URL into the above parse error handling
     MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
     mx->tcpClient = clientConnection;
-    if ((request = HttpRequest::FromUrl(http->uri, mx, parser_->method())) == NULL) {
+    request = HttpRequest::FromUrlXXX(http->uri, mx, parser_->method());
+    if (!request) {
         debugs(33, 5, "Invalid URL: " << http->uri);
         // setReplyToError() requires log_uri
         http->setLogUriToRawUri(http->uri, parser_->method());

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -415,7 +415,7 @@ storeDigestRewriteStart(void *datanotused)
 
     const char *url = internalLocalUri("/squid-internal-periodic/", SBuf(StoreDigestFileName));
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initCacheDigest);
-    auto req = HttpRequest::FromUrl(url, mx);
+    auto req = HttpRequest::FromUrlXXX(url, mx);
 
     RequestFlags flags;
     flags.cachable = true;

--- a/src/tests/stub_HttpRequest.cc
+++ b/src/tests/stub_HttpRequest.cc
@@ -48,7 +48,8 @@ int HttpRequest::prefixLen() const STUB_RETVAL(0)
 void HttpRequest::swapOut(StoreEntry *) STUB
 void HttpRequest::pack(Packable *) const STUB
 void HttpRequest::httpRequestPack(void *, Packable *) STUB
-HttpRequest * HttpRequest::FromUrl(const char *, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(NULL)
+HttpRequest * HttpRequest::FromUrl(const SBuf &, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr)
+HttpRequest * HttpRequest::FromUrlXXX(const char *, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr)
 ConnStateData *HttpRequest::pinnedConnection() STUB_RETVAL(NULL)
 const SBuf HttpRequest::storeId() STUB_RETVAL(SBuf("."))
 void HttpRequest::ignoreRange(const char *) STUB

--- a/src/tests/stub_libanyp.cc
+++ b/src/tests/stub_libanyp.cc
@@ -14,7 +14,7 @@
 #include "anyp/Uri.h"
 AnyP::Uri::Uri(AnyP::UriScheme const &) {STUB}
 void AnyP::Uri::touch() STUB
-bool AnyP::Uri::parse(const HttpRequestMethod&, const SBuf) STUB_RETVAL(true)
+bool AnyP::Uri::parse(const HttpRequestMethod&, const SBuf &) STUB_RETVAL(true)
 void AnyP::Uri::host(const char *) STUB
 static SBuf nil;
 const SBuf &AnyP::Uri::path() const STUB_RETVAL(nil)

--- a/src/tests/stub_libanyp.cc
+++ b/src/tests/stub_libanyp.cc
@@ -14,7 +14,7 @@
 #include "anyp/Uri.h"
 AnyP::Uri::Uri(AnyP::UriScheme const &) {STUB}
 void AnyP::Uri::touch() STUB
-bool AnyP::Uri::parse(const HttpRequestMethod&, const char *) STUB_RETVAL(true)
+bool AnyP::Uri::parse(const HttpRequestMethod&, const SBuf) STUB_RETVAL(true)
 void AnyP::Uri::host(const char *) STUB
 static SBuf nil;
 const SBuf &AnyP::Uri::path() const STUB_RETVAL(nil)

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -49,6 +49,7 @@ testHttpRequest::testCreateFromUrl()
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
     HttpRequest *aRequest = HttpRequest::FromUrl(url, mx);
     expected_port = 90;
+    CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
@@ -60,6 +61,7 @@ testHttpRequest::testCreateFromUrl()
     url = "http://foo:90/bar";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 90;
+    CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
@@ -71,6 +73,7 @@ testHttpRequest::testCreateFromUrl()
     url = "http://foo/bar";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_PUT);
     expected_port = 80;
+    CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_PUT);
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
@@ -88,6 +91,7 @@ testHttpRequest::testCreateFromUrl()
     url = "foo:45";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
     expected_port = 45;
+    CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_CONNECT);
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -47,7 +47,7 @@ testHttpRequest::testCreateFromUrl()
     unsigned short expected_port;
     const char * url = "http://foo:90/bar";
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
-    HttpRequest *aRequest = HttpRequest::FromUrl(url, mx);
+    auto aRequest = HttpRequest::FromUrlXXX(url, mx);
     expected_port = 90;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -59,7 +59,7 @@ testHttpRequest::testCreateFromUrl()
 
     /* vanilla url */
     url = "http://foo:90/bar";
-    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
     expected_port = 90;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -71,7 +71,7 @@ testHttpRequest::testCreateFromUrl()
 
     /* vanilla url, different method */
     url = "http://foo/bar";
-    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_PUT);
+    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_PUT);
     expected_port = 80;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -84,12 +84,12 @@ testHttpRequest::testCreateFromUrl()
     /* a connect url with non-CONNECT data */
     HttpRequest *nullRequest = nullptr;
     url = ":foo/bar";
-    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
+    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_CONNECT);
     CPPUNIT_ASSERT_EQUAL(nullRequest, aRequest);
 
     /* a CONNECT url with CONNECT data */
     url = "foo:45";
-    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
+    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_CONNECT);
     expected_port = 45;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -114,7 +114,7 @@ testHttpRequest::testIPv6HostColonBug()
     /* valid IPv6 address without port */
     const char *url = "http://[2000:800::45]/foo";
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
-    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
     expected_port = 80;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);
@@ -125,7 +125,7 @@ testHttpRequest::testIPv6HostColonBug()
 
     /* valid IPv6 address with port */
     url = "http://[2000:800::45]:90/foo";
-    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
     expected_port = 90;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);
@@ -136,7 +136,7 @@ testHttpRequest::testIPv6HostColonBug()
 
     /* IPv6 address as invalid (bug trigger) */
     url = "http://2000:800::45/foo";
-    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
     expected_port = 80;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -55,7 +55,6 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(SBuf("http://foo:90/bar"), url);
 
     /* vanilla url */
     url = "http://foo:90/bar";
@@ -67,7 +66,6 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(SBuf("http://foo:90/bar"), url);
 
     /* vanilla url, different method */
     url = "http://foo/bar";
@@ -79,14 +77,12 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(SBuf("http://foo/bar"), url);
 
     /* a connect url with non-CONNECT data */
     HttpRequest *nullRequest = nullptr;
     url = ":foo/bar";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
     CPPUNIT_ASSERT_EQUAL(nullRequest, aRequest);
-    CPPUNIT_ASSERT_EQUAL(SBuf(":foo/bar"), url);
 
     /* a CONNECT url with CONNECT data */
     url = "foo:45";
@@ -98,7 +94,6 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf(), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_NONE, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(SBuf("foo:45"), url);
 
     // XXX: check METHOD_NONE input handling
 }
@@ -122,7 +117,6 @@ testHttpRequest::testIPv6HostColonBug()
     CPPUNIT_ASSERT_EQUAL(String("[2000:800::45]"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(SBuf("http://[2000:800::45]/foo"), url);
 
     /* valid IPv6 address with port */
     url = "http://[2000:800::45]:90/foo";
@@ -133,7 +127,6 @@ testHttpRequest::testIPv6HostColonBug()
     CPPUNIT_ASSERT_EQUAL(String("[2000:800::45]"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(SBuf("http://[2000:800::45]:90/foo"), url);
 
     /* IPv6 address as invalid (bug trigger) */
     url = "http://2000:800::45/foo";
@@ -144,7 +137,6 @@ testHttpRequest::testIPv6HostColonBug()
     CPPUNIT_ASSERT_EQUAL(String("[2000:800::45]"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(SBuf("http://2000:800::45/foo"), url);
 }
 
 void

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -45,7 +45,7 @@ testHttpRequest::testCreateFromUrl()
 {
     /* vanilla url, implict method */
     unsigned short expected_port;
-    char * url = xstrdup("http://foo:90/bar");
+    const char * url = "http://foo:90/bar";
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
     HttpRequest *aRequest = HttpRequest::FromUrl(url, mx);
     expected_port = 90;
@@ -55,10 +55,9 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
     CPPUNIT_ASSERT_EQUAL(String("http://foo:90/bar"), String(url));
-    xfree(url);
 
     /* vanilla url */
-    url = xstrdup("http://foo:90/bar");
+    url = "http://foo:90/bar";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 90;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -67,10 +66,9 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
     CPPUNIT_ASSERT_EQUAL(String("http://foo:90/bar"), String(url));
-    xfree(url);
 
     /* vanilla url, different method */
-    url = xstrdup("http://foo/bar");
+    url = "http://foo/bar";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_PUT);
     expected_port = 80;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -79,17 +77,15 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
     CPPUNIT_ASSERT_EQUAL(String("http://foo/bar"), String(url));
-    xfree(url);
 
     /* a connect url with non-CONNECT data */
     HttpRequest *nullRequest = nullptr;
-    url = xstrdup(":foo/bar");
+    url = ":foo/bar";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
-    xfree(url);
     CPPUNIT_ASSERT_EQUAL(nullRequest, aRequest);
 
     /* a CONNECT url with CONNECT data */
-    url = xstrdup("foo:45");
+    url = "foo:45";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
     expected_port = 45;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -98,7 +94,6 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(SBuf(), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_NONE, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
     CPPUNIT_ASSERT_EQUAL(String("foo:45"), String(url));
-    xfree(url);
 
     // XXX: check METHOD_NONE input handling
 }
@@ -110,11 +105,11 @@ void
 testHttpRequest::testIPv6HostColonBug()
 {
     unsigned short expected_port;
-    char * url = NULL;
+    const char * url = nullptr;
     HttpRequest *aRequest = NULL;
 
     /* valid IPv6 address without port */
-    url = xstrdup("http://[2000:800::45]/foo");
+    url = "http://[2000:800::45]/foo";
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 80;
@@ -124,10 +119,9 @@ testHttpRequest::testIPv6HostColonBug()
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
     CPPUNIT_ASSERT_EQUAL(String("http://[2000:800::45]/foo"), String(url));
-    xfree(url);
 
     /* valid IPv6 address with port */
-    url = xstrdup("http://[2000:800::45]:90/foo");
+    url = "http://[2000:800::45]:90/foo";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 90;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -136,10 +130,9 @@ testHttpRequest::testIPv6HostColonBug()
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
     CPPUNIT_ASSERT_EQUAL(String("http://[2000:800::45]:90/foo"), String(url));
-    xfree(url);
 
     /* IPv6 address as invalid (bug trigger) */
-    url = xstrdup("http://2000:800::45/foo");
+    url = "http://2000:800::45/foo";
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 80;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -148,7 +141,6 @@ testHttpRequest::testIPv6HostColonBug()
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
     CPPUNIT_ASSERT_EQUAL(String("http://2000:800::45/foo"), String(url));
-    xfree(url);
 }
 
 void

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -45,9 +45,9 @@ testHttpRequest::testCreateFromUrl()
 {
     /* vanilla url, implict method */
     unsigned short expected_port;
-    const char * url = "http://foo:90/bar";
+    SBuf url("http://foo:90/bar");
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
-    auto aRequest = HttpRequest::FromUrlXXX(url, mx);
+    HttpRequest *aRequest = HttpRequest::FromUrl(url, mx);
     expected_port = 90;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -55,11 +55,11 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(String("http://foo:90/bar"), String(url));
+    CPPUNIT_ASSERT_EQUAL(SBuf("http://foo:90/bar"), url);
 
     /* vanilla url */
     url = "http://foo:90/bar";
-    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 90;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -67,11 +67,11 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(String("http://foo:90/bar"), String(url));
+    CPPUNIT_ASSERT_EQUAL(SBuf("http://foo:90/bar"), url);
 
     /* vanilla url, different method */
     url = "http://foo/bar";
-    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_PUT);
+    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_PUT);
     expected_port = 80;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -79,17 +79,18 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/bar"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(String("http://foo/bar"), String(url));
+    CPPUNIT_ASSERT_EQUAL(SBuf("http://foo/bar"), url);
 
     /* a connect url with non-CONNECT data */
     HttpRequest *nullRequest = nullptr;
     url = ":foo/bar";
-    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_CONNECT);
+    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
     CPPUNIT_ASSERT_EQUAL(nullRequest, aRequest);
+    CPPUNIT_ASSERT_EQUAL(SBuf(":foo/bar"), url);
 
     /* a CONNECT url with CONNECT data */
     url = "foo:45";
-    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_CONNECT);
+    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_CONNECT);
     expected_port = 45;
     CPPUNIT_ASSERT(aRequest != nullptr);
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -97,7 +98,7 @@ testHttpRequest::testCreateFromUrl()
     CPPUNIT_ASSERT_EQUAL(String("foo"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf(), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_NONE, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(String("foo:45"), String(url));
+    CPPUNIT_ASSERT_EQUAL(SBuf("foo:45"), url);
 
     // XXX: check METHOD_NONE input handling
 }
@@ -112,38 +113,38 @@ testHttpRequest::testIPv6HostColonBug()
     HttpRequest *aRequest = NULL;
 
     /* valid IPv6 address without port */
-    const char *url = "http://[2000:800::45]/foo";
+    SBuf url("http://[2000:800::45]/foo");
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
-    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 80;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);
     CPPUNIT_ASSERT_EQUAL(String("[2000:800::45]"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(String("http://[2000:800::45]/foo"), String(url));
+    CPPUNIT_ASSERT_EQUAL(SBuf("http://[2000:800::45]/foo"), url);
 
     /* valid IPv6 address with port */
     url = "http://[2000:800::45]:90/foo";
-    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 90;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);
     CPPUNIT_ASSERT_EQUAL(String("[2000:800::45]"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(String("http://[2000:800::45]:90/foo"), String(url));
+    CPPUNIT_ASSERT_EQUAL(SBuf("http://[2000:800::45]:90/foo"), url);
 
     /* IPv6 address as invalid (bug trigger) */
     url = "http://2000:800::45/foo";
-    aRequest = HttpRequest::FromUrlXXX(url, mx, Http::METHOD_GET);
+    aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 80;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
     CPPUNIT_ASSERT(aRequest->method == Http::METHOD_GET);
     CPPUNIT_ASSERT_EQUAL(String("[2000:800::45]"), String(aRequest->url.host()));
     CPPUNIT_ASSERT_EQUAL(SBuf("/foo"), aRequest->url.path());
     CPPUNIT_ASSERT_EQUAL(AnyP::PROTO_HTTP, static_cast<AnyP::ProtocolType>(aRequest->url.getScheme()));
-    CPPUNIT_ASSERT_EQUAL(String("http://2000:800::45/foo"), String(url));
+    CPPUNIT_ASSERT_EQUAL(SBuf("http://2000:800::45/foo"), url);
 }
 
 void

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -109,11 +109,10 @@ void
 testHttpRequest::testIPv6HostColonBug()
 {
     unsigned short expected_port;
-    const char * url = nullptr;
     HttpRequest *aRequest = NULL;
 
     /* valid IPv6 address without port */
-    url = "http://[2000:800::45]/foo";
+    const char *url = "http://[2000:800::45]/foo";
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 80;

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -49,9 +49,6 @@ public:
     HttpRequest::Pointer urlres_r;
     AccessLogEntry::Pointer ale; ///< details of the requesting transaction
 
-    struct {
-        bool force_menu = false;
-    } flags;
     char reqbuf[URN_REQBUF_SZ] = { '\0' };
     int reqofs = 0;
 
@@ -133,12 +130,6 @@ urnFindMinRtt(url_entry * urls, const HttpRequestMethod &, int *rtt_ret)
 void
 UrnState::setUriResFromRequest(HttpRequest *r)
 {
-    static const SBuf menu(".menu");
-    if (r->url.path().startsWith(menu)) {
-        r->url.path(r->url.path().substr(5)); // strip prefix "menu."
-        flags.force_menu = true;
-    }
-
     SBuf query = r->url.absolute();
     const char *host = r->url.host();
     // TODO: use class AnyP::Uri instead of generating a string and re-parsing
@@ -369,9 +360,7 @@ urnHandleReply(void *data, StoreIOBuffer result)
     rep = new HttpReply;
     rep->setHeaders(Http::scFound, NULL, "text/html", mb->length(), 0, squid_curtime);
 
-    if (urnState->flags.force_menu) {
-        debugs(51, 3, "urnHandleReply: forcing menu");
-    } else if (min_u) {
+    if (min_u) {
         rep->header.putStr(Http::HdrType::LOCATION, min_u->url);
     }
 

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -38,7 +38,6 @@ public:
 
     void created (StoreEntry *newEntry);
     void start (HttpRequest *, StoreEntry *);
-    char *getHost(const SBuf &urlpath);
     void setUriResFromRequest(HttpRequest *);
 
     virtual ~UrnState();
@@ -131,18 +130,6 @@ urnFindMinRtt(url_entry * urls, const HttpRequestMethod &, int *rtt_ret)
     return min_u;
 }
 
-char *
-UrnState::getHost(const SBuf &urlpath)
-{
-    /** FIXME: this appears to be parsing the URL. *very* badly. */
-    /*   a proper encapsulated URI/URL type needs to clear this up. */
-    size_t p;
-    if ((p = urlpath.find(':')) != SBuf::npos)
-        return SBufToCstring(urlpath.substr(0, p-1));
-
-    return SBufToCstring(urlpath);
-}
-
 void
 UrnState::setUriResFromRequest(HttpRequest *r)
 {
@@ -152,12 +139,11 @@ UrnState::setUriResFromRequest(HttpRequest *r)
         flags.force_menu = true;
     }
 
-    SBuf uri = r->url.path();
+    SBuf query = r->url.absolute();
+    const char *host = r->url.host();
     // TODO: use class AnyP::Uri instead of generating a string and re-parsing
     LOCAL_ARRAY(char, local_urlres, 4096);
-    char *host = getHost(uri);
-    snprintf(local_urlres, 4096, "http://%s/uri-res/N2L?urn:" SQUIDSBUFPH, host, SQUIDSBUFPRINT(uri));
-    safe_free(host);
+    snprintf(local_urlres, 4096, "http://%s/uri-res/N2L?" SQUIDSBUFPH, host, SQUIDSBUFPRINT(query));
     safe_free(urlres);
     urlres_r = HttpRequest::FromUrl(local_urlres, r->masterXaction);
 

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -131,7 +131,7 @@ void
 UrnState::setUriResFromRequest(HttpRequest *r)
 {
     const auto &query = r->url.absolute();
-    const char *host = r->url.host();
+    const auto host = r->url.host();
     // TODO: use class AnyP::Uri instead of generating a string and re-parsing
     LOCAL_ARRAY(char, local_urlres, 4096);
     snprintf(local_urlres, 4096, "http://%s/uri-res/N2L?" SQUIDSBUFPH, host, SQUIDSBUFPRINT(query));

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -136,7 +136,7 @@ UrnState::setUriResFromRequest(HttpRequest *r)
     LOCAL_ARRAY(char, local_urlres, 4096);
     snprintf(local_urlres, 4096, "http://%s/uri-res/N2L?" SQUIDSBUFPH, host, SQUIDSBUFPRINT(query));
     safe_free(urlres);
-    urlres_r = HttpRequest::FromUrl(local_urlres, r->masterXaction);
+    urlres_r = HttpRequest::FromUrlXXX(local_urlres, r->masterXaction);
 
     if (!urlres_r) {
         debugs(52, 3, "Bad uri-res URL " << local_urlres);

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -130,7 +130,7 @@ urnFindMinRtt(url_entry * urls, const HttpRequestMethod &, int *rtt_ret)
 void
 UrnState::setUriResFromRequest(HttpRequest *r)
 {
-    SBuf query = r->url.absolute();
+    const auto &query = r->url.absolute();
     const char *host = r->url.host();
     // TODO: use class AnyP::Uri instead of generating a string and re-parsing
     LOCAL_ARRAY(char, local_urlres, 4096);


### PR DESCRIPTION
Initial replacement of URI/URL parse method internals with
SBuf and Tokenizer based parse.

For now this parsing only handles the scheme section of
URL. With this we add the missing check for alpha character
as first in the scheme name for unknown schemes and
prohibit URL without any scheme (previously accepted).

Also polishes the documentation, URN and asterisk-form
URI parsing.

Also, adds validation of URN NID portion characters to
ensure valid authority host names are generated for
THTTP lookup URLs.