### PR TITLE
Prevent truncation for large origin-relative domains

### DIFF
--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -180,8 +180,8 @@ urlAppendDomain(char *host)
     /* For IPv4 addresses check for a dot */
     /* For IPv6 addresses also check for a colon */
     if (Config.appendDomain && !strchr(host, '.') && !strchr(host, ':')) {
-        const int64_t dlen = strlen(host);
-        const int64_t want = dlen + Config.appendDomainLen;
+        const uint64_t dlen = strlen(host);
+        const uint64_t want = dlen + Config.appendDomainLen;
         if (want > SQUIDHOSTNAMELEN - 1) {
             debugs(23, 2, "URL domain too large (" << dlen << " bytes)");
             return false;

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -377,8 +377,14 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const char *url)
     }
 
     /* For IPV6 addresses also check for a colon */
-    if (Config.appendDomain && !strchr(foundHost, '.') && !strchr(foundHost, ':'))
-        strncat(foundHost, Config.appendDomain, SQUIDHOSTNAMELEN - strlen(foundHost) - 1);
+    if (Config.appendDomain && strchr(foundHost, '.') == 0 && strchr(foundHost, ':') == 0) {
+        const auto dlen = strlen(foundHost);
+        if (dlen > (SQUIDHOSTNAMELEN - Config.appendDomainLen - 1)) {
+            debugs(23, DBG_IMPORTANT, MYNAME << ": URL domain too large (" << dlen << " bytes)");
+            return false;
+        }
+        strncat(foundHost, Config.appendDomain, SQUIDHOSTNAMELEN - dlen - 1);
+    }
 
     /* remove trailing dots from hostnames */
     while ((l = strlen(foundHost)) > 0 && foundHost[--l] == '.')

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -167,12 +167,22 @@ urlParseProtocol(const char *b)
     return AnyP::PROTO_NONE;
 }
 
+/**
+ * Appends configured append_domain to hostname, assuming
+ * the given buffer is at least SQUIDHOSTNAMELEN bytes long,
+ * and that the host FQDN is not a 'dotless' TLD.
+ *
+ * \returns false if and only if there is not enough space to append
+ */
 bool
 urlAppendDomain(char *host)
 {
+    /* For IPv4 addresses check for a dot */
+    /* For IPv6 addresses also check for a colon */
     if (Config.appendDomain && !strchr(host, '.') && !strchr(host, ':')) {
-        const auto dlen = strlen(host);
-        if (dlen > (SQUIDHOSTNAMELEN - Config.appendDomainLen - 1)) {
+        const int64_t dlen = strlen(host);
+        const int64_t want = dlen + Config.appendDomainLen;
+        if (want > SQUIDHOSTNAMELEN - 1) {
             debugs(23, 2, "URL domain too large (" << dlen << " bytes)");
             return false;
         }
@@ -390,7 +400,6 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const char *url)
         return false;
     }
 
-    /* For IPV6 addresses also check for a colon */
     if (!urlAppendDomain(foundHost))
         return false;
 

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -193,6 +193,7 @@ bool urlIsRelative(const char *);
 char *urlMakeAbsolute(const HttpRequest *, const char *);
 char *urlRInternal(const char *host, unsigned short port, const char *dir, const char *name);
 char *urlInternal(const char *dir, const char *name);
+bool urlAppendDomain(char *host); ///< apply append_domain config to the given hostname
 
 enum MatchDomainNameFlags {
     mdnNone = 0,

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -99,18 +99,9 @@ internalRemoteUri(bool encrypt, const char *host, unsigned short port, const cha
 
     /*
      * append the domain in order to mirror the requests with appended
-     * domains
+     * domains. If that fails, just use the hostname anyway.
      */
-
-    /* For IPv6 addresses also check for a colon */
-    if (Config.appendDomain && strchr(lc_host, '.') == 0 && strchr(lc_host, ':') == 0) {
-        const auto dlen = strlen(lc_host);
-        if (dlen > (SQUIDHOSTNAMELEN - Config.appendDomainLen - 1)) {
-            debugs(23, DBG_IMPORTANT, MYNAME << ": URL domain too large (" << dlen << " bytes)");
-        } else {
-            strncat(lc_host, Config.appendDomain, SQUIDHOSTNAMELEN - dlen - 1);
-        }
-    }
+    (void)urlAppendDomain(lc_host);
 
     /* build URI */
     AnyP::Uri tmp(AnyP::PROTO_HTTP);

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -103,9 +103,14 @@ internalRemoteUri(bool encrypt, const char *host, unsigned short port, const cha
      */
 
     /* For IPv6 addresses also check for a colon */
-    if (Config.appendDomain && !strchr(lc_host, '.') && !strchr(lc_host, ':'))
-        strncat(lc_host, Config.appendDomain, SQUIDHOSTNAMELEN -
-                strlen(lc_host) - 1);
+    if (Config.appendDomain && strchr(lc_host, '.') == 0 && strchr(lc_host, ':') == 0) {
+        const auto dlen = strlen(lc_host);
+        if (dlen > (SQUIDHOSTNAMELEN - Config.appendDomainLen - 1)) {
+            debugs(23, DBG_IMPORTANT, MYNAME << ": URL domain too large (" << dlen << " bytes)");
+        } else {
+            strncat(lc_host, Config.appendDomain, SQUIDHOSTNAMELEN - dlen - 1);
+        }
+    }
 
     /* build URI */
     AnyP::Uri tmp(AnyP::PROTO_HTTP);


### PR DESCRIPTION
The domain in a URL must obey hostname length restrictions after
append_domain is applied, not just MAX_URL for the normalized
absolute-URL.