### PR TITLE
Docs: Improved lexgrog compatibility

### DIFF
--- a/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
+++ b/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
@@ -8,7 +8,7 @@ use Pod::Usage;
 
 =head1 NAME
 
-B<url_lfs_rewrite> - a URL-rewriter based on local file existence
+ url_lfs_rewrite - a URL-rewriter based on local file existence
 
 =head1 SYNOPSIS
 

--- a/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
+++ b/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
@@ -8,7 +8,7 @@ use Pod::Usage;
 
 =head1 NAME
 
-B<url_lfs_rewrite>
+B<url_lfs_rewrite> - a URL-rewriter based on local file existence
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
The generated url_lfs_reqwrite.8 manpage was not parsable by lexgrog:

    $ lexgrog url_lfs_rewrite.8.gz
    url_lfs_rewrite.8.gz: parse failed
