### PR TITLE
protection against buggy 304 Not Modified replies

### DIFF
--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -82,7 +82,7 @@ public:
     /* Interface functions */
     void clean();
     void append(const HttpHeader * src);
-    bool update(HttpHeader const *fresh);
+    bool update(HttpHeader const *fresh, bool update_content_length=true);
     void compact();
     int parse(const char *header_start, size_t len, Http::ContentLengthInterpreter &interpreter);
     /// Parses headers stored in a buffer.
@@ -173,7 +173,7 @@ protected:
     /// If block starts where it ends, then there are no fields in the header.
     static bool Isolate(const char **parse_start, size_t l, const char **blk_start, const char **blk_end);
     bool needUpdate(const HttpHeader *fresh) const;
-    bool skipUpdateHeader(const Http::HdrType id) const;
+    bool skipUpdateHeader(const Http::HdrType id, bool update_content_length=true) const;
     void updateWarnings();
 
 private:

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -258,7 +258,7 @@ HttpReply::updateOnNotModified(HttpReply const * freshRep)
     assert(freshRep);
 
     /* update raw headers */
-    if (!header.update(&freshRep->header))
+    if (!header.update(&freshRep->header, false))
         return false;
 
     /* clean cache */

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -28,7 +28,7 @@ HttpHeader::~HttpHeader() {STUB}
 HttpHeader &HttpHeader::operator =(const HttpHeader &other) STUB_RETVAL(*this)
 void HttpHeader::clean() STUB
 void HttpHeader::append(const HttpHeader *) STUB
-bool HttpHeader::update(HttpHeader const *) STUB_RETVAL(false)
+bool HttpHeader::update(HttpHeader const *, bool) STUB_RETVAL(false)
 void HttpHeader::compact() STUB
 int HttpHeader::parse(const char *, size_t, Http::ContentLengthInterpreter &) STUB_RETVAL(-1)
 int HttpHeader::parse(const char *, size_t, bool, size_t &, Http::ContentLengthInterpreter &) STUB_RETVAL(-1)
@@ -83,7 +83,7 @@ void HttpHeader::removeHopByHopEntries() STUB
 void HttpHeader::removeConnectionHeaderEntries() STUB
 bool HttpHeader::Isolate(const char **, size_t, const char **, const char **) STUB_RETVAL(false)
 bool HttpHeader::needUpdate(const HttpHeader *fresh) const STUB_RETVAL(false)
-bool HttpHeader::skipUpdateHeader(const Http::HdrType) const STUB_RETVAL(false)
+bool HttpHeader::skipUpdateHeader(const Http::HdrType, bool) const STUB_RETVAL(false)
 void HttpHeader::updateWarnings() STUB
 int httpHeaderParseQuotedString(const char *, const int, String *) STUB_RETVAL(-1)
 SBuf httpHeaderQuoteString(const char *) STUB_RETVAL(SBuf())


### PR DESCRIPTION
When Squid tries to refresh its cache after its local cached content is expired, some buggy upstream servers reply "304 Not Modified" status with a "Content-Length" header set to 0.

After that, Squids updates its response headers to the client with the all the ones he got from the upstream server but "Warning".

Squid should protect itself from those buggy inputs, otherwise it will send back an inconsistent reply to the client (Content-Length set to 0 followed by the previously cached body).