### PR TITLE
Fixed startup assertions when using a src_as or dst_as ACL

### DIFF
--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -229,6 +229,7 @@ asnCacheStart(int as)
 {
     AnyP::Uri whoisUrl(AnyP::PROTO_WHOIS);
     whoisUrl.host(Config.as_whois_server);
+    whoisUrl.port(WHOIS_PORT);
 
     SBuf asPath("/!gAS");
     asPath.appendf("%d", as);

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -28,7 +28,6 @@
 #include "Store.h"
 #include "StoreClient.h"
 
-#define WHOIS_PORT 43
 #ifndef AS_REQBUF_SZ
 #define AS_REQBUF_SZ    4096
 #endif
@@ -229,7 +228,7 @@ asnCacheStart(int as)
 {
     AnyP::Uri whoisUrl(AnyP::PROTO_WHOIS);
     whoisUrl.host(Config.as_whois_server);
-    whoisUrl.port(WHOIS_PORT);
+    whoisUrl.defaultPort();
 
     SBuf asPath("/!gAS");
     asPath.appendf("%d", as);

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -466,6 +466,12 @@ AnyP::Uri::touch()
     authorityWithPort_.clear();
 }
 
+void
+AnyP::Uri::defaultPort()
+{
+    port(getScheme().defaultPort());
+}
+
 SBuf &
 AnyP::Uri::authority(bool requirePort) const
 {

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -466,12 +466,6 @@ AnyP::Uri::touch()
     authorityWithPort_.clear();
 }
 
-void
-AnyP::Uri::defaultPort()
-{
-    port(getScheme().defaultPort());
-}
-
 SBuf &
 AnyP::Uri::authority(bool requirePort) const
 {

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -82,6 +82,8 @@ public:
 
     void port(unsigned short p) {port_=p; touch();}
     unsigned short port() const {return port_;}
+    /// initialize the port with the default port number for this URL's scheme
+    void defaultPort();
 
     void path(const char *p) {path_=p; touch();}
     void path(const SBuf &p) {path_=p; touch();}

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -82,8 +82,8 @@ public:
 
     void port(unsigned short p) {port_=p; touch();}
     unsigned short port() const {return port_;}
-    /// initialize the port with the default port number for this URL's scheme
-    void defaultPort();
+    /// reset the port to the default port number for the current scheme
+    void defaultPort() { port(getScheme().defaultPort()); }
 
     void path(const char *p) {path_=p; touch();}
     void path(const SBuf &p) {path_=p; touch();}

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -23,8 +23,6 @@
 
 #include <cerrno>
 
-#define WHOIS_PORT 43
-
 class WhoisState
 {
     CBDATA_CLASS(WhoisState);


### PR DESCRIPTION
Specify the port for generated whois URLs when requesting AS numbers.
