### PR TITLE
ntlm_fake_auth: add ability to test delayed responses

### DIFF
--- a/src/auth/ntlm/fake/ntlm_fake_auth.cc
+++ b/src/auth/ntlm/fake/ntlm_fake_auth.cc
@@ -40,6 +40,7 @@
 #include "ntlmauth/support_bits.cci"
 
 #include <cctype>
+#include <chrono>
 #include <cstring>
 #if HAVE_CRYPT_H
 #include <crypt.h>
@@ -50,6 +51,7 @@
 #if HAVE_GETOPT_H
 #include <getopt.h>
 #endif
+#include <thread>
 
 /* A couple of harmless helper macros */
 #define SEND(X) {debug("sending '%s' to squid\n",X); printf(X "\n");}
@@ -67,6 +69,7 @@
 const char *authenticate_ntlm_domain = "WORKGROUP";
 int strip_domain_enabled = 0;
 int NTLM_packet_debug_enabled = 0;
+unsigned int response_delay = 0;
 
 /*
  * options:
@@ -80,9 +83,10 @@ static void
 usage(void)
 {
     fprintf(stderr,
-            "Usage: %s [-d] [-v] [-h]\n"
+            "Usage: %s [-d] [-t N] [-v] [-h]\n"
             " -d  enable debugging.\n"
             " -S  strip domain from username.\n"
+            " -t  timeout to delay responses.\n"
             " -v  enable verbose NTLM packet debugging.\n"
             " -h  this message\n\n",
             my_program_name);
@@ -94,7 +98,7 @@ process_options(int argc, char *argv[])
     int opt, had_error = 0;
 
     opterr = 0;
-    while (-1 != (opt = getopt(argc, argv, "hdvS"))) {
+    while (-1 != (opt = getopt(argc, argv, "hdvSt:"))) {
         switch (opt) {
         case 'd':
             debug_enabled = 1;
@@ -105,6 +109,12 @@ process_options(int argc, char *argv[])
             break;
         case 'S':
             strip_domain_enabled = 1;
+            break;
+        case 't':
+            if (!xstrtoui(optarg, nullptr, &response_delay, 0, 86400)) {
+                fprintf(stderr, "ERROR: invalid parameter value for -t '%s'", optarg);
+                usage();
+            }
             break;
         case 'h':
             usage();
@@ -171,6 +181,10 @@ main(int argc, char *argv[])
             hex_dump((unsigned char *)decodedBuf, decodedLen);
         } else
             debug("Got '%s' from Squid\n", buf);
+
+        if (response_delay > 0) {
+            std::this_thread::sleep_for(std::chrono::seconds(response_delay));
+        }
 
         if (strncmp(buf, "YR", 2) == 0) {
             char nonce[NTLM_NONCE_LEN];

--- a/src/auth/ntlm/fake/ntlm_fake_auth.cc
+++ b/src/auth/ntlm/fake/ntlm_fake_auth.cc
@@ -86,7 +86,7 @@ usage(void)
             "Usage: %s [-d] [-t N] [-v] [-h]\n"
             " -d  enable debugging.\n"
             " -S  strip domain from username.\n"
-            " -t  timeout to delay responses.\n"
+            " -t  timeout to delay responses (milliseconds).\n"
             " -v  enable verbose NTLM packet debugging.\n"
             " -h  this message\n\n",
             my_program_name);
@@ -183,7 +183,7 @@ main(int argc, char *argv[])
             debug("Got '%s' from Squid\n", buf);
 
         if (response_delay > 0) {
-            std::this_thread::sleep_for(std::chrono::seconds(response_delay));
+            std::this_thread::sleep_for(std::chrono::milliseconds(response_delay));
         }
 
         if (strncmp(buf, "YR", 2) == 0) {

--- a/src/auth/ntlm/fake/ntlm_fake_auth.cc
+++ b/src/auth/ntlm/fake/ntlm_fake_auth.cc
@@ -114,6 +114,7 @@ process_options(int argc, char *argv[])
             if (!xstrtoui(optarg, nullptr, &response_delay, 0, 86400)) {
                 fprintf(stderr, "ERROR: invalid parameter value for -t '%s'", optarg);
                 usage();
+                had_error = 1;
             }
             break;
         case 'h':


### PR DESCRIPTION
Add a -t parameter which sets a timeout to artificially delay
authentication responses by a fixed amount longer than their
normal delay.

This enables the fake authenticator to be used to test NTLM
client and Squid behaviour under various network latency and
stress conditions which delay ActiveDirectory responses.