### PR TITLE
Squid crashes when ICAPS and a sslcrtvalidator used together

### DIFF
--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -741,7 +741,7 @@ Adaptation::Icap::Xaction::handleSecuredPeer(Security::EncryptorAnswer &answer)
     securer = NULL;
 
     if (closer != NULL) {
-        if (answer.conn != NULL && answer.conn->isOpen())
+        if (Comm::IsConnOpen(answer.conn))
             comm_remove_close_handler(answer.conn->fd, closer);
         else
             closer->cancel("securing completed");

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -741,7 +741,7 @@ Adaptation::Icap::Xaction::handleSecuredPeer(Security::EncryptorAnswer &answer)
     securer = NULL;
 
     if (closer != NULL) {
-        if (answer.conn != NULL)
+        if (answer.conn != NULL && answer.conn->isOpen())
             comm_remove_close_handler(answer.conn->fd, closer);
         else
             closer->cancel("securing completed");


### PR DESCRIPTION
Squid hits an assertions when tries to remove an comm_close handler from
the already closed connection object.

This is a Measurement Factory project