### PR TITLE
Fix basic_pop3_auth startup errors

### DIFF
--- a/src/auth/basic/POP3/basic_pop3_auth.pl.in
+++ b/src/auth/basic/POP3/basic_pop3_auth.pl.in
@@ -89,14 +89,14 @@ if ( @ARGV != 1 ) {
     exit 1
 }
 
-$server = shift @ARGV;
+my $server = shift @ARGV;
 
 while(<>) {
     my ($username, $password) = split(/\s+/);
     $username =~ s/%([0-9a-f][0-9a-f])/pack("H2",$1)/gie;
     $password =~ s/%([0-9a-f][0-9a-f])/pack("H2",$1)/gie;
 
-    $pop = Net::POP3->new($server);
+    my $pop = Net::POP3->new($server);
     if (!$pop) {
 	print "ERR Server not responding\n";
 	next;


### PR DESCRIPTION
90cf12e added "use strict" which requires declaring all variables.

Originally reported (against Squid v3) at
https://bugs.launchpad.net/ubuntu/+source/squid3/+bug/1755189