### PR TITLE
Supply ALE to request_header_access/reply_header_access

### DIFF
--- a/src/HttpHeaderTools.cc
+++ b/src/HttpHeaderTools.cc
@@ -341,7 +341,7 @@ httpHdrMangleList(HttpHeader *l, HttpRequest *request, const AccessLogEntryPoint
     if (hms) {
         int headers_deleted = 0;
         while ((e = l->getEntry(&p))) {
-            if (0 == httpHdrMangle(e, request, hms, al))
+            if (httpHdrMangle(e, request, hms, al) == 0)
                 l->delAt(p, headers_deleted);
         }
 

--- a/src/HttpHeaderTools.cc
+++ b/src/HttpHeaderTools.cc
@@ -273,7 +273,7 @@ httpHeaderQuoteString(const char *raw)
  * \retval 1    Header has no access controls to test
  */
 static int
-httpHdrMangle(HttpHeaderEntry * e, HttpRequest * request, HeaderManglers *hms)
+httpHdrMangle(HttpHeaderEntry * e, HttpRequest * request, HeaderManglers *hms, const AccessLogEntryPointer &al)
 {
     int retval;
 
@@ -288,6 +288,12 @@ httpHdrMangle(HttpHeaderEntry * e, HttpRequest * request, HeaderManglers *hms)
     }
 
     ACLFilledChecklist checklist(hm->access_list, request, NULL);
+
+    checklist.al = al;
+    if (al && al->reply) {
+        checklist.reply = al->reply.getRaw();
+        HTTPMSGLOCK(checklist.reply);
+    }
 
     if (checklist.fastCheck().allowed()) {
         /* aclCheckFast returns true for allow. */
@@ -335,7 +341,7 @@ httpHdrMangleList(HttpHeader *l, HttpRequest *request, const AccessLogEntryPoint
     if (hms) {
         int headers_deleted = 0;
         while ((e = l->getEntry(&p))) {
-            if (0 == httpHdrMangle(e, request, hms))
+            if (0 == httpHdrMangle(e, request, hms, al))
                 l->delAt(p, headers_deleted);
         }
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -168,6 +168,10 @@ peerAllowedToUse(const CachePeer * p, PeerSelector * ps)
 
     ACLFilledChecklist checklist(p->access, request, NULL);
     checklist.al = ps->al;
+    if (ps->al && ps->al->reply) {
+        checklist.reply = ps->al->reply.getRaw();
+        HTTPMSGLOCK(checklist.reply);
+    }
     checklist.syncAle(request, nullptr);
     return checklist.fastCheck().allowed();
 }


### PR DESCRIPTION
Commit cb36505 already covered many (but not all) similar cases.

Also supply HttpReply to cache_peer_access. Lack of reply
caused "ACL is used in context without an HTTP response" bug.