### PR TITLE
Default value 1.0 of netdbEntry::rtt cause squid always try direct connect

### DIFF
--- a/src/icmp/net_db.h
+++ b/src/icmp/net_db.h
@@ -55,7 +55,7 @@ public:
     int pings_sent = 0;
     int pings_recv = 0;
     double hops = 0;
-    double rtt = 1.0;
+    double rtt = 0.0;
     time_t next_ping_time = 0;
     time_t last_use_time = 0;
     int link_count = 0;


### PR DESCRIPTION
netdbEntry::rtt value is initialized to 1.0, in peer selection, it will be treated as a very nearby host, and will try direct connect. This become a problem if the actual host is actually unreachable, but it never replies echo ICMP nor does the intermediate routers replies Network Unreachable ICMP. In our case, squid just keeps trying direct connect and fail, instead of using parents.

I am not sure if changing default to 0.0 will cause other problems, but after browsing the code I only found comparisons with rtt, so I guess it is ok. And from our daily use, there is no strange behaviors.