### PR TITLE
Add GeneratingCONNECT step for the existing at_step ACL

### DIFF
--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -171,7 +171,7 @@ Acl::Init()
     RegisterMaker("user_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509UserAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509CAAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509Fingerprint, "-sha1", true), new ACLServerCertificateStrategy, name); });
-    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<int>(new ACLAtStepData, new ACLAtStepStrategy, name); });
+    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<XactionSteps>(new ACLAtStepData, new ACLAtStepStrategy, name); });
     RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLServerNameData, new ACLServerNameStrategy, name); });
     RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLRegexData, new ACLServerNameStrategy, name); });
 #endif

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -171,7 +171,7 @@ Acl::Init()
     RegisterMaker("user_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509UserAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509CAAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509Fingerprint, "-sha1", true), new ACLServerCertificateStrategy, name); });
-    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<XactionSteps>(new ACLAtStepData, new ACLAtStepStrategy, name); });
+    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<XactionStep>(new ACLAtStepData, new ACLAtStepStrategy, name); });
     RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLServerNameData, new ACLServerNameStrategy, name); });
     RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLRegexData, new ACLServerNameStrategy, name); });
 #endif

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -171,7 +171,7 @@ Acl::Init()
     RegisterMaker("user_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509UserAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509CAAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509Fingerprint, "-sha1", true), new ACLServerCertificateStrategy, name); });
-    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<Ssl::BumpStep>(new ACLAtStepData, new ACLAtStepStrategy, name); });
+    RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<int>(new ACLAtStepData, new ACLAtStepStrategy, name); });
     RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLServerNameData, new ACLServerNameStrategy, name); });
     RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLRegexData, new ACLServerNameStrategy, name); });
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -490,6 +490,7 @@ squid_SOURCES = \
 	wordlist.cc \
 	XactionInitiator.h \
 	XactionInitiator.cc \
+	XactionStep.h \
 	$(WIN32_SOURCE) \
 	$(WINSVC_SOURCE)
 

--- a/src/MasterXaction.h
+++ b/src/MasterXaction.h
@@ -55,8 +55,7 @@ public:
     /// the initiator of this transaction
     XactionInitiator initiator;
 
-    /// It is true while squid is generating a CONNECT request to a peer
-    /// to serve the transaction
+    /// whether we are currently creating a CONNECT header (to be sent to peer)
     bool generatingConnect = false;
 
     // TODO: add state from other Jobs in the transaction

--- a/src/MasterXaction.h
+++ b/src/MasterXaction.h
@@ -55,6 +55,10 @@ public:
     /// the initiator of this transaction
     XactionInitiator initiator;
 
+    /// It is true while squid is generating a CONNECT request to a peer
+    /// to serve the transaction
+    bool generatingConnect = false;
+
     // TODO: add state from other Jobs in the transaction
 };
 

--- a/src/XactionStep.h
+++ b/src/XactionStep.h
@@ -21,3 +21,4 @@ typedef enum {
 } XactionStep;
 
 #endif /* SQUID_XACTIONSTEPS_H */
+

--- a/src/XactionStep.h
+++ b/src/XactionStep.h
@@ -9,16 +9,17 @@
 #ifndef SQUID_XACTIONSTEPS_H
 #define SQUID_XACTIONSTEPS_H
 
-typedef enum {
-    xstepUnknown = 0,
-    xstepGeneratingConnect,
+enum class XactionStep  {
+    enumBegin_ = 0, // for WholeEnum iteration
+    unknown = enumBegin_,
+    generatingConnect,
 #if USE_OPENSSL
-    xstepTlsBump1,
-    xstepTlsBump2,
-    xstepTlsBump3,
+    tlsBump1,
+    tlsBump2,
+    tlsBump3,
 #endif
-    xstepValuesEnd
-} XactionStep;
+    enumEnd_ // for WholeEnum iteration
+};
 
 #endif /* SQUID_XACTIONSTEPS_H */
 

--- a/src/XactionStep.h
+++ b/src/XactionStep.h
@@ -10,14 +10,14 @@
 #define SQUID_XACTIONSTEPS_H
 
 typedef enum {
-    xaStepUnknown = 0,
-    xaStepGeneratingConnect,
+    xstepUnknown = 0,
+    xstepGeneratingConnect,
 #if USE_OPENSSL
-    xaStepTlsBump1,
-    xaStepTlsBump2,
-    xaStepTlsBump3,
+    xstepTlsBump1,
+    xstepTlsBump2,
+    xstepTlsBump3,
 #endif
-    xaStepValuesEnd
+    xstepValuesEnd
 } XactionStep;
 
 #endif /* SQUID_XACTIONSTEPS_H */

--- a/src/XactionStep.h
+++ b/src/XactionStep.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 1996-2019 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_XACTIONSTEPS_H
+#define SQUID_XACTIONSTEPS_H
+
+typedef enum {
+    xaStepUnknown = 0,
+    xaStepGeneratingConnect,
+#if USE_OPENSSL
+    xaStepTlsBump1,
+    xaStepTlsBump2,
+    xaStepTlsBump3,
+#endif
+    xaStepValuesEnd
+} XactionStep;
+
+#endif /* SQUID_XACTIONSTEPS_H */

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -16,24 +16,19 @@
 #include "ssl/ServerBump.h"
 
 int
-ACLAtStepStrategy::match (ACLData<int> * &data, ACLFilledChecklist *checklist)
+ACLAtStepStrategy::match (ACLData<XactionSteps> * &data, ACLFilledChecklist *checklist)
 {
     Must(checklist->request);
     Must(checklist->request->masterXaction);
-    if (checklist->request->masterXaction->generatingConnect && data->match(ACLAtStepData::atStepGeneratingConnect))
+    if (checklist->request->masterXaction->generatingConnect && data->match(xaStepGeneratingConnect))
         return 1;
 
 #if USE_OPENSSL
-    static std::map<Ssl::BumpStep, ACLAtStepData::AtStepValues> BumpAtStepMap= {
-        {Ssl::bumpStep1, ACLAtStepData::atStepSslBump1},
-        {Ssl::bumpStep2, ACLAtStepData::atStepSslBump2},
-        {Ssl::bumpStep3, ACLAtStepData::atStepSslBump3}
-    };
     Ssl::ServerBump *bump = NULL;
     if (checklist->conn() != NULL && (bump = checklist->conn()->serverBump()))
-        return data->match(BumpAtStepMap[bump->step]);
+        return data->match(bump->step);
     else
-        return data->match(BumpAtStepMap[Ssl::bumpStep1]);
+        return data->match(xaStepTlsBump1);
 #endif
     return 0;
 }

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -25,10 +25,10 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
     if (checklist->conn() != NULL && (bump = checklist->conn()->serverBump()))
         return data->match(bump->step);
     else
-        return data->match(xstepTlsBump1);
+        return data->match(XactionStep::tlsBump1);
 #endif
 
-    if (data->match(xstepGeneratingConnect)) {
+    if (data->match(XactionStep::generatingConnect)) {
         if (!checklist->request)
             return 0; // we have warned about the missing request earlier
 

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -13,7 +13,9 @@
 #include "acl/FilledChecklist.h"
 #include "client_side.h"
 #include "http/Stream.h"
+#if USE_OPENSSL
 #include "ssl/ServerBump.h"
+#endif
 
 int
 ACLAtStepStrategy::match (ACLData<XactionSteps> * &data, ACLFilledChecklist *checklist)

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -22,7 +22,7 @@ ACLAtStepStrategy::match (ACLData<XactionStep> * &data, ACLFilledChecklist *chec
 {
     Must(checklist->request);
     Must(checklist->request->masterXaction);
-    if (checklist->request->masterXaction->generatingConnect && data->match(xaStepGeneratingConnect))
+    if (checklist->request->masterXaction->generatingConnect && data->match(xstepGeneratingConnect))
         return 1;
 
 #if USE_OPENSSL
@@ -30,7 +30,7 @@ ACLAtStepStrategy::match (ACLData<XactionStep> * &data, ACLFilledChecklist *chec
     if (checklist->conn() != NULL && (bump = checklist->conn()->serverBump()))
         return data->match(bump->step);
     else
-        return data->match(xaStepTlsBump1);
+        return data->match(xstepTlsBump1);
 #endif
     return 0;
 }

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -8,8 +8,6 @@
 
 #include "squid.h"
 
-#if USE_OPENSSL
-
 #include "acl/AtStep.h"
 #include "acl/AtStepData.h"
 #include "acl/FilledChecklist.h"
@@ -18,15 +16,24 @@
 #include "ssl/ServerBump.h"
 
 int
-ACLAtStepStrategy::match (ACLData<Ssl::BumpStep> * &data, ACLFilledChecklist *checklist)
+ACLAtStepStrategy::match (ACLData<int> * &data, ACLFilledChecklist *checklist)
 {
+    Must(checklist->request);
+    Must(checklist->request->masterXaction);
+    if (checklist->request->masterXaction->generatingConnect && data->match(ACLAtStepData::atStepGeneratingConnect))
+        return 1;
+
+#if USE_OPENSSL
+    static std::map<Ssl::BumpStep, ACLAtStepData::AtStepValues> BumpAtStepMap= {
+        {Ssl::bumpStep1, ACLAtStepData::atStepSslBump1},
+        {Ssl::bumpStep2, ACLAtStepData::atStepSslBump2},
+        {Ssl::bumpStep3, ACLAtStepData::atStepSslBump3}
+    };
     Ssl::ServerBump *bump = NULL;
     if (checklist->conn() != NULL && (bump = checklist->conn()->serverBump()))
-        return data->match(bump->step);
+        return data->match(BumpAtStepMap[bump->step]);
     else
-        return data->match(Ssl::bumpStep1);
+        return data->match(BumpAtStepMap[Ssl::bumpStep1]);
+#endif
     return 0;
 }
-
-#endif /* USE_OPENSSL */
-

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -18,9 +18,9 @@
 #endif
 
 int
-ACLAtStepStrategy::match (ACLData<XactionStep> * &data, ACLFilledChecklist *checklist)
+ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *checklist)
 {
-    #if USE_OPENSSL
+#if USE_OPENSSL
     Ssl::ServerBump *bump = NULL;
     if (checklist->conn() != NULL && (bump = checklist->conn()->serverBump()))
         return data->match(bump->step);
@@ -42,3 +42,4 @@ ACLAtStepStrategy::match (ACLData<XactionStep> * &data, ACLFilledChecklist *chec
 
     return 0;
 }
+

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -18,7 +18,7 @@
 #endif
 
 int
-ACLAtStepStrategy::match (ACLData<XactionSteps> * &data, ACLFilledChecklist *checklist)
+ACLAtStepStrategy::match (ACLData<XactionStep> * &data, ACLFilledChecklist *checklist)
 {
     Must(checklist->request);
     Must(checklist->request->masterXaction);

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -33,7 +33,7 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
             return 0; // we have warned about the missing request earlier
 
         if (!checklist->request->masterXaction) {
-            debugs(28, DBG_IMPORTANT, "missing MasterXaction object, treating as a mismatch");
+            debugs(28, DBG_IMPORTANT, "at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
             return 0;
         }
 

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -42,7 +42,7 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
             return 0; // we have warned about the missing request earlier
 
         if (!checklist->request->masterXaction) {
-            debugs(28, DBG_IMPORTANT, "at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
+            debugs(28, DBG_IMPORTANT, "BUG: at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
             return 0;
         }
 

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -26,7 +26,7 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
     // - No ssl_bump action has matched yet.
     // - The ssl_bump client-first action has already matched.
     // - Another ssl_bump action has already matched, but
-    //   ConnStateData::serverBump() has not been build yet.
+    //   ConnStateData::serverBump() has not been built yet.
     auto currentSslBumpStep = XactionStep::tlsBump1;
 
     if (checklist->conn() != NULL &&

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -29,9 +29,10 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
     //   ConnStateData::serverBump() has not been built yet.
     auto currentSslBumpStep = XactionStep::tlsBump1;
 
-    if (checklist->conn() != NULL &&
-        checklist->conn()->serverBump())
-        currentSslBumpStep = checklist->conn()->serverBump()->step;
+    if (const auto mgr = checklist->conn()) {
+        if (const auto serverBump = mgr->serverBump())
+            currentSslBumpStep = serverBump->step;
+    }
 
     if (data->match(currentSslBumpStep))
         return 1;

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -26,22 +26,28 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
         (bump = checklist->conn()->serverBump()) &&
         data->match(bump->step))
         return 1;
-#endif
 
-    if (checklist->request && data->match(XactionStep::generatingConnect)) {
-        if (!checklist->request->masterXaction)
-            debugs(28, DBG_IMPORTANT, "at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
-        else if (checklist->request->masterXaction->generatingConnect)
-            return 1;
-    }
-
-#if USE_OPENSSL
     // We need the following to cover the case of bumping at SslBump1 step
     // where the connStateData::serverBump() is not build yet.
     // The following also has the meaning that if no bumping preformed
     // or a client-first bumping is applied then the request is remaining
     // at SslBump1 bumping processing step.
-    return data->match(XactionStep::tlsBump1);
+    if (data->match(XactionStep::tlsBump1))
+        return 1;
 #endif
+
+    if (data->match(XactionStep::generatingConnect)) {
+        if (!checklist->request)
+            return 0; // we have warned about the missing request earlier
+
+        if (!checklist->request->masterXaction) {
+            debugs(28, DBG_IMPORTANT, "at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
+            return 0;
+        }
+
+        return checklist->request->masterXaction->generatingConnect ? 1 : 0;
+    }
+
+    return 0;
 }
 

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -10,10 +10,10 @@
 #define SQUID_ACLATSTEP_H
 
 #include "acl/Strategy.h"
-#include "enums.h"
+#include "XactionStep.h"
 
 /// \ingroup ACLAPI
-class ACLAtStepStrategy : public ACLStrategy<XactionSteps>
+class ACLAtStepStrategy : public ACLStrategy<XactionStep>
 {
 
 public:

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -13,13 +13,12 @@
 #include "XactionStep.h"
 
 /// \ingroup ACLAPI
-class ACLAtStepStrategy : public ACLStrategy<XactionStep>
+class ACLAtStepStrategy: public ACLStrategy<XactionStep>
 {
 
 public:
     virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
-
 
 #endif /* SQUID_ACLATSTEP_H */
 

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -10,9 +10,10 @@
 #define SQUID_ACLATSTEP_H
 
 #include "acl/Strategy.h"
+#include "enums.h"
 
 /// \ingroup ACLAPI
-class ACLAtStepStrategy : public ACLStrategy<int>
+class ACLAtStepStrategy : public ACLStrategy<XactionSteps>
 {
 
 public:

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -9,20 +9,16 @@
 #ifndef SQUID_ACLATSTEP_H
 #define SQUID_ACLATSTEP_H
 
-#if USE_OPENSSL
-
 #include "acl/Strategy.h"
-#include "ssl/support.h"
 
 /// \ingroup ACLAPI
-class ACLAtStepStrategy : public ACLStrategy<Ssl::BumpStep>
+class ACLAtStepStrategy : public ACLStrategy<int>
 {
 
 public:
     virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
-#endif /* USE_OPENSSL */
 
 #endif /* SQUID_ACLATSTEP_H */
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -12,6 +12,7 @@
 #include "cache_cf.h"
 #include "ConfigParser.h"
 #include "Debug.h"
+#include "sbuf/Stream.h"
 #include "wordlist.h"
 
 const char *ACLAtStepData::AtStepValuesStr[] = {
@@ -56,11 +57,7 @@ void
 ACLAtStepData::parse()
 {
     while (const char *t = ConfigParser::strtokFile()) {
-        const auto at = AtStep(t);
-        if (at == xstepValuesEnd) {
-            debugs(28, DBG_CRITICAL, "FATAL: invalid AtStep step: " << t);
-            self_destruct();
-        }
+        const auto at = AtStep(t); // throws on error
         values.push_back(at);
     }
 }
@@ -93,6 +90,6 @@ ACLAtStepData::AtStep(const char *atStr)
         if (strcasecmp(atStr, AtStepValuesStr[at]) == 0)
             return static_cast<XactionStep>(at);
 
-    return xstepValuesEnd;
+    throw TexcHere(ToSBuf("invalid AtStep step: ", atStr));
 }
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -59,8 +59,7 @@ void
 ACLAtStepData::parse()
 {
     while (const char *t = ConfigParser::strtokFile()) {
-        const auto at = AtStep(t); // throws on error
-        values.push_back(at);
+        values.push_back(AtStep(t));
     }
 }
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -37,7 +37,7 @@ ACLAtStepData::~ACLAtStepData()
 }
 
 bool
-ACLAtStepData::match(XactionSteps toFind)
+ACLAtStepData::match(XactionStep toFind)
 {
     for (auto it = values.cbegin(); it != values.cend(); ++it) {
         if (*it == toFind)
@@ -82,7 +82,7 @@ ACLAtStepData::clone() const
 }
 
 const char *
-ACLAtStepData::AtStepStr(XactionSteps at)
+ACLAtStepData::AtStepStr(XactionStep at)
 {
     if (at >=0 && at < xaStepValuesEnd)
         return AtStepValuesStr[at];
@@ -90,12 +90,12 @@ ACLAtStepData::AtStepStr(XactionSteps at)
         return "-";
 }
 
-XactionSteps
+XactionStep
 ACLAtStepData::AtStep(const char *atStr)
 {
     for (auto at = 0; at < xaStepValuesEnd; ++at)
         if (strcasecmp(atStr, AtStepValuesStr[at]) == 0)
-            return static_cast<XactionSteps>(at);
+            return static_cast<XactionStep>(at);
 
     return xaStepValuesEnd;
 }

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -15,13 +15,15 @@
 #include "sbuf/Stream.h"
 #include "wordlist.h"
 
+// keep in sync with XactionStep
 const char *ACLAtStepData::AtStepValuesStr[] = {
+    "",
+    "GeneratingCONNECT",
 #if USE_OPENSSL
     "SslBump1",
     "SslBump2",
     "SslBump3",
 #endif
-    "GeneratingCONNECT",
     nullptr
 };
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -37,7 +37,7 @@ ACLAtStepData::~ACLAtStepData()
 }
 
 bool
-ACLAtStepData::match(int toFind)
+ACLAtStepData::match(XactionSteps toFind)
 {
     for (auto it = values.cbegin(); it != values.cend(); ++it) {
         if (*it == toFind)
@@ -61,7 +61,7 @@ ACLAtStepData::parse()
 {
     while (const char *t = ConfigParser::strtokFile()) {
         const auto at = AtStep(t);
-        if (at == atStepValuesEnd) {
+        if (at == xaStepValuesEnd) {
             debugs(28, DBG_CRITICAL, "FATAL: invalid AtStep step: " << t);
             self_destruct();
         }
@@ -82,21 +82,21 @@ ACLAtStepData::clone() const
 }
 
 const char *
-ACLAtStepData::AtStepStr(int at)
+ACLAtStepData::AtStepStr(XactionSteps at)
 {
-    if (at >=0 && at < atStepValuesEnd)
+    if (at >=0 && at < xaStepValuesEnd)
         return AtStepValuesStr[at];
     else
         return "-";
 }
 
-int
+XactionSteps
 ACLAtStepData::AtStep(const char *atStr)
 {
-    for (auto at = 0; at < atStepValuesEnd; ++at)
+    for (auto at = 0; at < xaStepValuesEnd; ++at)
         if (strcasecmp(atStr, AtStepValuesStr[at]) == 0)
-            return at;
+            return static_cast<XactionSteps>(at);
 
-    return atStepValuesEnd;
+    return xaStepValuesEnd;
 }
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -42,7 +42,7 @@ ACLAtStepData::~ACLAtStepData()
 bool
 ACLAtStepData::match(XactionStep toFind)
 {
-    auto found = std::find(values.cbegin(), values.cend(), toFind);
+    const auto found = std::find(values.cbegin(), values.cend(), toFind);
     return (found != values.cend());
 }
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -27,9 +27,10 @@ static const char *StepNames[xstepValuesEnd] = {
 };
 
 static const char *
-StepName(XactionStep xstep)
+StepName(const XactionStep xstep)
 {
-    return (0 <= xstep && xstep < xstepValuesEnd) ? StepNames[xstep] : "-";
+    assert(0 <= xstep && xstep < xstepValuesEnd);
+    return StepNames[xstep];
 }
 
 static XactionStep

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -91,6 +91,6 @@ ACLAtStepData::AtStep(const char *atStr)
         if (strcasecmp(atStr, AtStepValuesStr[at]) == 0)
             return static_cast<XactionStep>(at);
 
-    throw TexcHere(ToSBuf("invalid AtStep step: ", atStr));
+    throw TextException(ToSBuf("invalid AtStep step: ", atStr), Here());
 }
 

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -39,20 +39,16 @@ ACLAtStepData::~ACLAtStepData()
 bool
 ACLAtStepData::match(XactionStep toFind)
 {
-    for (auto it = values.cbegin(); it != values.cend(); ++it) {
-        if (*it == toFind)
-            return true;
-    }
-    return false;
+    auto found = std::find(values.cbegin(), values.cend(), toFind);
+    return (found != values.cend());
 }
 
 SBufList
 ACLAtStepData::dump() const
 {
     SBufList sl;
-    for (auto it = values.cbegin(); it != values.cend(); ++it) {
-        sl.push_back(SBuf(AtStepStr(*it)));
-    }
+    for (const auto value : values)
+        sl.push_back(SBuf(AtStepStr(value)));
     return sl;
 }
 
@@ -84,7 +80,7 @@ ACLAtStepData::clone() const
 const char *
 ACLAtStepData::AtStepStr(XactionStep at)
 {
-    if (at >=0 && at < xstepValuesEnd)
+    if (0 <= at && at < xstepValuesEnd)
         return AtStepValuesStr[at];
     else
         return "-";

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -61,7 +61,7 @@ ACLAtStepData::parse()
 {
     while (const char *t = ConfigParser::strtokFile()) {
         const auto at = AtStep(t);
-        if (at == xaStepValuesEnd) {
+        if (at == xstepValuesEnd) {
             debugs(28, DBG_CRITICAL, "FATAL: invalid AtStep step: " << t);
             self_destruct();
         }
@@ -84,7 +84,7 @@ ACLAtStepData::clone() const
 const char *
 ACLAtStepData::AtStepStr(XactionStep at)
 {
-    if (at >=0 && at < xaStepValuesEnd)
+    if (at >=0 && at < xstepValuesEnd)
         return AtStepValuesStr[at];
     else
         return "-";
@@ -93,10 +93,10 @@ ACLAtStepData::AtStepStr(XactionStep at)
 XactionStep
 ACLAtStepData::AtStep(const char *atStr)
 {
-    for (auto at = 0; at < xaStepValuesEnd; ++at)
+    for (auto at = 0; at < xstepValuesEnd; ++at)
         if (strcasecmp(atStr, AtStepValuesStr[at]) == 0)
             return static_cast<XactionStep>(at);
 
-    return xaStepValuesEnd;
+    return xstepValuesEnd;
 }
 

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -11,10 +11,10 @@
 
 #include "acl/Acl.h"
 #include "acl/Data.h"
-#include "enums.h"
+#include "XactionStep.h"
 #include <list>
 
-class ACLAtStepData : public ACLData<XactionSteps>
+class ACLAtStepData : public ACLData<XactionStep>
 {
     MEMPROXY_CLASS(ACLAtStepData);
 
@@ -23,16 +23,16 @@ public:
     ACLAtStepData(ACLAtStepData const &);
     ACLAtStepData &operator= (ACLAtStepData const &);
     virtual ~ACLAtStepData();
-    bool match(XactionSteps);
+    bool match(XactionStep);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
     virtual ACLAtStepData *clone() const;
 
-    static const char *AtStepStr(XactionSteps);
-    static XactionSteps AtStep(const char *);
+    static const char *AtStepStr(XactionStep);
+    static XactionStep AtStep(const char *);
 
-    std::list<XactionSteps> values;
+    std::list<XactionStep> values;
 
 private:
     static const char *AtStepValuesStr[];

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -29,13 +29,7 @@ public:
     bool empty() const;
     virtual ACLAtStepData *clone() const;
 
-    static const char *AtStepStr(XactionStep);
-    static XactionStep AtStep(const char *);
-
     std::list<XactionStep> values;
-
-private:
-    static const char *AtStepValuesStr[];
 };
 
 #endif /* SQUID_ACLSSL_ERRORDATA_H */

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -11,37 +11,28 @@
 
 #include "acl/Acl.h"
 #include "acl/Data.h"
+#include "enums.h"
 #include <list>
 
-class ACLAtStepData : public ACLData<int>
+class ACLAtStepData : public ACLData<XactionSteps>
 {
     MEMPROXY_CLASS(ACLAtStepData);
 
 public:
-    enum AtStepValues {
-#if USE_OPENSSL
-        atStepSslBump1,
-        atStepSslBump2,
-        atStepSslBump3,
-#endif
-        atStepGeneratingConnect,
-        atStepValuesEnd
-    };
-
     ACLAtStepData();
     ACLAtStepData(ACLAtStepData const &);
     ACLAtStepData &operator= (ACLAtStepData const &);
     virtual ~ACLAtStepData();
-    bool match(int);
+    bool match(XactionSteps);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
     virtual ACLAtStepData *clone() const;
 
-    static const char *AtStepStr(int);
-    static int AtStep(const char *);
+    static const char *AtStepStr(XactionSteps);
+    static XactionSteps AtStep(const char *);
 
-    std::list<int> values;
+    std::list<XactionSteps> values;
 
 private:
     static const char *AtStepValuesStr[];

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -9,33 +9,43 @@
 #ifndef SQUID_ACLATSTEPDATA_H
 #define SQUID_ACLATSTEPDATA_H
 
-#if USE_OPENSSL
-
 #include "acl/Acl.h"
 #include "acl/Data.h"
-#include "ssl/support.h"
-
 #include <list>
 
-class ACLAtStepData : public ACLData<Ssl::BumpStep>
+class ACLAtStepData : public ACLData<int>
 {
     MEMPROXY_CLASS(ACLAtStepData);
 
 public:
+    enum AtStepValues {
+#if USE_OPENSSL
+        atStepSslBump1,
+        atStepSslBump2,
+        atStepSslBump3,
+#endif
+        atStepGeneratingConnect,
+        atStepValuesEnd
+    };
+
     ACLAtStepData();
     ACLAtStepData(ACLAtStepData const &);
     ACLAtStepData &operator= (ACLAtStepData const &);
     virtual ~ACLAtStepData();
-    bool match(Ssl::BumpStep);
+    bool match(int);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
     virtual ACLAtStepData *clone() const;
 
-    std::list<Ssl::BumpStep> values;
-};
+    static const char *AtStepStr(int);
+    static int AtStep(const char *);
 
-#endif /* USE_OPENSSL */
+    std::list<int> values;
+
+private:
+    static const char *AtStepValuesStr[];
+};
 
 #endif /* SQUID_ACLSSL_ERRORDATA_H */
 

--- a/src/acl/Makefile.am
+++ b/src/acl/Makefile.am
@@ -65,6 +65,10 @@ libacls_la_SOURCES = \
 	AnyOf.h \
 	Asn.cc \
 	Asn.h \
+	AtStep.cc \
+	AtStep.h \
+	AtStepData.cc \
+	AtStepData.h \
 	ConnectionsEncrypted.cc \
 	ConnectionsEncrypted.h \
 	ConnMark.cc \
@@ -159,10 +163,6 @@ libacls_la_SOURCES = \
 EXTRA_libacls_la_SOURCES =
 
 SSL_ACLS = \
-	AtStep.cc \
-	AtStep.h \
-	AtStepData.cc \
-	AtStepData.h \
         CertificateData.cc \
         CertificateData.h  \
         Certificate.cc \

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1431,8 +1431,7 @@ endif
 acl aclname at_step step
 	  # match against various request processing steps [fast]
 	  # Valid steps are:
-	  #   GeneratingCONNECT: While generates and process CONNECT request
-	  #                      to a peer
+	  #   GeneratingCONNECT: While generates CONNECT request to a peer
 IF USE_OPENSSL
 	  # The following steps can also be used to match against the
 	  # current step during ssl_bump evaluation.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1428,6 +1428,24 @@ endif
 	  #  acl hasWhatMyLoggingDaemonNeeds has request
 	  #  acl hasWhatMyLoggingDaemonNeeds has response
 
+acl aclname at_step step
+	  # match against various request processing steps [fast]
+	  # Valid steps are:
+	  #   GeneratingCONNECT: While generates and process CONNECT request
+	  #                      to a peer
+IF USE_OPENSSL
+	  # The following steps can also be used to match against the
+	  # current step during ssl_bump evaluation.
+	  # Never matches and should not be used outside the ssl_bump context.
+	  #
+	  # At each SslBump step, Squid evaluates ssl_bump directives to find
+	  # the next bumping action (e.g., peek or splice). Valid SslBump step
+	  # values and the corresponding ssl_bump evaluation moments are:
+	  #   SslBump1: After getting TCP-level and HTTP CONNECT info.
+	  #   SslBump2: After getting SSL Client Hello info.
+	  #   SslBump3: After getting SSL Server Hello info.
+ENDIF
+
 IF USE_OPENSSL
 	acl aclname ssl_error errorname
 	  # match against SSL certificate validation error [fast]
@@ -1458,17 +1476,6 @@ IF USE_OPENSSL
 	  # Optional argument specifies the digest algorithm to use.
 	  # The SHA1 digest algorithm is the default and is currently
 	  # the only algorithm supported (-sha1).
-
-	acl aclname at_step step
-	  # match against the current step during ssl_bump evaluation [fast]
-	  # Never matches and should not be used outside the ssl_bump context.
-	  #
-	  # At each SslBump step, Squid evaluates ssl_bump directives to find
-	  # the next bumping action (e.g., peek or splice). Valid SslBump step
-	  # values and the corresponding ssl_bump evaluation moments are:
-	  #   SslBump1: After getting TCP-level and HTTP CONNECT info.
-	  #   SslBump2: After getting SSL Client Hello info.
-	  #   SslBump3: After getting SSL Server Hello info.
 
 	acl aclname ssl::server_name [option] .foo.com ...
 	  # matches server name obtained from various sources [fast]

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1429,9 +1429,9 @@ endif
 	  #  acl hasWhatMyLoggingDaemonNeeds has response
 
 acl aclname at_step step
-	  # match against various request processing steps [fast]
+	  # match against the current request processing step [fast]
 	  # Valid steps are:
-	  #   GeneratingCONNECT: While generates CONNECT request to a peer
+	  #   GeneratingCONNECT: Generating HTTP CONNECT request headers
 IF USE_OPENSSL
 	  # The following ssl_bump processing steps are recognized:
 	  #   SslBump1: After getting TCP-level and HTTP CONNECT info.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1433,13 +1433,7 @@ acl aclname at_step step
 	  # Valid steps are:
 	  #   GeneratingCONNECT: While generates CONNECT request to a peer
 IF USE_OPENSSL
-	  # The following steps can also be used to match against the
-	  # current step during ssl_bump evaluation.
-	  # Never matches and should not be used outside the ssl_bump context.
-	  #
-	  # At each SslBump step, Squid evaluates ssl_bump directives to find
-	  # the next bumping action (e.g., peek or splice). Valid SslBump step
-	  # values and the corresponding ssl_bump evaluation moments are:
+	  # The following ssl_bump processing steps are recognized:
 	  #   SslBump1: After getting TCP-level and HTTP CONNECT info.
 	  #   SslBump2: After getting SSL Client Hello info.
 	  #   SslBump3: After getting SSL Server Hello info.

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3118,7 +3118,7 @@ ConnStateData::startPeekAndSplice()
     Http::StreamPointer context = pipeline.front();
     ClientHttpRequest *http = context ? context->http : nullptr;
 
-    if (sslServerBump->step == xaStepTlsBump1) {
+    if (sslServerBump->at(xaStepTlsBump1)) {
         sslServerBump->step = xaStepTlsBump2;
         // Run a accessList check to check if want to splice or continue bumping
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3118,8 +3118,8 @@ ConnStateData::startPeekAndSplice()
     Http::StreamPointer context = pipeline.front();
     ClientHttpRequest *http = context ? context->http : nullptr;
 
-    if (sslServerBump->step == Ssl::bumpStep1) {
-        sslServerBump->step = Ssl::bumpStep2;
+    if (sslServerBump->step == xaStepTlsBump1) {
+        sslServerBump->step = xaStepTlsBump2;
         // Run a accessList check to check if want to splice or continue bumping
 
         ACLFilledChecklist *acl_checklist = new ACLFilledChecklist(Config.accessList.ssl_bump, sslServerBump->request.getRaw(), nullptr);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3118,8 +3118,8 @@ ConnStateData::startPeekAndSplice()
     Http::StreamPointer context = pipeline.front();
     ClientHttpRequest *http = context ? context->http : nullptr;
 
-    if (sslServerBump->at(xstepTlsBump1)) {
-        sslServerBump->step = xstepTlsBump2;
+    if (sslServerBump->at(XactionStep::tlsBump1)) {
+        sslServerBump->step = XactionStep::tlsBump2;
         // Run a accessList check to check if want to splice or continue bumping
 
         ACLFilledChecklist *acl_checklist = new ACLFilledChecklist(Config.accessList.ssl_bump, sslServerBump->request.getRaw(), nullptr);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3118,8 +3118,8 @@ ConnStateData::startPeekAndSplice()
     Http::StreamPointer context = pipeline.front();
     ClientHttpRequest *http = context ? context->http : nullptr;
 
-    if (sslServerBump->at(xaStepTlsBump1)) {
-        sslServerBump->step = xaStepTlsBump2;
+    if (sslServerBump->at(xstepTlsBump1)) {
+        sslServerBump->step = xstepTlsBump2;
         // Run a accessList check to check if want to splice or continue bumping
 
         ACLFilledChecklist *acl_checklist = new ACLFilledChecklist(Config.accessList.ssl_bump, sslServerBump->request.getRaw(), nullptr);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -126,29 +126,35 @@ Http::Tunneler::writeRequest()
 {
     debugs(83, 5, connection);
 
-    HttpHeader hdr_out(hoRequest);
     Http::StateFlags flags;
     flags.peering = true;
-
-    Must(request->masterXaction);
-    request->masterXaction->generatingConnect = true;
     // flags.tunneling = false; // the CONNECT request itself is not tunneled
     // flags.toOrigin = false; // the next HTTP hop is a non-originserver peer
+
     MemBuf mb;
     mb.init();
     mb.appendf("CONNECT %s HTTP/1.1\r\n", url.c_str());
-    HttpStateData::httpBuildRequestHeader(request.getRaw(),
-                                          nullptr, // StoreEntry
-                                          al,
-                                          &hdr_out,
-                                          flags);
-    hdr_out.packInto(&mb);
-    hdr_out.clean();
+    try {
+        Must(request->masterXaction);
+        request->masterXaction->generatingConnect = true;
+        HttpHeader hdr_out(hoRequest);
+        HttpStateData::httpBuildRequestHeader(request.getRaw(),
+                                              nullptr, // StoreEntry
+                                              al,
+                                              &hdr_out,
+                                              flags);
+        hdr_out.packInto(&mb);
+        hdr_out.clean();
+        request->masterXaction->generatingConnect = false;
+    } catch (const std::exception &e) {
+        request->masterXaction->generatingConnect = false;
+        handleException(e);
+        return;
+    }
     mb.append("\r\n", 2);
 
     debugs(11, 2, "Tunnel Server REQUEST: " << connection <<
            ":\n----------\n" << mb.buf << "\n----------");
-    request->masterXaction->generatingConnect = false;
     fd_note(connection->fd, "Tunnel Server CONNECT");
 
     typedef CommCbMemFunT<Http::Tunneler, CommIoCbParams> Dialer;

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -129,6 +129,9 @@ Http::Tunneler::writeRequest()
     HttpHeader hdr_out(hoRequest);
     Http::StateFlags flags;
     flags.peering = true;
+
+    Must(request->masterXaction);
+    request->masterXaction->generatingConnect = true;
     // flags.tunneling = false; // the CONNECT request itself is not tunneled
     // flags.toOrigin = false; // the next HTTP hop is a non-originserver peer
     MemBuf mb;
@@ -336,6 +339,9 @@ void
 Http::Tunneler::callBack()
 {
     debugs(83, 5, connection << status());
+    Must(request);
+    Must(request->masterXaction);
+    request->masterXaction->generatingConnect = false;
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -148,6 +148,7 @@ Http::Tunneler::writeRequest()
 
     debugs(11, 2, "Tunnel Server REQUEST: " << connection <<
            ":\n----------\n" << mb.buf << "\n----------");
+    request->masterXaction->generatingConnect = false;
     fd_note(connection->fd, "Tunnel Server CONNECT");
 
     typedef CommCbMemFunT<Http::Tunneler, CommIoCbParams> Dialer;
@@ -341,7 +342,6 @@ Http::Tunneler::callBack()
     debugs(83, 5, connection << status());
     Must(request);
     Must(request->masterXaction);
-    request->masterXaction->generatingConnect = false;
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -348,8 +348,6 @@ void
 Http::Tunneler::callBack()
 {
     debugs(83, 5, connection << status());
-    Must(request);
-    Must(request->masterXaction);
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/enums.h
+++ b/src/enums.h
@@ -240,5 +240,15 @@ typedef enum {
 } htcp_clr_reason;
 #endif /* USE_HTCP */
 
+typedef enum {
+#if USE_OPENSSL
+    xaStepTlsBump1,
+    xaStepTlsBump2,
+    xaStepTlsBump3,
+#endif
+    xaStepGeneratingConnect,
+    xaStepValuesEnd
+} XactionSteps;
+
 #endif /* SQUID_ENUMS_H */
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -240,15 +240,5 @@ typedef enum {
 } htcp_clr_reason;
 #endif /* USE_HTCP */
 
-typedef enum {
-#if USE_OPENSSL
-    xaStepTlsBump1,
-    xaStepTlsBump2,
-    xaStepTlsBump3,
-#endif
-    xaStepGeneratingConnect,
-    xaStepValuesEnd
-} XactionSteps;
-
 #endif /* SQUID_ENUMS_H */
 

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -48,7 +48,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSplice()
     // Mark Step3 of bumping
     if (request->clientConnectionManager.valid()) {
         if (Ssl::ServerBump *serverBump = request->clientConnectionManager->serverBump()) {
-            serverBump->step = xaStepTlsBump3;
+            serverBump->step = xstepTlsBump3;
         }
     }
 
@@ -166,7 +166,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
         if (hostName)
             SSL_set_ex_data(serverSession.get(), ssl_ex_index_server, (void*)hostName);
 
-        Must(!csd->serverBump() || csd->serverBump()->at(xaStepTlsBump1, xaStepTlsBump2));
+        Must(!csd->serverBump() || csd->serverBump()->at(xstepTlsBump1, xstepTlsBump2));
         if (csd->sslBumpMode == Ssl::bumpPeek || csd->sslBumpMode == Ssl::bumpStare) {
             auto clientSession = fd_table[clientConn->fd].ssl.get();
             Must(clientSession);

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -48,7 +48,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSplice()
     // Mark Step3 of bumping
     if (request->clientConnectionManager.valid()) {
         if (Ssl::ServerBump *serverBump = request->clientConnectionManager->serverBump()) {
-            serverBump->step = xstepTlsBump3;
+            serverBump->step = XactionStep::tlsBump3;
         }
     }
 
@@ -166,7 +166,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
         if (hostName)
             SSL_set_ex_data(serverSession.get(), ssl_ex_index_server, (void*)hostName);
 
-        Must(!csd->serverBump() || csd->serverBump()->at(xstepTlsBump1, xstepTlsBump2));
+        Must(!csd->serverBump() || csd->serverBump()->at(XactionStep::tlsBump1, XactionStep::tlsBump2));
         if (csd->sslBumpMode == Ssl::bumpPeek || csd->sslBumpMode == Ssl::bumpStare) {
             auto clientSession = fd_table[clientConn->fd].ssl.get();
             Must(clientSession);

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -166,7 +166,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
         if (hostName)
             SSL_set_ex_data(serverSession.get(), ssl_ex_index_server, (void*)hostName);
 
-        Must(!csd->serverBump() || csd->serverBump()->step <= xaStepTlsBump2);
+        Must(!csd->serverBump() || csd->serverBump()->at(xaStepTlsBump1, xaStepTlsBump2));
         if (csd->sslBumpMode == Ssl::bumpPeek || csd->sslBumpMode == Ssl::bumpStare) {
             auto clientSession = fd_table[clientConn->fd].ssl.get();
             Must(clientSession);

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -48,7 +48,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSplice()
     // Mark Step3 of bumping
     if (request->clientConnectionManager.valid()) {
         if (Ssl::ServerBump *serverBump = request->clientConnectionManager->serverBump()) {
-            serverBump->step = Ssl::bumpStep3;
+            serverBump->step = xaStepTlsBump3;
         }
     }
 
@@ -166,7 +166,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
         if (hostName)
             SSL_set_ex_data(serverSession.get(), ssl_ex_index_server, (void*)hostName);
 
-        Must(!csd->serverBump() || csd->serverBump()->step <= Ssl::bumpStep2);
+        Must(!csd->serverBump() || csd->serverBump()->step <= xaStepTlsBump2);
         if (csd->sslBumpMode == Ssl::bumpPeek || csd->sslBumpMode == Ssl::bumpStare) {
             auto clientSession = fd_table[clientConn->fd].ssl.get();
             Must(clientSession);

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -21,7 +21,7 @@
 CBDATA_NAMESPACED_CLASS_INIT(Ssl, ServerBump);
 
 Ssl::ServerBump::ServerBump(ClientHttpRequest *http, StoreEntry *e, Ssl::BumpMode md):
-    step(xaStepTlsBump1)
+    step(xstepTlsBump1)
 {
     assert(http->request);
     request = http->request;

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -21,7 +21,7 @@
 CBDATA_NAMESPACED_CLASS_INIT(Ssl, ServerBump);
 
 Ssl::ServerBump::ServerBump(ClientHttpRequest *http, StoreEntry *e, Ssl::BumpMode md):
-    step(xstepTlsBump1)
+    step(XactionStep::tlsBump1)
 {
     assert(http->request);
     request = http->request;

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -21,7 +21,7 @@
 CBDATA_NAMESPACED_CLASS_INIT(Ssl, ServerBump);
 
 Ssl::ServerBump::ServerBump(ClientHttpRequest *http, StoreEntry *e, Ssl::BumpMode md):
-    step(bumpStep1)
+    step(xaStepTlsBump1)
 {
     assert(http->request);
     request = http->request;

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -41,6 +41,12 @@ public:
     /// whether there was a successful connection to (and peeking at) the origin server
     bool connectedOk() const {return entry && entry->isEmpty();}
 
+    /// whether we are at the bumping step atStepVal
+    bool at(const XactionStep atStepVal) { return step == atStepVal;}
+
+    /// whether we are at one of the bumping steps atStepVal1 or atStepVal2
+    bool at(const XactionStep atStepVal1, const XactionStep atStepVal2) { return step == atStepVal1 || step == atStepVal2;}
+
     /// faked, minimal request; required by Client API
     HttpRequest::Pointer request;
     StoreEntry *entry; ///< for receiving Squid-generated error messages

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -25,7 +25,7 @@ class ClientHttpRequest;
 namespace Ssl
 {
 
-typedef XactionStep BumpStep;
+using BumpStep = XactionStep;
 
 /**
  * Maintains bump-server-first related information.

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -12,11 +12,11 @@
 #include "base/AsyncJob.h"
 #include "base/CbcPointer.h"
 #include "comm/forward.h"
-#include "enums.h"
 #include "HttpRequest.h"
 #include "ip/Address.h"
 #include "security/forward.h"
 #include "Store.h"
+#include "XactionStep.h"
 
 class ConnStateData;
 class store_client;
@@ -52,7 +52,7 @@ public:
         Ssl::BumpMode step2; ///< The SSL bump mode at step2
         Ssl::BumpMode step3; ///< The SSL bump mode at step3
     } act; ///< bumping actions at various bumping steps
-    XactionSteps step; ///< The TLS bumping step
+    XactionStep step; ///< The TLS bumping step
 
 private:
     Security::SessionPointer serverSession; ///< The TLS session object on server side.

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -43,11 +43,11 @@ public:
     /// whether there was a successful connection to (and peeking at) the origin server
     bool connectedOk() const {return entry && entry->isEmpty();}
 
-    /// whether we are at the bumping step atStepVal
-    bool at(const Ssl::BumpStep atStepVal) { return step == atStepVal;}
+    /// whether we are currently performing the given processing step
+    bool at(const BumpStep stp) const { return step == stp; }
 
-    /// whether we are at one of the bumping steps atStepVal1 or atStepVal2
-    bool at(const Ssl::BumpStep atStepVal1, const Ssl::BumpStep atStepVal2) { return step == atStepVal1 || step == atStepVal2;}
+    /// whether we are currently performing one of the given processing steps
+    bool at(const BumpStep step1, const BumpStep step2) const { return at(step1) || at(step2); }
 
     /// faked, minimal request; required by Client API
     HttpRequest::Pointer request;

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -25,6 +25,8 @@ class ClientHttpRequest;
 namespace Ssl
 {
 
+typedef XactionStep BumpStep;
+
 /**
  * Maintains bump-server-first related information.
  */
@@ -42,10 +44,10 @@ public:
     bool connectedOk() const {return entry && entry->isEmpty();}
 
     /// whether we are at the bumping step atStepVal
-    bool at(const XactionStep atStepVal) { return step == atStepVal;}
+    bool at(const Ssl::BumpStep atStepVal) { return step == atStepVal;}
 
     /// whether we are at one of the bumping steps atStepVal1 or atStepVal2
-    bool at(const XactionStep atStepVal1, const XactionStep atStepVal2) { return step == atStepVal1 || step == atStepVal2;}
+    bool at(const Ssl::BumpStep atStepVal1, const Ssl::BumpStep atStepVal2) { return step == atStepVal1 || step == atStepVal2;}
 
     /// faked, minimal request; required by Client API
     HttpRequest::Pointer request;
@@ -58,7 +60,7 @@ public:
         Ssl::BumpMode step2; ///< The SSL bump mode at step2
         Ssl::BumpMode step3; ///< The SSL bump mode at step3
     } act; ///< bumping actions at various bumping steps
-    XactionStep step; ///< The TLS bumping step
+    Ssl::BumpStep step; ///< The SSL bumping step
 
 private:
     Security::SessionPointer serverSession; ///< The TLS session object on server side.

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -12,6 +12,7 @@
 #include "base/AsyncJob.h"
 #include "base/CbcPointer.h"
 #include "comm/forward.h"
+#include "enums.h"
 #include "HttpRequest.h"
 #include "ip/Address.h"
 #include "security/forward.h"
@@ -51,7 +52,7 @@ public:
         Ssl::BumpMode step2; ///< The SSL bump mode at step2
         Ssl::BumpMode step3; ///< The SSL bump mode at step3
     } act; ///< bumping actions at various bumping steps
-    Ssl::BumpStep step; ///< The SSL bumping step
+    XactionSteps step; ///< The TLS bumping step
 
 private:
     Security::SessionPointer serverSession; ///< The TLS session object on server side.

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -134,8 +134,6 @@ extern const EVP_MD *DefaultSignHash;
  */
 enum BumpMode {bumpNone = 0, bumpClientFirst, bumpServerFirst, bumpPeek, bumpStare, bumpBump, bumpSplice, bumpTerminate, /*bumpErr,*/ bumpEnd};
 
-enum BumpStep {bumpStep1, bumpStep2, bumpStep3};
-
 /**
  \ingroup  ServerProtocolSSLAPI
  * Short names for ssl-bump modes

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -101,7 +101,7 @@ public:
             return false;
 #if USE_OPENSSL
         // We are bumping and we had already send "OK CONNECTED"
-        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->step > Ssl::bumpStep1)
+        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->step > xaStepTlsBump1)
             return false;
 #endif
         return !(request != NULL &&

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -101,7 +101,7 @@ public:
             return false;
 #if USE_OPENSSL
         // We are bumping and we had already send "OK CONNECTED"
-        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->at(xstepTlsBump2, xstepTlsBump3))
+        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->at(XactionStep::tlsBump2, XactionStep::tlsBump3))
             return false;
 #endif
         return !(request != NULL &&

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -101,7 +101,7 @@ public:
             return false;
 #if USE_OPENSSL
         // We are bumping and we had already send "OK CONNECTED"
-        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->at(xaStepTlsBump2, xaStepTlsBump3))
+        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->at(xstepTlsBump2, xstepTlsBump3))
             return false;
 #endif
         return !(request != NULL &&

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -101,7 +101,7 @@ public:
             return false;
 #if USE_OPENSSL
         // We are bumping and we had already send "OK CONNECTED"
-        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->step > xaStepTlsBump1)
+        if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->at(xaStepTlsBump2, xaStepTlsBump3))
             return false;
 #endif
         return !(request != NULL &&


### PR DESCRIPTION
The new step allows admins to customize CONNECT request generation using
request_header_access and request_header_replace. As detailed below,
matching the request method does not work for those purposes.

request_header_access controls what HTTP request headers Squid _sends_.
However, this directive, like most other ACL-driven Squid directives,
uses the received request, _not_ the being-formed to-be-sent request.
This can be confusing, but it is the correct design/behavior.

When Squid is about to send a CONNECT request to a cache peer, what
_received_ request should request_header_access ACLs look at? There are
several ways to answer that question:

1. The received CONNECT request (or, for intercepted TLS connections,
   its faked equivalent). This is how the current CONNECT-sending code
   works when establishing the tunnel for a not-yet-bumped client
   connection. Problems:
    
    1. The CONNECT request received by Squid was not meant for the cache
       peer. It was meant specifically for this Squid. While it may have
       info useful for request_header_access checks, it is conceptually
       wrong to think of whats happening as "forwarding of that received
       CONNECT to the cache peer". Unlike GET requests, the CONNECT
       request that this Squid will send to the cache peer is dedicated
       to the Squid-peer connection. It is generated, not forwarded.
    
    2. That CONNECT request may have been received a long time ago, and
       Squid may have forwarded many bumped GET requests since then. It
       feels strange to consult such an old/"disconnected" message.
2. The received (and bumped) GET request. This is how the current
   CONNECT-sending code works when establishing the tunnel for an
   already bumped client connection. Problem:
    
    1. Squid is about to send a generated CONNECT request, not to
       forward a received GET request (the latter will happen later,
       after the CONNECT transaction). The two requests may differ a
       lot. Using a GET request when generating a CONNECT request is
       confusing: "Why is my CONNECT method ACL does not match when
       Squid sends a CONNECT request?!"

3. No request. Problems:
    
    1. Some old configurations that use request-specific ACLs with
       request_header_access will generate runtime "missing request"
       warnings and may fail to work correctly.
    
    2. Extra admin work is required to store request-specific
       information as connection annotations that request_header_access
       ACLs can still access.
    
    3. Conceptually, there is a request that Squid is establishing this
       CONNECT tunnel for. Squid will access-log that request. Hiding
       that information from ACLs feels odd/wrong. And some of that info
       would still be accessible to ACLs (via ALE/etc.). This hiding
       does not really hide all of the details.

Our solution preserves what received request Squid is looking at. Items
1 and 2 above still apply (depending on the configuration and on the
request being processed), with their unique problems intact. Those
problems are not as bad as the problems associated with the item 3!

The at_step ACL was added for SslBump but, IIRC, we knew that it may
eventually cover other request processing steps. Generating a CONNECT
request is one of those other steps.

This is a Measurement Factory project.