### PR TITLE
Use and prefer pkg-config when ./configure-ing libxml2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -900,41 +900,45 @@ fi
 
 AC_ARG_WITH(libxml2, AS_HELP_STRING([--without-libxml2],[Do not use libxml2 for ESI. Default: auto-detect]))
 if test "x$squid_opt_use_esi" != "xno" -a "x$with_libxml2" != "xno" ; then
-  AC_CHECK_LIB([xml2], [main], [XMLLIB="-lxml2"; HAVE_LIBXML2=1])
-  dnl Find the main header and include path...
-  AC_CACHE_CHECK([location of libxml2 include files], [ac_cv_libxml2_include], [
-    AC_CHECK_HEADERS([libxml/parser.h], [], [
-      AC_MSG_NOTICE([Testing in /usr/include/libxml2])
-      SAVED_CPPFLAGS="$CPPFLAGS"
-      CPPFLAGS="-I/usr/include/libxml2 $CPPFLAGS"
-      unset ac_cv_header_libxml_parser_h
-      AC_CHECK_HEADERS([libxml/parser.h], [ac_cv_libxml2_include="-I/usr/include/libxml2"], [
-        AC_MSG_NOTICE([Testing in /usr/local/include/libxml2])
-        CPPFLAGS="-I/usr/local/include/libxml2 $SAVED_CPPFLAGS"
+  SQUID_STATE_SAVE([squid_libxml2_save])
+  PKG_CHECK_MODULES([LIBXML2],[libxml-2.0],[],[
+    AC_CHECK_LIB([xml2], [main], [LIBXML2_LIBS="$LIBXML2_LIBS -lxml2"])
+    dnl Find the main header and include path...
+    AC_CACHE_CHECK([location of libxml2 include files], [ac_cv_libxml2_include], [
+      AC_CHECK_HEADERS([libxml/parser.h], [], [
+        AC_MSG_NOTICE([Testing in /usr/include/libxml2])
+        SAVED_CPPFLAGS="$CPPFLAGS"
+        CPPFLAGS="-I/usr/include/libxml2 $CPPFLAGS"
         unset ac_cv_header_libxml_parser_h
-        AC_CHECK_HEADERS([libxml/parser.h], [ac_cv_libxml2_include="-I/usr/local/include/libxml2"], [
-          AC_MSG_NOTICE([Failed to find libxml2 header file libxml/parser.h])
+        AC_CHECK_HEADERS([libxml/parser.h], [LIBXML2_CFLAGS="$LIBXML2_CFLAGS -I/usr/include/libxml2"], [
+          AC_MSG_NOTICE([Testing in /usr/local/include/libxml2])
+          CPPFLAGS="-I/usr/local/include/libxml2 $SAVED_CPPFLAGS"
+          unset ac_cv_header_libxml_parser_h
+          AC_CHECK_HEADERS([libxml/parser.h], [LIBXML2_CFLAGS="$LIBXML2_CFLAGS -I/usr/local/include/libxml2"], [
+            AC_MSG_NOTICE([Failed to find libxml2 header file libxml/parser.h])
+          ])
         ])
+        CPPFLAGS="$SAVED_CPPFLAGS"
       ])
-      CPPFLAGS="$SAVED_CPPFLAGS"
     ])
   ])
-  if test "x$ac_cv_libxml2_include" != "x"; then
-      SQUID_CXXFLAGS="$ac_cv_libxml2_include $SQUID_CXXFLAGS"
-      CPPFLAGS="$ac_cv_libxml2_include $CPPFLAGS"
-  fi
+  CPPFLAGS="$CPPFLAGS $LIBXML2_CFLAGS"
   dnl Now that we know where to look find the headers...
   AC_CHECK_HEADERS(libxml/parser.h libxml/HTMLparser.h libxml/HTMLtree.h)
-  AC_DEFINE_UNQUOTED(HAVE_LIBXML2, $HAVE_LIBXML2, [Define to 1 if you have the libxml2 library])
-  AS_IF(test "x$HAVE_LIBXML2" = "x1",[
+  SQUID_STATE_ROLLBACK([squid_libxml2_save])
+
+  if test "x$LIBXML2_LIBS" != "x"; then
+    HAVE_LIBXML2=1
     squid_opt_use_esi=yes
-  ],[
-    AS_IF(test "x$with_libxml2" = "xyes",[
-      AC_MSG_ERROR([Required library libxml2 not found.])
-    ],[
-      AC_MSG_NOTICE([Library libxml2 not found.])
-    ])
-  ])
+    SQUID_CXXFLAGS="$SQUID_CXXFLAGS $LIBXML2_CFLAGS"
+    CPPFLAGS="$CPPFLAGS $LIBXML2_CFLAGS"
+    XMLLIB="$LIBXML2_LIBS"
+    AC_DEFINE_UNQUOTED(HAVE_LIBXML2, $HAVE_LIBXML2, [Define to 1 if you have the libxml2 library])
+  elif test "x$with_libxml2" = "xyes"; then
+    AC_MSG_ERROR([Required library libxml2 not found])
+  else
+    AC_MSG_NOTICE([Library libxml2 not found.])
+  fi
 fi
 
 AS_IF([test "x$squid_opt_use_esi" = "xyes"],[


### PR DESCRIPTION
The old method of trying to locate libxml2 via AC_CHECK_LIB() is
preserved to accommodate environments without pkg-config. 

pkg-config knows about libxml2 dependencies like lz or -liconv that the
old method misses.