### PR TITLE
Fix netdb exchange with a TLS cache_peer

### DIFF
--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -1272,7 +1272,7 @@ netdbExchangeStart(void *data)
 #if USE_ICMP
     CachePeer *p = (CachePeer *)data;
     static const SBuf netDB("netdb");
-    char *uri = internalRemoteUri(p->host, p->http_port, "/squid-internal-dynamic/", netDB);
+    char *uri = internalRemoteUri(p->secure.encryptTransport, p->host, p->http_port, "/squid-internal-dynamic/", netDB);
     debugs(38, 3, "Requesting '" << uri << "'");
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initIcmp);
     HttpRequestPointer req(HttpRequest::FromUrl(uri, mx));

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -132,7 +132,10 @@ internalRemoteUri(bool encrypt, const char *host, unsigned short port, const cha
 char *
 internalLocalUri(const char *dir, const SBuf &name)
 {
-    return internalRemoteUri(false, getMyHostname(),
+    // XXX: getMy*() may return https_port info, but we force http URIs
+    // because we have not checked whether the callers can handle https.
+    const bool secure = false;
+    return internalRemoteUri(secure, getMyHostname(),
                              getMyPort(), dir, name);
 }
 

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -82,7 +82,7 @@ internalStaticCheck(const SBuf &urlPath)
  * makes internal url with a given host and port (remote internal url)
  */
 char *
-internalRemoteUri(const char *host, unsigned short port, const char *dir, const SBuf &name)
+internalRemoteUri(bool encrypt, const char *host, unsigned short port, const char *dir, const SBuf &name)
 {
     static char lc_host[SQUIDHOSTNAMELEN];
     assert(host && !name.isEmpty());
@@ -115,7 +115,7 @@ internalRemoteUri(const char *host, unsigned short port, const char *dir, const 
     static MemBuf mb;
 
     mb.reset();
-    mb.appendf("http://" SQUIDSBUFPH, SQUIDSBUFPRINT(tmp.authority()));
+    mb.appendf("%s://" SQUIDSBUFPH, encrypt ? "https" : "http", SQUIDSBUFPRINT(tmp.authority()));
 
     if (dir)
         mb.append(dir, strlen(dir));
@@ -132,7 +132,7 @@ internalRemoteUri(const char *host, unsigned short port, const char *dir, const 
 char *
 internalLocalUri(const char *dir, const SBuf &name)
 {
-    return internalRemoteUri(getMyHostname(),
+    return internalRemoteUri(false, getMyHostname(),
                              getMyPort(), dir, name);
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -24,7 +24,7 @@ void internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest *, Sto
 bool internalCheck(const SBuf &urlPath);
 bool internalStaticCheck(const SBuf &urlPath);
 char *internalLocalUri(const char *dir, const SBuf &name);
-char *internalRemoteUri(const char *, unsigned short, const char *, const SBuf &);
+char *internalRemoteUri(bool, const char *, unsigned short, const char *, const SBuf &);
 const char *internalHostname(void);
 int internalHostnameIs(const char *);
 

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -323,7 +323,7 @@ peerDigestRequest(PeerDigest * pd)
     if (p->digest_url)
         url = xstrdup(p->digest_url);
     else
-        url = xstrdup(internalRemoteUri(p->host, p->http_port, "/squid-internal-periodic/", SBuf(StoreDigestFileName)));
+        url = xstrdup(internalRemoteUri(p->secure.encryptTransport, p->host, p->http_port, "/squid-internal-periodic/", SBuf(StoreDigestFileName)));
     debugs(72, 2, url);
 
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initCacheDigest);


### PR DESCRIPTION
Squid uses http-scheme URLs when sending netdb exchange (and possibly
other) requests to a cache_peer. If a DIRECT path is selected for that
cache_peer URL, then Squid sends a clear text HTTP request to that
cache_peer. If that cache_peer expects a TLS connection, it will reject
that request (with, e.g., error:transaction-end-before-headers),
resulting in an HTTP 503 or 504 netdb fetch error.

Workaround this by adding an internalRemoteUri() parameter to indicate
whether https or http URL scheme should be used. Netdb fetches from
CachePeer::secure peers now get an https scheme and, hence, a TLS
connection.