### PR TITLE
Made Coverity happier after Bug 4864 fix

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -971,6 +971,7 @@ FwdState::usePinned()
     ++n_tries;
     request->flags.pinned = true;
 
+    assert(connManager);
     if (connManager->pinnedAuth())
         request->flags.auth = true;
 


### PR DESCRIPTION
... by addressing the following false-positive:
CID 1442832: Null pointer dereferences (FORWARD_NULL)

The Comm::IsConnOpen() test guarantees that connManager is not nil. An
explicit assert() might reduce bugs when this code is refactored.