### PR TITLE
Bug 4885: Excessive memory usage when running out of descriptors

### DIFF
--- a/src/base/CbcPointer.h
+++ b/src/base/CbcPointer.h
@@ -41,6 +41,8 @@ public:
     Cbc *valid() const { return get(); } ///< was set and is valid
     bool operator !() const { return !valid(); } ///< invalid or was not set
     bool operator ==(const CbcPointer<Cbc> &o) const { return lock == o.lock; }
+    bool operator <(const CbcPointer<Cbc> &o) const { return lock < o.lock; }
+    bool operator >(const CbcPointer<Cbc> &o) const { return lock > o.lock; }
 
     CbcPointer &operator =(const CbcPointer &p);
     CbcPointer &operator =(CbcPointer &&);

--- a/src/base/CbcPointer.h
+++ b/src/base/CbcPointer.h
@@ -41,8 +41,6 @@ public:
     Cbc *valid() const { return get(); } ///< was set and is valid
     bool operator !() const { return !valid(); } ///< invalid or was not set
     bool operator ==(const CbcPointer<Cbc> &o) const { return lock == o.lock; }
-    bool operator <(const CbcPointer<Cbc> &o) const { return lock < o.lock; }
-    bool operator >(const CbcPointer<Cbc> &o) const { return lock > o.lock; }
 
     CbcPointer &operator =(const CbcPointer &p);
     CbcPointer &operator =(CbcPointer &&);

--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -24,6 +24,10 @@ Comm::AcceptLimiter::Instance()
 void
 Comm::AcceptLimiter::defer(const Comm::TcpAcceptor::Pointer &afd)
 {
+    if (afd->isLimited > Squid_MaxFD >> 2) {
+        // Do not push to deferred_ once we have reached our backlog size
+        return;
+    }
     ++ (afd->isLimited);
     debugs(5, 5, afd->conn << " x" << afd->isLimited);
     deferred_.push_back(afd);

--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -26,20 +26,19 @@ Comm::AcceptLimiter::defer(const Comm::TcpAcceptor::Pointer &afd)
 {
     ++ (afd->isLimited);
     debugs(5, 5, afd->conn << " x" << afd->isLimited);
-    deferred_.push_back(afd);
     deferred_.insert(afd);
 }
 
 void
 Comm::AcceptLimiter::removeDead(const Comm::TcpAcceptor::Pointer &afd)
 {
-   std::set<TcpAcceptor::Pointer>::iterator it;
-   it = deferred_.find(afd);
-   if (it != deferred_.end()) {
-       -- afd->isLimited;
-       debugs(5, 5, afd->conn << " x" << afd->isLimited);
-       deferred_.erase(it);
-       debugs(5, 4, "Abandoned client TCP SYN by closing socket: " << afd->conn);
+    std::set<TcpAcceptor::Pointer>::iterator it;
+    it = deferred_.find(afd);
+    if (it != deferred_.end()) {
+        -- afd->isLimited;
+        debugs(5, 5, afd->conn << " x" << afd->isLimited);
+        deferred_.erase(it);
+        debugs(5, 4, "Abandoned client TCP SYN by closing socket: " << afd->conn);
     }
 }
 

--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -45,7 +45,7 @@ void
 Comm::AcceptLimiter::kick()
 {
     debugs(5, 5, "size=" << deferred_.size());
-    while (deferred_.size() > 0 && fdNFree() >= RESERVED_FD) {
+    while (deferred_.size() > 0 && Comm::TcpAcceptor::okToAccept()) {
         /* NP: shift() is equivalent to pop_front(). Giving us a FIFO queue. */
         TcpAcceptor::Pointer temp = deferred_.front();
         deferred_.erase(deferred_.begin());

--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -32,8 +32,7 @@ Comm::AcceptLimiter::defer(const Comm::TcpAcceptor::Pointer &afd)
 void
 Comm::AcceptLimiter::removeDead(const Comm::TcpAcceptor::Pointer &afd)
 {
-    std::set<TcpAcceptor::Pointer>::iterator it;
-    it = deferred_.find(afd);
+    const auto it = deferred_.find(afd);
     if (it != deferred_.end()) {
         -- afd->isLimited;
         debugs(5, 5, afd->conn << " x" << afd->isLimited);
@@ -45,11 +44,10 @@ Comm::AcceptLimiter::removeDead(const Comm::TcpAcceptor::Pointer &afd)
 void
 Comm::AcceptLimiter::kick()
 {
-    std::set<TcpAcceptor::Pointer>::iterator it;
     debugs(5, 5, "size=" << deferred_.size());
 
     while (deferred_.size() > 0 && fdNFree() >= RESERVED_FD) {
-        it = deferred_.begin();
+        const auto it = deferred_.begin();
         TcpAcceptor::Pointer temp = *it;
         deferred_.erase(it);
         if (temp.valid()) {

--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -24,8 +24,7 @@ Comm::AcceptLimiter::Instance()
 void
 Comm::AcceptLimiter::defer(const Comm::TcpAcceptor::Pointer &afd)
 {
-    ++ (afd->isLimited);
-    debugs(5, 5, afd->conn << " x" << afd->isLimited);
+    debugs(5, 5, "deferring " << afd->conn);
     deferred_.insert(afd);
 }
 
@@ -34,8 +33,6 @@ Comm::AcceptLimiter::removeDead(const Comm::TcpAcceptor::Pointer &afd)
 {
     const auto it = deferred_.find(afd);
     if (it != deferred_.end()) {
-        -- afd->isLimited;
-        debugs(5, 5, afd->conn << " x" << afd->isLimited);
         deferred_.erase(it);
         debugs(5, 4, "Abandoned client TCP SYN by closing socket: " << afd->conn);
     }
@@ -52,7 +49,6 @@ Comm::AcceptLimiter::kick()
         deferred_.erase(it);
         if (temp.valid()) {
             debugs(5, 5, "doing one.");
-            -- temp->isLimited;
             temp->acceptNext();
             break;
         }

--- a/src/comm/AcceptLimiter.h
+++ b/src/comm/AcceptLimiter.h
@@ -17,7 +17,7 @@ namespace Comm
 {
 
 /**
- * FIFO Queue holding listener socket handlers which have been activated
+ * Set holding listener socket handlers which have been activated
  * ready to dupe their FD and accept() a new client connection.
  * But when doing so there were not enough FD available to handle the
  * new connection. These handlers are awaiting some FD to become free.
@@ -25,16 +25,6 @@ namespace Comm
  * defer - used only by Comm layer ConnAcceptor adding themselves when FD are limited.
  * removeDead - used only by Comm layer ConnAcceptor to remove themselves when dying.
  * kick - used by Comm layer when FD are closed.
- */
-/* TODO this algorithm can be optimized further:
- *
- * 1) reduce overheads by only pushing one entry per port to the list?
- * use TcpAcceptor::isLimited as a flag whether to re-list when kick()'ing
- * or to NULL an entry while scanning the list for empty spaces.
- * Side effect: TcpAcceptor->kick() becomes allowed to pull off multiple accept()'s in bunches
- *
- * 2) re-implement as a std::queue instead of std::vector
- * storing head/tail pointers for fast push/pop and avoiding the whole shift() overhead
  */
 class AcceptLimiter
 {

--- a/src/comm/AcceptLimiter.h
+++ b/src/comm/AcceptLimiter.h
@@ -17,7 +17,7 @@ namespace Comm
 {
 
 /**
- * Deque holding listener socket handlers which have been activated
+ * FIFO Queue holding listener socket handlers which have been activated
  * ready to dupe their FD and accept() a new client connection.
  * But when doing so there were not enough FD available to handle the
  * new connection. These handlers are awaiting some FD to become free.

--- a/src/comm/AcceptLimiter.h
+++ b/src/comm/AcceptLimiter.h
@@ -11,7 +11,7 @@
 
 #include "comm/TcpAcceptor.h"
 
-#include <vector>
+#include <set>
 
 namespace Comm
 {
@@ -56,7 +56,7 @@ private:
     static AcceptLimiter Instance_;
 
     /** FIFO queue */
-    std::vector<TcpAcceptor::Pointer> deferred_;
+    std::set<TcpAcceptor::Pointer> deferred_;
 };
 
 }; // namepace Comm

--- a/src/comm/AcceptLimiter.h
+++ b/src/comm/AcceptLimiter.h
@@ -11,13 +11,13 @@
 
 #include "comm/TcpAcceptor.h"
 
-#include <set>
+#include <deque>
 
 namespace Comm
 {
 
 /**
- * Set holding listener socket handlers which have been activated
+ * Deque holding listener socket handlers which have been activated
  * ready to dupe their FD and accept() a new client connection.
  * But when doing so there were not enough FD available to handle the
  * new connection. These handlers are awaiting some FD to become free.
@@ -45,7 +45,8 @@ public:
 private:
     static AcceptLimiter Instance_;
 
-    std::set<TcpAcceptor::Pointer> deferred_;
+    /** FIFO queue */
+    std::deque<TcpAcceptor::Pointer> deferred_;
 };
 
 }; // namepace Comm

--- a/src/comm/AcceptLimiter.h
+++ b/src/comm/AcceptLimiter.h
@@ -55,7 +55,6 @@ public:
 private:
     static AcceptLimiter Instance_;
 
-    /** FIFO queue */
     std::set<TcpAcceptor::Pointer> deferred_;
 };
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -43,7 +43,6 @@ CBDATA_NAMESPACED_CLASS_INIT(Comm, TcpAcceptor);
 Comm::TcpAcceptor::TcpAcceptor(const Comm::ConnectionPointer &newConn, const char *, const Subscription::Pointer &aSub) :
     AsyncJob("Comm::TcpAcceptor"),
     errcode(0),
-    isLimited(0),
     theCallSub(aSub),
     conn(newConn),
     listenPort_()
@@ -52,7 +51,6 @@ Comm::TcpAcceptor::TcpAcceptor(const Comm::ConnectionPointer &newConn, const cha
 Comm::TcpAcceptor::TcpAcceptor(const AnyP::PortCfgPointer &p, const char *, const Subscription::Pointer &aSub) :
     AsyncJob("Comm::TcpAcceptor"),
     errcode(0),
-    isLimited(0),
     theCallSub(aSub),
     conn(p->listenConn),
     listenPort_(p)

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -307,6 +307,7 @@ Comm::TcpAcceptor::acceptOne()
            " accepted new connection " << newConnDetails <<
            " handler Subscription: " << theCallSub);
     notify(flag, newConnDetails);
+    SetSelect(conn->fd, COMM_SELECT_READ, doAccept, this, 0);
 }
 
 void
@@ -315,7 +316,6 @@ Comm::TcpAcceptor::acceptNext()
     Must(IsConnOpen(conn));
     debugs(5, 2, HERE << "connection on " << conn);
     acceptOne();
-    SetSelect(conn->fd, COMM_SELECT_READ, doAccept, this, 0);
 }
 
 void

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -233,7 +233,6 @@ Comm::TcpAcceptor::doAccept(int fd, void *data)
         } else {
             afd->acceptNext();
         }
-        SetSelect(fd, COMM_SELECT_READ, Comm::TcpAcceptor::doAccept, afd, 0);
 
     } catch (const std::exception &e) {
         fatalf("FATAL: error while accepting new client connection: %s\n", e.what());
@@ -318,6 +317,7 @@ Comm::TcpAcceptor::acceptNext()
     Must(IsConnOpen(conn));
     debugs(5, 2, HERE << "connection on " << conn);
     acceptOne();
+    SetSelect(conn->fd, COMM_SELECT_READ, doAccept, this, 0);
 }
 
 void

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -78,7 +78,6 @@ public:
 
 protected:
     friend class AcceptLimiter;
-    int32_t isLimited;                   ///< whether this socket is delayed and on the AcceptLimiter queue.
 
 private:
     Subscription::Pointer theCallSub;    ///< used to generate AsyncCalls handling our events.

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -76,6 +76,10 @@ public:
     /// errno code of the last accept() or listen() action if one occurred.
     int errcode;
 
+    /// Method to test if there are enough file descriptors to open a new client connection
+    /// if not the accept() will be postponed
+    static bool okToAccept();
+
 protected:
     friend class AcceptLimiter;
 
@@ -91,10 +95,6 @@ private:
 
     /// listen socket closure handler
     AsyncCall::Pointer closer_;
-
-    /// Method to test if there are enough file descriptors to open a new client connection
-    /// if not the accept() will be postponed
-    static bool okToAccept();
 
     /// Method callback for whenever an FD is ready to accept a client connection.
     static void doAccept(int fd, void *data);


### PR DESCRIPTION
TcpAcceptor now stops listening when it cannot accept due to FD limits.
We also no longer defer/queue the same limited TcpAcceptor multiple
times. These changes prevent unbounded memory growth and improve
performance of Squids running out of file descriptors. They should have
no impact on other Squids.