### PR TITLE
Fix Coverity reported issue for Uninitialized members

### DIFF
--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -171,7 +171,7 @@ public:
     err_type type = ERR_NONE;
     int page_id = ERR_NONE;
     char *err_language = nullptr;
-    Http::StatusCode httpStatus;
+    Http::StatusCode httpStatus = Http::scNone;
 #if USE_AUTH
     Auth::UserRequest::Pointer auth_user_request;
 #endif


### PR DESCRIPTION
Coverity reports that the ErrorState::httpStatus member is not initialized
in private "ErrorState(err_type type)" which is only used by the other public
constructors of ErrorState class.

Coverity Scan issue 1444393