### PR TITLE
Fixed bootstrapping on Debian

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -8,6 +8,7 @@
 
 To build and install the Squid Cache, type:
 
+        % ./bootstrap.sh
 	% ./configure --prefix=/usr/local/squid
         % make all
         % make install

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,6 +93,11 @@ then
   LIBTOOL_BIN="glibtool"
 else
   LIBTOOL_BIN="libtool"
+  lsb_release_id="$(lsb_release -si)"
+  if [ -n "${lsb_release_id}" ] \
+         && [ "${lsb_release_id}" = "Debian" ]; then
+      LIBTOOL_BIN="libtoolize"
+  fi
 fi
 
 # Adjust paths of required autool packages
@@ -138,7 +143,7 @@ do
 	    # Bootstrap the autotool subsystems
 	    bootstrap aclocal$amver $acincludeflag
 	    bootstrap autoheader$acver
-	    bootstrap_libtoolize ${LIBTOOL_BIN}ize${ltver}
+	    bootstrap_libtoolize ${LIBTOOL_BIN}${ltver}
 	    bootstrap automake$amver --foreign --add-missing --copy -f
 	    bootstrap autoconf$acver --force
 	fi ); then


### PR DESCRIPTION
I did had some difficulties to run the `bootstrap.sh` in order to build squid-cache from source on a Debian box. It seems to me that the Debian libtool packages is naming the binary 'libtoolize' which makes `find_variant` reporting an error.

As its seems lsb_release is required to run this script, I'm using it to detect if the Linux system is Debian or not and if, change the `LIBTOOL_BIN` path.

Seems to work on Debian, but I'm unsure on the repercussion on other distro.

Is this going ok or not?