### PR TITLE
Fix the SQUID_CC_REQUIRE_ARGUMENT autoconf function

### DIFF
--- a/acinclude/compiler-flags.m4
+++ b/acinclude/compiler-flags.m4
@@ -41,7 +41,7 @@ AC_DEFUN([SQUID_CC_REQUIRE_ARGUMENT],[
     SAVED_CFLAGS="$CFLAGS"
     SAVED_CXXFLAGS="$CXXFLAGS"
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM($3,$4)],[$1=no],[],[$1=no])
-    if test "x$1" != "xno" ; then
+    if test "x$$1" != "xno" ; then
       CFLAGS="$CFLAGS $2"
       CXXFLAGS="$CXXFLAGS $2"
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM($3,$4)],[$1=yes],[$1=no],[$1=no])


### PR DESCRIPTION
Inside AC_DEFUN(), autoconf replaces `$1` with the first argument of the
function.  In this case, the first argument is a variable name. To get
the _value_ of that variable, one has to use `$$1`.

One known effect of this fix (in many build environments) is the
disappearance of the following annoying extra error when a build fails
for some other reason:

    unrecognized command line option -Wno-deprecated-register
