### PR TITLE
Bug 4864: !Comm::MonitorsRead assertion in maybeReadVirginBody()

### DIFF
--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -117,6 +117,11 @@ private:
     void doneWithRetries();
     void completed();
     void retryOrBail();
+
+    /// whether a pinned to-peer connection can be replaced with another one
+    /// (in order to retry or reforward a failed request)
+    bool pinnedCanRetry() const;
+
     ErrorState *makeConnectingError(const err_type type) const;
     void connectedToPeer(Security::EncryptorAnswer &answer);
     static void RegisterWithCacheManager(void);

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -278,6 +278,9 @@ peerSelectDnsPaths(ps_state *psstate)
         // Send an empty IP address marked as PINNED
         const Comm::ConnectionPointer p = new Comm::Connection();
         p->peerType = PINNED;
+        // Caller requires to check for pinned connections through
+        // CachePeer object:
+        p->setPeer(fs->_peer.get());
         psstate->paths->push_back(p);
         psstate->servers = fs->next;
         delete fs;

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -274,6 +274,17 @@ peerSelectDnsPaths(ps_state *psstate)
         return;
     }
 
+    if (fs && fs->code == PINNED) {
+        // Send an empty IP address marked as PINNED
+        const Comm::ConnectionPointer p = new Comm::Connection();
+        p->peerType = PINNED;
+        psstate->paths->push_back(p);
+        psstate->servers = fs->next;
+        delete fs;
+        peerSelectDnsPaths(psstate);
+        return;
+    }
+
     // convert the list of FwdServer destinations into destinations IP addresses
     if (fs && psstate->paths->size() < (unsigned int)Config.forward_max_tries) {
         // send the next one off for DNS lookup.


### PR DESCRIPTION
This assertion is probably triggered when Squid retries/reforwards
server-first or step2+ bumped connections (after they fail).
Retrying/reforwarding such pinned connections is wrong because the
corresponding client-to-Squid TLS connection was negotiated based on the
now-failed Squid-to-server TLS connection, and there is no mechanism to
ensure that the new Squid-to-server TLS connection will have exactly the
same properties. Squid should forward the error to client instead.

Also fixed peer selection code that could return more than one PINNED
paths with only the first path having the destination of the actual
pinned connection.

This is a limited backport of master commit 3dde9e52 (GitHub PR #351).

This is a Measurement Factory project.