### PR TITLE
Do not stall if xactions overwrite a recently active cache entry

### DIFF
--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -251,6 +251,13 @@ Transients::addEntry(StoreEntry *e, const cache_key *key, const Store::IoStatus 
     }
 }
 
+bool
+Transients::hasWriter(const StoreEntry &e) {
+    if (!e.hasTransients() || !e.mem_obj)
+        return false;
+    return map->peekAtWriter(e.mem_obj->xitTable.index);
+}
+
 void
 Transients::noteFreeMapSlice(const Ipc::StoreMapSliceId)
 {

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -253,7 +253,7 @@ Transients::addEntry(StoreEntry *e, const cache_key *key, const Store::IoStatus 
 
 bool
 Transients::hasWriter(const StoreEntry &e) {
-    if (!e.hasTransients() || !e.mem_obj)
+    if (!e.hasTransients())
         return false;
     return map->peekAtWriter(e.mem_obj->xitTable.index);
 }

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -252,7 +252,8 @@ Transients::addEntry(StoreEntry *e, const cache_key *key, const Store::IoStatus 
 }
 
 bool
-Transients::hasWriter(const StoreEntry &e) {
+Transients::hasWriter(const StoreEntry &e)
+{
     if (!e.hasTransients())
         return false;
     return map->peekAtWriter(e.mem_obj->xitTable.index);

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -283,6 +283,11 @@ Transients::completeWriting(const StoreEntry &e)
 {
     assert(e.hasTransients());
     assert(isWriter(e));
+    // The not freed Transients entry may eventually become 'unattached',
+    // so that it cannot be anchored anymore. Though we handle this situation,
+    // there are some risks the entry metadata becomes stale and, hence, we
+    // should drop such entries. TODO: should we drop this entry immediately to
+    // avoid such risks?
     map->switchWritingToReading(e.mem_obj->xitTable.index);
     e.mem_obj->xitTable.io = Store::ioReading;
 }

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -85,6 +85,9 @@ public:
     bool isReader(const StoreEntry &) const;
     /// whether the entry is in "writing to Transients" I/O state
     bool isWriter(const StoreEntry &) const;
+    /// whether there is a writer into the Transients entry, this
+    /// StoreEntry is attached to
+    bool hasWriter(const StoreEntry &);
 
     static int64_t EntryLimit();
 

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -85,8 +85,7 @@ public:
     bool isReader(const StoreEntry &) const;
     /// whether the entry is in "writing to Transients" I/O state
     bool isWriter(const StoreEntry &) const;
-    /// whether there is a writer into the Transients entry, this
-    /// StoreEntry is attached to
+    /// whether we or somebody else are in the "writing to Transients" I/O state
     bool hasWriter(const StoreEntry &);
 
     static int64_t EntryLimit();

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -85,7 +85,7 @@ public:
     bool isReader(const StoreEntry &) const;
     /// whether the entry is in "writing to Transients" I/O state
     bool isWriter(const StoreEntry &) const;
-    /// whether we or somebody else are in the "writing to Transients" I/O state
+    /// whether we or somebody else is in the "writing to Transients" I/O state
     bool hasWriter(const StoreEntry &);
 
     static int64_t EntryLimit();

--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -91,6 +91,26 @@ Ipc::ReadWriteLock::switchExclusiveToShared()
     unlockExclusive();
 }
 
+bool
+Ipc::ReadWriteLock::unlockSharedAndSwitchToExclusive()
+{
+    assert(readers > 0);
+    if (!writeLevel++) { // we are the first writer + lock "new" readers out
+        assert(!appending);
+        unlockShared();
+        if (!readers) {
+            writing = true;
+            return true;
+        }
+        // somebody is still reading: fall through
+    } else {
+        // somebody is still writing: just stop reading
+        unlockShared();
+    }
+    --writeLevel;
+    return false;
+}
+
 void
 Ipc::ReadWriteLock::startAppending()
 {

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -35,8 +35,8 @@ public:
     void unlockExclusive(); ///< undo successful exclusiveLock()
     void unlockHeaders(); ///< undo successful lockHeaders()
     void switchExclusiveToShared(); ///< stop writing, start reading
-    ///< same as unlockShared() but attempts to get writer lock beforehand
-    /// \returns true of the writer lock was acquired
+    /// same as unlockShared() but also attempts to get a writer lock beforehand
+    /// \returns whether the writer lock was acquired
     bool unlockSharedAndSwitchToExclusive();
 
     void startAppending(); ///< writer keeps its lock but also allows reading

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -35,6 +35,9 @@ public:
     void unlockExclusive(); ///< undo successful exclusiveLock()
     void unlockHeaders(); ///< undo successful lockHeaders()
     void switchExclusiveToShared(); ///< stop writing, start reading
+    ///< same as unlockShared() but attempts to get writer lock beforehand
+    /// \returns true of the writer lock was acquired
+    bool unlockSharedAndSwitchToExclusive();
 
     void startAppending(); ///< writer keeps its lock but also allows reading
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -253,6 +253,18 @@ Ipc::StoreMap::peekAtReader(const sfileno fileno) const
     return NULL;
 }
 
+const Ipc::StoreMap::Anchor *
+Ipc::StoreMap::peekAtWriter(const sfileno fileno) const
+{
+    const Anchor &s = anchorAt(fileno);
+    if (s.writing())
+        return &s; // immediate access by lock holder so no locking
+    if (s.reading())
+        return nullptr;
+    assert(false); // must be locked for reading or writing
+    return nullptr;
+}
+
 const Ipc::StoreMap::Anchor &
 Ipc::StoreMap::peekAtEntry(const sfileno fileno) const
 {

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -247,10 +247,8 @@ Ipc::StoreMap::peekAtReader(const sfileno fileno) const
     const Anchor &s = anchorAt(fileno);
     if (s.reading())
         return &s; // immediate access by lock holder so no locking
-    if (s.writing())
-        return NULL; // the caller is not a read lock holder
-    assert(false); // must be locked for reading or writing
-    return NULL;
+    assert(s.writing()); // must be locked for reading or writing
+    return nullptr;
 }
 
 const Ipc::StoreMap::Anchor *
@@ -259,9 +257,7 @@ Ipc::StoreMap::peekAtWriter(const sfileno fileno) const
     const Anchor &s = anchorAt(fileno);
     if (s.writing())
         return &s; // immediate access by lock holder so no locking
-    if (s.reading())
-        return nullptr;
-    assert(false); // must be locked for reading or writing
+    assert(s.reading()); // must be locked for reading or writing
     return nullptr;
 }
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -450,6 +450,23 @@ Ipc::StoreMap::closeForReading(const sfileno fileno)
     debugs(54, 5, "closed entry " << fileno << " for reading " << path);
 }
 
+void
+Ipc::StoreMap::closeForReadingAndFreeIdle(const sfileno fileno)
+{
+    Anchor &s = anchorAt(fileno);
+    assert(s.reading());
+
+    if (!s.lock.unlockSharedAndSwitchToExclusive()) {
+        debugs(54, 5, "closed entry " << fileno << " for reading " << path);
+        return;
+    }
+
+    assert(s.writing());
+    assert(!s.reading());
+    freeChain(fileno, s, false);
+    debugs(54, 5, "closed idle entry " << fileno << " for reading " << path);
+}
+
 bool
 Ipc::StoreMap::openForUpdating(Update &update, const sfileno fileNoHint)
 {

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -453,7 +453,7 @@ Ipc::StoreMap::closeForReading(const sfileno fileno)
 void
 Ipc::StoreMap::closeForReadingAndFreeIdle(const sfileno fileno)
 {
-    Anchor &s = anchorAt(fileno);
+    auto &s = anchorAt(fileno);
     assert(s.reading());
 
     if (!s.lock.unlockSharedAndSwitchToExclusive()) {

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -262,6 +262,9 @@ public:
     /// only works on locked entries; returns nil unless the slice is readable
     const Anchor *peekAtReader(const sfileno fileno) const;
 
+    /// only works on locked entries; returns nil unless the slice is writable
+    const Anchor *peekAtWriter(const sfileno fileno) const;
+
     /// only works on locked entries; returns the corresponding Anchor
     const Anchor &peekAtEntry(const sfileno fileno) const;
 

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -291,6 +291,8 @@ public:
     const Anchor *openForReadingAt(const sfileno fileno);
     /// closes open entry after reading, decrements read level
     void closeForReading(const sfileno fileno);
+    /// same as closeForReading() but also frees the entry if it is unlocked
+    void closeForReadingAndFreeIdle(const sfileno fileno);
 
     /// writeable slice within an entry chain created by openForWriting()
     Slice &writeableSlice(const AnchorId anchorId, const SliceId sliceId);

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -259,10 +259,12 @@ public:
     /// undoes partial update, unlocks, and cleans up
     void abortUpdating(Update &update);
 
-    /// only works on locked entries; returns nil unless the slice is readable
+    /// the caller must hold a lock on the entry
+    /// \returns nullptr unless the slice is readable
     const Anchor *peekAtReader(const sfileno fileno) const;
 
-    /// only works on locked entries; returns nil unless the slice is writable
+    /// the caller must hold a lock on the entry
+    /// \returns nullptr unless the slice is writeable
     const Anchor *peekAtWriter(const sfileno fileno) const;
 
     /// only works on locked entries; returns the corresponding Anchor

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -267,7 +267,8 @@ public:
     /// \returns nullptr unless the slice is writeable
     const Anchor *peekAtWriter(const sfileno fileno) const;
 
-    /// only works on locked entries; returns the corresponding Anchor
+    /// the caller must hold a lock on the entry
+    /// \returns the corresponding Anchor
     const Anchor &peekAtEntry(const sfileno fileno) const;
 
     /// free the entry if possible or mark it as waiting to be freed if not

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -355,6 +355,8 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         const bool found = anchorToCache(entry, inSync);
         if (found && !inSync)
             throw TexcHere("cannot sync");
+        else if (!found && !transients->hasWriter(entry)) // cannot anchor right now and will not be able in the future
+            throw TexcHere("unattached transients entry");
     }
 }
 

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -355,8 +355,12 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         const bool found = anchorToCache(entry, inSync);
         if (found && !inSync)
             throw TexcHere("cannot sync");
-        else if (!found && !transients->hasWriter(entry)) // cannot anchor right now and will not be able in the future
+        else if (!found && !transients->hasWriter(entry)) {
+            // Cannot anchor right now and will not be able in the future.
+            // Prevent others from falling into the same trap.
+            stopSharing(entry);
             throw TexcHere("unattached transients entry");
+        }
     }
 }
 

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -356,18 +356,14 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         if (found && !inSync)
             throw TexcHere("cannot sync");
         if (!found) {
-            if (transients->hasWriter(entry)) {
-                Transients::EntryStatus entryStatus;
-                transients->status(entry, entryStatus);
-                if (!entryStatus.collapsed) {
-                    debugs(20, DBG_IMPORTANT, "BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
-                    throw TexcHere("transients entry missing ENTRY_REQUIRES_COLLAPSING");
-                }
-            } else {
+            if (!transients->hasWriter(entry)) {
                 // Cannot anchor right now and will not be able in the future.
                 // Prevent others from falling into the same trap.
                 stopSharing(entry);
                 throw TexcHere("unattached transients entry");
+            } else if (!entry.hittingRequiresCollapsing()) {
+                debugs(20, DBG_IMPORTANT, "BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
+                throw TexcHere("transients entry missing ENTRY_REQUIRES_COLLAPSING");
             }
         }
     }

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -356,16 +356,20 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         if (found && !inSync)
             throw TexcHere("cannot sync");
         if (!found) {
-            if (!transients->hasWriter(entry)) {
+            const auto hasWriter = transients->hasWriter(entry);
+            if (!hasWriter) {
                 // prevent others from falling into the same trap
                 stopSharing(entry);
-                throw TexcHere("unattached transients entry missing writer");
             }
 
+            // !found should imply hittingRequiresCollapsing() regardless of writer presence
             if (!entry.hittingRequiresCollapsing()) {
                 debugs(20, DBG_IMPORTANT, "BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
                 throw TexcHere("transients entry missing ENTRY_REQUIRES_COLLAPSING");
             }
+
+            if (!hasWriter)
+                throw TexcHere("unattached transients entry missing writer");
         }
     }
 }

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -356,12 +356,8 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         if (found && !inSync)
             throw TexcHere("cannot sync");
         if (!found) {
-            if (!transients->hasWriter(entry)) {
-                // Cannot anchor right now and will not be able in the future.
-                // Prevent others from falling into the same trap.
-                stopSharing(entry);
-                throw TexcHere("unattached transients entry");
-            } else if (!entry.hittingRequiresCollapsing()) {
+            assert(transients->hasWriter(entry));
+            if (!entry.hittingRequiresCollapsing()) {
                 debugs(20, DBG_IMPORTANT, "BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
                 throw TexcHere("transients entry missing ENTRY_REQUIRES_COLLAPSING");
             }

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -356,7 +356,12 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         if (found && !inSync)
             throw TexcHere("cannot sync");
         if (!found) {
-            assert(transients->hasWriter(entry));
+            if (!transients->hasWriter(entry)) {
+                // prevent others from falling into the same trap
+                stopSharing(entry);
+                throw TexcHere("unattached transients entry missing writer");
+            }
+
             if (!entry.hittingRequiresCollapsing()) {
                 debugs(20, DBG_IMPORTANT, "BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
                 throw TexcHere("transients entry missing ENTRY_REQUIRES_COLLAPSING");

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -359,12 +359,12 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
             // !found should imply hittingRequiresCollapsing() regardless of writer presence
             if (!entry.hittingRequiresCollapsing()) {
                 debugs(20, DBG_IMPORTANT, "BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
-                throw TexcHere("transients entry missing ENTRY_REQUIRES_COLLAPSING");
+                throw TextException("transients entry missing ENTRY_REQUIRES_COLLAPSING", Here());
             }
 
             if (!transients->hasWriter(entry)) {
                 // prevent others from falling into the same trap
-                throw TexcHere("unattached transients entry missing writer");
+                throw TextException("unattached transients entry missing writer", Here());
             }
         }
     }


### PR DESCRIPTION
After the last transaction that cached or read the reply R1 ended, its
Transients entry T1 was not freed. Subsequent requests (with different
public keys) could occupy the same shared memory and rock slots (purging
unlocked R1), preventing Squid from attaching a T1-derived StoreEntry to
the cache. Another request for R1 would receive T1 and stall because its
worker W1 kept waiting for a notification from another worker W2,
incorrectly assuming that W2 exists and is going to fetch R1 for W1.
That request was aborted after a timeout.

A Transients entry represents active transaction(s). Broadcasts stop
when there are no transactions to inform. We must remove idle (i.e.
unlocked) Transients entries to avoid feeding new transactions with
stale info. We now do that when unlocking a Transients entry and also
double check that a found unattached Transients entry has a writer.
