### PR TITLE
Happy Eyeballs: Do not wait for already exhausted spares

### DIFF
--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -65,14 +65,11 @@ ResolvedPeers::findSpareOrNextPeer(const Comm::Connection &currentPeer)
     const auto familyToAvoid = ConnectionFamily(currentPeer);
     // Optimization: Also stop at the first mismatching peer because all
     // same-peer paths are grouped together.
-    auto found = std::find_if(paths_.begin(), paths_.end(),
+    return std::find_if(paths_.begin(), paths_.end(),
     [peerToMatch, familyToAvoid](const Comm::ConnectionPointer &conn) {
         return peerToMatch != conn->getPeer() ||
                familyToAvoid != ConnectionFamily(*conn);
     });
-    if (found != paths_.end() && peerToMatch == (*found)->getPeer())
-        return found;
-    return paths_.end();
 }
 
 Comm::ConnectionPointer


### PR DESCRIPTION
ResolvedPeers::findSpareOrNextPeer() never returned the next peer. That
bug made doneWithSpares() return false when the next peer was present,
even though no spares were expected. The exact effects of this bug are
not known, but wrong false doneWithSpares() outcome may force Squid to
wait for more spare addresses that would never come, possibly slowing
down transactions.