### PR TITLE
Fix Security::ServerOptions copy-constructor

### DIFF
--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -35,6 +35,7 @@ public:
         // is more secure to have only a small set of trusted CA.
         flags.tlsDefaultCa.defaultTo(false);
     }
+    ServerOptions(const ServerOptions &o): ServerOptions() { *this = o; }
     ServerOptions &operator =(const ServerOptions &);
     ServerOptions(ServerOptions &&o) { this->operator =(o); }
     ServerOptions &operator =(ServerOptions &&o) { this->operator =(o); return *this; }

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -35,7 +35,6 @@ public:
         // is more secure to have only a small set of trusted CA.
         flags.tlsDefaultCa.defaultTo(false);
     }
-    ServerOptions(const ServerOptions &) = default;
     ServerOptions &operator =(const ServerOptions &);
     ServerOptions(ServerOptions &&o) { this->operator =(o); }
     ServerOptions &operator =(ServerOptions &&o) { this->operator =(o); return *this; }


### PR DESCRIPTION
clientCaStack uses a std::unique_ptr which cannot be copied.