### PR TITLE
Add http_port sslflags=CONDITIONAL_AUTH

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2365,8 +2365,10 @@ DOC_START
 				immediately, but wait until acl processing
 				requires a certificate (not yet implemented).
 			    CONDITIONAL_AUTH
-				Do not fail auth if client certificate is
-				not provided.
+				Request a client certificate during the TLS
+				handshake, but ignore certificate absence in
+				the TLS client Hello. If the client does
+				supply a certificate, it is validated.
 			    NO_SESSION_REUSE
 				Don't allow for session reuse. Each connection
 				will result in a new SSL session.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2364,6 +2364,9 @@ DOC_START
 				Don't request client certificates
 				immediately, but wait until acl processing
 				requires a certificate (not yet implemented).
+			    CONDITIONAL_AUTH
+				Do not fail auth if client certificate is
+				not provided.
 			    NO_SESSION_REUSE
 				Don't allow for session reuse. Each connection
 				will result in a new SSL session.

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -539,7 +539,7 @@ Security::PeerOptions::parseOptions()
 /**
  * Parses the TLS flags squid.conf parameter
  */
-long
+Security::ParsedPortFlags
 Security::PeerOptions::parseFlags()
 {
     if (sslFlags.isEmpty())
@@ -547,7 +547,7 @@ Security::PeerOptions::parseFlags()
 
     static struct {
         SBuf label;
-        long mask;
+        ParsedPortFlags mask;
     } flagTokens[] = {
         { SBuf("NO_DEFAULT_CA"), SSL_FLAG_NO_DEFAULT_CA },
         { SBuf("DELAYED_AUTH"), SSL_FLAG_DELAYED_AUTH },
@@ -565,9 +565,9 @@ Security::PeerOptions::parseFlags()
     ::Parser::Tokenizer tok(sslFlags);
     static const CharacterSet delims("Flag-delimiter", ":,");
 
-    long fl = 0;
+    ParsedPortFlags fl = 0;
     do {
-        long found = 0;
+        ParsedPortFlags found = 0;
         for (size_t i = 0; flagTokens[i].mask; ++i) {
             if (tok.skip(flagTokens[i].label)) {
                 found = flagTokens[i].mask;

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -569,6 +569,7 @@ Security::PeerOptions::parseFlags()
     do {
         ParsedPortFlags found = 0;
         for (size_t i = 0; flagTokens[i].mask; ++i) {
+            // XXX: skips FOO in FOOBAR, missing merged flags and trailing typos
             if (tok.skip(flagTokens[i].label)) {
                 found = flagTokens[i].mask;
                 break;
@@ -587,7 +588,7 @@ Security::PeerOptions::parseFlags()
 
     if ((fl & (SSL_FLAG_DONT_VERIFY_PEER|SSL_FLAG_CONDITIONAL_AUTH)) ==
         (SSL_FLAG_DONT_VERIFY_PEER|SSL_FLAG_CONDITIONAL_AUTH))
-        fatal("ERROR: DONT_VERIFY_PEER and CONDITIONAL_AUTH are mutually exclusive");
+        throw TextException("DONT_VERIFY_PEER and CONDITIONAL_AUTH are mutually exclusive", Here());
 
     return fl;
 }

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -552,6 +552,7 @@ Security::PeerOptions::parseFlags()
         { SBuf("NO_DEFAULT_CA"), SSL_FLAG_NO_DEFAULT_CA },
         { SBuf("DELAYED_AUTH"), SSL_FLAG_DELAYED_AUTH },
         { SBuf("DONT_VERIFY_PEER"), SSL_FLAG_DONT_VERIFY_PEER },
+        { SBuf("CONDITIONAL_AUTH"), SSL_FLAG_CONDITIONAL_AUTH },
         { SBuf("DONT_VERIFY_DOMAIN"), SSL_FLAG_DONT_VERIFY_DOMAIN },
         { SBuf("NO_SESSION_REUSE"), SSL_FLAG_NO_SESSION_REUSE },
 #if X509_V_FLAG_CRL_CHECK
@@ -583,6 +584,10 @@ Security::PeerOptions::parseFlags()
         } else
             fl |= found;
     } while (tok.skipOne(delims));
+
+    if ((fl & (SSL_FLAG_DONT_VERIFY_PEER|SSL_FLAG_CONDITIONAL_AUTH)) ==
+        (SSL_FLAG_DONT_VERIFY_PEER|SSL_FLAG_CONDITIONAL_AUTH))
+        fatal("ERROR: DONT_VERIFY_PEER and CONDITIONAL_AUTH are mutually exclusive");
 
     return fl;
 }

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -98,7 +98,7 @@ private:
     bool optsReparse = true;
 
 public:
-    ParsedPortFlags parsedFlags = 0;   ///< parsed value of sslFlags
+    ParsedPortFlags parsedFlags = 0; ///< parsed value of sslFlags
 
     std::list<Security::KeyData> certs; ///< details from the cert= and file= config parameters
     std::list<SBuf> caFiles;  ///< paths of files containing trusted Certificate Authority

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -11,6 +11,7 @@
 
 #include "base/YesNoNone.h"
 #include "ConfigParser.h"
+#include "security/forward.h"
 #include "security/KeyData.h"
 
 class Packable;
@@ -69,7 +70,7 @@ public:
     virtual void dumpCfg(Packable *, const char *pfx) const;
 
 private:
-    long parseFlags();
+    ParsedPortFlags parseFlags();
     void loadCrlFile();
     void loadKeysFile();
 
@@ -97,7 +98,7 @@ private:
     bool optsReparse = true;
 
 public:
-    long parsedFlags = 0;   ///< parsed value of sslFlags
+    ParsedPortFlags parsedFlags = 0;   ///< parsed value of sslFlags
 
     std::list<Security::KeyData> certs; ///< details from the cert= and file= config parameters
     std::list<SBuf> caFiles;  ///< paths of files containing trusted Certificate Authority

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -430,20 +430,13 @@ Security::ServerOptions::updateContextClientCa(Security::ContextPointer &ctx)
             return;
         }
 
-        if (parsedFlags & SSL_FLAG_DELAYED_AUTH) {
-            debugs(83, 9, "Not requesting client certificates until acl processing requires one");
-            SSL_CTX_set_verify(ctx.get(), SSL_VERIFY_NONE, nullptr);
-        } else {
-            debugs(83, 9, "Requiring client certificates.");
-            Ssl::SetupVerifyCallback(ctx);
-        }
+        Ssl::ConfigurePeerVerification(ctx, parsedFlags);
 
         updateContextCrl(ctx);
         updateContextTrust(ctx);
 
     } else {
-        debugs(83, 9, "Not requiring any client certificates");
-        SSL_CTX_set_verify(ctx.get(), SSL_VERIFY_NONE, NULL);
+        Ssl::DisablePeerVerification(ctx);
     }
 #endif
 }

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -137,6 +137,11 @@ typedef std::shared_ptr<struct gnutls_priority_st> ParsedOptions;
 class ParsedOptions {}; // we never parse/use TLS options in this case
 #endif
 
+/// bitmask representing configured http(s)_port `sslflags`
+/// as well tls_outgoing_options `flags`, cache_peer `sslflags`, and
+/// icap_service `tls-flags`
+typedef long ParsedPortFlags;
+
 class PeerConnector;
 class PeerOptions;
 

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -49,6 +49,7 @@
 #define SSL_FLAG_NO_SESSION_REUSE   (1<<4)
 #define SSL_FLAG_VERIFY_CRL         (1<<5)
 #define SSL_FLAG_VERIFY_CRL_ALL     (1<<6)
+#define SSL_FLAG_CONDITIONAL_AUTH   (1<<7)
 
 /// Network/connection security abstraction layer
 namespace Security

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -413,7 +413,7 @@ Ssl::ConfigurePeerVerification(Security::ContextPointer &ctx, const Security::Pa
         mode = SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
     }
 
-    SSL_CTX_set_verify(ctx.get(),mode,(mode != SSL_VERIFY_NONE) ? ssl_verify_cb : nullptr);
+    SSL_CTX_set_verify(ctx.get(), mode, (mode != SSL_VERIFY_NONE) ? ssl_verify_cb : nullptr);
 }
 
 void
@@ -1330,3 +1330,4 @@ BIO *Ssl::BIO_new_SBuf(SBuf *buf)
 }
 
 #endif /* USE_OPENSSL */
+

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -390,7 +390,7 @@ ssl_verify_cb(int ok, X509_STORE_CTX * ctx)
 }
 
 void
-Ssl::ConfigurePeerVerification(Security::ContextPointer &ctx, int flags)
+Ssl::ConfigurePeerVerification(Security::ContextPointer &ctx, const Security::ParsedPortFlags flags)
 {
     int mode;
 
@@ -559,7 +559,7 @@ Ssl::InitServerContext(Security::ContextPointer &ctx, AnyP::PortCfg &port)
 }
 
 bool
-Ssl::InitClientContext(Security::ContextPointer &ctx, Security::PeerOptions &peer, long fl)
+Ssl::InitClientContext(Security::ContextPointer &ctx, Security::PeerOptions &peer, Security::ParsedPortFlags fl)
 {
     if (!ctx)
         return false;

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -394,10 +394,7 @@ Ssl::ConfigurePeerVerification(Security::ContextPointer &ctx, const Security::Pa
 {
     int mode;
 
-    if ((flags & (SSL_FLAG_DONT_VERIFY_PEER|SSL_FLAG_CONDITIONAL_AUTH)) ==
-        (SSL_FLAG_DONT_VERIFY_PEER|SSL_FLAG_CONDITIONAL_AUTH))
-        throw TextException("ERROR: DONT_VERIFY_PEER and CONDITIONAL_AUTH are mutually exclusive", Here());
-
+    // assume each flag is exclusive; flags creator must check this assumption
     if (flags & SSL_FLAG_DONT_VERIFY_PEER) {
         debugs(83, DBG_IMPORTANT, "SECURITY WARNING: Peer certificates are not verified for validity!");
         debugs(83, DBG_IMPORTANT, "UPGRADE NOTICE: The DONT_VERIFY_PEER flag is deprecated. Remove the clientca= option to disable client certificates.");

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -86,7 +86,8 @@ bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &);
 bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, long flags);
 
 /// set the certificate verify callback for a context
-void SetupVerifyCallback(Security::ContextPointer &);
+void ConfigurePeerVerification(Security::ContextPointer &, int);
+void DisablePeerVerification(Security::ContextPointer &);
 
 /// if required, setup callback for generating ephemeral RSA keys
 void MaybeSetupRsaCallback(Security::ContextPointer &);

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -83,10 +83,10 @@ typedef RefCount<CertValidationResponse> CertValidationResponsePointer;
 bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &);
 
 /// initialize a TLS client context with OpenSSL specific settings
-bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, long flags);
+bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, Security::ParsedPortFlags);
 
 /// set the certificate verify callback for a context
-void ConfigurePeerVerification(Security::ContextPointer &, int);
+void ConfigurePeerVerification(Security::ContextPointer &, const Security::ParsedPortFlags);
 void DisablePeerVerification(Security::ContextPointer &);
 
 /// if required, setup callback for generating ephemeral RSA keys

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -53,8 +53,8 @@ namespace Ssl
 {
 int AskPasswordCb(char *, int, int, void *) STUB_RETVAL(0)
 bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &) STUB_RETVAL(false)
-bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, const char *) STUB_RETVAL(false)
-void ConfigurePeerVerification(Security::ContextPointer &, int) STUB
+bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, Security::ParsedPortFlags) STUB_RETVAL(false)
+void ConfigurePeerVerification(Security::ContextPointer &, const Security::ParsedPortFlags) STUB
 void DisablePeerVerification(Security::ContextPointer &) STUB
 void MaybeSetupRsaCallback(Security::ContextPointer &) STUB
 } // namespace Ssl

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -54,7 +54,8 @@ namespace Ssl
 int AskPasswordCb(char *, int, int, void *) STUB_RETVAL(0)
 bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &) STUB_RETVAL(false)
 bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, const char *) STUB_RETVAL(false)
-void SetupVerifyCallback(Security::ContextPointer &) STUB
+void ConfigurePeerVerification(Security::ContextPointer &, int) STUB
+void DisablePeerVerification(Security::ContextPointer &) STUB
 void MaybeSetupRsaCallback(Security::ContextPointer &) STUB
 } // namespace Ssl
 const char *sslGetUserEmail(SSL *ssl) STUB_RETVAL(NULL)


### PR DESCRIPTION
Enabling this flag removes SSL_VERIFY_FAIL_IF_NO_PEER_CERT from the
SSL_CTX_set_verify callback. Meaning a client certificate verify
occurs iff provided.