### PR TITLE
ESI: throw on large stack recursions

### DIFF
--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -930,7 +930,7 @@ void
 ESIContext::addStackElement (ESIElement::Pointer element)
 {
     /* Put on the stack to allow skipping of 'invalid' markup */
-    assert (parserState.stackdepth <11);
+    Must(parserState.stackdepth < 10);
     assert (!failed());
     debugs(86, 5, "ESIContext::addStackElement: About to add ESI Node " << element.getRaw());
 
@@ -1188,7 +1188,7 @@ ESIContext::addLiteral (const char *s, int len)
     assert (len);
     debugs(86, 5, "literal length is " << len);
     /* give a literal to the current element */
-    assert (parserState.stackdepth <11);
+    Must(parserState.stackdepth < 10);
     ESIElement::Pointer element (new esiLiteral (this, s, len));
 
     if (!parserState.top()->addElement(element)) {


### PR DESCRIPTION
This reduces the impact on concurrent clients to only those
accessing the malformed resource.

Depending on what type of recursion is being performed the
resource may appear to the client with missing segments, or
not at all.