### PR TITLE
Update netdb when tunneling requests

### DIFF
--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -27,6 +27,7 @@
 #include "globals.h"
 #include "http.h"
 #include "http/Stream.h"
+#include "icmp/net_db.h"
 #include "HttpRequest.h"
 #include "ip/QosConfig.h"
 #include "LogTags.h"
@@ -1049,6 +1050,8 @@ tunnelConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xe
     if (conn->getPeer() && conn->getPeer()->options.no_delay)
         tunnelState->server.setDelayId(DelayId());
 #endif
+
+    netdbPingSite(tunnelState->request->url.host());
 
     tunnelState->request->hier.resetPeerNotes(conn, tunnelState->getHost());
 


### PR DESCRIPTION
Updating netdb on tunneled transactions (e.g., CONNECT requests) is
especially important for origin servers that are only reached via
tunnels. Without updates, requests for such sites may always through a
cache_peer, even if a direct connection to them is much faster.