### PR TITLE
Bug 4989: Leaking StoreEntry objects on Cache Digest rebuilds

### DIFF
--- a/src/Store.h
+++ b/src/Store.h
@@ -128,7 +128,7 @@ public:
     /// TODO: Rename and make private so only those two methods can call this.
     bool checkCachable();
     int checkNegativeHit() const;
-    int locked() const;
+    int locked() const { return lock_count; }
     int validToSend() const;
     bool memoryCachable(); ///< checkCachable() and can be cached in memory
 

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -436,7 +436,8 @@ MimeIcon::created(StoreEntry *newEntry)
     e->flush();
     e->complete();
     e->timestampsSet();
-    e->unlock("MimeIcon::created");
+    // MimeIcons are only loaded once, prevent accidental destruction
+    // e->unlock("MimeIcon::created");
     debugs(25, 3, "Loaded icon " << url_);
 }
 

--- a/src/store.cc
+++ b/src/store.cc
@@ -1250,24 +1250,6 @@ storeLateRelease(void *)
     eventAdd("storeLateRelease", storeLateRelease, NULL, 0.0, 1);
 }
 
-/* return 1 if a store entry is locked */
-int
-StoreEntry::locked() const
-{
-    if (lock_count)
-        return 1;
-
-    /*
-     * SPECIAL, PUBLIC entries should be "locked";
-     * XXX: Their owner should lock them then instead of relying on this hack.
-     */
-    if (EBIT_TEST(flags, ENTRY_SPECIAL))
-        if (!EBIT_TEST(flags, KEY_PRIVATE))
-            return 1;
-
-    return 0;
-}
-
 bool
 StoreEntry::validLength() const
 {

--- a/src/store.cc
+++ b/src/store.cc
@@ -1201,12 +1201,8 @@ StoreEntry::release(const bool shareable)
 
     if (locked()) {
         releaseRequest(shareable);
-        /* "releaseRequest" may allow some entries such as cache digests to be
-         * unlocked immediately, so we should retest and release if possible. */
-        if (locked()) {
-            PROF_stop(storeRelease);
-            return;
-        }
+        PROF_stop(storeRelease);
+        return;
     }
 
     if (Store::Controller::store_dirs_rebuilding && hasDisk()) {

--- a/src/store.cc
+++ b/src/store.cc
@@ -1201,8 +1201,12 @@ StoreEntry::release(const bool shareable)
 
     if (locked()) {
         releaseRequest(shareable);
-        PROF_stop(storeRelease);
-        return;
+        /* "releaseRequest" may allow some entries such as cache digests to be
+         * unlocked immediately, so we should retest and release if possible. */
+        if (locked()) {
+            PROF_stop(storeRelease);
+            return;
+        }
     }
 
     if (Store::Controller::store_dirs_rebuilding && hasDisk()) {

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -449,7 +449,7 @@ storeDigestRewriteResume(void)
     /* setting public key will mark the old digest entry for removal once unlocked */
     e->setPublicKey();
     if (const auto oldEntry = sd_state.publicEntry) {
-        oldEntry->release();
+        oldEntry->release(true);
         sd_state.publicEntry = nullptr;
         oldEntry->unlock("storeDigestRewriteResume");
     }

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -448,10 +448,12 @@ storeDigestRewriteResume(void)
     EBIT_SET(e->flags, ENTRY_SPECIAL);
     /* setting public key will mark the old digest entry for removal once unlocked */
     e->setPublicKey();
-    if (sd_state.publicEntry) {
-        sd_state.publicEntry->unlock("storeDigestRewriteResume");
+    if (const auto oldEntry = sd_state.publicEntry) {
+        oldEntry->release();
         sd_state.publicEntry = nullptr;
+        oldEntry->unlock("storeDigestRewriteResume");
     }
+    assert(e->locked());
     /* fake reply */
     HttpReply *rep = new HttpReply;
     rep->setHeaders(Http::scOkay, "Cache Digest OK",

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -426,7 +426,7 @@ storeDigestRewriteStart(void *data)
         data = nullptr;
     }
 
-    const auto e = storeCreateEntry(url, url, flags, Http::METHOD_GET);
+    StoreEntry *e = storeCreateEntry(url, url, flags, Http::METHOD_GET);
     assert(e);
     sd_state.rewrite_lock = e;
     debugs(71, 3, "storeDigestRewrite: url: " << url << " key: " << e->getMD5Text());

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -474,7 +474,6 @@ static void
 storeDigestRewriteFinish(StoreEntry * e)
 {
     assert(e == sd_state.rewrite_lock);
-    assert(!sd_state.publicEntry);
     e->complete();
     e->timestampsSet();
     debugs(71, 2, "storeDigestRewriteFinish: digest expires at " << e->expires <<

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -454,6 +454,7 @@ storeDigestRewriteResume(void)
         oldEntry->unlock("storeDigestRewriteResume");
     }
     assert(e->locked());
+    sd_state.publicEntry = e;
     /* fake reply */
     HttpReply *rep = new HttpReply;
     rep->setHeaders(Http::scOkay, "Cache Digest OK",
@@ -480,7 +481,6 @@ storeDigestRewriteFinish(StoreEntry * e)
            " (" << std::showpos << (int) (e->expires - squid_curtime) << ")");
     /* is this the write order? @?@ */
     e->mem_obj->unlinkRequest();
-    sd_state.publicEntry = e;
     sd_state.rewrite_lock = NULL;
     ++sd_state.rewrite_count;
     eventAdd("storeDigestRewriteStart", storeDigestRewriteStart, NULL, (double)

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -73,7 +73,7 @@ static void storeDigestRebuildStart(void *datanotused);
 static void storeDigestRebuildResume(void);
 static void storeDigestRebuildFinish(void);
 static void storeDigestRebuildStep(void *datanotused);
-static void storeDigestRewriteStart(void *);
+static EVH storeDigestRewriteStart;
 static void storeDigestRewriteResume(void);
 static void storeDigestRewriteFinish(StoreEntry * e);
 static EVH storeDigestSwapOutStep;
@@ -480,7 +480,7 @@ storeDigestRewriteFinish(StoreEntry * e)
     sd_state.rewrite_lock = NULL;
     ++sd_state.rewrite_count;
     eventAdd("storeDigestRewriteStart", storeDigestRewriteStart, e, (double)
-             Config.digest.rewrite_period, 1);
+             Config.digest.rewrite_period, 1, false);
     /* resume pending Rebuild if any */
 
     if (sd_state.rebuild_lock)

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -50,7 +50,6 @@ void StoreEntry::swapOutFileClose(int how) STUB
 const char *StoreEntry::url() const STUB_RETVAL(NULL)
 bool StoreEntry::checkCachable() STUB_RETVAL(false)
 int StoreEntry::checkNegativeHit() const STUB_RETVAL(0)
-int StoreEntry::locked() const STUB_RETVAL(0)
 int StoreEntry::validToSend() const STUB_RETVAL(0)
 bool StoreEntry::memoryCachable() STUB_RETVAL(false)
 void StoreEntry::createMemObject() STUB


### PR DESCRIPTION
When writing a newly generated Cache Digest to cache, Squid relied on a
cache key collision to purge the old digest entry. Since 4310f8b, the
collision resolution method -- forcePublicKey() -- leaked an idle (i.e.
lock_count=0) digest entry. If Squid still had unlocked entries lying
around, then the problem could extend to clashes unrelated to Digests.

Until 4310f8b, StoreEntry::forcePublicKey() called setPrivateKey()
before releasing the old entry. That explicit call was wasteful in many
cases, but, unbeknownst to its removal authors, it allowed release() to
destroy an idle Cache Digest entry by effectively disabling the
ENTRY_SPECIAL hack in StoreEntry::locked().

This change removes the ENTRY_SPECIAL hack in StoreEntry::locked(),
addressing an old TODO. The two ENTRY_SPECIAL creators (icons and Cache
Digests) now lock their entries to prevent their unwanted destruction.

Also explicitly release the old Cache Digest entry (instead of relying
on the implicit key collision) to avoid the unchecked assumption that
the Cache Digest key never changes.
