### PR TITLE
Send HTTP/500 (Internal Server Error) when lacking peers

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -445,7 +445,7 @@ FwdState::useDestinations()
 
         debugs(17, 3, HERE << "Connection failed: " << entry->url());
         if (!err) {
-            const auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
+            const auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al);
             fail(anErr);
         } // else use actual error from last connection attempt
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -445,7 +445,7 @@ FwdState::useDestinations()
 
         debugs(17, 3, HERE << "Connection failed: " << entry->url());
         if (!err) {
-            const auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request, al);
+            const auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
             fail(anErr);
         } // else use actual error from last connection attempt
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1078,7 +1078,7 @@ TunnelStateData::noteDestinationsEnd(ErrorState *selectionError)
         if (savedError)
             return sendError(savedError, "all found paths have failed");
 
-        return sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al),
+        return sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al),
                          "path selection found no paths");
     }
     // else continue to use one of the previously noted destinations;


### PR DESCRIPTION
... instead of sending HTTP/503 (Service Unavailable) in
tunneling cases.

Tunneling code reported 503 while regular forwarding code reported 500
errors under identical "no peers to try" circumstances.

For consistency sake, we need to use one of these codes in both places.
We considered and rejected 503 because RFC7231 limits its usage to
several specific cases, not including 'lacking peers' case.