### PR TITLE
Fix openSUSE ./configure-time Linux PAM authentication detection

### DIFF
--- a/acinclude/pam.m4
+++ b/acinclude/pam.m4
@@ -21,7 +21,7 @@ AC_DEFUN([CHECK_STRUCT_PAM_CONV], [
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <security/pam_appl.h>
 static int
-password_conversation(int num_msg, const struct pam_message **msg, struct pam_response **resp, void *appdata_ptr) {}
+password_conversation(int num_msg, const struct pam_message **msg, struct pam_response **resp, void *appdata_ptr) { return 0; }
 static struct pam_conv conv = { &password_conversation, 0 };
 ]])], [
    squid_cv_pam_conv_signature=linux
@@ -29,7 +29,7 @@ static struct pam_conv conv = { &password_conversation, 0 };
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <security/pam_appl.h>
 static int
-password_conversation(int num_msg, struct pam_message **msg, struct pam_response **resp, void *appdata_ptr) {}
+password_conversation(int num_msg, struct pam_message **msg, struct pam_response **resp, void *appdata_ptr) { return 0; }
 static struct pam_conv conv = { &password_conversation, 0 };
 ]])], [ 
   squid_cv_pam_conv_signature=solaris


### PR DESCRIPTION
Recently, openSUSE Factory enabled -Wreturn-type in CFLAGS which
resulted in ./configure failing to detect Linux type of PAM
authentication.