### PR TITLE
RFC 8586: Loop Detection in Content Delivery Networks

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7309,6 +7309,9 @@ DOC_START
 	need an identification token to allow control targeting. Because
 	a farm of surrogates may all perform the same tasks, they may share
 	an identification token.
+
+	When the surrogate is a reverse-proxy this ID is also
+	used as cdn-id for CDN-Loop detection (RFC 8586).
 DOC_END
 
 NAME: http_accel_surrogate_remote

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7310,7 +7310,7 @@ DOC_START
 	a farm of surrogates may all perform the same tasks, they may share
 	an identification token.
 
-	When the surrogate is a reverse-proxy this ID is also
+	When the surrogate is a reverse-proxy, this ID is also
 	used as cdn-id for CDN-Loop detection (RFC 8586).
 DOC_END
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1136,7 +1136,8 @@ clientInterpretRequestHeaders(ClientHttpRequest * http)
 
     // headers only relevant to reverse-proxy
     if (request->flags.accelerated) {
-        // check for surrogate_id value in the CDN-Loop header (if any)
+        // check for a cdn-info member with a cdn-id matching surrogate_id
+        // XXX: HttpHeader::hasListMember() does not handle OWS around ";" yet
         if (req_hdr->hasListMember(Http::HdrType::CDN_LOOP, Config.Accel.surrogate_id, ',')) {
             debugObj(33, DBG_IMPORTANT, "WARNING: Forwarding loop detected for:\n",
                      request, (ObjPackMethod) & httpRequestPack);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1121,8 +1121,6 @@ clientInterpretRequestHeaders(ClientHttpRequest * http)
          */
 
         if (strListIsSubstr(&s, ThisCache2, ',')) {
-            debugObj(33, 1, "WARNING: Forwarding loop detected for:\n",
-                     request, (ObjPackMethod) & httpRequestPack);
             request->flags.loopDetected = true;
         }
 
@@ -1138,11 +1136,13 @@ clientInterpretRequestHeaders(ClientHttpRequest * http)
     if (request->flags.accelerated) {
         // check for a cdn-info member with a cdn-id matching surrogate_id
         // XXX: HttpHeader::hasListMember() does not handle OWS around ";" yet
-        if (req_hdr->hasListMember(Http::HdrType::CDN_LOOP, Config.Accel.surrogate_id, ',')) {
-            debugObj(33, DBG_IMPORTANT, "WARNING: Forwarding loop detected for:\n",
-                     request, (ObjPackMethod) & httpRequestPack);
+        if (req_hdr->hasListMember(Http::HdrType::CDN_LOOP, Config.Accel.surrogate_id, ','))
             request->flags.loopDetected = true;
-        }
+    }
+
+    if (request->flags.loopDetected) {
+        debugObj(33, DBG_IMPORTANT, "WARNING: Forwarding loop detected for:\n",
+                 request, (ObjPackMethod) & httpRequestPack);
     }
 
 #if USE_FORW_VIA_DB

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1134,6 +1134,16 @@ clientInterpretRequestHeaders(ClientHttpRequest * http)
         s.clean();
     }
 
+    // headers only relevant to reverse-proxy
+    if (request->flags.accelerated) {
+        // check for surrogate_id value in the CDN-Loop header (if any)
+        if (req_hdr->hasListMember(Http::HdrType::CDN_LOOP, Config.Accel.surrogate_id, ',')) {
+            debugObj(33, DBG_IMPORTANT, "WARNING: Forwarding loop detected for:\n",
+                     request, (ObjPackMethod) & httpRequestPack);
+            request->flags.loopDetected = true;
+        }
+    }
+
 #if USE_FORW_VIA_DB
 
     if (req_hdr->has(Http::HdrType::X_FORWARDED_FOR)) {

--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -32,6 +32,7 @@ enum HdrType {
     AUTHENTICATION_INFO,            /**< RFC 2617 */
     AUTHORIZATION,                  /**< RFC 7235, 4559 */
     CACHE_CONTROL,                  /**< RFC 7234 */
+    CDN_LOOP,                       /**< RFC 8586 */
     CONNECTION,                     /**< RFC 7230 */
     CONTENT_BASE,                   /**< obsoleted RFC 2068 */
     CONTENT_DISPOSITION,            /**< RFC 2183, 6266 */

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -1,32 +1,32 @@
-/* C++ code produced by gperf version 3.0.4 */
-/* Command-line: gperf --output-file=RegisteredHeadersHash.cci -m 100000 RegisteredHeadersHash.gperf  */
+/* C++ code produced by gperf version 3.1 */
+/* Command-line: gperf -m 100000 RegisteredHeadersHash.gperf  */
 /* Computed positions: -k'1,9,$' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
-&& ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
-&& (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
-&& ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
-&& ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
-&& ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
-&& ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
-&& ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
-&& ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
-&& ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
-&& ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
-&& ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
-&& ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
-&& ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
-&& ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
-&& ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
-&& ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
-&& ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
-&& ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
-&& ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
-&& ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
-&& ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
-&& ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
+      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
+      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
+      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
+      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
+      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
+      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
+      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
+      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
+      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
+      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
+      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
+      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
+      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
+      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
+      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
+      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
+      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
+      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
+      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
+      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
+      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
 /* The character set is not based on ISO-646.  */
-#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
 #endif
 
 #line 1 "RegisteredHeadersHash.gperf"
@@ -42,26 +42,26 @@
  */
 #line 24 "RegisteredHeadersHash.gperf"
 struct HeaderTableRecord;
-        enum
-{
-    TOTAL_KEYWORDS = 88,
+enum
+  {
+    TOTAL_KEYWORDS = 89,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 25,
-    MIN_HASH_VALUE = 7,
-    MAX_HASH_VALUE = 113
-};
+    MIN_HASH_VALUE = 13,
+    MAX_HASH_VALUE = 114
+  };
 
-/* maximum key range = 107, duplicates = 0 */
+/* maximum key range = 102, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
 static unsigned char gperf_downcase[256] =
-{
-    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
-    15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
-    30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
-    45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
-    60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
+  {
+      0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
+     15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+     30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+     45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+     60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
     107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
     122,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104,
     105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
@@ -75,307 +75,313 @@ static unsigned char gperf_downcase[256] =
     225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
     240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254,
     255
-};
+  };
 #endif
 
 #ifndef GPERF_CASE_MEMCMP
 #define GPERF_CASE_MEMCMP 1
 static int
-gperf_case_memcmp (const char *s1, const char *s2, unsigned int n)
+gperf_case_memcmp (const char *s1, const char *s2, size_t n)
 {
-    for (; n > 0;)
+  for (; n > 0;)
     {
-        unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
-        unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
-        if (c1 == c2)
+      unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
+      unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
+      if (c1 == c2)
         {
-            n--;
-            continue;
+          n--;
+          continue;
         }
-        return (int)c1 - (int)c2;
+      return (int)c1 - (int)c2;
     }
-    return 0;
+  return 0;
 }
 #endif
 
 class HttpHeaderHashTable
 {
 private:
-    static inline unsigned int HttpHeaderHash (const char *str, unsigned int len);
+  static inline unsigned int HttpHeaderHash (const char *str, size_t len);
 public:
-    static const struct HeaderTableRecord *lookup (const char *str, unsigned int len);
+  static const struct HeaderTableRecord *lookup (const char *str, size_t len);
 };
 
 inline unsigned int
-HttpHeaderHashTable::HttpHeaderHash (const char *str, unsigned int len)
+HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 {
-    static const unsigned char asso_values[] =
+  static const unsigned char asso_values[] =
     {
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114,  14, 114, 114,   5, 114, 114, 114, 114,
-        64, 114, 114,  14, 114, 114, 114, 114,   1, 114,
-        114, 114, 114, 114, 114,   4,   5,  15,  29,   1,
-        17,  60,  35,  19, 114,  51,  15,  42,   8,  50,
-        11, 114,   1,  19,   7,  28,   4,  41,  33,  15,
-        114, 114, 114, 114, 114, 114, 114,   4,   5,  15,
-        29,   1,  17,  60,  35,  19, 114,  51,  15,  42,
-        8,  50,  11, 114,   1,  19,   7,  28,   4,  41,
-        33,  15, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114, 114, 114, 114, 114
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115,  27, 115, 115,   4, 115, 115, 115, 115,
+       26, 115, 115,  33, 115, 115, 115, 115,  25, 115,
+      115, 115, 115, 115, 115,  15,   7,   7,  10,   4,
+       33,  66,  42,  22, 115,  63,  10,  33,  18,  44,
+       11, 115,   4,  28,  10,  42,  23,  26,  31,  30,
+      115, 115, 115, 115, 115, 115, 115,  15,   7,   7,
+       10,   4,  33,  66,  42,  22, 115,  63,  10,  33,
+       18,  44,  11, 115,   4,  28,  10,  42,  23,  26,
+       31,  30, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+      115, 115, 115, 115, 115, 115
     };
-    int hval = len;
+  unsigned int hval = len;
 
-    switch (hval)
+  switch (hval)
     {
-    default:
-        hval += asso_values[(unsigned char)str[8]];
-    /*FALLTHROUGH*/
-    case 8:
-    case 7:
-    case 6:
-    case 5:
-    case 4:
-    case 3:
-    case 2:
-    case 1:
-        hval += asso_values[(unsigned char)str[0]];
+      default:
+        hval += asso_values[static_cast<unsigned char>(str[8])];
+      /*FALLTHROUGH*/
+      case 8:
+      case 7:
+      case 6:
+      case 5:
+      case 4:
+      case 3:
+      case 2:
+      case 1:
+        hval += asso_values[static_cast<unsigned char>(str[0])];
         break;
     }
-    return hval + asso_values[(unsigned char)str[len - 1]];
+  return hval + asso_values[static_cast<unsigned char>(str[len - 1])];
 }
 
 static const unsigned char lengthtable[] =
-{
-    0,  0,  0,  0,  0,  0,  0,  5,  3,  7,  2,  3,  0,  5,
-    6,  7, 13,  6,  9,  9, 11,  6,  6,  4, 15,  7,  6,  7,
-    8, 13, 13,  8,  6, 12,  4, 12,  7, 18, 18, 10, 13,  7,
-    13, 16,  0, 19,  4, 16, 13, 10,  5, 13, 17, 10, 16, 20,
-    17,  6, 19, 16, 14, 11,  8,  4,  6,  4, 10, 18, 15,  3,
-    4, 19, 13, 14, 10, 14, 13, 12, 15, 14, 15, 12, 11, 10,
-    9, 10,  7, 15, 19, 17,  0, 13, 16, 25,  0,  0,  0,  0,
-    0,  0, 21,  0,  0,  0,  0,  0,  0,  0,  7, 13,  0,  0,
-    0, 11
-};
+  {
+     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  5,
+     0,  7,  2,  6,  4,  5,  6,  7,  3,  0,  6, 13,  8,  9,
+    13, 11, 12,  6,  6, 12,  8,  9,  8, 16,  6,  7,  7,  3,
+     7, 18,  7, 13,  5, 18, 13, 15, 16, 16, 13,  7, 19, 13,
+     4,  4, 19, 17, 15, 13,  9, 16, 10, 17, 14, 19,  6, 11,
+     4, 13,  8, 14,  4,  6, 13,  4, 15, 10, 10, 14, 20, 18,
+    11, 19, 15, 11, 12, 10, 25, 12,  0, 16, 14,  0,  3, 17,
+     0,  7, 10,  0,  0,  0,  0, 10,  0, 13,  0,  0, 13, 21,
+     0, 10, 15
+  };
 
 static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
-{
-    {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 78 "RegisteredHeadersHash.gperf"
+  {
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""},
+#line 79 "RegisteredHeadersHash.gperf"
     {"Range", Http::HdrType::RANGE, Http::HdrFieldType::ftPRange, HdrKind::RequestHeader},
+    {""},
+#line 80 "RegisteredHeadersHash.gperf"
+    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 86 "RegisteredHeadersHash.gperf"
+    {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 48 "RegisteredHeadersHash.gperf"
+    {"Cookie", Http::HdrType::COOKIE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 50 "RegisteredHeadersHash.gperf"
+    {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
+#line 87 "RegisteredHeadersHash.gperf"
+    {"Title", Http::HdrType::TITLE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 52 "RegisteredHeadersHash.gperf"
+    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 88 "RegisteredHeadersHash.gperf"
+    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
 #line 31 "RegisteredHeadersHash.gperf"
     {"Age", Http::HdrType::AGE, Http::HdrFieldType::ftInt, HdrKind::ReplyHeader},
-#line 79 "RegisteredHeadersHash.gperf"
-    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 85 "RegisteredHeadersHash.gperf"
-    {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 94 "RegisteredHeadersHash.gperf"
-    {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
     {""},
-#line 86 "RegisteredHeadersHash.gperf"
-    {"Title", Http::HdrType::TITLE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 51 "RegisteredHeadersHash.gperf"
-    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 87 "RegisteredHeadersHash.gperf"
-    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 80 "RegisteredHeadersHash.gperf"
+#line 78 "RegisteredHeadersHash.gperf"
+    {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 81 "RegisteredHeadersHash.gperf"
     {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
+#line 37 "RegisteredHeadersHash.gperf"
+    {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 90 "RegisteredHeadersHash.gperf"
+    {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 46 "RegisteredHeadersHash.gperf"
+    {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
+#line 82 "RegisteredHeadersHash.gperf"
+    {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 39 "RegisteredHeadersHash.gperf"
+    {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
 #line 26 "RegisteredHeadersHash.gperf"
     {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 89 "RegisteredHeadersHash.gperf"
-    {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 69 "RegisteredHeadersHash.gperf"
-    {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 81 "RegisteredHeadersHash.gperf"
-    {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 71 "RegisteredHeadersHash.gperf"
+#line 72 "RegisteredHeadersHash.gperf"
     {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
 #line 47 "RegisteredHeadersHash.gperf"
-    {"Cookie", Http::HdrType::COOKIE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 93 "RegisteredHeadersHash.gperf"
-    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 29 "RegisteredHeadersHash.gperf"
-    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 109 "RegisteredHeadersHash.gperf"
-    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 82 "RegisteredHeadersHash.gperf"
-    {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 52 "RegisteredHeadersHash.gperf"
-    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 60 "RegisteredHeadersHash.gperf"
-    {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
-#line 35 "RegisteredHeadersHash.gperf"
-    {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 45 "RegisteredHeadersHash.gperf"
-    {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
-#line 66 "RegisteredHeadersHash.gperf"
-    {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 77 "RegisteredHeadersHash.gperf"
-    {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 38 "RegisteredHeadersHash.gperf"
-    {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 49 "RegisteredHeadersHash.gperf"
-    {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
-#line 46 "RegisteredHeadersHash.gperf"
     {"Content-Type", Http::HdrType::CONTENT_TYPE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 91 "RegisteredHeadersHash.gperf"
-    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 72 "RegisteredHeadersHash.gperf"
-    {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 33 "RegisteredHeadersHash.gperf"
-    {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 113 "RegisteredHeadersHash.gperf"
-    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
-#line 30 "RegisteredHeadersHash.gperf"
-    {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 97 "RegisteredHeadersHash.gperf"
-    {"X-Cache", Http::HdrType::X_CACHE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 76 "RegisteredHeadersHash.gperf"
-    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 75 "RegisteredHeadersHash.gperf"
-    {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-    {""},
-#line 74 "RegisteredHeadersHash.gperf"
-    {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 55 "RegisteredHeadersHash.gperf"
-    {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 41 "RegisteredHeadersHash.gperf"
+#line 61 "RegisteredHeadersHash.gperf"
+    {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
+#line 70 "RegisteredHeadersHash.gperf"
+    {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 67 "RegisteredHeadersHash.gperf"
+    {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 42 "RegisteredHeadersHash.gperf"
     {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 101 "RegisteredHeadersHash.gperf"
-    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 83 "RegisteredHeadersHash.gperf"
-    {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+    {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 53 "RegisteredHeadersHash.gperf"
+    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 49 "RegisteredHeadersHash.gperf"
+    {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 95 "RegisteredHeadersHash.gperf"
+    {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 98 "RegisteredHeadersHash.gperf"
+    {"X-Cache", Http::HdrType::X_CACHE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 73 "RegisteredHeadersHash.gperf"
+    {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 110 "RegisteredHeadersHash.gperf"
+    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 77 "RegisteredHeadersHash.gperf"
+    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
 #line 32 "RegisteredHeadersHash.gperf"
     {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 33 "RegisteredHeadersHash.gperf"
+    {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
 #line 36 "RegisteredHeadersHash.gperf"
     {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 105 "RegisteredHeadersHash.gperf"
-    {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 92 "RegisteredHeadersHash.gperf"
-    {"User-Agent", Http::HdrType::USER_AGENT, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 43 "RegisteredHeadersHash.gperf"
-    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 104 "RegisteredHeadersHash.gperf"
-    {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 58 "RegisteredHeadersHash.gperf"
-    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
-#line 112 "RegisteredHeadersHash.gperf"
-    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 61 "RegisteredHeadersHash.gperf"
-    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
-#line 96 "RegisteredHeadersHash.gperf"
+#line 29 "RegisteredHeadersHash.gperf"
+    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 97 "RegisteredHeadersHash.gperf"
     {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 44 "RegisteredHeadersHash.gperf"
+    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 102 "RegisteredHeadersHash.gperf"
+    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 92 "RegisteredHeadersHash.gperf"
+    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+#line 40 "RegisteredHeadersHash.gperf"
+    {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 65 "RegisteredHeadersHash.gperf"
+    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 56 "RegisteredHeadersHash.gperf"
+    {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 94 "RegisteredHeadersHash.gperf"
+    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 75 "RegisteredHeadersHash.gperf"
+    {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 106 "RegisteredHeadersHash.gperf"
+    {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 100 "RegisteredHeadersHash.gperf"
+    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 35 "RegisteredHeadersHash.gperf"
+    {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 54 "RegisteredHeadersHash.gperf"
+    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 76 "RegisteredHeadersHash.gperf"
+    {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+#line 84 "RegisteredHeadersHash.gperf"
+    {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 59 "RegisteredHeadersHash.gperf"
+    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
+#line 99 "RegisteredHeadersHash.gperf"
+    {"X-Cache-Lookup", Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 62 "RegisteredHeadersHash.gperf"
+    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
+#line 71 "RegisteredHeadersHash.gperf"
+    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 108 "RegisteredHeadersHash.gperf"
+    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 55 "RegisteredHeadersHash.gperf"
+    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 30 "RegisteredHeadersHash.gperf"
+    {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 58 "RegisteredHeadersHash.gperf"
+    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 43 "RegisteredHeadersHash.gperf"
+    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
+#line 51 "RegisteredHeadersHash.gperf"
+    {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
+#line 113 "RegisteredHeadersHash.gperf"
+    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 101 "RegisteredHeadersHash.gperf"
+    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 66 "RegisteredHeadersHash.gperf"
+    {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 104 "RegisteredHeadersHash.gperf"
+    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 38 "RegisteredHeadersHash.gperf"
+    {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+#line 93 "RegisteredHeadersHash.gperf"
+    {"User-Agent", Http::HdrType::USER_AGENT, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 27 "RegisteredHeadersHash.gperf"
     {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 107 "RegisteredHeadersHash.gperf"
-    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 57 "RegisteredHeadersHash.gperf"
-    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 54 "RegisteredHeadersHash.gperf"
-    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 70 "RegisteredHeadersHash.gperf"
-    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 50 "RegisteredHeadersHash.gperf"
-    {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
-#line 62 "RegisteredHeadersHash.gperf"
-    {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 102 "RegisteredHeadersHash.gperf"
-    {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 105 "RegisteredHeadersHash.gperf"
+    {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 103 "RegisteredHeadersHash.gperf"
-    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 63 "RegisteredHeadersHash.gperf"
-    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 65 "RegisteredHeadersHash.gperf"
-    {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 39 "RegisteredHeadersHash.gperf"
-    {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 100 "RegisteredHeadersHash.gperf"
-    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 98 "RegisteredHeadersHash.gperf"
-    {"X-Cache-Lookup", Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 110 "RegisteredHeadersHash.gperf"
-    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
-#line 56 "RegisteredHeadersHash.gperf"
-    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 64 "RegisteredHeadersHash.gperf"
-    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 67 "RegisteredHeadersHash.gperf"
-    {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
-#line 99 "RegisteredHeadersHash.gperf"
-    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 42 "RegisteredHeadersHash.gperf"
-    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
-#line 106 "RegisteredHeadersHash.gperf"
-    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 68 "RegisteredHeadersHash.gperf"
-    {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
-#line 44 "RegisteredHeadersHash.gperf"
+    {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 45 "RegisteredHeadersHash.gperf"
     {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 37 "RegisteredHeadersHash.gperf"
-    {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 53 "RegisteredHeadersHash.gperf"
-    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 111 "RegisteredHeadersHash.gperf"
-    {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 48 "RegisteredHeadersHash.gperf"
-    {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 28 "RegisteredHeadersHash.gperf"
-    {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
 #line 34 "RegisteredHeadersHash.gperf"
     {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 88 "RegisteredHeadersHash.gperf"
+#line 107 "RegisteredHeadersHash.gperf"
+    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 85 "RegisteredHeadersHash.gperf"
+    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 68 "RegisteredHeadersHash.gperf"
+    {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
+#line 114 "RegisteredHeadersHash.gperf"
+    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
+#line 74 "RegisteredHeadersHash.gperf"
+    {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+#line 69 "RegisteredHeadersHash.gperf"
+    {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
+    {""},
+#line 41 "RegisteredHeadersHash.gperf"
+    {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 57 "RegisteredHeadersHash.gperf"
+    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+    {""},
+#line 64 "RegisteredHeadersHash.gperf"
+    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 89 "RegisteredHeadersHash.gperf"
     {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
     {""},
-#line 108 "RegisteredHeadersHash.gperf"
-    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 40 "RegisteredHeadersHash.gperf"
-    {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 73 "RegisteredHeadersHash.gperf"
-    {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-    {""}, {""}, {""}, {""}, {""}, {""},
-#line 90 "RegisteredHeadersHash.gperf"
-    {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
-    {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 95 "RegisteredHeadersHash.gperf"
+#line 96 "RegisteredHeadersHash.gperf"
     {"Warning", Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 59 "RegisteredHeadersHash.gperf"
+#line 63 "RegisteredHeadersHash.gperf"
+    {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+    {""}, {""}, {""}, {""},
+#line 112 "RegisteredHeadersHash.gperf"
+    {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
+    {""},
+#line 109 "RegisteredHeadersHash.gperf"
+    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
+    {""}, {""},
+#line 60 "RegisteredHeadersHash.gperf"
     {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-    {""}, {""}, {""},
-#line 84 "RegisteredHeadersHash.gperf"
-    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader}
-};
+#line 91 "RegisteredHeadersHash.gperf"
+    {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
+    {""},
+#line 111 "RegisteredHeadersHash.gperf"
+    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
+#line 28 "RegisteredHeadersHash.gperf"
+    {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader}
+  };
 
 const struct HeaderTableRecord *
-HttpHeaderHashTable::lookup (const char *str, unsigned int len)
+HttpHeaderHashTable::lookup (const char *str, size_t len)
 {
-    if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
+  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-        int key = HttpHeaderHash (str, len);
+      unsigned int key = HttpHeaderHash (str, len);
 
-        if (key <= MAX_HASH_VALUE && key >= 0)
-            if (len == lengthtable[key])
-            {
-                const char *s = HttpHeaderDefinitionsTable[key].name;
+      if (key <= MAX_HASH_VALUE)
+        if (len == lengthtable[key])
+          {
+            const char *s = HttpHeaderDefinitionsTable[key].name;
 
-                if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_memcmp (str, s, len))
-                    return &HttpHeaderDefinitionsTable[key];
-            }
+            if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_memcmp (str, s, len))
+              return &HttpHeaderDefinitionsTable[key];
+          }
     }
-    return 0;
+  return 0;
 }
-#line 114 "RegisteredHeadersHash.gperf"
+#line 115 "RegisteredHeadersHash.gperf"
 

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -34,6 +34,7 @@ Alternate-Protocol, Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr
 Authentication-Info, Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader
 Authorization, Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader
 Cache-Control, Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader
+CDN-Loop, Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader
 Connection, Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader
 Content-Base, Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader
 Content-Disposition, Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None


### PR DESCRIPTION
Support the CDN-Loop header as a source for loop detection.

This header is only relevant to CDN installations. For which the
surrogate_id configuration directive specifies the authoritative
ID.

Squid does not add this header by default, preferring to use the
Via mechanism instead. Administrators may add it to requests
with the request_header_add directive or remove with
request_header_remove.