### PR TITLE
Made Coverity happier after e863656 (timestamps for FATAL)

### DIFF
--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -103,7 +103,8 @@ Debug::Context *Debug::Current = nullptr;
 Debug::Context::Context(const int aSection, const int aLevel):
     level(aLevel),
     sectionLevel(Levels[aSection]),
-    upper(Current)
+    upper(Current),
+    forceAlert(false)
 {
     buf.setf(std::ios::fixed);
     buf.precision(2);


### PR DESCRIPTION
CID 1441976: Uninitialized scalar field (UNINIT_CTOR)

The forgotten stub data member is currently unused.