### PR TITLE
Made Coverity happier after f5e1794 (Peering for SslBump)

### DIFF
--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -171,7 +171,7 @@ public:
     err_type type = ERR_NONE;
     int page_id = ERR_NONE;
     char *err_language = nullptr;
-    Http::StatusCode httpStatus;
+    Http::StatusCode httpStatus = Http::scNone;
 #if USE_AUTH
     Auth::UserRequest::Pointer auth_user_request;
 #endif


### PR DESCRIPTION
CID 1444393: Uninitialized members (UNINIT_CTOR)

From the current code point of view, this is a false positive because
the private constructor which lacked initialization was only used from
other constructors that do initialize httpStatus.