### PR TITLE
Bug 4978: eCAP crash after using MyHost().newRequest()

### DIFF
--- a/src/adaptation/ecap/MessageRep.cc
+++ b/src/adaptation/ecap/MessageRep.cc
@@ -204,8 +204,7 @@ Adaptation::Ecap::RequestLineRep::uri(const Area &aUri)
 {
     // TODO: if method is not set, AnyP::Uri::parse will assume it is not connect;
     // Can we change AnyP::Uri::parse API to remove the method parameter?
-    auto uriBuffer = aUri.toString();
-    const bool ok = theMessage.url.parse(theMessage.method, uriBuffer.c_str());
+    const auto ok = theMessage.url.parse(theMessage.method, aUri.toString().c_str());
     Must(ok);
 }
 

--- a/src/adaptation/ecap/MessageRep.cc
+++ b/src/adaptation/ecap/MessageRep.cc
@@ -204,8 +204,8 @@ Adaptation::Ecap::RequestLineRep::uri(const Area &aUri)
 {
     // TODO: if method is not set, AnyP::Uri::parse will assume it is not connect;
     // Can we change AnyP::Uri::parse API to remove the method parameter?
-    const char *buf = aUri.toString().c_str();
-    const bool ok = theMessage.url.parse(theMessage.method, buf);
+    auto uriBuffer = aUri.toString();
+    const bool ok = theMessage.url.parse(theMessage.method, uriBuffer.c_str());
     Must(ok);
 }
 


### PR DESCRIPTION
Since commit 8babada, Squid was using a c_str() result after its
std::string toString() source went out of scope.
