### PR TITLE
Bug 5008: SIGBUS in PagePool::level() with custom rock slot size

### DIFF
--- a/src/ipc/mem/PagePool.cc
+++ b/src/ipc/mem/PagePool.cc
@@ -28,7 +28,7 @@ Ipc::Mem::PagePool::PagePool(const char *const id):
     pageIndex(shm_old(PageStack)(id)),
     theLevels(reinterpret_cast<Levels_t *>(
                   reinterpret_cast<char *>(pageIndex.getRaw()) +
-                  pageIndex->stackSize() + pageIndex->paddingSize())),
+                  pageIndex->stackSize() + pageIndex->levelsPaddingSize())),
     theBuf(reinterpret_cast<char *>(theLevels + PageId::maxPurpose))
 {
 }

--- a/src/ipc/mem/PagePool.cc
+++ b/src/ipc/mem/PagePool.cc
@@ -26,9 +26,9 @@ Ipc::Mem::PagePool::Init(const char *const id, const unsigned int capacity, cons
 
 Ipc::Mem::PagePool::PagePool(const char *const id):
     pageIndex(shm_old(PageStack)(id)),
-    theLevels(reinterpret_cast<Levels_t *>(
+    theLevels(reinterpret_cast<Ipc::Mem::PageStack::Levels_t *>(
                   reinterpret_cast<char *>(pageIndex.getRaw()) +
-                  pageIndex->stackSize())),
+                  pageIndex->stackSize() + pageIndex->paddingSize())),
     theBuf(reinterpret_cast<char *>(theLevels + PageId::maxPurpose))
 {
 }

--- a/src/ipc/mem/PagePool.cc
+++ b/src/ipc/mem/PagePool.cc
@@ -26,7 +26,7 @@ Ipc::Mem::PagePool::Init(const char *const id, const unsigned int capacity, cons
 
 Ipc::Mem::PagePool::PagePool(const char *const id):
     pageIndex(shm_old(PageStack)(id)),
-    theLevels(reinterpret_cast<Ipc::Mem::PageStack::Levels_t *>(
+    theLevels(reinterpret_cast<Levels_t *>(
                   reinterpret_cast<char *>(pageIndex.getRaw()) +
                   pageIndex->stackSize() + pageIndex->paddingSize())),
     theBuf(reinterpret_cast<char *>(theLevels + PageId::maxPurpose))

--- a/src/ipc/mem/PagePool.h
+++ b/src/ipc/mem/PagePool.h
@@ -49,9 +49,9 @@ public:
 
 private:
     Ipc::Mem::Pointer<PageStack> pageIndex; ///< free pages index
-    typedef std::atomic<size_t> Levels_t;
+    
     /// number of shared memory pages used now for each purpose
-    Levels_t * const theLevels;
+    Ipc::Mem::PageStack::Levels_t * const theLevels;
     char *const theBuf; ///< pages storage
 };
 

--- a/src/ipc/mem/PagePool.h
+++ b/src/ipc/mem/PagePool.h
@@ -49,9 +49,10 @@ public:
 
 private:
     Ipc::Mem::Pointer<PageStack> pageIndex; ///< free pages index
+    using Levels_t = PageStack::Levels_t;
     
     /// number of shared memory pages used now for each purpose
-    Ipc::Mem::PageStack::Levels_t * const theLevels;
+    Levels_t * const theLevels;
     char *const theBuf; ///< pages storage
 };
 

--- a/src/ipc/mem/PagePool.h
+++ b/src/ipc/mem/PagePool.h
@@ -50,7 +50,7 @@ public:
 private:
     Ipc::Mem::Pointer<PageStack> pageIndex; ///< free pages index
     using Levels_t = PageStack::Levels_t;
-    
+
     /// number of shared memory pages used now for each purpose
     Levels_t * const theLevels;
     char *const theBuf; ///< pages storage

--- a/src/ipc/mem/PageStack.cc
+++ b/src/ipc/mem/PageStack.cc
@@ -124,7 +124,7 @@ Ipc::Mem::PageStack::SharedMemorySize(const uint32_t, const unsigned int capacit
 {
     const size_t levelsSize = PageId::maxPurpose * sizeof(std::atomic<Ipc::Mem::PageStack::Value>);
     const size_t pagesDataSize = capacity * pageSize;
-    return StackSize(capacity) + PaddingSize(capacity) + levelsSize + pagesDataSize;
+    return StackSize(capacity) + LevelsPaddingSize(capacity) + levelsSize + pagesDataSize;
 }
 
 size_t
@@ -140,15 +140,9 @@ Ipc::Mem::PageStack::stackSize() const
 }
 
 size_t
-Ipc::Mem::PageStack::PaddingSize(const unsigned int capacity)
+Ipc::Mem::PageStack::LevelsPaddingSize(const unsigned int capacity)
 {
      const auto displacement = StackSize(capacity) % alignof(Levels_t);
      return displacement ? alignof(Levels_t) - displacement : 0;
-}
-
-size_t
-Ipc::Mem::PageStack::paddingSize() const
-{
-    return PaddingSize(theCapacity);
 }
 

--- a/src/ipc/mem/PageStack.cc
+++ b/src/ipc/mem/PageStack.cc
@@ -124,7 +124,7 @@ Ipc::Mem::PageStack::SharedMemorySize(const uint32_t, const unsigned int capacit
 {
     const size_t levelsSize = PageId::maxPurpose * sizeof(std::atomic<Ipc::Mem::PageStack::Value>);
     const size_t pagesDataSize = capacity * pageSize;
-    return StackSize(capacity) + PaddingSize(capacity) + pagesDataSize + levelsSize;
+    return StackSize(capacity) + PaddingSize(capacity) + levelsSize + pagesDataSize;
 }
 
 size_t

--- a/src/ipc/mem/PageStack.cc
+++ b/src/ipc/mem/PageStack.cc
@@ -124,7 +124,7 @@ Ipc::Mem::PageStack::SharedMemorySize(const uint32_t, const unsigned int capacit
 {
     const size_t levelsSize = PageId::maxPurpose * sizeof(std::atomic<Ipc::Mem::PageStack::Value>);
     const size_t pagesDataSize = capacity * pageSize;
-    return StackSize(capacity) + pagesDataSize + levelsSize;
+    return StackSize(capacity) + PaddingSize(capacity) + pagesDataSize + levelsSize;
 }
 
 size_t
@@ -137,5 +137,17 @@ size_t
 Ipc::Mem::PageStack::stackSize() const
 {
     return StackSize(theCapacity);
+}
+
+size_t
+Ipc::Mem::PageStack::PaddingSize(const unsigned int capacity)
+{
+     return StackSize(capacity) % alignof(Levels_t) == 0 ? 0 : alignof(Levels_t) - StackSize(capacity) % alignof(Levels_t);
+}
+
+size_t
+Ipc::Mem::PageStack::paddingSize() const
+{
+    return PaddingSize(theCapacity);
 }
 

--- a/src/ipc/mem/PageStack.cc
+++ b/src/ipc/mem/PageStack.cc
@@ -142,7 +142,7 @@ Ipc::Mem::PageStack::stackSize() const
 size_t
 Ipc::Mem::PageStack::LevelsPaddingSize(const unsigned int capacity)
 {
-     const auto displacement = StackSize(capacity) % alignof(Levels_t);
-     return displacement ? alignof(Levels_t) - displacement : 0;
+    const auto displacement = StackSize(capacity) % alignof(Levels_t);
+    return displacement ? alignof(Levels_t) - displacement : 0;
 }
 

--- a/src/ipc/mem/PageStack.cc
+++ b/src/ipc/mem/PageStack.cc
@@ -142,7 +142,8 @@ Ipc::Mem::PageStack::stackSize() const
 size_t
 Ipc::Mem::PageStack::PaddingSize(const unsigned int capacity)
 {
-     return StackSize(capacity) % alignof(Levels_t) == 0 ? 0 : alignof(Levels_t) - StackSize(capacity) % alignof(Levels_t);
+     const auto displacement = StackSize(capacity) % alignof(Levels_t);
+     return displacement ? alignof(Levels_t) - displacement : 0;
 }
 
 size_t

--- a/src/ipc/mem/PageStack.h
+++ b/src/ipc/mem/PageStack.h
@@ -53,8 +53,7 @@ public:
     static size_t StackSize(const unsigned int capacity);
     size_t stackSize() const;
     
-    /// padding a certain number of bytes to 
-    /// initialize TheLevels on the alignment boundary
+    /// \returns the number of padding bytes to align PagePool::theLevels array
     static size_t LevelsPaddingSize(const unsigned int capacity);
     size_t levelsPaddingSize() const { return LevelsPaddingSize(theCapacity); }
 

--- a/src/ipc/mem/PageStack.h
+++ b/src/ipc/mem/PageStack.h
@@ -55,8 +55,8 @@ public:
     
     /// padding a certain number of bytes to 
     /// initialize TheLevels on the alignment boundary
-    static size_t PaddingSize(const unsigned int capacity);
-    size_t paddingSize() const;
+    static size_t LevelsPaddingSize(const unsigned int capacity);
+    size_t levelsPaddingSize() const { return LevelsPaddingSize(theCapacity); }
 
 
 private:

--- a/src/ipc/mem/PageStack.h
+++ b/src/ipc/mem/PageStack.h
@@ -52,11 +52,10 @@ public:
     /// shared counters and page data
     static size_t StackSize(const unsigned int capacity);
     size_t stackSize() const;
-    
+
     /// \returns the number of padding bytes to align PagePool::theLevels array
     static size_t LevelsPaddingSize(const unsigned int capacity);
     size_t levelsPaddingSize() const { return LevelsPaddingSize(theCapacity); }
-
 
 private:
     /// stack index and size type (may temporary go negative)

--- a/src/ipc/mem/PageStack.h
+++ b/src/ipc/mem/PageStack.h
@@ -28,6 +28,7 @@ class PageStack
 {
 public:
     typedef uint32_t Value; ///< stack item type (a free page number)
+    typedef std::atomic<size_t> Levels_t;
 
     PageStack(const uint32_t aPoolId, const unsigned int aCapacity, const size_t aPageSize);
 
@@ -51,6 +52,12 @@ public:
     /// shared counters and page data
     static size_t StackSize(const unsigned int capacity);
     size_t stackSize() const;
+    
+    /// padding a certain number of bytes to 
+    /// initialize TheLevels on the alignment boundary
+    static size_t PaddingSize(const unsigned int capacity);
+    size_t paddingSize() const;
+
 
 private:
     /// stack index and size type (may temporary go negative)


### PR DESCRIPTION
SMP Squids were crashing on arm64 due to incorrect memory alignment of
Ipc::Mem::PagePool::theLevels array. The relative position of the array
depends on the number of workers and the number of pages (influenced by
the cache capacity and slot size), so some configurations worked OK.

We have to manually align manually positioned fields inside shared
memory segments. Thankfully, C++11 provides alignment-computing APIs.