### PR TITLE
Add support for buffer-size= to UDP logging #359

### DIFF
--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -205,7 +205,8 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
      * applications like netcat have a small default receive buffer and will
      * truncate!
      */
-    bufsz = 1400;
+    if(bufsz > 1400)
+        bufsz = 1400;
     if (bufsz > 0) {
         ll->buf = static_cast<char*>(xmalloc(bufsz));
         ll->bufsz = bufsz;

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -205,7 +205,7 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
      * applications like netcat have a small default receive buffer and will
      * truncate!
      */
-    if(bufsz > 1400)
+    if (bufsz > 1400)
         bufsz = 1400;
     if (bufsz > 0) {
         ll->buf = static_cast<char*>(xmalloc(bufsz));


### PR DESCRIPTION
Allow admin control of buffering for log outputs written to UDP
receivers using the buffer-size= parameter.

buffer-size=0byte disables buffering and sends UDP packets
immediately regardless of line size.

When non-0 values are used lines shorter than the buffer may be
delayed and aggregated into a later UDP packet.

Log lines larger than the buffer size will be sent immediately
and may trigger delivery of previously buffered content to
retain log order (at time of send, not UDP arrival).

To avoid truncation problems known with common recipients
the buffer size remains capped at 1400 bytes.