### PR TITLE
Send Connection:close with the known-last request on a connection

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -1926,10 +1926,10 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
         delete cc;
     }
 
-    /* maybe append Connection: keep-alive */
-    if (flags.keepalive) {
-        hdr_out->putStr(Http::HdrType::CONNECTION, "keep-alive");
-    }
+    // Always send Connection because older servers need explicit "keep-alive"
+    // while modern servers need explicit "close", and we do not always know
+    // the server expectations.
+    hdr_out->putStr(Http::HdrType::CONNECTION, flags.keepalive ? "keep-alive" : "close");
 
     /* append Front-End-Https */
     if (flags.front_end_https) {

--- a/src/http.cc
+++ b/src/http.cc
@@ -1926,8 +1926,8 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
         delete cc;
     }
 
-    // Always send Connection because older servers need explicit "keep-alive"
-    // while modern servers need explicit "close", and we do not always know
+    // Always send Connection because HTTP/1.0 servers need explicit "keep-alive"
+    // while HTTP/1.1 servers need explicit "close", and we do not always know
     // the server expectations.
     hdr_out->putStr(Http::HdrType::CONNECTION, flags.keepalive ? "keep-alive" : "close");
 

--- a/src/http/StateFlags.h
+++ b/src/http/StateFlags.h
@@ -16,7 +16,7 @@ class StateFlags
 {
 public:
     unsigned int front_end_https = 0; ///< send "Front-End-Https: On" header (off/on/auto=2)
-    bool keepalive = false;
+    bool keepalive = false; ///< whether to keep the connection persistent
     bool only_if_cached = false;
     bool handling1xx = false;       ///< we are ignoring or forwarding 1xx response
     bool headers_parsed = false;


### PR DESCRIPTION
Squid did not send Connection:close request header on a to-be-closed
HTTP/1.1 connection, violating RFC 7230 Section 6.6 "SHOULD send"
requirement.