### PR TITLE
Fix build broken by missing <map> in 36c774

### DIFF
--- a/src/proxyp/Elements.cc
+++ b/src/proxyp/Elements.cc
@@ -11,28 +11,53 @@
 #include "proxyp/Elements.h"
 #include "sbuf/Stream.h"
 
+#include <algorithm>
 #include <limits>
-
-const ProxyProtocol::FieldMap ProxyProtocol::PseudoHeaderFields = {
-    { SBuf(":version"), ProxyProtocol::Two::htPseudoVersion },
-    { SBuf(":command"), ProxyProtocol::Two::htPseudoCommand },
-    { SBuf(":src_addr"), ProxyProtocol::Two::htPseudoSrcAddr },
-    { SBuf(":dst_addr"), ProxyProtocol::Two::htPseudoDstAddr },
-    { SBuf(":src_port"), ProxyProtocol::Two::htPseudoSrcPort },
-    { SBuf(":dst_port"), ProxyProtocol::Two::htPseudoDstPort }
-};
+#include <map>
 
 namespace ProxyProtocol {
+namespace Two {
+
+/// a mapping between pseudo header names and ids
+typedef std::map<SBuf, FieldType> FieldMap;
+static const FieldMap PseudoHeaderFields = {
+    { SBuf(":version"), htPseudoVersion },
+    { SBuf(":command"), htPseudoCommand },
+    { SBuf(":src_addr"), htPseudoSrcAddr },
+    { SBuf(":dst_addr"), htPseudoDstAddr },
+    { SBuf(":src_port"), htPseudoSrcPort },
+    { SBuf(":dst_port"), htPseudoDstPort }
+};
+
+} // namespace Two
+
 static Two::FieldType NameToFieldType(const SBuf &);
 static Two::FieldType IntegerToFieldType(const SBuf &);
+
 } // namespace ProxyProtocol
+
+
+const SBuf &
+ProxyProtocol::PseudoFieldTypeToFieldName(const Two::FieldType fieldType)
+{
+    // reverse PseudoHeaderFields so that we can look up names by FieldType
+    typedef std::vector<SBuf> PsuedoFieldNames;
+    static PsuedoFieldNames psuedoFieldNames;
+    if (psuedoFieldNames.empty()) {
+        std::for_each(Two::PseudoHeaderFields.begin(), Two::PseudoHeaderFields.end(),
+            [](const Two::FieldMap::value_type &item) {
+                psuedoFieldNames.at(item.second) = item.first;
+            });
+    }
+    return psuedoFieldNames.at(fieldType - Two::htPseudoBegin);
+}
 
 /// FieldNameToFieldType() helper that handles pseudo headers
 ProxyProtocol::Two::FieldType
 ProxyProtocol::NameToFieldType(const SBuf &name)
 {
-    const auto it = PseudoHeaderFields.find(name);
-    if (it != PseudoHeaderFields.end())
+    const auto it = Two::PseudoHeaderFields.find(name);
+    if (it != Two::PseudoHeaderFields.end())
         return it->second;
 
     static const SBuf pseudoMark(":");

--- a/src/proxyp/Elements.cc
+++ b/src/proxyp/Elements.cc
@@ -41,15 +41,15 @@ const SBuf &
 ProxyProtocol::PseudoFieldTypeToFieldName(const Two::FieldType fieldType)
 {
     // "flip" PseudoHeaderFields so that we can look up names by FieldType
-    typedef std::vector<SBuf> PsuedoFieldNames;
-    static PsuedoFieldNames psuedoFieldNames;
-    if (psuedoFieldNames.empty()) {
+    typedef std::vector<SBuf> PseudoFieldNames;
+    static PseudoFieldNames pseudoFieldNames;
+    if (pseudoFieldNames.empty()) {
         std::for_each(Two::PseudoHeaderFields.begin(), Two::PseudoHeaderFields.end(),
             [](const Two::FieldMap::value_type &item) {
-                psuedoFieldNames.at(item.second) = item.first;
+                pseudoFieldNames.at(item.second) = item.first;
             });
     }
-    return psuedoFieldNames.at(fieldType - Two::htPseudoBegin);
+    return pseudoFieldNames.at(fieldType - Two::htPseudoBegin);
 }
 
 /// FieldNameToFieldType() helper that handles pseudo headers

--- a/src/proxyp/Elements.cc
+++ b/src/proxyp/Elements.cc
@@ -19,7 +19,7 @@ namespace ProxyProtocol {
 namespace Two {
 
 /// a mapping between pseudo header names and ids
-typedef std::vector<std::pair<SBuf, FieldType> > FieldMap;
+typedef std::vector< std::pair<SBuf, FieldType> > FieldMap;
 static const FieldMap PseudoHeaderFields = {
     { SBuf(":version"), htPseudoVersion },
     { SBuf(":command"), htPseudoCommand },
@@ -36,14 +36,13 @@ static Two::FieldType IntegerToFieldType(const SBuf &);
 
 } // namespace ProxyProtocol
 
-
 const SBuf &
 ProxyProtocol::PseudoFieldTypeToFieldName(const Two::FieldType fieldType)
 {
     const auto it = std::find_if(Two::PseudoHeaderFields.begin(), Two::PseudoHeaderFields.end(),
-            [fieldType](const Two::FieldMap::value_type &item) {
-                return item.second == fieldType;
-            });
+    [fieldType](const Two::FieldMap::value_type &item) {
+        return item.second == fieldType;
+    });
 
     assert(it != Two::PseudoHeaderFields.end());
     return it->first;
@@ -54,9 +53,9 @@ ProxyProtocol::Two::FieldType
 ProxyProtocol::NameToFieldType(const SBuf &name)
 {
     const auto it = std::find_if(Two::PseudoHeaderFields.begin(), Two::PseudoHeaderFields.end(),
-            [&name](const Two::FieldMap::value_type &item) {
-                return item.first == name;
-            });
+    [&name](const Two::FieldMap::value_type &item) {
+        return item.first == name;
+    });
 
     if (it != Two::PseudoHeaderFields.end())
         return it->second;

--- a/src/proxyp/Elements.cc
+++ b/src/proxyp/Elements.cc
@@ -40,7 +40,7 @@ static Two::FieldType IntegerToFieldType(const SBuf &);
 const SBuf &
 ProxyProtocol::PseudoFieldTypeToFieldName(const Two::FieldType fieldType)
 {
-    // reverse PseudoHeaderFields so that we can look up names by FieldType
+    // "flip" PseudoHeaderFields so that we can look up names by FieldType
     typedef std::vector<SBuf> PsuedoFieldNames;
     static PsuedoFieldNames psuedoFieldNames;
     if (psuedoFieldNames.empty()) {

--- a/src/proxyp/Elements.h
+++ b/src/proxyp/Elements.h
@@ -11,8 +11,6 @@
 
 #include "sbuf/SBuf.h"
 
-#include <map>
-
 // https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 namespace ProxyProtocol {
 namespace Two {
@@ -36,12 +34,14 @@ typedef enum {
 
     // IDs for PROXY protocol header pseudo-headers.
     // Larger than 255 to avoid clashes with possible TLV type IDs.
-    htPseudoVersion = 0x101,
-    htPseudoCommand = 0x102,
-    htPseudoSrcAddr = 0x103,
-    htPseudoDstAddr = 0x104,
-    htPseudoSrcPort = 0x105,
-    htPseudoDstPort = 0x106
+    htPseudoBegin = 0x101, // smallest pseudo-header value (for iteration)
+    htPseudoVersion,
+    htPseudoCommand,
+    htPseudoSrcAddr,
+    htPseudoDstAddr,
+    htPseudoSrcPort,
+    htPseudoDstPort,
+    htPseudoEnd // largest pseudo-header value plus 1 (for iteration)
 } FieldType;
 
 /// PROXY protocol 'command' field value
@@ -78,9 +78,9 @@ public:
 
 } // namespace Two
 
-typedef std::map<SBuf, Two::FieldType> FieldMap;
-/// a mapping between pseudo header names and ids
-extern const FieldMap PseudoHeaderFields;
+/// \returns human-friendly PROXY protocol field name for the given field type
+/// from the [htPseudoBegin,htPseudoEnd) range
+const SBuf &PseudoFieldTypeToFieldName(const Two::FieldType);
 
 /// Parses human-friendly PROXY protocol field type representation.
 /// Only pseudo headers can (and should) be represented by their names.

--- a/src/proxyp/Elements.h
+++ b/src/proxyp/Elements.h
@@ -11,6 +11,8 @@
 
 #include "sbuf/SBuf.h"
 
+#include <map>
+
 // https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 namespace ProxyProtocol {
 namespace Two {

--- a/src/proxyp/Header.cc
+++ b/src/proxyp/Header.cc
@@ -7,6 +7,7 @@
  */
 
 #include "squid.h"
+#include "base/EnumIterator.h"
 #include "proxyp/Elements.h"
 #include "proxyp/Header.h"
 #include "sbuf/Stream.h"
@@ -24,10 +25,10 @@ SBuf
 ProxyProtocol::Header::toMime() const
 {
     SBufStream result;
-    for (const auto &p: PseudoHeaderFields) {
-        const auto value = getValues(p.second);
+    for (const auto fieldType: EnumRange(Two::htPseudoBegin, Two::htPseudoEnd)) {
+        const auto value = getValues(fieldType);
         if (!value.isEmpty())
-            result << p.first << ": " << value << "\r\n";
+            result << PseudoFieldTypeToFieldName(fieldType) << ": " << value << "\r\n";
     }
     // cannot reuse Header::getValues(): need the original TLVs layout
     for (const auto &tlv: tlvs)


### PR DESCRIPTION
In all tested environments, something else #included `<map>`.