### PR TITLE
Bug 4875 pt1: GCC-8 compile errors with -O3 optimization

### DIFF
--- a/src/String.cc
+++ b/src/String.cc
@@ -163,7 +163,7 @@ String::append( char const *str, int len)
     assert(str && len >= 0);
 
     PROF_start(StringAppend);
-    if (len_ + len + 1/*'\0'*/ < size_) {
+    if (len_ + len + 1 /*'\0'*/ < size_) {
         xstrncpy(buf_+len_, str, len+1);
         len_ += len;
     } else {

--- a/src/String.cc
+++ b/src/String.cc
@@ -163,8 +163,8 @@ String::append( char const *str, int len)
     assert(str && len >= 0);
 
     PROF_start(StringAppend);
-    if (len_ + len < size_) {
-        strncat(buf_, str, len);
+    if (len_ + len + 1/*'\0'*/ < size_) {
+        xstrncpy(buf_+len_, str, len+1);
         len_ += len;
     } else {
         // Create a temporary string and absorb it later.


### PR DESCRIPTION
 Use xstrncpy instead of strncat for String appending

Our xstrncpy() is safer, not assuming the existing char*
is nul-terminated and accounting explicitly for the
nul-terminator byte.

GCC-8 -O3 optimizations were exposing a strncat() output
truncation of the terminator when insufficient space was
available in the String buffer.

We suspect the GCC error to be a false-positive for -O3
builds and, even it it is accurate, these changes should
not affect builds with lower optimization levels.