### PR TITLE
Switching SSL_library_init with OPENSSL_init_ssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1331,7 +1331,7 @@ if test "x$with_openssl" = "xyes"; then
     AC_CHECK_LIB(crypto,[CRYPTO_new_ex_data],[LIBOPENSSL_LIBS="-lcrypto $LIBOPENSSL_LIBS"],[
       AC_MSG_ERROR([library 'crypto' is required for OpenSSL])
     ],$LIBOPENSSL_LIBS)
-    AC_CHECK_LIB(ssl,[SSL_library_init],[LIBOPENSSL_LIBS="-lssl $LIBOPENSSL_LIBS"],[
+    AC_CHECK_LIB(ssl,[OPENSSL_init_ssl],[LIBOPENSSL_LIBS="-lssl $LIBOPENSSL_LIBS"],[
       AC_MSG_ERROR([library 'ssl' is required for OpenSSL])
     ],$LIBOPENSSL_LIBS)
   ])


### PR DESCRIPTION
As explained here https://github.com/tsiv/ccminer-cryptonight/issues/25

Tested on Debian GNU/Linux 9 (stretch)

