### PR TITLE
Suggest disallowing access to link-local IP addresses

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1003,7 +1003,7 @@ ENDIF
 DEFAULT: all src all
 DEFAULT: manager url_regex -i ^cache_object:// +i ^https?://[^/]+/squid-internal-mgr/
 DEFAULT: localhost src 127.0.0.1/32 ::1
-DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1/128 ::/128
+DEFAULT: to_localhost dst 127.0.0.0/8 169.254.0.0/16 0.0.0.0/32 ::1/128 ::/128
 DEFAULT: CONNECT method CONNECT
 DEFAULT_DOC: ACLs all, manager, localhost, to_localhost, and CONNECT are predefined.
 DOC_START


### PR DESCRIPTION
The Capital One hack was caused by a misconfigured proxy (no suggestion that it was Squid, 
of course) that allowed external access to the EC2 instance metadata endpoint at 
http://169.254.169.254/latest/meta-data/

It seems to me there's no reason for Squid to allow access to this IP address which is covered
 by the link-local IP range.

The `to_localhost` restriction is commented out by default so this PR will have no effect on the
 default configuration.