### PR TITLE
Bug 4912: same-name notes being appended instead of replaced

### DIFF
--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -355,6 +355,15 @@ NotePairs::appendNewOnly(const NotePairs *src)
 }
 
 void
+NotePairs::replaceOrAddOrAppend(const NotePairs *src, const std::vector<SBuf> &appendKeys)
+{
+    for (auto e: src->entries)
+        if (std::find(appendKeys.begin(), appendKeys.end(), e->name()) == appendKeys.end())
+            remove(e->name());
+    append(src);
+}
+
+void
 NotePairs::replaceOrAdd(const NotePairs *src)
 {
     for (auto e: src->entries)

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -355,11 +355,12 @@ NotePairs::appendNewOnly(const NotePairs *src)
 }
 
 void
-NotePairs::replaceOrAddOrAppend(const NotePairs *src, const std::vector<SBuf> &appendKeys)
+NotePairs::replaceOrAddOrAppend(const NotePairs *src, const NotePairs::Names &appendables)
 {
-    for (auto e: src->entries)
-        if (std::find(appendKeys.begin(), appendKeys.end(), e->name()) == appendKeys.end())
+    for (const auto e: src->entries) {
+        if (std::find(appendables.begin(), appendables.end(), e->name()) == appendables.end())
             remove(e->name());
+    }
     append(src);
 }
 

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -200,6 +200,11 @@ public:
     void append(const NotePairs *src);
 
     /// Replace existing list entries with the src NotePairs entries.
+    /// Do not replace some special keys but append them instead.
+    /// Entries which do not exist in the destination set are added.
+    void replaceOrAddOrAppend(const NotePairs *src, const std::vector<SBuf> &appendKeys);
+
+    /// Replace existing list entries with the src NotePairs entries.
     /// Entries which do not exist in the destination set are added.
     void replaceOrAdd(const NotePairs *src);
 

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -191,6 +191,7 @@ public:
         SBuf theValue;
     };
     typedef std::vector<Entry::Pointer> Entries;      ///< The key/value pair entries
+    typedef std::vector<SBuf> Names;
 
     NotePairs() {}
     NotePairs &operator=(NotePairs const &) = delete;
@@ -200,9 +201,9 @@ public:
     void append(const NotePairs *src);
 
     /// Replace existing list entries with the src NotePairs entries.
-    /// Do not replace some special keys but append them instead.
+    /// Do not replace but append entries named in the appendables
     /// Entries which do not exist in the destination set are added.
-    void replaceOrAddOrAppend(const NotePairs *src, const std::vector<SBuf> &appendKeys);
+    void replaceOrAddOrAppend(const NotePairs *src, const Names &appendables);
 
     /// Replace existing list entries with the src NotePairs entries.
     /// Entries which do not exist in the destination set are added.

--- a/src/auth/basic/UserRequest.cc
+++ b/src/auth/basic/UserRequest.cc
@@ -168,7 +168,7 @@ Auth::Basic::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 
     // add new helper kv-pair notes to the credentials object
     // so that any transaction using those credentials can access them
-    r->auth_user_request->user()->notes.appendNewOnly(&reply.notes);
+    r->auth_user_request->user()->notes.replaceOrAdd(&reply.notes);
 
     /* this is okay since we only play with the Auth::Basic::User child fields below
      * and do not pass the pointer itself anywhere */

--- a/src/auth/basic/UserRequest.cc
+++ b/src/auth/basic/UserRequest.cc
@@ -168,8 +168,8 @@ Auth::Basic::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 
     // add new helper kv-pair notes to the credentials object
     // so that any transaction using those credentials can access them
-    static const std::vector<SBuf> appendKeys = { SBuf("group"), SBuf("tag") };
-    r->auth_user_request->user()->notes.replaceOrAddOrAppend(&reply.notes, appendKeys);
+    static const NotePairs::Names appendables = { SBuf("group"), SBuf("tag") };
+    r->auth_user_request->user()->notes.replaceOrAddOrAppend(&reply.notes, appendables);
 
     /* this is okay since we only play with the Auth::Basic::User child fields below
      * and do not pass the pointer itself anywhere */

--- a/src/auth/basic/UserRequest.cc
+++ b/src/auth/basic/UserRequest.cc
@@ -168,7 +168,8 @@ Auth::Basic::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 
     // add new helper kv-pair notes to the credentials object
     // so that any transaction using those credentials can access them
-    r->auth_user_request->user()->notes.replaceOrAdd(&reply.notes);
+    static const std::vector<SBuf> appendKeys = { SBuf("group"), SBuf("tag") };
+    r->auth_user_request->user()->notes.replaceOrAddOrAppend(&reply.notes, appendKeys);
 
     /* this is okay since we only play with the Auth::Basic::User child fields below
      * and do not pass the pointer itself anywhere */

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -327,7 +327,8 @@ Auth::Digest::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 
     // add new helper kv-pair notes to the credentials object
     // so that any transaction using those credentials can access them
-    auth_user_request->user()->notes.appendNewOnly(&reply.notes);
+    static const NotePairs::Names appendables = { SBuf("group"), SBuf("nonce"), SBuf("tag") };
+    auth_user_request->user()->notes.replaceOrAddOrAppend(&reply.notes, appendables);
     // remove any private credentials detail which got added.
     auth_user_request->user()->notes.remove("ha1");
 

--- a/src/auth/negotiate/UserRequest.cc
+++ b/src/auth/negotiate/UserRequest.cc
@@ -278,7 +278,8 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
 
     // add new helper kv-pair notes to the credentials object
     // so that any transaction using those credentials can access them
-    auth_user_request->user()->notes.appendNewOnly(&reply.notes);
+    static const NotePairs::Names appendables = { SBuf("group"), SBuf("tag") };
+    auth_user_request->user()->notes.replaceOrAddOrAppend(&reply.notes, appendables);
     // remove any private credentials detail which got added.
     auth_user_request->user()->notes.remove("token");
 

--- a/src/auth/ntlm/UserRequest.cc
+++ b/src/auth/ntlm/UserRequest.cc
@@ -272,7 +272,8 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 
     // add new helper kv-pair notes to the credentials object
     // so that any transaction using those credentials can access them
-    auth_user_request->user()->notes.appendNewOnly(&reply.notes);
+    static const NotePairs::Names appendables = { SBuf("group"), SBuf("tag") };
+    auth_user_request->user()->notes.replaceOrAddOrAppend(&reply.notes, appendables);
     // remove any private credentials detail which got added.
     auth_user_request->user()->notes.remove("token");
 


### PR DESCRIPTION
When auth helper replies with clt_conn_tag=foo (or any KV pair) and
then later in future replaces it with clt_conn_tag=bar. The new pair
was getting appended instead of getting replaced.

i.e. notes would contain two KV pairs:
clt_conn_tag=foo
clt_conn_tag=bar

This fixes it and also fixes:
https://bugs.squid-cache.org/show_bug.cgi?id=4912