### PR TITLE
Add the NO_TLSv1_3 option to available  tls-options values

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2909,7 +2909,7 @@ DOC_START
 	min-version=1.N
 			The minimum TLS protocol version to permit.
 			To control SSLv3 use the options= parameter.
-			Supported Values: 1.0 (default), 1.1, 1.2
+			Supported Values: 1.0 (default), 1.1, 1.2, 1.3
 
 	options=...	Specify various TLS/SSL implementation options.
 

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -221,13 +221,6 @@ Security::PeerOptions::updateTlsVersionLimits()
             add = ":-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.3";
 #endif
             break;
-        case 7:
-#if USE_OPENSSL
-            add = ":NO_SSLv3:NO_TLSv1:NO_TLSv1_1:NO_TLSv1_2";
-#elif USE_GNUTLS
-            add = ":-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.2";
-#endif
-            break;
         default: // nothing
             break;
         }
@@ -412,6 +405,8 @@ static struct ssl_option {
     {
         "NO_TLSv1_3", SSL_OP_NO_TLSv1_3
     },
+#else
+    { "NO_TLSv1_3", 0 },
 #endif
 #if SSL_OP_NO_COMPRESSION
     {

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -195,30 +195,37 @@ Security::PeerOptions::updateTlsVersionLimits()
         switch (sslVersion) {
         case 3:
 #if USE_OPENSSL
-            add = ":NO_TLSv1:NO_TLSv1_1:NO_TLSv1_2";
+            add = ":NO_TLSv1:NO_TLSv1_1:NO_TLSv1_2:NO_TLSv1_3";
 #elif USE_GNUTLS
-            add = ":-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.2";
+            add = ":-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.2:-VERS-TLS1.3";
 #endif
             break;
         case 4:
 #if USE_OPENSSL
-            add = ":NO_SSLv3:NO_TLSv1_1:NO_TLSv1_2";
+            add = ":NO_SSLv3:NO_TLSv1_1:NO_TLSv1_2:NO_TLSv1_3";
 #elif USE_GNUTLS
-            add = ":+VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.2";
+            add = ":+VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.2:-VERS-TLS1.3";
 #endif
             break;
         case 5:
 #if USE_OPENSSL
-            add = ":NO_SSLv3:NO_TLSv1:NO_TLSv1_2";
+            add = ":NO_SSLv3:NO_TLSv1:NO_TLSv1_2:NO_TLSv1_3";
 #elif USE_GNUTLS
-            add = ":-VERS-TLS1.0:+VERS-TLS1.1:-VERS-TLS1.2";
+            add = ":-VERS-TLS1.0:+VERS-TLS1.1:-VERS-TLS1.2:-VERS-TLS1.3";
 #endif
             break;
         case 6:
 #if USE_OPENSSL
-            add = ":NO_SSLv3:NO_TLSv1:NO_TLSv1_1";
+            add = ":NO_SSLv3:NO_TLSv1:NO_TLSv1_1:NO_TLSv1_3";
 #elif USE_GNUTLS
-            add = ":-VERS-TLS1.0:-VERS-TLS1.1";
+            add = ":-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.3";
+#endif
+            break;
+        case 7:
+#if USE_OPENSSL
+            add = ":NO_SSLv3:NO_TLSv1:NO_TLSv1_1:NO_TLSv1_2";
+#elif USE_GNUTLS
+            add = ":-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.2";
 #endif
             break;
         default: // nothing
@@ -400,6 +407,11 @@ static struct ssl_option {
     },
 #else
     { "NO_TLSv1_2", 0 },
+#endif
+#if SSL_OP_NO_TLSv1_3
+    {
+        "NO_TLSv1_3", SSL_OP_NO_TLSv1_3
+    },
 #endif
 #if SSL_OP_NO_COMPRESSION
     {


### PR DESCRIPTION
... also fix the deprecated sslversion option to exclude tls v1.3 from
allowed protocols where required.

This is a Measurement Factory project