### PR TITLE
RFC 7230: server MUST reject messages with BWS after field-name

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1421,7 +1421,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
 
     if (name_len > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        debugs(55, DBG_IMPORTANT, "WARNING: rejecting due to header name of " << name_len << " bytes (" << Raw('value_start', value_start) << ")");
+        debugs(55, 2, "found header name of " << name_len << " bytes (" << Raw("value_start", value_start, name_len) << ")");
         return NULL;
     }
 
@@ -1452,7 +1452,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
             --name_len;
 
         if (!name_len) {
-            debugs(55, DBG_IMPORTANT, "WARNING: rejecting due to header with name of " << name_len << " bytes");
+            debugs(55, 2, "found header with only whitespace for name");
             return NULL;
         }
     }
@@ -1487,7 +1487,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
 
     if (field_end - value_start > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        debugs(55, DBG_IMPORTANT, "WARNING: rejecting due to '" << theName << "' header of " << (field_end - value_start) << " bytes");
+        debugs(55, 2, "WARNING: found '" << theName << "' header of " << (field_end - value_start) << " bytes");
         return NULL;
     }
 

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -469,7 +469,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             break;      /* terminating blank line */
         }
 
-        auto *e = HttpHeaderEntry::parse(field_start, field_end, owner);
+        const auto e = HttpHeaderEntry::parse(field_start, field_end, owner);
         if (!e) {
             debugs(55, warnOnError, "WARNING: unparseable HTTP header field {" <<
                    getStringPrefix(field_start, field_end-field_start) << "}");
@@ -1421,7 +1421,8 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
 
     if (name_len > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        debugs(55, 2, "found header name of " << name_len << " bytes (" << Raw("value_start", value_start, name_len) << ")");
+        // TODO: update this to show proper name_len in Raw markup, but not print all that
+        debugs(55, 2, "ignoring huge header field (" << Raw("field_start", field_start, 100) << "...)");
         return NULL;
     }
 

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1404,7 +1404,7 @@ HttpHeaderEntry::~HttpHeaderEntry()
 
 /* parses and inits header entry, returns true/false */
 HttpHeaderEntry *
-HttpHeaderEntry::parse(const char *field_start, const char *field_end, http_hdr_owner_type &msgType)
+HttpHeaderEntry::parse(const char *field_start, const char *field_end, const http_hdr_owner_type msgType)
 {
     /* note: name_start == field_start */
     const char *name_end = (const char *)memchr(field_start, ':', field_end - field_start);
@@ -1421,7 +1421,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, http_hdr_
 
     if (name_len > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        debugs(55, DBG_IMPORTANT, "WARNING: rejecting due to header name of " << name_len << " bytes");
+        debugs(55, DBG_IMPORTANT, "WARNING: rejecting due to header name of " << name_len << " bytes (" << Raw('value_start', value_start) << ")");
         return NULL;
     }
 
@@ -1487,7 +1487,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, http_hdr_
 
     if (field_end - value_start > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        debugs(55, DBG_IMPORTANT, "WARNING: rejecting due to header of " << (field_end - value_start) << " bytes");
+        debugs(55, DBG_IMPORTANT, "WARNING: rejecting due to '" << theName << "' header of " << (field_end - value_start) << " bytes");
         return NULL;
     }
 

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -54,7 +54,7 @@ class HttpHeaderEntry
 public:
     HttpHeaderEntry(Http::HdrType id, const SBuf &name, const char *value);
     ~HttpHeaderEntry();
-    static HttpHeaderEntry *parse(const char *field_start, const char *field_end);
+    static HttpHeaderEntry *parse(const char *field_start, const char *field_end, http_hdr_owner_type &msgType);
     HttpHeaderEntry *clone() const;
     void packInto(Packable *p) const;
     int getInt() const;

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -54,7 +54,7 @@ class HttpHeaderEntry
 public:
     HttpHeaderEntry(Http::HdrType id, const SBuf &name, const char *value);
     ~HttpHeaderEntry();
-    static HttpHeaderEntry *parse(const char *field_start, const char *field_end, http_hdr_owner_type &msgType);
+    static HttpHeaderEntry *parse(const char *field_start, const char *field_end, const http_hdr_owner_type msgType);
     HttpHeaderEntry *clone() const;
     void packInto(Packable *p) const;
     int getInt() const;

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -16,7 +16,7 @@
 #include "HttpHeader.h"
 HttpHeaderEntry::HttpHeaderEntry(Http::HdrType, const SBuf &, const char *) {STUB}
 HttpHeaderEntry::~HttpHeaderEntry() {STUB}
-HttpHeaderEntry *HttpHeaderEntry::parse(const char *, const char *, http_hdr_owner_type &) STUB_RETVAL(nullptr)
+HttpHeaderEntry *HttpHeaderEntry::parse(const char *, const char *, const http_hdr_owner_type) STUB_RETVAL(nullptr)
 HttpHeaderEntry *HttpHeaderEntry::clone() const STUB_RETVAL(nullptr)
 void HttpHeaderEntry::packInto(Packable *) const STUB
 int HttpHeaderEntry::getInt() const STUB_RETVAL(0)

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -16,7 +16,7 @@
 #include "HttpHeader.h"
 HttpHeaderEntry::HttpHeaderEntry(Http::HdrType, const SBuf &, const char *) {STUB}
 HttpHeaderEntry::~HttpHeaderEntry() {STUB}
-HttpHeaderEntry *HttpHeaderEntry::parse(const char *, const char *) STUB_RETVAL(nullptr)
+HttpHeaderEntry *HttpHeaderEntry::parse(const char *, const char *, http_hdr_owner_type &) STUB_RETVAL(nullptr)
 HttpHeaderEntry *HttpHeaderEntry::clone() const STUB_RETVAL(nullptr)
 void HttpHeaderEntry::packInto(Packable *) const STUB
 int HttpHeaderEntry::getInt() const STUB_RETVAL(0)


### PR DESCRIPTION
Obey the RFC requirement to reject HTTP requests with whitespace
between field-name and the colon delimiter. Rejection is
critical in the presence of broken HTTP agents that mishandle
malformed messages.

Also obey requirement to always strip such whitespace from HTTP
response messages. The relaxed parser is no longer necessary for
this response change.

For now non-HTTP protocols retain the old behaviour of removal
only when using the relaxed parser.