### PR TITLE
Fix build after ccfbe8f (Report context of cache.log messages)

### DIFF
--- a/src/base/InstanceId.cc
+++ b/src/base/InstanceId.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 1996-2019 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "base/InstanceId.h"
+
+#include <iostream>
+
+std::ostream&
+operator <<(std::ostream &os, const ScopedId &id)
+{
+    if (id.value)
+        os << id.scope << id.value;
+    else if (id.scope)
+        os << id.scope;
+    else
+        os << "[unknown]";
+    return os;
+}
+

--- a/src/base/InstanceId.h
+++ b/src/base/InstanceId.h
@@ -32,17 +32,7 @@ public:
     uint64_t value;
 };
 
-inline std::ostream&
-operator <<(std::ostream &os, const ScopedId &id)
-{
-    if (id.value)
-        os << id.scope << id.value;
-    else if (id.scope)
-        os << id.scope;
-    else
-        os << "[unknown]";
-    return os;
-}
+std::ostream &operator <<(std::ostream &os, const ScopedId &id);
 
 typedef unsigned int InstanceIdDefaultValueType;
 /** Identifier for class instances

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -33,6 +33,7 @@ libbase_la_SOURCES = \
 	HardFun.h \
 	Here.cc \
 	Here.h \
+	InstanceId.cc \
 	InstanceId.h \
 	Lock.h \
 	LookupTable.h \


### PR DESCRIPTION
In some environments (e.g., Ubuntu 14 without libcppunit-dev), GCC
correctly complained that it does not know how to print "[unknown]",
probably because none of the other headers imported `<ostream>` before
importing base/InstanceId.h.