### PR TITLE
Report context of level-0/1 cache.log messages

### DIFF
--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -49,13 +49,16 @@ AccessLogEntry::getLogClientIp(char *buf, size_t bufsz) const
 SBuf
 AccessLogEntry::getLogMethod() const
 {
+    static const SBuf dash("-");
     SBuf method;
     if (icp.opcode)
         method.append(icp_opcode_str[icp.opcode]);
     else if (htcp.opcode)
         method.append(htcp.opcode);
-    else
+    else if (http.method)
         method = http.method.image();
+    else
+        method = dash;
     return method;
 }
 

--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -120,14 +120,14 @@ AccessLogEntry::~AccessLogEntry()
 #endif
 }
 
-std::ostream &
-AccessLogEntry::briefCodeContext(std::ostream &os) const
+ScopedId
+AccessLogEntry::codeContextGist() const
 {
     if (request) {
         if (const auto &mx = request->masterXaction)
-            os << mx->id;
+            return mx->id.detach();
     }
-    return os;
+    return ScopedId();
 }
 
 std::ostream &

--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -120,6 +120,48 @@ AccessLogEntry::~AccessLogEntry()
 #endif
 }
 
+std::ostream &
+AccessLogEntry::briefCodeContext(std::ostream &os) const
+{
+    if (request) {
+        if (const auto &mx = request->masterXaction)
+            os << mx->id;
+    }
+    return os;
+}
+
+std::ostream &
+AccessLogEntry::detailCodeContext(std::ostream &os) const
+{
+    // TODO: Consider printing all instead of the first most important detail.
+
+    if (request) {
+        if (const auto &mx = request->masterXaction)
+            return os << Debug::Extra << "current master transaction: " << mx->id;
+    }
+
+    // provide helpful details since we cannot identify the transaction exactly
+
+    if (tcpClient)
+        return os << Debug::Extra << "current from-client connection: " << tcpClient;
+    else if (!cache.caddr.isNoAddr())
+        return os << Debug::Extra << "current client: " << cache.caddr;
+
+    const auto optionalMethod = [this,&os]() {
+        if (hasLogMethod())
+            os << getLogMethod() << ' ';
+        return "";
+    };
+    if (const auto uri = effectiveVirginUrl())
+        return os << Debug::Extra << "current client request: " << optionalMethod() << *uri;
+    else if (!url.isEmpty())
+        return os << Debug::Extra << "current request: " << optionalMethod() << url;
+    else if (hasLogMethod())
+        return os << Debug::Extra << "current request method: " << getLogMethod();
+
+    return os;
+}
+
 const SBuf *
 AccessLogEntry::effectiveVirginUrl() const
 {

--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -127,7 +127,8 @@ AccessLogEntry::codeContextGist() const
         if (const auto &mx = request->masterXaction)
             return mx->id.detach();
     }
-    return ScopedId();
+    // TODO: Carefully merge ALE and MasterXaction.
+    return ScopedId("ALE w/o master");
 }
 
 std::ostream &

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -56,6 +56,9 @@ public:
     /// Fetch the external ACL provided 'user=' string, or nil if none is available.
     const char *getExtUser() const;
 
+    /// whether we know what the request method is
+    bool hasLogMethod() const { return icp.opcode || htcp.opcode || http.method; }
+
     /// Fetch the transaction method string (ICP opcode, HTCP opcode or HTTP method)
     SBuf getLogMethod() const;
 

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -10,7 +10,7 @@
 #define SQUID_HTTPACCESSLOGENTRY_H
 
 #include "anyp/PortCfg.h"
-#include "base/RefCount.h"
+#include "base/CodeContext.h"
 #include "comm/Connection.h"
 #include "HierarchyLogEntry.h"
 #include "http/ProtocolVersion.h"
@@ -36,14 +36,18 @@ class HttpReply;
 class HttpRequest;
 class CustomLog;
 
-class AccessLogEntry: public RefCountable
+class AccessLogEntry: public CodeContext
 {
 
 public:
     typedef RefCount<AccessLogEntry> Pointer;
 
     AccessLogEntry();
-    ~AccessLogEntry();
+    virtual ~AccessLogEntry();
+
+    /* CodeContext API */
+    virtual std::ostream &detailCodeContext(std::ostream &os) const override;
+    virtual std::ostream &briefCodeContext(std::ostream &os) const override;
 
     /// Fetch the client IP log string into the given buffer.
     /// Knows about several alternate locations of the IP

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -47,7 +47,7 @@ public:
 
     /* CodeContext API */
     virtual std::ostream &detailCodeContext(std::ostream &os) const override;
-    virtual std::ostream &briefCodeContext(std::ostream &os) const override;
+    virtual ScopedId codeContextGist() const override;
 
     /// Fetch the client IP log string into the given buffer.
     /// Knows about several alternate locations of the IP

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -100,7 +100,7 @@ public:
     /// configures the active debugging context to write syslog ALERT
     static void ForceAlert();
 
-    /// Prefixes debugs() lines after the first one.
+    /// prefixes each grouped debugs() line after the first one in the group
     static std::ostream& Extra(std::ostream &os) { return os << "\n    "; }
 
 private:

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -99,6 +99,10 @@ public:
 
     /// configures the active debugging context to write syslog ALERT
     static void ForceAlert();
+
+    /// Prefixes debugs() lines after the first one.
+    static std::ostream& Extra(std::ostream &os) { return os << "\n    "; }
+
 private:
     static Context *Current; ///< deepest active context; nil outside debugs()
 };

--- a/src/DiskIO/IpcIo/IpcIoFile.h
+++ b/src/DiskIO/IpcIo/IpcIoFile.h
@@ -166,7 +166,7 @@ public:
     ReadRequest *readRequest; ///< set if this is a read requests
     WriteRequest *writeRequest; ///< set if this is a write request
 
-    CodeContextPointer codeContext; ///< requestor's context
+    CodeContext::Pointer codeContext; ///< requestor's context
 
 private:
     IpcIoPendingRequest(const IpcIoPendingRequest &d); // not implemented

--- a/src/DiskIO/IpcIo/IpcIoFile.h
+++ b/src/DiskIO/IpcIo/IpcIoFile.h
@@ -166,6 +166,8 @@ public:
     ReadRequest *readRequest; ///< set if this is a read requests
     WriteRequest *writeRequest; ///< set if this is a write request
 
+    CodeContextPointer codeContext; ///< requestor's context
+
 private:
     IpcIoPendingRequest(const IpcIoPendingRequest &d); // not implemented
     IpcIoPendingRequest &operator =(const IpcIoPendingRequest &d); // ditto

--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -79,3 +79,23 @@ AnyP::PortCfg::clone() const
     return b;
 }
 
+ScopedId
+AnyP::PortCfg::codeContextGist() const
+{
+    // Unfortunately, .name lifetime is too short in FTP use cases.
+    // TODO: Consider adding InstanceId<uint32_t> to all RefCountable classes.
+    return ScopedId("port");
+}
+
+std::ostream &
+AnyP::PortCfg::detailCodeContext(std::ostream &os) const
+{
+    // parsePortSpecification() defaults optional port name to the required
+    // listening address so we cannot easily distinguish one from the other.
+    if (name)
+        os << Debug::Extra << "listening port: " << name;
+    else if (s.port())
+        os << Debug::Extra << "listening port address: " << s;
+    return os;
+}
+

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -12,6 +12,7 @@
 #include "anyp/forward.h"
 #include "anyp/ProtocolVersion.h"
 #include "anyp/TrafficMode.h"
+#include "base/CodeContext.h"
 #include "comm/Connection.h"
 #include "sbuf/SBuf.h"
 #include "security/ServerOptions.h"
@@ -19,12 +20,16 @@
 namespace AnyP
 {
 
-class PortCfg : public RefCountable
+class PortCfg : public CodeContext
 {
 public:
     PortCfg();
     ~PortCfg();
     AnyP::PortCfgPointer clone() const;
+
+    /* CodeContext API */
+    virtual ScopedId codeContextGist() const override;
+    virtual std::ostream &detailCodeContext(std::ostream &os) const override;
 
     PortCfgPointer next;
 

--- a/src/base/AsyncCall.cc
+++ b/src/base/AsyncCall.cc
@@ -18,9 +18,13 @@ InstanceIdDefinitions(AsyncCall, "call");
 
 /* AsyncCall */
 
-AsyncCall::AsyncCall(int aDebugSection, int aDebugLevel,
-                     const char *aName): name(aName), debugSection(aDebugSection),
-    debugLevel(aDebugLevel), theNext(0), isCanceled(NULL)
+AsyncCall::AsyncCall(int aDebugSection, int aDebugLevel, const char *aName):
+    name(aName),
+    codeContext(CodeContext::Current()),
+    debugSection(aDebugSection),
+    debugLevel(aDebugLevel),
+    theNext(nullptr),
+    isCanceled(nullptr)
 {
     debugs(debugSection, debugLevel, "The AsyncCall " << name << " constructed, this=" << this <<
            " [" << id << ']');
@@ -91,8 +95,12 @@ ScheduleCall(const char *fileName, int fileLine, AsyncCall::Pointer &call)
 {
     debugs(call->debugSection, call->debugLevel, fileName << "(" << fileLine <<
            ") will call " << *call << " [" << call->id << ']' );
+
+    // Support callback creators that did not get their context from service A,
+    // but the current caller (service B) got that context from another source.
     if (!call->codeContext)
         call->codeContext = CodeContext::Current();
+
     AsyncCallQueue::Instance().schedule(call);
     return true;
 }

--- a/src/base/AsyncCall.cc
+++ b/src/base/AsyncCall.cc
@@ -7,9 +7,9 @@
  */
 
 #include "squid.h"
-#include "AsyncCall.h"
 #include "base/AsyncCall.h"
 #include "base/AsyncCallQueue.h"
+#include "base/CodeContext.h"
 #include "cbdata.h"
 #include "Debug.h"
 #include <ostream>
@@ -91,6 +91,8 @@ ScheduleCall(const char *fileName, int fileLine, AsyncCall::Pointer &call)
 {
     debugs(call->debugSection, call->debugLevel, fileName << "(" << fileLine <<
            ") will call " << *call << " [" << call->id << ']' );
+    if (!call->codeContext)
+        call->codeContext = CodeContext::Current();
     AsyncCallQueue::Instance().schedule(call);
     return true;
 }

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_ASYNCCALL_H
 #define SQUID_ASYNCCALL_H
 
+#include "base/forward.h"
 #include "base/InstanceId.h"
 #include "event.h"
 #include "RefCount.h"
@@ -32,9 +33,6 @@
  * method calls, but they give you a uniform interface and handy call
  * debugging.
  */
-
-class CallDialer;
-class AsyncCallQueue;
 
 /**
  \todo add unique call IDs
@@ -74,6 +72,10 @@ public:
 
 public:
     const char *const name;
+
+    /// what the callee is expected to work on
+    CodeContextPointer codeContext;
+
     const int debugSection;
     const int debugLevel;
     const InstanceId<AsyncCall> id;

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ASYNCCALL_H
 #define SQUID_ASYNCCALL_H
 
-#include "base/forward.h"
+#include "base/CodeContext.h"
 #include "base/InstanceId.h"
 #include "event.h"
 #include "RefCount.h"
@@ -33,6 +33,9 @@
  * method calls, but they give you a uniform interface and handy call
  * debugging.
  */
+
+class CallDialer;
+class AsyncCallQueue;
 
 /**
  \todo add unique call IDs
@@ -74,7 +77,7 @@ public:
     const char *const name;
 
     /// what the callee is expected to work on
-    CodeContextPointer codeContext;
+    CodeContext::Pointer codeContext;
 
     const int debugSection;
     const int debugLevel;

--- a/src/base/AsyncCallQueue.cc
+++ b/src/base/AsyncCallQueue.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "base/AsyncCall.h"
 #include "base/AsyncCallQueue.h"
+#include "base/CodeContext.h"
 #include "Debug.h"
 
 AsyncCallQueue *AsyncCallQueue::TheInstance = 0;
@@ -38,8 +39,12 @@ bool
 AsyncCallQueue::fire()
 {
     const bool made = theHead != NULL;
-    while (theHead != NULL)
+    while (theHead != NULL) {
+        CodeContext::SwitchTo(theHead->codeContext);
         fireNext();
+    }
+    if (made)
+        CodeContext::Clear();
     return made;
 }
 

--- a/src/base/AsyncCallQueue.cc
+++ b/src/base/AsyncCallQueue.cc
@@ -40,7 +40,7 @@ AsyncCallQueue::fire()
 {
     const bool made = theHead != NULL;
     while (theHead != NULL) {
-        CodeContext::SwitchTo(theHead->codeContext);
+        CodeContext::Reset(theHead->codeContext);
         fireNext();
     }
     if (made)

--- a/src/base/AsyncCallQueue.cc
+++ b/src/base/AsyncCallQueue.cc
@@ -38,7 +38,7 @@ bool
 AsyncCallQueue::fire()
 {
     const bool made = theHead != NULL;
-    while (theHead != NULL) {
+    while (theHead) {
         CodeContext::Reset(theHead->codeContext);
         fireNext();
     }

--- a/src/base/AsyncCallQueue.cc
+++ b/src/base/AsyncCallQueue.cc
@@ -11,7 +11,6 @@
 #include "squid.h"
 #include "base/AsyncCall.h"
 #include "base/AsyncCallQueue.h"
-#include "base/CodeContext.h"
 #include "Debug.h"
 
 AsyncCallQueue *AsyncCallQueue::TheInstance = 0;

--- a/src/base/AsyncCallQueue.cc
+++ b/src/base/AsyncCallQueue.cc
@@ -44,7 +44,7 @@ AsyncCallQueue::fire()
         fireNext();
     }
     if (made)
-        CodeContext::Clear();
+        CodeContext::Reset();
     return made;
 }
 

--- a/src/base/CodeContext.cc
+++ b/src/base/CodeContext.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 1996-2019 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS code_contexts for details.
+ */
+
+#include "squid.h"
+#include "base/CodeContext.h"
+#include "Debug.h"
+
+/// guarantees forever pointer existence starting from the first use
+static CodeContext::Pointer &
+Instance()
+{
+    static const auto Instance = new CodeContext::Pointer(nullptr);
+    return *Instance;
+}
+
+const CodeContext::Pointer &
+CodeContext::Current()
+{
+    return Instance();
+}
+
+void
+CodeContext::Clear()
+{
+    if (auto &instance = Instance()) {
+        debugs(1, 7, CurrentCodeContextBrief);
+        instance = nullptr;
+    }
+}
+
+void
+CodeContext::SwitchTo(const Pointer codeCtx)
+{
+    if (codeCtx) {
+        if (codeCtx == Current())
+            return; // no context changes
+        Instance() = codeCtx;
+        debugs(1, 5, CurrentCodeContextBrief);
+        return;
+    }
+
+    Clear();
+}
+
+std::ostream &
+CurrentCodeContextBrief(std::ostream &os)
+{
+    if (const auto ctx = CodeContext::Current())
+        ctx->briefCodeContext(os);
+    return os;
+}
+
+std::ostream &
+CurrentCodeContextDetail(std::ostream &os)
+{
+    if (const auto ctx = CodeContext::Current())
+        ctx->detailCodeContext(os);
+    return os;
+}
+

--- a/src/base/CodeContext.cc
+++ b/src/base/CodeContext.cc
@@ -24,26 +24,41 @@ CodeContext::Current()
     return Instance();
 }
 
+/// Switches the current context to the given known context. Improves debugging
+/// output by replacing omni-directional "Reset" with directional "Entering".
+void
+CodeContext::Entering(const Pointer &codeCtx)
+{
+    Instance() = codeCtx;
+    debugs(1, 5, CurrentCodeContextBrief);
+}
+
+/// Forgets the current known context. Improves debugging output by replacing
+/// omni-directional "Reset" with directional "Leaving".
+void
+CodeContext::Leaving()
+{
+    debugs(1, 7, CurrentCodeContextBrief);
+    Instance() = nullptr;
+}
+
 void
 CodeContext::Reset()
 {
-    if (auto &instance = Instance()) {
-        debugs(1, 7, CurrentCodeContextBrief);
-        instance = nullptr;
-    }
+    if (Instance())
+        Leaving();
 }
 
 void
 CodeContext::Reset(const Pointer codeCtx)
 {
-    if (!codeCtx)
-        return Reset();
-
     if (codeCtx == Current())
         return; // context has not actually changed
 
-    Instance() = codeCtx;
-    debugs(1, 5, CurrentCodeContextBrief);
+    if (!codeCtx)
+        return Leaving();
+
+    Entering(codeCtx);
 }
 
 std::ostream &

--- a/src/base/CodeContext.cc
+++ b/src/base/CodeContext.cc
@@ -34,7 +34,7 @@ CodeContext::Clear()
 }
 
 void
-CodeContext::SwitchTo(const Pointer codeCtx)
+CodeContext::Reset(const Pointer codeCtx)
 {
     if (codeCtx) {
         if (codeCtx == Current())

--- a/src/base/CodeContext.cc
+++ b/src/base/CodeContext.cc
@@ -25,7 +25,7 @@ CodeContext::Current()
 }
 
 void
-CodeContext::Clear()
+CodeContext::Reset()
 {
     if (auto &instance = Instance()) {
         debugs(1, 7, CurrentCodeContextBrief);
@@ -36,15 +36,14 @@ CodeContext::Clear()
 void
 CodeContext::Reset(const Pointer codeCtx)
 {
-    if (codeCtx) {
-        if (codeCtx == Current())
-            return; // no context changes
-        Instance() = codeCtx;
-        debugs(1, 5, CurrentCodeContextBrief);
-        return;
-    }
+    if (!codeCtx)
+        return Reset();
 
-    Clear();
+    if (codeCtx == Current())
+        return; // context has not actually changed
+
+    Instance() = codeCtx;
+    debugs(1, 5, CurrentCodeContextBrief);
 }
 
 std::ostream &

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -32,6 +32,9 @@ public:
 
     virtual ~CodeContext() {}
 
+    // TODO: This should probably become some kind of <char*,id> tuple so that
+    // we can preserve context gist across Reset()-triggered destruction _and_
+    // pass (master transaction?) context gist to SMP workers (e.g., disker).
     /// writes a word or two to help identify code context in debug messages
     virtual std::ostream &briefCodeContext(std::ostream &os) const = 0;
 
@@ -42,6 +45,51 @@ public:
 /* convenience context-reporting wrappers that also reduce linking problems */
 std::ostream &CurrentCodeContextBrief(std::ostream &os);
 std::ostream &CurrentCodeContextDetail(std::ostream &os);
+
+/// Convenience class that automatically restores the current/outer CodeContext
+/// when leaving the scope of the new-context following/inner code. \see Run().
+class CodeContextGuard
+{
+public:
+    CodeContextGuard(const CodeContext::Pointer &newContext): savedCodeContext(CodeContext::Current()) { CodeContext::Reset(newContext); }
+    ~CodeContextGuard() { CodeContext::Reset(savedCodeContext); }
+
+    // no copying of any kind (for simplicity and to prevent accidental copies)
+    CodeContextGuard(CodeContextGuard &&) = delete;
+
+    CodeContext::Pointer savedCodeContext;
+};
+
+/// Executes service `callback` in `callbackContext`. If an exception occurs,
+/// the callback context is preserved, so that the exception is associated with
+/// the callback that triggered them (rather than with the service).
+///
+/// Service code running in its own service context should use this function.
+template <typename Fun>
+inline void
+CallBack(const CodeContext::Pointer &callbackContext, Fun &&callback)
+{
+    // TODO: Consider catching exceptions and letting CodeContext handle them.
+    const auto savedCodeContext(CodeContext::Current());
+    CodeContext::Reset(callbackContext);
+    callback();
+    CodeContext::Reset(savedCodeContext);
+}
+
+/// Executes `service` in `serviceContext` but due to automatic caller context
+/// restoration, service exceptions are associated with the caller that suffered
+/// from (and/or caused) them (rather than with the service itself).
+///
+/// Service code running in caller's context should use this function to escape
+/// into service context (e.g., for submitting caller-agnostic requests).
+template <typename Fun>
+inline void
+CallService(const CodeContext::Pointer &serviceContext, Fun &&service)
+{
+    // TODO: Consider catching exceptions and letting CodeContext handle them.
+    CodeContextGuard guard(serviceContext);
+    service();
+}
 
 #endif
 

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -40,6 +40,10 @@ public:
 
     /// appends human-friendly context description line(s) to a cache.log record
     virtual std::ostream &detailCodeContext(std::ostream &os) const = 0;
+
+private:
+    static void Entering(const Pointer &codeCtx);
+    static void Leaving();
 };
 
 /* convenience context-reporting wrappers that also reduce linking problems */

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -24,7 +24,7 @@ public:
     // XXX: Document
     static const Pointer &Current(); // may be nil (i.e. unknown)
     static void Clear();
-    static void SwitchTo(const Pointer codeCtx);
+    static void Reset(const Pointer codeCtx);
 
     virtual ~CodeContext() {}
 
@@ -40,3 +40,4 @@ std::ostream &CurrentCodeContextBrief(std::ostream &os);
 std::ostream &CurrentCodeContextDetail(std::ostream &os);
 
 #endif
+

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 1996-2019 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS code_contexts for details.
+ */
+
+#ifndef SQUID_BASE_CODE_CONTEXT_H
+#define SQUID_BASE_CODE_CONTEXT_H
+
+#include "base/RefCount.h"
+
+#include <iosfwd>
+
+/// Interface for reporting what Squid code is working on.
+/// Such reports are usually requested outside creator's call stack.
+/// They are especially useful for attributing low-level errors to transactions.
+class CodeContext: public RefCountable
+{
+public:
+    typedef RefCount<CodeContext> Pointer;
+
+    // XXX: Document
+    static const Pointer &Current(); // may be nil (i.e. unknown)
+    static void Clear();
+    static void SwitchTo(const Pointer codeCtx);
+
+    virtual ~CodeContext() {}
+
+    /// writes a word or two to help identify code context in debug messages
+    virtual std::ostream &briefCodeContext(std::ostream &os) const = 0;
+
+    /// appends human-friendly context description line(s) to a cache.log record
+    virtual std::ostream &detailCodeContext(std::ostream &os) const = 0;
+};
+
+/* convenience context-reporting wrappers that also reduce linking problems */
+std::ostream &CurrentCodeContextBrief(std::ostream &os);
+std::ostream &CurrentCodeContextDetail(std::ostream &os);
+
+#endif

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -102,5 +102,20 @@ CallService(const CodeContext::Pointer &serviceContext, Fun &&service)
     service();
 }
 
+/// Executes context `creator` in the service context. If an exception occurs,
+/// the creator context is preserved, so that the exception is associated with
+/// the creator that triggered them (rather than with the service).
+///
+/// Service code running in its own context should use this function to create
+/// new code contexts. TODO: Use or, if this pattern is not repeated, remove.
+template <typename Fun>
+inline void
+CallContextCreator(Fun &&creator)
+{
+    const auto savedCodeContext(CodeContext::Current());
+    creator();
+    CodeContext::Reset(savedCodeContext);
+}
+
 #endif
 

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -21,10 +21,14 @@ class CodeContext: public RefCountable
 public:
     typedef RefCount<CodeContext> Pointer;
 
-    // XXX: Document
-    static const Pointer &Current(); // may be nil (i.e. unknown)
-    static void Clear();
-    static void Reset(const Pointer codeCtx);
+    /// \returns the known global context or, to indicate unknown context, nil
+    static const Pointer &Current();
+
+    /// forgets the current context, setting it to nil/unknown
+    static void Reset();
+
+    /// changes the current context; nil argument sets it to nil/unknown
+    static void Reset(const Pointer);
 
     virtual ~CodeContext() {}
 

--- a/src/base/InstanceId.h
+++ b/src/base/InstanceId.h
@@ -65,8 +65,9 @@ public:
     /// writes a compact text representation of the ID
     std::ostream &print(std::ostream &) const;
 
+    // TODO: Refactor into static Scope().
     /// \returns Class-specific nickname (with endless lifetime)
-    const char *prefix() const; // TODO: Refactor into static Scope().
+    const char * prefix() const;
 
     /// \returns a copy of the ID usable outside our Class context
     ScopedId detach() const { return ScopedId(prefix(), value); }

--- a/src/base/InstanceId.h
+++ b/src/base/InstanceId.h
@@ -19,23 +19,26 @@ class ScopedId
 {
 public:
     ScopedId(): scope(nullptr), value(0) {}
-    ScopedId(const char *s, uint64_t v): scope(s), value(v) {}
+    explicit ScopedId(const char *s): scope(s), value(0) {}
+    // when the values is zero/unknown, use other constructors
+    ScopedId(const char *s, uint64_t v): scope(s), value(v) { /* assert(value) */ }
 
-    /// whether the ID is "set" or "known"; the scope part does not matter
-    explicit operator bool() const { return value; }
-
-    /// the prefix() of the InstanceId object that we were detached from
+    /// either the prefix() of the InstanceId object that we were detached from
+    /// or, for 0 values, some other description (with endless lifetime) or nil
     const char *scope;
 
-    /// the value of the InstanceId object that we were detached from
+    /// either the value of the InstanceId object that we were detached from
+    /// or, if our creator did not know the exact value, zero
     uint64_t value;
 };
 
 inline std::ostream&
 operator <<(std::ostream &os, const ScopedId &id)
 {
-    if (id)
+    if (id.value)
         os << id.scope << id.value;
+    else if (id.scope)
+        os << id.scope;
     else
         os << "[unknown]";
     return os;

--- a/src/base/InstanceId.h
+++ b/src/base/InstanceId.h
@@ -62,11 +62,11 @@ public:
     bool operator !=(const InstanceId &o) const { return !(*this == o); }
     void change();
 
-    /// prints class-pecific prefix followed by ID value; \todo: use HEX for value printing?
+    /// writes a compact text representation of the ID
     std::ostream &print(std::ostream &) const;
 
-    /// returns the class-pecific prefix
-    const char * prefix() const;
+    /// \returns Class-specific nickname (with endless lifetime)
+    const char *prefix() const; // TODO: Refactor into static Scope().
 
     /// \returns a copy of the ID usable outside our Class context
     ScopedId detach() const { return ScopedId(prefix(), value); }

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -24,6 +24,8 @@ libbase_la_SOURCES = \
 	CbDataList.h \
 	CharacterSet.cc \
 	CharacterSet.h \
+	CodeContext.cc \
+	CodeContext.h \
 	EnumIterator.h \
 	File.cc \
 	File.h \

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -35,12 +35,18 @@ public:
         dereference();
     }
 
-    RefCount (const RefCount &p) : p_(p.p_) {
+    RefCount(const RefCount<C> &p): p_(p.p_) {
         reference (p);
     }
 
-    RefCount (RefCount &&p) : p_(std::move(p.p_)) {
+    RefCount(RefCount<C> &&p): p_(p.p_) {
         p.p_=NULL;
+    }
+
+    /// Base::Pointer = Derived::Pointer
+    template <class Other>
+    RefCount(const RefCount<Other> &p): p_(p.getRaw()) {
+        reference(*this);
     }
 
     RefCount& operator = (const RefCount& p) {

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -35,11 +35,11 @@ public:
         dereference();
     }
 
-    RefCount(const RefCount<C> &p): p_(p.p_) {
+    RefCount (const RefCount &p) : p_(p.p_) {
         reference (p);
     }
 
-    RefCount(RefCount<C> &&p): p_(p.p_) {
+    RefCount (RefCount &&p) : p_(std::move(p.p_)) {
         p.p_=NULL;
     }
 

--- a/src/base/Subscription.h
+++ b/src/base/Subscription.h
@@ -10,6 +10,7 @@
 #define _SQUID_BASE_SUBSCRIPTION_H
 
 #include "base/AsyncCall.h"
+#include "base/CodeContext.h"
 
 /** API for creating a series of AsyncCalls.
  * This is necessary because the same AsyncCall callback must not be
@@ -50,7 +51,13 @@ class CallSubscription: public Subscription
 public:
     /// Must be passed an object. nil pointers are not permitted.
     explicit CallSubscription(const RefCount<Call_> &aCall) : call(aCall) { assert(aCall != NULL); }
-    virtual AsyncCall::Pointer callback() const { return new Call_(*call); }
+    virtual AsyncCall::Pointer callback() const
+    {
+        const AsyncCall::Pointer cb = new Call_(*call);
+        if (!cb->codeContext || CodeContext::Current())
+            cb->codeContext = CodeContext::Current();
+        return cb;
+    }
 
 private:
     const RefCount<Call_> call; ///< gets copied to create callback calls

--- a/src/base/Subscription.h
+++ b/src/base/Subscription.h
@@ -10,7 +10,6 @@
 #define _SQUID_BASE_SUBSCRIPTION_H
 
 #include "base/AsyncCall.h"
-#include "base/CodeContext.h"
 
 /** API for creating a series of AsyncCalls.
  * This is necessary because the same AsyncCall callback must not be

--- a/src/base/TextException.cc
+++ b/src/base/TextException.cc
@@ -36,9 +36,9 @@ TextException::~TextException() throw()
 std::ostream &
 TextException::print(std::ostream &os) const
 {
-    os << std::runtime_error::what() << "\n" <<
-       "    exception location: " << where << "\n";
-    // TODO: error_detail: " << (ERR_DETAIL_EXCEPTION_START+id()) << "\n";
+    os << std::runtime_error::what() <<
+        Debug::Extra << "exception location: " << where;
+    // TODO: ...error_detail: " << (ERR_DETAIL_EXCEPTION_START+id());
     return os;
 }
 

--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -74,9 +74,9 @@ std::ostream &CurrentException(std::ostream &);
     try { \
         code \
     } catch (...) { \
-        debugs(0, DBG_IMPORTANT, "BUG: ignoring exception;\n" << \
-               "    bug location: " << Here() << "\n" << \
-               "    ignored exception: " << CurrentException); \
+        debugs(0, DBG_IMPORTANT, "BUG: ignoring exception;" << \
+               Debug::Extra << "bug location: " << Here() << \
+               Debug::Extra << "ignored exception: " << CurrentException); \
     }
 
 #endif /* SQUID__TEXTEXCEPTION_H */

--- a/src/base/forward.h
+++ b/src/base/forward.h
@@ -9,10 +9,16 @@
 #ifndef SQUID_SRC_BASE_FORWARD_H
 #define SQUID_SRC_BASE_FORWARD_H
 
-template<class Cbc> class CbcPointer;
-
+class AsyncCallQueue;
 class AsyncJob;
+class CallDialer;
+class CodeContext;
+
+template<class Cbc> class CbcPointer;
+template<class RefCountableKid> class RefCount;
+
 typedef CbcPointer<AsyncJob> AsyncJobPointer;
+typedef RefCount<CodeContext> CodeContextPointer;
 
 #endif /* SQUID_SRC_BASE_FORWARD_H */
 

--- a/src/base/forward.h
+++ b/src/base/forward.h
@@ -13,6 +13,7 @@ class AsyncCallQueue;
 class AsyncJob;
 class CallDialer;
 class CodeContext;
+class ScopedId;
 
 template<class Cbc> class CbcPointer;
 template<class RefCountableKid> class RefCount;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2623,20 +2623,25 @@ ConnStateData::postHttpsAccept()
 
         MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
         mx->tcpClient = clientConnection;
-        // Create a fake HTTP request for ssl_bump ACL check,
+        // Create a fake HTTP request and ALE for the ssl_bump ACL check,
         // using tproxy/intercept provided destination IP and port.
+        // XXX: Merge with subsequent fakeAConnectRequest(), buildFakeRequest().
+        // XXX: Do this earlier (e.g., in Http[s]::One::Server constructor).
         HttpRequest *request = new HttpRequest(mx);
         static char ip[MAX_IPSTRLEN];
         assert(clientConnection->flags & (COMM_TRANSPARENT | COMM_INTERCEPTION));
         request->url.host(clientConnection->local.toStr(ip, sizeof(ip)));
         request->url.port(clientConnection->local.port());
         request->myportname = port->name;
+        const AccessLogEntry::Pointer connectAle = new AccessLogEntry;
+        CodeContext::SwitchTo(connectAle);
+        // TODO: Use these request/ALE when waiting for new bumped transactions.
 
         ACLFilledChecklist *acl_checklist = new ACLFilledChecklist(Config.accessList.ssl_bump, request, NULL);
         acl_checklist->src_addr = clientConnection->remote;
         acl_checklist->my_addr = port->s;
         // Build a local AccessLogEntry to allow requiresAle() acls work
-        acl_checklist->al = new AccessLogEntry;
+        acl_checklist->al = connectAle;
         acl_checklist->al->cache.start_time = current_time;
         acl_checklist->al->tcpClient = clientConnection;
         acl_checklist->al->cache.port = port;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3367,8 +3367,8 @@ clientHttpConnectionsOpen(void)
         const SBuf &scheme = AnyP::UriScheme(s->transport.protocol).image();
 
         if (MAXTCPLISTENPORTS == NHttpSockets) {
-            debugs(1, DBG_IMPORTANT, "WARNING: You have too many '" << scheme << "_port' lines.");
-            debugs(1, DBG_IMPORTANT, "         The limit is " << MAXTCPLISTENPORTS << " HTTP ports.");
+            debugs(1, DBG_IMPORTANT, "WARNING: You have too many '" << scheme << "_port' lines." <<
+                   Debug::Extra << "The limit is " << MAXTCPLISTENPORTS << " HTTP ports.");
             continue;
         }
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2634,7 +2634,7 @@ ConnStateData::postHttpsAccept()
         request->url.port(clientConnection->local.port());
         request->myportname = port->name;
         const AccessLogEntry::Pointer connectAle = new AccessLogEntry;
-        CodeContext::SwitchTo(connectAle);
+        CodeContext::Reset(connectAle);
         // TODO: Use these request/ALE when waiting for new bumped transactions.
 
         ACLFilledChecklist *acl_checklist = new ACLFilledChecklist(Config.accessList.ssl_bump, request, NULL);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -168,6 +168,7 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
 {
     setConn(aConn);
     al = new AccessLogEntry;
+    CodeContext::SwitchTo(al);
     al->cache.start_time = current_time;
     if (aConn) {
         al->tcpClient = clientConnection = aConn->clientConnection;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -168,7 +168,7 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
 {
     setConn(aConn);
     al = new AccessLogEntry;
-    CodeContext::SwitchTo(al);
+    CodeContext::Reset(al);
     al->cache.start_time = current_time;
     if (aConn) {
         al->tcpClient = clientConnection = aConn->clientConnection;

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -562,8 +562,6 @@ commSetConnTimeout(const Comm::ConnectionPointer &conn, int timeout, AsyncCall::
         F->timeout = 0;
     } else {
         if (callback != NULL) {
-            if (!callback->codeContext)
-                callback->codeContext = CodeContext::Current();
             typedef CommTimeoutCbParams Params;
             Params &params = GetCommParams<Params>(callback);
             params.conn = conn;
@@ -775,8 +773,6 @@ comm_lingering_close(int fd)
     debugs(5, 3, HERE << "FD " << fd << " timeout " << timeout);
     assert(fd_table[fd].flags.open);
     if (callback != NULL) {
-        if (!callback->codeContext)
-            callback->codeContext = CodeContext::Current();
         typedef FdeCbParams Params;
         Params &params = GetCommParams<Params>(callback);
         params.fd = fd;
@@ -991,8 +987,7 @@ comm_add_close_handler(int fd, AsyncCall::Pointer &call)
 //        assert(c->handler != handler || c->data != data);
 
     call->setNext(fd_table[fd].closeHandler);
-    if (!call->codeContext)
-        call->codeContext = CodeContext::Current();
+
     fd_table[fd].closeHandler = call;
 }
 

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1582,7 +1582,7 @@ checkTimeouts(void)
                 // TODO: CodeContext::Reset(F's context);
                 F->writeQuotaHandler->selectWaiting = true;
                 Comm::SetSelect(fd, COMM_SELECT_WRITE, Comm::HandleWrite, COMMIO_FD_WRITECB(fd), 0);
-                CodeContext::Clear();
+                CodeContext::Reset();
             }
             continue;
 #endif
@@ -1605,7 +1605,7 @@ checkTimeouts(void)
 
     }
 
-    CodeContext::Clear();
+    CodeContext::Reset();
 }
 
 /// Start waiting for a possibly half-closed connection to close

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -866,7 +866,6 @@ _comm_close(int fd, char const *file, int line)
     if ( (shutting_down || reconfiguring) && (!F->flags.open || F->type == FD_FILE))
         return;
 
-
     /* The following fails because ipc.c is doing calls to pipe() to create sockets! */
     if (!isOpen(fd)) {
         debugs(50, DBG_IMPORTANT, HERE << "BUG 3556: FD " << fd << " is not an open socket.");

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1572,14 +1572,14 @@ checkTimeouts(void)
 
         if (writeTimedOut(fd)) {
             // We have an active write callback and we are timed out
-            // TODO: CodeContext::SwitchTo(F's context);
+            // TODO: CodeContext::Reset(F's context);
             debugs(5, 5, "checkTimeouts: FD " << fd << " auto write timeout");
             Comm::SetSelect(fd, COMM_SELECT_WRITE, NULL, NULL, 0);
             COMMIO_FD_WRITECB(fd)->finish(Comm::COMM_ERROR, ETIMEDOUT);
 #if USE_DELAY_POOLS
         } else if (F->writeQuotaHandler != nullptr && COMMIO_FD_WRITECB(fd)->conn != nullptr) {
             if (!F->writeQuotaHandler->selectWaiting && F->writeQuotaHandler->quota() && !F->closing()) {
-                // TODO: CodeContext::SwitchTo(F's context);
+                // TODO: CodeContext::Reset(F's context);
                 F->writeQuotaHandler->selectWaiting = true;
                 Comm::SetSelect(fd, COMM_SELECT_WRITE, Comm::HandleWrite, COMMIO_FD_WRITECB(fd), 0);
                 CodeContext::Clear();
@@ -1590,7 +1590,7 @@ checkTimeouts(void)
         else if (AlreadyTimedOut(F))
             continue;
 
-        // TODO: CodeContext::SwitchTo(F's context);
+        // TODO: CodeContext::Reset(F's context);
         debugs(5, 5, "checkTimeouts: FD " << fd << " Expired");
 
         if (F->timeoutHandler != NULL) {

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -836,7 +836,7 @@ comm_close_complete(const FdeCbParams &params)
     ++ statCounter.syscalls.sock.closes;
 
     /* When one connection closes, give accept() a chance, if need be */
-    CodeContext::Reset(); // switch from an FD-specific context
+    CodeContext::Reset(); // exit FD-specific context
     Comm::AcceptLimiter::Instance().kick();
 }
 

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -291,6 +291,7 @@ Comm::ConnOpener::createFd()
     debugs(5, 3, conn_ << " will timeout in " << (deadline_ - squid_curtime));
 
     // Update the fd_table directly because commSetConnTimeout() needs open conn_
+    calls_.timeout_->codeContext = CodeContext::Current();
     assert(temporaryFd_ < Squid_MaxFD);
     assert(fd_table[temporaryFd_].flags.open);
     typedef CommTimeoutCbParams Params;

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -291,7 +291,6 @@ Comm::ConnOpener::createFd()
     debugs(5, 3, conn_ << " will timeout in " << (deadline_ - squid_curtime));
 
     // Update the fd_table directly because commSetConnTimeout() needs open conn_
-    calls_.timeout_->codeContext = CodeContext::Current();
     assert(temporaryFd_ < Squid_MaxFD);
     assert(fd_table[temporaryFd_].flags.open);
     typedef CommTimeoutCbParams Params;

--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -19,6 +19,8 @@
 #include "SquidTime.h"
 #include <ostream>
 
+InstanceIdDefinitions(Comm::Connection, "conn");
+
 class CachePeer;
 bool
 Comm::IsConnOpen(const Comm::ConnectionPointer &conn)
@@ -154,10 +156,25 @@ Comm::Connection::connectTimeout(const time_t fwdStart) const
     return min(ctimeout, ftimeout);
 }
 
+ScopedId
+Comm::Connection::codeContextGist() const {
+    return id.detach();
+}
+
+std::ostream &
+Comm::Connection::detailCodeContext(std::ostream &os) const
+{
+    return os << Debug::Extra << "connection: " << *this;
+}
+
 std::ostream &
 operator << (std::ostream &os, const Comm::Connection &conn)
 {
-    os << "local=" << conn.local << " remote=" << conn.remote;
+    os << conn.id;
+    if (!conn.local.isNoAddr())
+        os << " local=" << conn.local;
+    if (!conn.remote.isNoAddr())
+        os << " remote=" << conn.remote;
     if (conn.peerType)
         os << ' ' << hier_code_str[conn.peerType];
     if (conn.fd >= 0)

--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -171,9 +171,9 @@ std::ostream &
 operator << (std::ostream &os, const Comm::Connection &conn)
 {
     os << conn.id;
-    if (!conn.local.isNoAddr())
+    if (!conn.local.isNoAddr() || conn.local.port())
         os << " local=" << conn.local;
-    if (!conn.remote.isNoAddr())
+    if (!conn.remote.isNoAddr() || conn.remote.port())
         os << " remote=" << conn.remote;
     if (conn.peerType)
         os << ' ' << hier_code_str[conn.peerType];

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -11,6 +11,8 @@
 #ifndef _SQUIDCONNECTIONDETAIL_H_
 #define _SQUIDCONNECTIONDETAIL_H_
 
+#include "base/CodeContext.h"
+#include "base/InstanceId.h"
 #include "comm/forward.h"
 #include "defines.h"
 #if USE_SQUID_EUI
@@ -62,7 +64,7 @@ namespace Comm
  * These objects should not be passed around directly,
  * but a Comm::ConnectionPointer should be passed instead.
  */
-class Connection : public RefCountable
+class Connection: public CodeContext
 {
     MEMPROXY_CLASS(Comm::Connection);
 
@@ -70,7 +72,7 @@ public:
     Connection();
 
     /** Clear the connection properties and close any open socket. */
-    ~Connection();
+    virtual ~Connection();
 
     /** Copy an existing connections IP and properties.
      * This excludes the FD. The new copy will be a closed connection.
@@ -123,6 +125,10 @@ public:
     Security::NegotiationHistory *tlsNegotiations();
     const Security::NegotiationHistory *hasTlsNegotiations() const {return tlsHistory;}
 
+    /* CodeContext API */
+    virtual ScopedId codeContextGist() const override;
+    virtual std::ostream &detailCodeContext(std::ostream &os) const override;
+
 private:
     /** These objects may not be exactly duplicated. Use copyDetails() instead. */
     Connection(const Connection &c);
@@ -168,6 +174,8 @@ public:
     Eui::Eui48 remoteEui48;
     Eui::Eui64 remoteEui64;
 #endif
+
+    InstanceId<Connection> id;
 
 private:
     /** cache_peer data object (if any) */

--- a/src/comm/IoCallback.cc
+++ b/src/comm/IoCallback.cc
@@ -63,6 +63,9 @@ Comm::IoCallback::setCallback(Comm::iocb_type t, AsyncCall::Pointer &cb, char *b
     freefunc = f;
     size = sz;
     offset = 0;
+
+    if (!callback->codeContext)
+        callback->codeContext = CodeContext::Current(); // may be nil
 }
 
 void

--- a/src/comm/IoCallback.cc
+++ b/src/comm/IoCallback.cc
@@ -63,9 +63,6 @@ Comm::IoCallback::setCallback(Comm::iocb_type t, AsyncCall::Pointer &cb, char *b
     freefunc = f;
     size = sz;
     offset = 0;
-
-    if (!callback->codeContext)
-        callback->codeContext = CodeContext::Current(); // may be nil
 }
 
 void

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -180,11 +180,11 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     if (timeout)
         F->timeout = squid_curtime + timeout;
 
-    if (timeout || handler) // exclude cleanup requests
+    if (timeout || handler) // all non-cleanup requests
         F->codeContext = CodeContext::Current(); // TODO: Avoid clearing if set?
-    else if (!ev.events) // no more FD-associated work expected
+    else if (!ev.events) // full cleanup: no more FD-associated work expected
         F->codeContext = nullptr;
-    // other cleanup requests do not alter F->codeContext
+    // else: direction-specific/timeout cleanup requests preserve F->codeContext
 }
 
 static void commIncomingStats(StoreEntry * sentry);

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -181,7 +181,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
         F->timeout = squid_curtime + timeout;
 
     if (timeout || handler) // exclude cleanup requests
-        F->codeContext = CodeContext::Current(); // may be nil
+        F->codeContext = CodeContext::Current(); // TODO: Avoid clearing if set?
     else if (!ev.events) // no more FD-associated work expected
         F->codeContext = nullptr;
     // other cleanup requests do not alter F->codeContext

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -256,7 +256,7 @@ Comm::DoSelect(int msec)
     for (i = 0, cevents = pevents; i < num; ++i, ++cevents) {
         fd = cevents->data.fd;
         F = &fd_table[fd];
-        CodeContext::SwitchTo(F->codeContext);
+        CodeContext::Reset(F->codeContext);
         debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "got FD " << fd << " events=" <<
                std::hex << cevents->events << " monitoring=" << F->epoll_state <<
                " F->read_handler=" << F->read_handler << " F->write_handler=" << F->write_handler);

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -180,7 +180,11 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     if (timeout)
         F->timeout = squid_curtime + timeout;
 
-    F->codeContext = CodeContext::Current(); // may be nil
+    if (timeout || handler) // exclude cleanup requests
+        F->codeContext = CodeContext::Current(); // may be nil
+    else if (!ev.events) // no more FD-associated work expected
+        F->codeContext = nullptr;
+    // other cleanup requests do not alter F->codeContext
 }
 
 static void commIncomingStats(StoreEntry * sentry);

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -294,7 +294,7 @@ Comm::DoSelect(int msec)
         }
     }
 
-    CodeContext::Clear();
+    CodeContext::Reset();
 
     PROF_stop(comm_handle_ready_fd);
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -11,7 +11,6 @@
 #include "squid.h"
 #include "acl/FilledChecklist.h"
 #include "anyp/PortCfg.h"
-#include "base/CodeContext.h"
 #include "base/TextException.h"
 #include "client_db.h"
 #include "comm/AcceptLimiter.h"
@@ -38,21 +37,6 @@
 // required for accept_filter to build.
 #include <netinet/tcp.h>
 #endif
-
-/// Executes context `creator` in the service context. If an exception occurs,
-/// the creator context is preserved, so that the exception is associated with
-/// the creator that triggered them (rather than with the service).
-///
-/// Service code running in its own context should use this function to create
-/// new code contexts. TODO: Use or, if this pattern is not repeated, remove.
-template <typename Fun>
-inline void
-CallContextCreator(Fun &&creator)
-{
-    const auto savedCodeContext(CodeContext::Current());
-    creator();
-    CodeContext::Reset(savedCodeContext);
-}
 
 CBDATA_NAMESPACED_CLASS_INIT(Comm, TcpAcceptor);
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "acl/FilledChecklist.h"
 #include "anyp/PortCfg.h"
+#include "base/CodeContext.h"
 #include "base/TextException.h"
 #include "client_db.h"
 #include "comm/AcceptLimiter.h"
@@ -37,6 +38,21 @@
 // required for accept_filter to build.
 #include <netinet/tcp.h>
 #endif
+
+/// Executes context `creator` in the service context. If an exception occurs,
+/// the creator context is preserved, so that the exception is associated with
+/// the creator that triggered them (rather than with the service).
+///
+/// Service code running in its own context should use this function to create
+/// new code contexts. TODO: Use or, if this pattern is not repeated, remove.
+template <typename Fun>
+inline void
+CallContextCreator(Fun &&creator)
+{
+    const auto savedCodeContext(CodeContext::Current());
+    creator();
+    CodeContext::Reset(savedCodeContext);
+}
 
 CBDATA_NAMESPACED_CLASS_INIT(Comm, TcpAcceptor);
 
@@ -74,7 +90,8 @@ Comm::TcpAcceptor::unsubscribe(const char *reason)
 void
 Comm::TcpAcceptor::start()
 {
-    // XXX: CodeContext::Reset(context_);
+    if (listenPort_)
+        CodeContext::Reset(listenPort_);
     debugs(5, 5, HERE << status() << " AsyncCall Subscription: " << theCallSub);
 
     Must(IsConnOpen(conn));
@@ -154,7 +171,7 @@ Comm::TcpAcceptor::setListen()
     errcode = errno = 0;
     if (listen(conn->fd, Squid_MaxFD >> 2) < 0) {
         errcode = errno;
-        debugs(50, DBG_CRITICAL, "ERROR: listen(" << status() << ", " << (Squid_MaxFD >> 2) << "): " << xstrerr(errcode));
+        debugs(50, DBG_CRITICAL, "ERROR: listen(..., " << (Squid_MaxFD >> 2) << ") system call failed: " << xstrerr(errcode));
         return;
     }
 
@@ -256,20 +273,21 @@ Comm::TcpAcceptor::okToAccept()
     return false;
 }
 
-static void
-logAcceptError(const Comm::ConnectionPointer &conn)
+void
+Comm::TcpAcceptor::logAcceptError(const ConnectionPointer &tcpClient) const
 {
     AccessLogEntry::Pointer al = new AccessLogEntry;
     CodeContext::Reset(al);
-    al->tcpClient = conn;
+    al->tcpClient = tcpClient;
     al->url = "error:accept-client-connection";
     al->setVirginUrlForMissingRequest(al->url);
     ACLFilledChecklist ch(nullptr, nullptr, nullptr);
-    ch.src_addr = conn->remote;
-    ch.my_addr = conn->local;
+    ch.src_addr = tcpClient->remote;
+    ch.my_addr = tcpClient->local;
     ch.al = al;
     accessLogLog(al, &ch);
-    // XXX: CodeContext::Reset(context_);
+
+    CodeContext::Reset(listenPort_);
 }
 
 void
@@ -299,10 +317,13 @@ Comm::TcpAcceptor::acceptOne()
         /* register interest again */
         debugs(5, 5, "try later: " << conn << " handler Subscription: " << theCallSub);
     } else {
+        // TODO: When ALE, MasterXaction merge, use them or ClientConn instead.
+        CodeContext::Reset(newConnDetails);
         debugs(5, 5, "Listener: " << conn <<
                " accepted new connection " << newConnDetails <<
                " handler Subscription: " << theCallSub);
         notify(flag, newConnDetails);
+        CodeContext::Reset(listenPort_);
     }
 
     SetSelect(conn->fd, COMM_SELECT_READ, doAccept, this, 0);
@@ -371,7 +392,7 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
             debugs(50, 3, status() << ": " << xstrerr(errcode));
             return Comm::COMM_ERROR;
         } else {
-            debugs(50, DBG_IMPORTANT, MYNAME << status() << ": " << xstrerr(errcode));
+            debugs(50, DBG_IMPORTANT, "ERROR: failed to accept an incoming connection: " << xstrerr(errcode));
             return Comm::COMM_ERROR;
         }
     }

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -74,6 +74,7 @@ Comm::TcpAcceptor::unsubscribe(const char *reason)
 void
 Comm::TcpAcceptor::start()
 {
+    // XXX: CodeContext::SwitchTo(context_);
     debugs(5, 5, HERE << status() << " AsyncCall Subscription: " << theCallSub);
 
     Must(IsConnOpen(conn));
@@ -259,6 +260,7 @@ static void
 logAcceptError(const Comm::ConnectionPointer &conn)
 {
     AccessLogEntry::Pointer al = new AccessLogEntry;
+    CodeContext::SwitchTo(al);
     al->tcpClient = conn;
     al->url = "error:accept-client-connection";
     al->setVirginUrlForMissingRequest(al->url);
@@ -267,6 +269,7 @@ logAcceptError(const Comm::ConnectionPointer &conn)
     ch.my_addr = conn->local;
     ch.al = al;
     accessLogLog(al, &ch);
+    // XXX: CodeContext::SwitchTo(context_);
 }
 
 void

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -74,7 +74,7 @@ Comm::TcpAcceptor::unsubscribe(const char *reason)
 void
 Comm::TcpAcceptor::start()
 {
-    // XXX: CodeContext::SwitchTo(context_);
+    // XXX: CodeContext::Reset(context_);
     debugs(5, 5, HERE << status() << " AsyncCall Subscription: " << theCallSub);
 
     Must(IsConnOpen(conn));
@@ -260,7 +260,7 @@ static void
 logAcceptError(const Comm::ConnectionPointer &conn)
 {
     AccessLogEntry::Pointer al = new AccessLogEntry;
-    CodeContext::SwitchTo(al);
+    CodeContext::Reset(al);
     al->tcpClient = conn;
     al->url = "error:accept-client-connection";
     al->setVirginUrlForMissingRequest(al->url);
@@ -269,7 +269,7 @@ logAcceptError(const Comm::ConnectionPointer &conn)
     ch.my_addr = conn->local;
     ch.al = al;
     accessLogLog(al, &ch);
-    // XXX: CodeContext::SwitchTo(context_);
+    // XXX: CodeContext::Reset(context_);
 }
 
 void

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -105,6 +105,7 @@ private:
     void handleClosure(const CommCloseCbParams &io);
     /// whether we are listening on one of the squid.conf *ports
     bool intendedForUserConnections() const { return bool(listenPort_); }
+    void logAcceptError(const ConnectionPointer &tcpClient) const;
 };
 
 } // namespace Comm

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -19,10 +19,6 @@
 /* for shutting_down flag in xassert() */
 #include "globals.h"
 
-#if SQUID_HACK_TO_MARK_DEBUG_LINES_THAT_KNOW_THEIR_CONTEXT
-#include "base/CodeContext.h"
-#endif
-
 char *Debug::debugOptions = NULL;
 int Debug::override_X = 0;
 int Debug::log_stderr = -1;
@@ -840,10 +836,6 @@ Debug::Start(const int section, const int level)
     }
 
     Current = future;
-
-#if SQUID_HACK_TO_MARK_DEBUG_LINES_THAT_KNOW_THEIR_CONTEXT
-    Current->buf << (CodeContext::Current() ? "!! " : "?? ");
-#endif
 
     return future->buf;
 }

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -851,6 +851,7 @@ Debug::Start(const int section, const int level)
 void
 Debug::Finish()
 {
+    // TODO: #include "base/CodeContext.h" instead if doing so works well.
     extern std::ostream &CurrentCodeContextDetail(std::ostream &os);
     if (Current->level <= DBG_IMPORTANT)
         Current->buf << CurrentCodeContextDetail;

--- a/src/fde.h
+++ b/src/fde.h
@@ -9,8 +9,8 @@
 #ifndef SQUID_FDE_H
 #define SQUID_FDE_H
 
-#include "base/forward.h"
 #include "base/CodeContext.h" /* XXX: Remove by de-inlining ctor and clear() */
+#include "base/forward.h"
 #include "comm.h"
 #include "defines.h"
 #include "ip/Address.h"

--- a/src/fde.h
+++ b/src/fde.h
@@ -167,7 +167,7 @@ public:
                                                 connection, whereas nfmarkToServer is the value to set on packets
                                                 *leaving* Squid.   */
 
-    // XXX: Separate readerContext from writerContext (e.g., for pipelining).
+    // TODO: Separate readerContext from writerContext for pipelining users.
     /// What the I/O handlers are supposed to work on.
     CodeContextPointer codeContext;
 

--- a/src/fde.h
+++ b/src/fde.h
@@ -9,6 +9,8 @@
 #ifndef SQUID_FDE_H
 #define SQUID_FDE_H
 
+#include "base/forward.h"
+#include "base/CodeContext.h" /* XXX: Remove by de-inlining ctor and clear() */
 #include "comm.h"
 #include "defines.h"
 #include "ip/Address.h"
@@ -164,6 +166,10 @@ public:
                                                 nfmarkToServer in that this is the value we *receive* from the,
                                                 connection, whereas nfmarkToServer is the value to set on packets
                                                 *leaving* Squid.   */
+
+    // XXX: Separate readerContext from writerContext (e.g., for pipelining).
+    /// What the I/O handlers are supposed to work on.
+    CodeContextPointer codeContext;
 
 private:
     // I/O methods connect Squid to the device/stack/library fde represents

--- a/src/fde.h
+++ b/src/fde.h
@@ -167,7 +167,9 @@ public:
                                                 connection, whereas nfmarkToServer is the value to set on packets
                                                 *leaving* Squid.   */
 
-    // TODO: Separate readerContext from writerContext for pipelining users.
+    // TODO: Remove: Auto-convert legacy SetSelect() callers to AsyncCalls like
+    // comm_add_close_handler(CLCB) does, making readMethod_/writeMethod_
+    // AsyncCalls and giving each read/write a dedicated context instead.
     /// What the I/O handlers are supposed to work on.
     CodeContextPointer codeContext;
 

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1087,9 +1087,11 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_REQUEST_METHOD:
-            sb = al->getLogMethod();
-            out = sb.c_str();
-            quote = 1;
+            if (al->hasLogMethod()) {
+                sb = al->getLogMethod();
+                out = sb.c_str();
+                quote = 1;
+            }
             break;
 
         case LFT_REQUEST_URI:

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -922,15 +922,18 @@ htcpClrReply(htcpDataHeader * dhdr, int purgeSucceeded, Ip::Address &from)
 ScopedId
 htcpSpecifier::codeContextGist() const
 {
-    if (al)
-        return al->codeContextGist();
+    if (al) {
+        const auto gist = al->codeContextGist();
+        if (gist.value)
+            return gist;
+    }
 
     if (request) {
         if (const auto &mx = request->masterXaction)
             return mx->id.detach();
     }
 
-    return ScopedId();
+    return ScopedId("HTCP w/o master");
 }
 
 std::ostream &

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -136,7 +136,7 @@ public:
     }
 
     /* CodeContext API */
-    virtual std::ostream &briefCodeContext(std::ostream &os) const; // override
+    virtual ScopedId codeContextGist() const; // override
     virtual std::ostream &detailCodeContext(std::ostream &os) const; // override
 
     /* StoreClient API */
@@ -919,18 +919,18 @@ htcpClrReply(htcpDataHeader * dhdr, int purgeSucceeded, Ip::Address &from)
     htcpSend(pkt, (int) pktlen, from);
 }
 
-std::ostream &
-htcpSpecifier::briefCodeContext(std::ostream &os) const
+ScopedId
+htcpSpecifier::codeContextGist() const
 {
     if (al)
-        return al->briefCodeContext(os);
+        return al->codeContextGist();
 
     if (request) {
         if (const auto &mx = request->masterXaction)
-            return os << mx->id;
+            return mx->id.detach();
     }
 
-    return os;
+    return ScopedId();
 }
 
 std::ostream &

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1295,7 +1295,7 @@ htcpForwardClr(char *buf, int sz)
 static void
 htcpHandleMsg(char *buf, int sz, Ip::Address &from)
 {
-    // TODO: function-scoped CodeContext::SwitchTo("HTCP message from", from);
+    // TODO: function-scoped CodeContext::Reset("HTCP message from", from);
 
     htcpHeader htcpHdr;
     htcpDataHeader hdr;

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -12,7 +12,6 @@
 #include "AccessLogEntry.h"
 #include "acl/Acl.h"
 #include "acl/FilledChecklist.h"
-#include "base/CodeContext.h"
 #include "CachePeer.h"
 #include "comm.h"
 #include "comm/Connection.h"

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -120,7 +120,7 @@ struct _htcpAuthHeader {
     Countstr signature;
 };
 
-class htcpSpecifier : public CodeContext, public StoreClient
+class htcpSpecifier: public CodeContext, public StoreClient
 {
     MEMPROXY_CLASS(htcpSpecifier);
 
@@ -1295,7 +1295,7 @@ htcpForwardClr(char *buf, int sz)
 static void
 htcpHandleMsg(char *buf, int sz, Ip::Address &from)
 {
-    // TODO: function-scoped CodeContext::Reset("HTCP message from", from);
+    // TODO: function-scoped CodeContext::Reset(...("HTCP message from", from))
 
     htcpHeader htcpHdr;
     htcpDataHeader hdr;

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -12,6 +12,7 @@
 #include "AccessLogEntry.h"
 #include "acl/Acl.h"
 #include "acl/FilledChecklist.h"
+#include "base/CodeContext.h"
 #include "CachePeer.h"
 #include "comm.h"
 #include "comm/Connection.h"
@@ -119,7 +120,7 @@ struct _htcpAuthHeader {
     Countstr signature;
 };
 
-class htcpSpecifier : public RefCountable, public StoreClient
+class htcpSpecifier : public CodeContext, public StoreClient
 {
     MEMPROXY_CLASS(htcpSpecifier);
 
@@ -133,6 +134,10 @@ public:
     void setDataHeader(htcpDataHeader *aDataHeader) {
         dhdr = aDataHeader;
     }
+
+    /* CodeContext API */
+    virtual std::ostream &briefCodeContext(std::ostream &os) const; // override
+    virtual std::ostream &detailCodeContext(std::ostream &os) const; // override
 
     /* StoreClient API */
     void created(StoreEntry *);
@@ -914,6 +919,35 @@ htcpClrReply(htcpDataHeader * dhdr, int purgeSucceeded, Ip::Address &from)
     htcpSend(pkt, (int) pktlen, from);
 }
 
+std::ostream &
+htcpSpecifier::briefCodeContext(std::ostream &os) const
+{
+    if (al)
+        return al->briefCodeContext(os);
+
+    if (request) {
+        if (const auto &mx = request->masterXaction)
+            return os << mx->id;
+    }
+
+    return os;
+}
+
+std::ostream &
+htcpSpecifier::detailCodeContext(std::ostream &os) const
+{
+    if (al)
+        return al->detailCodeContext(os);
+
+    if (request) {
+        if (const auto &mx = request->masterXaction)
+            return os << Debug::Extra << "current master transaction: " << mx->id;
+    }
+
+    // TODO: Report method, uri, and version if they have been set
+    return os;
+}
+
 void
 htcpSpecifier::checkHit()
 {
@@ -1261,6 +1295,8 @@ htcpForwardClr(char *buf, int sz)
 static void
 htcpHandleMsg(char *buf, int sz, Ip::Address &from)
 {
+    // TODO: function-scoped CodeContext::SwitchTo("HTCP message from", from);
+
     htcpHeader htcpHdr;
     htcpDataHeader hdr;
     char *hbuf;

--- a/src/http/RequestMethod.h
+++ b/src/http/RequestMethod.h
@@ -44,6 +44,9 @@ public:
         return *this;
     }
 
+    /// whether the method is set/known
+    explicit operator bool() const { return theMethod != Http::METHOD_NONE; }
+
     bool operator == (Http::MethodType const & aMethod) const { return theMethod == aMethod; }
     bool operator == (HttpRequestMethod const & aMethod) const {
         return theMethod == aMethod.theMethod &&

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -88,6 +88,8 @@ Http::Stream::writeComplete(size_t size)
     case STREAM_COMPLETE: {
         debugs(33, 5, clientConnection << " Stream complete, keepalive is " <<
                http->request->flags.proxyKeepalive);
+        // XXX: This code assumes we are done with the transaction, but we may
+        // still be receiving request body. TODO: Extend stopSending() instead.
         ConnStateData *c = getConn();
         if (!http->request->flags.proxyKeepalive)
             clientConnection->close();
@@ -570,6 +572,7 @@ Http::Stream::noteIoError(const int xerrno)
 void
 Http::Stream::finished()
 {
+    CodeContext::Reset(clientConnection);
     ConnStateData *conn = getConn();
 
     /* we can't handle any more stream data - detach */

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1775,6 +1775,7 @@ neighborsHtcpReply(const cache_key * key, HtcpReplyData * htcp, const Ip::Addres
     }
 
     debugs(15, 3, "neighborsHtcpReply: e = " << e);
+    // TODO: Refactor (ping_reply_callback,ircb_data) to add CodeContext.
     mem->ping_reply_callback(p, ntype, AnyP::PROTO_HTCP, htcp, mem->ircb_data);
 }
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -565,9 +565,8 @@ neighbors_init(void)
                 if (thisPeer->http_port != s->s.port())
                     continue;
 
-                debugs(15, DBG_IMPORTANT, "WARNING: Peer looks like this host");
-
-                debugs(15, DBG_IMPORTANT, "         Ignoring " <<
+                debugs(15, DBG_IMPORTANT, "WARNING: Peer looks like this host." <<
+                       Debug::Extra << "Ignoring " <<
                        neighborTypeStr(thisPeer) << " " << thisPeer->host <<
                        "/" << thisPeer->http_port << "/" <<
                        thisPeer->icp.port);

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -26,6 +26,9 @@ Comm::ConnectionPointer Comm::Connection::copyDetails() const STUB_RETVAL(NULL)
 void Comm::Connection::close() STUB
 CachePeer * Comm::Connection::getPeer() const STUB_RETVAL(NULL)
 void Comm::Connection::setPeer(CachePeer * p) STUB
+ScopedId Comm::Connection::codeContextGist() const STUB_RETVAL(id.detach())
+std::ostream &Comm::Connection::detailCodeContext(std::ostream &os) const STUB_RETVAL(os)
+InstanceIdDefinitions(Comm::Connection, "conn");
 
 #include "comm/ConnOpener.h"
 CBDATA_NAMESPACED_CLASS_INIT(Comm, ConnOpener);


### PR DESCRIPTION
Most runtime level-0/1 cache.log messages do not carry information
sufficient to identify the transaction that caused the problem. Admins
are forced to guess the transaction based on message timestamp and, if
they are lucky to get one, request URL. The associated triage and
mitigation delay costs are often significant and can be huge, especially
when administering busy proxies in complex deployment environments.

The focus of this change is associating level-0/1 cache.log messages
with access.log records, but the same API is also used for associating
master transactions with (sections of) debugging cache.log messages.

Since level-0/1 messages are rare, association code usually wastes
resources. This performance overhead is reduced by saving pointers to
the existing transaction information (e.g., ALE). ALE gives access to
HttpRequest and MasterXaction (where available), is available in
contexts where HttpRequest and MasterXaction do not exist, and (unlike
HttpRequest) represents the whole master transaction rather than its
(often repeated) component.

CodeContext::Current() represents the current master transaction (or a
similar "primary processing task" context). A new context is created
when the master transaction (or a similar "primary processing task")
starts. Context changes usually happen in low-level transaction-unaware
callback-calling "context switching" code such as DoSelect().

The vast majority of AsyncCalls, including AsyncCall-based callbacks,
should run in their creator's context. This association is easily
automated. The primary difficulty is in handling C-style typeless calls
that prohibit context storage and restoration automation:

* In our design, the "context switching" code is ultimately responsible
  for associating the being-saved callback with the current code context
  and for restoring CodeContext::Current() when calling that callback.

* An alternative design would task the higher-level callback creator and
  callback recipient with saving/restoring CodeContext::Current(). That
  design is inferior because there are a lot more callback creators and
  recipients than "context switchers". That alternative would require a
  lot more manual changes.

The code context remains unknown if the context creator is not
instrumented to set CodeContext::Current(). TODO: Instrument ICP query
listener. Check for others.

The code context gets forgotten if the context switcher dealing with
C-style callbacks does not remember and restore CodeContext::Current().
TODO: Instrument remaining DoSelect()s, event.cc, as well as DNS, ICP,
HTCP, and IPC listeners/handlers. Check for others.

This change covers epoll DoSelect(), TcpAcceptor, ConnStateData, and SMP
disk I/O (IpcIoFile). It already annotates several level-0/1 messages
and significantly improves complex debugging. The remaining
instrumentation TODOs are likely to use similar techniques.

Squid might report wrong context until all context switchers are
instrumented, but the vast majority of uninstrumented cases result in
benign loss of context knowledge rather than mis-attribution. No design
guarantees correct attribution until all C-style callbacks are gone.

TODO: Remove legacy ctx_enter()/exit() debugging that covers very little
while suffering from worse mis-attribution problems.


Also log "-" instead of the made-up method "NONE".