### PR TITLE
Bug 4969: GCC-9 build failure: stringop-truncation

### DIFF
--- a/lib/smblib/smblib-util.c
+++ b/lib/smblib/smblib-util.c
@@ -401,7 +401,7 @@ int SMB_Negotiate(SMB_Handle_Type Con_Handle, const char *Prots[])
 
         p = (SMB_Hdr(pkt) + SMB_negrLM_buf_offset + Con_Handle -> Encrypt_Key_Len);
 
-        strncpy(p, Con_Handle -> Svr_PDom, sizeof(Con_Handle -> Svr_PDom) - 1);
+        xstrncpy(p, Con_Handle -> Svr_PDom, sizeof(Con_Handle -> Svr_PDom));
 
         break;
 
@@ -424,7 +424,7 @@ int SMB_Negotiate(SMB_Handle_Type Con_Handle, const char *Prots[])
 
         p = (SMB_Hdr(pkt) + SMB_negrLM_buf_offset + Con_Handle -> Encrypt_Key_Len);
 
-        strncpy(p, Con_Handle -> Svr_PDom, sizeof(Con_Handle -> Svr_PDom) - 1);
+        xstrncpy(p, Con_Handle -> Svr_PDom, sizeof(Con_Handle -> Svr_PDom));
 
         break;
 
@@ -538,8 +538,8 @@ SMB_Tree_Handle SMB_TreeConnect(SMB_Handle_Type Con_Handle,
 
     tree -> next = tree -> prev = NULL;
     tree -> con = Con_Handle;
-    strncpy(tree -> path, path, sizeof(tree -> path));
-    strncpy(tree -> device_type, device, sizeof(tree -> device_type));
+    xstrncpy(tree -> path, path, sizeof(tree -> path));
+    xstrncpy(tree -> device_type, device, sizeof(tree -> device_type));
 
     /* Now plug in the values ... */
 


### PR DESCRIPTION
GCC-9 with Squid use of -Werror makes these warning hard
errors which can no longer be ignored. We are thus required
to alter this third-party code when built for Squid.

Truncation of these strings is fine. Rather than suppress
GCC warnings, switch to xstrncpy() which has similar
behaviour but guarantees c-string terminator exists within
the copied range limit (removing need for two -1 hacks).

This change will add terminators on path and device_type
values in the rare case of overly long configured values.
It is not clear what ancient Domain Controllers would do
when handed un-terminated c-string in those cases, but was
unlikely to be good.