### PR TITLE
Fixed on_unsupported_protocol tunnel action

### DIFF
--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -59,6 +59,16 @@ AnyP::Uri::host(const char *src)
     touch();
 }
 
+SBuf
+AnyP::Uri::hostOrIp() const
+{
+    static char ip[MAX_IPSTRLEN];
+    if (hostIsNumeric())
+        return SBuf(hostIP().toStr(ip, sizeof(ip)));
+    else
+        return SBuf(host());
+}
+
 const SBuf &
 AnyP::Uri::path() const
 {

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -80,6 +80,11 @@ public:
     int hostIsNumeric(void) const {return hostIsNumeric_;}
     Ip::Address const & hostIP(void) const {return hostAddr_;}
 
+    /// \returns the host subcomponent of the authority component
+    /// If the host is an IPv6 address, returns that IP address without
+    /// [brackets]! See RFC 3986 Section 3.2.2.
+    SBuf hostOrIp() const;
+
     void port(unsigned short p) {port_=p; touch();}
     unsigned short port() const {return port_;}
 

--- a/src/err_type.h
+++ b/src/err_type.h
@@ -76,6 +76,7 @@ typedef enum {
 
     ERR_SECURE_ACCEPT_FAIL, // Rejects the SSL connection intead of error page
     ERR_REQUEST_START_TIMEOUT, // Aborts the connection instead of error page
+    ERR_REQUEST_PARSE_TIMEOUT, // Aborts the connection instead of error page
 
     /* Cache Manager GUI can install a manager index/home page */
     MGR_INDEX,

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -74,14 +74,18 @@ Http::One::Server::parseOneRequest()
 {
     PROF_start(HttpServer_parseOneRequest);
 
+    // reset because the protocol may have changed if this is the first request
+    // and because we never bypass parsing failures of N+1st same-proto request
+    preservingClientData_ = shouldPreserveClientData();
+
     // parser is incremental. Generate new parser state if we,
     // a) do not have one already
     // b) have completed the previous request parsing already
     if (!parser_ || !parser_->needsMoreData())
-        parser_ = new Http1::RequestParser(mayTunnelUnsupportedProto());
+        parser_ = new Http1::RequestParser(preservingClientData_);
 
     /* Process request */
-    Http::Stream *context = parseHttpRequest(this, parser_);
+    Http::Stream *context = parseHttpRequest(parser_);
 
     PROF_stop(HttpServer_parseOneRequest);
     return context;


### PR DESCRIPTION
Instead of tunneling traffic, a matching on_unsupported_protocol
"tunnel" action resulted in a Squid error response sent to the client
(or, where an error response was not possible, in a connection closure).
The following three cases were fixed:

    * port: http_port (real CONNECT)
    * ssl_bump action: client-first or step1 bump
    * handling phase: parsing TLS client handshake
    * expected data: TLS Client Hello

    * port: http_port (real CONNECT)
    * ssl_bump action: client-first or step1 bump
    * handling phase: parsing the first bumped HTTP request
    * expected data: HTTP request header

    * port: https_port (fake CONNECT)
    * ssl_bump action: any action except terminate
    * handling phase: parsing TLS client handshake
    * expected data: TLS Client Hello

Also, when on_unsupported_protocol was configured, Squid wasted RAM and
CPU cycles to buffer client HTTP requests beyond the point of no return
(i.e., roughly, beyond the first HTTP request on a connection or in a
tunnel), when on_unsupported_protocol settings no longer apply.

Client handshake accumulation is now driven by preservingClientData_. We
set that data member when the connection is accepted (because we may
decide to start preserving bytes right away) and reset it whenever that
decision may change, including when switching to a new protocol inside
CONNECT tunnel and confirming the expected/supported protocol by
successfully parsing its handshake.

Squid does not stop handshake preservation when on_unsupported_protocol
gets disabled during reconfiguration, but Squid will not tunnel
preserved bytes if that happens (and will not tunnel a partial handshake
if on_unsupported_protocol configuration keeps changing).

Also changed how IPv6-based certificates are generated. Their CN field
value is no longer surrounded by [square brackets]. This change was done
to improve Squid code that had to be modified to fix
on_unsupported_protocol. It affects certificate cache key so old
IPv6-based certificates will never be found (and will eventually be
purged) while new ones will be generated and cached instead. We believe
these IPv6-based certificates are rare and untrusted by browsers so the
change in their CN should not have a significant affect on users.

This is a Measurement Factory project.