### PR TITLE
Fix %>ru for CONNECT requests

### DIFF
--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -120,7 +120,7 @@ AccessLogEntry::~AccessLogEntry()
 const SBuf *
 AccessLogEntry::effectiveVirginUrl() const
 {
-    const SBuf *effectiveUrl = request ? &request->url.absolute() : &virginUrlForMissingRequest_;
+    const SBuf *effectiveUrl = request ? &request->effectiveRequestUri() : &virginUrlForMissingRequest_;
     if (effectiveUrl && !effectiveUrl->isEmpty())
         return effectiveUrl;
     // We can not use ALE::url here because it may contain a request URI after

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -109,7 +109,7 @@ ACLFilledChecklist::verifyAle() const
             showDebugWarning("URL");
             // XXX: al->url should be the request URL from client,
             // but request->url may be different (e.g.,redirected)
-            al->url = request->url.absolute();
+            al->url = request->effectiveRequestUri();
         }
     }
 


### PR DESCRIPTION
Commit bec110e (a.k.a. v4 commit fbbd5cd5) broke CONNECT URI logging
because it incorrectly assumed that URI::absolute() supports all URIs.
As the result, Squid logged CONNECT URLs as "://host:port".

Also fixed a similar wrong assumption in ACLFilledChecklist::verifyAle()
which may affect URL-related ACL checks for CONNECT requests, albeit
only in already buggy cases where Squid warns about "ALE missing URL".

This is a Measurement Factory project