### PR TITLE
Supply ALE for note ACL

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -6779,6 +6779,7 @@ DOC_START
 	    logformat myFormat ... %{key}note ...
 
 	This clause only supports fast acl types.
+	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 DOC_END
 
 NAME: relaxed_header_parser

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -6777,6 +6777,8 @@ DOC_START
 
 	    note key value acl ...
 	    logformat myFormat ... %{key}note ...
+
+	This clause only supports fast acl types.
 DOC_END
 
 NAME: relaxed_header_parser

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -427,7 +427,7 @@ ClientHttpRequest::logRequest()
     if (request) {
         SBuf matched;
         for (auto h: Config.notes) {
-            if (h->match(request, al->reply, NULL, matched)) {
+            if (h->match(request, al->reply, al, matched)) {
                 request->notes()->add(h->key(), matched);
                 debugs(33, 3, h->key() << " " << matched);
             }


### PR DESCRIPTION
The following cache.log WARNING is a symptom of this bug:

    ACL is used in context without an ALE state. Assuming mismatch.

Commit cb36505 already covered many (but not all) similar cases.