### PR TITLE
Bug 4919: master commit b599471 leaks memory

### DIFF
--- a/src/BodyPipe.cc
+++ b/src/BodyPipe.cc
@@ -397,12 +397,14 @@ BodyPipe::postAppend(size_t size)
     thePutSize += size;
     debugs(91,7, HERE << "added " << size << " bytes" << status());
 
-    if (!mayNeedMoreData())
-        clearProducer(true); // reached end-of-body
-
     // We should not consume here even if mustAutoConsume because the
     // caller may not be ready for the data to be consumed during this call.
     scheduleBodyDataNotification();
+
+    // Do this check after scheduleBodyDataNotification() to ensure the
+    // natural order of "more body data" and "production ended" events.
+    if (!mayNeedMoreData())
+        clearProducer(true); // reached end-of-body
 
     startAutoConsumptionIfNeeded();
 }


### PR DESCRIPTION
Restored the natural order of the following two notifications:
* BodyConsumer::noteMoreBodyDataAvailable() and
* BodyConsumer::noteBodyProductionEnded() or noteBodyProducerAborted().

Commit b599471 unintentionally reordered those two notifications. Client
kids (and possibly other BodyConsumers) relied on the natural order to
end their work. If an HttpStateData job was done with the Squid-to-peer
connection and only waiting for the last adapted body bytes, it would
get stuck and leak many objects. This use case was not tested during
b599471 work.