### PR TITLE
Bug 4877: Add missing text about external_acl_type %DATA changes

### DIFF
--- a/doc/release-notes/release-4.sgml
+++ b/doc/release-notes/release-4.sgml
@@ -335,6 +335,8 @@ This section gives a thorough account of those changes in three categories:
 	<p>New parameter <em>on-persistent-overload=</em> to set the action taken
 	   when the helper queue is overloaded.
 	<p>Format field updated to accept any logformat %macro code.
+	<p>The optional <em>acl-value</em> fields in this helper input now expand
+	   to a dash ('-') if the %DATA macro is not specified explicitly.
 
 	<tag>http_port</tag>
 	<p>New option <em>tls-min-version=1.N</em> to set minimum TLS version allowed.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -862,6 +862,8 @@ DOC_START
 
 			If you do not specify a DATA macro inside FORMAT,
 			Squid automatically appends %DATA to your FORMAT.
+			Note that Squid-3.x may expand %DATA to whitespace
+			or nothing in this case.
 
 			By default, Squid applies URL-encoding to each ACL
 			argument inside the argument string. If an explicit


### PR DESCRIPTION
Conversion of external_acl_type to using logformat macros was
not quite seamless. The %DATA macro now expands to a dash '-' to
fix helpers using it explicitly from receiving incorrect number
of fields (and misaligned input) on their input lines.

Unfortunately that also results in the implicit use of that
macro expanding to non-whitespace ('-'). That small fact was not
documented in the initial v4 release notes and config texts.