### PR TITLE
Fixed on_unsupported_protocol tunnel action

### DIFF
--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -63,8 +63,10 @@ SBuf
 AnyP::Uri::hostOrIp() const
 {
     static char ip[MAX_IPSTRLEN];
-    SBuf hostOrIp_(hostIsNumeric() ? hostIP().toStr(ip, sizeof(ip)) : host());
-    return hostOrIp_;
+    if (hostIsNumeric())
+        return  SBuf(hostIP().toStr(ip, sizeof(ip)));
+    else
+        return SBuf(host());
 }
 
 const SBuf &

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -59,6 +59,14 @@ AnyP::Uri::host(const char *src)
     touch();
 }
 
+SBuf
+AnyP::Uri::hostOrIp() const
+{
+    static char ip[MAX_IPSTRLEN];
+    SBuf hostOrIp_(hostIsNumeric() ? hostIP().toStr(ip, sizeof(ip)) : host());
+    return hostOrIp_;
+}
+
 const SBuf &
 AnyP::Uri::path() const
 {

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -64,7 +64,7 @@ AnyP::Uri::hostOrIp() const
 {
     static char ip[MAX_IPSTRLEN];
     if (hostIsNumeric())
-        return  SBuf(hostIP().toStr(ip, sizeof(ip)));
+        return SBuf(hostIP().toStr(ip, sizeof(ip)));
     else
         return SBuf(host());
 }

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -80,7 +80,9 @@ public:
     int hostIsNumeric(void) const {return hostIsNumeric_;}
     Ip::Address const & hostIP(void) const {return hostAddr_;}
 
-    /// \return the hostname or the unformatted ip address
+    /// \returns the host subcomponent of the authority component
+    /// If the host is an IPv6 address, returns that IP address without
+    /// [brackets]! See RFC 3986 Section 3.2.2.
     SBuf hostOrIp() const;
 
     void port(unsigned short p) {port_=p; touch();}

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -80,6 +80,9 @@ public:
     int hostIsNumeric(void) const {return hostIsNumeric_;}
     Ip::Address const & hostIP(void) const {return hostAddr_;}
 
+    /// \return the hostname or the unformatted ip address
+    SBuf hostOrIp() const;
+
     void port(unsigned short p) {port_=p; touch();}
     unsigned short port() const {return port_;}
     /// reset the port to the default port number for the current scheme

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2675,18 +2675,18 @@ ConnStateData::sslCrtdHandleReply(const Helper::Reply &reply)
     }
 
     if (reply.result == Helper::BrokenHelper) {
-        debugs(33, 5, HERE << "Certificate for " << tlsConnectHostOrIp << " cannot be generated. ssl_crtd response: " << reply);
+        debugs(33, 5, "Certificate for " << tlsConnectHostOrIp << " cannot be generated. ssl_crtd response: " << reply);
     } else if (!reply.other().hasContent()) {
         debugs(1, DBG_IMPORTANT, HERE << "\"ssl_crtd\" helper returned <NULL> reply.");
     } else {
         Ssl::CrtdMessage reply_message(Ssl::CrtdMessage::REPLY);
         if (reply_message.parse(reply.other().content(), reply.other().contentSize()) != Ssl::CrtdMessage::OK) {
-            debugs(33, 5, HERE << "Reply from ssl_crtd for " << tlsConnectHostOrIp << " is incorrect");
+            debugs(33, 5, "Reply from ssl_crtd for " << tlsConnectHostOrIp << " is incorrect");
         } else {
             if (reply.result != Helper::Okay) {
-                debugs(33, 5, HERE << "Certificate for " << tlsConnectHostOrIp << " cannot be generated. ssl_crtd response: " << reply_message.getBody());
+                debugs(33, 5, "Certificate for " << tlsConnectHostOrIp << " cannot be generated. ssl_crtd response: " << reply_message.getBody());
             } else {
-                debugs(33, 5, HERE << "Certificate for " << tlsConnectHostOrIp << " was successfully recieved from ssl_crtd");
+                debugs(33, 5, "Certificate for " << tlsConnectHostOrIp << " was successfully recieved from ssl_crtd");
                 if (sslServerBump && (sslServerBump->act.step1 == Ssl::bumpPeek || sslServerBump->act.step1 == Ssl::bumpStare)) {
                     doPeekAndSpliceStep();
                     auto ssl = fd_table[clientConnection->fd].ssl.get();
@@ -3188,9 +3188,9 @@ ConnStateData::httpsPeeked(PinnedIdleContext pic)
 
     if (Comm::IsConnOpen(pic.connection)) {
         notePinnedConnectionBecameIdle(pic);
-        debugs(33, 5, HERE << "bumped HTTPS server: " << tlsConnectHostOrIp);
+        debugs(33, 5, "bumped HTTPS server: " << tlsConnectHostOrIp);
     } else
-        debugs(33, 5, HERE << "Error while bumping: " << tlsConnectHostOrIp);
+        debugs(33, 5, "Error while bumping: " << tlsConnectHostOrIp);
 
     getSslContextStart();
 }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1570,7 +1570,7 @@ ConnStateData::tunnelOnError(const HttpRequestMethod &method, const err_type req
     checklist.my_addr = clientConnection->local;
     checklist.conn(this);
     const char *log_uri = http ? http->log_uri : nullptr;
-    checklist.syncAle(request.getRaw(), log_uri);
+    checklist.syncAle(request, log_uri);
     auto answer = checklist.fastCheck();
     if (answer.allowed() && answer.kind == 1) {
         debugs(33, 3, "Request will be tunneled to server");

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2987,7 +2987,7 @@ ConnStateData::switchToHttps(ClientHttpRequest *http, Ssl::BumpMode bumpServerMo
 
     // If the protocol has changed, then reset preservingClientData_.
     // Otherwise, its value initially set in start() is still valid/fresh.
-    // Requires parsingTlsHandshake which is initialized above.
+    // shouldPreserveClientData() uses parsingTlsHandshake which is reset above.
     if (insideConnectTunnel)
         preservingClientData_ = shouldPreserveClientData();
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2265,7 +2265,7 @@ ConnStateData::start()
         whenClientIpKnown();
 
     // requires needProxyProtocolHeader_ which is initialized above
-    preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
+    preservingClientData_ = shouldPreserveClientData();
 }
 
 void
@@ -2957,7 +2957,7 @@ ConnStateData::switchToHttps(ClientHttpRequest *http, Ssl::BumpMode bumpServerMo
     // If the protocol has changed, then reset preservingClientData_.
     // Otherwise, its value initially set in start() is still valid/fresh.
     if (insideConnectTunnel)
-        preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
+        preservingClientData_ = shouldPreserveClientData();
 
     // We are going to read new request
     flags.readMore = true;
@@ -4013,7 +4013,7 @@ ConnStateData::checkLogging()
 }
 
 bool
-ConnStateData::preserveHttpBytesForTunnellingUnsupportedProto() const
+ConnStateData::shouldPreserveClientData() const
 {
     // do not tunnel on errors while expecting PROXY protocol bytes
     if (needProxyProtocolHeader_)

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4026,6 +4026,10 @@ ConnStateData::shouldPreserveClientData() const
     if (!Config.accessList.on_unsupported_protocol)
         return false;
 
+    // Exclude FTP ports. They do not support on_unsupported_protocol.
+    if (port->transport.protocol == AnyP::PROTO_FTP)
+        return false;
+
 #if USE_OPENSSL
     // We are parsing client hello request
     if (parsingTlsHandshake)
@@ -4036,8 +4040,7 @@ ConnStateData::shouldPreserveClientData() const
         return true;
 #endif
 
-    // the 1st HTTP or FTP request on a connection to a plain intercepting port
-    // XXX: Exclude FTP ports. They do not support on_unsupported_protocol.
+    // the 1st HTTP request on a connection to a plain intercepting port
     if (!pipeline.nrequests && !port->secure.encryptTransport && transparent())
         return true;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2248,6 +2248,8 @@ ConnStateData::start()
     } else
         whenClientIpKnown();
 
+    // requires needProxyProtocolHeader_ which is initialized above
+    preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
 }
 
 void
@@ -3994,6 +3996,10 @@ ConnStateData::checkLogging()
 bool
 ConnStateData::preserveHttpBytesForTunnellingUnsupportedProto() const
 {
+    // do not tunnel on errors while expecting PROXY protocol bytes
+    if (needProxyProtocolHeader_)
+        return false;
+
     // If our decision here is negative, configuration changes are irrelevant.
     // Otherwise, clientTunnelOnError() rechecks configuration before tunneling.
     if (!Config.accessList.on_unsupported_protocol)

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4016,14 +4016,12 @@ ConnStateData::preserveHttpBytesForTunnellingUnsupportedProto() const
 #if USE_OPENSSL
     // The first HTTP request on a bumped connection.
     // XXX: sslBumpMode != bumpEnd includes non-bumped bumpSplice and bumpNone.
-    // XXX: parsedBumpedRequestCount == 1 means the _second_ HTTP request
-    if (sslBumpMode != Ssl::bumpEnd && parsedBumpedRequestCount <= 1)
+    if (!parsedBumpedRequestCount && sslBumpMode != Ssl::bumpEnd)
         return true;
 #endif
 
     // the first request in a connection to a plain intercepting port
-    // XXX: pipeline.nrequests == 1 may mean the _second_ request
-    if (!port->secure.encryptTransport && transparent() && pipeline.nrequests <= 1)
+    if (!pipeline.nrequests && !port->secure.encryptTransport && transparent())
         return true;
 
     return false;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4018,7 +4018,7 @@ ConnStateData::checkLogging()
 bool
 ConnStateData::shouldPreserveClientData() const
 {
-    // do not tunnel on errors while expecting PROXY protocol bytes
+    // PROXY protocol bytes are meant for us and, hence, cannot be tunneled
     if (needProxyProtocolHeader_)
         return false;
 
@@ -4027,7 +4027,7 @@ ConnStateData::shouldPreserveClientData() const
     if (!Config.accessList.on_unsupported_protocol)
         return false;
 
-    // Exclude FTP ports. They do not support on_unsupported_protocol.
+    // TODO: Explain why we do not tunnel intercepted ftp_port bytes.
     if (port->transport.protocol == AnyP::PROTO_FTP)
         return false;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1934,7 +1934,7 @@ ConnStateData::clientParseRequests()
             // for some lookups, ie rDNS and IDENT.
             whenClientIpKnown();
 
-            // Done with the PROXY protocol which clears preservingClientData_.
+            // Done with PROXY protocol which has cleared preservingClientData_.
             // If the next protocol supports on_unsupported_protocol, then its
             // parseOneRequest() must reset preservingClientData_.
             assert(!preservingClientData_);
@@ -2950,7 +2950,7 @@ ConnStateData::switchToHttps(ClientHttpRequest *http, Ssl::BumpMode bumpServerMo
     const auto insideConnectTunnel = receivedFirstByte_;
     debugs(33, 5, (insideConnectTunnel ? "post-CONNECT " : "raw TLS ") << clientConnection);
 
-    tlsConnectHostOrIp =  request->url.hostOrIp();
+    tlsConnectHostOrIp = request->url.hostOrIp();
     tlsConnectPort = request->url.port();
     resetSslCommonName(request->url.host());
 
@@ -4025,13 +4025,14 @@ ConnStateData::shouldPreserveClientData() const
         return false;
 
 #if USE_OPENSSL
-    // The first HTTP request on a bumped connection.
+    // the 1st HTTP request on a bumped connection
     // XXX: sslBumpMode != bumpEnd includes non-bumped bumpSplice and bumpNone.
     if (!parsedBumpedRequestCount && sslBumpMode != Ssl::bumpEnd)
         return true;
 #endif
 
-    // the first request in a connection to a plain intercepting port
+    // the 1st HTTP or FTP request on a connection to a plain intercepting port
+    // XXX: Exclude FTP ports. They do not support on_unsupported_protocol.
     if (!pipeline.nrequests && !port->secure.encryptTransport && transparent())
         return true;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1916,6 +1916,11 @@ ConnStateData::clientParseRequests()
             // we have been waiting for PROXY to provide client-IP
             // for some lookups, ie rDNS and IDENT.
             whenClientIpKnown();
+
+            // Done with the PROXY protocol which clears preservingClientData_.
+            // If the next protocol supports on_unsupported_protocol, then its
+            // parseOneRequest() must reset preservingClientData_.
+            assert(!preservingClientData_);
         }
 
         if (Http::StreamPointer context = parseOneRequest()) {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2727,7 +2727,7 @@ ConnStateData::sslCrtdHandleReply(const Helper::Reply &reply)
 
 void ConnStateData::buildSslCertGenerationParams(Ssl::CertificateProperties &certProperties)
 {
-    certProperties.commonName =  sslCommonName_.isEmpty() ? tlsConnectHostOrIp.c_str() : sslCommonName_.c_str();
+    certProperties.commonName = sslCommonName_.isEmpty() ? tlsConnectHostOrIp.c_str() : sslCommonName_.c_str();
 
     const bool connectedOk = sslServerBump && sslServerBump->connectedOk();
     if (connectedOk) {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4032,7 +4032,6 @@ ConnStateData::shouldPreserveClientData() const
         return false;
 
 #if USE_OPENSSL
-    // We are parsing client hello request
     if (parsingTlsHandshake)
         return true;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4012,7 +4012,7 @@ ConnStateData::shouldPreserveClientData() const
     if (!Config.accessList.on_unsupported_protocol)
         return false;
 
-    // TODO: Explain why we do not tunnel intercepted ftp_port bytes.
+    // TODO: Figure out whether/how we can support FTP tunneling.
     if (port->transport.protocol == AnyP::PROTO_FTP)
         return false;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4000,13 +4000,13 @@ ConnStateData::preserveHttpBytesForTunnellingUnsupportedProto() const
 {
 #if USE_OPENSSL
     // The first HTTP request on a bumped connection.
-    const bool firstBumpedRequest = sslBumpMode != Ssl::bumpEnd && parsedBumpedRequestCount <= 1;
+    const auto firstBumpedRequest = sslBumpMode != Ssl::bumpEnd && parsedBumpedRequestCount <= 1;
 #else
-    const bool firstBumpedRequest = false;
+    const auto firstBumpedRequest = false;
 #endif
 
     // the first request in a connection to a plain intercepting port
-    bool firstTransparentPlainRequest = !port->secure.encryptTransport && transparent() && pipeline.nrequests <= 1;
+    const auto firstTransparentPlainRequest = !port->secure.encryptTransport && transparent() && pipeline.nrequests <= 1;
 
     return firstBumpedRequest || firstTransparentPlainRequest;
 }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2165,7 +2165,8 @@ ConnStateData::requestTimeout(const CommTimeoutCbParams &io)
     if (!Comm::IsConnOpen(io.conn))
         return;
 
-    if (tunnelOnError(HttpRequestMethod(), ERR_REQUEST_START_TIMEOUT))
+    const err_type error = receivedFirstByte_ ? ERR_REQUEST_PARSE_TIMEOUT : ERR_REQUEST_START_TIMEOUT;
+    if (tunnelOnError(HttpRequestMethod(), error))
         return;
 
     /*

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2995,9 +2995,6 @@ ConnStateData::parseTlsHandshake()
     catch (const std::exception &ex) {
         debugs(83, 2, "error on FD " << clientConnection->fd << ": " << ex.what());
         unsupportedProtocol = true;
-
-        // We are still able to tunnel unsupported protocol if allowed
-        ableToTunnelUnsupportedProto_ = true;
     }
 
     parsingTlsHandshake = false;

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -317,7 +317,9 @@ public:
     /// build a fake http request
     ClientHttpRequest *buildFakeRequest(Http::MethodType const method, SBuf &useHost, unsigned short usePort, const SBuf &payload);
 
-    /// TLS or HTTP client data which may need to forward as-is
+    /// From-client handshake bytes (including bytes at the beginning of a
+    /// CONNECT tunnel) which we may need to forward as-is if their syntax does
+    /// not match the expected TLS or HTTP protocol (on_unsupported_protocol).
     SBuf preservedClientData;
 
     /* Registered Runner API */
@@ -366,7 +368,7 @@ protected:
 
     BodyPipe::Pointer bodyPipe; ///< set when we are reading request body
 
-    /// whether preservedClientData_ is valid and should be kept up to date
+    /// whether preservedClientData is valid and should be kept up to date
     bool preservingClientData_;
 
 private:

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -301,12 +301,12 @@ public:
     /// generates and sends to tunnel.cc a fake request with a given payload
     bool initiateTunneledRequest(HttpRequest::Pointer const &cause, Http::MethodType const method, const char *reason, const SBuf &payload);
 
-    /// whether we should preserve incoming data for a future possible
-    /// tunneling of unsupported protocol decision
-    bool preserveDataForTunnellingUnsupportedProto();
+    /// whether we should preserve incoming HTTP request data for a future
+    /// possible tunneling of unsupported protocol decision
+    bool preserveHttpBytesForTunnellingUnsupportedProto() const;
 
     /// whether tunneling of unsupported protocol is allowed for this connection
-    bool ableToTunnelUnsupportedProto() const {return ableToTunnelUnsupportedProto_;}
+    bool ableToTunnelUnsupportedProto() const;
 
     /// build a fake http request
     ClientHttpRequest *buildFakeRequest(Http::MethodType const method, SBuf &useHost, unsigned short usePort, const SBuf &payload);
@@ -361,6 +361,7 @@ protected:
 
     BodyPipe::Pointer bodyPipe; ///< set when we are reading request body
 
+    bool ableToTunnelUnsupportedProto_;
 private:
     /* ::Server API */
     virtual bool connFinishedWithConn(int size);
@@ -427,8 +428,6 @@ private:
     /// If set, are propagated to the current and all future master transactions
     /// on the connection.
     NotePairs::Pointer theNotes;
-
-    bool ableToTunnelUnsupportedProto_;
 };
 
 const char *findTrailingHTTPVersion(const char *uriAndHTTPVersion, const char *end = NULL);

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -398,10 +398,11 @@ private:
 #if USE_OPENSSL
     bool switchedToHttps_;
     bool parsingTlsHandshake; ///< whether we are getting/parsing TLS Hello bytes
-    uint32_t parsedBumpedRequestCount; ///< The number of bumped HTTP requests
+    /// The number of parsed HTTP requests headers on a bumped client connection
+    uint64_t parsedBumpedRequestCount;
 
     /// The SSL server host name appears in CONNECT request or the server ip address for the intercepted requests
-    String sslConnectHostOrIp; ///< The SSL server host name as passed in the CONNECT request
+    SBuf sslConnectHostOrIp; ///< The SSL server host name as passed in the CONNECT request
     unsigned short tlsConnectPort; ///< The TLS server port number as passed in the CONNECT request
     SBuf sslCommonName_; ///< CN name for SSL certificate generation
 

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -398,6 +398,7 @@ private:
 #if USE_OPENSSL
     bool switchedToHttps_;
     bool parsingTlsHandshake; ///< whether we are getting/parsing TLS Hello bytes
+    uint32_t parsedBumpedRequestCount; ///< The number of bumped HTTP requests
 
     /// The SSL server host name appears in CONNECT request or the server ip address for the intercepted requests
     String sslConnectHostOrIp; ///< The SSL server host name as passed in the CONNECT request

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -308,11 +308,16 @@ public:
     /// whether tunneling of unsupported protocol is allowed for this connection
     bool ableToTunnelUnsupportedProto() const;
 
+    /// keep preservedClientData up to date if we may use it later
+    void preserveClientDataIfNeeded() {
+        if (preservingClientData_)
+            preservedClientData = inBuf;
+    }
+
     /// build a fake http request
     ClientHttpRequest *buildFakeRequest(Http::MethodType const method, SBuf &useHost, unsigned short usePort, const SBuf &payload);
 
-    /// client data which may need to forward as-is to server after an
-    /// on_unsupported_protocol tunnel decision.
+    /// TLS or HTTP client data which may need to forward as-is
     SBuf preservedClientData;
 
     /* Registered Runner API */
@@ -361,7 +366,9 @@ protected:
 
     BodyPipe::Pointer bodyPipe; ///< set when we are reading request body
 
-    bool ableToTunnelUnsupportedProto_;
+    /// whether preservedClientData_ is valid and should be kept up to date
+    bool preservingClientData_;
+
 private:
     /* ::Server API */
     virtual bool connFinishedWithConn(int size);

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -305,14 +305,14 @@ public:
     /// possible tunneling of unsupported protocol decision
     bool preserveHttpBytesForTunnellingUnsupportedProto() const;
 
-    /// whether tunneling of unsupported protocol is allowed for this connection
-    bool ableToTunnelUnsupportedProto() const;
-
     /// keep preservedClientData up to date if we may use it later
     void preserveClientDataIfNeeded() {
         if (preservingClientData_)
             preservedClientData = inBuf;
     }
+
+    // TODO: move to the protected section when removing clientTunnelOnError()
+    bool tunnelOnError(const HttpRequestMethod &, const err_type);
 
     /// build a fake http request
     ClientHttpRequest *buildFakeRequest(Http::MethodType const method, SBuf &useHost, unsigned short usePort, const SBuf &payload);

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -301,8 +301,12 @@ public:
     /// generates and sends to tunnel.cc a fake request with a given payload
     bool initiateTunneledRequest(HttpRequest::Pointer const &cause, Http::MethodType const method, const char *reason, const SBuf &payload);
 
+    /// whether we should preserve incoming data for a future possible
+    /// tunneling of unsupported protocol decision
+    bool preserveDataForTunnellingUnsupportedProto();
+
     /// whether tunneling of unsupported protocol is allowed for this connection
-    bool mayTunnelUnsupportedProto();
+    bool ableToTunnelUnsupportedProto() const {return ableToTunnelUnsupportedProto_;}
 
     /// build a fake http request
     ClientHttpRequest *buildFakeRequest(Http::MethodType const method, SBuf &useHost, unsigned short usePort, const SBuf &payload);
@@ -423,6 +427,8 @@ private:
     /// If set, are propagated to the current and all future master transactions
     /// on the connection.
     NotePairs::Pointer theNotes;
+
+    bool ableToTunnelUnsupportedProto_;
 };
 
 const char *findTrailingHTTPVersion(const char *uriAndHTTPVersion, const char *end = NULL);

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -402,7 +402,7 @@ private:
     uint64_t parsedBumpedRequestCount;
 
     /// The SSL server host name appears in CONNECT request or the server ip address for the intercepted requests
-    SBuf sslConnectHostOrIp; ///< The SSL server host name as passed in the CONNECT request
+    SBuf tlsConnectHostOrIp; ///< The SSL server host name as passed in the CONNECT request
     unsigned short tlsConnectPort; ///< The TLS server port number as passed in the CONNECT request
     SBuf sslCommonName_; ///< CN name for SSL certificate generation
 

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -406,8 +406,8 @@ private:
     /// The number of parsed HTTP requests headers on a bumped client connection
     uint64_t parsedBumpedRequestCount;
 
-    /// The SSL server host name appears in CONNECT request or the server ip address for the intercepted requests
-    SBuf tlsConnectHostOrIp; ///< The SSL server host name as passed in the CONNECT request
+    /// The TLS server host name appears in CONNECT request or the server ip address for the intercepted requests
+    SBuf tlsConnectHostOrIp; ///< The TLS server host name as passed in the CONNECT request
     unsigned short tlsConnectPort; ///< The TLS server port number as passed in the CONNECT request
     SBuf sslCommonName_; ///< CN name for SSL certificate generation
 

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -301,9 +301,9 @@ public:
     /// generates and sends to tunnel.cc a fake request with a given payload
     bool initiateTunneledRequest(HttpRequest::Pointer const &cause, Http::MethodType const method, const char *reason, const SBuf &payload);
 
-    /// whether we should preserve incoming HTTP request data for a future
-    /// possible tunneling of unsupported protocol decision
-    bool preserveHttpBytesForTunnellingUnsupportedProto() const;
+    /// whether we should start saving inBuf client bytes in anticipation of
+    /// tunneling them to the server later (on_unsupported_protocol)
+    bool shouldPreserveClientData() const;
 
     /// keep preservedClientData up to date if we may use it later
     void preserveClientDataIfNeeded() {

--- a/src/err_type.h
+++ b/src/err_type.h
@@ -76,6 +76,7 @@ typedef enum {
 
     ERR_SECURE_ACCEPT_FAIL, // Rejects the SSL connection intead of error page
     ERR_REQUEST_START_TIMEOUT, // Aborts the connection instead of error page
+    ERR_REQUEST_PARSE_TIMEOUT, // Aborts the connection instead of error page
     ERR_RELAY_REMOTE, // Sends server reply instead of error page
 
     /* Cache Manager GUI can install a manager index/home page */

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -78,7 +78,7 @@ Http::One::Server::parseOneRequest()
     // a) do not have one already
     // b) have completed the previous request parsing already
     if (!parser_ || !parser_->needsMoreData())
-        parser_ = new Http1::RequestParser(mayTunnelUnsupportedProto());
+        parser_ = new Http1::RequestParser(preserveDataForTunnellingUnsupportedProto());
 
     /* Process request */
     Http::Stream *context = parseHttpRequest(this, parser_);

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -75,7 +75,10 @@ Http::One::Server::parseOneRequest()
 {
     PROF_start(HttpServer_parseOneRequest);
 
+    // reset because the protocol may have changed if this is the first request
+    // and because we never bypass parsing failures of N+1st same-proto request
     preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
+
     // parser is incremental. Generate new parser state if we,
     // a) do not have one already
     // b) have completed the previous request parsing already

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -53,7 +53,6 @@ Http::One::Server::start()
     AsyncCall::Pointer timeoutCall =  JobCallback(33, 5,
                                       TimeoutDialer, this, Http1::Server::requestTimeout);
     commSetConnTimeout(clientConnection, Config.Timeout.request_start_timeout, timeoutCall);
-
     readSomeData();
 }
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -56,7 +56,7 @@ Http::One::Server::start()
 
     // We may want to tunnel intercepted connection if timeout exceed before
     // any bytes are received.
-    ableToTunnelUnsupportedProto_ = preserveHttpBytesForTunnellingUnsupportedProto();
+    preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
 
     readSomeData();
 }
@@ -79,12 +79,12 @@ Http::One::Server::parseOneRequest()
 {
     PROF_start(HttpServer_parseOneRequest);
 
-    ableToTunnelUnsupportedProto_ = preserveHttpBytesForTunnellingUnsupportedProto();
+    preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
     // parser is incremental. Generate new parser state if we,
     // a) do not have one already
     // b) have completed the previous request parsing already
     if (!parser_ || !parser_->needsMoreData())
-        parser_ = new Http1::RequestParser(ableToTunnelUnsupportedProto());
+        parser_ = new Http1::RequestParser(preservingClientData_);
 
     /* Process request */
     Http::Stream *context = parseHttpRequest(this, parser_);

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -85,7 +85,7 @@ Http::One::Server::parseOneRequest()
         parser_ = new Http1::RequestParser(preservingClientData_);
 
     /* Process request */
-    Http::Stream *context = parseHttpRequest(this, parser_);
+    Http::Stream *context = parseHttpRequest(parser_);
 
     PROF_stop(HttpServer_parseOneRequest);
     return context;

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -54,10 +54,6 @@ Http::One::Server::start()
                                       TimeoutDialer, this, Http1::Server::requestTimeout);
     commSetConnTimeout(clientConnection, Config.Timeout.request_start_timeout, timeoutCall);
 
-    // We may want to tunnel intercepted connection if timeout exceed before
-    // any bytes are received.
-    preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
-
     readSomeData();
 }
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -77,7 +77,7 @@ Http::One::Server::parseOneRequest()
 
     // reset because the protocol may have changed if this is the first request
     // and because we never bypass parsing failures of N+1st same-proto request
-    preservingClientData_ = preserveHttpBytesForTunnellingUnsupportedProto();
+    preservingClientData_ = shouldPreserveClientData();
 
     // parser is incremental. Generate new parser state if we,
     // a) do not have one already


### PR DESCRIPTION
Instead of tunneling traffic, a matching on_unsupported_protocol
"tunnel" action resulted in a Squid error response sent to the client
(or, where an error response was not possible, in a connection closure).
The following three cases were fixed:

    * port: http_port (real CONNECT)
    * ssl_bump action: client-first or step1 bump
    * handling phase: parsing TLS client handshake
    * expected data: TLS Client Hello

    * port: http_port (real CONNECT)
    * ssl_bump action: client-first or step1 bump
    * handling phase: parsing the first bumped HTTP request
    * expected data: HTTP request header

    * port: https_port (fake CONNECT)
    * ssl_bump action: any action except terminate
    * handling phase: parsing TLS client handshake
    * expected data: TLS Client Hello

Also, when on_unsupported_protocol was configured, Squid wasted RAM and
CPU cycles to buffer client HTTP requests beyond the point of no return
(i.e., roughly, beyond the first HTTP request on a connection or in a
tunnel), when on_unsupported_protocol settings no longer apply.

Client handshake accumulation is now driven by preservingClientData_. We
set that data member when the connection is accepted (because we may
decide to start preserving bytes right away) and reset it whenever that
decision may change, including when switching to a new protocol inside
CONNECT tunnel and confirming the expected/supported protocol by
successfully parsing its handshake.

Squid does not stop handshake preservation when on_unsupported_protocol
gets disabled during reconfiguration, but Squid will not tunnel
preserved bytes if that happens (and will not tunnel a partial handshake
if on_unsupported_protocol configuration keeps changing).


Also changed how IPv6-based certificates are generated. Their CN field
value is no longer surrounded by [square brackets]. This change was done
to improve Squid code that had to be modified to fix
on_unsupported_protocol. It affects certificate cache key so old
IPv6-based certificates will never be found (and will eventually be
purged) while new ones will be generated and cached instead. We believe
these IPv6-based certificates are rare and untrusted by browsers so the
change in their CN should not have a significant affect on users.

This is a Measurement Factory project.