### PR TITLE
Fixed build after a56fcf0 (Reuse helpers after timeout)

### DIFF
--- a/src/helper.h
+++ b/src/helper.h
@@ -25,8 +25,9 @@
 #include "sbuf/SBuf.h"
 
 #include <list>
-#include <unordered_map>
+#include <map>
 #include <queue>
+#include <unordered_map>
 
 class Packable;
 class wordlist;


### PR DESCRIPTION
In all tested environments, something else #included `<map>`,
apparently, but that old explicit #include should not have been removed.

Also fixed STL #include order.