### PR TITLE
Bug 4987: restore support for the "cache_object://" URI scheme

### DIFF
--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -142,8 +142,11 @@ uriParseScheme(Parser::Tokenizer &tok)
      * Scheme names consist of a sequence of characters beginning with a
      * letter and followed by any combination of letters, digits, plus
      * ("+"), period ("."), or hyphen ("-").
+     *
+     * The underscore ("_") required to match "cache_object://" squid
+     * special URI scheme.
      */
-    static const auto schemeChars = CharacterSet("scheme", "+.-") + CharacterSet::ALPHA + CharacterSet::DIGIT;
+    static const auto schemeChars = CharacterSet("scheme", "+.-") + CharacterSet("special", "_") + CharacterSet::ALPHA + CharacterSet::DIGIT;
 
     SBuf str;
     if (tok.prefix(str, schemeChars, 16) && tok.skip(':') && CharacterSet::ALPHA[str.at(0)]) {

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -146,7 +146,11 @@ uriParseScheme(Parser::Tokenizer &tok)
      * The underscore ("_") required to match "cache_object://" squid
      * special URI scheme.
      */
-    static const auto schemeChars = CharacterSet("scheme", "+.-") + CharacterSet("special", "_") + CharacterSet::ALPHA + CharacterSet::DIGIT;
+    static const auto schemeChars =
+#if USE_HTTP_VIOLATIONS
+        CharacterSet("special", "_") +
+#endif
+        CharacterSet("scheme", "+.-") + CharacterSet::ALPHA + CharacterSet::DIGIT;
 
     SBuf str;
     if (tok.prefix(str, schemeChars, 16) && tok.skip(':') && CharacterSet::ALPHA[str.at(0)]) {


### PR DESCRIPTION
Broken by commit 6c880a1.