### PR TITLE
Fixed negotiate_kerberos_auth memory leaks

### DIFF
--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -351,6 +351,7 @@ main(int argc, char *const argv[])
     char default_keytab[MAXPATHLEN];
 #if HAVE_KRB5_MEMORY_KEYTAB
     char *memory_keytab_name = NULL;
+    char *memory_keytab_name_env = NULL;
 #endif
     char *rcache_type = NULL;
     char *rcache_type_env = NULL;
@@ -560,10 +561,10 @@ main(int argc, char *const argv[])
                 debug((char *) "%s| %s: ERROR: Writing list into keytab %s\n",
                       LogTime(), PROGRAM, memory_keytab_name);
             } else {
-                keytab_name_env = (char *) xmalloc(strlen("KRB5_KTNAME=")+strlen(memory_keytab_name)+1);
-                strcpy(keytab_name_env, "KRB5_KTNAME=");
-                strcat(keytab_name_env, memory_keytab_name);
-                putenv(keytab_name_env);
+                memory_keytab_name_env = (char *) xmalloc(strlen("KRB5_KTNAME=")+strlen(memory_keytab_name)+1);
+                strcpy(memory_keytab_name_env, "KRB5_KTNAME=");
+                strcat(memory_keytab_name_env, memory_keytab_name);
+                putenv(memory_keytab_name_env);
                 xfree(keytab_name);
                 keytab_name = xstrdup(memory_keytab_name);
                 debug((char *) "%s| %s: INFO: Changed keytab to %s\n",
@@ -640,6 +641,16 @@ main(int argc, char *const argv[])
                 xfree(spnegoToken);
             }
             xfree(token);
+            xfree(rcache_type);
+            xfree(rcache_type_env);
+            xfree(rcache_dir);
+            xfree(rcache_dir_env);
+            xfree(keytab_name);
+            xfree(keytab_name_env);
+#if HAVE_KRB5_MEMORY_KEYTAB
+            xfree(memory_keytab_name);
+            xfree(memory_keytab_name_env);
+#endif
             fprintf(stdout, "BH quit command\n");
             exit(EXIT_SUCCESS);
         }

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -219,8 +219,8 @@ krb5_error_code krb5_free_kt_list(krb5_context context, krb5_kt_list list)
  */
 krb5_error_code krb5_read_keytab(krb5_context context, char *name, krb5_kt_list *list)
 {
-    krb5_keytab kt;
     krb5_kt_list lp = NULL, tail = NULL, back = NULL;
+    krb5_keytab kt;
     krb5_keytab_entry *entry;
     krb5_kt_cursor cursor;
     krb5_error_code retval = 0;

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -81,7 +81,7 @@ check_k5_err(krb5_context context, const char *function, krb5_error_code code)
 #elif HAVE_KRB5_FREE_ERROR_STRING
         krb5_free_error_string(context, (char *)errmsg);
 #else
-        ffree(errmsg);
+        xfree(errmsg);
 #endif
     }
     return code;


### PR DESCRIPTION
The fixed leaks do not affect runtime (i.e. request processing) code.
The helper was not deallocating some memory when exiting.
