### PR TITLE
Bug 4856: Exit when GoIntoBackground() fork() call fails

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1860,13 +1860,12 @@ GoIntoBackground()
     pid_t pid;
     if ((pid = fork()) < 0) {
         int xerrno = errno;
-        syslog(LOG_ALERT, "fork failed: %s", xstrerr(xerrno));
-        // continue anyway, mimicking --foreground mode (XXX?)
+        throw TexcHere(ToSBuf("failed to fork(2) the master process: ", xstrerr(xerrno)));
     } else if (pid > 0) {
         // parent
         exit(EXIT_SUCCESS);
     }
-    // child, running as a background daemon (or a failed-to-fork parent)
+    // child, running as a background daemon
 }
 
 static void


### PR DESCRIPTION
Ignoring the (implicit/default) command-line instruction to background
Squid is wrong in general and confuses at least some daemon managers.