### PR TITLE
Do not maintain a persistent connection with an HTTP/1.0 client

### DIFF
--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -268,6 +268,13 @@ Http::Message::persistent() const
         static SBuf close("close", 5);
         return !httpHeaderHasConnDir(&header, close);
     }
+#if USE_HTTP_VIOLATIONS
+    else {
+        /* for old versions of HTTP: persistent if has "keep-alive" */
+        static SBuf keepAlive("keep-alive", 10);
+        return httpHeaderHasConnDir(&header, keepAlive);
+    }
+#endif
     // RFC 7230 section 6.3: MUST NOT maintain a persistent connection with an HTTP/1.0 client
     return false;
 }

--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -267,11 +267,9 @@ Http::Message::persistent() const
          */
         static SBuf close("close", 5);
         return !httpHeaderHasConnDir(&header, close);
-    } else {
-        /* for old versions of HTTP: persistent if has "keep-alive" */
-        static SBuf keepAlive("keep-alive", 10);
-        return httpHeaderHasConnDir(&header, keepAlive);
     }
+    // RFC 7230 section 6.3: MUST NOT maintain a persistent connection with an HTTP/1.0 client
+    return false;
 }
 
 void


### PR DESCRIPTION
This is an RFC 7230 section 6.3 requirement.
For backward compatibility, the new requirement is applied only when
USE_HTTP_VIOLATIONS is off.