### PR TITLE
Remove userinfo support from old protocols

### DIFF
--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -495,10 +495,10 @@ AnyP::Uri::absolute() const
         absolute_.append(":",1);
         if (getScheme() != AnyP::PROTO_URN) {
             absolute_.append("//", 2);
-            const bool omitUserInfo = getScheme() == AnyP::PROTO_HTTP ||
-                                      getScheme() == AnyP::PROTO_HTTPS ||
-                                      userInfo().isEmpty();
-            if (!omitUserInfo) {
+            const bool allowUserInfo = getScheme() == AnyP::PROTO_FTP ||
+                                       getScheme() == AnyP::PROTO_UNKNOWN;
+
+            if (allowUserInfo && !userInfo().isEmpty()) {
                 absolute_.append(userInfo());
                 absolute_.append("@", 1);
             }


### PR DESCRIPTION
RFC 1738 defines the URL schemes for gopher and wais as not
having the userinfo@ segment.

coap, coaps, whois and cache_object also do not use this segment.

For these cases we can obey the RFC7230 requirement to ignore the
segment when producing normalized absolute URL.

Of the supported protocols only FTP requires userinfo, and because
we cannot be certain for unknown protocols allow it as well.