### PR TITLE
Detail validation errors for loaded-from-file certificate chains

### DIFF
--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -119,14 +119,15 @@ Security::KeyData::loadX509ChainFromFile()
             }
 #endif
             // checks that the chained certs are actually part of a chain for validating cert
-            if (X509_check_issued(ca, latestCert.get()) == X509_V_OK) {
+            int checkCode = X509_check_issued(ca, latestCert.get());
+            if (checkCode == X509_V_OK) {
                 debugs(83, DBG_PARSE_NOTE(3), "Adding issuer CA: " << nameStr);
                 // OpenSSL API requires that we order certificates such that the
                 // chain can be appended directly into the on-wire traffic.
                 latestCert = CertPointer(ca);
                 chain.emplace_front(latestCert);
             } else {
-                debugs(83, DBG_PARSE_NOTE(2), "Ignoring non-issuer CA from " << certFile << ": " << nameStr);
+                debugs(83, DBG_PARSE_NOTE(2), "Ignoring non-issuer CA from " << certFile << ": " << nameStr << ". Reason: " << checkCode);
             }
             OPENSSL_free(nameStr);
         }

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -127,7 +127,7 @@ Security::KeyData::loadX509ChainFromFile()
                 latestCert = CertPointer(ca);
                 chain.emplace_front(latestCert);
             } else {
-                debugs(83, DBG_PARSE_NOTE(2), "Ignoring non-issuer CA from " << certFile << ": " << nameStr << ". Reason: " << X509_verify_cert_error_string(checkCode));
+                debugs(83, DBG_PARSE_NOTE(2), certFile << ": Ignoring non-issuer CA " << nameStr << ": " << X509_verify_cert_error_string(checkCode) << " (" << checkCode << ")");
             }
             OPENSSL_free(nameStr);
         }

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -119,7 +119,7 @@ Security::KeyData::loadX509ChainFromFile()
             }
 #endif
             // checks that the chained certs are actually part of a chain for validating cert
-            int checkCode = X509_check_issued(ca, latestCert.get());
+            const auto checkCode = X509_check_issued(ca, latestCert.get());
             if (checkCode == X509_V_OK) {
                 debugs(83, DBG_PARSE_NOTE(3), "Adding issuer CA: " << nameStr);
                 // OpenSSL API requires that we order certificates such that the
@@ -127,7 +127,7 @@ Security::KeyData::loadX509ChainFromFile()
                 latestCert = CertPointer(ca);
                 chain.emplace_front(latestCert);
             } else {
-                debugs(83, DBG_PARSE_NOTE(2), "Ignoring non-issuer CA from " << certFile << ": " << nameStr << ". Reason: " << checkCode);
+                debugs(83, DBG_PARSE_NOTE(2), "Ignoring non-issuer CA from " << certFile << ": " << nameStr << ". Reason: " << X509_verify_cert_error_string(checkCode));
             }
             OPENSSL_free(nameStr);
         }


### PR DESCRIPTION
This just adds logging of the openssl failure reason for
checking the certificate chain.