### PR TITLE
 Cleanup: Use SBuf for peer Digest labels

### DIFF
--- a/src/CacheDigest.cc
+++ b/src/CacheDigest.cc
@@ -217,7 +217,7 @@ cacheDigestGuessStatsUpdate(CacheDigestGuessStats * stats, int real_hit, int gue
 }
 
 void
-cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * sentry, const char *label)
+cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * sentry, const SBuf &label)
 {
     const int true_count = stats->trueHits + stats->trueMisses;
     const int false_count = stats->falseHits + stats->falseMisses;
@@ -225,15 +225,15 @@ cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * se
     const int miss_count = stats->trueMisses + stats->falseMisses;
     const int tot_count = true_count + false_count;
 
-    assert(label);
+    assert(!label.isEmpty());
     assert(tot_count == hit_count + miss_count);    /* paranoid */
 
     if (!tot_count) {
-        storeAppendPrintf(sentry, "no guess stats for %s available\n", label);
+        storeAppendPrintf(sentry, "no guess stats for " SQUIDSBUFPH " available\n", SQUIDSBUFPRINT(label));
         return;
     }
 
-    storeAppendPrintf(sentry, "Digest guesses stats for %s:\n", label);
+    storeAppendPrintf(sentry, "Digest guesses stats for " SQUIDSBUFPH ":\n", SQUIDSBUFPRINT(label));
     storeAppendPrintf(sentry, "guess\t hit\t\t miss\t\t total\t\t\n");
     storeAppendPrintf(sentry, " \t #\t %%\t #\t %%\t #\t %%\t\n");
     storeAppendPrintf(sentry, "true\t %d\t %.2f\t %d\t %.2f\t %d\t %.2f\n",

--- a/src/CacheDigest.cc
+++ b/src/CacheDigest.cc
@@ -253,13 +253,13 @@ cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * se
 }
 
 void
-cacheDigestReport(CacheDigest * cd, const char *label, StoreEntry * e)
+cacheDigestReport(CacheDigest * cd, const SBuf &label, StoreEntry * e)
 {
     CacheDigestStats stats;
     assert(cd && e);
     cacheDigestStats(cd, &stats);
-    storeAppendPrintf(e, "%s digest: size: %d bytes\n",
-                      label ? label : "", stats.bit_count / 8
+    storeAppendPrintf(e, SQUIDSBUFPH " digest: size: %d bytes\n",
+                      SQUIDSBUFPRINT(label), stats.bit_count / 8
                      );
     storeAppendPrintf(e, "\t entries: count: %" PRIu64 " capacity: %" PRIu64 " util: %d%%\n",
                       cd->count,

--- a/src/CacheDigest.h
+++ b/src/CacheDigest.h
@@ -62,7 +62,7 @@ public:
 
 void cacheDigestGuessStatsUpdate(CacheDigestGuessStats * stats, int real_hit, int guess_hit);
 void cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * sentry, const char *label);
-void cacheDigestReport(CacheDigest * cd, const char *label, StoreEntry * e);
+void cacheDigestReport(CacheDigest * cd, const SBuf &label, StoreEntry * e);
 
 #endif /* SQUID_CACHEDIGEST_H_ */
 

--- a/src/CacheDigest.h
+++ b/src/CacheDigest.h
@@ -61,7 +61,7 @@ public:
 };
 
 void cacheDigestGuessStatsUpdate(CacheDigestGuessStats * stats, int real_hit, int guess_hit);
-void cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * sentry, const char *label);
+void cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * sentry, const SBuf &label);
 void cacheDigestReport(CacheDigest * cd, const SBuf &label, StoreEntry * e);
 
 #endif /* SQUID_CACHEDIGEST_H_ */

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -81,7 +81,7 @@ public:
 
     CachePeer *peer = nullptr;          /**< pointer back to peer structure, argh */
     CacheDigest *cd = nullptr;            /**< actual digest structure */
-    String host;                /**< copy of peer->host */
+    SBuf host;                        ///< copy of peer->host
     const char *req_result = nullptr;     /**< text status of the last request */
 
     struct {

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -703,8 +703,10 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
 static int
 peerDigestFetchedEnough(DigestFetchState * fetch, char *buf, ssize_t size, const char *step_name)
 {
+    static const SBuf hostUnknown("<unknown>"); // peer host (if any)
+    SBuf host = hostUnknown;
+
     PeerDigest *pd = NULL;
-    const char *host = "<unknown>"; /* peer host */
     const char *reason = NULL;  /* reason for completion */
     const char *no_bug = NULL;  /* successful completion if set */
     const int pdcb_valid = cbdataReferenceValid(fetch->pd);
@@ -725,7 +727,7 @@ peerDigestFetchedEnough(DigestFetchState * fetch, char *buf, ssize_t size, const
 #endif
 
         else
-            host = pd->host.termedBuf();
+            host = pd->host;
     }
 
     debugs(72, 6, step_name << ": peer " << host << ", offset: " <<
@@ -834,8 +836,7 @@ static void
 peerDigestPDFinish(DigestFetchState * fetch, int pcb_valid, int err)
 {
     PeerDigest *pd = fetch->pd;
-    const char *host = pd->host.termedBuf();
-
+    const auto host = pd->host;
     pd->times.received = squid_curtime;
     pd->times.req_delay = fetch->resp_time;
     pd->stats.sent.kbytes += fetch->sent.bytes;
@@ -931,7 +932,7 @@ peerDigestSetCBlock(PeerDigest * pd, const char *buf)
 {
     StoreDigestCBlock cblock;
     int freed_size = 0;
-    const char *host = pd->host.termedBuf();
+    const auto host = pd->host;
 
     memcpy(&cblock, buf, sizeof(cblock));
     /* network -> host conversions */
@@ -1050,10 +1051,10 @@ peerDigestStatsReport(const PeerDigest * pd, StoreEntry * e)
 
     assert(pd);
 
-    const char *host = pd->host.termedBuf();
-    storeAppendPrintf(e, "\npeer digest from %s\n", host);
+    auto host = pd->host;
+    storeAppendPrintf(e, "\npeer digest from " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(host));
 
-    cacheDigestGuessStatsReport(&pd->stats.guess, e, host);
+    cacheDigestGuessStatsReport(&pd->stats.guess, e, host.c_str());
 
     storeAppendPrintf(e, "\nevent\t timestamp\t secs from now\t secs from init\n");
     appendTime(initialized);

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -1054,7 +1054,7 @@ peerDigestStatsReport(const PeerDigest * pd, StoreEntry * e)
     auto host = pd->host;
     storeAppendPrintf(e, "\npeer digest from " SQUIDSBUFPH "\n", SQUIDSBUFPRINT(host));
 
-    cacheDigestGuessStatsReport(&pd->stats.guess, e, host.c_str());
+    cacheDigestGuessStatsReport(&pd->stats.guess, e, host);
 
     storeAppendPrintf(e, "\nevent\t timestamp\t secs from now\t secs from init\n");
     appendTime(initialized);

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1583,7 +1583,8 @@ statPeerSelect(StoreEntry * sentry)
     const int tot_used = f->cd.times_used + f->icp.times_used;
 
     /* totals */
-    cacheDigestGuessStatsReport(&f->cd.guess, sentry, "all peers");
+    static const SBuf label("all peers");
+    cacheDigestGuessStatsReport(&f->cd.guess, sentry, label);
     /* per-peer */
     storeAppendPrintf(sentry, "\nPer-peer statistics:\n");
 

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -197,7 +197,8 @@ storeDigestReport(StoreEntry * e)
     }
 
     if (store_digest) {
-        cacheDigestReport(store_digest, "store", e);
+        static const SBuf label("store");
+        cacheDigestReport(store_digest, label, e);
         storeAppendPrintf(e, "\t added: %d rejected: %d ( %.2f %%) del-ed: %d\n",
                           sd_stats.add_count,
                           sd_stats.rej_count,

--- a/src/tests/stub_CacheDigest.cc
+++ b/src/tests/stub_CacheDigest.cc
@@ -27,7 +27,7 @@ void CacheDigest::add(const cache_key *) STUB
 void CacheDigest::remove(const cache_key *) STUB
 double CacheDigest::usedMaskPercent() const STUB_RETVAL(0.0)
 void cacheDigestGuessStatsUpdate(CacheDigestGuessStats *, int, int) STUB
-void cacheDigestGuessStatsReport(const CacheDigestGuessStats *, StoreEntry *, const char *) STUB
+void cacheDigestGuessStatsReport(const CacheDigestGuessStats *, StoreEntry *, const SBuf &) STUB
 void cacheDigestReport(CacheDigest *, const SBuf &, StoreEntry *) STUB
 uint32_t CacheDigest::CalcMaskSize(uint64_t, uint8_t) STUB_RETVAL(1)
 

--- a/src/tests/stub_CacheDigest.cc
+++ b/src/tests/stub_CacheDigest.cc
@@ -28,6 +28,6 @@ void CacheDigest::remove(const cache_key *) STUB
 double CacheDigest::usedMaskPercent() const STUB_RETVAL(0.0)
 void cacheDigestGuessStatsUpdate(CacheDigestGuessStats *, int, int) STUB
 void cacheDigestGuessStatsReport(const CacheDigestGuessStats *, StoreEntry *, const char *) STUB
-void cacheDigestReport(CacheDigest *, const char *, StoreEntry *) STUB
+void cacheDigestReport(CacheDigest *, const SBuf &, StoreEntry *) STUB
 uint32_t CacheDigest::CalcMaskSize(uint64_t, uint8_t) STUB_RETVAL(1)
 


### PR DESCRIPTION
... removing one more unnecessary use of String.