### PR TITLE
Bug 4875 pt2: GCC-8 compile errors with -O3 optimization

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -161,7 +161,6 @@ static bool setLogformat(CustomLog *cl, const char *name, const bool dieWhenMiss
 static void configDoConfigure(void);
 static void parse_refreshpattern(RefreshPattern **);
 static uint64_t parseTimeUnits(const char *unit,  bool allowMsec);
-static void parseTimeLine(time_msec_t * tptr, const char *units, bool allowMsec, bool expectMoreArguments);
 static void parse_u_short(unsigned short * var);
 static void parse_string(char **);
 static void default_all(void);
@@ -1044,19 +1043,19 @@ parse_obsolete(const char *name)
 
 /* Parse a time specification from the config file.  Store the
  * result in 'tptr', after converting it to 'units' */
-static void
-parseTimeLine(time_msec_t * tptr, const char *units,  bool allowMsec,  bool expectMoreArguments = false)
+static time_msec_t
+parseTimeLine(const char *units,  bool allowMsec,  bool expectMoreArguments = false)
 {
     time_msec_t u = parseTimeUnits(units, allowMsec);
     if (u == 0) {
         self_destruct();
-        return;
+        return 0;
     }
 
     char *token = ConfigParser::NextToken();;
     if (!token) {
         self_destruct();
-        return;
+        return 0;
     }
 
     double d = xatof(token);
@@ -1069,7 +1068,7 @@ parseTimeLine(time_msec_t * tptr, const char *units,  bool allowMsec,  bool expe
 
         } else if (!expectMoreArguments) {
             self_destruct();
-            return;
+            return 0;
 
         } else {
             token = NULL; // show default units if dying below
@@ -1078,13 +1077,14 @@ parseTimeLine(time_msec_t * tptr, const char *units,  bool allowMsec,  bool expe
     } else
         token = NULL; // show default units if dying below.
 
-    *tptr = static_cast<time_msec_t>(m * d);
+    time_msec_t result = static_cast<time_msec_t>(m * d);
 
-    if (static_cast<double>(*tptr) * 2 != m * d * 2) {
+    if (static_cast<double>(result) * 2 != m * d * 2) {
         debugs(3, DBG_CRITICAL, "FATAL: Invalid value '" <<
                d << " " << (token ? token : units) << ": integer overflow (time_msec_t).");
         self_destruct();
     }
+    return result;
 }
 
 static uint64_t
@@ -2976,8 +2976,7 @@ dump_time_t(StoreEntry * entry, const char *name, time_t var)
 void
 parse_time_t(time_t * var)
 {
-    time_msec_t tval = 0;
-    parseTimeLine(&tval, T_SECOND_STR, false);
+    time_msec_t tval = parseTimeLine(T_SECOND_STR, false);
     *var = static_cast<time_t>(tval/1000);
 }
 
@@ -2999,7 +2998,7 @@ dump_time_msec(StoreEntry * entry, const char *name, time_msec_t var)
 void
 parse_time_msec(time_msec_t * var)
 {
-    parseTimeLine(var, T_SECOND_STR, true);
+    *var = parseTimeLine(T_SECOND_STR, true);
 }
 
 static void
@@ -4872,8 +4871,7 @@ static void free_ftp_epsv(acl_access **ftp_epsv)
 static void
 parse_UrlHelperTimeout(SquidConfig::UrlHelperTimeout *config)
 {
-    time_msec_t tval;
-    parseTimeLine(&tval, T_SECOND_STR, false, true);
+    time_msec_t tval = parseTimeLine(T_SECOND_STR, false, true);
     Config.Timeout.urlRewrite = static_cast<time_t>(tval/1000);
 
     char *key, *value;

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2976,7 +2976,7 @@ dump_time_t(StoreEntry * entry, const char *name, time_t var)
 void
 parse_time_t(time_t * var)
 {
-    time_msec_t tval;
+    time_msec_t tval = 0;
     parseTimeLine(&tval, T_SECOND_STR, false);
     *var = static_cast<time_t>(tval/1000);
 }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1052,7 +1052,7 @@ parseTimeLine(const char *units,  bool allowMsec,  bool expectMoreArguments = fa
         return 0;
     }
 
-    char *token = ConfigParser::NextToken();;
+    char *token = ConfigParser::NextToken();
     if (!token) {
         self_destruct();
         return 0;
@@ -1077,7 +1077,7 @@ parseTimeLine(const char *units,  bool allowMsec,  bool expectMoreArguments = fa
     } else
         token = NULL; // show default units if dying below.
 
-    time_msec_t result = static_cast<time_msec_t>(m * d);
+    const auto result = static_cast<time_msec_t>(m * d);
 
     if (static_cast<double>(result) * 2 != m * d * 2) {
         debugs(3, DBG_CRITICAL, "FATAL: Invalid value '" <<
@@ -4871,7 +4871,7 @@ static void free_ftp_epsv(acl_access **ftp_epsv)
 static void
 parse_UrlHelperTimeout(SquidConfig::UrlHelperTimeout *config)
 {
-    time_msec_t tval = parseTimeLine(T_SECOND_STR, false, true);
+    const auto tval = parseTimeLine(T_SECOND_STR, false, true);
     Config.Timeout.urlRewrite = static_cast<time_t>(tval/1000);
 
     char *key, *value;


### PR DESCRIPTION
GCC-8 warnings exposed at -O3 optimization causes its
own static analyzer to detect optimized code is eliding
initialization on paths that do not use the
configuration variables.

Refactor the parseTimeLine() API to return the parsed
values so that there is no need to initialize anything prior
to parsing.