### PR TITLE
Set ALE::reply to the 200 (Connection established)

### DIFF
--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -117,6 +117,14 @@ HttpReply::pack() const
 }
 
 HttpReply *
+HttpReply::MakeConnectionEstablished() {
+
+    std::unique_ptr<HttpReply> rep(new HttpReply);
+    rep->sline.set(Http::ProtocolVersion(), Http::scOkay, "Connection established");
+    return rep.release();
+}
+
+HttpReply *
 HttpReply::make304() const
 {
     static const Http::HdrType ImsEntries[] = {Http::HdrType::DATE, Http::HdrType::CONTENT_TYPE, Http::HdrType::EXPIRES, Http::HdrType::LAST_MODIFIED, /* eof */ Http::HdrType::OTHER};

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -116,12 +116,12 @@ HttpReply::pack() const
     return mb;
 }
 
-HttpReply *
+HttpReplyPointer
 HttpReply::MakeConnectionEstablished() {
 
-    std::unique_ptr<HttpReply> rep(new HttpReply);
+    HttpReplyPointer rep(new HttpReply);
     rep->sline.set(Http::ProtocolVersion(), Http::scOkay, "Connection established");
-    return rep.release();
+    return rep;
 }
 
 HttpReply *

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -81,6 +81,9 @@ public:
     /** \return a ready to use mem buffer with a packed reply */
     MemBuf *pack() const;
 
+    /// construct and return a 200 (Connection established)
+    static HttpReply *MakeConnectionEstablished();
+
     /** construct a 304 reply and return it */
     HttpReply *make304() const;
 

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -81,7 +81,7 @@ public:
     /** \return a ready to use mem buffer with a packed reply */
     MemBuf *pack() const;
 
-    /// construct and return a 200 (Connection established)
+    /// construct and return an HTTP/200 (Connection Established) response
     static HttpReply *MakeConnectionEstablished();
 
     /** construct a 304 reply and return it */

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -82,7 +82,7 @@ public:
     MemBuf *pack() const;
 
     /// construct and return an HTTP/200 (Connection Established) response
-    static HttpReply *MakeConnectionEstablished();
+    static HttpReplyPointer MakeConnectionEstablished();
 
     /** construct a 304 reply and return it */
     HttpReply *make304() const;

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -252,8 +252,6 @@ public:
     void copyServerBytes();
 };
 
-static const char *const conn_established = "HTTP/1.1 200 Connection established\r\n\r\n";
-
 static ERCB tunnelErrorComplete;
 static CLCB tunnelServerClosed;
 static CLCB tunnelClientClosed;
@@ -863,7 +861,10 @@ TunnelStateData::notePeerReadyToShovel()
         *status_ptr = Http::scOkay;
         AsyncCall::Pointer call = commCbCall(5,5, "tunnelConnectedWriteDone",
                                              CommIoCbPtrFun(tunnelConnectedWriteDone, this));
-        client.write(conn_established, strlen(conn_established), call, nullptr);
+        al->reply = HttpReply::MakeConnectionEstablished();
+        const auto mb = al->reply->pack();
+        client.write(mb->content(), mb->contentSize(), call, mb->freeFunc());
+        delete mb;
     }
 }
 


### PR DESCRIPTION
... thus addressing a TODO. Lack of reply may cause
"ACL is used in context without an HTTP response" errors in some
contexts. These contexts (if any) should be fixed separately.