### PR TITLE
When using OpenSSL, trust intermediate CAs from trusted stores

### DIFF
--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -287,6 +287,7 @@ Security::PeerOptions::createClientContext(bool setOptions)
         updateContextNpn(t);
         updateContextCa(t);
         updateContextCrl(t);
+        updateContextTrust(t);
     }
 
     return t;
@@ -700,6 +701,23 @@ Security::PeerOptions::updateContextCrl(Security::ContextPointer &ctx)
 #endif
 
 #endif /* USE_OPENSSL */
+}
+
+void
+Security::PeerOptions::updateContextTrust(Security::ContextPointer &ctx)
+{
+#if USE_OPENSSL
+#if defined(X509_V_FLAG_PARTIAL_CHAIN)
+    const auto st = SSL_CTX_get_cert_store(ctx.get());
+    assert(st);
+    if (X509_STORE_set_flags(st, X509_V_FLAG_PARTIAL_CHAIN) != 1) {
+        debugs(83, DBG_IMPORTANT, "ERROR: Failed to enable trust in intermediate CA certificates: " <<
+               Security::ErrorString(ERR_get_error()));
+    }
+#endif
+#elif USE_GNUTLS
+    // Modern GnuTLS versions trust intermediate CA certificates by default.
+#endif /* TLS library */
 }
 
 void

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -56,6 +56,9 @@ public:
     /// setup the CRL details for the given context
     void updateContextCrl(Security::ContextPointer &);
 
+    /// decide which CAs to trust
+    void updateContextTrust(Security::ContextPointer &);
+
     /// setup any library-specific options that can be set for the given session
     void updateSessionOptions(Security::SessionPointer &);
 

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -439,6 +439,7 @@ Security::ServerOptions::updateContextClientCa(Security::ContextPointer &ctx)
         }
 
         updateContextCrl(ctx);
+        updateContextTrust(ctx);
 
     } else {
         debugs(83, 9, "Not requiring any client certificates");

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -86,6 +86,7 @@ void Security::PeerOptions::updateTlsVersionLimits() STUB
 Security::ContextPointer Security::PeerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer())
 void Security::PeerOptions::updateContextCa(Security::ContextPointer &) STUB
 void Security::PeerOptions::updateContextCrl(Security::ContextPointer &) STUB
+void Security::PeerOptions::updateContextTrust(Security::ContextPointer &) STUB
 void Security::PeerOptions::updateSessionOptions(Security::SessionPointer &) STUB
 void Security::PeerOptions::dumpCfg(Packable*, char const*) const STUB
 void Security::PeerOptions::parseOptions() STUB


### PR DESCRIPTION
According to [1], GnuTLS and NSS do that by default.

Use case: Chrome and Mozilla no longer trust Semantic root CAs _but_
still trust several whitelisted Semantic intermediate CAs[2]. Squid
built with OpenSSL cannot do that without X509_V_FLAG_PARTIAL_CHAIN.

[1] https://www.openldap.org/lists/openldap-devel/201506/msg00012.html
[2] https://wiki.mozilla.org/CA/Additional_Trust_Changes#Symantec