### PR TITLE
Fix "BUG: Lost previously bumped from-Squid connection"

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1011,9 +1011,8 @@ FwdState::usePinned()
     debugs(17, 7, "connection manager: " << connManager);
 
     try {
-        const auto temp = ConnStateData::BorrowPinnedConnection(request, al);
-        debugs(17, 5, "connection: " << temp);
-        serverConn = temp;
+        serverConn = ConnStateData::BorrowPinnedConnection(request, al);
+        debugs(17, 5, "connection: " << serverConn);
     } catch (ErrorState * const anErr) {
         syncHierNote(nullptr, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1010,6 +1010,8 @@ FwdState::usePinned()
     const auto connManager = request->pinnedConnection();
     debugs(17, 7, "connection manager: " << connManager);
 
+    const auto peerDenied = connManager && connManager->pinning.peerAccessDenied;
+
     // the client connection may close while we get here, nullifying connManager
     const auto temp = connManager ? connManager->borrowPinnedConnection(request) : nullptr;
     debugs(17, 5, "connection: " << temp);
@@ -1018,7 +1020,7 @@ FwdState::usePinned()
     if (!Comm::IsConnOpen(temp)) {
         syncHierNote(temp, connManager ? connManager->pinning.host : request->url.host());
         serverConn = nullptr;
-        const auto errType = connManager && connManager->pinning.peerAccessDenied ? ERR_CANNOT_FORWARD : ERR_ZERO_SIZE_OBJECT;
+        const auto errType = peerDenied ? ERR_CANNOT_FORWARD : ERR_ZERO_SIZE_OBJECT;
         const auto anErr = new ErrorState(errType, Http::scServiceUnavailable, request, al);
         fail(anErr);
         // Connection managers monitor their idle pinned to-server

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1033,7 +1033,7 @@ FwdState::usePinned()
 
     // the server may close the pinned connection before this request
     const auto reused = true;
-    syncWithServerConn(temp, connManager->pinning.host, reused);
+    syncWithServerConn(serverConn, connManager->pinning.host, reused);
 
     dispatch();
 }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1028,8 +1028,6 @@ FwdState::usePinned()
     }
 
     if (connManager->pinning.peerAccessDenied) {
-        // The peer selection policy denies access to pinned connection.
-        // Return an error page to the client.
         serverConn = nullptr;
         temp->close();
         fail(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al));

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1319,9 +1319,14 @@ FwdState::exhaustedTries() const
 }
 
 bool
-FwdState::retriablePinned() const
+FwdState::pinnedCanRetry() const
 {
     assert(request->flags.pinned);
+
+    // pconn race on pinned connection: Currently we do not have any mechanism
+    // to retry current pinned connection path.
+    if (pconnRace == raceHappened)
+        return false;
 
     // If a bumped connection was pinned, then the TLS client was given our peer
     // details. Do not retry because we do not ensure that those details stay
@@ -1333,19 +1338,6 @@ FwdState::retriablePinned() const
     // The other pinned cases are FTP proxying and connection-based HTTP
     // authentication. TODO: Do these cases have restrictions?
     return true;
-}
-
-bool
-FwdState::pinnedCanRetry() const
-{
-    assert(request->flags.pinned);
-
-    // pconn race on pinned connection: Currently we do not have any mechanism
-    // to retry current pinned connection path.
-    if (pconnRace == raceHappened)
-        return false;
-
-    return retriablePinned();
 }
 
 time_t

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -127,10 +127,6 @@ private:
 
     void usePinned();
 
-    /// If request use an existing pinned to-peer connection and this
-    /// connection is alive and healthy return the pinned connection.
-    Comm::ConnectionPointer healthyPinnedConnection();
-
     /// whether a pinned to-peer connection can be replaced with another one
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -131,11 +131,6 @@ private:
     /// connection is alive and healthy return the pinned connection.
     Comm::ConnectionPointer healthyPinnedConnection();
 
-    /// Whether the kind of pinned to-peer connection can be replaced with
-    /// another one. For example the bumped connections can not be retried,
-    /// but FTP proxying related pinned connections can retried.
-    bool retriablePinned() const;
-
     /// whether a pinned to-peer connection can be replaced with another one
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -127,6 +127,15 @@ private:
 
     void usePinned();
 
+    /// If request use an existing pinned to-peer connection and this
+    /// connection is alive and healthy return the pinned connection.
+    Comm::ConnectionPointer healthyPinnedConnection();
+
+    /// Whether the kind of pinned to-peer connection can be replaced with
+    /// another one. For example the bumped connections can not be retried,
+    /// but FTP proxying related pinned connections can retried.
+    bool retriablePinned() const;
+
     /// whether a pinned to-peer connection can be replaced with another one
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3927,14 +3927,14 @@ ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntry
     if (!Comm::IsConnOpen(pinning.serverConnection))
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
     else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0)
-        throw pinningError(ERR_CANNOT_FORWARD);
+        throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_CONFLICT_HOST
     else if (request && pinning.port != request->url.port())
-        throw pinningError(ERR_CANNOT_FORWARD);
+        throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_CONFLICT_HOST
     else if (pinning.peer && !cbdataReferenceValid(pinning.peer))
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
 
     if (pinning.peerAccessDenied)
-        throw pinningError(ERR_CANNOT_FORWARD); // TODO: Why not ERR_ACCESS_DENIED?
+        throw pinningError(ERR_CANNOT_FORWARD); // or generalize ERR_FORWARDING_DENIED
 
     stopPinnedConnectionMonitoring();
     return pinning.serverConnection;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3916,8 +3916,8 @@ ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntry
 
     const auto pinningError = [&](const err_type type) {
         unpinConnection(true);
-        // TODO: Should we return NewForwarding() here instead?
-        return new ErrorState(type, Http::scServiceUnavailable, request, ale);
+        HttpRequestPointer requestPointer = request;
+        return ErrorState::NewForwarding(type, requestPointer, ale);
     };
 
     // XXX: Remove this change-minimization hack before the official commit:
@@ -3946,11 +3946,10 @@ ConnStateData::BorrowPinnedConnection(HttpRequest *request, const AccessLogEntry
     if (const auto connManager = request ? request->pinnedConnection() : nullptr)
         return connManager->borrowPinnedConnection(request, ale);
 
-    // TODO: Should we return NewForwarding() here instead?
-
     // ERR_CANNOT_FORWARD is somewhat misleading here; we can still forward, but
     // there is no point since the client connection is now gone
-    throw new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, ale);
+    HttpRequestPointer requestPointer = request;
+    throw ErrorState::NewForwarding(ERR_CANNOT_FORWARD, requestPointer, ale);
 }
 
 void

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3934,7 +3934,7 @@ ConnStateData::borrowPinnedConnection(HttpRequest *request, const AccessLogEntry
         throw pinningError(ERR_ZERO_SIZE_OBJECT);
 
     if (pinning.peerAccessDenied)
-        throw pinningError(ERR_CANNOT_FORWARD);
+        throw pinningError(ERR_CANNOT_FORWARD); // TODO: Why not ERR_ACCESS_DENIED?
 
     stopPinnedConnectionMonitoring();
     return pinning.serverConnection;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3917,6 +3917,8 @@ ConnStateData::validatePinnedConnection(HttpRequest *request)
     bool valid = true;
     if (!Comm::IsConnOpen(pinning.serverConnection))
         valid = false;
+    else if (pinning.peerAccessDenied)
+        valid = false;
     else if (pinning.auth && pinning.host && request && strcasecmp(pinning.host, request->url.host()) != 0)
         valid = false;
     else if (request && pinning.port != request->url.port())

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2204,6 +2204,7 @@ ConnStateData::ConnStateData(const MasterXaction::Pointer &xact) :
     pinning.pinned = false;
     pinning.auth = false;
     pinning.zeroReply = false;
+    pinning.peerAccessDenied = false;
     pinning.peer = NULL;
 
     // store the details required for creating more MasterXaction objects as new requests come in
@@ -3966,6 +3967,7 @@ ConnStateData::unpinConnection(const bool andClose)
     safe_free(pinning.host);
 
     pinning.zeroReply = false;
+    pinning.peerAccessDenied = false;
 
     /* NOTE: pinning.pinned should be kept. This combined with fd == -1 at the end of a request indicates that the host
      * connection has gone away */

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -139,6 +139,7 @@ public:
         bool auth;               /* pinned for www authentication */
         bool reading;   ///< we are monitoring for peer connection closure
         bool zeroReply; ///< server closed w/o response (ERR_ZERO_SIZE_OBJECT)
+        bool peerAccessDenied; ///< cache_peer_access acl rules denies the pinned connection use
         CachePeer *peer;             /* CachePeer the connection goes via */
         AsyncCall::Pointer readHandler; ///< detects serverConnection closure
         AsyncCall::Pointer closeHandler; /*The close handler for pinned server side connection*/

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -47,6 +47,22 @@ class ServerBump;
 }
 #endif
 
+/// An std::runtime_error with an error type description.
+class PinningException: public std::runtime_error
+{
+public:
+    enum PinningErrorType {
+        errNone,
+        errPolicy, //< pinning policy error, eg authentication failure
+        errConnectionGone //< one of the pinned connection sides is gone
+    };
+    PinningException(const PinningErrorType type, const char *descr):
+        std::runtime_error(descr),
+        errType(type)
+        {}
+    PinningErrorType errType;
+};
+
 /**
  * Legacy Server code managing a connection to a client.
  *
@@ -183,14 +199,20 @@ public:
     /// Undo pinConnection() and, optionally, close the pinned connection.
     void unpinConnection(const bool andClose);
     /// Returns validated pinnned server connection (and stops its monitoring).
+    /// Throws a PinningException on errors
     Comm::ConnectionPointer borrowPinnedConnection(HttpRequest *request);
+
+    /// A static borrowPinnedConnection variant which also check if the
+    /// HttpRequest object is linked with a valid ConnStateData object
+    /// Throws a PinningException on errors;
+    static Comm::ConnectionPointer BorrowPinnedConnection(HttpRequest *request);
     /**
-     * Checks if there is pinning info if it is valid. It can close the server side connection
+     * Checks if pinning info is valid. It can close the server side connection
      * if pinned info is not valid.
+     * It trows a PinningException if pinned info is not valid
      \param request   if it is not NULL also checks if the pinning info refers to the request client side HttpRequest
-     \return          The details of the server side connection (may be closed if failures were present).
      */
-    const Comm::ConnectionPointer validatePinnedConnection(HttpRequest *request);
+    void validatePinnedConnection(HttpRequest *request);
     /**
      * returts the pinned CachePeer if exists, NULL otherwise
      */

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -139,7 +139,7 @@ public:
         bool auth;               /* pinned for www authentication */
         bool reading;   ///< we are monitoring for peer connection closure
         bool zeroReply; ///< server closed w/o response (ERR_ZERO_SIZE_OBJECT)
-        bool peerAccessDenied; ///< cache_peer_access acl rules denies the pinned connection use
+        bool peerAccessDenied; ///< cache_peer_access denied pinned connection reuse
         CachePeer *peer;             /* CachePeer the connection goes via */
         AsyncCall::Pointer readHandler; ///< detects serverConnection closure
         AsyncCall::Pointer closeHandler; /*The close handler for pinned server side connection*/

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -183,12 +183,9 @@ public:
     void pinBusyConnection(const Comm::ConnectionPointer &pinServerConn, const HttpRequest::Pointer &request);
     /// Undo pinConnection() and, optionally, close the pinned connection.
     void unpinConnection(const bool andClose);
-    /// Returns validated pinnned server connection (and stops its monitoring).
-    /// \throws a pointer to ErrorState if validation fails
-    Comm::ConnectionPointer borrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &);
 
-    /// borrowPinnedConnection() for callers w/o direct access to ConnStateData
-    /// \throws a pointer to ErrorState
+    /// \returns validated pinned to-server connection, stopping its monitoring
+    /// \throws a newly allocated ErrorState if validation fails
     static Comm::ConnectionPointer BorrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &);
     /**
      * returts the pinned CachePeer if exists, NULL otherwise
@@ -332,6 +329,9 @@ protected:
     void finishDechunkingRequest(bool withSuccess);
     void abortChunkedRequestBody(const err_type error);
     err_type handleChunkedRequestBody();
+
+    /// ConnStateData-specific part of BorrowPinnedConnection()
+    Comm::ConnectionPointer borrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &);
 
     void startPinnedConnectionMonitoring();
     void clientPinnedConnectionRead(const CommIoCbParams &io);

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -568,8 +568,7 @@ PeerSelector::selectPinned()
     const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
     // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
-    if (!usePinned)
-        request->pinnedConnection()->pinning.peerAccessDenied = true;
+    request->pinnedConnection()->pinning.peerAccessDenied = !usePinned;
 
     addSelection(pear, PINNED);
     if (entry)

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -566,14 +566,14 @@ PeerSelector::selectPinned()
 
     const auto pear = request->pinnedConnection()->pinnedPeer();
     const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
-    if (usePinned) {
-        addSelection(pear, PINNED);
-        if (entry)
-            entry->ping_status = PING_DONE; // skip ICP
-    }
-
     // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
+    if (!usePinned)
+        request->pinnedConnection()->pinning.peerAccessDenied = true;
+
+    addSelection(pear, PINNED);
+    if (entry)
+        entry->ping_status = PING_DONE; // skip ICP
 }
 
 /**

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -564,16 +564,15 @@ PeerSelector::selectPinned()
     if (!request->pinnedConnection())
         return;
 
-    if (Comm::IsConnOpen(request->pinnedConnection()->validatePinnedConnection(request))) {
-        const auto pear = request->pinnedConnection()->pinnedPeer();
-        const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
-        if (usePinned) {
-            addSelection(pear, PINNED);
-            if (entry)
-                entry->ping_status = PING_DONE; // skip ICP
-        }
+    const auto pear = request->pinnedConnection()->pinnedPeer();
+    const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
+    if (usePinned) {
+        addSelection(pear, PINNED);
+        if (entry)
+            entry->ping_status = PING_DONE; // skip ICP
     }
-    // If the pinned connection is prohibited (for this request) or gone, then
+
+    // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
 }
 

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -564,13 +564,13 @@ PeerSelector::selectPinned()
     if (!request->pinnedConnection())
         return;
 
-    const auto pear = request->pinnedConnection()->pinnedPeer();
-    const bool usePinned = pear ? peerAllowedToUse(pear, this) : (direct != DIRECT_NO);
+    const auto peer = request->pinnedConnection()->pinnedPeer();
+    const auto usePinned = peer ? peerAllowedToUse(peer, this) : (direct != DIRECT_NO);
     // If the pinned connection is prohibited (for this request) then
     // the initiator must decide whether it is OK to open a new one instead.
     request->pinnedConnection()->pinning.peerAccessDenied = !usePinned;
 
-    addSelection(pear, PINNED);
+    addSelection(peer, PINNED);
     if (entry)
         entry->ping_status = PING_DONE; // skip ICP
 }

--- a/src/tests/stub_client_side.cc
+++ b/src/tests/stub_client_side.cc
@@ -34,7 +34,7 @@ bool ConnStateData::handleRequestBodyData() STUB_RETVAL(false)
 void ConnStateData::pinBusyConnection(const Comm::ConnectionPointer &, const HttpRequest::Pointer &) STUB
 void ConnStateData::notePinnedConnectionBecameIdle(PinnedIdleContext) STUB
 void ConnStateData::unpinConnection(const bool) STUB
-const Comm::ConnectionPointer ConnStateData::validatePinnedConnection(HttpRequest *) STUB_RETVAL(nullptr)
+Comm::ConnectionPointer ConnStateData::BorrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &) STUB_RETVAL(nullptr)
 void ConnStateData::clientPinnedConnectionClosed(const CommCloseCbParams &) STUB
 void ConnStateData::connStateClosed(const CommCloseCbParams &) STUB
 void ConnStateData::requestTimeout(const CommTimeoutCbParams &) STUB

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1174,7 +1174,7 @@ TunnelStateData::usePinned()
     const auto connManager = request->pinnedConnection();
     try {
         const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw(), al);
-        debugs(26,7, "pinned peer connection: " << serverConn);
+        debugs(26, 7, "pinned peer connection: " << serverConn);
 
         Must(connManager);
 
@@ -1187,12 +1187,13 @@ TunnelStateData::usePinned()
         // the server may close the pinned connection before this request
         const auto reused = true;
         connectDone(serverConn, connManager->pinning.host, reused);
-    } catch (const PinningException &ex) {
+    } catch (ErrorState * const error) {
         syncHierNote(serverConn, connManager ? connManager->pinning.host : request->url.host());
         // a PINNED path failure is fatal; do not wait for more paths
-        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al), ex.what());
+        sendError(error, "pinned path failure");
         return;
     }
+
 }
 
 CBDATA_CLASS_INIT(TunnelStateData);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1188,7 +1188,7 @@ TunnelStateData::usePinned()
         const auto reused = true;
         connectDone(serverConn, connManager->pinning.host, reused);
     } catch (ErrorState * const error) {
-        syncHierNote(serverConn, connManager ? connManager->pinning.host : request->url.host());
+        syncHierNote(nullptr, connManager ? connManager->pinning.host : request->url.host());
         // a PINNED path failure is fatal; do not wait for more paths
         sendError(error, "pinned path failure");
         return;

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1034,18 +1034,6 @@ TunnelStateData::connectedToPeer(Security::EncryptorAnswer &answer)
     // and wait for the tunnelEstablishmentDone() call
 }
 
-static Comm::ConnectionPointer
-borrowPinnedConnection(HttpRequest *request)
-{
-    // pinned_connection may become nil after a pconn race
-    if (ConnStateData *pinned_connection = request ? request->pinnedConnection() : nullptr) {
-        Comm::ConnectionPointer serverConn = pinned_connection->borrowPinnedConnection(request);
-        return serverConn;
-    }
-
-    return nullptr;
-}
-
 void
 TunnelStateData::noteDestination(Comm::ConnectionPointer path)
 {
@@ -1184,32 +1172,27 @@ TunnelStateData::usePinned()
 {
     Must(request);
     const auto connManager = request->pinnedConnection();
-    const auto serverConn = borrowPinnedConnection(request.getRaw());
-    debugs(26,7, "pinned peer connection: " << serverConn);
+    try {
+        const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw());
+        debugs(26,7, "pinned peer connection: " << serverConn);
 
-    const char *fail = nullptr;
-    if (!Comm::IsConnOpen(serverConn))
-        fail = "pinned path failure";
+        Must(connManager);
 
-    if (fail) {
+        // Set HttpRequest pinned related flags for consistency even if
+        // they are not really used by tunnel.cc code.
+        request->flags.pinned = true;
+        if (connManager->pinnedAuth())
+            request->flags.auth = true;
+
+        // the server may close the pinned connection before this request
+        const auto reused = true;
+        connectDone(serverConn, connManager->pinning.host, reused);
+    } catch (const PinningException &ex) {
         syncHierNote(serverConn, connManager ? connManager->pinning.host : request->url.host());
         // a PINNED path failure is fatal; do not wait for more paths
-        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al),
-                  fail);
+        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al), ex.what());
         return;
     }
-
-    Must(connManager);
-
-    // Set HttpRequest pinned related flags for consistency even if
-    // they are not really used by tunnel.cc code.
-    request->flags.pinned = true;
-    if (connManager->pinnedAuth())
-        request->flags.auth = true;
-
-    // the server may close the pinned connection before this request
-    const auto reused = true;
-    connectDone(serverConn, connManager->pinning.host, reused);
 }
 
 CBDATA_CLASS_INIT(TunnelStateData);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1191,9 +1191,6 @@ TunnelStateData::usePinned()
     if (!Comm::IsConnOpen(serverConn))
         fail = "pinned path failure";
 
-    if (request->pinnedConnection()->pinning.peerAccessDenied)
-        fail = "pinned path access denied";
-
     if (fail) {
         syncHierNote(serverConn, connManager ? connManager->pinning.host : request->url.host());
         // a PINNED path failure is fatal; do not wait for more paths

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1176,8 +1176,6 @@ TunnelStateData::usePinned()
         const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw(), al);
         debugs(26, 7, "pinned peer connection: " << serverConn);
 
-        Must(connManager);
-
         // Set HttpRequest pinned related flags for consistency even if
         // they are not really used by tunnel.cc code.
         request->flags.pinned = true;

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1194,7 +1194,7 @@ TunnelStateData::usePinned()
     if (request->pinnedConnection()->pinning.peerAccessDenied)
         fail = "pinned path access denied";
 
-    if (fail){
+    if (fail) {
         syncHierNote(serverConn, connManager ? connManager->pinning.host : request->url.host());
         // a PINNED path failure is fatal; do not wait for more paths
         sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al),

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1173,7 +1173,7 @@ TunnelStateData::usePinned()
     Must(request);
     const auto connManager = request->pinnedConnection();
     try {
-        const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw());
+        const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw(), al);
         debugs(26,7, "pinned peer connection: " << serverConn);
 
         Must(connManager);


### PR DESCRIPTION
FwdState assumed that PeerSelector always returns the connection pinned
by previous SslBump steps. That assumption was wrong in two cases:
 
1. The previously pinned connection got closed.
2. PeerSelector policies prevent pinned connection reuse. For example,
    connection destination is now denied by cache_peer_access rules.

PeerSelector now returns a PINNED selection even if a pinned connection
cannot or should not be used. The initiator is now fully responsible for
checking the returned connection usability, including the new
ConnStateData::pinning::peerAccessDenied flag. Unusable pinned
connection is now treated as any other fatal (for the transaction)
forwarding problem rather than an internal BUG.

The above changes do not change traffic on the wire but remove bogus
level-1 BUG messages from cache.log.

We also polished which error page is returned depending on the pinning
validation problem: ERR_ZERO_SIZE_OBJECT is returned when the validation
failed because of the peer disappearance or to-server connection
closure. Other cases use ERR_CANNOT_FORWARD. Eventually, these errors
can be detailed further to distinguish various problems. We may also
want to generalize ERR_CONFLICT_HOST and/or ERR_FORWARDING_DENIED to
make them applicable in this context.

This is a Measurement Factory project.