### PR TITLE
Add local FS to systemd startup dependencies

### DIFF
--- a/tools/systemd/squid.service
+++ b/tools/systemd/squid.service
@@ -8,7 +8,7 @@
 [Unit]
 Description=Squid Web Proxy Server
 Documentation=man:squid(8)
-After=network.target network-online.target nss-lookup.target
+After=network.target network-online.target nss-lookup.target local-fs.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
The squid -z startup process requires that disk FS are
running if any cache_dir are configured.