### PR TITLE
Fix URN response handling

### DIFF
--- a/src/urn.cc
+++ b/src/urn.cc
@@ -83,10 +83,14 @@ CBDATA_CLASS_INIT(UrnState);
 UrnState::~UrnState()
 {
     if (urlres_e) {
-        storeUnregister(sc, urlres_e, this);
+        if (sc)
+            storeUnregister(sc, urlres_e, this);
         urlres_e->unlock("~UrnState+res");
-        entry->unlock("~UrnState+prime");
     }
+
+    if (entry)
+        entry->unlock("~UrnState+prime");
+
     safe_free(urlres);
 }
 


### PR DESCRIPTION
urnHandleReply() may be called several times while copying the entry
from the store. Each time it must use the buffer length that is left
(from the previous call).

Also do not abandon a urn entry, still having clients attached.

Also allow urnHandleReply() to produce a reply if it receives a
zero-sized buffer. This may happen after the entry has been fully
stored.