### PR TITLE
Remove non-standard, redundant new/delete operator replacements

### DIFF
--- a/src/SquidNew.cc
+++ b/src/SquidNew.cc
@@ -31,7 +31,7 @@ void operator delete[](void *address)
     xfree(address);
 }
 
-void *operator new(size_t size, const std::nothrow_t &tag)
+void *operator new(size_t size, const std::nothrow_t &tag) noexcept
 {
     return xmalloc(size);
 }
@@ -39,7 +39,7 @@ void operator delete(void *address, const std::nothrow_t &tag)
 {
     xfree(address);
 }
-void *operator new[](size_t size, const std::nothrow_t &tag)
+void *operator new[](size_t size, const std::nothrow_t &tag) noexcept
 {
     return xmalloc(size);
 }

--- a/src/SquidNew.cc
+++ b/src/SquidNew.cc
@@ -22,31 +22,6 @@ void operator delete(void *address)
 {
     xfree(address);
 }
-void *operator new[](size_t size)
-{
-    return xmalloc(size);
-}
-void operator delete[](void *address)
-{
-    xfree(address);
-}
-
-void *operator new(size_t size, const std::nothrow_t &tag) noexcept
-{
-    return xmalloc(size);
-}
-void operator delete(void *address, const std::nothrow_t &tag)
-{
-    xfree(address);
-}
-void *operator new[](size_t size, const std::nothrow_t &tag) noexcept
-{
-    return xmalloc(size);
-}
-void operator delete[](void *address, const std::nothrow_t &tag)
-{
-    xfree(address);
-}
 
 #endif /* !defined(__clang__) */
 


### PR DESCRIPTION
This change also fixes icc builds: Commit 39cca4e missed noexcept
specification for nothrow variants of new and delete operators,
and the icc compiler did not like that.

Furthermore, we can simplify the replacements because, according
to cppreference, with C++11, "replacing the throwing single object
allocation functions is sufficient to handle all [allocations and
deallocations]".