### PR TITLE
Bug 5009: Build failure with older clang libc++

### DIFF
--- a/src/acl/Options.cc
+++ b/src/acl/Options.cc
@@ -246,14 +246,14 @@ Acl::ParseFlags(const Options &options, const ParameterFlags &flags)
 const Acl::Options &
 Acl::NoOptions()
 {
-    static const Options none = {};
+    static const Options none;
     return none;
 }
 
 const Acl::ParameterFlags &
 Acl::NoFlags()
 {
-    static const ParameterFlags none = {};
+    static const ParameterFlags none;
     return none;
 }
 


### PR DESCRIPTION
Older clang libc++ implementations correctly reject implicit usage of an
explicit (in C++11) std::map copy constructor with "chosen constructor
is explicit in copy-initialization" errors. The same code becomes legal
in C++14[1], so newer libc++ implementation allow implicit usage (even
in C++11), but there is no need for copy-initialization here at all.
Evidently, libstdc++ has never declared constructors explicit.

The bug was seen with Apple clang in Xcode 5.1.1 (roughly upstream clang
3.4) and Xcode 6.2 (roughly upstream clang 3.5), both using libc++.

[1] http://cplusplus.github.io/LWG/lwg-defects.html#2193