### PR TITLE
Initialize StoreMapSlice when reserving a new cache slot

### DIFF
--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -772,13 +772,15 @@ MemStore::reserveSapForWriting(Ipc::Mem::PageId &page)
 {
     Ipc::Mem::PageId slot;
     if (freeSlots->pop(slot)) {
-        debugs(20, 5, "got a previously free slot: " << slot);
+        const auto slotId = slot.number - 1;
+        debugs(20, 5, "got a previously free slot: " << slotId);
 
         if (Ipc::Mem::GetPage(Ipc::Mem::PageId::cachePage, page)) {
             debugs(20, 5, "and got a previously free page: " << page);
-            return slot.number - 1;
+            map->prepFreeSlice(slotId);
+            return slotId;
         } else {
-            debugs(20, 3, "but there is no free page, returning " << slot);
+            debugs(20, 3, "but there is no free page, returning " << slotId);
             freeSlots->push(slot);
         }
     }
@@ -791,8 +793,10 @@ MemStore::reserveSapForWriting(Ipc::Mem::PageId &page)
         assert(!waitingFor); // noteFreeMapSlice() should have cleared it
         assert(slot.set());
         assert(page.set());
-        debugs(20, 5, "got previously busy " << slot << " and " << page);
-        return slot.number - 1;
+        const auto slotId = slot.number - 1;
+        map->prepFreeSlice(slotId);
+        debugs(20, 5, "got previously busy " << slotId << " and " << page);
+        return slotId;
     }
     assert(waitingFor.slot == &slot && waitingFor.page == &page);
     waitingFor.slot = NULL;

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -190,7 +190,7 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
     // allocate the first slice during the first write
     if (!coreOff) {
         assert(sidCurrent < 0);
-        sidCurrent = dir->reserveSlotForWriting(swap_filen); // throws
+        sidCurrent = dir->reserveSlotForWriting(); // throws on failures
         assert(sidCurrent >= 0);
         writeAnchor().start = sidCurrent;
     }
@@ -207,7 +207,7 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
         // We do not write a full buffer without overflow because
         // we would not yet know what to set the nextSlot to.
         if (overflow) {
-            const SlotId sidNext = dir->reserveSlotForWriting(swap_filen); // throws
+            const auto sidNext = dir->reserveSlotForWriting(); // throws
             assert(sidNext >= 0);
             writeToDisk(sidNext);
         } else if (Store::Root().transientReaders(*e)) {

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -190,7 +190,7 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
     // allocate the first slice during the first write
     if (!coreOff) {
         assert(sidCurrent < 0);
-        sidCurrent = reserveSlotForWriting(); // throws on failures
+        sidCurrent = dir->reserveSlotForWriting(swap_filen); // throws
         assert(sidCurrent >= 0);
         writeAnchor().start = sidCurrent;
     }
@@ -207,7 +207,7 @@ Rock::IoState::tryWrite(char const *buf, size_t size, off_t coreOff)
         // We do not write a full buffer without overflow because
         // we would not yet know what to set the nextSlot to.
         if (overflow) {
-            const SlotId sidNext = reserveSlotForWriting(); // throws
+            const SlotId sidNext = dir->reserveSlotForWriting(swap_filen); // throws
             assert(sidNext >= 0);
             writeToDisk(sidNext);
         } else if (Store::Root().transientReaders(*e)) {
@@ -304,21 +304,6 @@ Rock::IoState::writeBufToDisk(const SlotId sidNext, const bool eof, const bool l
 
     // theFile->write may call writeCompleted immediatelly
     theFile->write(r);
-}
-
-/// finds and returns a free db slot to fill or throws
-Rock::SlotId
-Rock::IoState::reserveSlotForWriting()
-{
-    SlotId slotId;
-    if (dir->useFreeSlot(slotId, swap_filen))
-        return slotId;
-
-    // This may happen when the number of available db slots is close to the
-    // number of concurrent requests reading or writing those slots, which may
-    // happen when the db is "small" compared to the request traffic OR when we
-    // are rebuilding and have not loaded "many" entries or empty slots yet.
-    throw TexcHere("ran out of free db slots");
 }
 
 void

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -310,9 +310,9 @@ Rock::IoState::writeBufToDisk(const SlotId sidNext, const bool eof, const bool l
 Rock::SlotId
 Rock::IoState::reserveSlotForWriting()
 {
-    Ipc::Mem::PageId pageId;
-    if (dir->useFreeSlot(pageId, swap_filen))
-        return pageId.number-1;
+    SlotId slotId;
+    if (dir->useFreeSlot(slotId, swap_filen))
+        return slotId;
 
     // This may happen when the number of available db slots is close to the
     // number of concurrent requests reading or writing those slots, which may

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -311,7 +311,7 @@ Rock::SlotId
 Rock::IoState::reserveSlotForWriting()
 {
     Ipc::Mem::PageId pageId;
-    if (dir->useFreeSlot(pageId))
+    if (dir->useFreeSlot(pageId, swap_filen))
         return pageId.number-1;
 
     // This may happen when the number of available db slots is close to the

--- a/src/fs/rock/RockIoState.h
+++ b/src/fs/rock/RockIoState.h
@@ -66,7 +66,6 @@ private:
     size_t writeToBuffer(char const *buf, size_t size);
     void writeToDisk(const SlotId nextSlot);
     void writeBufToDisk(const SlotId nextSlot, const bool eof, const bool lastWrite);
-    SlotId reserveSlotForWriting();
 
     void callBack(int errflag);
 

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -711,12 +711,14 @@ Rock::SwapDir::diskOffsetLimit() const
 }
 
 bool
-Rock::SwapDir::useFreeSlot(Ipc::Mem::PageId &pageId, const sfileno filen)
+Rock::SwapDir::useFreeSlot(Ipc::StoreMapSliceId &slotId, const sfileno filen)
 {
+    Ipc::Mem::PageId pageId;
+
     if (freeSlots->pop(pageId)) {
-        const auto sid = pageId.number - 1;
-        map->writeableSlice(filen, sid).reset();
-        debugs(47, 5, "got a previously free slot: " << pageId);
+        slotId = pageId.number - 1;
+        map->writeableSlice(filen, slotId).reset();
+        debugs(47, 5, "got a previously free slot: " << slotId);
         return true;
     }
 
@@ -726,9 +728,9 @@ Rock::SwapDir::useFreeSlot(Ipc::Mem::PageId &pageId, const sfileno filen)
     if (map->purgeOne()) {
         assert(!waitingForPage); // noteFreeMapSlice() should have cleared it
         assert(pageId.set());
-        const auto sid = pageId.number - 1;
-        map->writeableSlice(filen, sid).reset();
-        debugs(47, 5, "got a previously busy slot: " << pageId);
+        slotId = pageId.number - 1;
+        map->writeableSlice(filen, slotId).reset();
+        debugs(47, 5, "got a previously busy slot: " << slotId);
         return true;
     }
     assert(waitingForPage == &pageId);

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -711,9 +711,11 @@ Rock::SwapDir::diskOffsetLimit() const
 }
 
 bool
-Rock::SwapDir::useFreeSlot(Ipc::Mem::PageId &pageId)
+Rock::SwapDir::useFreeSlot(Ipc::Mem::PageId &pageId, const sfileno filen)
 {
     if (freeSlots->pop(pageId)) {
+        const auto sid = pageId.number - 1;
+        map->writeableSlice(filen, sid).reset();
         debugs(47, 5, "got a previously free slot: " << pageId);
         return true;
     }
@@ -724,6 +726,8 @@ Rock::SwapDir::useFreeSlot(Ipc::Mem::PageId &pageId)
     if (map->purgeOne()) {
         assert(!waitingForPage); // noteFreeMapSlice() should have cleared it
         assert(pageId.set());
+        const auto sid = pageId.number - 1;
+        map->writeableSlice(filen, sid).reset();
         debugs(47, 5, "got a previously busy slot: " << pageId);
         return true;
     }

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -711,14 +711,14 @@ Rock::SwapDir::diskOffsetLimit() const
 }
 
 Rock::SlotId
-Rock::SwapDir::reserveSlotForWriting(const sfileno filen)
+Rock::SwapDir::reserveSlotForWriting()
 {
     Ipc::Mem::PageId pageId;
 
     if (freeSlots->pop(pageId)) {
         const auto slotId = pageId.number - 1;
-        map->writeableSlice(filen, slotId).reset();
         debugs(47, 5, "got a previously free slot: " << slotId);
+        map->prepFreeSlice(slotId);
         return slotId;
     }
 
@@ -729,8 +729,8 @@ Rock::SwapDir::reserveSlotForWriting(const sfileno filen)
         assert(!waitingForPage); // noteFreeMapSlice() should have cleared it
         assert(pageId.set());
         const auto slotId = pageId.number - 1;
-        map->writeableSlice(filen, slotId).reset();
         debugs(47, 5, "got a previously busy slot: " << slotId);
+        map->prepFreeSlice(slotId);
         return slotId;
     }
     assert(waitingForPage == &pageId);

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -63,7 +63,7 @@ public:
     int64_t slotLimitActual() const; ///< total number of slots in this db
 
     /// removes a slot from a list of free slots or returns false
-    bool useFreeSlot(Ipc::Mem::PageId &pageId, const sfileno);
+    bool useFreeSlot(Ipc::StoreMapSliceId &slotId, const sfileno);
     /// whether the given slot ID may point to a slot in this db
     bool validSlotId(const SlotId slotId) const;
     /// purges one or more entries to make full() false and free some slots

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -63,7 +63,7 @@ public:
     int64_t slotLimitActual() const; ///< total number of slots in this db
 
     /// removes a slot from a list of free slots or returns false
-    bool useFreeSlot(Ipc::Mem::PageId &pageId);
+    bool useFreeSlot(Ipc::Mem::PageId &pageId, const sfileno);
     /// whether the given slot ID may point to a slot in this db
     bool validSlotId(const SlotId slotId) const;
     /// purges one or more entries to make full() false and free some slots

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -62,10 +62,12 @@ public:
     int64_t slotLimitAbsolute() const; ///< Rock store implementation limit
     int64_t slotLimitActual() const; ///< total number of slots in this db
 
-    /// removes a slot from a list of free slots or returns false
-    bool useFreeSlot(Ipc::StoreMapSliceId &slotId, const sfileno);
     /// whether the given slot ID may point to a slot in this db
     bool validSlotId(const SlotId slotId) const;
+
+    /// finds and returns a free db slot to fill or throws
+    SlotId reserveSlotForWriting(const sfileno);
+
     /// purges one or more entries to make full() false and free some slots
     void purgeSome();
 

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -66,7 +66,7 @@ public:
     bool validSlotId(const SlotId slotId) const;
 
     /// finds and returns a free db slot to fill or throws
-    SlotId reserveSlotForWriting(const sfileno);
+    SlotId reserveSlotForWriting();
 
     /// purges one or more entries to make full() false and free some slots
     void purgeSome();

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -360,6 +360,14 @@ Ipc::StoreMap::freeChainAt(SliceId sliceId, const SliceId splicingPoint)
     debugs(54, 7, "freed chain #" << chainId << " in " << path);
 }
 
+void
+Ipc::StoreMap::prepFreeSlice(const SliceId sliceId)
+{
+    // TODO: Move freeSlots here, along with reserveSlotForWriting() logic.
+    assert(validSlice(sliceId));
+    sliceAt(sliceId).reset();
+}
+
 Ipc::StoreMap::SliceId
 Ipc::StoreMap::sliceContaining(const sfileno fileno, const uint64_t bytesNeeded) const
 {

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -346,8 +346,7 @@ Ipc::StoreMap::freeChainAt(SliceId sliceId, const SliceId splicingPoint)
     while (sliceId >= 0) {
         Slice &slice = sliceAt(sliceId);
         const SliceId nextId = slice.next;
-        slice.size = 0;
-        slice.next = -1;
+        slice.clear();
         if (cleaner)
             cleaner->noteFreeMapSlice(sliceId); // might change slice state
         if (sliceId == splicingPoint) {
@@ -365,7 +364,7 @@ Ipc::StoreMap::prepFreeSlice(const SliceId sliceId)
 {
     // TODO: Move freeSlots here, along with reserveSlotForWriting() logic.
     assert(validSlice(sliceId));
-    sliceAt(sliceId).reset();
+    sliceAt(sliceId).clear();
 }
 
 Ipc::StoreMap::SliceId

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -30,7 +30,7 @@ class StoreMapSlice
 public:
     typedef uint32_t Size;
 
-    StoreMapSlice() { reset(); }
+    StoreMapSlice(): size(0), next(-1) {}
     StoreMapSlice(const StoreMapSlice &o) {
         size.exchange(o.size);
         next.exchange(o.next);

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -42,7 +42,8 @@ public:
         return *this;
     }
 
-    void reset() { size = 0; next = -1; }
+    /// restore default-constructed state
+    void clear() { size = 0; next = -1; }
 
     std::atomic<Size> size; ///< slice contents size
     std::atomic<StoreMapSliceId> next; ///< ID of the next entry slice

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -30,7 +30,7 @@ class StoreMapSlice
 public:
     typedef uint32_t Size;
 
-    StoreMapSlice(): size(0), next(-1) {}
+    StoreMapSlice() { reset(); }
     StoreMapSlice(const StoreMapSlice &o) {
         size.exchange(o.size);
         next.exchange(o.next);
@@ -41,6 +41,8 @@ public:
         next.store(o.next);
         return *this;
     }
+
+    void reset() { size = 0; next = -1; }
 
     std::atomic<Size> size; ///< slice contents size
     std::atomic<StoreMapSliceId> next; ///< ID of the next entry slice

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -294,6 +294,9 @@ public:
     /// readable anchor for the entry created by openForReading()
     const Anchor &readableEntry(const AnchorId anchorId) const;
 
+    /// prepare a chain-unaffiliated slice for being added to an entry chain
+    void prepFreeSlice(const SliceId sliceId);
+
     /// Returns the ID of the entry slice containing n-th byte or
     /// a negative ID if the entry does not store that many bytes (yet).
     /// Requires a read lock.


### PR DESCRIPTION
Rock sets the StoreMapSlice::next field when sending a slice to disk. To
avoid writing slice A twice, Rock allocates a new slice B to prime
A.next right before writing A. Scheduling A's writing and, sometimes,
lack of data to fill B create a gap between B's allocation and B's
writing (which sets B.next). During that time, A.next points to B, but
B.next is untouched.

If writing slice A or swapout in general fails, the chain of failed
entry slices (now containing both A and B) is freed. If untouched B.next
contains garbage, then freeChainAt() adds "random" slices after B to the
free slice pool. Subsequent swapouts use those incorrectly freed slices,
effectively overwriting portions of random cache entries, corrupting the
cache.

How did B.next get dirty in the first place? freeChainAt() cleans the
slices it frees, but Rock also makes direct noteFreeMapSlice() calls.
Shared memory cache may have avoided this corruption because it makes no
such calls.

Ipc::StoreMap::prepFreeSlice() now clears allocated slices. Long-term,
we may be able to move free slice management into StoreMap to automate
this cleanup.

Also simplified and polished slot allocation code a little, removing the
Rock::IoState::reserveSlotForWriting() middleman. This change also
improves the symmetry between Rock and shared memory cache code.
