### PR TITLE
Bug 4796: comm.cc !isOpen(conn->fd) assertion when rotating logs

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1151,8 +1151,6 @@ mainInitialize(void)
 
     _db_init(Debug::cache_log, Debug::debugOptions);
 
-    fd_open(fileno(debug_log), FD_LOG, Debug::cache_log);
-
     debugs(1, DBG_CRITICAL, "Starting Squid Cache version " << version_string << " for " << CONFIG_HOST_TYPE << "...");
     debugs(1, DBG_CRITICAL, "Service Name: " << service_name);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1151,6 +1151,10 @@ mainInitialize(void)
 
     _db_init(Debug::cache_log, Debug::debugOptions);
 
+    // Do not register cache.log descriptor with Comm (for now).
+    // See https://bugs.squid-cache.org/show_bug.cgi?id=4796
+    // fd_open(fileno(debug_log), FD_LOG, Debug::cache_log);
+
     debugs(1, DBG_CRITICAL, "Starting Squid Cache version " << version_string << " for " << CONFIG_HOST_TYPE << "...");
     debugs(1, DBG_CRITICAL, "Service Name: " << service_name);
 


### PR DESCRIPTION
Squid abandoned cache.log file descriptor maintenance, calling fd_open()
but then closing the descriptor without fd_close(). If the original file
descriptor value was reused for another purpose, Squid would either hit
the reported assertion or log a "Closing open FD" WARNING (depending on
the new purpose). The cache.log file descriptor is closed on log
rotation and reconfiguration events.

This short-term solution avoids assertions and WARNINGs but sacrifices
cache.log listing in fd_table and, hence, mgr:filedescriptors reports.

The correct long-term solution is to properly maintain descriptor meta
information across cache.log closures/openings, but doing so from inside
of debug.cc is technically difficult due to linking boundaries/problems.