### PR TITLE
Support worker-dedicated listening queues (SO_REUSEPORT)

### DIFF
--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -39,6 +39,7 @@ AnyP::PortCfg::PortCfg() :
     ftp_track_dirs(false),
     vport(0),
     disable_pmtu_discovery(0),
+    workerQueues(false),
     listenConn()
 {
     memset(&tcp_keepalive, 0, sizeof(tcp_keepalive));
@@ -71,6 +72,7 @@ AnyP::PortCfg::clone() const
     b->vhost = vhost;
     b->vport = vport;
     b->connection_auth_disabled = connection_auth_disabled;
+    b->workerQueues = workerQueues;
     b->ftp_track_dirs = ftp_track_dirs;
     b->disable_pmtu_discovery = disable_pmtu_discovery;
     b->tcp_keepalive = tcp_keepalive;

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -46,6 +46,7 @@ public:
 
     int vport;               ///< virtual port support. -1 if dynamic, >0 static
     int disable_pmtu_discovery;
+    bool workerQueues; ///< whether listening queues should be worker-specific
 
     struct {
         unsigned int idle;

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -100,6 +100,9 @@
 #if HAVE_GRP_H
 #include <grp.h>
 #endif
+#if HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
@@ -3736,6 +3739,14 @@ parse_port_option(AnyP::PortCfgPointer &s, char *token)
         s->secure.parse(token+4);
     } else if (strcmp(token, "ftp-track-dirs") == 0) {
         s->ftp_track_dirs = true;
+    } else if (strcmp(token, "worker-queues") == 0) {
+#if !defined(SO_REUSEADDR)
+#error missing system #include that #defines SO_* constants
+#endif
+#if !defined(SO_REUSEPORT)
+        throw TexcHere(ToSBuf(cfg_directive, ' ', token, " option requires building Squid where SO_REUSEPORT is supported by the TCP stack"));
+#endif
+        s->workerQueues = true;
     } else {
         debugs(3, DBG_CRITICAL, "FATAL: Unknown " << cfg_directive << " option '" << token << "'.");
         self_destruct();

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2418,6 +2418,30 @@ DOC_START
 			The proxy_protocol_access is required to whitelist
 			downstream proxies which can be trusted.
 
+	   worker-queues
+			Ask TCP stack to maintain a dedicated listening queue
+			for each worker accepting requests at this port.
+			Requires TCP stack that supports the SO_REUSEPORT socket
+			option.
+
+			Cons: Enabling worker-specific queues allows any process
+			running as Squid's effective user to accept requests
+			destined to this port! Also, a stuck worker is assigned
+			the same number of new connections as active workers,
+			inconveniencing more users compared to the single shared
+			queue (default) configuration where a blocked worker
+			cannot affect new connections (as long as there are
+			other, active workers running).
+
+			Pros: Worker-specific listening queues significantly
+			improve CPU core utilization in most SMP environments by
+			reducing skew in mapping of new connections to workers.
+			Without this option, the TCP stack assigns more
+			connections to busier workers, often overloading some
+			CPU cores while underutilizing others. SO_REUSEPORT was
+			specifically designed for busy SMP servers, and is a
+			popular solution for reducing CPU allocation skew.
+
 	If you run Squid on a dual-homed machine with an internal
 	and an external interface we recommend you to specify the
 	internal address:port in http_port. This way Squid will only be

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2424,23 +2424,9 @@ DOC_START
 			Requires TCP stack that supports the SO_REUSEPORT socket
 			option.
 
-			Cons: Enabling worker-specific queues allows any process
-			running as Squid's effective user to accept requests
-			destined to this port! Also, a stuck worker is assigned
-			the same number of new connections as active workers,
-			inconveniencing more users compared to the single shared
-			queue (default) configuration where a blocked worker
-			cannot affect new connections (as long as there are
-			other, active workers running).
-
-			Pros: Worker-specific listening queues significantly
-			improve CPU core utilization in most SMP environments by
-			reducing skew in mapping of new connections to workers.
-			Without this option, the TCP stack assigns more
-			connections to busier workers, often overloading some
-			CPU cores while underutilizing others. SO_REUSEPORT was
-			specifically designed for busy SMP servers, and is a
-			popular solution for reducing CPU allocation skew.
+			SECURITY WARNING: Enabling worker-specific queues
+			allows any process running as Squid's effective user to
+			accept requests destined to this port.
 
 	If you run Squid on a dual-homed machine with an internal
 	and an external interface we recommend you to specify the

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2426,7 +2426,7 @@ DOC_START
 
 			SECURITY WARNING: Enabling worker-specific queues
 			allows any process running as Squid's effective user to
-			accept requests destined to this port.
+			easily accept requests destined to this port.
 
 	If you run Squid on a dual-homed machine with an internal
 	and an external interface we recommend you to specify the

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3362,7 +3362,8 @@ clientHttpConnectionsOpen(void)
         s->listenConn->local = s->s;
 
         s->listenConn->flags = COMM_NONBLOCKING | (s->flags.tproxyIntercept ? COMM_TRANSPARENT : 0) |
-                               (s->flags.natIntercept ? COMM_INTERCEPTION : 0);
+                               (s->flags.natIntercept ? COMM_INTERCEPTION : 0) |
+                               (s->workerQueues ? COMM_REUSEPORT : 0);
 
         typedef CommCbFunPtrCallT<CommAcceptCbPtrFun> AcceptCall;
         if (s->transport.protocol == AnyP::PROTO_HTTP) {

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -480,7 +480,7 @@ comm_apply_flags(int new_socket,
                 const auto errorMessage = ToSBuf("cannot enable SO_REUSEPORT socket option when binding to ",
                                                  addr, ": ", xstrerr(savedErrno));
                 if (reconfiguring)
-                    debugs(5, DBG_IMPORTANT, errorMessage);
+                    debugs(5, DBG_IMPORTANT, "ERROR: " << errorMessage);
                 else
                     throw TexcHere(errorMessage);
             }

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -32,6 +32,7 @@
 #include "pconn.h"
 #include "profiler/Profiler.h"
 #include "sbuf/SBuf.h"
+#include "sbuf/Stream.h"
 #include "SquidConfig.h"
 #include "StatCounters.h"
 #include "StoreIOBuffer.h"
@@ -471,6 +472,20 @@ comm_apply_flags(int new_socket,
         if ( addr.isNoAddr() )
             debugs(5,0,"CRITICAL: Squid is attempting to bind() port " << addr << "!!");
 
+#if defined(SO_REUSEPORT)
+        if (flags & COMM_REUSEPORT) {
+            int on = 1;
+            if (setsockopt(new_socket, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<char*>(&on), sizeof(on)) < 0) {
+                const auto savedErrno = errno;
+                const auto errorMessage = ToSBuf("cannot enable SO_REUSEPORT socket option when binding to ",
+                                                 addr, ": ", xstrerr(savedErrno));
+                if (reconfiguring)
+                    debugs(5, DBG_IMPORTANT, errorMessage);
+                else
+                    throw TexcHere(errorMessage);
+            }
+        }
+#endif
         if (commBind(new_socket, *AI) != Comm::OK) {
             comm_close(new_socket);
             return -1;

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -47,6 +47,7 @@ namespace Comm
 #define COMM_DOBIND             0x08  // requires a bind()
 #define COMM_TRANSPARENT        0x10  // arrived via TPROXY
 #define COMM_INTERCEPTION       0x20  // arrived via NAT
+#define COMM_REUSEPORT          0x40 //< needs SO_REUSEPORT
 
 /**
  * Store data about the physical and logical attributes of a connection.

--- a/src/ipc/StartListening.cc
+++ b/src/ipc/StartListening.cc
@@ -39,7 +39,10 @@ Ipc::StartListening(int sock_type, int proto, const Comm::ConnectionPointer &lis
     Must(cbd);
     cbd->conn = listenConn;
 
-    if (UsingSmp()) { // if SMP is on, share
+    const auto giveEachWorkerItsOwnQueue = listenConn->flags & COMM_REUSEPORT;
+    if (!giveEachWorkerItsOwnQueue && UsingSmp()) {
+        // Ask Coordinator for a listening socket.
+        // All askers share one listening queue.
         OpenListenerParams p;
         p.sock_type = sock_type;
         p.proto = proto;


### PR DESCRIPTION
This performance optimization has a few cons, including security
concerns, but it improves CPU core utilization/balance in many SMP
environments and is supported by many high-performance servers. Enabled
by the new `*_port worker-queues` configuration option.

Worker-dedicated listening queues reduce client-worker affinity for
requests submitted over different TCP connections. The effect of that
reduction on Squid performance depends on the environment, but many busy
SMP proxies handling modern traffic should benefit.

TODO: Linux tests show load balancing effects of SO_REUSEPORT, but
untested FreeBSD probably needs SO_REUSEPORT_LB to get those effects.

Recommended reading:
* https://blog.cloudflare.com/the-sad-state-of-linux-socket-balancing/
* https://lwn.net/Articles/542629/
* https://stackoverflow.com/a/14388707

