### PR TITLE
basic_ldap_auth: Return BH on internal errors; polished messages

### DIFF
--- a/src/auth/basic/LDAP/basic_ldap_auth.cc
+++ b/src/auth/basic/LDAP/basic_ldap_auth.cc
@@ -607,9 +607,9 @@ recover:
                 goto recover;
             }
             if (LDAP_SECURITY_ERROR(e))
-                SEND_ERR(HLP_MSG(ldap_err2string(e)));
+                SEND_ERR(ldap_err2string(e));
             else
-                SEND_BH(HLP_MSG(ldap_err2string(e)));
+                SEND_BH(ldap_err2string(e));
         } else {
             SEND_OK("");
         }


### PR DESCRIPTION
Basic LDAP auth helper now returns BH instead of ERR in case of errors
other than LDAP_SECURITY_ERROR, per helper guidelines.

Motivation: I have a wrapper around Basic LDAP auth helper. If an LDAP
server is down, then the helper returns BH, and the wrapper uses
a fallback authentication source.

Also converted printf() to SEND_*() macros and reduced message
verbosity.