### PR TITLE
Bug 4915: Detect IPv6 loopback binding errors

### DIFF
--- a/src/ip/tools.cc
+++ b/src/ip/tools.cc
@@ -60,7 +60,7 @@ Ip::ProbeTransport()
     // Test for IPv6 loopback/localhost address binding
     Ip::Address ip;
     ip.setLocalhost();
-    if (ip.isIPv6()) { // false on --disable-ipv6 builds
+    if (ip.isIPv6()) { // paranoid; always succeeds if we got this far
         struct sockaddr_in6 sin;
         ip.getSockAddr(sin);
         if (bind(s, reinterpret_cast<struct sockaddr *>(&sin), sizeof(sin)) != 0) {

--- a/src/ip/tools.cc
+++ b/src/ip/tools.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "Debug.h"
+#include "ip/Address.h"
 #include "ip/tools.h"
 
 #if HAVE_UNISTD_H
@@ -55,8 +56,21 @@ Ip::ProbeTransport()
     debugs(3, 2, "Missing RFC 3493 compliance - attempting split IPv4 and IPv6 stacks ...");
     EnableIpv6 |= IPV6_SPECIAL_SPLITSTACK;
 #endif
-    // TODO: attempt to use the socket to connect somewhere ?
-    //  needs to be safe to contact and with guaranteed working IPv6 at the other end.
+
+    // Test for IPv6 loopback/localhost address binding
+    Ip::Address ip;
+    ip.setLocalhost();
+    if (ip.isIPv6()) { // false on --disable-ipv6 builds
+        struct sockaddr_in6 sin;
+        ip.getSockAddr(sin);
+        if (bind(s, reinterpret_cast<struct sockaddr *>(&sin), sizeof(sin)) != 0) {
+            debugs(3, DBG_CRITICAL, "WARNING: BCP 177 violation. Detected non-functional IPv6 loopback.");
+            EnableIpv6 = IPV6_OFF;
+        } else {
+            debugs(3, 2, "Detected functional IPv6 loopback ...");
+        }
+    }
+
     close(s);
 
 #if USE_IPV6


### PR DESCRIPTION
Systems which have been partially 'IPv6 disabled' may allow
sockets to be opened and used but missing the IPv6 loopback
address.

Implement the outstanding TODO to detect such failures and
disable IPv6 support properly within Squid when they are found.

This should fix bug 4915 auth_param helper startup and similar
external_acl_type helper issues. For security such helpers are
not permitted to use the machine default IP address which is
globally accessible.