### PR TITLE
Fix OpenSSL builds that define OPENSSL_NO_ENGINE

### DIFF
--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -485,7 +485,7 @@ Ssl::Initialize(void)
 
     SQUID_OPENSSL_init_ssl();
 
-#if HAVE_OPENSSL_ENGINE_H
+#if !defined(OPENSSL_NO_ENGINE)
     if (::Config.SSL.ssl_engine) {
         ENGINE_load_builtin_engines();
         ENGINE *e;


### PR DESCRIPTION
Even with ENGINE support disabled, OpenSSL provides the openssl/engine.h
header. We have to use OPENSSL_NO_ENGINE to detect ENGINE support.
