### PR TITLE
Add support for buffer-size= to UDP logging

### DIFF
--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -166,7 +166,7 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         path += 2;
     }
     strAddr = xstrdup(path);
-    char *flush_time = (char *) strchr(strAddr, ','); 
+    char *flush_time = (char *) strchr(strAddr, ',');
     if (flush_time) {
         *flush_time = '\0';
         ++flush_time;

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -148,14 +148,6 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         path += 2;
     }
     strAddr = xstrdup(path);
-    char *flush_time = (char *) strchr(strAddr, ',');
-    if (flush_time) {
-        *flush_time = '\0';
-        ++flush_time;
-        int flushperiod = atoi(flush_time);
-        /* Start the flush event */
-        eventAdd("logfile_mod_udp_flush", logfileUdpFlushEvent, lf, flushperiod, 1);
-    }
     if (!GetHostWithPort(strAddr, &addr)) {
         if (lf->flags.fatal) {
             fatalf("Invalid UDP logging address '%s'\n", lf->path);

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -109,22 +109,22 @@ logfile_mod_udp_rotate(Logfile *, const int16_t)
 {
 }
 
-/*                                                                             
- * only schedule a flush (write) if one isn't scheduled.                       
- */                                                                            
-static void                                                                    
-logfileUdpFlushEvent(void *data)                                               
-{                                                                              
-    Logfile *lf = static_cast<Logfile *>(data);                                
-                                                                               
-    /*                                                                         
-     * This might work better if we keep track of when we wrote last and only  
-     * schedule a write if we haven't done so in the last second or two.       
-     */                                                                        
-    logfile_mod_udp_flush(lf);                                                 
-    eventAdd("logfile_mod_udp_flush", logfileUdpFlushEvent, lf, 1.0, 1);       
-}                                                                              
-                                                                               
+/*
+ * only schedule a flush (write) if one isn't scheduled.
+ */
+static void
+logfileUdpFlushEvent(void *data)
+{
+    Logfile *lf = static_cast<Logfile *>(data);
+
+    /*
+     * This might work better if we keep track of when we wrote last and only
+     * schedule a write if we haven't done so in the last second or two.
+     */
+    logfile_mod_udp_flush(lf);
+    eventAdd("logfile_mod_udp_flush", logfileUdpFlushEvent, lf, 1.0, 1);
+}
+
 static void
 logfile_mod_udp_close(Logfile * lf)
 {
@@ -229,7 +229,7 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         ll->bufsz = bufsz;
     }
 
-     /* Start the flush event */                                         
+     /* Start the flush event */
      eventAdd("logfile_mod_udp_flush", logfileUdpFlushEvent, lf, 1.0, 1);
 
     return 1;

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -109,29 +109,11 @@ logfile_mod_udp_rotate(Logfile *, const int16_t)
 {
 }
 
-/*
- * only schedule a flush (write) if one isn't scheduled.
- */
-static void
-logfileUdpFlushEvent(void *data)
-{
-    Logfile *lf = static_cast<Logfile *>(data);
-
-    /*
-     * This might work better if we keep track of when we wrote last and only
-     * schedule a write if we haven't done so in the last second or two.
-     */
-    logfile_mod_udp_flush(lf);
-    eventAdd("logfile_mod_udp_flush", logfileUdpFlushEvent, lf, 1.0, 1);
-}
-
 static void
 logfile_mod_udp_close(Logfile * lf)
 {
     l_udp_t *ll = (l_udp_t *) lf->data;
     lf->f_flush(lf);
-
-    eventDelete(logfileUdpFlushEvent, lf);
 
     if (ll->fd >= 0)
         file_close(ll->fd);
@@ -144,7 +126,7 @@ logfile_mod_udp_close(Logfile * lf)
 }
 
 /*
- * This code expects the path to be //host:port,flush_time
+ * This code expects the path to be //host:port
  */
 int
 logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_flag)
@@ -231,7 +213,8 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
      * applications like netcat have a small default receive buffer and will
      * truncate!
      */
-    bufsz = 1400;
+    if (bufsz > 1400)
+        bufsz = 1400;
     if (bufsz > 0) {
         ll->buf = static_cast<char*>(xmalloc(bufsz));
         ll->bufsz = bufsz;

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -144,7 +144,7 @@ logfile_mod_udp_close(Logfile * lf)
 }
 
 /*
- * This code expects the path to be //host:port
+ * This code expects the path to be //host:port,flush_time
  */
 int
 logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_flag)
@@ -166,6 +166,14 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         path += 2;
     }
     strAddr = xstrdup(path);
+    char *flush_time = (char *) strchr(strAddr, ','); 
+    if (flush_time) {
+        *flush_time = '\0';
+        ++flush_time;
+        int flushperiod = atoi(flush_time);
+        /* Start the flush event */
+        eventAdd("logfile_mod_udp_flush", logfileUdpFlushEvent, lf, flushperiod, 1);
+    }
     if (!GetHostWithPort(strAddr, &addr)) {
         if (lf->flags.fatal) {
             fatalf("Invalid UDP logging address '%s'\n", lf->path);
@@ -228,9 +236,6 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         ll->buf = static_cast<char*>(xmalloc(bufsz));
         ll->bufsz = bufsz;
     }
-
-     /* Start the flush event */
-     eventAdd("logfile_mod_udp_flush", logfileUdpFlushEvent, lf, 1.0, 1);
 
     return 1;
 }


### PR DESCRIPTION
Allow admin control of buffering for log outputs written to UDP
receivers using the buffer-size= parameter.

buffer-size=0byte disables buffering and sends UDP packets
immediately regardless of line size.

When non-0 values are used lines shorter than the buffer may be
delayed and aggregated into a later UDP packet.

Log lines larger than the buffer size will be sent immediately
and may trigger delivery of previously buffered content to
retain log order (at time of send, not UDP arrival).

To avoid truncation problems known with common recipients
the buffer size remains capped at 1400 bytes.