### PR TITLE
Bug 4842: Memory leak when http_reply_access uses external_acl

### DIFF
--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -312,6 +312,7 @@ Http::One::Server::handleReply(HttpReply *rep, StoreIOBuffer receivedData)
     }
 
     assert(rep);
+    HTTPMSGUNLOCK(http->al->reply);
     http->al->reply = rep;
     HTTPMSGLOCK(http->al->reply);
     context->sendStartOfMessage(rep, receivedData);


### PR DESCRIPTION
Http::One::Server::handleReply() sets AccessLogEntry::reply which may
already be set. It is already set, for example, when the ACL code 
has already called syncAle() because external ACLs require an ALE.

This bug was introduced by commit fbbea6620.

This is a Measurement Factory project.