### PR TITLE
Enable use of rep_header acl in reply_header_access directive.

### DIFF
--- a/src/HttpHeaderTools.h
+++ b/src/HttpHeaderTools.h
@@ -25,6 +25,7 @@
 class HeaderWithAcl;
 class HttpHeader;
 class HttpRequest;
+class HttpReply;
 class StoreEntry;
 
 typedef std::list<HeaderWithAcl> HeaderWithAclList;
@@ -131,7 +132,7 @@ void httpHeaderPutStrf(HttpHeader * hdr, Http::HdrType id, const char *fmt,...) 
 
 const char *getStringPrefix(const char *str, size_t len);
 
-void httpHdrMangleList(HttpHeader *, HttpRequest *, const AccessLogEntryPointer &al, req_or_rep_t req_or_rep);
+void httpHdrMangleList(HttpHeader *, HttpRequest *, HttpReply *, const AccessLogEntryPointer &al, req_or_rep_t req_or_rep);
 
 #endif
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1638,7 +1638,7 @@ clientReplyContext::buildReplyHeader()
         /* TODO: else case: drop any controls intended specifically for our surrogate ID */
     }
 
-    httpHdrMangleList(hdr, request, http->al, ROR_REPLY);
+    httpHdrMangleList(hdr, request, reply, http->al, ROR_REPLY);
 }
 
 void

--- a/src/http.cc
+++ b/src/http.cc
@@ -1928,7 +1928,7 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
     }
 
     /* Now mangle the headers. */
-    httpHdrMangleList(hdr_out, request, al, ROR_REQUEST);
+    httpHdrMangleList(hdr_out, request, nullptr, al, ROR_REQUEST);
 
     strConnection.clean();
 }

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -338,7 +338,7 @@ Http::One::Server::writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &ca
     // paranoid: ContentLengthInterpreter has cleaned non-generated replies
     rep->removeIrrelevantContentLength();
     rep->header.putStr(Http::HdrType::CONNECTION, "keep-alive");
-    httpHdrMangleList(&rep->header, http->request, http->al, ROR_REPLY);
+    httpHdrMangleList(&rep->header, http->request, nullptr, http->al, ROR_REPLY);
 
     MemBuf *mb = rep->pack();
 


### PR DESCRIPTION
If an acl of type rep_header is used in reply_header_access, squid reports "ACL is used in context without an HTTP response. Assuming mismatch".

This patch passes HttpReply object to ACLFilledChecklist to enable evaluation of reply acls.