### PR TITLE
Preserve caller context across DNS lookups

### DIFF
--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -1110,6 +1110,7 @@ idnsCallbackNewCallerWithOldAnswers(IDNSCB *callback, void *cbdata, const idns_q
     for (auto query = master; query; query = query->slave) {
         if (query->pending)
             continue; // no answer yet
+        // no CallBack(CodeContext...) -- we always run in requestor's context
         if (!idnsCallbackOneWithAnswer(callback, cbdata, *query, lastAnswer))
             break; // the caller disappeared
     }

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -1123,7 +1123,7 @@ idnsCallbackAllCallersWithNewAnswer(const idns_query * const answered, const boo
     for (auto looker = master; looker; looker = looker->queue) {
         CallBack(looker->codeContext, [&] {
             (void)idnsCallbackOneWithAnswer(looker->callback, looker->callback_data,
-                    *answered, lastAnswer);
+            *answered, lastAnswer);
         });
     }
 }

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -104,7 +104,9 @@ class idns_query
     CBDATA_CLASS(idns_query);
 
 public:
-    idns_query() : codeContext(CodeContext::Current()) {
+    idns_query():
+        codeContext(CodeContext::Current())
+    {
         callback = nullptr;
         memset(&query, 0, sizeof(query));
         *buf = 0;

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -144,8 +144,11 @@ public:
     struct timeval sent_t;
     struct timeval queue_t;
     dlink_node lru;
+
     IDNSCB *callback;
     void *callback_data = nullptr;
+    CodeContext::Pointer codeContext; ///< requestor's context
+
     int attempt = 0;
     int rcode = 0;
     idns_query *queue = nullptr;
@@ -156,8 +159,6 @@ public:
     rfc1035_message *message = nullptr;
     int ancount = 0;
     const char *error = nullptr;
-
-    CodeContext::Pointer codeContext; ///< requestor's context
 };
 
 InstanceIdDefinitions(idns_query,  "dns");


### PR DESCRIPTION
For now, the context is restored when communicating with _individual_
callers waiting for their DNS lookup results. Eventually, we might also
support establishing a multi-caller context during DNS answer parsing,
before individual callers are notified. That feature would most likely
require making idns_query refcount-based (a serious change). Or we could
realize that maintaining a very basic query ID-based context is enough.