### PR TITLE
Fix memory leak when rejecting SNMP queries

### DIFF
--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -409,6 +409,7 @@ snmpDecodePacket(SnmpRequest * rq)
             snmpConstructReponse(rq);
         } else {
             debugs(49, DBG_IMPORTANT, "WARNING: SNMP agent query DENIED from : " << rq->from);
+            snmp_free_pdu(PDU);
         }
         xfree(Community);
 


### PR DESCRIPTION
SNMP queries denied by snmp_access rules and queries with certain
unsupported SNMPv2 commands were leaking a few hundred bytes each. Such
queries trigger "SNMP agent query DENIED from..." WARNINGs in cache.log.