### PR TITLE
Fix bootstrap.sh on debian testing and unstable

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -141,6 +141,9 @@ do
 	    bootstrap_libtoolize ${LIBTOOL_BIN}ize${ltver}
 	    bootstrap automake$amver --foreign --add-missing --copy -f
 	    bootstrap autoconf$acver --force
+        # sometimes the autofiles in libltdl have a version mismatch.
+        # force-refresh them
+        (cd libltdl; bootstrap autoreconf -fi)
 	fi ); then
 	    : # OK
 	else

--- a/test-suite/buildtests/layer-00-bootstrap.opts
+++ b/test-suite/buildtests/layer-00-bootstrap.opts
@@ -17,9 +17,6 @@ cd ${topc}
 # echo "DEBUG: topB=${topb}"
 # echo "DEBUG: topC=${topc}"
 
-# Display branch info for log analysis to verify correct branch was tested
-bzr info
-
 ## Bootstrap the sources in case configure or makefiles changed.
 ./bootstrap.sh
 exit $?


### PR DESCRIPTION
For some reason, the libtool-provided aclocal version, installed
in libltdl, is misaligned with the one installed on the system,
causing configure to fail.
Add one step during bootstrap force-refreshing the aclocal files
in libltdl.