### PR TITLE
Support logformat %codes in error page templates

### DIFF
--- a/src/CacheManager.h
+++ b/src/CacheManager.h
@@ -43,7 +43,7 @@ public:
     Mgr::Action::Pointer createRequestedAction(const Mgr::ActionParams &);
     const Menu& menu() const { return menu_; }
 
-    void Start(const Comm::ConnectionPointer &client, HttpRequest * request, StoreEntry * entry, const AccessLogEntryPointer &);
+    void start(const Comm::ConnectionPointer &client, HttpRequest *request, StoreEntry *entry, const AccessLogEntryPointer &ale);
 
     static CacheManager* GetInstance();
     const char *ActionProtection(const Mgr::ActionProfilePointer &profile);

--- a/src/CacheManager.h
+++ b/src/CacheManager.h
@@ -10,6 +10,7 @@
 #define SQUID_CACHEMANAGER_H
 
 #include "comm/forward.h"
+#include "log/forward.h"
 #include "mgr/Action.h"
 #include "mgr/ActionProfile.h"
 #include "mgr/Command.h"
@@ -42,7 +43,7 @@ public:
     Mgr::Action::Pointer createRequestedAction(const Mgr::ActionParams &);
     const Menu& menu() const { return menu_; }
 
-    void Start(const Comm::ConnectionPointer &client, HttpRequest * request, StoreEntry * entry);
+    void Start(const Comm::ConnectionPointer &client, HttpRequest * request, StoreEntry * entry, const AccessLogEntryPointer &);
 
     static CacheManager* GetInstance();
     const char *ActionProtection(const Mgr::ActionProfilePointer &profile);

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -7,6 +7,7 @@
  */
 
 #include "squid.h"
+#include "base/Here.h"
 #include "cache_cf.h"
 #include "ConfigParser.h"
 #include "Debug.h"
@@ -240,6 +241,12 @@ ConfigParser::SetCfgLine(char *line)
         CfgLineTokens_.pop();
         free(token);
     }
+}
+
+SourceLocation
+ConfigParser::CurrentLocation()
+{
+    return SourceLocation(cfg_directive, cfg_filename, config_lineno);
 }
 
 char *

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -13,6 +13,7 @@
 #include "Debug.h"
 #include "fatal.h"
 #include "globals.h"
+#include "sbuf/Stream.h"
 
 bool ConfigParser::RecognizeQuotedValues = true;
 bool ConfigParser::StrictMode = true;
@@ -243,10 +244,10 @@ ConfigParser::SetCfgLine(char *line)
     }
 }
 
-SourceLocation
+SBuf
 ConfigParser::CurrentLocation()
 {
-    return SourceLocation(cfg_directive, cfg_filename, config_lineno);
+    return ToSBuf(SourceLocation(cfg_directive, cfg_filename, config_lineno));
 }
 
 char *

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -10,13 +10,13 @@
 #define SQUID_CONFIGPARSER_H
 
 #include "SquidString.h"
+#include "sbuf/forward.h"
 
 #include <queue>
 #include <stack>
 #include <string>
 
 class wordlist;
-class SourceLocation; // TODO: Add and use base/forward.h
 
 /**
  * Limit to how long any given config line may be.
@@ -127,7 +127,7 @@ public:
     /// Do not allow %macros inside quoted strings
     static void DisableMacros() {AllowMacros_ = false;}
 
-    static SourceLocation CurrentLocation();
+    static SBuf CurrentLocation();
 
     /// configuration_includes_quoted_values in squid.conf
     static bool RecognizeQuotedValues;

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -16,6 +16,8 @@
 #include <string>
 
 class wordlist;
+class SourceLocation; // TODO: Add and use base/forward.h
+
 /**
  * Limit to how long any given config line may be.
  * This affects squid.conf and all included files.
@@ -124,6 +126,8 @@ public:
 
     /// Do not allow %macros inside quoted strings
     static void DisableMacros() {AllowMacros_ = false;}
+
+    static SourceLocation CurrentLocation();
 
     /// configuration_includes_quoted_values in squid.conf
     static bool RecognizeQuotedValues;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -333,7 +333,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;
 
-            auto anErr = new ErrorState(page_id, Http::scForbidden, request, al);
+            const auto anErr = new ErrorState(page_id, Http::scForbidden, request, al);
             errorAppendEntry(entry, anErr); // frees anErr
             return;
         }
@@ -352,7 +352,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
 
     if (shutting_down) {
         /* more yuck */
-        auto anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
+        const auto anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
         errorAppendEntry(entry, anErr); // frees anErr
         return;
     }
@@ -430,7 +430,7 @@ FwdState::useDestinations()
 
         debugs(17, 3, HERE << "Connection failed: " << entry->url());
         if (!err) {
-            auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
+            const auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
             fail(anErr);
         } // else use actual error from last connection attempt
 
@@ -683,7 +683,7 @@ FwdState::retryOrBail()
     request->hier.stopPeerClock(false);
 
     if (self != NULL && !err && shutting_down && entry->isEmpty()) {
-        auto anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
+        const auto anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
         errorAppendEntry(entry, anErr);
     }
 
@@ -809,7 +809,7 @@ FwdState::connectTimeout(int fd)
     assert(fd == serverDestinations[0]->fd);
 
     if (entry->isEmpty()) {
-        auto anErr = new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request, al);
+        const auto anErr = new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request, al);
         anErr->xerrno = ETIMEDOUT;
         fail(anErr);
 
@@ -881,7 +881,7 @@ FwdState::connectStart()
     // origin server
     if (serverDestinations[0]->getPeer() && !serverDestinations[0]->getPeer()->options.originserver && request->flags.sslBumped) {
         debugs(50, 4, "fwdConnectStart: Ssl bumped connections through parent proxy are not allowed");
-        auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al);
+        const auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al);
         fail(anErr);
         stopAndDestroy("SslBump misconfiguration");
         return;
@@ -1088,7 +1088,7 @@ FwdState::dispatch()
 
         default:
             debugs(17, DBG_IMPORTANT, "WARNING: Cannot retrieve '" << entry->url() << "'.");
-            auto anErr = new ErrorState(ERR_UNSUP_REQ, Http::scBadRequest, request, al);
+            const auto anErr = new ErrorState(ERR_UNSUP_REQ, Http::scBadRequest, request, al);
             fail(anErr);
             // Set the dont_retry flag because this is not a transient (network) error.
             flags.dont_retry = true;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -367,7 +367,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
 
     case AnyP::PROTO_CACHE_OBJECT:
         debugs(17, 2, "calling CacheManager due to request scheme " << request->url.getScheme());
-        CacheManager::GetInstance()->Start(clientConn, request, entry, al);
+        CacheManager::GetInstance()->start(clientConn, request, entry, al);
         return;
 
     case AnyP::PROTO_URN:

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -248,7 +248,7 @@ FwdState::completed()
     if (entry->store_status == STORE_PENDING) {
         if (entry->isEmpty()) {
             if (!err) // we quit (e.g., fd closed) before an error or content
-                fail(new ErrorState(ERR_READ_ERROR, Http::scBadGateway, request));
+                fail(new ErrorState(ERR_READ_ERROR, Http::scBadGateway, request, al));
             assert(err);
             errorAppendEntry(entry, err);
             err = NULL;
@@ -333,7 +333,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;
 
-            ErrorState *anErr = new ErrorState(page_id, Http::scForbidden, request);
+            ErrorState *anErr = new ErrorState(page_id, Http::scForbidden, request, al);
             errorAppendEntry(entry, anErr); // frees anErr
             return;
         }
@@ -352,14 +352,14 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
 
     if (shutting_down) {
         /* more yuck */
-        ErrorState *anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request);
+        ErrorState *anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
         errorAppendEntry(entry, anErr); // frees anErr
         return;
     }
 
     if (request->flags.internal) {
         debugs(17, 2, "calling internalStart() due to request flag");
-        internalStart(clientConn, request, entry);
+        internalStart(clientConn, request, entry, al);
         return;
     }
 
@@ -367,7 +367,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
 
     case AnyP::PROTO_CACHE_OBJECT:
         debugs(17, 2, "calling CacheManager due to request scheme " << request->url.getScheme());
-        CacheManager::GetInstance()->Start(clientConn, request, entry);
+        CacheManager::GetInstance()->Start(clientConn, request, entry, al);
         return;
 
     case AnyP::PROTO_URN:
@@ -430,7 +430,7 @@ FwdState::useDestinations()
 
         debugs(17, 3, HERE << "Connection failed: " << entry->url());
         if (!err) {
-            ErrorState *anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request);
+            ErrorState *anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
             fail(anErr);
         } // else use actual error from last connection attempt
 
@@ -683,7 +683,7 @@ FwdState::retryOrBail()
     request->hier.stopPeerClock(false);
 
     if (self != NULL && !err && shutting_down && entry->isEmpty()) {
-        ErrorState *anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request);
+        ErrorState *anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
         errorAppendEntry(entry, anErr);
     }
 
@@ -809,7 +809,7 @@ FwdState::connectTimeout(int fd)
     assert(fd == serverDestinations[0]->fd);
 
     if (entry->isEmpty()) {
-        ErrorState *anErr = new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request);
+        ErrorState *anErr = new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request, al);
         anErr->xerrno = ETIMEDOUT;
         fail(anErr);
 
@@ -881,7 +881,7 @@ FwdState::connectStart()
     // origin server
     if (serverDestinations[0]->getPeer() && !serverDestinations[0]->getPeer()->options.originserver && request->flags.sslBumped) {
         debugs(50, 4, "fwdConnectStart: Ssl bumped connections through parent proxy are not allowed");
-        ErrorState *anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request);
+        ErrorState *anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al);
         fail(anErr);
         stopAndDestroy("SslBump misconfiguration");
         return;
@@ -957,7 +957,7 @@ FwdState::usePinned()
     if (!Comm::IsConnOpen(temp)) {
         syncHierNote(temp, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;
-        const auto anErr = new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, request);
+        const auto anErr = new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, request, al);
         fail(anErr);
         // Connection managers monitor their idle pinned to-server
         // connections and close from-client connections upon seeing
@@ -1088,7 +1088,7 @@ FwdState::dispatch()
 
         default:
             debugs(17, DBG_IMPORTANT, "WARNING: Cannot retrieve '" << entry->url() << "'.");
-            ErrorState *anErr = new ErrorState(ERR_UNSUP_REQ, Http::scBadRequest, request);
+            ErrorState *anErr = new ErrorState(ERR_UNSUP_REQ, Http::scBadRequest, request, al);
             fail(anErr);
             // Set the dont_retry flag because this is not a transient (network) error.
             flags.dont_retry = true;
@@ -1164,7 +1164,7 @@ ErrorState *
 FwdState::makeConnectingError(const err_type type) const
 {
     return new ErrorState(type, request->flags.needValidation ?
-                          Http::scGatewayTimeout : Http::scServiceUnavailable, request);
+                          Http::scGatewayTimeout : Http::scServiceUnavailable, request, al);
 }
 
 static void

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -333,7 +333,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
             if (page_id == ERR_NONE)
                 page_id = ERR_FORWARDING_DENIED;
 
-            ErrorState *anErr = new ErrorState(page_id, Http::scForbidden, request, al);
+            auto anErr = new ErrorState(page_id, Http::scForbidden, request, al);
             errorAppendEntry(entry, anErr); // frees anErr
             return;
         }
@@ -352,7 +352,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
 
     if (shutting_down) {
         /* more yuck */
-        ErrorState *anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
+        auto anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
         errorAppendEntry(entry, anErr); // frees anErr
         return;
     }
@@ -430,7 +430,7 @@ FwdState::useDestinations()
 
         debugs(17, 3, HERE << "Connection failed: " << entry->url());
         if (!err) {
-            ErrorState *anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
+            auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
             fail(anErr);
         } // else use actual error from last connection attempt
 
@@ -683,7 +683,7 @@ FwdState::retryOrBail()
     request->hier.stopPeerClock(false);
 
     if (self != NULL && !err && shutting_down && entry->isEmpty()) {
-        ErrorState *anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
+        auto anErr = new ErrorState(ERR_SHUTTING_DOWN, Http::scServiceUnavailable, request, al);
         errorAppendEntry(entry, anErr);
     }
 
@@ -809,7 +809,7 @@ FwdState::connectTimeout(int fd)
     assert(fd == serverDestinations[0]->fd);
 
     if (entry->isEmpty()) {
-        ErrorState *anErr = new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request, al);
+        auto anErr = new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request, al);
         anErr->xerrno = ETIMEDOUT;
         fail(anErr);
 
@@ -881,7 +881,7 @@ FwdState::connectStart()
     // origin server
     if (serverDestinations[0]->getPeer() && !serverDestinations[0]->getPeer()->options.originserver && request->flags.sslBumped) {
         debugs(50, 4, "fwdConnectStart: Ssl bumped connections through parent proxy are not allowed");
-        ErrorState *anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al);
+        auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al);
         fail(anErr);
         stopAndDestroy("SslBump misconfiguration");
         return;
@@ -1088,7 +1088,7 @@ FwdState::dispatch()
 
         default:
             debugs(17, DBG_IMPORTANT, "WARNING: Cannot retrieve '" << entry->url() << "'.");
-            ErrorState *anErr = new ErrorState(ERR_UNSUP_REQ, Http::scBadRequest, request, al);
+            auto anErr = new ErrorState(ERR_UNSUP_REQ, Http::scBadRequest, request, al);
             fail(anErr);
             // Set the dont_retry flag because this is not a transient (network) error.
             flags.dont_retry = true;

--- a/src/HttpBody.cc
+++ b/src/HttpBody.cc
@@ -9,41 +9,14 @@
 /* DEBUG: section 56    HTTP Message Body */
 
 #include "squid.h"
+#include "base/Packable.h"
 #include "HttpBody.h"
-#include "MemBuf.h"
-
-HttpBody::HttpBody() : mb(new MemBuf)
-{}
-
-HttpBody::~HttpBody()
-{
-    delete mb;
-}
-
-void
-HttpBody::clear()
-{
-    mb->clean();
-}
-
-/* set body by absorbing mb */
-void
-HttpBody::setMb(MemBuf * mb_)
-{
-    delete mb;
-    /* note: protection against assign-to-self is not needed
-     * as MemBuf doesn't have a copy-constructor. If such a constructor
-     * is ever added, add such protection here.
-     */
-    mb = mb_;       /* absorb */
-}
 
 void
 HttpBody::packInto(Packable * p) const
 {
     assert(p);
-
-    if (mb->contentSize())
-        p->append(mb->content(), mb->contentSize());
+    if (const auto size = contentSize())
+        p->append(content(), size);
 }
 

--- a/src/HttpBody.h
+++ b/src/HttpBody.h
@@ -9,7 +9,9 @@
 #ifndef HTTPBODY_H_
 #define HTTPBODY_H_
 
-#include "MemBuf.h"
+#include "sbuf/SBuf.h"
+
+class Packable; // TODO: Add and use base/forward.h.
 
 /** Representation of a short predetermined message
  *
@@ -19,14 +21,9 @@
 class HttpBody
 {
 public:
-    HttpBody();
-    ~HttpBody();
-    /** absorb the MemBuf, discarding anything currently stored
-     *
-     * After this call the lifetime of the passed MemBuf is managed
-     * by the HttpBody.
-     */
-    void setMb(MemBuf *);
+    HttpBody() {}
+
+    void set(const SBuf &content) { raw_ = content; }
 
     /** output the HttpBody contents into the supplied container
      *
@@ -35,20 +32,22 @@ public:
     void packInto(Packable *) const;
 
     /// clear the HttpBody content
-    void clear();
+    void clear() { raw_.clear(); }
 
     /// \return true if there is any content in the HttpBody
-    bool hasContent() const { return (mb->contentSize()>0); }
+    bool hasContent() const { return raw_.length() > 0; }
 
     /// \return size of the HttpBody's message content
-    mb_size_t contentSize() const { return mb->contentSize(); }
+    size_t contentSize() const { return raw_.length(); }
 
-    /// \return pointer to the storage of the HttpBody
-    char *content() const { return mb->content(); }
+    /// \return body bytes (possibly not nil-terminated)
+    const char *content() const { return raw_.rawContent(); }
+
 private:
     HttpBody& operator=(const HttpBody&); //not implemented
     HttpBody(const HttpBody&); // not implemented
-    MemBuf *mb;
+
+    SBuf raw_; // body bytes
 };
 
 #endif /* HTTPBODY_H_ */

--- a/src/HttpBody.h
+++ b/src/HttpBody.h
@@ -23,7 +23,7 @@ class HttpBody
 public:
     HttpBody() {}
 
-    void set(const SBuf &content) { raw_ = content; }
+    void set(const SBuf &newContent) { raw_ = newContent; }
 
     /** output the HttpBody contents into the supplied container
      *

--- a/src/acl/AclDenyInfoList.h
+++ b/src/acl/AclDenyInfoList.h
@@ -13,6 +13,7 @@
 #include "err_type.h"
 #include "errorpage.h"
 #include "mem/forward.h"
+#include "sbuf/forward.h"
 
 /// deny_info representation. Currently a POD.
 class AclDenyInfoList
@@ -20,9 +21,9 @@ class AclDenyInfoList
     MEMPROXY_CLASS(AclDenyInfoList);
 
 public:
-    AclDenyInfoList(const char *t) {
+    AclDenyInfoList(const char *t, const SBuf &aCfgLocation) {
         err_page_name = xstrdup(t);
-        err_page_id = errorReservePageId(t);
+        err_page_id = errorReservePageId(t, aCfgLocation);
     }
     ~AclDenyInfoList() {
         xfree(err_page_name);

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -113,7 +113,7 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
         return;
     }
 
-    if (ErrorState::IsDenyInfoUrl(t))
+    if (ErrorPage::IsDenyInfoUrl(t))
         ErrorPage::ValidateCodes(t, true, ToSBuf(ConfigParser::CurrentLocation()));
 
     AclDenyInfoList *A = new AclDenyInfoList(t);

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -111,6 +111,15 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
         debugs(28, DBG_CRITICAL, "aclParseDenyInfoLine: missing 'error page' parameter.");
         return;
     }
+    const char *err = nullptr;
+    if (ErrorState::IsDenyInfoUrl(t) && !ErrorState::ParseCheck(t, true, err)) {
+        debugs(28, DBG_CRITICAL, "aclParseDenyInfoLine: " << cfg_filename << " line " << config_lineno << ": " << config_input_line);
+        //if (!reconfiguring)
+        //    fatalf("Fatal: error parsing deny info URL: %s\n", err);
+        //else
+        debugs(28, DBG_CRITICAL, "error parsing deny info URL: " << err);
+        return;
+    }
 
     AclDenyInfoList *A = new AclDenyInfoList(t);
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -113,9 +113,10 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
     }
 
     if (ErrorState::IsDenyInfoUrl(t)) {
-        // throws on error
-        (void)ErrTextValidator("aclParseDenyInfoLine").useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).throws().validate(t);
-        // if (!validated) return;//eg when reconfiguring
+        ErrTextValidator validator("aclParseDenyInfoLine");
+        if (!reconfiguring)
+            validator = validator.throws();
+        (void)validator.useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).validate(t);
     }
 
     AclDenyInfoList *A = new AclDenyInfoList(t);

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -111,14 +111,11 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
         debugs(28, DBG_CRITICAL, "aclParseDenyInfoLine: missing 'error page' parameter.");
         return;
     }
-    const char *err = nullptr;
-    if (ErrorState::IsDenyInfoUrl(t) && !ErrorState::ParseCheck(t, true, err)) {
-        debugs(28, DBG_CRITICAL, "aclParseDenyInfoLine: " << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        //if (!reconfiguring)
-        //    fatalf("Fatal: error parsing deny info URL: %s\n", err);
-        //else
-        debugs(28, DBG_CRITICAL, "error parsing deny info URL: " << err);
-        return;
+
+    if (ErrorState::IsDenyInfoUrl(t)) {
+        // throws on error
+        (void)ErrTextValidator("aclParseDenyInfoLine").useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).throws(/*!reconfiguring*/).validate(t);
+        // if (!validated) return;//eg when reconfiguring
     }
 
     AclDenyInfoList *A = new AclDenyInfoList(t);

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -113,10 +113,7 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
         return;
     }
 
-    if (ErrorPage::IsDenyInfoUrl(t))
-        ErrorPage::ValidateCodes(t, true, ToSBuf(ConfigParser::CurrentLocation()));
-
-    AclDenyInfoList *A = new AclDenyInfoList(t);
+    const auto A = new AclDenyInfoList(t, ConfigParser::CurrentLocation());
 
     /* next expect a list of ACL names */
     while ((t = ConfigParser::NextToken())) {

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -115,7 +115,7 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
     if (ErrorState::IsDenyInfoUrl(t)) {
         ErrTextValidator validator("aclParseDenyInfoLine");
         if (!reconfiguring)
-            validator = validator.throws();
+            validator.throws();
         (void)validator.useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).validate(t);
     }
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -114,8 +114,7 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
 
     if (ErrorState::IsDenyInfoUrl(t)) {
         ErrTextValidator validator("aclParseDenyInfoLine");
-        if (!reconfiguring)
-            validator.throws();
+        validator.bypassReconfigurationErrorsXXX();
         (void)validator.useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).validate(t);
     }
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -27,6 +27,7 @@
 #include "errorpage.h"
 #include "globals.h"
 #include "HttpRequest.h"
+#include "src/sbuf/Stream.h"
 
 #include <set>
 #include <algorithm>
@@ -112,11 +113,8 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
         return;
     }
 
-    if (ErrorState::IsDenyInfoUrl(t)) {
-        ErrTextValidator validator("aclParseDenyInfoLine");
-        validator.bypassReconfigurationErrorsXXX();
-        (void)validator.useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).validate(t);
-    }
+    if (ErrorState::IsDenyInfoUrl(t))
+        ErrorPage::ValidateCodes(t, true, ToSBuf(ConfigParser::CurrentLocation()));
 
     AclDenyInfoList *A = new AclDenyInfoList(t);
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -114,7 +114,7 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
 
     if (ErrorState::IsDenyInfoUrl(t)) {
         // throws on error
-        (void)ErrTextValidator("aclParseDenyInfoLine").useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).throws(/*!reconfiguring*/).validate(t);
+        (void)ErrTextValidator("aclParseDenyInfoLine").useCfgContext(cfg_filename, config_lineno, config_input_line).warn(DBG_CRITICAL).throws().validate(t);
         // if (!validated) return;//eg when reconfiguring
     }
 

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 16    Cache Manager Objects */
 
 #include "squid.h"
+#include "AccessLogEntry.h"
 #include "base/TextException.h"
 #include "CacheManager.h"
 #include "comm/Connection.h"

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -308,7 +308,7 @@ CacheManager::Start(const Comm::ConnectionPointer &client, HttpRequest * request
 
     Mgr::Command::Pointer cmd = ParseUrl(entry->url());
     if (!cmd) {
-        auto err = new ErrorState(ERR_INVALID_URL, Http::scNotFound, request, al);
+        const auto err = new ErrorState(ERR_INVALID_URL, Http::scNotFound, request, al);
         err->url = xstrdup(entry->url());
         errorAppendEntry(entry, err);
         entry->expires = squid_curtime;

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -308,7 +308,7 @@ CacheManager::Start(const Comm::ConnectionPointer &client, HttpRequest * request
 
     Mgr::Command::Pointer cmd = ParseUrl(entry->url());
     if (!cmd) {
-        ErrorState *err = new ErrorState(ERR_INVALID_URL, Http::scNotFound, request, al);
+        auto err = new ErrorState(ERR_INVALID_URL, Http::scNotFound, request, al);
         err->url = xstrdup(entry->url());
         errorAppendEntry(entry, err);
         entry->expires = squid_curtime;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1531,7 +1531,7 @@ bool ConnStateData::serveDelayedError(Http::Stream *context)
                 request->hier = sslServerBump->request->hier;
 
                 // Create an error object and fill it
-                ErrorState *err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request);
+                ErrorState *err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request, http->al);
                 err->src_addr = clientConnection->remote;
                 Ssl::ErrorDetail *errDetail = new Ssl::ErrorDetail(
                     SQUID_X509_V_ERR_DOMAIN_MISMATCH,

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1531,7 +1531,7 @@ bool ConnStateData::serveDelayedError(Http::Stream *context)
                 request->hier = sslServerBump->request->hier;
 
                 // Create an error object and fill it
-                auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request, http->al);
+                const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request, http->al);
                 err->src_addr = clientConnection->remote;
                 Ssl::ErrorDetail *errDetail = new Ssl::ErrorDetail(
                     SQUID_X509_V_ERR_DOMAIN_MISMATCH,

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1531,7 +1531,7 @@ bool ConnStateData::serveDelayedError(Http::Stream *context)
                 request->hier = sslServerBump->request->hier;
 
                 // Create an error object and fill it
-                ErrorState *err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request, http->al);
+                auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request, http->al);
                 err->src_addr = clientConnection->remote;
                 Ssl::ErrorDetail *errDetail = new Ssl::ErrorDetail(
                     SQUID_X509_V_ERR_DOMAIN_MISMATCH,

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2348,3 +2348,4 @@ clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
 
     return err;
 }
+

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2340,7 +2340,7 @@ ErrorState *
 clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
                  Ip::Address &src_addr, HttpRequest * request, const AccessLogEntry::Pointer &al)
 {
-    auto err = new ErrorState(page_id, status, request, al);
+    const auto err = new ErrorState(page_id, status, request, al);
     err->src_addr = src_addr;
 
     if (url)

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -53,7 +53,7 @@ CBDATA_CLASS_INIT(clientReplyContext);
 
 /* Local functions */
 extern "C" CSS clientReplyStatus;
-ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, Ip::Address &, HttpRequest *);
+ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, Ip::Address &, HttpRequest *, const AccessLogEntry::Pointer &);
 
 /* privates */
 
@@ -111,7 +111,8 @@ clientReplyContext::setReplyToError(
 #endif
 )
 {
-    ErrorState *errstate = clientBuildError(err, status, uri, addr, failedrequest);
+    //TODO: check again http->al
+    ErrorState *errstate = clientBuildError(err, status, uri, addr, failedrequest, http->al);
 
     if (unparsedrequest)
         errstate->request_hdrs = xstrdup(unparsedrequest);
@@ -767,7 +768,7 @@ clientReplyContext::processMiss()
         http->al->http.code = Http::scForbidden;
         Ip::Address tmp_noaddr;
         tmp_noaddr.setNoAddr();
-        err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, nullptr, conn ? conn->remote : tmp_noaddr, http->request);
+        err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, nullptr, conn ? conn->remote : tmp_noaddr, http->request, http->al);
         createStoreEntry(r->method, RequestFlags());
         errorAppendEntry(http->storeEntry(), err);
         triggerInitialStoreRead();
@@ -809,7 +810,7 @@ clientReplyContext::processOnlyIfCachedMiss()
     tmp_noaddr.setNoAddr();
     ErrorState *err = clientBuildError(ERR_ONLY_IF_CACHED_MISS, Http::scGatewayTimeout, NULL,
                                        http->getConn() ? http->getConn()->clientConnection->remote : tmp_noaddr,
-                                       http->request);
+                                       http->request, http->al);
     removeClientStoreReference(&sc, http);
     startError(err);
 }
@@ -986,7 +987,7 @@ clientReplyContext::purgeFoundObject(StoreEntry *entry)
         tmp_noaddr.setNoAddr(); // TODO: make a global const
         ErrorState *err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, NULL,
                                            http->getConn() ? http->getConn()->clientConnection->remote : tmp_noaddr,
-                                           http->request);
+                                           http->request, http->al);
         startError(err);
         return; // XXX: leaking unused entry if some store does not keep it
     }
@@ -1026,7 +1027,7 @@ clientReplyContext::purgeRequest()
         Ip::Address tmp_noaddr;
         tmp_noaddr.setNoAddr();
         ErrorState *err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, NULL,
-                                           http->getConn() ? http->getConn()->clientConnection->remote : tmp_noaddr, http->request);
+                                           http->getConn() ? http->getConn()->clientConnection->remote : tmp_noaddr, http->request, http->al);
         startError(err);
         return;
     }
@@ -1965,7 +1966,7 @@ clientReplyContext::sendBodyTooLargeError()
     http->logType.update(LOG_TCP_DENIED_REPLY);
     ErrorState *err = clientBuildError(ERR_TOO_BIG, Http::scForbidden, NULL,
                                        http->getConn() != NULL ? http->getConn()->clientConnection->remote : tmp_noaddr,
-                                       http->request);
+                                       http->request, http->al);
     removeClientStoreReference(&(sc), http);
     HTTPMSGUNLOCK(reply);
     startError(err);
@@ -1981,7 +1982,7 @@ clientReplyContext::sendPreconditionFailedError()
     tmp_noaddr.setNoAddr();
     ErrorState *const err =
         clientBuildError(ERR_PRECONDITION_FAILED, Http::scPreconditionFailed,
-                         NULL, http->getConn() ? http->getConn()->clientConnection->remote : tmp_noaddr, http->request);
+                         NULL, http->getConn() ? http->getConn()->clientConnection->remote : tmp_noaddr, http->request, http->al);
     removeClientStoreReference(&sc, http);
     HTTPMSGUNLOCK(reply);
     startError(err);
@@ -2094,7 +2095,7 @@ clientReplyContext::processReplyAccessResult(const allow_t &accessAllowed)
         tmp_noaddr.setNoAddr();
         err = clientBuildError(page_id, Http::scForbidden, NULL,
                                http->getConn() != NULL ? http->getConn()->clientConnection->remote : tmp_noaddr,
-                               http->request);
+                               http->request, http->al);
 
         removeClientStoreReference(&sc, http);
 
@@ -2337,9 +2338,9 @@ clientReplyContext::createStoreEntry(const HttpRequestMethod& m, RequestFlags re
 
 ErrorState *
 clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
-                 Ip::Address &src_addr, HttpRequest * request)
+                 Ip::Address &src_addr, HttpRequest * request, const AccessLogEntry::Pointer &al)
 {
-    ErrorState *err = new ErrorState(page_id, status, request);
+    ErrorState *err = new ErrorState(page_id, status, request, al);
     err->src_addr = src_addr;
 
     if (url)
@@ -2347,4 +2348,3 @@ clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
 
     return err;
 }
-

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -111,7 +111,6 @@ clientReplyContext::setReplyToError(
 #endif
 )
 {
-    //TODO: check again http->al
     auto errstate = clientBuildError(err, status, uri, addr, failedrequest, http->al);
 
     if (unparsedrequest)

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -112,7 +112,7 @@ clientReplyContext::setReplyToError(
 )
 {
     //TODO: check again http->al
-    ErrorState *errstate = clientBuildError(err, status, uri, addr, failedrequest, http->al);
+    auto errstate = clientBuildError(err, status, uri, addr, failedrequest, http->al);
 
     if (unparsedrequest)
         errstate->request_hdrs = xstrdup(unparsedrequest);
@@ -2340,7 +2340,7 @@ ErrorState *
 clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
                  Ip::Address &src_addr, HttpRequest * request, const AccessLogEntry::Pointer &al)
 {
-    ErrorState *err = new ErrorState(page_id, status, request, al);
+    auto err = new ErrorState(page_id, status, request, al);
     err->src_addr = src_addr;
 
     if (url)

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -84,7 +84,7 @@ static const char *const crlf = "\r\n";
 static void clientFollowXForwardedForCheck(allow_t answer, void *data);
 #endif /* FOLLOW_X_FORWARDED_FOR */
 
-ErrorState *clientBuildError(err_type, Http::StatusCode, char const *url, Ip::Address &, HttpRequest *);
+ErrorState *clientBuildError(err_type, Http::StatusCode, char const *url, Ip::Address &, HttpRequest *, const AccessLogEntry::Pointer &);
 
 CBDATA_CLASS_INIT(ClientRequestContext);
 
@@ -808,7 +808,7 @@ ClientRequestContext::clientAccessCheckDone(const allow_t &answer)
         error = clientBuildError(page_id, status,
                                  NULL,
                                  http->getConn() != NULL ? http->getConn()->clientConnection->remote : tmpnoaddr,
-                                 http->request
+                                 http->request, http->al
                                 );
 
 #if USE_AUTH
@@ -2171,8 +2171,9 @@ ClientHttpRequest::calloutsError(const err_type error, const int errDetail)
         calloutContext->error = clientBuildError(error, Http::scInternalServerError,
                                 NULL,
                                 c != NULL ? c->clientConnection->remote : noAddr,
-                                request
-                                                );
+                                request,
+                                al
+                                );
 #if USE_AUTH
         calloutContext->error->auth_user_request =
             c != NULL && c->getAuth() != NULL ? c->getAuth() : request->auth_user_request;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -2173,7 +2173,7 @@ ClientHttpRequest::calloutsError(const err_type error, const int errDetail)
                                 c != NULL ? c->clientConnection->remote : noAddr,
                                 request,
                                 al
-                                );
+                                                );
 #if USE_AUTH
         calloutContext->error->auth_user_request =
             c != NULL && c->getAuth() != NULL ? c->getAuth() : request->auth_user_request;

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -856,7 +856,7 @@ Client::handledEarlyAdaptationAbort()
 {
     if (entry->isEmpty()) {
         debugs(11,8, "adaptation failure with an empty entry: " << *entry);
-        auto err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, request.getRaw(), fwd->al);
+        const auto err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, request.getRaw(), fwd->al);
         err->detailError(ERR_DETAIL_ICAP_RESPMOD_EARLY);
         fwd->fail(err);
         fwd->dontRetry(true);
@@ -893,7 +893,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 
-    auto err = new ErrorState(page_id, Http::scForbidden, request.getRaw(), fwd->al);
+    const auto err = new ErrorState(page_id, Http::scForbidden, request.getRaw(), fwd->al);
     err->detailError(ERR_DETAIL_RESPMOD_BLOCK_EARLY);
     fwd->fail(err);
     fwd->dontRetry(true);
@@ -932,7 +932,7 @@ Client::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer group)
 void
 Client::sendBodyIsTooLargeError()
 {
-    auto err = new ErrorState(ERR_TOO_BIG, Http::scForbidden, request.getRaw(), fwd->al);
+    const auto err = new ErrorState(ERR_TOO_BIG, Http::scForbidden, request.getRaw(), fwd->al);
     fwd->fail(err);
     fwd->dontRetry(true);
     abortOnData("Virgin body too large.");

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -364,7 +364,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     if (io.flag) {
         debugs(11, DBG_IMPORTANT, "sentRequestBody error: FD " << io.fd << ": " << xstrerr(io.xerrno));
         ErrorState *err;
-        err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request);
+        err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = io.xerrno;
         fwd->fail(err);
         abortOnData("I/O error while sending request body");
@@ -856,7 +856,7 @@ Client::handledEarlyAdaptationAbort()
 {
     if (entry->isEmpty()) {
         debugs(11,8, "adaptation failure with an empty entry: " << *entry);
-        ErrorState *err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, request.getRaw());
+        ErrorState *err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, request.getRaw(), fwd->al);
         err->detailError(ERR_DETAIL_ICAP_RESPMOD_EARLY);
         fwd->fail(err);
         fwd->dontRetry(true);
@@ -893,7 +893,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 
-    ErrorState *err = new ErrorState(page_id, Http::scForbidden, request.getRaw());
+    ErrorState *err = new ErrorState(page_id, Http::scForbidden, request.getRaw(), fwd->al);
     err->detailError(ERR_DETAIL_RESPMOD_BLOCK_EARLY);
     fwd->fail(err);
     fwd->dontRetry(true);
@@ -932,7 +932,7 @@ Client::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer group)
 void
 Client::sendBodyIsTooLargeError()
 {
-    ErrorState *err = new ErrorState(ERR_TOO_BIG, Http::scForbidden, request.getRaw());
+    ErrorState *err = new ErrorState(ERR_TOO_BIG, Http::scForbidden, request.getRaw(), fwd->al);
     fwd->fail(err);
     fwd->dontRetry(true);
     abortOnData("Virgin body too large.");

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -856,7 +856,7 @@ Client::handledEarlyAdaptationAbort()
 {
     if (entry->isEmpty()) {
         debugs(11,8, "adaptation failure with an empty entry: " << *entry);
-        ErrorState *err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, request.getRaw(), fwd->al);
+        auto err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, request.getRaw(), fwd->al);
         err->detailError(ERR_DETAIL_ICAP_RESPMOD_EARLY);
         fwd->fail(err);
         fwd->dontRetry(true);
@@ -893,7 +893,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 
-    ErrorState *err = new ErrorState(page_id, Http::scForbidden, request.getRaw(), fwd->al);
+    auto err = new ErrorState(page_id, Http::scForbidden, request.getRaw(), fwd->al);
     err->detailError(ERR_DETAIL_RESPMOD_BLOCK_EARLY);
     fwd->fail(err);
     fwd->dontRetry(true);
@@ -932,7 +932,7 @@ Client::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer group)
 void
 Client::sendBodyIsTooLargeError()
 {
-    ErrorState *err = new ErrorState(ERR_TOO_BIG, Http::scForbidden, request.getRaw(), fwd->al);
+    auto err = new ErrorState(ERR_TOO_BIG, Http::scForbidden, request.getRaw(), fwd->al);
     fwd->fail(err);
     fwd->dontRetry(true);
     abortOnData("Virgin body too large.");

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -257,7 +257,7 @@ Ftp::Client::failed(err_type error, int xerrno, ErrorState *err)
         ftperr = err;
     } else {
         Http::StatusCode httpStatus = failedHttpStatus(error);
-        ftperr = new ErrorState(error, httpStatus, fwd->request);
+        ftperr = new ErrorState(error, httpStatus, fwd->request, fwd->al);
     }
 
     ftperr->xerrno = xerrno;

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1150,7 +1150,7 @@ Ftp::Gateway::start()
     if (!checkAuth(&request->header)) {
         /* create appropriate reply */
         SBuf realm(ftpRealm()); // local copy so SBuf will not disappear too early
-        HttpReply *reply = ftpAuthRequired(request.getRaw(), realm, fwd->al);
+        auto reply = ftpAuthRequired(request.getRaw(), realm, fwd->al);
         entry->replaceHttpReply(reply);
         serverComplete();
         return;
@@ -2437,7 +2437,7 @@ ftpFail(Ftp::Gateway *ftpState)
     }
 
     Http::StatusCode sc = ftpState->failedHttpStatus(error_code);
-    ErrorState *ftperr = new ErrorState(error_code, sc, ftpState->fwd->request, ftpState->fwd->al);
+    auto ftperr = new ErrorState(error_code, sc, ftpState->fwd->request, ftpState->fwd->al);
     ftpState->failed(error_code, code, ftperr);
     ftperr->detailError(code);
     HttpReply *newrep = ftperr->BuildHttpReply();

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1150,7 +1150,7 @@ Ftp::Gateway::start()
     if (!checkAuth(&request->header)) {
         /* create appropriate reply */
         SBuf realm(ftpRealm()); // local copy so SBuf will not disappear too early
-        auto reply = ftpAuthRequired(request.getRaw(), realm, fwd->al);
+        const auto reply = ftpAuthRequired(request.getRaw(), realm, fwd->al);
         entry->replaceHttpReply(reply);
         serverComplete();
         return;

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -2437,7 +2437,7 @@ ftpFail(Ftp::Gateway *ftpState)
     }
 
     Http::StatusCode sc = ftpState->failedHttpStatus(error_code);
-    auto ftperr = new ErrorState(error_code, sc, ftpState->fwd->request, ftpState->fwd->al);
+    const auto ftperr = new ErrorState(error_code, sc, ftpState->fwd->request, ftpState->fwd->al);
     ftpState->failed(error_code, code, ftperr);
     ftperr->detailError(code);
     HttpReply *newrep = ftperr->BuildHttpReply();

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -2626,9 +2626,9 @@ Ftp::Gateway::haveParsedReplyHeaders()
 }
 
 HttpReply *
-Ftp::Gateway::ftpAuthRequired(HttpRequest * request, SBuf &realm, AccessLogEntry::Pointer &al)
+Ftp::Gateway::ftpAuthRequired(HttpRequest * request, SBuf &realm, AccessLogEntry::Pointer &ale)
 {
-    ErrorState err(ERR_CACHE_ACCESS_DENIED, Http::scUnauthorized, request, al);
+    ErrorState err(ERR_CACHE_ACCESS_DENIED, Http::scUnauthorized, request, ale);
     HttpReply *newrep = err.BuildHttpReply();
 #if HAVE_AUTH_MODULE_BASIC
     /* add Authenticate header */

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -73,6 +73,16 @@ typedef struct {
 
 namespace ErrorPage {
 
+/// state and parameters shared by several ErrorState::compile*() methods
+class Build
+{
+public:
+    SBuf output; ///< compilation result
+    const char *input = nullptr; ///< template bytes that need to be compiled
+    bool building_deny_info_url = false; ///< whether we compile deny_info URI
+    bool allowRecursion = false; ///< whether top-level compile() calls are OK
+};
+
 /// pretty-prints error page/deny_info building error
 class BuildErrorPrinter
 {

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -155,7 +155,7 @@ private:
     virtual bool parse() {
         if (validator.initialised()) {
             validator.useFileContext(lastTemplateFile.c_str());
-            return validator.validate(text());
+            validator.validate(text());
         }
         return true;
     }
@@ -1404,7 +1404,7 @@ ErrTextValidator::useFileContext(const char *templateFilename)
     return *this;
 }
 
-bool
+void
 ErrTextValidator::validate(const char *text)
 {
     Must (initialised());
@@ -1441,7 +1441,5 @@ ErrTextValidator::validate(const char *text)
 
     // The caller should handle all possible thrown exceptions.
     anErr.convertAndWriteTo(text, content, (ctx == CtxConfig), true);
-
-    return onError_ == doReport ? true : (handler->errors() != 0);
 }
 

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -268,8 +268,7 @@ errorInitialize(void)
     if (Config.errorStylesheet) {
         ErrorPageFile tmpl("StylesSheet", ERR_MAX, validator);
         tmpl.loadFromFile(Config.errorStylesheet);
-        if (tmpl.loaded())
-            error_stylesheet.appendf("%s",tmpl.text());
+        error_stylesheet.appendf("%s",tmpl.text());
     }
 
 #if USE_OPENSSL

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -851,7 +851,6 @@ ErrorState::Dump(MemBuf * mb)
 /// \ingroup ErrorPageInternal
 #define CVT_BUF_SZ 512
 
-/// compile @Squid{%code} sequence containing a single logformat %code
 void
 ErrorState::compileLogformatCode(Build &build)
 {
@@ -888,7 +887,6 @@ ErrorState::compileLogformatCode(Build &build)
     build.input += remainingSize;
 }
 
-/// compile a single-letter %code like %D
 void
 ErrorState::compileLegacyCode(Build &build)
 {
@@ -1346,7 +1344,6 @@ ErrorState::BuildHttpReply()
     return rep;
 }
 
-/// locates the right error page template for this error and compiles it
 SBuf
 ErrorState::buildBody()
 {
@@ -1383,20 +1380,12 @@ ErrorState::buildBody()
     return compileBody(error_text[page_id], true);
 }
 
-/// compiles error page or error detail template (i.e. anything but deny_url)
-/// * \param input  the template text to be compiled
-/// * \param allowRecursion  whether to compile %codes which produce %codes
 SBuf
 ErrorState::compileBody(const char *input, bool allowRecursion)
 {
     return compile(input, false, allowRecursion);
 }
 
-/// replaces all legacy and logformat %codes in the given input
-/// \param input  the template text to be converted
-/// \param building_deny_info_url  whether input is a deny_info URL parameter
-/// \param allowRecursion  whether to compile %codes which produce %codes
-/// \returns the given input with all %codes substituted
 SBuf
 ErrorState::compile(const char *input, bool building_deny_info_url, bool allowRecursion)
 {

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -183,6 +183,8 @@ ErrorState::ErrorHandler::handleError(const SBuf &msg)
     report(msg);
 }
 
+/// Like the ErrorState::ErrorHandler but throws after
+/// reports the error
 class ThrownErrorHandler: public ErrorState::ErrorHandler
 {
 public:

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1499,8 +1499,7 @@ ErrorPage::ImportStaticErrorText(const int page_id, const char *text, const SBuf
 static void
 ErrorPage::ValidateCodes(const int page_id, const SBuf &inputLocation)
 {
-    AccessLogEntry::Pointer alp = new AccessLogEntry; // TODO: static?
-    ErrorState anErr(err_type(page_id), Http::scNone, nullptr, alp);
+    ErrorState anErr(err_type(page_id), Http::scNone, nullptr, nullptr);
     anErr.inputLocation = inputLocation;
     anErr.validate();
 }

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1386,18 +1386,22 @@ ErrTextValidator::validate(const char *text)
     try {
         anErr.convertAndWriteTo(text, content, (ctx == CtxConfig), true);
     } catch (const std::exception &ex) {
-        if (warn_ >= 0) {
-            if (ctx == CtxConfig)
-                debugs(4, warn_, name_ << ": " <<  ctxFilename << " line " << ctxLineNo_ << ": " << ctxLine_);
-            else if (ctx == CtxFile)
-                debugs(4, warn_, name_ << "Error while parsing file " <<  ctxFilename);
-        }
-        if (fatal_)
+        if (ctx == CtxConfig)
+            debugs(4, warn_, name_ << ": " <<  ctxFilename << " line " << ctxLineNo_ << ": " << ctxLine_);
+        else if (ctx == CtxFile)
+            debugs(4, warn_, name_ << ": Error while parsing file " <<  ctxFilename);
+        debugs(4, warn_, name_ << ": " <<  ex.what());
+
+        switch(onError_) {
+        case doQuit:
             fatalf("Fatal: %s:'%s'", name_.c_str(), ex.what());
-        else if (throw_)
+            break;
+        case doThrow:
             throw TexcHere(ToSBuf(name_, ": ", ex.what()));
-        else if (warn_ >= 0)
-            debugs(4, warn_, name_ << ": " <<  ex.what());
+            break;
+        case default:
+            break;
+        }
         return false;
     }
     return true;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -416,12 +416,17 @@ TemplateFile::loadFromFile(const char *path)
     if (len < 0) {
         int xerrno = errno;
         debugs(4, DBG_CRITICAL, MYNAME << "ERROR: failed to fully read: '" << path << "': " << xstrerr(xerrno));
+        wasLoaded = false;
         return false;
     }
 
-    if (!(wasLoaded = parse()))
+    if (!parse()) {
         debugs(4, DBG_CRITICAL, "ERROR: parsing error in template file: " << path);
+        wasLoaded = false;
+        return false;
+    }
 
+    wasLoaded = true;
     return wasLoaded;
 }
 

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1523,3 +1523,4 @@ ErrorPage::ValidateStaticError(const int page_id, const SBuf &inputLocation)
     anErr.inputLocation = inputLocation;
     anErr.validate();
 }
+

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -211,12 +211,12 @@ public:
     virtual ~ErrorPageFile() override {}
 
     /// The template text data read from disk
-    const char *text() { return textBuf.c_str(); }
+    const char *text() { return template_.c_str(); }
 
 protected:
     virtual void setDefault() override {
-        textBuf = "Internal Error: Missing Template ";
-        textBuf.append(templateName.termedBuf());
+        template_ = "Internal Error: Missing Template ";
+        template_.append(templateName.termedBuf());
     }
 };
 
@@ -379,7 +379,7 @@ TemplateFile::loadDefault()
     if (!loaded()) {
         // TODO: on reconfigure reject all of the new configuration
         debugs(1, (templateCode < TCP_RESET ? DBG_CRITICAL : 3), "WARNING: failed to find or read error text file " << templateName);
-        textBuf.clear();
+        template_.clear();
         setDefault();
         wasLoaded = true;
     }
@@ -434,9 +434,9 @@ TemplateFile::loadFromFile(const char *path)
         return wasLoaded;
     }
 
-    textBuf.clear();
+    template_.clear();
     while ((len = FD_READ_METHOD(fd, buf, sizeof(buf))) > 0) {
-        textBuf.append(buf, len);
+        template_.append(buf, len);
     }
 
     if (len < 0) {

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -383,8 +383,6 @@ TemplateFile::loadDefault()
         setDefault();
         wasLoaded = true;
     }
-
-    return;
 }
 
 bool
@@ -1516,6 +1514,11 @@ ErrorPage::ImportStaticErrorText(const int page_id, const char *text, const SBuf
 static void
 ErrorPage::ValidateStaticError(const int page_id, const SBuf &inputLocation)
 {
+    // Supplying nil ALE pointer limits validation to logformat %code
+    // recognition by Format::Token::parse(). This is probably desirable
+    // because actual %code assembly is slow and should not affect validation
+    // when our ALE cannot have any real data (this code is not associated
+    // with any real transaction).
     ErrorState anErr(err_type(page_id), Http::scNone, nullptr, nullptr);
     anErr.inputLocation = inputLocation;
     anErr.validate();

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -203,6 +203,24 @@ static const char *errorFindHardText(err_type type);
 static IOCB errorSendComplete;
 
 /// \ingroup ErrorPageInternal
+/// manages an error page template
+class ErrorPageFile: public TemplateFile
+{
+public:
+    ErrorPageFile(const char *name, const err_type code) : TemplateFile(name, code) {}
+    virtual ~ErrorPageFile() override {}
+
+    /// The template text data read from disk
+    const char *text() { return textBuf.c_str(); }
+
+protected:
+    virtual void setDefault() override {
+        textBuf = "Internal Error: Missing Template ";
+        textBuf.append(templateName.termedBuf());
+    }
+};
+
+/// \ingroup ErrorPageInternal
 err_type &operator++ (err_type &anErr)
 {
     int tmp = (int)anErr;
@@ -252,7 +270,7 @@ errorInitialize(void)
              *  (a) default language translation directory (error_default_language)
              *  (b) admin specified custom directory (error_directory)
              */
-            TemplateFile errTmpl(err_type_str[i], i);
+            ErrorPageFile errTmpl(err_type_str[i], i);
             errTmpl.loadDefault();
             ImportStaticErrorText(i, errTmpl.text(), errTmpl.filename);
         } else {
@@ -264,7 +282,7 @@ errorInitialize(void)
 
             if (info->filename) {
                 /** But only if they are not redirection URL. */
-                TemplateFile errTmpl(info->filename, ERR_MAX);
+                ErrorPageFile errTmpl(info->filename, ERR_MAX);
                 errTmpl.loadDefault();
                 ImportStaticErrorText(i, errTmpl.text(), errTmpl.filename);
             } else {
@@ -278,7 +296,7 @@ errorInitialize(void)
 
     // look for and load stylesheet into global MemBuf for it.
     if (Config.errorStylesheet) {
-        TemplateFile tmpl("StylesSheet", ERR_MAX);
+        ErrorPageFile tmpl("StylesSheet", ERR_MAX);
         tmpl.loadFromFile(Config.errorStylesheet);
         error_stylesheet.appendf("%s",tmpl.text());
     }
@@ -362,9 +380,8 @@ TemplateFile::loadDefault()
         // TODO: on reconfigure reject all of the new configuration
         debugs(1, (templateCode < TCP_RESET ? DBG_CRITICAL : 3), "WARNING: failed to find or read error text file " << templateName);
         textBuf.clear();
-        textBuf.append("Internal Error: Missing Template ");
-        textBuf.append(templateName.termedBuf());
-        wasLoaded = parse();
+        setDefault();
+        wasLoaded = true;
     }
 
     return;
@@ -1340,7 +1357,7 @@ ErrorState::buildBody()
         if (err_language && err_language != Config.errorDefaultLanguage)
             safe_free(err_language);
 
-        TemplateFile localeTmpl(err_type_str[page_id], static_cast<err_type>(page_id));
+        ErrorPageFile localeTmpl(err_type_str[page_id], static_cast<err_type>(page_id));
         if (localeTmpl.loadFor(request.getRaw())) {
             inputLocation = localeTmpl.filename;
             assert(localeTmpl.language());

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -26,15 +26,15 @@
 #include "MemBuf.h"
 #include "MemObject.h"
 #include "rfc1738.h"
+#include "sbuf/Stream.h"
 #include "SquidConfig.h"
+#include "SquidTime.h"
 #include "Store.h"
 #include "tools.h"
 #include "wordlist.h"
 #if USE_AUTH
 #include "auth/UserRequest.h"
 #endif
-#include "sbuf/Stream.h"
-#include "SquidTime.h"
 #if USE_OPENSSL
 #include "ssl/ErrorDetailManager.h"
 #endif

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -411,14 +411,16 @@ TemplateFile::loadFromFile(const char *path)
     while ((len = FD_READ_METHOD(fd, buf, sizeof(buf))) > 0) {
         textBuf.append(buf, len);
     }
-    file_close(fd);
 
     if (len < 0) {
         int xerrno = errno;
+        file_close(fd);
         debugs(4, DBG_CRITICAL, MYNAME << "ERROR: failed to fully read: '" << path << "': " << xstrerr(xerrno));
         wasLoaded = false;
         return false;
     }
+
+    file_close(fd);
 
     if (!parse()) {
         debugs(4, DBG_CRITICAL, "ERROR: parsing error in template file: " << path);

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -135,9 +135,8 @@ operator <<(std::ostream &os, const BuildErrorPrinter &context)
 
 static const char *IsDenyInfoUri(const int page_id);
 
-/// check input for %code errors
 static void ImportStaticErrorText(const int page_id, const char *text, const SBuf &inputLocation);
-static void ValidateCodes(const int page_id, const SBuf &inputLocation);
+static void ValidateStaticError(const int page_id, const SBuf &inputLocation);
 
 } // namespace ErrorPage
 
@@ -255,8 +254,6 @@ errorInitialize(void)
              */
             TemplateFile errTmpl(err_type_str[i], i);
             errTmpl.loadDefault();
-
-            // TemplateFile::loadDefault always builds a template
             ImportStaticErrorText(i, errTmpl.text(), errTmpl.filename);
         } else {
             /** \par
@@ -269,7 +266,6 @@ errorInitialize(void)
                 /** But only if they are not redirection URL. */
                 TemplateFile errTmpl(info->filename, ERR_MAX);
                 errTmpl.loadDefault();
-
                 ImportStaticErrorText(i, errTmpl.text(), errTmpl.filename);
             } else {
                 assert(info->uri);
@@ -1476,16 +1472,18 @@ ErrorPage::BuildErrorPrinter::print(std::ostream &os) const {
     return os;
 }
 
+/// add error page template to the global index
 static void
 ErrorPage::ImportStaticErrorText(const int page_id, const char *text, const SBuf &inputLocation)
 {
     assert(!error_text[page_id]);
     error_text[page_id] = xstrdup(text);
-    ValidateCodes(page_id, inputLocation);
+    ValidateStaticError(page_id, inputLocation);
 }
 
+/// validate static error page
 static void
-ErrorPage::ValidateCodes(const int page_id, const SBuf &inputLocation)
+ErrorPage::ValidateStaticError(const int page_id, const SBuf &inputLocation)
 {
     ErrorState anErr(err_type(page_id), Http::scNone, nullptr, nullptr);
     anErr.inputLocation = inputLocation;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -197,9 +197,10 @@ int operator - (err_type const &anErr, err_type const &anErr2)
 }
 
 bool
-ErrorPage::IsDenyInfoUrl(const char *text)
+ErrorPage::IsDenyInfoUrl(const char *input)
 {
-    return text[0] == '3' || (text[0] != '2' && text[0] != '4' && text[0] != '5' && strchr(text, ':'));
+    const auto start = input[0];
+    return start == '3' || (start != '2' && start != '4' && start != '5' && strchr(input, ':'));
 }
 
 void

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1282,7 +1282,6 @@ ErrorState::BuildContent()
         }
     } while(!result /*&& !(useDefaultTemplate)*/);
 
-
 #if USE_ERR_LOCALES
     if (localeTmpl)
         delete localeTmpl;
@@ -1399,10 +1398,11 @@ ErrTextValidator::validate(const char *text)
         case doThrow:
             throw TexcHere(ToSBuf(name_, ": ", ex.what()));
             break;
-        case default:
+        default:
             break;
         }
         return false;
     }
     return true;
 }
+

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -267,6 +267,7 @@ errorInitialize(void)
     // look for and load stylesheet into global MemBuf for it.
     if (Config.errorStylesheet) {
         ErrorPageFile tmpl("StylesSheet", ERR_MAX, validator);
+        tmpl.loadFromFile(Config.errorStylesheet);
         if (tmpl.loaded())
             error_stylesheet.appendf("%s",tmpl.text());
     }

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -404,6 +404,7 @@ public:
     ErrTextValidator &report() { onError_ = doReport; return *this; }
 
     /// Validate the passed text
+    /// \retval true if text validated false otherwise
     bool validate(const char *text);
 
     /// \return true if the object initialized and can be used to validate text

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -15,10 +15,11 @@
 #include "comm/forward.h"
 #include "err_detail_type.h"
 #include "err_type.h"
-#include "log/forward.h"
 #include "http/forward.h"
 #include "http/StatusCode.h"
 #include "ip/Address.h"
+#include "log/forward.h"
+#include "sbuf/SBuf.h"
 #include "SquidString.h"
 /* auth/UserRequest.h is empty unless USE_AUTH is defined */
 #include "auth/UserRequest.h"

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -73,8 +73,7 @@ typedef void ERCB(int fd, void *, size_t);
    Z - Preformatted error message               x
  \endverbatim
  *
- * Also the squid logformat codes supported using the @Squid{%logformat_code}
- * syntax.
+ * Plus logformat %codes embedded using @Squid{%logformat_code} syntax.
  */
 
 class MemBuf;
@@ -116,20 +115,12 @@ public:
     /// set error type-specific detail code
     void detailError(int dCode) {detailCode = dCode;}
 
-    /**
-     * replaces all legacy and logformat %codes in the given input
-     * \param text            The string to be converted
-     * \param building_deny_info_url  Whether the text input is a deny info url
-     * \param allowRecursion  Whether to convert codes which output may contain codes
-     * \returns the given input with all %code replaced
-     */
+    /// replaces all legacy and logformat %codes in the given input
+    /// \param input  the string to be converted
+    /// \param building_deny_info_url  Whether input is a deny_info parameter
+    /// \param allowRecursion  whether to compile %codes which produce %codes
+    /// \returns the given input with all %code replaced
     SBuf compile(const char *input, bool building_deny_info_url, bool allowRecursion);
-
-    /// Checks if the text can be parsed correctly.
-    static bool ParseCheck(const char *text, bool is_deny_info_url, const char *&err);
-
-    /// True if the text is a URL deny info
-    static bool IsDenyInfoUrl(const char *text);
 
     /// the source of the error template (for reporting purposes)
     SBuf inputLocation;
@@ -137,37 +128,10 @@ public:
 private:
     typedef ErrorPage::Build Build;
 
-    /**
-     * Locates error page template to be used for this error
-     * and constructs the HTML page content from it.
-     */
-    SBuf BuildContent();
+    SBuf buildBody();
+    SBuf compileBody(const char *text, bool allowRecursion);
 
-    /**
-     * Convert the given template string into textual output
-     * Throws on parse error
-     *
-     * \param text            The string to be converted
-     * \param allowRecursion  Whether to convert codes which output may contain codes
-     */
-    SBuf compileText(const char *text, bool allowRecursion);
-
-    /**
-     * Map the Error page and deny_info template % codes into textual output.
-     *
-     * Several of the codes produce blocks of non-URL compatible results.
-     * When processing the deny_info location URL they will be skipped.
-     *
-     * \param token                    The token following % which need to be converted
-     * \param building_deny_info_url   Perform special deny_info actions, such as URL-encoding and token skipping.
-     * \ allowRecursion   True if the codes which do recursions should converted
-     */
     void compileLegacyCode(Build &build);
-
-    /// Handle the @Squid{%logformat_code} formatting code.
-    /// On success updates 'start' to point after the @Squid{}
-    /// formatting code and appends the generated string to 'result'.
-    /// Throws on parse error.
     void compileLogformatCode(Build &build);
 
     /// React to a compile() error, throwing if buildContext allows.
@@ -376,8 +340,11 @@ bool strHdrAcptLangGetItem(const String &hdr, char *lang, int langLen, size_t &p
 
 namespace ErrorPage {
 
-/// check loaded configuration text for %code errors
-void ValidateCodes(const char *text, bool building_deny_info_url, const SBuf &inputLocation);
+/// whether input looks like a deny_info redirect URL parameter
+bool IsDenyInfoUrl(const char *input);
+
+/// check input for %code errors
+void ValidateCodes(const char *input, bool building_deny_info_url, const SBuf &inputLocation);
 
 } // namespace ErrorPage
 

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -80,15 +80,13 @@ class wordlist;
 
 namespace ErrorPage {
 
-/// state and parameters shared by several ErrorState::compile*() methods
-class Build
-{
-public:
-    SBuf output; ///< compilation result
-    const char *input = nullptr; ///< template bytes that need to be compiled
-    bool building_deny_info_url = false; ///< whether we compile deny_info URI
-    bool allowRecursion = false; ///< whether top-level compile() calls are OK
-};
+class Build;
+
+/// whether input looks like a deny_info redirect URL parameter
+bool IsDenyInfoUrl(const char *input);
+
+/// check input for %code errors
+void ValidateCodes(const char *input, bool building_deny_info_url, const SBuf &inputLocation);
 
 } // namespace ErrorPage
 
@@ -335,16 +333,6 @@ protected:
  * \return true if something looking like a language token has been placed in lang, false otherwise
  */
 bool strHdrAcptLangGetItem(const String &hdr, char *lang, int langLen, size_t &pos);
-
-namespace ErrorPage {
-
-/// whether input looks like a deny_info redirect URL parameter
-bool IsDenyInfoUrl(const char *input);
-
-/// check input for %code errors
-void ValidateCodes(const char *input, bool building_deny_info_url, const SBuf &inputLocation);
-
-} // namespace ErrorPage
 
 #endif /* SQUID_ERRORPAGE_H */
 

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -176,18 +176,19 @@ public:
     char *request_hdrs = nullptr;
     char *err_msg = nullptr; /* Preformatted error message from the cache */
 
+    AccessLogEntryPointer al; ///< transaction details (or nil)
+
 #if USE_OPENSSL
     Ssl::ErrorDetail *detail = nullptr;
 #endif
     /// type-specific detail about the transaction error;
     /// overwrites xerrno; overwritten by detail, if any.
     int detailCode = ERR_DETAIL_NONE;
-    AccessLogEntryPointer al;
 
 private:
     void noteBuildError_(const char *msg, const char *near, const bool forceBypass);
 
-    static const SBuf LogFormatStart;
+    static const SBuf LogformatMagic; ///< marks each embedded logformat entry
 };
 
 /**
@@ -269,6 +270,7 @@ public:
      *  (a) admin specified custom directory (error_directory)
      *  (b) default language translation directory (error_default_language)
      *  (c) English sub-directory where errors should ALWAYS exist
+     * If all of the above fail, setDefault() is called.
      */
     void loadDefault();
 
@@ -307,7 +309,7 @@ protected:
      */
     bool tryLoadTemplate(const char *lang);
 
-    SBuf textBuf; ///< A Buffer to store the template
+    SBuf textBuf; ///< loaded template text
     bool wasLoaded; ///< True if the template data read from disk without any problem
     String errLanguage; ///< The error language of the template.
     String templateName; ///< The name of the template

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -309,7 +309,7 @@ protected:
      */
     bool tryLoadTemplate(const char *lang);
 
-    SBuf textBuf; ///< loaded template text
+    SBuf template_; ///< raw template contents
     bool wasLoaded; ///< True if the template data read from disk without any problem
     String errLanguage; ///< The error language of the template.
     String templateName; ///< The name of the template

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -404,11 +404,10 @@ public:
     /// \retval this
     ErrTextValidator &report() { onError_ = doReport; return *this; }
 
-    /// Check the given template text for errors.
-    /// On errors it may throws, report the error in cache.log file or
-    /// return false, depending the configured error action.
-    /// \retval true if the text is validated false otherwise
-    bool validate(const char *text);
+    /// Check the given error template text for problems. If problems are
+    /// found, either throw or just report the problem to cache.log, depending
+    /// on whether throws() was called to enable throwing.
+    void validate(const char *text);
 
     /// \return true if the object initialized and can be used to validate text
     bool initialised() { return name_.length() != 0;}

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -264,9 +264,6 @@ public:
     /// return true if the data loaded from disk without any problem
     bool loaded() const {return wasLoaded;}
 
-    /// loaded template (or an empty string)
-    const char *text() { return textBuf.c_str(); }
-
     /**
      * Load the page_name template from a file which  probably exist at:
      *  (a) admin specified custom directory (error_directory)
@@ -297,8 +294,11 @@ public:
     bool silent; ///< Whether to print error messages on cache.log file or not. It is user defined.
 
 protected:
-    /// post-processes the loaded template
+    /// post-process the loaded template
     virtual bool parse() { return true; }
+
+    /// recover from loadDefault() failure to load or parse() a template
+    virtual void setDefault() {}
 
     /**
      * Try to load the "page_name" template for a given language "lang"

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -115,12 +115,25 @@ public:
 private:
     typedef ErrorPage::Build Build;
 
+    /// locates the right error page template for this error and compiles it
     SBuf buildBody();
+
+    /// compiles error page or error detail template (i.e. anything but deny_url)
+    /// \param input  the template text to be compiled
+    /// \param allowRecursion  whether to compile %codes which produce %codes
     SBuf compileBody(const char *text, bool allowRecursion);
 
+    /// compile a single-letter %code like %D
     void compileLegacyCode(Build &build);
+
+    /// compile @Squid{%code} sequence containing a single logformat %code
     void compileLogformatCode(Build &build);
 
+    /// replaces all legacy and logformat %codes in the given input
+    /// \param input  the template text to be converted
+    /// \param building_deny_info_url  whether input is a deny_info URL parameter
+    /// \param allowRecursion  whether to compile %codes which produce %codes
+    /// \returns the given input with all %codes substituted
     SBuf compile(const char *input, bool building_deny_info_url, bool allowRecursion);
 
     /// React to a compile() error, throwing if buildContext allows.

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -177,7 +177,7 @@ public:
     char *request_hdrs = nullptr;
     char *err_msg = nullptr; /* Preformatted error message from the cache */
 
-    AccessLogEntryPointer al; ///< transaction details (or nil)
+    AccessLogEntryPointer ale; ///< transaction details (or nil)
 
 #if USE_OPENSSL
     Ssl::ErrorDetail *detail = nullptr;

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -395,18 +395,22 @@ public:
     /// \retval this
     ErrTextValidator &warn(int level) { warn_ = level; return *this; }
 
-    /// The ErrTextValidator::validate throws on parse errors
+    /// If Squid is reconfiguring, report but then ignore parsing errors
+    /// instead of throwing. Otherwise, throw. Eventually, callers (possibly
+    /// indirect ones) should be fixed to catch thrown errors and reject
+    /// problematic reconfigurations.
     /// \retval this
-    ErrTextValidator &throws() { onError_ = doThrow; return *this; }
+    ErrTextValidator &bypassReconfigurationErrorsXXX();
 
-    /// Report and then ignore parse errors, the ErrTextValidator::validate
-    /// returns always true
+    /// Report but then ignore parsing errors instead of throwing. Eventually,
+    /// callers (possibly indirect ones) should be fixed to catch thrown
+    /// errors and reject problematic reconfigurations.
     /// \retval this
-    ErrTextValidator &report() { onError_ = doReport; return *this; }
+    ErrTextValidator &bypassAllErrorsXXX() { bypassErrors_ = true; return *this; }
 
-    /// Check the given error template text for problems. If problems are
+    /// Check the given error template text for problems. If a problem is
     /// found, either throw or just report the problem to cache.log, depending
-    /// on whether throws() was called to enable throwing.
+    /// on whether bypass*ErrorsXXX() was called to prevent throwing.
     void validate(const char *text);
 
     /// \return true if the object initialized and can be used to validate text
@@ -417,10 +421,6 @@ private:
         CtxFile, ///< It is used to parse a squid templates
         CtxConfig ///< It is used to parse a text from squid configuration file (eg from deny_info line)
     };
-    enum OnError {
-        doReport, ///< Just report the error using squid log
-        doThrow ///< Reports and then throws on error
-    };
 
     Context ctx = CtxUnknown; ///< The current context type
 
@@ -428,7 +428,7 @@ private:
     /// function name or caller class name.
     SBuf name_;
 
-    OnError onError_ = doReport; ///< Action when an error detected
+    bool bypassErrors_ = false; ///< whether to suppress throwing on errors
     int warn_ = 3; ///< The debug level to use for error messages
     SBuf ctxFilename; ///< The configuration file or the error page template
 

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -395,16 +395,19 @@ public:
     /// \retval this
     ErrTextValidator &warn(int level) { warn_ = level; return *this; }
 
-    /// Throw on parse errors
+    /// The ErrTextValidator::validate throws on parse errors
     /// \retval this
     ErrTextValidator &throws() { onError_ = doThrow; return *this; }
 
-    /// Just report parse errors
+    /// Report and then ignore parse errors, the ErrTextValidator::validate
+    /// returns always true
     /// \retval this
     ErrTextValidator &report() { onError_ = doReport; return *this; }
 
-    /// Validate the passed text
-    /// \retval true if text validated false otherwise
+    /// Check the given template text for errors.
+    /// On errors it may throws, report the error in cache.log file or
+    /// return false, depending the configured error action.
+    /// \retval true if the text is validated false otherwise
     bool validate(const char *text);
 
     /// \return true if the object initialized and can be used to validate text

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -330,33 +330,57 @@ protected:
     SBuf lastTemplateFile; ///< The last used path
 };
 
+/// Checks error pages text for syntax errors
 class ErrTextValidator {
 public:
     ErrTextValidator() {}
     ErrTextValidator(const char *aName) : name_(aName) {}
 
+    /// Setup the current object to handle the checked text as a configuration
+    /// file error page formatted string like those can be found in deny_info
+    /// configuration parameter.
+    /// \par filename the configuration file path
+    /// \par lineNo the number of parsed line
+    /// \par line the configuration file line
+    /// The parameters used to describe the error to the caller
     ErrTextValidator &useCfgContext(const char *filename, int lineNo, const char *line);
 
+    /// Setup the current object to handle checked text as a template error
+    /// page.
     ErrTextValidator &useFileContext(const char *templateFilename);
 
+    /// The debug level to use for debug messages
     ErrTextValidator &warn(int level) { warn_ = level; return *this; }
 
-    ErrTextValidator &fatal(bool abort = true) { fatal_ = abort; return *this; }
+    /// Treat the parse errors as fatal
+    ErrTextValidator &fatal() { onError_ = doQuit; return *this; }
 
-    ErrTextValidator &throws(bool doThrow = true) { throw_ = doThrow; return *this; }
+    /// Throw on parse errors
+    ErrTextValidator &throws() { onError_ = doThrow; return *this; }
 
+    /// Validate the passed text
     bool validate(const char *text);
 
+    /// \return true if the object initialized and can be used to validate text
     bool initialised() { return name_.length() != 0;}
 private:
     enum Context {CtxUnknown, CtxFile, CtxConfig};
-    Context ctx = CtxUnknown;
+    enum OnError {doReturn, doQuit, doThrow};
+
+    Context ctx = CtxUnknown; ///< The current context type
+
+    /// A name for validator to be used for debugging. It can be the caller
+    /// function name or caller class name.
     SBuf name_;
-    bool fatal_ = false;
-    bool throw_ = false;
-    int warn_ = -1;
-    SBuf ctxFilename;
+
+    OnError onError_ = doReturn; ///< Action when error detected
+    int warn_ = 3; ///< The debug level to use for error messages
+    SBuf ctxFilename; ///< The configuration file or the error page template
+
+    /// The current configuration file line number on CtxConfig context.
     int ctxLineNo_ = 0;
+
+    /// The current configuration file line on CtxConfig context.
     SBuf ctxLine_;
 };
 

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -26,8 +26,6 @@
 #include "ssl/ErrorDetail.h"
 #endif
 
-#include <memory>
-
 /// error page callback
 typedef void ERCB(int fd, void *, size_t);
 

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -264,6 +264,9 @@ public:
     /// return true if the data loaded from disk without any problem
     bool loaded() const {return wasLoaded;}
 
+    /// loaded template (or an empty string)
+    const char *text() { return textBuf.c_str(); }
+
     /**
      * Load the page_name template from a file which  probably exist at:
      *  (a) admin specified custom directory (error_directory)

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1402,7 +1402,7 @@ ESIContext::freeResources ()
     /* don't touch incoming, it's a pointer into buffered anyway */
 }
 
-ErrorState *clientBuildError (err_type, Http::StatusCode, char const *, Ip::Address &, HttpRequest *, const AccessLogEntry::Pointer &);
+ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, Ip::Address &, HttpRequest *, const AccessLogEntry::Pointer &);
 
 /* This can ONLY be used before we have sent *any* data to the client */
 void
@@ -1420,10 +1420,11 @@ ESIContext::fail ()
     flags.error = 1;
     /* create an error object */
     // XXX: with the in-direction on remote IP. does the http->getConn()->clientConnection exist?
-    auto err = clientBuildError(errorpage, errorstatus, NULL, http->getConn()->clientConnection->remote, http->request, http->al);
+    const auto err = clientBuildError(errorpage, errorstatus, nullptr, http->getConn()->clientConnection->remote, http->request, http->al);
     err->err_msg = errormessage;
     errormessage = NULL;
     rep = err->BuildHttpReply();
+    // XXX: Leaking err!
     assert (rep->body.hasContent());
     size_t errorprogress = rep->body.contentSize();
     /* Tell esiSend where to start sending from */

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1420,7 +1420,7 @@ ESIContext::fail ()
     flags.error = 1;
     /* create an error object */
     // XXX: with the in-direction on remote IP. does the http->getConn()->clientConnection exist?
-    ErrorState * err = clientBuildError(errorpage, errorstatus, NULL, http->getConn()->clientConnection->remote, http->request, http->al);
+    auto err = clientBuildError(errorpage, errorstatus, NULL, http->getConn()->clientConnection->remote, http->request, http->al);
     err->err_msg = errormessage;
     errormessage = NULL;
     rep = err->BuildHttpReply();

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1402,7 +1402,7 @@ ESIContext::freeResources ()
     /* don't touch incoming, it's a pointer into buffered anyway */
 }
 
-ErrorState *clientBuildError (err_type, Http::StatusCode, char const *, Ip::Address &, HttpRequest *);
+ErrorState *clientBuildError (err_type, Http::StatusCode, char const *, Ip::Address &, HttpRequest *, const AccessLogEntry::Pointer &);
 
 /* This can ONLY be used before we have sent *any* data to the client */
 void
@@ -1420,7 +1420,7 @@ ESIContext::fail ()
     flags.error = 1;
     /* create an error object */
     // XXX: with the in-direction on remote IP. does the http->getConn()->clientConnection exist?
-    ErrorState * err = clientBuildError(errorpage, errorstatus, NULL, http->getConn()->clientConnection->remote, http->request);
+    ErrorState * err = clientBuildError(errorpage, errorstatus, NULL, http->getConn()->clientConnection->remote, http->request, http->al);
     err->err_msg = errormessage;
     errormessage = NULL;
     rep = err->BuildHttpReply();

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -100,7 +100,7 @@ Format::Format::parse(const char *def)
     return true;
 }
 
-int
+size_t
 Format::AssembleOne(const char *token, MemBuf &mb, const AccessLogEntryPointer &al)
 {
     Token tkn;
@@ -114,7 +114,7 @@ Format::AssembleOne(const char *token, MemBuf &mb, const AccessLogEntryPointer &
         fmt.format = nullptr;
     } else
         mb.append("-", 1);
-    return tokenSize;
+    return static_cast<size_t>(tokenSize);
 }
 
 void

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -103,6 +103,9 @@ Format::Format::parse(const char *def)
 int
 Format::Format::AssembleToken(const char *token, MemBuf &mb, const AccessLogEntryPointer &al)
 {
+    if (*token != '%')
+        return 0;
+
     Token tkn;
     enum Quoting quote = LOG_QUOTE_NONE;
     int tokenSize;

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -96,16 +96,16 @@ Format::Format::parse(const char *def)
 }
 
 size_t
-Format::AssembleOne(const char *token, MemBuf &mb, const AccessLogEntryPointer &al)
+Format::AssembleOne(const char *token, MemBuf &mb, const AccessLogEntryPointer &ale)
 {
     Token tkn;
     enum Quoting quote = LOG_QUOTE_NONE;
     const auto tokenSize = tkn.parse(token, &quote);
     assert(tokenSize > 0);
-    if (al != nullptr) {
+    if (ale != nullptr) {
         Format fmt("SimpleToken");
         fmt.format = &tkn;
-        fmt.assemble(mb, al, 0);
+        fmt.assemble(mb, ale, 0);
         fmt.format = nullptr;
     } else
         mb.append("-", 1);

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -103,27 +103,17 @@ Format::Format::parse(const char *def)
 int
 Format::AssembleOne(const char *token, MemBuf &mb, const AccessLogEntryPointer &al)
 {
-    if (*token != '%')
-        return 0;
-
     Token tkn;
     enum Quoting quote = LOG_QUOTE_NONE;
-    int tokenSize;
-    try {
-        if ((tokenSize = tkn.parse(token, &quote))) {
-            if (al != nullptr) {
-                Format fmt("SimpleToken");
-                fmt.format = &tkn;
-                fmt.assemble(mb, al, 0);
-                fmt.format = nullptr;
-            } else
-                mb.append("-", 1);
-        }
-    } catch (...) {
-        debugs(46, 5, "Unknown token: " << token);
-        tokenSize = 0;
-    }
-
+    const auto tokenSize = tkn.parse(token, &quote);
+    assert(tokenSize > 0);
+    if (al != nullptr) {
+        Format fmt("SimpleToken");
+        fmt.format = &tkn;
+        fmt.assemble(mb, al, 0);
+        fmt.format = nullptr;
+    } else
+        mb.append("-", 1);
     return tokenSize;
 }
 

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -82,19 +82,14 @@ Format::Format::parse(const char *def)
      * token but it can be an escaped sequence), or a string. */
     cur = def;
     eos = def + strlen(def);
-    try {
-        format = new_lt = last_lt = new Token;
-        cur += new_lt->parse(cur, &quote);
+    format = new_lt = last_lt = new Token;
+    cur += new_lt->parse(cur, &quote);
 
-        while (cur < eos) {
-            new_lt = new Token;
-            last_lt->next = new_lt;
-            last_lt = new_lt;
-            cur += new_lt->parse(cur, &quote);
-        }
-    } catch (const std::exception &ex) {
-        debugs(46, DBG_CRITICAL, ex.what());
-        return false;
+    while (cur < eos) {
+        new_lt = new Token;
+        last_lt->next = new_lt;
+        last_lt = new_lt;
+        cur += new_lt->parse(cur, &quote);
     }
 
     return true;

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -101,7 +101,7 @@ Format::Format::parse(const char *def)
 }
 
 int
-Format::Format::AssembleToken(const char *token, MemBuf &mb, const AccessLogEntryPointer &al)
+Format::AssembleOne(const char *token, MemBuf &mb, const AccessLogEntryPointer &al)
 {
     if (*token != '%')
         return 0;

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -65,7 +65,7 @@ public:
 /// Ignores any input characters after the expression.
 /// \param start  where the logformat expression begins
 /// \return the length of the parsed %code expression
-size_t AssembleOne(const char *start, MemBuf &buf, const AccessLogEntryPointer &al);
+size_t AssembleOne(const char *start, MemBuf &buf, const AccessLogEntryPointer &ale);
 
 } // namespace Format
 

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -56,6 +56,11 @@ public:
     /// dump this whole list of formats into the provided StoreEntry
     void dump(StoreEntry * entry, const char *directiveName, bool eol = true) const;
 
+    /// assemble a single logformat code
+    /// \return true on success, false otherwise
+    static int AssembleToken(const char *token, MemBuf &mb, const AccessLogEntryPointer &al);
+
+
     char *name;
     Token *format;
     Format *next;

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -56,14 +56,14 @@ public:
     /// dump this whole list of formats into the provided StoreEntry
     void dump(StoreEntry * entry, const char *directiveName, bool eol = true) const;
 
-    /// assemble a single logformat code
-    /// \return true on success, false otherwise
-    static int AssembleToken(const char *token, MemBuf &mb, const AccessLogEntryPointer &al);
-
     char *name;
     Token *format;
     Format *next;
 };
+
+/// compile a single logformat %code expression into the given buffer
+/// \return the length of the %code expression (or zero on errors)s
+int AssembleOne(const char *start, MemBuf &buf, const AccessLogEntryPointer &al);
 
 } // namespace Format
 

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -60,7 +60,6 @@ public:
     /// \return true on success, false otherwise
     static int AssembleToken(const char *token, MemBuf &mb, const AccessLogEntryPointer &al);
 
-
     char *name;
     Token *format;
     Format *next;

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -62,7 +62,7 @@ public:
 };
 
 /// compile a single logformat %code expression into the given buffer
-/// \return the length of the %code expression (or zero on errors)s
+/// \return the length of the parsed %code expression
 int AssembleOne(const char *start, MemBuf &buf, const AccessLogEntryPointer &al);
 
 } // namespace Format

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -61,9 +61,11 @@ public:
     Format *next;
 };
 
-/// compile a single logformat %code expression into the given buffer
+/// Compiles a single logformat %code expression into the given buffer.
+/// Ignores any input characters after the expression.
+/// \param start  where the logformat expression begins
 /// \return the length of the parsed %code expression
-int AssembleOne(const char *start, MemBuf &buf, const AccessLogEntryPointer &al);
+size_t AssembleOne(const char *start, MemBuf &buf, const AccessLogEntryPointer &al);
 
 } // namespace Format
 

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -442,9 +442,8 @@ Format::Token::parse(const char *def, Quoting *quoting)
             }
         }
 
-        if (type == LFT_NONE) {
-            throw TexcHere(SBuf().appendf("Can't parse configuration token: '%s'\n", def));
-        }
+        if (type == LFT_NONE)
+            throw TexcHere(ToSBuf("Unsupported %code: '", def, "'"));
 
         // when {arg} field is after the token (old external_acl_type token syntax)
         // but accept only if there was none before the token

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -443,7 +443,7 @@ Format::Token::parse(const char *def, Quoting *quoting)
         }
 
         if (type == LFT_NONE) {
-            fatalf("Can't parse configuration token: '%s'\n", def);
+            throw TexcHere(SBuf().appendf("Can't parse configuration token: '%s'\n", def));
         }
 
         // when {arg} field is after the token (old external_acl_type token syntax)

--- a/src/format/Token.h
+++ b/src/format/Token.h
@@ -44,7 +44,6 @@ public:
     /** parses a single token. Returns the token length in characters,
      * and fills in this item with the token information.
      * def is for sure null-terminated.
-     * Throws a TextException on parse error
      */
     int parse(const char *def, enum Quoting *quote);
 

--- a/src/format/Token.h
+++ b/src/format/Token.h
@@ -44,6 +44,7 @@ public:
     /** parses a single token. Returns the token length in characters,
      * and fills in this item with the token information.
      * def is for sure null-terminated.
+     * Throws a TextException on parse error
      */
     int parse(const char *def, enum Quoting *quote);
 

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -710,7 +710,7 @@ gopherTimeout(const CommTimeoutCbParams &io)
     GopherStateData *gopherState = static_cast<GopherStateData *>(io.data);
     debugs(10, 4, HERE << io.conn << ": '" << gopherState->entry->url() << "'" );
 
-    gopherState->fwd->fail(new ErrorState(ERR_READ_TIMEOUT, Http::scGatewayTimeout, gopherState->fwd->request));
+    gopherState->fwd->fail(new ErrorState(ERR_READ_TIMEOUT, Http::scGatewayTimeout, gopherState->fwd->request, gopherState->fwd->al));
 
     if (Comm::IsConnOpen(io.conn))
         io.conn->close();
@@ -790,13 +790,13 @@ gopherReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm
                                                  CommIoCbPtrFun(gopherReadReply, gopherState));
             comm_read(conn, buf, read_sz, call);
         } else {
-            ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, gopherState->fwd->request);
+            ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, gopherState->fwd->request, gopherState->fwd->al);
             err->xerrno = xerrno;
             gopherState->fwd->fail(err);
             gopherState->serverConn->close();
         }
     } else if (len == 0 && entry->isEmpty()) {
-        gopherState->fwd->fail(new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, gopherState->fwd->request));
+        gopherState->fwd->fail(new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scServiceUnavailable, gopherState->fwd->request, gopherState->fwd->al));
         gopherState->serverConn->close();
     } else if (len == 0) {
         /* Connection closed; retrieval done. */
@@ -839,7 +839,7 @@ gopherSendComplete(const Comm::ConnectionPointer &conn, char *, size_t size, Com
 
     if (errflag) {
         ErrorState *err;
-        err = new ErrorState(ERR_WRITE_ERROR, Http::scServiceUnavailable, gopherState->fwd->request);
+        err = new ErrorState(ERR_WRITE_ERROR, Http::scServiceUnavailable, gopherState->fwd->request, gopherState->fwd->al);
         err->xerrno = xerrno;
         err->port = gopherState->fwd->request->url.port();
         err->url = xstrdup(entry->url());

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -790,7 +790,7 @@ gopherReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm
                                                  CommIoCbPtrFun(gopherReadReply, gopherState));
             comm_read(conn, buf, read_sz, call);
         } else {
-            auto err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, gopherState->fwd->request, gopherState->fwd->al);
+            const auto err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, gopherState->fwd->request, gopherState->fwd->al);
             err->xerrno = xerrno;
             gopherState->fwd->fail(err);
             gopherState->serverConn->close();
@@ -838,7 +838,7 @@ gopherSendComplete(const Comm::ConnectionPointer &conn, char *, size_t size, Com
     }
 
     if (errflag) {
-        auto err = new ErrorState(ERR_WRITE_ERROR, Http::scServiceUnavailable, gopherState->fwd->request, gopherState->fwd->al);
+        const auto err = new ErrorState(ERR_WRITE_ERROR, Http::scServiceUnavailable, gopherState->fwd->request, gopherState->fwd->al);
         err->xerrno = xerrno;
         err->port = gopherState->fwd->request->url.port();
         err->url = xstrdup(entry->url());

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -838,8 +838,7 @@ gopherSendComplete(const Comm::ConnectionPointer &conn, char *, size_t size, Com
     }
 
     if (errflag) {
-        ErrorState *err;
-        err = new ErrorState(ERR_WRITE_ERROR, Http::scServiceUnavailable, gopherState->fwd->request, gopherState->fwd->al);
+        auto err = new ErrorState(ERR_WRITE_ERROR, Http::scServiceUnavailable, gopherState->fwd->request, gopherState->fwd->al);
         err->xerrno = xerrno;
         err->port = gopherState->fwd->request->url.port();
         err->url = xstrdup(entry->url());

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -790,7 +790,7 @@ gopherReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm
                                                  CommIoCbPtrFun(gopherReadReply, gopherState));
             comm_read(conn, buf, read_sz, call);
         } else {
-            ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, gopherState->fwd->request, gopherState->fwd->al);
+            auto err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, gopherState->fwd->request, gopherState->fwd->al);
             err->xerrno = xerrno;
             gopherState->fwd->fail(err);
             gopherState->serverConn->close();

--- a/src/http.cc
+++ b/src/http.cc
@@ -1211,7 +1211,7 @@ HttpStateData::readReply(const CommIoCbParams &io)
     // case Comm::COMM_ERROR:
     default: // no other flags should ever occur
         debugs(11, 2, io.conn << ": read failure: " << xstrerr(rd.xerrno));
-        ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request, fwd->al);
+        auto err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = rd.xerrno;
         fwd->fail(err);
         flags.do_next_read = false;
@@ -1598,7 +1598,7 @@ HttpStateData::wroteLast(const CommIoCbParams &io)
     request->hier.notePeerWrite();
 
     if (io.flag) {
-        ErrorState *err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request, fwd->al);
+        auto err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = io.xerrno;
         fwd->fail(err);
         closeServer();
@@ -2435,7 +2435,7 @@ HttpStateData::handleRequestBodyProducerAborted()
         // We might also get here if client-side aborts, but then our response
         // should not matter because either client-side will provide its own or
         // there will be no response at all (e.g., if the the client has left).
-        ErrorState *err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, fwd->request, fwd->al);
+        auto err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, fwd->request, fwd->al);
         err->detailError(ERR_DETAIL_SRV_REQMOD_REQ_BODY);
         fwd->fail(err);
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -156,7 +156,7 @@ HttpStateData::httpTimeout(const CommTimeoutCbParams &)
     debugs(11, 4, serverConnection << ": '" << entry->url() << "'");
 
     if (entry->store_status == STORE_PENDING) {
-        fwd->fail(new ErrorState(ERR_READ_TIMEOUT, Http::scGatewayTimeout, fwd->request));
+        fwd->fail(new ErrorState(ERR_READ_TIMEOUT, Http::scGatewayTimeout, fwd->request, fwd->al));
     }
 
     closeServer();
@@ -1211,7 +1211,7 @@ HttpStateData::readReply(const CommIoCbParams &io)
     // case Comm::COMM_ERROR:
     default: // no other flags should ever occur
         debugs(11, 2, io.conn << ": read failure: " << xstrerr(rd.xerrno));
-        ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request);
+        ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = rd.xerrno;
         fwd->fail(err);
         flags.do_next_read = false;
@@ -1314,7 +1314,7 @@ HttpStateData::continueAfterParsingHeader()
 
     assert(error != ERR_NONE);
     entry->reset();
-    fwd->fail(new ErrorState(error, Http::scBadGateway, fwd->request));
+    fwd->fail(new ErrorState(error, Http::scBadGateway, fwd->request, fwd->al));
     flags.do_next_read = false;
     closeServer();
     mustStop("HttpStateData::continueAfterParsingHeader");
@@ -1598,7 +1598,7 @@ HttpStateData::wroteLast(const CommIoCbParams &io)
     request->hier.notePeerWrite();
 
     if (io.flag) {
-        ErrorState *err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request);
+        ErrorState *err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = io.xerrno;
         fwd->fail(err);
         closeServer();
@@ -2435,7 +2435,7 @@ HttpStateData::handleRequestBodyProducerAborted()
         // We might also get here if client-side aborts, but then our response
         // should not matter because either client-side will provide its own or
         // there will be no response at all (e.g., if the the client has left).
-        ErrorState *err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, fwd->request);
+        ErrorState *err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, fwd->request, fwd->al);
         err->detailError(ERR_DETAIL_SRV_REQMOD_REQ_BODY);
         fwd->fail(err);
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -1211,7 +1211,7 @@ HttpStateData::readReply(const CommIoCbParams &io)
     // case Comm::COMM_ERROR:
     default: // no other flags should ever occur
         debugs(11, 2, io.conn << ": read failure: " << xstrerr(rd.xerrno));
-        auto err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request, fwd->al);
+        const auto err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = rd.xerrno;
         fwd->fail(err);
         flags.do_next_read = false;
@@ -1598,7 +1598,7 @@ HttpStateData::wroteLast(const CommIoCbParams &io)
     request->hier.notePeerWrite();
 
     if (io.flag) {
-        auto err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request, fwd->al);
+        const auto err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = io.xerrno;
         fwd->fail(err);
         closeServer();
@@ -2435,7 +2435,7 @@ HttpStateData::handleRequestBodyProducerAborted()
         // We might also get here if client-side aborts, but then our response
         // should not matter because either client-side will provide its own or
         // there will be no response at all (e.g., if the the client has left).
-        auto err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, fwd->request, fwd->al);
+        const auto err = new ErrorState(ERR_ICAP_FAILURE, Http::scInternalServerError, fwd->request, fwd->al);
         err->detailError(ERR_DETAIL_SRV_REQMOD_REQ_BODY);
         fwd->fail(err);
     }

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 76    Internal Squid Object handling */
 
 #include "squid.h"
+#include "AccessLogEntry.h"
 #include "CacheManager.h"
 #include "comm/Connection.h"
 #include "errorpage.h"
@@ -28,7 +29,7 @@
  * return Http::scNotFound for others
  */
 void
-internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest * request, StoreEntry * entry)
+internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest * request, StoreEntry * entry, const AccessLogEntry::Pointer &al)
 {
     ErrorState *err;
     const SBuf upath = request->url.path();
@@ -55,11 +56,11 @@ internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest * request, 
         entry->complete();
     } else if (upath.startsWith(mgrPfx)) {
         debugs(17, 2, "calling CacheManager due to URL-path " << mgrPfx);
-        CacheManager::GetInstance()->Start(clientConn, request, entry);
+        CacheManager::GetInstance()->Start(clientConn, request, entry, al);
     } else {
         debugObj(76, 1, "internalStart: unknown request:\n",
                  request, (ObjPackMethod) & httpRequestPack);
-        err = new ErrorState(ERR_INVALID_REQ, Http::scNotFound, request);
+        err = new ErrorState(ERR_INVALID_REQ, Http::scNotFound, request, al);
         errorAppendEntry(entry, err);
     }
 }

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -29,7 +29,7 @@
  * return Http::scNotFound for others
  */
 void
-internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest * request, StoreEntry * entry, const AccessLogEntry::Pointer &al)
+internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest * request, StoreEntry * entry, const AccessLogEntry::Pointer &ale)
 {
     ErrorState *err;
     const SBuf upath = request->url.path();
@@ -56,11 +56,11 @@ internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest * request, 
         entry->complete();
     } else if (upath.startsWith(mgrPfx)) {
         debugs(17, 2, "calling CacheManager due to URL-path " << mgrPfx);
-        CacheManager::GetInstance()->Start(clientConn, request, entry, al);
+        CacheManager::GetInstance()->start(clientConn, request, entry, ale);
     } else {
         debugObj(76, 1, "internalStart: unknown request:\n",
                  request, (ObjPackMethod) & httpRequestPack);
-        err = new ErrorState(ERR_INVALID_REQ, Http::scNotFound, request, al);
+        err = new ErrorState(ERR_INVALID_REQ, Http::scNotFound, request, ale);
         errorAppendEntry(entry, err);
     }
 }

--- a/src/internal.h
+++ b/src/internal.h
@@ -15,12 +15,13 @@
 #define SQUID_INTERNAL_H_
 
 #include "comm/forward.h"
+#include "log/forward.h"
 #include "sbuf/forward.h"
 
 class HttpRequest;
 class StoreEntry;
 
-void internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest *, StoreEntry *);
+void internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest *, StoreEntry *, const AccessLogEntryPointer &);
 bool internalCheck(const SBuf &urlPath);
 bool internalStaticCheck(const SBuf &urlPath);
 char *internalLocalUri(const char *dir, const SBuf &name);

--- a/src/log/Makefile.am
+++ b/src/log/Makefile.am
@@ -29,6 +29,7 @@ liblog_la_SOURCES = \
 	FormatSquidNative.cc \
 	FormatSquidReferer.cc \
 	FormatSquidUseragent.cc \
+	forward.h \
 	ModDaemon.cc \
 	ModDaemon.h \
 	ModStdio.cc \

--- a/src/log/forward.h
+++ b/src/log/forward.h
@@ -15,3 +15,4 @@ class AccessLogEntry;
 typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
 
 #endif /* SQUID_FORMAT_FORWARD_H */
+

--- a/src/log/forward.h
+++ b/src/log/forward.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 1996-2017 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_FORMAT_FORWARD_H
+#define SQUID_FORMAT_FORWARD_H
+
+#include "base/RefCount.h"
+
+class AccessLogEntry;
+typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
+
+#endif /* SQUID_FORMAT_FORWARD_H */

--- a/src/mgr/Forwarder.cc
+++ b/src/mgr/Forwarder.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 16    Cache Manager API */
 
 #include "squid.h"
+#include "AccessLogEntry.h"
 #include "base/AsyncJobCalls.h"
 #include "base/TextException.h"
 #include "comm/Connection.h"

--- a/src/mgr/Forwarder.cc
+++ b/src/mgr/Forwarder.cc
@@ -26,9 +26,9 @@
 CBDATA_NAMESPACED_CLASS_INIT(Mgr, Forwarder);
 
 Mgr::Forwarder::Forwarder(const Comm::ConnectionPointer &aConn, const ActionParams &aParams,
-                          HttpRequest* aRequest, StoreEntry* anEntry, const AccessLogEntryPointer &alp):
+                          HttpRequest* aRequest, StoreEntry* anEntry, const AccessLogEntryPointer &anAle):
     Ipc::Forwarder(new Request(KidIdentifier, 0, aConn, aParams), 10),
-    httpRequest(aRequest), entry(anEntry), conn(aConn), al(alp)
+    httpRequest(aRequest), entry(anEntry), conn(aConn), ale(anAle)
 {
     debugs(16, 5, HERE << conn);
     Must(Comm::IsConnOpen(conn));
@@ -72,14 +72,14 @@ void
 Mgr::Forwarder::handleError()
 {
     debugs(16, DBG_CRITICAL, "ERROR: uri " << entry->url() << " exceeds buffer size");
-    sendError(new ErrorState(ERR_INVALID_URL, Http::scUriTooLong, httpRequest, al));
+    sendError(new ErrorState(ERR_INVALID_URL, Http::scUriTooLong, httpRequest, ale));
     mustStop("long URI");
 }
 
 void
 Mgr::Forwarder::handleTimeout()
 {
-    sendError(new ErrorState(ERR_LIFETIME_EXP, Http::scRequestTimeout, httpRequest, al));
+    sendError(new ErrorState(ERR_LIFETIME_EXP, Http::scRequestTimeout, httpRequest, ale));
     Ipc::Forwarder::handleTimeout();
 }
 
@@ -87,7 +87,7 @@ void
 Mgr::Forwarder::handleException(const std::exception &e)
 {
     if (entry != NULL && httpRequest != NULL && Comm::IsConnOpen(conn))
-        sendError(new ErrorState(ERR_INVALID_RESP, Http::scInternalServerError, httpRequest, al));
+        sendError(new ErrorState(ERR_INVALID_RESP, Http::scInternalServerError, httpRequest, ale));
     Ipc::Forwarder::handleException(e);
 }
 

--- a/src/mgr/Forwarder.cc
+++ b/src/mgr/Forwarder.cc
@@ -26,9 +26,9 @@
 CBDATA_NAMESPACED_CLASS_INIT(Mgr, Forwarder);
 
 Mgr::Forwarder::Forwarder(const Comm::ConnectionPointer &aConn, const ActionParams &aParams,
-                          HttpRequest* aRequest, StoreEntry* anEntry):
+                          HttpRequest* aRequest, StoreEntry* anEntry, const AccessLogEntryPointer &alp):
     Ipc::Forwarder(new Request(KidIdentifier, 0, aConn, aParams), 10),
-    httpRequest(aRequest), entry(anEntry), conn(aConn)
+    httpRequest(aRequest), entry(anEntry), conn(aConn), al(alp)
 {
     debugs(16, 5, HERE << conn);
     Must(Comm::IsConnOpen(conn));
@@ -72,14 +72,14 @@ void
 Mgr::Forwarder::handleError()
 {
     debugs(16, DBG_CRITICAL, "ERROR: uri " << entry->url() << " exceeds buffer size");
-    sendError(new ErrorState(ERR_INVALID_URL, Http::scUriTooLong, httpRequest));
+    sendError(new ErrorState(ERR_INVALID_URL, Http::scUriTooLong, httpRequest, al));
     mustStop("long URI");
 }
 
 void
 Mgr::Forwarder::handleTimeout()
 {
-    sendError(new ErrorState(ERR_LIFETIME_EXP, Http::scRequestTimeout, httpRequest));
+    sendError(new ErrorState(ERR_LIFETIME_EXP, Http::scRequestTimeout, httpRequest, al));
     Ipc::Forwarder::handleTimeout();
 }
 
@@ -87,7 +87,7 @@ void
 Mgr::Forwarder::handleException(const std::exception &e)
 {
     if (entry != NULL && httpRequest != NULL && Comm::IsConnOpen(conn))
-        sendError(new ErrorState(ERR_INVALID_RESP, Http::scInternalServerError, httpRequest));
+        sendError(new ErrorState(ERR_INVALID_RESP, Http::scInternalServerError, httpRequest, al));
     Ipc::Forwarder::handleException(e);
 }
 

--- a/src/mgr/Forwarder.h
+++ b/src/mgr/Forwarder.h
@@ -34,7 +34,7 @@ class Forwarder: public Ipc::Forwarder
 
 public:
     Forwarder(const Comm::ConnectionPointer &aConn, const ActionParams &aParams, HttpRequest* aRequest,
-              StoreEntry* anEntry, const AccessLogEntryPointer &);
+              StoreEntry* anEntry, const AccessLogEntryPointer &anAle);
     virtual ~Forwarder();
 
 protected:
@@ -53,7 +53,7 @@ private:
     StoreEntry* entry; ///< Store entry expecting the response
     Comm::ConnectionPointer conn; ///< HTTP client connection descriptor
     AsyncCall::Pointer closer; ///< comm_close handler for the HTTP connection
-    AccessLogEntryPointer al; ///< more transaction details
+    AccessLogEntryPointer ale; ///< more transaction details
 };
 
 } // namespace Mgr

--- a/src/mgr/Forwarder.h
+++ b/src/mgr/Forwarder.h
@@ -53,7 +53,7 @@ private:
     StoreEntry* entry; ///< Store entry expecting the response
     Comm::ConnectionPointer conn; ///< HTTP client connection descriptor
     AsyncCall::Pointer closer; ///< comm_close handler for the HTTP connection
-    AccessLogEntryPointer al; ///< info for the future access.log entry
+    AccessLogEntryPointer al; ///< more transaction details
 };
 
 } // namespace Mgr

--- a/src/mgr/Forwarder.h
+++ b/src/mgr/Forwarder.h
@@ -13,6 +13,7 @@
 
 #include "comm/forward.h"
 #include "ipc/Forwarder.h"
+#include "log/forward.h"
 #include "mgr/ActionParams.h"
 
 class CommCloseCbParams;
@@ -33,7 +34,7 @@ class Forwarder: public Ipc::Forwarder
 
 public:
     Forwarder(const Comm::ConnectionPointer &aConn, const ActionParams &aParams, HttpRequest* aRequest,
-              StoreEntry* anEntry);
+              StoreEntry* anEntry, const AccessLogEntryPointer &);
     virtual ~Forwarder();
 
 protected:
@@ -52,6 +53,7 @@ private:
     StoreEntry* entry; ///< Store entry expecting the response
     Comm::ConnectionPointer conn; ///< HTTP client connection descriptor
     AsyncCall::Pointer closer; ///< comm_close handler for the HTTP connection
+    AccessLogEntryPointer al; ///< info for the future access.log entry
 };
 
 } // namespace Mgr

--- a/src/mgr/Inquirer.cc
+++ b/src/mgr/Inquirer.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 16    Cache Manager API */
 
 #include "squid.h"
+#include "AccessLogEntry.h"
 #include "base/TextException.h"
 #include "comm.h"
 #include "comm/Connection.h"

--- a/src/mgr/Inquirer.cc
+++ b/src/mgr/Inquirer.cc
@@ -77,8 +77,7 @@ Mgr::Inquirer::start()
         const char *url = aggrAction->command().params.httpUri.termedBuf();
         const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initIpc);
         HttpRequest *req = HttpRequest::FromUrl(url, mx);
-        AccessLogEntry::Pointer nilAl;
-        ErrorState err(ERR_INVALID_URL, Http::scNotFound, req, nilAl);
+        ErrorState err(ERR_INVALID_URL, Http::scNotFound, req, nullptr);
         std::unique_ptr<HttpReply> reply(err.BuildHttpReply());
         replyBuf.reset(reply->pack());
     } else {

--- a/src/mgr/Inquirer.cc
+++ b/src/mgr/Inquirer.cc
@@ -77,7 +77,8 @@ Mgr::Inquirer::start()
         const char *url = aggrAction->command().params.httpUri.termedBuf();
         const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initIpc);
         HttpRequest *req = HttpRequest::FromUrl(url, mx);
-        ErrorState err(ERR_INVALID_URL, Http::scNotFound, req);
+        AccessLogEntry::Pointer nilAl;
+        ErrorState err(ERR_INVALID_URL, Http::scNotFound, req, nilAl);
         std::unique_ptr<HttpReply> reply(err.BuildHttpReply());
         replyBuf.reset(reply->pack());
     } else {

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -406,7 +406,7 @@ PeerSelector::noteIps(const Dns::CachedIps *ia, const Dns::LookupDetails &detail
         delete lastError;
         lastError = NULL;
         if (fs->code == HIER_DIRECT) {
-            lastError = new ErrorState(ERR_DNS_FAIL, Http::scServiceUnavailable, request);
+            lastError = new ErrorState(ERR_DNS_FAIL, Http::scServiceUnavailable, request, al);
             lastError->dnsError = details.error;
         }
     }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -111,7 +111,7 @@ Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
         if (!ctx) {
             debugs(83, DBG_IMPORTANT, "Error initializing TLS connection: No security context.");
         } // else CreateClientSession() did the appropriate debugs() already
-        ErrorState *anErr = new ErrorState(ERR_SOCKET_FAILURE, Http::scInternalServerError, request.getRaw(), al);
+        auto anErr = new ErrorState(ERR_SOCKET_FAILURE, Http::scInternalServerError, request.getRaw(), al);
         anErr->xerrno = xerrno;
         noteNegotiationDone(anErr);
         bail(anErr);
@@ -250,7 +250,7 @@ Security::PeerConnector::sslFinalized()
                    " certificate: " << e.what() << "; will now block to " <<
                    "validate that certificate.");
             // fall through to do blocking in-process generation.
-            ErrorState *anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
+            auto anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
 
             noteNegotiationDone(anErr);
             bail(anErr);
@@ -516,7 +516,7 @@ Security::PeerConnector::noteNegotiationError(const int ret, const int ssl_error
            ": " << Security::ErrorString(ssl_lib_error) << " (" <<
            ssl_error << "/" << ret << "/" << xerr << ")");
 
-    ErrorState *anErr = ErrorState::NewForwarding(ERR_SECURE_CONNECT_FAIL, request, al);
+    auto anErr = ErrorState::NewForwarding(ERR_SECURE_CONNECT_FAIL, request, al);
     anErr->xerrno = sysErrNo;
 
 #if USE_OPENSSL
@@ -586,7 +586,7 @@ Security::PeerConnector::swanSong()
     AsyncJob::swanSong();
     if (callback != NULL) { // paranoid: we have left the caller waiting
         debugs(83, DBG_IMPORTANT, "BUG: Unexpected state while connecting to a cache_peer or origin server");
-        ErrorState *anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
+        auto anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
         bail(anErr);
         assert(!callback);
         return;

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -111,7 +111,7 @@ Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
         if (!ctx) {
             debugs(83, DBG_IMPORTANT, "Error initializing TLS connection: No security context.");
         } // else CreateClientSession() did the appropriate debugs() already
-        auto anErr = new ErrorState(ERR_SOCKET_FAILURE, Http::scInternalServerError, request.getRaw(), al);
+        const auto anErr = new ErrorState(ERR_SOCKET_FAILURE, Http::scInternalServerError, request.getRaw(), al);
         anErr->xerrno = xerrno;
         noteNegotiationDone(anErr);
         bail(anErr);
@@ -250,7 +250,7 @@ Security::PeerConnector::sslFinalized()
                    " certificate: " << e.what() << "; will now block to " <<
                    "validate that certificate.");
             // fall through to do blocking in-process generation.
-            auto anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
+            const auto anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
 
             noteNegotiationDone(anErr);
             bail(anErr);
@@ -516,7 +516,7 @@ Security::PeerConnector::noteNegotiationError(const int ret, const int ssl_error
            ": " << Security::ErrorString(ssl_lib_error) << " (" <<
            ssl_error << "/" << ret << "/" << xerr << ")");
 
-    auto anErr = ErrorState::NewForwarding(ERR_SECURE_CONNECT_FAIL, request, al);
+    const auto anErr = ErrorState::NewForwarding(ERR_SECURE_CONNECT_FAIL, request, al);
     anErr->xerrno = sysErrNo;
 
 #if USE_OPENSSL
@@ -586,7 +586,7 @@ Security::PeerConnector::swanSong()
     AsyncJob::swanSong();
     if (callback != NULL) { // paranoid: we have left the caller waiting
         debugs(83, DBG_IMPORTANT, "BUG: Unexpected state while connecting to a cache_peer or origin server");
-        auto anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
+        const auto anErr = new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al);
         bail(anErr);
         assert(!callback);
         return;

--- a/src/ssl/ErrorDetail.cc
+++ b/src/ssl/ErrorDetail.cc
@@ -596,6 +596,7 @@ int Ssl::ErrorDetail::convert(const char *code, const char **value) const
             return len;
         }
     }
+    // TODO: Support logformat %codes.
     return 0;
 }
 

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -194,8 +194,8 @@ Ssl::ErrorDetailFile::parse()
     textBuf.append("\n\n"); // ensure detailEntryEnd() finds the last entry
 
     while (const auto size = detailEntryEnd(textBuf.rawContent(), textBuf.length())) {
-        const char *s = textBuf.c_str();
-        const char *e = s + size;
+        auto *s = textBuf.c_str();
+        const auto e = s + size;
 
         //ignore spaces, new lines and comment lines (starting with #) at the beggining
         for (; (*s == '\n' || *s == ' '  || *s == '\t' || *s == '#')  && s < e; ++s) {
@@ -255,7 +255,7 @@ Ssl::ErrorDetailFile::parse()
 
         textBuf.consume(size);
     }
-    debugs(83, 9, "unparsed data size: " << textBuf.length() << " Content: " << textBuf.c_str());
+    debugs(83, 9, Raw("unparsed data", textBuf.rawContent(), textBuf.length()));
     return true;
 }
 

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -191,9 +191,9 @@ Ssl::ErrorDetailFile::parse()
     if (!theDetails)
         return false;
 
-    textBuf.append("\n\n");
+    textBuf.append("\n\n"); // ensure detailEntryEnd() finds the last entry
 
-    while (size_t size = detailEntryEnd(textBuf.rawContent(), textBuf.length())) {
+    while (const auto size = detailEntryEnd(textBuf.rawContent(), textBuf.length())) {
         const char *s = textBuf.c_str();
         const char *e = s + size;
 

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -191,10 +191,11 @@ Ssl::ErrorDetailFile::parse()
     if (!theDetails)
         return false;
 
-    textBuf.append("\n\n"); // ensure detailEntryEnd() finds the last entry
+    auto buf = template_;
+    buf.append("\n\n"); // ensure detailEntryEnd() finds the last entry
 
-    while (const auto size = detailEntryEnd(textBuf.rawContent(), textBuf.length())) {
-        auto *s = textBuf.c_str();
+    while (const auto size = detailEntryEnd(buf.rawContent(), buf.length())) {
+        auto *s = buf.c_str();
         const auto e = s + size;
 
         //ignore spaces, new lines and comment lines (starting with #) at the beggining
@@ -253,9 +254,9 @@ Ssl::ErrorDetailFile::parse()
 
         }// else {only spaces and black lines; just ignore}
 
-        textBuf.consume(size);
+        buf.consume(size);
     }
-    debugs(83, 9, Raw("unparsed data", textBuf.rawContent(), textBuf.length()));
+    debugs(83, 9, Raw("unparsed data", buf.rawContent(), buf.length()));
     return true;
 }
 

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -254,7 +254,7 @@ Ssl::ErrorDetailFile::parse()
 
         textBuf.consume(size);
     }
-    debugs(83, 9, HERE << " unparsed data size: " << textBuf.length() << " Content: " << textBuf.c_str());
+    debugs(83, 9, "unparsed data size: " << textBuf.length() << " Content: " << textBuf.c_str());
     return true;
 }
 

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -36,7 +36,7 @@ public:
 
 private:
     ErrorDetailsList::Pointer  theDetails;
-    virtual bool parse();
+    virtual bool parse() override;
 };
 }// namespace Ssl
 

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -237,6 +237,7 @@ Ssl::ErrorDetailFile::parse()
                 const int detailsParseOk = httpHeaderParseQuotedString(tmp.termedBuf(), tmp.size(), &entry.detail);
                 tmp = parser.getByName("descr");
                 const int descrParseOk = httpHeaderParseQuotedString(tmp.termedBuf(), tmp.size(), &entry.descr);
+                // TODO: Validate "descr" and "detail" field values.
 
                 if (!detailsParseOk || !descrParseOk) {
                     debugs(83, DBG_IMPORTANT, HERE <<

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -194,8 +194,8 @@ Ssl::ErrorDetailFile::parse()
     textBuf.append("\n\n");
 
     while (size_t size = detailEntryEnd(textBuf.rawContent(), textBuf.length())) {
-        const char *s = textBuf.rawContent();
-        const char *e = textBuf.rawContent() + size;
+        const char *s = textBuf.c_str();
+        const char *e = s + size;
 
         //ignore spaces, new lines and comment lines (starting with #) at the beggining
         for (; (*s == '\n' || *s == ' '  || *s == '\t' || *s == '#')  && s < e; ++s) {

--- a/src/tests/stub_cache_manager.cc
+++ b/src/tests/stub_cache_manager.cc
@@ -15,7 +15,7 @@
 #include "tests/STUB.h"
 
 Mgr::Action::Pointer CacheManager::createNamedAction(char const* action) STUB_RETVAL(NULL)
-void CacheManager::Start(const Comm::ConnectionPointer &conn, HttpRequest * request, StoreEntry * entry, const AccessLogEntryPointer &)
+void CacheManager::start(const Comm::ConnectionPointer &, HttpRequest *, StoreEntry *, const AccessLogEntryPointer &)
 {
     std::cerr << HERE << "\n";
     STUB

--- a/src/tests/stub_cache_manager.cc
+++ b/src/tests/stub_cache_manager.cc
@@ -15,7 +15,7 @@
 #include "tests/STUB.h"
 
 Mgr::Action::Pointer CacheManager::createNamedAction(char const* action) STUB_RETVAL(NULL)
-void CacheManager::Start(const Comm::ConnectionPointer &conn, HttpRequest * request, StoreEntry * entry)
+void CacheManager::Start(const Comm::ConnectionPointer &conn, HttpRequest * request, StoreEntry * entry, const AccessLogEntryPointer &)
 {
     std::cerr << HERE << "\n";
     STUB

--- a/src/tests/stub_errorpage.cc
+++ b/src/tests/stub_errorpage.cc
@@ -15,7 +15,9 @@
 err_type errorReservePageId(const char *page_name) STUB_RETVAL(err_type())
 void errorAppendEntry(StoreEntry * entry, ErrorState * err) STUB
 bool strHdrAcptLangGetItem(const String &hdr, char *lang, int langLen, size_t &pos) STUB_RETVAL(false)
-bool TemplateFile::loadDefault() STUB_RETVAL(false)
+void TemplateFile::loadDefault() STUB
 TemplateFile::TemplateFile(char const*, err_type) STUB
 bool TemplateFile::loadFor(const HttpRequest *) STUB_RETVAL(false)
-
+bool ErrorState::IsDenyInfoUrl(const char *) STUB_RETVAL(false)
+ErrTextValidator &ErrTextValidator::useCfgContext(const char *filename, int lineNo, const char *line) STUB_RETVAL(*this)
+bool ErrTextValidator::validate(char const*) STUB_RETVAL(false)

--- a/src/tests/stub_errorpage.cc
+++ b/src/tests/stub_errorpage.cc
@@ -18,3 +18,4 @@ bool strHdrAcptLangGetItem(const String &hdr, char *lang, int langLen, size_t &p
 void TemplateFile::loadDefault() STUB
 TemplateFile::TemplateFile(char const*, err_type) STUB
 bool TemplateFile::loadFor(const HttpRequest *) STUB_RETVAL(false)
+

--- a/src/tests/stub_errorpage.cc
+++ b/src/tests/stub_errorpage.cc
@@ -19,5 +19,4 @@ void TemplateFile::loadDefault() STUB
 TemplateFile::TemplateFile(char const*, err_type) STUB
 bool TemplateFile::loadFor(const HttpRequest *) STUB_RETVAL(false)
 bool ErrorState::IsDenyInfoUrl(const char *) STUB_RETVAL(false)
-ErrTextValidator &ErrTextValidator::useCfgContext(const char *filename, int lineNo, const char *line) STUB_RETVAL(*this)
-bool ErrTextValidator::validate(char const*) STUB_RETVAL(false)
+void ErrorPage::ValidateCodes(const char *, bool, const SBuf &) STUB

--- a/src/tests/stub_errorpage.cc
+++ b/src/tests/stub_errorpage.cc
@@ -12,11 +12,9 @@
 #define STUB_API "errorpage.cc"
 #include "tests/STUB.h"
 
-err_type errorReservePageId(const char *page_name) STUB_RETVAL(err_type())
+err_type errorReservePageId(const char *, const SBuf &) STUB_RETVAL(err_type(0))
 void errorAppendEntry(StoreEntry * entry, ErrorState * err) STUB
 bool strHdrAcptLangGetItem(const String &hdr, char *lang, int langLen, size_t &pos) STUB_RETVAL(false)
 void TemplateFile::loadDefault() STUB
 TemplateFile::TemplateFile(char const*, err_type) STUB
 bool TemplateFile::loadFor(const HttpRequest *) STUB_RETVAL(false)
-bool ErrorState::IsDenyInfoUrl(const char *) STUB_RETVAL(false)
-void ErrorPage::ValidateCodes(const char *, bool, const SBuf &) STUB

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1038,7 +1038,7 @@ tunnelConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xe
     TunnelStateData *tunnelState = (TunnelStateData *)data;
 
     if (status != Comm::OK) {
-        auto err = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw(), tunnelState->al);
+        const auto err = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw(), tunnelState->al);
         err->xerrno = xerrno;
         // on timeout is this still:    err->xerrno = ETIMEDOUT;
         err->port = conn->remote.port();

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1038,7 +1038,7 @@ tunnelConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xe
     TunnelStateData *tunnelState = (TunnelStateData *)data;
 
     if (status != Comm::OK) {
-        ErrorState *err = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw(), tunnelState->al);
+        auto err = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw(), tunnelState->al);
         err->xerrno = xerrno;
         // on timeout is this still:    err->xerrno = ETIMEDOUT;
         err->port = conn->remote.port();

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -465,7 +465,7 @@ TunnelStateData::informUserOfPeerError(const char *errMsg, const size_t sz)
 
     // if we have no reply suitable to relay, use 502 Bad Gateway
     if (!sz || sz > static_cast<size_t>(connectRespBuf->contentSize()))
-        return sendError(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw()),
+        return sendError(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al),
                          "peer error without reply");
 
     // if we need to send back the server response. write its headers to the client
@@ -1038,7 +1038,7 @@ tunnelConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int xe
     TunnelStateData *tunnelState = (TunnelStateData *)data;
 
     if (status != Comm::OK) {
-        ErrorState *err = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw());
+        ErrorState *err = new ErrorState(ERR_CONNECT_FAIL, Http::scServiceUnavailable, tunnelState->request.getRaw(), tunnelState->al);
         err->xerrno = xerrno;
         // on timeout is this still:    err->xerrno = ETIMEDOUT;
         err->port = conn->remote.port();
@@ -1113,7 +1113,7 @@ tunnelStart(ClientHttpRequest * http)
         ch.syncAle(request, http->log_uri);
         if (ch.fastCheck().denied()) {
             debugs(26, 4, HERE << "MISS access forbidden.");
-            err = new ErrorState(ERR_FORWARDING_DENIED, Http::scForbidden, request);
+            err = new ErrorState(ERR_FORWARDING_DENIED, Http::scForbidden, request, http->al);
             http->al->http.code = Http::scForbidden;
             errorSend(http->getConn()->clientConnection, err);
             return;
@@ -1253,7 +1253,7 @@ TunnelStateData::noteDestinationsEnd(ErrorState *selectionError)
         if (savedError)
             return sendError(savedError, "all found paths have failed");
 
-        return sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw()),
+        return sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al),
                          "path selection found no paths");
     }
     // else continue to use one of the previously noted destinations;
@@ -1325,7 +1325,7 @@ TunnelStateData::usePinned()
     debugs(26,7, "pinned peer connection: " << serverConn);
     if (!Comm::IsConnOpen(serverConn)) {
         // a PINNED path failure is fatal; do not wait for more paths
-        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw()),
+        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al),
                   "pinned path failure");
         return;
     }

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -48,7 +48,7 @@ public:
     StoreEntry *urlres_e = nullptr;
     HttpRequest::Pointer request;
     HttpRequest::Pointer urlres_r;
-    AccessLogEntry::Pointer ale; ///< master transaction summary
+    AccessLogEntry::Pointer ale; ///< details of the requesting transaction
 
     struct {
         bool force_menu = false;

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -163,7 +163,7 @@ UrnState::setUriResFromRequest(HttpRequest *r)
 
     if (!urlres_r) {
         debugs(52, 3, "Bad uri-res URL " << local_urlres);
-        auto err = new ErrorState(ERR_URN_RESOLVE, Http::scNotFound, r, ale);
+        const auto err = new ErrorState(ERR_URN_RESOLVE, Http::scNotFound, r, ale);
         err->url = xstrdup(local_urlres);
         errorAppendEntry(entry, err);
         return;

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -163,7 +163,7 @@ UrnState::setUriResFromRequest(HttpRequest *r)
 
     if (!urlres_r) {
         debugs(52, 3, "Bad uri-res URL " << local_urlres);
-        ErrorState *err = new ErrorState(ERR_URN_RESOLVE, Http::scNotFound, r, ale);
+        auto err = new ErrorState(ERR_URN_RESOLVE, Http::scNotFound, r, ale);
         err->url = xstrdup(local_urlres);
         errorAppendEntry(entry, err);
         return;

--- a/src/urn.h
+++ b/src/urn.h
@@ -11,14 +11,12 @@
 #ifndef SQUID_URN_H_
 #define SQUID_URN_H_
 
-class AccessLogEntry;
+#include "log/forward.h"
+
 class HttpRequest;
 class StoreEntry;
 
-template <class C> class RefCount;
-typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
-
-void urnStart(HttpRequest *, StoreEntry *, const AccessLogEntryPointer &ale);
+void urnStart(HttpRequest *, StoreEntry *, const AccessLogEntryPointer &);
 
 #endif /* SQUID_URN_H_ */
 

--- a/src/urn.h
+++ b/src/urn.h
@@ -16,7 +16,7 @@
 class HttpRequest;
 class StoreEntry;
 
-void urnStart(HttpRequest *, StoreEntry *, const AccessLogEntryPointer &);
+void urnStart(HttpRequest *, StoreEntry *, const AccessLogEntryPointer &ale);
 
 #endif /* SQUID_URN_H_ */
 

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -128,7 +128,7 @@ WhoisState::readReply(const Comm::ConnectionPointer &conn, char *aBuffer, size_t
                                                  CommIoCbPtrFun(whoisReadReply, this));
             comm_read(conn, aBuffer, BUFSIZ, call);
         } else {
-            ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, fwd->request);
+            ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, fwd->request, fwd->al);
             err->xerrno = xerrno;
             fwd->fail(err);
             conn->close();

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -128,7 +128,7 @@ WhoisState::readReply(const Comm::ConnectionPointer &conn, char *aBuffer, size_t
                                                  CommIoCbPtrFun(whoisReadReply, this));
             comm_read(conn, aBuffer, BUFSIZ, call);
         } else {
-            auto err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, fwd->request, fwd->al);
+            const auto err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, fwd->request, fwd->al);
             err->xerrno = xerrno;
             fwd->fail(err);
             conn->close();

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -128,7 +128,7 @@ WhoisState::readReply(const Comm::ConnectionPointer &conn, char *aBuffer, size_t
                                                  CommIoCbPtrFun(whoisReadReply, this));
             comm_read(conn, aBuffer, BUFSIZ, call);
         } else {
-            ErrorState *err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, fwd->request, fwd->al);
+            auto err = new ErrorState(ERR_READ_ERROR, Http::scInternalServerError, fwd->request, fwd->al);
             err->xerrno = xerrno;
             fwd->fail(err);
             conn->close();


### PR DESCRIPTION
... using `@Squid{%code}` syntax which allows Squid to distinguish newly
supported logformat %codes like `%http::<rm` from classic single-letter
error page %codes like `%M` (that are never enclosed in `@Squid{}`).

This improvement gives error pages access to more information about the
failed transaction and paves the way towards unifying the two partially
duplicated %code interfaces (and underlying code).

Some single-letter error page %codes have similar logformat %codes. For
example, error page `%i` will often be replaced with the same characters
as `@Squid{%>a}`. However, admins should not rely on expansion
equivalence because most codes may be rendered differently under some
conditions, and the two rendering algorithms are not kept in sync. For
example, error page `%i` does not account for log_uses_indirect_client.

Only a few letters remain unused by the error page %codes. Most
(possibly all) new codes should be added to the logformat instead,
within an appropriate error_page:: namespace if needed.

Side effects of updating error page parsing and assembly code include:

* Leave bad %codes in deny_info URLs instead of removing them. This
  helps in triage and is consistent with how bad %codes are already
  handled in error pages.

* Report bad deny_info %codes at startup and reconfiguration. Startup
  errors should eventually become fatal, just like logformat errors are.

* Report bad error page %codes at startup and reconfiguration (except
  for `%;` sequences found in all existing error pages templates).

* Fixed parsing of non-default error-details.txt that did not end with
  an empty line.

* Fixed unterminated c-string printing when reporting error-details.txt
  parsing problems.

* Upgraded MsgBody to use SBuf.

This is a Measurement Factory project.
