### PR TITLE
Fixed forward_max_tries documentation and implementation

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -626,7 +626,7 @@ FwdState::checkRetry()
     if (!entry->isEmpty())
         return false;
 
-    if (n_tries >= Config.forward_max_tries)
+    if (!forwardTriesAllowed())
         return false;
 
     if (!EnoughTimeToReForward(start_t))
@@ -1110,7 +1110,7 @@ FwdState::reforward()
         return 0;
     }
 
-    if (n_tries >= Config.forward_max_tries)
+    if (!forwardTriesAllowed())
         return 0;
 
     if (request->bodyNibbled())
@@ -1258,6 +1258,12 @@ FwdState::logReplyStatus(int tries, const Http::StatusCode status)
         tries = MAX_FWD_STATS_IDX;
 
     ++ FwdReplyCodes[tries][status];
+}
+
+bool
+FwdState::forwardTriesAllowed() const
+{
+    return n_tries < Config.forward_max_tries;
 }
 
 /**** PRIVATE NON-MEMBER FUNCTIONS ********************************************/

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -722,7 +722,6 @@ FwdState::handleUnregisteredServerEnd()
 void
 FwdState::connectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xerrno)
 {
-    n_tries++;
     if (status != Comm::OK) {
         ErrorState *const anErr = makeConnectingError(ERR_CONNECT_FAIL);
         anErr->xerrno = xerrno;
@@ -890,6 +889,7 @@ FwdState::connectStart()
         serverConn = pinned_connection ? pinned_connection->borrowPinnedConnection(request, serverDestinations[0]->getPeer()) : nullptr;
         if (Comm::IsConnOpen(serverConn)) {
             flags.connected_okay = true;
+            ++n_tries;
             request->flags.pinned = true;
 
             if (pinned_connection->pinnedAuth())
@@ -933,6 +933,7 @@ FwdState::connectStart()
         serverConn = temp;
         flags.connected_okay = true;
         debugs(17, 3, HERE << "reusing pconn " << serverConnection());
+        ++n_tries;
 
         closeHandler = comm_add_close_handler(serverConnection()->fd,  fwdServerClosedWrapper, this);
 
@@ -959,6 +960,7 @@ FwdState::connectStart()
     Comm::ConnOpener *cs = new Comm::ConnOpener(serverDestinations[0], calls.connector, connTimeout);
     if (host)
         cs->setHost(host);
+    ++n_tries;
     AsyncJob::Start(cs);
 }
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -626,7 +626,7 @@ FwdState::checkRetry()
     if (!entry->isEmpty())
         return false;
 
-    if (!forwardTriesAllowed())
+    if (exhaustedTries())
         return false;
 
     if (!EnoughTimeToReForward(start_t))
@@ -1112,7 +1112,7 @@ FwdState::reforward()
         return 0;
     }
 
-    if (!forwardTriesAllowed())
+    if (exhaustedTries())
         return 0;
 
     if (request->bodyNibbled())
@@ -1263,9 +1263,9 @@ FwdState::logReplyStatus(int tries, const Http::StatusCode status)
 }
 
 bool
-FwdState::forwardTriesAllowed() const
+FwdState::exhaustedTries() const
 {
-    return n_tries < Config.forward_max_tries;
+    return n_tries >= Config.forward_max_tries;
 }
 
 /**** PRIVATE NON-MEMBER FUNCTIONS ********************************************/

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -132,6 +132,8 @@ private:
 
     void syncWithServerConn(const char *host);
     void syncHierNote(const Comm::ConnectionPointer &server, const char *host);
+    /// whether we have not yet run out of possible forward attempts
+    bool forwardTriesAllowed() const;
 
 public:
     StoreEntry *entry;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -147,7 +147,7 @@ private:
     ErrorState *err;
     Comm::ConnectionPointer clientConn;        ///< a possibly open connection to the client.
     time_t start_t;
-    int n_tries;  ///< the number of forwarding attempts, done so far
+    int n_tries; ///< the number of forwarding attempts so far
 
     // AsyncCalls which we set and may need cancelling.
     struct {

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -132,7 +132,7 @@ private:
 
     void syncWithServerConn(const char *host);
     void syncHierNote(const Comm::ConnectionPointer &server, const char *host);
-    /// whether we have not yet run out of possible forward attempts
+    /// whether we have not yet run out of permitted forwarding attempts
     bool forwardTriesAllowed() const;
 
 public:
@@ -147,7 +147,7 @@ private:
     ErrorState *err;
     Comm::ConnectionPointer clientConn;        ///< a possibly open connection to the client.
     time_t start_t;
-    int n_tries;  ///< the number of different forward paths tried so far
+    int n_tries;  ///< the number of forwarding attempts, done so far
 
     // AsyncCalls which we set and may need cancelling.
     struct {

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -132,8 +132,9 @@ private:
 
     void syncWithServerConn(const char *host);
     void syncHierNote(const Comm::ConnectionPointer &server, const char *host);
-    /// whether we have not yet run out of permitted forwarding attempts
-    bool forwardTriesAllowed() const;
+
+    /// whether we have used up all permitted forwarding attempts
+    bool exhaustedTries() const;
 
 public:
     StoreEntry *entry;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -145,7 +145,7 @@ private:
     ErrorState *err;
     Comm::ConnectionPointer clientConn;        ///< a possibly open connection to the client.
     time_t start_t;
-    int n_tries;
+    int n_tries;  ///< the number of different forward paths tried so far
 
     // AsyncCalls which we set and may need cancelling.
     struct {

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3924,8 +3924,10 @@ DEFAULT: 25
 TYPE: int
 LOC: Config.forward_max_tries
 DOC_START
-	Controls how many different forward paths Squid will try
-	before giving up. See also forward_timeout.
+	Limits the number of forwarding attempts to fetch the response.
+	This comprises all forwarding attempts, including different
+	forward paths as well as the same path retries in case of
+	persistent connection. See also forward_timeout.
 	
 	NOTE: connect_retries (default: none) can make each of these
 	possible forwarding paths be tried multiple times.
@@ -10098,7 +10100,7 @@ DOC_START
 	value and the configured value will be over-ridden.
 
 	Note: These re-tries are in addition to forward_max_tries
-	which limit how many different addresses may be tried to find
+	which limit how many forwarding attempts may be performed to find
 	a useful server.
 DOC_END
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3932,13 +3932,15 @@ DEFAULT: 25
 TYPE: int
 LOC: Config.forward_max_tries
 DOC_START
-	Limits the number of forwarding attempts to fetch the response.
-	This comprises all forwarding attempts, including different
-	forward paths as well as the same path retries in case of
-	persistent connection. See also forward_timeout.
+	Limits the number of attempts to forward the request.
+
+	For the purpose of this limit, Squid counts all high-level request
+	forwarding attempts, including any same-destination retries after
+	certain persistent connection failures and any attempts to use a
+	different peer. However, low-level connection reopening attempts
+	(enabled using connect_retries) are not counted.
 	
-	NOTE: connect_retries (default: none) can make each of these
-	possible forwarding paths be tried multiple times.
+	See also: forward_timeout and connect_retries.
 DOC_END
 
 COMMENT_START
@@ -10097,19 +10099,23 @@ LOC: Config.connect_retries
 DEFAULT: 0
 DEFAULT_DOC: Do not retry failed connections.
 DOC_START
-	This sets the maximum number of connection attempts made for each
-	TCP connection. The connect_retries attempts must all still
-	complete within the connection timeout period.
+	Limits the number of reopening attempts when establishing a single
+	TCP connection. All these attempts must still complete before the
+	applicable connection opening timeout expires.
 
-	The default is not to re-try if the first connection attempt fails.
-	The (not recommended) maximum is 10 tries.
+	By default and when connect_retries is set to zero, Squid does not
+	retry failed connection opening attempts.
 
-	A warning message will be generated if it is set to a too-high
-	value and the configured value will be over-ridden.
+	The (not recommended) maximum is 10 tries. An attempt to configure a
+	higher value results in the value of 10 being used (with a warning).
 
-	Note: These re-tries are in addition to forward_max_tries
-	which limit how many forwarding attempts may be performed to find
-	a useful server.
+	Squid may open connections to retry various high-level forwarding
+	failures. For an outside observer, that activity may look like a
+	low-level connection reopening attempt, but those high-level retries
+	are governed by forward_max_tries instead.
+
+	See also: connect_timeout, forward_timeout, icap_connect_timeout,
+	ident_timeout, and forward_max_tries.
 DOC_END
 
 NAME: retry_on_error


### PR DESCRIPTION
Before 1c8f25b, FwdState::n_tries counted the total number of forwarding
attempts, including pinned and persistent connection retries. Since that
revision, it started counting just those retries. What should n_tries
count? The counter is used to honor the forward_max_tries directive, but
that directive was documented to limit the number of _different_ paths
to try. Neither 1c8f25b~1 nor 1c8f25b code matched that documentation!

Continuing to count just pinned and persistent connection retries (as in
1c8f25b) would violate any reasonable forward_max_tries intent and admin
expectations. There are two ways to fix this problem, synchronizing code
and documentation:

* Count just the attempts to use a different forwarding path, matching
  forward_max_tries documentation but not what Squid has ever done. This
  approach makes it difficult for an admin to limit the total number of
  forwarding attempts in environments where, say, the second attempt is
  unlikely to succeed and will just incur wasteful delays (Squid bug
  4788 report is probably about one of such use cases). Also,
  implementing this approach may be more difficult because it requires
  adding a new counter for retries and, for some interpretations of
  "different", even a container of previously visited paths.

* Count all forwarding attempts (as before 1c8f25b) and adjust
  forward_max_tries documentation to match this historical behavior.
  This approach does not have known unique flaws.

Also fixed FwdState::n_tries off-by-one comparison bug discussed during
Squid bug 4788 triage.

Also fixed admin concern behind Squid bug 4788 "forward_max_tries 1 does
not prevent some retries": While the old forward_max_tries documentation
actually excluded pconn retries, technically invalidating the bug
report, the admin now has a knob to limit those retries.
