### PR TITLE
Bug 4947: EventScheduler loops on same task forever

### DIFF
--- a/src/event.cc
+++ b/src/event.cc
@@ -225,6 +225,7 @@ EventScheduler::timeRemaining() const
 int
 EventScheduler::checkEvents(int)
 {
+    getCurrentTime();
     int result = timeRemaining();
     if (result != 0)
         return result;


### PR DESCRIPTION
The event scheduler itself does not update the time variables, which in some conditions may cause it to loop over the same task forever, and the task itself may never complete and simply abort and reschedule itself if it also does not update the time variables and is waiting for a certain timeout.

The fix adds a call to "getCurrentTime()" when the event scheduler checks events in the queue to avoid this condition.