### PR TITLE
Improve const correctness for hash_link

### DIFF
--- a/include/hash.h
+++ b/include/hash.h
@@ -44,7 +44,7 @@ SQUIDCEXTERN void hashFreeMemory(hash_table *);
 SQUIDCEXTERN void hashFreeItems(hash_table *, HASHFREE *);
 SQUIDCEXTERN HASHHASH hash_string;
 SQUIDCEXTERN HASHHASH hash4;
-SQUIDCEXTERN const char *hashKeyStr(hash_link *);
+SQUIDCEXTERN const char *hashKeyStr(const hash_link *);
 
 /*
  *  Here are some good prime number choices.  It's important not to

--- a/lib/hash.cc
+++ b/lib/hash.cc
@@ -314,7 +314,7 @@ hashPrime(int n)
  * return the key of a hash_link as a const string
  */
 const char *
-hashKeyStr(hash_link * hl)
+hashKeyStr(const hash_link * hl)
 {
     return (const char *) hl->key;
 }


### PR DESCRIPTION
hash_link does not need to be modified to fetch its key
value. This allows display and fetch of hash keys for
objects which are const.