### PR TITLE
Fix expiration of self-signed generated certs to be 3 years

### DIFF
--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -504,7 +504,7 @@ static bool buildCertificate(Security::CertPointer & cert, Ssl::CertificatePrope
     if (aTime) {
         if (!X509_set1_notAfter(cert.get(), aTime))
             return false;
-    } else if (!X509_gmtime_adj(X509_getm_notAfter(cert.get()), 60*60*24*356*3))
+    } else if (!X509_gmtime_adj(X509_getm_notAfter(cert.get()), 60*60*24*365*3))
         return false;
 
     int addedExtensions = 0;


### PR DESCRIPTION
Generated self-signed certificates lifetime was incorrectly set to 
356*3 days, which is approximately 27 days shorter than 3 years.

The fixed problem does not affect Squids using "sslproxy_cert_adapt
setValidAfter" and Squids using a configured signing CA certificate.
