### PR TITLE
Bug 4953: to_localhost does not include ::

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1003,7 +1003,7 @@ ENDIF
 DEFAULT: all src all
 DEFAULT: manager url_regex -i ^cache_object:// +i ^https?://[^/]+/squid-internal-mgr/
 DEFAULT: localhost src 127.0.0.1/32 ::1
-DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1/128 ::/128
 DEFAULT: CONNECT method CONNECT
 DEFAULT_DOC: ACLs all, manager, localhost, to_localhost, and CONNECT are predefined.
 DOC_START


### PR DESCRIPTION
Some OS treat unspecified destination address as an implicit
localhost connection attempt. Add ::/128 alongside the
to_localhost 0.0.0.0/32 address to let admin forbid these
connections when DNS entries wrongly contain [::].

Also, adjust ::1 to ::1/128 to match IPv4 range-based definition
and clarify that IPv6 localhost is /128 rather than /127.