### PR TITLE
Make configure check compatible with OpenSSL 1.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1335,7 +1335,7 @@ if test "x$with_openssl" = "xyes"; then
     AC_CHECK_LIB(crypto,[CRYPTO_new_ex_data],[LIBOPENSSL_LIBS="-lcrypto $LIBOPENSSL_LIBS"],[
       AC_MSG_ERROR([library 'crypto' is required for OpenSSL])
     ],$LIBOPENSSL_LIBS)
-    AC_CHECK_LIB(ssl,[SSL_library_init],[LIBOPENSSL_LIBS="-lssl $LIBOPENSSL_LIBS"],[
+    AC_CHECK_LIB(ssl,[SSL_CTX_new],[LIBOPENSSL_LIBS="-lssl $LIBOPENSSL_LIBS"],[
       AC_MSG_ERROR([library 'ssl' is required for OpenSSL])
     ],$LIBOPENSSL_LIBS)
   ])


### PR DESCRIPTION
OpenSSL 1.1 [deprecated the `SSL_library_init` function](https://www.openssl.org/docs/man1.1.0/man3/SSL_library_init.html), and this function is not present if OpenSSL is compiled without deprecated support (which is the case of several distributions, such as [Homebrew](https://github.com/Homebrew/homebrew-core)).

The `AC_CHECK_LIB` should therefore check for a function that is present in `libssl` for both OpenSSL 1.0 and 1.1. `SSL_CTX_new` is a good candidate.

I can confirm that this patch fixes the build with OpenSSL 1.1, and does not break build with OpenSSL 1.0, on macOS 10.14.

---

Another possibility would be to have _two_ tests, one for OpenSSL 1.0 and one for OpenSSL 1.1. If this is what is desired, the [OpenSSL wiki](https://wiki.openssl.org/index.php/Library_Initialization#Autoconf) suggests using:

```
     FOUND_SSL_LIB="no"
     AC_CHECK_LIB(ssl, OPENSSL_init_ssl, [FOUND_SSL_LIB="yes"])
     AC_CHECK_LIB(ssl, SSL_library_init, [FOUND_SSL_LIB="yes"])
     AS_IF([test "x$FOUND_SSL_LIB" = xno], [AC_MSG_ERROR([library 'ssl' is required for OpenSSL])])
```

but that is more complex.