### PR TITLE
Fix parsing of certificate validator responses

### DIFF
--- a/src/ssl/cert_validate_message.cc
+++ b/src/ssl/cert_validate_message.cc
@@ -171,7 +171,7 @@ Ssl::CertValidationMsg::parseResponse(CertValidationResponse &resp, std::string 
             return false;
         }
 
-        param = value + value_len +1;
+        param = value + value_len;
     }
 
     /*Run through parsed errors to check for errors*/


### PR DESCRIPTION
If a certificate validator did not end its response with an end-of-line
or whitespace character, then Squid, while parsing the response,
accessed the bytes after the end of the buffer where the response is
stored.

This is a Measurement Factory project.