### PR TITLE
Preserve caller context across Happy Eyeballs connection attempts

### DIFF
--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -64,6 +64,8 @@ public:
     /// The current peer has no spares left to try.
     /// Prime exhaustion ends this wait (by changing currentPeer).
     bool forNewPeer = false;
+
+    CodeContext::Pointer codeContext; ///< requestor's context
 };
 
 /// Final result (an open connection or an error) sent to the job initiator.

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -38,6 +38,8 @@ public:
     /// nullifies but does not cancel the callback
     void clear() { *this = HappySpareWait(); }
 
+    CodeContext::Pointer codeContext; ///< requestor's context
+
     /// a pending noteGavePrimeItsChance() or noteSpareAllowance() call
     AsyncCall::Pointer callback;
 
@@ -64,8 +66,6 @@ public:
     /// The current peer has no spares left to try.
     /// Prime exhaustion ends this wait (by changing currentPeer).
     bool forNewPeer = false;
-
-    CodeContext::Pointer codeContext; ///< requestor's context
 };
 
 /// Final result (an open connection or an error) sent to the job initiator.


### PR DESCRIPTION
To efficiently enforce various global and local limits, Happy Eyeballs
jobs uses two stand-alone HappyOrderEnforcer services that create job
calls. Thus, they need manual adjustments to preserve job context.

If similar changes are required in many places, we may want to add a
CodeContext member to the AsyncJob itself so that callbacks can
magically restore their context without service modifications (assuming
the job was created in or somehow provided the right context before
those callbacks).