### PR TITLE
Fix client_connection_mark handling of clientless transactions

### DIFF
--- a/src/acl/ConnMark.cc
+++ b/src/acl/ConnMark.cc
@@ -55,7 +55,7 @@ Acl::ConnMark::match(ACLChecklist *cl)
             debugs(28, 7, "skipped " << m << " mismatching " << asHex(connmark));
         }
     } else {
-        debugs(28, 7, "Can't do CONNMARK check. No client connection");
+        debugs(28, 7, "fails: no client connection");
     }
 
     return 0;

--- a/src/acl/ConnMark.cc
+++ b/src/acl/ConnMark.cc
@@ -42,15 +42,22 @@ int
 Acl::ConnMark::match(ACLChecklist *cl)
 {
     const auto *checklist = Filled(cl);
-    const auto connmark = checklist->conn()->clientConnection->nfConnmark;
+    const auto conn = checklist->conn();
 
-    for (const auto &m : marks) {
-        if (m.matches(connmark)) {
-            debugs(28, 5, "found " << m << " matching " << asHex(connmark));
-            return 1;
+    if (conn && conn->clientConnection) {
+        const auto connmark = conn->clientConnection->nfConnmark;
+
+        for (const auto &m : marks) {
+            if (m.matches(connmark)) {
+                debugs(28, 5, "found " << m << " matching " << asHex(connmark));
+                return 1;
+            }
+            debugs(28, 7, "skipped " << m << " mismatching " << asHex(connmark));
         }
-        debugs(28, 7, "skipped " << m << " mismatching " << asHex(connmark));
+    } else {
+        debugs(28, 7, "Can't do CONNMARK check. No client connection");
     }
+
     return 0;
 }
 


### PR DESCRIPTION
Also affects the deprecated clientside_mark ACL.

Broken since CONNMARK matching was added in commit 653d992.