### PR TITLE
Log "-" instead of the made-up method "NONE".

### DIFF
--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -49,13 +49,16 @@ AccessLogEntry::getLogClientIp(char *buf, size_t bufsz) const
 SBuf
 AccessLogEntry::getLogMethod() const
 {
+    static const SBuf dash("-");
     SBuf method;
     if (icp.opcode)
         method.append(icp_opcode_str[icp.opcode]);
     else if (htcp.opcode)
         method.append(htcp.opcode);
-    else
+    else if (http.method)
         method = http.method.image();
+    else
+        method = dash;
     return method;
 }
 

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -56,6 +56,9 @@ public:
     /// Fetch the external ACL provided 'user=' string, or nil if none is available.
     const char *getExtUser() const;
 
+    /// whether we know what the request method is
+    bool hasLogMethod() const { return icp.opcode || htcp.opcode || http.method; }
+
     /// Fetch the transaction method string (ICP opcode, HTCP opcode or HTTP method)
     SBuf getLogMethod() const;
 

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1087,9 +1087,11 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_REQUEST_METHOD:
-            sb = al->getLogMethod();
-            out = sb.c_str();
-            quote = 1;
+            if (al->hasLogMethod()) {
+                sb = al->getLogMethod();
+                out = sb.c_str();
+                quote = 1;
+            }
             break;
 
         case LFT_REQUEST_URI:

--- a/src/http/RequestMethod.h
+++ b/src/http/RequestMethod.h
@@ -44,6 +44,9 @@ public:
         return *this;
     }
 
+    /// whether the method is set/known
+    explicit operator bool() const { return theMethod != Http::METHOD_NONE; }
+
     bool operator == (Http::MethodType const & aMethod) const { return theMethod == aMethod; }
     bool operator == (HttpRequestMethod const & aMethod) const {
         return theMethod == aMethod.theMethod &&


### PR DESCRIPTION
Also useful for the future ALE-using context-reporting code that must be
silent regarding unknowns, including unknown request methods.