### PR TITLE
Hash Digest noncedata

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -115,7 +115,7 @@ authDigestNonceEncode(digest_nonce_h * nonce)
     SquidMD5Final((unsigned char *) H, &Md5Ctx);
 
     nonce->key = xcalloc(sizeof(HASHHEX), 1);
-    CvtHex(H, reinterpret_cast<char *>(nonce->key));
+    CvtHex(H, static_cast<char *>(nonce->key));
 }
 
 digest_nonce_h *

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -112,7 +112,7 @@ authDigestNonceEncode(digest_nonce_h * nonce)
     HASH H;
     SquidMD5Init(&Md5Ctx);
     SquidMD5Update(&Md5Ctx, reinterpret_cast<const uint8_t *>(&nonce->noncedata), sizeof(nonce->noncedata));
-    SquidMD5Final((unsigned char *) H, &Md5Ctx);
+    SquidMD5Final(reinterpret_cast<uint8_t *>(H), &Md5Ctx);
 
     nonce->key = xcalloc(sizeof(HASHHEX), 1);
     CvtHex(H, static_cast<char *>(nonce->key));

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -29,7 +29,7 @@ class User;
 typedef struct _digest_nonce_data digest_nonce_data;
 typedef struct _digest_nonce_h digest_nonce_h;
 
-/* data to be encoded into the nonce's b64 representation */
+/* data to be encoded into the nonce's hex representation */
 struct _digest_nonce_data {
     time_t creationtime;
     /* in memory address of the nonce struct (similar purpose to an ETag) */
@@ -58,7 +58,7 @@ struct _digest_nonce_h : public hash_link {
 void authDigestNonceUnlink(digest_nonce_h * nonce);
 int authDigestNonceIsValid(digest_nonce_h * nonce, char nc[9]);
 int authDigestNonceIsStale(digest_nonce_h * nonce);
-const char *authenticateDigestNonceNonceb64(const digest_nonce_h * nonce);
+const char *authenticateDigestNonceNonceHex(const digest_nonce_h * nonce);
 int authDigestNonceLastRequest(digest_nonce_h * nonce);
 void authenticateDigestNonceShutdown(void);
 void authDigestNoncePurge(digest_nonce_h * nonce);

--- a/src/auth/digest/UserRequest.h
+++ b/src/auth/digest/UserRequest.h
@@ -44,7 +44,7 @@ public:
     virtual void startHelperLookup(HttpRequest *request, AccessLogEntry::Pointer &al, AUTHCB *, void *);
     virtual const char *credentialsStr();
 
-    char *nonceb64;             /* "dcd98b7102dd2f0e8b11d0f600bfb0c093" */
+    char *noncehex;             /* "dcd98b7102dd2f0e8b11d0f600bfb0c093" */
     char *cnonce;               /* "0a4f113b" */
     char *realm;                /* = "testrealm@host.com" */
     char *pszPass;              /* = "Circle Of Life" */


### PR DESCRIPTION
These commits together
1. Hash the noncedata for Digest nonces before encoding,
   to match the documentation.
2. Encode Digest nonces using hex, rather than base64.