### PR TITLE
Bug 4914: Do not call setsid() in --foreground mode

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1866,6 +1866,7 @@ GoIntoBackground()
         exit(EXIT_SUCCESS);
     }
     // child, running as a background daemon
+    Must(setsid() > 0); // ought to succeed after fork()
 }
 
 static void
@@ -1910,14 +1911,6 @@ watch_child(const CommandLine &masterCommand)
 
     if (!opt_foreground)
         GoIntoBackground();
-
-    // TODO: Fails with --foreground if the calling process is process group
-    //       leader, which is always (?) the case. Should probably moved to
-    //       GoIntoBackground and executed only after successfully forking
-    if (setsid() < 0) {
-        int xerrno = errno;
-        syslog(LOG_ALERT, "setsid failed: %s", xstrerr(xerrno));
-    }
 
     closelog();
 


### PR DESCRIPTION
Squid executed in --foreground is always a process group leader. Thus,
setsid(2) is unnecessary and always fails (with EPERM) for such Squids.