### PR TITLE
Size how much printable data gets printed by Raw

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1539,8 +1539,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
 
     if (name_len > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        // TODO: update this to show proper name_len in Raw markup, but not print all that
-        debugs(55, 2, "ignoring huge header field (" << Raw("field_start", field_start, 100) << "...)");
+        debugs(55, 2, "ignoring huge " << Raw("field-name", field_start, name_len).atMost(100));
         return nullptr;
     }
 
@@ -1584,8 +1583,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
      */
     for (const char *pos = field_start; pos < (field_start+name_len); ++pos) {
         if (!CharacterSet::TCHAR[*pos]) {
-            debugs(55, 2, "found header with invalid characters in " <<
-                   Raw("field-name", field_start, min(name_len,100)) << "...");
+            debugs(55, 2, "found invalid characters in " << Raw("field-name", field_start, name_len).atMost(100));
             return nullptr;
         }
     }

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -486,7 +486,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
     int warnOnError = (Config.onoff.relaxed_header_parser <= 0 ? DBG_IMPORTANT : 2);
 
     assert(header_start && header_end);
-    debugs(55, 7, "parsing hdr: (" << this << ")" << std::endl << getStringPrefix(header_start, hdrLen));
+    debugs(55, 3, "parsing hdr: (" << this << ")" << std::endl << Raw("", header_start, hdrLen).minLevel(3).whole());
     ++ HttpHeaderStats[owner].parsedCount;
 
     char *nulpos;
@@ -613,8 +613,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
 
     if (clen.headerWideProblem) {
         debugs(55, warnOnError, "WARNING: " << clen.headerWideProblem <<
-               " Content-Length field values in" <<
-               Raw("header", header_start, hdrLen));
+               " Content-Length field values in header (hdr: " << this << ")");
     }
 
     String rawTe;

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -534,7 +534,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             if (memchr(this_line, '\r', field_end - this_line)) {
                 hasBareCr = "bare CR";
                 debugs(55, warnOnError, "WARNING: suspicious CR characters in " <<
-                       Raw("field", field_start, field_end-field_start).asHex().minLevel(warnOnError));
+                       Raw("field", field_start, field_end-field_start).hex().minLevel(warnOnError));
 
                 if (Config.onoff.relaxed_header_parser) {
                     char *p = (char *) this_line;   /* XXX Warning! This destroys original header content and violates specifications somewhat */

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1528,7 +1528,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
 
     if (name_len > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        debugs(55, 2, "ignoring huge " << Raw("field-name", field_start, name_len));
+        debugs(55, 2, "ignoring field with huge " << Raw("field-name", field_start, name_len).minLevel(2));
         return nullptr;
     }
 

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1539,7 +1539,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
 
     if (name_len > 65534) {
         /* String must be LESS THAN 64K and it adds a terminating NULL */
-        debugs(55, 2, "ignoring huge " << Raw("field-name", field_start, name_len).atMost(100));
+        debugs(55, 2, "ignoring huge " << Raw("field-name", field_start, name_len));
         return nullptr;
     }
 
@@ -1583,7 +1583,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
      */
     for (const char *pos = field_start; pos < (field_start+name_len); ++pos) {
         if (!CharacterSet::TCHAR[*pos]) {
-            debugs(55, 2, "found invalid characters in " << Raw("field-name", field_start, name_len).atMost(100));
+            debugs(55, 2, "found invalid character at position " << (pos-field_start) << " in " << Raw("field-name", field_start, name_len));
             return nullptr;
         }
     }

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -124,16 +124,6 @@ httpHeaderMaskInit(HttpHeaderMask * mask, int value)
     memset(mask, value, sizeof(*mask));
 }
 
-/** handy to printf prefixes of potentially very long buffers */
-static const char *
-getStringPrefix(const char *str, size_t sz)
-{
-#define SHORT_PREFIX_SIZE 512
-    LOCAL_ARRAY(char, buf, SHORT_PREFIX_SIZE);
-    xstrncpy(buf, str, (sz+1 > SHORT_PREFIX_SIZE) ? SHORT_PREFIX_SIZE : sz);
-    return buf;
-}
-
 void
 httpHeaderInitModule(void)
 {
@@ -492,7 +482,8 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
     char *nulpos;
     if ((nulpos = (char*)memchr(header_start, '\0', hdrLen))) {
         debugs(55, DBG_IMPORTANT, "WARNING: HTTP header contains NULL characters {" <<
-               getStringPrefix(header_start, nulpos-header_start) << "}\nNULL\n{" << getStringPrefix(nulpos+1, hdrLen-(nulpos-header_start)-1));
+               Raw("", header_start, nulpos-header_start).minLevel(DBG_IMPORTANT).whole() <<
+               "}\nNULL\n{" << Raw("", nulpos+1, hdrLen-(nulpos-header_start)-1).minLevel(DBG_IMPORTANT));
         clean();
         return 0;
     }
@@ -532,7 +523,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
                     if (cr_only) {
                         debugs(55, DBG_IMPORTANT, "SECURITY WARNING: Rejecting HTTP request with a CR+ "
                                "header field to prevent request smuggling attacks: {" <<
-                               getStringPrefix(header_start, hdrLen) << "}");
+                               Raw("", header_start, hdrLen).minLevel(DBG_IMPORTANT).whole() << "}");
                         clean();
                         return 0;
                     }
@@ -542,8 +533,8 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             /* Barf on stray CR characters */
             if (memchr(this_line, '\r', field_end - this_line)) {
                 hasBareCr = "bare CR";
-                debugs(55, warnOnError, "WARNING: suspicious CR characters in HTTP header {" <<
-                       getStringPrefix(field_start, field_end-field_start) << "}");
+                debugs(55, warnOnError, "WARNING: suspicious CR characters in " <<
+                       Raw("field", field_start, field_end-field_start).asHex().minLevel(warnOnError));
 
                 if (Config.onoff.relaxed_header_parser) {
                     char *p = (char *) this_line;   /* XXX Warning! This destroys original header content and violates specifications somewhat */
@@ -559,8 +550,8 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             }
 
             if (this_line + 1 == field_end && this_line > field_start) {
-                debugs(55, warnOnError, "WARNING: Blank continuation line in HTTP header {" <<
-                       getStringPrefix(header_start, hdrLen) << "}");
+                debugs(55, warnOnError, "WARNING: Blank continuation line in " <<
+                       Raw("field", field_start, field_end-field_start).whole().minLevel(warnOnError));
                 clean();
                 return 0;
             }
@@ -569,7 +560,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         if (field_start == field_end) {
             if (field_ptr < header_end) {
                 debugs(55, warnOnError, "WARNING: unparsable HTTP header field near {" <<
-                       getStringPrefix(field_start, hdrLen-(field_start-header_start)) << "}");
+                       Raw("", field_start, hdrLen-(field_start-header_start)).minLevel(warnOnError) << "}");
                 clean();
                 return 0;
             }
@@ -579,10 +570,9 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
 
         const auto e = HttpHeaderEntry::parse(field_start, field_end, owner);
         if (!e) {
-            debugs(55, warnOnError, "WARNING: unparsable HTTP header field {" <<
-                   getStringPrefix(field_start, field_end-field_start) << "}");
-            debugs(55, warnOnError, " in {" << getStringPrefix(header_start, hdrLen) << "}");
-
+            debugs(55, warnOnError, "WARNING: unparsable HTTP header " <<
+                   Raw("field", field_start, field_end-field_start).minLevel(warnOnError) <<
+                   " in hdr: " << this);
             clean();
             return 0;
         }
@@ -1562,8 +1552,8 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
         if (!stripWhitespace)
             return nullptr; // reject if we cannot strip
 
-        debugs(55, Config.onoff.relaxed_header_parser <= 0 ? 1 : 2,
-               "WARNING: Whitespace after header name in '" << getStringPrefix(field_start, field_end-field_start) << "'");
+        debugs(55, Config.onoff.relaxed_header_parser <= 0 ? DBG_IMPORTANT : 2,
+               "WARNING: Whitespace after field-name in '" << Raw("field", field_start, field_end-field_start).whole().minLevel(DBG_IMPORTANT));
 
         while (name_len > 0 && xisspace(field_start[name_len - 1]))
             --name_len;
@@ -1588,8 +1578,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
     }
 
     /* now we know we can parse it */
-
-    debugs(55, 9, "parsing HttpHeaderEntry: near '" <<  getStringPrefix(field_start, field_end-field_start) << "'");
+    debugs(55, DBG_DATA, Raw("field", field_start, field_end-field_start));
 
     /* is it a "known" field? */
     Http::HdrType id = Http::HeaderLookupTable.lookup(field_start,name_len).id;

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -578,7 +578,7 @@ AnyP::Uri::parse(const HttpRequestMethod& method, const SBuf &rawUrl)
         return true;
 
     } catch (...) {
-        debugs(23, 2, "error: " << CurrentException << " " << Raw("rawUrl", rawUrl.rawContent(), rawUrl.length()));
+        debugs(23, 2, "error: " << CurrentException << " " << Raw("rawUrl", rawUrl.rawContent(), rawUrl.length()).whole().minLevel(2));
         return false;
     }
 }
@@ -622,7 +622,7 @@ AnyP::Uri::parseUrn(Parser::Tokenizer &tok)
     host(nid.c_str());
     // TODO validate path characters
     path(tok.remaining());
-    debugs(23, 3, "Split URI into proto=urn, nid=" << nid << ", " << Raw("path",path().rawContent(),path().length()));
+    debugs(23, 3, "Split URI into proto=urn, nid=" << nid << ", " << Raw("path",path().rawContent(),path().length()).whole().minLevel(3));
 }
 
 /// Extracts and returns a (suspected but only partially validated) uri-host

--- a/src/base/Raw.cc
+++ b/src/base/Raw.cc
@@ -32,10 +32,11 @@ Raw::print(std::ostream &os) const
         else if (useGap_)
             os << ' ';
         if (data_) {
+            const auto data = static_cast<const char *>(data_);
             if (useHex_)
-                PrintHex(os, data_, printLimit);
+                PrintHex(os, data, printLimit);
             else
-                os.write(data_, printLimit);
+                os.write(data, printLimit);
             if (printLimit < size_)
                 os << "[..." << (size_ - printLimit) << " bytes...]";
         } else {

--- a/src/base/Raw.cc
+++ b/src/base/Raw.cc
@@ -23,8 +23,9 @@ Raw::print(std::ostream &os) const
         return os;
 
     // finalize debugging level if no level was set explicitly via minLevel()
+    const auto printLimit = std::min(size_, printableSize_);
     const int finalLevel = (level >= 0) ? level :
-                           (printableSize_ > 40 ? DBG_DATA : Debug::SectionLevel());
+                           (printLimit > 40 ? DBG_DATA : Debug::SectionLevel());
     if (finalLevel <= Debug::SectionLevel()) {
         if (label_)
             os << '=';
@@ -32,11 +33,11 @@ Raw::print(std::ostream &os) const
             os << ' ';
         if (data_) {
             if (useHex_)
-                PrintHex(os, data_, printableSize_);
+                PrintHex(os, data_, printLimit);
             else
-                os.write(data_, printableSize_);
-            if (printableSize_ < size_)
-                os << "[..." << (size_ - printableSize_) << " bytes...]";
+                os.write(data_, printLimit);
+            if (printLimit < size_)
+                os << "[..." << (size_ - printLimit) << " bytes...]";
         } else {
             os << "[null]";
         }

--- a/src/base/Raw.cc
+++ b/src/base/Raw.cc
@@ -24,7 +24,7 @@ Raw::print(std::ostream &os) const
 
     // finalize debugging level if no level was set explicitly via minLevel()
     const int finalLevel = (level >= 0) ? level :
-                           (size_ > 40 ? DBG_DATA : Debug::SectionLevel());
+                           (printableSize_ > 40 ? DBG_DATA : Debug::SectionLevel());
     if (finalLevel <= Debug::SectionLevel()) {
         if (label_)
             os << '=';
@@ -32,9 +32,11 @@ Raw::print(std::ostream &os) const
             os << ' ';
         if (data_) {
             if (useHex_)
-                PrintHex(os, data_, size_);
+                PrintHex(os, data_, printableSize_);
             else
-                os.write(data_, size_);
+                os.write(data_, printableSize_);
+            if (printableSize_ < size_)
+                os << "[..." << (size_ - printableSize_) << " bytes...]";
         } else {
             os << "[null]";
         }

--- a/src/base/Raw.h
+++ b/src/base/Raw.h
@@ -21,7 +21,7 @@
 class Raw
 {
 public:
-    Raw(const char *label, const char *data, const size_t size) :
+    Raw(const char *label, const void *data, const size_t size) :
         label_(label), data_(data), size_(size) {}
 
     /// limit data printing to at least the given debugging level
@@ -55,7 +55,7 @@ private:
     void printHex(std::ostream &os) const;
 
     const char *label_ = nullptr; ///< optional data name or ID; triggers size printing
-    const char *data_ = nullptr; ///< raw data to be printed
+    const void *data_ = nullptr; ///< raw data to be printed
     size_t size_ = 0; ///< data length
     size_t printableSize_ = 256; ///< do not print more data
     bool useHex_ = false; ///< whether hex() has been called

--- a/src/base/Raw.h
+++ b/src/base/Raw.h
@@ -20,8 +20,8 @@
 class Raw
 {
 public:
-    Raw(const char *const label, const void *const data, const size_t size):
-        label_(label), data_(data), size_(size) {}
+    Raw(const char * const label, const void * const data, const size_t size) :
+        label_(label), data_(data), size_(size) { atMost(size); }
 
     /// limit data printing to at least the given debugging level
     Raw &minLevel(const int aLevel) { level = aLevel; return *this; }

--- a/src/base/Raw.h
+++ b/src/base/Raw.h
@@ -11,7 +11,6 @@
 #ifndef SQUID_SRC_BASE_RAW_H
 #define SQUID_SRC_BASE_RAW_H
 
-#include <algorithm>
 #include <iosfwd>
 
 /// Prints raw and/or non-terminated data safely, efficiently, and beautifully.

--- a/src/base/Raw.h
+++ b/src/base/Raw.h
@@ -22,7 +22,7 @@ class Raw
 {
 public:
     Raw(const char *label, const char *data, const size_t size) :
-        label_(label), data_(data), size_(size) { atMost(size); }
+        label_(label), data_(data), size_(size) {}
 
     /// limit data printing to at least the given debugging level
     Raw &minLevel(const int aLevel) { level = aLevel; return *this; }

--- a/src/base/Raw.h
+++ b/src/base/Raw.h
@@ -21,7 +21,7 @@
 class Raw
 {
 public:
-    Raw(const char *label, const void *data, const size_t size) :
+    Raw(const char *const label, const void *const data, const size_t size):
         label_(label), data_(data), size_(size) {}
 
     /// limit data printing to at least the given debugging level

--- a/src/base/Raw.h
+++ b/src/base/Raw.h
@@ -28,7 +28,7 @@ public:
     Raw &minLevel(const int aLevel) { level = aLevel; return *this; }
 
     /// print no more than n bytes of data
-    Raw &atMost(const size_t n) { printableSize_ = std::min(n, printableSize_); return *this; }
+    Raw &atMost(const size_t n) { printableSize_ = n; return *this; }
 
     /// do not limit output size; caller responsible for huge dumps
     Raw &whole() { printableSize_ = size_; return *this; }

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -12,6 +12,7 @@
 #include "AccessLogEntry.h"
 #include "base/CharacterSet.h"
 #include "base/IoManip.h"
+#include "base/Raw.h"
 #include "cache_cf.h"
 #include "clients/forward.h"
 #include "comm/Connection.h"
@@ -1513,7 +1514,7 @@ ErrorPage::BuildErrorPrinter::printLocation(std::ostream &os) const {
 std::ostream &
 ErrorPage::BuildErrorPrinter::print(std::ostream &os) const {
     printLocation(os) << ": " << msg << " near ";
-    os << Raw("", errorLocation, strlen(errorLocation).atMost(15).minLevel(0);
+    os << Raw("", errorLocation, strlen(errorLocation)).atMost(15).minLevel(0);
 
     // XXX: We should not be converting (inner) exception to text if we are
     // going to throw again. See "add arbitrary (re)thrower-supplied details"

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1513,15 +1513,7 @@ ErrorPage::BuildErrorPrinter::printLocation(std::ostream &os) const {
 std::ostream &
 ErrorPage::BuildErrorPrinter::print(std::ostream &os) const {
     printLocation(os) << ": " << msg << " near ";
-
-    // TODO: Add support for prefix printing to Raw
-    const size_t maxContextLength = 15; // plus "..."
-    if (strlen(errorLocation) > maxContextLength) {
-        os.write(errorLocation, maxContextLength);
-        os << "...";
-    } else {
-        os << errorLocation;
-    }
+    os << Raw("", errorLocation, strlen(errorLocation).atMost(15).minLevel(0);
 
     // XXX: We should not be converting (inner) exception to text if we are
     // going to throw again. See "add arbitrary (re)thrower-supplied details"

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -913,7 +913,6 @@ Ftp::Server::handlePasvReply(const HttpReply *reply, StoreIOBuffer)
                addr,
                static_cast<int>(localPort / 256),
                static_cast<int>(localPort % 256));
-    debugs(9, 3, Raw("writing", mb.buf, mb.size));
     writeReply(mb);
 }
 
@@ -1086,7 +1085,6 @@ Ftp::Server::handleEpsvReply(const HttpReply *reply, StoreIOBuffer)
     mb.init();
     mb.appendf("229 Entering Extended Passive Mode (|||%u|)\r\n", localPort);
 
-    debugs(9, 3, Raw("writing", mb.buf, mb.size));
     writeReply(mb);
 }
 

--- a/src/store/SwapMetaView.cc
+++ b/src/store/SwapMetaView.cc
@@ -90,10 +90,8 @@ Store::SwapMetaView::checkExpectedLength(const size_t expectedLength) const
 std::ostream &
 Store::operator <<(std::ostream &os, const SwapMetaView &meta)
 {
-    os << "type=" << int(meta.rawType);
-    // XXX: Change Raw constructor to take void* data instead of casting here.
-    const auto rawValue = reinterpret_cast<const char*>(meta.rawValue);
-    os << Raw("value", rawValue, meta.rawLength).whole().minLevel(DBG_DATA).hex();
+    os << "type=" << int(meta.rawType)
+       << Raw("value", meta.rawValue, meta.rawLength).whole().minLevel(DBG_DATA).hex();
     return os;
 }
 

--- a/src/store/SwapMetaView.cc
+++ b/src/store/SwapMetaView.cc
@@ -93,7 +93,7 @@ Store::operator <<(std::ostream &os, const SwapMetaView &meta)
     os << "type=" << int(meta.rawType);
     // XXX: Change Raw constructor to take void* data instead of casting here.
     const auto rawValue = reinterpret_cast<const char*>(meta.rawValue);
-    os << Raw("value", rawValue, meta.rawLength).minLevel(DBG_DATA).hex();
+    os << Raw("value", rawValue, meta.rawLength).whole().minLevel(DBG_DATA).hex();
     return os;
 }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1063,7 +1063,7 @@ tunnelStartShoveling(TunnelStateData *tunnelState)
 
         if (tunnelState->http.valid() && tunnelState->http->getConn() && !tunnelState->http->getConn()->inBuf.isEmpty()) {
             SBuf * const in = &tunnelState->http->getConn()->inBuf;
-            debugs(26, DBG_DATA, "Tunnel client PUSH Payload: \n" << *in << "\n----------");
+            debugs(26, DBG_DATA, "Tunnel client PUSH Payload: \n" << Raw("", *in, in->length()) << "\n----------");
             tunnelState->preReadClientData.append(*in);
             in->consume(); // ConnStateData buffer accounting after the shuffle.
         }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1063,7 +1063,7 @@ tunnelStartShoveling(TunnelStateData *tunnelState)
 
         if (tunnelState->http.valid() && tunnelState->http->getConn() && !tunnelState->http->getConn()->inBuf.isEmpty()) {
             SBuf * const in = &tunnelState->http->getConn()->inBuf;
-            debugs(26, DBG_DATA, "Tunnel client PUSH Payload: \n" << Raw("", *in, in->length()) << "\n----------");
+            debugs(26, DBG_DATA, "Tunnel client PUSH Payload: \n" << Raw("", in->rawContent(), in->length()) << "\n----------");
             tunnelState->preReadClientData.append(*in);
             in->consume(); // ConnStateData buffer accounting after the shuffle.
         }


### PR DESCRIPTION
An arbitrary default of 256 bytes has been chosen. Callers can use the
whole() method to dump the entire data if necessary.

We size the number of characters to print rather than the total
data size of the output. Encodings (e.g., hex()) and decorations (e.g. labels and
truncation indicators) may result in more output characters than the
data size. For example, a 100-octet buffer sized to 10 octets would be
printed using 20 hex printables.