### PR TITLE
Remove unused SBufCaseInsensitiveLess

### DIFF
--- a/src/base/LookupTable.h
+++ b/src/base/LookupTable.h
@@ -47,13 +47,6 @@ struct LookupTableRecord
  *
  */
 
-class SBufCaseInsensitiveLess : public std::binary_function<SBuf, SBuf, bool> {
-public:
-    bool operator() (const SBuf &x, const SBuf &y) const {
-        return x.caseCmp(y) < 0;
-    }
-};
-
 template<typename EnumType, typename RecordType = LookupTableRecord<EnumType>, typename Hasher = CaseInsensitiveSBufHash >
 class LookupTable
 {


### PR DESCRIPTION
This class has been replaced by a proper hash in the
sbuf/Algorithms.h current code.

If this is needed in future we can define a lambda instead.