### PR TITLE
Bug 4918: Crashes when using OpenSSL prior to v1.0.2

### DIFF
--- a/compat/openssl.h
+++ b/compat/openssl.h
@@ -177,9 +177,9 @@ extern "C" {
     X509_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg, const X509 *x)
     {
         if (psig)
-            *psig = (ASN1_BIT_STRING *)&x->signature;
+            *psig = x->signature;
         if (palg)
-            *palg = (X509_ALGOR *)&x->sig_alg;
+            *palg = x->sig_alg;
     }
 #endif
 


### PR DESCRIPTION
The implementation of x509_get0_signature() replacement in 24b30fd was
based on OpenSSL v1.1.0 where `signature` and `sig_alg` members of
`x509_st` structure stopped being raw pointers and became structures.
The mismatch caused segfaults when using OpenSSL versions that lacked
x509_get0_signature() -- anything earlier than OpenSSL v1.0.2.

    // OpenSSL < v1.1.0
    struct x509_st {
        X509_CINF *cert_info;
        X509_ALGOR *sig_alg;
        ASN1_BIT_STRING *signature;
        ...
    }

    // OpenSSL >= v1.1.0
    struct x509_st {
        X509_CINF cert_info;
        X509_ALGOR sig_alg;
        ASN1_BIT_STRING signature;
        ...
    }

A C-style reinterpreting cast hid the type mismatch from the compilers
and reviewers.

Tested with OpenSSL v1.0.1f. The types of the two data members were
checked back to OpenSSL v0.9.6.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>