### PR TITLE
Bug 4942: --with-filedescriptors does not do anything

### DIFF
--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -248,9 +248,16 @@ SQUID_STATE_ROLLBACK(maxfd)
 
 AC_MSG_NOTICE([Default number of filedescriptors: $squid_filedescriptors_num])
 
-if test `expr $squid_filedescriptors_num % 64` != 0; then
-    AC_MSG_WARN([$squid_filedescriptors_num is not an multiple of 64. This may cause issues on certain platforms.])
-fi
+AS_IF([ test `expr $squid_filedescriptors_num % 64` != 0 ],[
+  AC_MSG_WARN([$squid_filedescriptors_num is not an multiple of 64. This may cause issues on certain platforms.])
+])
+
+AS_IF([ test "$squid_filedescriptors_num" -lt 512 ],[
+  AC_MSG_WARN([$squid_filedescriptors_num may not be enough filedescriptors if your])
+  AC_MSG_WARN([cache will be very busy.  Please see the FAQ page])
+  AC_MSG_WARN([http://wiki.squid-cache.org/SquidFaq/TroubleShooting])
+  AC_MSG_WARN([on how to increase your filedescriptor limit])
+])
 ])
 
 

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -236,14 +236,17 @@ int main(int argc, char **argv) {
 	fprintf (fp, "%d\n", i & ~0x3F);
 	return 0;
 }
-  ]])],[squid_filedescriptors_num=`cat conftestval`],[squid_filedescriptors_num=256],[squid_filedescriptors_num=256])
+  ]])],[squid_filedescriptors_limit=`cat conftestval`],[],[])
   dnl Microsoft MSVCRT.DLL supports 2048 maximum FDs
   case "$host_os" in
   mingw|mingw32)
-    squid_filedescriptors_num="2048"
+    squid_filedescriptors_limit="2048"
     ;;
   esac
-  AC_MSG_RESULT($squid_filedescriptors_num)
+  AC_MSG_RESULT($squid_filedescriptors_limit)
+  AS_IF([ test "x$squid_filedescriptors_num" = "x" ],[
+    squid_filedescriptors_num=$squid_filedescriptors_limit
+  ])
 SQUID_STATE_ROLLBACK(maxfd)
 
 AC_MSG_NOTICE([Default number of filedescriptors: $squid_filedescriptors_num])

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -166,14 +166,9 @@ dnl sets shell var squid_filedescriptors_num
 AC_DEFUN([SQUID_CHECK_MAXFD],[
 AC_CHECK_FUNCS(getrlimit setrlimit)
 AC_MSG_CHECKING(Maximum number of filedescriptors we can open)
-dnl damn! FreeBSD pthreads break dup2().
 SQUID_STATE_SAVE(maxfd)
-  case $host in
-  i386-unknown-freebsd*)
-      if echo "$LDFLAGS" | grep -q pthread; then
-  	LDFLAGS=`echo $LDFLAGS | sed -e "s/-pthread//"`
-      fi
-  esac
+dnl FreeBSD pthreads break dup2().
+  AS_CASE([$host_os],[freebsd],[ LDFLAGS=`echo $LDFLAGS | sed -e "s/-pthread//"` ])
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <unistd.h>
@@ -238,11 +233,7 @@ int main(int argc, char **argv) {
 }
   ]])],[squid_filedescriptors_limit=`cat conftestval`],[],[])
   dnl Microsoft MSVCRT.DLL supports 2048 maximum FDs
-  case "$host_os" in
-  mingw|mingw32)
-    squid_filedescriptors_limit="2048"
-    ;;
-  esac
+  AS_CASE(["$host_os"],[mingw|mingw32],[squid_filedescriptors_limit="2048"])
   AC_MSG_RESULT($squid_filedescriptors_limit)
   AS_IF([ test "x$squid_filedescriptors_num" = "x" ],[
     squid_filedescriptors_num=$squid_filedescriptors_limit

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -164,7 +164,7 @@ dnl checks the maximum number of filedescriptor we can open
 dnl sets shell var squid_filedescriptors_num
 
 AC_DEFUN([SQUID_CHECK_MAXFD],[
-AC_CHECK_FUNCS(setrlimit)
+AC_CHECK_FUNCS(getrlimit setrlimit)
 AC_MSG_CHECKING(Maximum number of filedescriptors we can open)
 dnl damn! FreeBSD pthreads break dup2().
 SQUID_STATE_SAVE(maxfd)
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
      */
     i = NOFILE;
 #else
-#if HAVE_SETRLIMIT
+#if HAVE_GETRLIMIT && HAVE_SETRLIMIT
     struct rlimit rl;
 #if defined(RLIMIT_NOFILE)
     if (getrlimit(RLIMIT_NOFILE, &rl) < 0) {

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -236,7 +236,12 @@ int main(int argc, char **argv) {
   AS_CASE(["$host_os"],[mingw|mingw32],[squid_filedescriptors_limit="2048"])
   AC_MSG_RESULT($squid_filedescriptors_limit)
   AS_IF([ test "x$squid_filedescriptors_num" = "x" ],[
-    squid_filedescriptors_num=$squid_filedescriptors_limit
+    AS_IF([ test "x$squid_filedescriptors_limit" != "x" ],[
+      squid_filedescriptors_num=$squid_filedescriptors_limit
+    ],[
+      AC_MSG_NOTICE([Unable to detect filedescriptor limits. Assuming 256 is okay.])
+      squid_filedescriptors_num=256
+    ])
   ])
 SQUID_STATE_ROLLBACK(maxfd)
 

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -246,6 +246,8 @@ int main(int argc, char **argv) {
   AC_MSG_RESULT($squid_filedescriptors_num)
 SQUID_STATE_ROLLBACK(maxfd)
 
+AC_MSG_NOTICE([Default number of filedescriptors: $squid_filedescriptors_num])
+
 if test `expr $squid_filedescriptors_num % 64` != 0; then
     AC_MSG_WARN([$squid_filedescriptors_num is not an multiple of 64. This may cause issues on certain platforms.])
 fi

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -257,6 +257,7 @@ AS_IF([ test "$squid_filedescriptors_num" -lt 512 ],[
   AC_MSG_WARN([http://wiki.squid-cache.org/SquidFaq/TroubleShooting])
   AC_MSG_WARN([on how to increase your filedescriptor limit])
 ])
+AC_DEFINE_UNQUOTED(SQUID_MAXFD,$squid_filedescriptors_num,[Maximum number of open filedescriptors])
 ])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3156,12 +3156,6 @@ AC_ARG_WITH(filedescriptors,
 
 SQUID_CHECK_DEFAULT_FD_SETSIZE
 SQUID_CHECK_MAXFD
-if test "$squid_filedescriptors_num" -lt 512 ; then
-    AC_MSG_WARN([$squid_filedescriptors_num may not be enough filedescriptors if your])
-    AC_MSG_WARN([cache will be very busy.  Please see the FAQ page])
-    AC_MSG_WARN([http://wiki.squid-cache.org/SquidFaq/TroubleShooting])
-    AC_MSG_WARN([on how to increase your filedescriptor limit])
-fi
 AC_DEFINE_UNQUOTED(SQUID_MAXFD, $squid_filedescriptors_num,[Maximum number of open filedescriptors])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3301,7 +3301,6 @@ AC_CHECK_FUNCS(\
 	getdtablesize \
 	getpagesize \
 	getpass \
-	getrlimit \
 	getrusage \
 	getspnam \
 	gettimeofday \

--- a/configure.ac
+++ b/configure.ac
@@ -3156,7 +3156,6 @@ AC_ARG_WITH(filedescriptors,
 
 SQUID_CHECK_DEFAULT_FD_SETSIZE
 SQUID_CHECK_MAXFD
-AC_DEFINE_UNQUOTED(SQUID_MAXFD, $squid_filedescriptors_num,[Maximum number of open filedescriptors])
 
 
 dnl Enable IPv6 support

--- a/configure.ac
+++ b/configure.ac
@@ -3156,9 +3156,6 @@ AC_ARG_WITH(filedescriptors,
 
 SQUID_CHECK_DEFAULT_FD_SETSIZE
 SQUID_CHECK_MAXFD
-if test "x$squid_filedescriptors_num" != "x"; then
-  AC_MSG_NOTICE([Default number of fieldescriptors: $squid_filedescriptors_num])
-fi
 if test "$squid_filedescriptors_num" -lt 512 ; then
     AC_MSG_WARN([$squid_filedescriptors_num may not be enough filedescriptors if your])
     AC_MSG_WARN([cache will be very busy.  Please see the FAQ page])


### PR DESCRIPTION
SQUID_CHECK_MAXFD has been unconditionally overwriting any
user-defined limit with an auto-detected limit from the build
machine. The change causing this was an incomplete fix for
bug 3970 added to v3.3 and later releases.

Fixing that problem has two notable side effects:

* the user-defined value now has the FD property checks applied
  to it (multiple of 64, too-few, etc). This means warnings will
  start to appear in build logs for a number of custom
  configurations. We should expect an increase in questions
  about that.

* builds which have previously been passing in outrageous values
  will actually start to use those values as the SQUID_MAXFD
  limit. This may result in surprising memory consumption or
  performance issues. Hopefully the warnings and new messages
  displaying auto-detected limit separate from the value used
  will reduce the admin surprise, but may not.

This PR also includes cleanup of the autoconf syntax within the
SQUID_CHECK_MAXFD macro and moves the ./configure warnings about
possible issues into that check macro.