### PR TITLE
Docs: update description of visible_hostname

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7303,9 +7303,8 @@ DOC_START
 		- the name returned by gethostname(2)
 		- the name "localhost"
 
-	If you have multiple proxies in a cluster and get errors about
-	IP-forwarding, you must set each proxy to have individual names
-	with this directive or unique_hostname.
+	See unique_hostname directive if you have multiple proxies in a
+	cluster which need to share a visible hostname.
 DOC_END
 
 NAME: unique_hostname

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7290,22 +7290,22 @@ LOC: Config.visibleHostname
 DEFAULT: none
 DEFAULT_DOC: Automatically detect the system host name
 DOC_START
-	The public domain name (FQDN) of this Proxy.
+	The public domain name (FQDN) of this proxy.
 
 	This name will be used in generated URLs sent to clients for
-	objects they need to download directly from Squid, and for other
-	generated responses (eg error pages) needing to display the proxy
-	name.
+	objects they need to download directly from Squid (e.g. CSS,
+	FTP icons) and for other generated responses (e.g. error pages)
+	needing to display the proxy name.
 
 	If not set, auto-detection of the system host name will be performed
 	based on the following details (in this order):
-		- rDNS name of first listening port address
-		- the return value of gethostname()
-		- the fallback name of "localhost"
+		- rDNS name for the first listening port address
+		- the named returned by gethostname(2)
+		- the name "localhost"
 
-	If you have multiple caches in a cluster and get errors about
-	IP-forwarding you must set them to have individual names with
-	this setting or unique_hostname.
+	If you have multiple proxies in a cluster and get errors about
+	IP-forwarding, you must set each proxy to have individual names
+	with this directive or unique_hostname.
 DOC_END
 
 NAME: unique_hostname

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7290,21 +7290,25 @@ LOC: Config.visibleHostname
 DEFAULT: none
 DEFAULT_DOC: Automatically detect the system host name
 DOC_START
-	The public domain name (FQDN) of this proxy.
+	The hostname of this proxy.
 
-	This name will be used in generated URLs sent to clients for
-	objects they need to download directly from Squid. For example;
-	CSS stylesheets, FTP icons.
-
-	This name will be used in generated responses sent to clients
-	for objects they need to display the proxy name. For example;
-	error pages.
+	Hosts connected to the Internet or handling messages which travel
+	over the Internet are required by RFC 1123 to have a name which
+	can be resolved in DNS (an FQDN).
 
 	If not set, auto-detection of the system host name will be performed
 	based on the following details (in this order):
 		- rDNS name for the first listening port address
 		- the name returned by gethostname(2)
 		- the name "localhost"
+
+	This name will be used in generated responses sent to clients
+	for objects they need to display the proxy name. For example;
+	error pages.
+
+	This name will also be used in generated URLs sent to clients for
+	objects they need to download directly from Squid. For example;
+	CSS stylesheets, FTP icons.
 
 	See unique_hostname directive if you have multiple proxies in a
 	cluster which need to share a visible hostname.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7290,11 +7290,22 @@ LOC: Config.visibleHostname
 DEFAULT: none
 DEFAULT_DOC: Automatically detect the system host name
 DOC_START
-	If you want to present a special hostname in error messages, etc,
-	define this.  Otherwise, the return value of gethostname()
-	will be used. If you have multiple caches in a cluster and
-	get errors about IP-forwarding you must set them to have individual
-	names with this setting.
+	The public domain name (FQDN) of this Proxy.
+
+	This name will be used in generated URLs sent to clients for
+	objects they need to download directly from Squid, and for other
+	generated responses (eg error pages) needing to display the proxy
+	name.
+
+	If not set, auto-detection of the system host name will be performed
+	based on the following details (in this order):
+		- rDNS name of first listening port address
+		- the return value of gethostname()
+		- the fallback name of "localhost"
+
+	If you have multiple caches in a cluster and get errors about
+	IP-forwarding you must set them to have individual names with
+	this setting or unique_hostname.
 DOC_END
 
 NAME: unique_hostname

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7300,7 +7300,7 @@ DOC_START
 	If not set, auto-detection of the system host name will be performed
 	based on the following details (in this order):
 		- rDNS name for the first listening port address
-		- the named returned by gethostname(2)
+		- the name returned by gethostname(2)
 		- the name "localhost"
 
 	If you have multiple proxies in a cluster and get errors about

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7293,9 +7293,12 @@ DOC_START
 	The public domain name (FQDN) of this proxy.
 
 	This name will be used in generated URLs sent to clients for
-	objects they need to download directly from Squid (e.g. CSS,
-	FTP icons) and for other generated responses (e.g. error pages)
-	needing to display the proxy name.
+	objects they need to download directly from Squid. For example;
+	CSS stylesheets, FTP icons.
+
+	This name will be used in generated responses sent to clients
+	for objects they need to display the proxy name. For example;
+	error pages.
 
 	If not set, auto-detection of the system host name will be performed
 	based on the following details (in this order):


### PR DESCRIPTION
Bring the documentation back into line with what the code
actually does.

Also, mention that this is an domain/FQDN not just a host name.