### PR TITLE
Detail TLS and CONNECT cache_peer negotiation failures

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -843,9 +843,6 @@ FwdState::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 
     // TODO: Reuse to-peer connections after a CONNECT error response.
 
-    if (const auto peer = serverConnection()->getPeer())
-        peerConnectFailed(peer);
-
     const auto error = answer.squidError.get();
     Must(error);
     answer.squidError.clear(); // preserve error for fail()

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -809,7 +809,7 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
     }
 
     // Check if we need to TLS before use
-    if (const auto *peer = conn->getPeer()) {
+    if (const auto *peer = answer.conn->getPeer()) {
         // Assume that it is only possible for the client-first from the
         // bumping modes to try connect to a remote server. The bumped
         // requests with other modes are using pinned connections or fails.
@@ -824,12 +824,12 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
                 !peer->options.originserver && // the "through a proxy" part
                 !peer->secure.encryptTransport) // the "exclude HTTPS proxies" part
 
-            return advanceDestination("establish tunnel thru proxy", conn, [this,&conn] {
-                establishTunnelThruProxy(conn);
+            return advanceDestination("establish tunnel thru proxy", answer.conn, [this,&answer] {
+                establishTunnelThruProxy(answer.conn);
             });
     }
 
-    secureConnectionToPeerIfNeeded(conn);
+    secureConnectionToPeerIfNeeded(answer.conn);
 }
 
 void
@@ -1078,8 +1078,6 @@ FwdState::usePinned()
     assert(connManager);
     if (connManager->pinnedAuth())
         request->flags.auth = true;
-
-    syncWithServerConn(connManager->pinning.host);
 
     // the server may close the pinned connection before this request
     const auto reused = true;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -998,8 +998,6 @@ FwdState::connectStart()
     assert(!destinations->empty());
     assert(!opening());
 
-    FwdStateEnterThrowingCode();
-
     // Ditch error page if it was created before.
     // A new one will be created if there's another problem
     delete err;
@@ -1026,8 +1024,6 @@ FwdState::connectStart()
     destinations->notificationPending = true; // start() is async
     connOpener = cs;
     AsyncJob::Start(cs);
-
-    FwdStateExitThrowingCode([] { /* no conn to cleanup yet */ });
 }
 
 /// send request on an existing connection dedicated to the requesting client

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -931,22 +931,20 @@ FwdState::secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &conn)
 void
 FwdState::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
 {
-    { // TODO: Remove this diff reduction before commit
-        HttpRequest::Pointer requestPointer = request;
-        AsyncCall::Pointer callback = asyncCall(17,4,
-                                                "FwdState::ConnectedToPeer",
-                                                FwdStatePeerAnswerDialer(&FwdState::connectedToPeer, this));
-        const auto sslNegotiationTimeout = connectingTimeout(conn);
-        Security::PeerConnector *connector = nullptr;
+    HttpRequest::Pointer requestPointer = request;
+    AsyncCall::Pointer callback = asyncCall(17,4,
+                                            "FwdState::ConnectedToPeer",
+                                            FwdStatePeerAnswerDialer(&FwdState::connectedToPeer, this));
+    const auto sslNegotiationTimeout = connectingTimeout(conn);
+    Security::PeerConnector *connector = nullptr;
 #if USE_OPENSSL
-        if (request->flags.sslPeek)
-            connector = new Ssl::PeekingPeerConnector(requestPointer, conn, clientConn, callback, al, sslNegotiationTimeout);
-        else
+    if (request->flags.sslPeek)
+        connector = new Ssl::PeekingPeerConnector(requestPointer, conn, clientConn, callback, al, sslNegotiationTimeout);
+    else
 #endif
-            connector = new Security::BlindPeerConnector(requestPointer, conn, callback, al, sslNegotiationTimeout);
-        connector->noteFwdPconnUse = true;
-        AsyncJob::Start(connector); // will call our callback
-    }
+        connector = new Security::BlindPeerConnector(requestPointer, conn, callback, al, sslNegotiationTimeout);
+    connector->noteFwdPconnUse = true;
+    AsyncJob::Start(connector); // will call our callback
 }
 
 /// called when all negotiations with the TLS-speaking peer have been completed

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -823,7 +823,6 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
         if (originWantsEncryptedTraffic && // the "encrypted traffic" part
                 !peer->options.originserver && // the "through a proxy" part
                 !peer->secure.encryptTransport) // the "exclude HTTPS proxies" part
-
             return advanceDestination("establish tunnel thru proxy", answer.conn, [this,&answer] {
                 establishTunnelThruProxy(answer.conn);
             });
@@ -896,7 +895,7 @@ FwdState::secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &conn)
 {
     assert(!request->flags.pinned);
 
-    const CachePeer *p = conn->getPeer();
+    const auto p = conn->getPeer();
     const bool peerWantsTls = p && p->secure.encryptTransport;
     // userWillTlsToPeerForUs assumes CONNECT == HTTPS
     const bool userWillTlsToPeerForUs = p && p->options.originserver &&
@@ -909,10 +908,11 @@ FwdState::secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &conn)
     // as is
     const bool needTlsToOrigin = !p && request->url.getScheme() == AnyP::PROTO_HTTPS && !clientFirstBump;
 
-    if (needTlsToPeer || needTlsToOrigin || needsBump)
+    if (needTlsToPeer || needTlsToOrigin || needsBump) {
         return advanceDestination("secure connection to peer", conn, [this,&conn] {
             secureConnectionToPeer(conn);
         });
+    }
 
     // if not encrypting just run the post-connect actions
     successfullyConnectedToPeer(conn);

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -832,7 +832,7 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
         if (originWantsEncryptedTraffic && // the "encrypted traffic" part
                 !peer->options.originserver && // the "through a proxy" part
                 !peer->secure.encryptTransport) // the "exclude HTTPS proxies" part
-            return advanceDestination("establish tunnel thru proxy", answer.conn, [this,&answer] {
+            return advanceDestination("establish tunnel through proxy", answer.conn, [this,&answer] {
                 establishTunnelThruProxy(answer.conn);
             });
     }

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -798,8 +798,8 @@ FwdState::noteConnection(HappyConnOpener::Answer &answer)
     if ((error = answer.error.get())) {
         flags.dont_retry = true; // or HappyConnOpener would not have given up
         syncHierNote(answer.conn, request->url.host());
-        answer.error.clear(); // preserve error for errorSendComplete()
         Must(!Comm::IsConnOpen(answer.conn));
+        answer.error.clear(); // preserve error for errorSendComplete()
     } else if (!Comm::IsConnOpen(answer.conn) || fd_table[answer.conn->fd].closing()) {
         syncHierNote(answer.conn, request->url.host());
         closePendingConnection(answer.conn, "conn was closed while waiting for noteConnection");

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -868,10 +868,10 @@ FwdState::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 {
     ErrorState *error = nullptr;
     if (!answer.positive()) {
+        Must(!Comm::IsConnOpen(answer.conn));
         error = answer.squidError.get();
         Must(error);
         answer.squidError.clear(); // preserve error for fail()
-        Must(!Comm::IsConnOpen(answer.conn));
     } else if (!Comm::IsConnOpen(answer.conn) || fd_table[answer.conn->fd].closing()) {
         // The socket could get closed while our callback was queued.
         // We close Connection here to sync Connection::fd.

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -102,6 +102,9 @@ public:
 
     void dontRetry(bool val) { flags.dont_retry = val; }
 
+    /// get rid of a to-server connection that failed to become serverConn
+    void closePendingConnection(const Comm::ConnectionPointer &conn, const char *reason);
+
     /** return a ConnectionPointer to the current server connection (may or may not be open) */
     Comm::ConnectionPointer const & serverConnection() const { return serverConn; };
 
@@ -131,6 +134,9 @@ private:
     /// (in order to retry or reforward a failed request)
     bool pinnedCanRetry() const;
 
+    template <typename StepStart>
+    void advanceDestination(const char *stepDescription, const Comm::ConnectionPointer &conn, const StepStart &startStep);
+
     ErrorState *makeConnectingError(const err_type type) const;
     void connectedToPeer(Security::EncryptorAnswer &answer);
     static void RegisterWithCacheManager(void);
@@ -138,6 +144,7 @@ private:
     void establishTunnelThruProxy(const Comm::ConnectionPointer &);
     void tunnelEstablishmentDone(Http::TunnelerAnswer &answer);
     void secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &);
+    void secureConnectionToPeer(const Comm::ConnectionPointer &conn);
     void successfullyConnectedToPeer(const Comm::ConnectionPointer &);
 
     /// stops monitoring server connection for closure and updates pconn stats

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -144,7 +144,7 @@ private:
     void establishTunnelThruProxy(const Comm::ConnectionPointer &);
     void tunnelEstablishmentDone(Http::TunnelerAnswer &answer);
     void secureConnectionToPeerIfNeeded(const Comm::ConnectionPointer &);
-    void secureConnectionToPeer(const Comm::ConnectionPointer &conn);
+    void secureConnectionToPeer(const Comm::ConnectionPointer &);
     void successfullyConnectedToPeer(const Comm::ConnectionPointer &);
 
     /// stops monitoring server connection for closure and updates pconn stats

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -89,7 +89,6 @@ void
 Http::Tunneler::handleConnectionClosure(const CommCloseCbParams &params)
 {
     bailWith(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
-    mustStop("server connection gone");
 }
 
 /// make sure we quit if/when the connection is gone
@@ -112,7 +111,6 @@ void
 Http::Tunneler::handleTimeout(const CommTimeoutCbParams &)
 {
     bailWith(new ErrorState(ERR_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al));
-    mustStop("server connection timedout");
 }
 
 void

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -121,6 +121,18 @@ Http::Tunneler::handleException(const std::exception& e)
 }
 
 void
+Http::Tunneler::callException(const std::exception &e)
+{
+    debugs(83, 5, status());
+    try {
+        handleException(e);
+    } catch (const std::exception &ex) {
+        debugs(83, DBG_CRITICAL, ex.what());
+    }
+    AsyncJob::callException(e);
+}
+
+void
 Http::Tunneler::startReadingResponse()
 {
     debugs(83, 5, connection << status());

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -44,6 +44,7 @@ Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest:
     assert(callback);
     assert(dynamic_cast<Http::TunnelerAnswer *>(callback->getDialer()));
     url = request->url.authority();
+    watchForClosures();
 }
 
 Http::Tunneler::~Tunneler()
@@ -80,7 +81,6 @@ Http::Tunneler::start()
     Must(peer); // bail if our peer was reconfigured away
     request->prepForPeering(*peer);
 
-    watchForClosures();
     writeRequest();
     startReadingResponse();
 }

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -144,8 +144,8 @@ Http::Tunneler::startReadingResponse()
 void
 Http::Tunneler::writeRequest()
 {
-    Must(Comm::IsConnOpen(connection));
-    Must(!fd_table[connection->fd].closing());
+    if (!Comm::IsConnOpen(connection) || fd_table[connection->fd].closing())
+        return;
 
     debugs(83, 5, connection);
 

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -132,6 +132,9 @@ Http::Tunneler::startReadingResponse()
 void
 Http::Tunneler::writeRequest()
 {
+    Must(Comm::IsConnOpen(connection));
+    Must(!fd_table[connection->fd].closing());
+
     debugs(83, 5, connection);
 
     Http::StateFlags flags;

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -385,6 +385,11 @@ Http::Tunneler::disconnect()
         closer = nullptr;
     }
 
+    if (reader) {
+        Comm::ReadCancel(connection->fd, reader);
+        reader = nullptr;
+    }
+
     // remove connection timeout handler
     commUnsetConnTimeout(connection);
 }
@@ -414,11 +419,6 @@ Http::Tunneler::swanSong()
             bailWith(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
         }
         assert(!callback);
-    }
-
-    if (reader) {
-        Comm::ReadCancel(connection->fd, reader);
-        reader = nullptr;
     }
 }
 

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -396,7 +396,8 @@ void
 Http::Tunneler::callBack()
 {
     debugs(83, 5, connection << status());
-    answer().conn = connection;
+    if (answer().positive())
+        answer().conn = connection;
     auto cb = callback;
     callback = nullptr;
     ScheduleCallHere(cb);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -360,7 +360,7 @@ Http::Tunneler::bailWith(ErrorState *error)
     Must(error);
     answer().squidError = error;
 
-    if (CachePeer *p = connection->getPeer())
+    if (const auto p = connection->getPeer())
         peerConnectFailed(p);
 
     callBack();

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -27,7 +27,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Http, Tunneler);
 
 Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest::Pointer &req, AsyncCall::Pointer &aCallback, time_t timeout, const AccessLogEntryPointer &alp):
     AsyncJob("Http::Tunneler"),
-    usesPconn_(false),
+    noteFwdPconnUse(false),
     connection(conn),
     request(req),
     callback(aCallback),
@@ -360,7 +360,7 @@ Http::Tunneler::bailWith(ErrorState *error)
     callBack();
     disconnect();
 
-    if (usesPconn_)
+    if (noteFwdPconnUse)
         fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
     connection->close();
     connection = nullptr;

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -377,7 +377,7 @@ Http::Tunneler::sendSuccess()
 void
 Http::Tunneler::disconnect()
 {
-    if (!connection)
+    if (!Comm::IsConnOpen(connection))
         return;
 
     if (closer) {

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -375,9 +375,10 @@ Http::Tunneler::disconnect(const bool andClose)
     if (!connection)
         return;
 
-    // remove close handler
-    comm_remove_close_handler(connection->fd, closer);
-    closer = nullptr;
+    if (closer) {
+        comm_remove_close_handler(connection->fd, closer);
+        closer = nullptr;
+    }
 
     // remove connection timeout handler
     commUnsetConnTimeout(connection);

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -362,6 +362,7 @@ Http::Tunneler::bailWith(ErrorState *error)
 
     if (noteFwdPconnUse)
         fwdPconnPool->noteUses(fd_table[connection->fd].pconn.uses);
+    // TODO: Reuse to-peer connections after a CONNECT error response.
     connection->close();
     connection = nullptr;
 }

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -120,25 +120,6 @@ Http::Tunneler::handleTimeout(const CommTimeoutCbParams &)
 }
 
 void
-Http::Tunneler::handleException(const std::exception& e)
-{
-    debugs(83, 2, e.what() << status());
-    bailWith(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
-}
-
-void
-Http::Tunneler::callException(const std::exception &e)
-{
-    debugs(83, 5, status());
-    try {
-        handleException(e);
-    } catch (const std::exception &ex) {
-        debugs(83, DBG_CRITICAL, ex.what());
-    }
-    AsyncJob::callException(e);
-}
-
-void
 Http::Tunneler::startReadingResponse()
 {
     debugs(83, 5, connection << status());

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -77,11 +77,9 @@ Http::Tunneler::start()
     Must(url.length());
     Must(lifetimeLimit >= 0);
 
-    // We are the only owners of connection Comm::Connection object and the
-    // only who can close it.
-    Must(Comm::IsConnOpen(connection));
-
-    // bail if somebody closed the connection while we were waiting to start()
+    // we own this Comm::Connection object and its fd exclusively, but must bail
+    // if others started closing the socket while we were waiting to start()
+    assert(Comm::IsConnOpen(connection));
     if (fd_table[connection->fd].closing()) {
         bailWith(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
         return;

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -97,7 +97,7 @@ protected:
     void callBack();
 
     /// A bailWith(), sendSuccess() helper: stops monitoring the connection.
-    void disconnect(const bool andClose);
+    void disconnect();
 
     TunnelerAnswer &answer();
 

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -65,7 +65,8 @@ public:
     void setDelayId(DelayId delay_id) {delayId = delay_id;}
 #endif
 
-    bool usesPconn_; ///< whether persistent connections are supported
+    /// hack: whether the connection requires fwdPconnPool->noteUses()
+    bool noteFwdPconnUse;
 
 protected:
     /* AsyncJob API */

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -26,13 +26,9 @@ typedef RefCount<AccessLogEntry> AccessLogEntryPointer;
 namespace Http
 {
 
-/// Establishes an HTTP CONNECT tunnel through a forward proxy.
-///
-/// The caller receives a call back with Http::TunnelerAnswer.
-///
-/// The job reports success, errors or connection closures to the caller.
-///
-/// This job may close the connection on timeout.
+/// Negotiates an HTTP CONNECT tunnel through a forward proxy using a given
+/// (open and, if needed, encrypted) TCP connection to that proxy. Owns the
+/// connection during these negotiations. The caller receives TunnelerAnswer.
 class Tunneler: virtual public AsyncJob
 {
     CBDATA_CLASS(Tunneler);
@@ -70,6 +66,7 @@ public:
 #endif
 
     bool usesPconn_; ///< whether persistent connections are supported
+
 protected:
     /* AsyncJob API */
     virtual ~Tunneler();
@@ -90,18 +87,16 @@ protected:
     void handleResponse(const bool eof);
     void bailOnResponseError(const char *error, HttpReply *);
 
-    /// Return an error to the caller
+    /// Sends the given error to the initiator.
     void bailWith(ErrorState*);
 
-    /// Return a ready to use connection to the caller
+    /// Sends the ready-to-use tunnel to the initiator.
     void sendSuccess();
 
-    /// Callback the caller class, and pass the ready to use
-    /// connection or an error if Tunneler failed.
+    /// A bailWith(), sendSuccess() helper: sends results to the initiator.
     void callBack();
 
-    /// Stop monitoring the connection
-    /// \param andClose if true also closes the connection
+    /// A bailWith(), sendSuccess() helper: stops monitoring the connection.
     void disconnect(const bool andClose);
 
     TunnelerAnswer &answer();

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -65,6 +65,9 @@ public:
     void setDelayId(DelayId delay_id) {delayId = delay_id;}
 #endif
 
+    /* AsyncJob API */
+    virtual void callException(const std::exception &e);
+
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;
 

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -66,7 +66,7 @@ public:
 #endif
 
     /* AsyncJob API */
-    virtual void callException(const std::exception &e);
+    virtual void callException(const std::exception &);
 
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -88,16 +88,16 @@ protected:
     void handleResponse(const bool eof);
     void bailOnResponseError(const char *error, HttpReply *);
 
-    /// Sends the given error to the initiator.
+    /// sends the given error to the initiator
     void bailWith(ErrorState*);
 
-    /// Sends the ready-to-use tunnel to the initiator.
+    /// sends the ready-to-use tunnel to the initiator
     void sendSuccess();
 
-    /// A bailWith(), sendSuccess() helper: sends results to the initiator.
+    /// a bailWith(), sendSuccess() helper: sends results to the initiator
     void callBack();
 
-    /// A bailWith(), sendSuccess() helper: stops monitoring the connection.
+    /// a bailWith(), sendSuccess() helper: stops monitoring the connection
     void disconnect();
 
     TunnelerAnswer &answer();

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -65,9 +65,6 @@ public:
     void setDelayId(DelayId delay_id) {delayId = delay_id;}
 #endif
 
-    /* AsyncJob API */
-    virtual void callException(const std::exception &);
-
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;
 
@@ -82,7 +79,6 @@ protected:
     void handleConnectionClosure(const CommCloseCbParams&);
     void watchForClosures();
     void handleTimeout(const CommTimeoutCbParams &);
-    void handleException(const std::exception&);
     void startReadingResponse();
     void writeRequest();
     void handleWrittenRequest(const CommIoCbParams&);

--- a/src/clients/HttpTunnelerAnswer.cc
+++ b/src/clients/HttpTunnelerAnswer.cc
@@ -32,7 +32,8 @@ Http::operator <<(std::ostream &os, const TunnelerAnswer &answer)
     if (answer.peerResponseStatus != Http::scNone)
         os << ' ' << answer.peerResponseStatus;
 
-    os << ' ' << answer.conn;
+    if (answer.conn)
+        os << ' ' << answer.conn;
 
     os << ']';
     return os;

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -7,6 +7,7 @@
  */
 
 #include "squid.h"
+#include "AccessLogEntry.h"
 #include "CachePeer.h"
 #include "comm/Connection.h"
 #include "errorpage.h"

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -56,11 +56,6 @@ Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerCon
     comm_add_close_handler(serverConn->fd, closeHandler);
 }
 
-Security::PeerConnector::~PeerConnector()
-{
-    // TODO: Remove if it stays empty.
-}
-
 bool Security::PeerConnector::doneAll() const
 {
     return (!callback || callback->canceled()) && AsyncJob::doneAll();
@@ -91,7 +86,7 @@ void
 Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
 {
     debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
-    auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
+    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
 }
@@ -100,7 +95,7 @@ void
 Security::PeerConnector::connectionClosed(const char *reason)
 {
     debugs(83, 5, reason << " socket closed/closing. this=" << (void*)this);
-    auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
+    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
 }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -87,7 +87,9 @@ Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
 {
     debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
     const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
+#if USE_OPENSSL
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+#endif
     bail(err);
 }
 
@@ -96,7 +98,9 @@ Security::PeerConnector::connectionClosed(const char *reason)
 {
     debugs(83, 5, reason << " socket closed/closing. this=" << (void*)this);
     const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
+#if USE_OPENSSL
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
+#endif
     bail(err);
 }
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -100,6 +100,25 @@ Security::PeerConnector::connectionClosed(const char *reason)
     bail(err);
 }
 
+void
+Security::PeerConnector::handleException(const std::exception& e)
+{
+    debugs(83, 2, e.what() << status());
+    bail(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
+}
+
+void
+Security::PeerConnector::callException(const std::exception &e)
+{
+    debugs(83, 5, status());
+    try {
+        handleException(e);
+    } catch (const std::exception &ex) {
+        debugs(83, DBG_CRITICAL, ex.what());
+    }
+    AsyncJob::callException(e);
+}
+
 bool
 Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
 {

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -86,7 +86,6 @@ Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
     auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
-    mustStop("Timedout");
 }
 
 void
@@ -96,7 +95,6 @@ Security::PeerConnector::connectionClosed(const char *reason)
     auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
     bail(err);
-    mustStop(reason);
 }
 
 bool

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -101,7 +101,7 @@ Security::PeerConnector::connectionClosed(const char *reason)
 }
 
 void
-Security::PeerConnector::handleException(const std::exception& e)
+Security::PeerConnector::handleException(const std::exception &e)
 {
     debugs(83, 2, e.what() << status());
     bail(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -34,7 +34,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Security, PeerConnector);
 
 Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerConn, AsyncCall::Pointer &aCallback, const AccessLogEntryPointer &alp, const time_t timeout) :
     AsyncJob("Security::PeerConnector"),
-    usesPconn_(false),
+    noteFwdPconnUse(false),
     serverConn(aServerConn),
     al(alp),
     callback(aCallback),
@@ -565,7 +565,7 @@ Security::PeerConnector::bail(ErrorState *error)
     callBack();
     disconnect();
 
-    if (usesPconn_)
+    if (noteFwdPconnUse)
         fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
     serverConn->close();
     serverConn = nullptr;

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -545,7 +545,7 @@ Security::PeerConnector::bail(ErrorState *error)
     Must(dialer);
     dialer->answer().error = error;
 
-    if (auto *p = serverConnection()->getPeer())
+    if (const auto p = serverConnection()->getPeer())
         peerConnectFailed(p);
 
     callBack();

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -563,18 +563,23 @@ Security::PeerConnector::bail(ErrorState *error)
         peerConnectFailed(p);
 
     callBack();
-    disconnect(true);
+    disconnect();
+
+    if (usesPconn_)
+        fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
+    serverConn->close();
+    serverConn = nullptr;
 }
 
 void
 Security::PeerConnector::sendSuccess()
 {
     callBack();
-    disconnect(false);
+    disconnect();
 }
 
 void
-Security::PeerConnector::disconnect(const bool andClose)
+Security::PeerConnector::disconnect()
 {
     if (closeHandler) {
         comm_remove_close_handler(serverConnection()->fd, closeHandler);
@@ -582,13 +587,6 @@ Security::PeerConnector::disconnect(const bool andClose)
     }
 
     commUnsetConnTimeout(serverConnection());
-
-    if (andClose) {
-        if (usesPconn_)
-            fwdPconnPool->noteUses(fd_table[serverConn->fd].pconn.uses);
-        serverConn->close();
-        serverConn = nullptr;
-    }
 }
 
 void

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -576,7 +576,10 @@ Security::PeerConnector::sendSuccess()
 void
 Security::PeerConnector::disconnect(const bool andClose)
 {
-    comm_remove_close_handler(serverConnection()->fd, closeHandler);
+    if (closeHandler) {
+        comm_remove_close_handler(serverConnection()->fd, closeHandler);
+        closeHandler = nullptr;
+    }
 
     commUnsetConnTimeout(serverConnection());
 

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -574,6 +574,9 @@ Security::PeerConnector::sendSuccess()
 void
 Security::PeerConnector::disconnect()
 {
+    if (!Comm::IsConnOpen(serverConnection()))
+         return;
+
     if (closeHandler) {
         comm_remove_close_handler(serverConnection()->fd, closeHandler);
         closeHandler = nullptr;

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -68,6 +68,10 @@ Security::PeerConnector::start()
     AsyncJob::start();
     debugs(83, 5, "this=" << (void*)this);
 
+    // bail if somebody closed the connection while we were waiting to start()
+    if (!Comm::IsConnOpen(serverConn) || fd_table[serverConn->fd].closing())
+        return bail(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
+
     Security::SessionPointer tmp;
     if (initialize(tmp))
         negotiate();

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -108,25 +108,6 @@ Security::PeerConnector::connectionClosed(const char *reason)
     bail(err);
 }
 
-void
-Security::PeerConnector::handleException(const std::exception &e)
-{
-    debugs(83, 2, e.what() << status());
-    bail(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
-}
-
-void
-Security::PeerConnector::callException(const std::exception &e)
-{
-    debugs(83, 5, status());
-    try {
-        handleException(e);
-    } catch (const std::exception &ex) {
-        debugs(83, DBG_CRITICAL, ex.what());
-    }
-    AsyncJob::callException(e);
-}
-
 bool
 Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
 {

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -83,14 +83,7 @@ void
 Security::PeerConnector::commCloseHandler(const CommCloseCbParams &params)
 {
     debugs(83, 5, "FD " << params.fd << ", Security::PeerConnector=" << params.data);
-    connectionClosed("Security::PeerConnector::commCloseHandler");
-}
-
-void
-Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
-{
-    debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
-    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
+    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
 #if USE_OPENSSL
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
 #endif
@@ -98,10 +91,10 @@ Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
 }
 
 void
-Security::PeerConnector::connectionClosed(const char *reason)
+Security::PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &)
 {
-    debugs(83, 5, reason << " socket closed/closing. this=" << (void*)this);
-    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scServiceUnavailable, request.getRaw(), al);
+    debugs(83, 5, serverConnection() << " timedout. this=" << (void*)this);
+    const auto err = new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scGatewayTimeout, request.getRaw(), al);
 #if USE_OPENSSL
     err->detail = new Ssl::ErrorDetail(SQUID_ERR_SSL_HANDSHAKE, nullptr, nullptr);
 #endif

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -68,11 +68,9 @@ Security::PeerConnector::start()
     AsyncJob::start();
     debugs(83, 5, "this=" << (void*)this);
 
-    // We are the only owners of the serverConn Comm::Connection object,
-    // it can be closed only by us.
-    Must(Comm::IsConnOpen(serverConn));
-
-    // bail if somebody closed the connection while we were waiting to start()
+    // we own this Comm::Connection object and its fd exclusively, but must bail
+    // if others started closing the socket while we were waiting to start()
+    assert(Comm::IsConnOpen(serverConn));
     if (fd_table[serverConn->fd].closing()) {
         bail(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
         return;

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -139,16 +139,16 @@ protected:
     /// mimics FwdState to minimize changes to FwdState::initiate/negotiateSsl
     Comm::ConnectionPointer const &serverConnection() const { return serverConn; }
 
-    /// Sends the given error to the initiator.
+    /// sends the given error to the initiator
     void bail(ErrorState *error);
 
-    /// Sends the encrypted connection to the initiator.
+    /// sends the encrypted connection to the initiator
     void sendSuccess();
 
-    /// A bail(), sendSuccess() helper: sends results to the initiator.
+    /// a bail(), sendSuccess() helper: sends results to the initiator
     void callBack();
 
-    /// A bail(), sendSuccess() helper: stops monitoring the connection.
+    /// a bail(), sendSuccess() helper: stops monitoring the connection
     void disconnect();
 
     /// If called the certificates validator will not used

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -59,7 +59,7 @@ public:
                   AsyncCall::Pointer &aCallback,
                   const AccessLogEntryPointer &alp,
                   const time_t timeout = 0);
-    virtual ~PeerConnector();
+    virtual ~PeerConnector() = default;
 
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -64,6 +64,9 @@ public:
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;
 
+    // AsyncJob API
+    virtual void callException(const std::exception &);
+
 protected:
     // AsyncJob API
     virtual void start();
@@ -79,6 +82,9 @@ protected:
 
     /// Inform us that the connection is closed. Does the required clean-up.
     void connectionClosed(const char *reason);
+
+    /// Handle exceptions
+    void handleException(const std::exception &);
 
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -153,7 +153,7 @@ protected:
     void callBack();
 
     /// A bail(), sendSuccess() helper: stops monitoring the connection.
-    void disconnect(const bool andClose);
+    void disconnect();
 
     /// If called the certificates validator will not used
     void bypassCertValidator() {useCertValidator_ = false;}

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -81,9 +81,9 @@ protected:
     void connectionClosed(const char *reason);
 
     /// Sets up TCP socket-related notification callbacks if things go wrong.
-    /// If socket already closed return false, else install the comm_close
+    /// If socket already closed throws, else install the comm_close
     /// handler to monitor the socket.
-    bool prepareSocket();
+    void prepareSocket();
 
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -61,7 +61,8 @@ public:
                   const time_t timeout = 0);
     virtual ~PeerConnector();
 
-    bool usesPconn_; ///< whether the connection came from a fwdPconnPool
+    /// hack: whether the connection requires fwdPconnPool->noteUses()
+    bool noteFwdPconnUse;
 
 protected:
     // AsyncJob API

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -80,11 +80,6 @@ protected:
     /// Inform us that the connection is closed. Does the required clean-up.
     void connectionClosed(const char *reason);
 
-    /// Sets up TCP socket-related notification callbacks if things go wrong.
-    /// If socket already closed throws, else install the comm_close
-    /// handler to monitor the socket.
-    void prepareSocket();
-
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);
 

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -64,9 +64,6 @@ public:
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;
 
-    // AsyncJob API
-    virtual void callException(const std::exception &);
-
 protected:
     // AsyncJob API
     virtual void start();
@@ -82,9 +79,6 @@ protected:
 
     /// Inform us that the connection is closed. Does the required clean-up.
     void connectionClosed(const char *reason);
-
-    /// Handle exceptions
-    void handleException(const std::exception &);
 
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -77,9 +77,6 @@ protected:
     /// The comm_close callback handler.
     void commCloseHandler(const CommCloseCbParams &params);
 
-    /// Inform us that the connection is closed. Does the required clean-up.
-    void connectionClosed(const char *reason);
-
     /// \returns true on successful TLS session initialization
     virtual bool initialize(Security::SessionPointer &);
 

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -250,7 +250,7 @@ Ssl::PeekingPeerConnector::noteNegotiationDone(ErrorState *error)
         if (splice) {
             if (!Comm::IsConnOpen(clientConn)) {
                 bail(new ErrorState(ERR_GATEWAY_FAILURE, Http::scInternalServerError, request.getRaw(), al));
-                throw TexcHere("client connection gone");
+                throw TextException("from-client connection gone", Here());
             }
             switchToTunnel(request.getRaw(), clientConn, serverConn);
             tunnelInsteadOfNegotiating();

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -92,7 +92,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSpliceMatched(const Ssl::BumpMode acti
     al->ssl.bumpMode = finalAction;
 
     if (finalAction == Ssl::bumpTerminate) {
-        serverConn->close();
+        bail(new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scForbidden, request.getRaw(), al));
         clientConn->close();
     } else if (finalAction != Ssl::bumpSplice) {
         //Allow write, proceed with the connection

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -143,9 +143,9 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
 
     if (ConnStateData *csd = request->clientConnectionManager.valid()) {
 
-        // client connection is required in the case we need to splice
-        // or terminate client and server connections
-        assert(clientConn != NULL);
+        // client connection supplies TLS client details and is also used if we
+        // need to splice or terminate the client and server connections
+        assert(Comm::IsConnOpen(clientConn));
         SBuf *hostName = NULL;
 
         //Enable Status_request TLS extension, required to bump some clients

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -94,6 +94,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSpliceMatched(const Ssl::BumpMode acti
     if (finalAction == Ssl::bumpTerminate) {
         bail(new ErrorState(ERR_SECURE_CONNECT_FAIL, Http::scForbidden, request.getRaw(), al));
         clientConn->close();
+        clientConn = nullptr;
     } else if (finalAction != Ssl::bumpSplice) {
         //Allow write, proceed with the connection
         srvBio->holdWrite(false);

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -57,7 +57,7 @@ void PeerConnector::swanSong() STUB
 const char *PeerConnector::status() const STUB_RETVAL("")
 void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB
 void PeerConnector::connectionClosed(const char *) STUB
-bool PeerConnector::prepareSocket() STUB_RETVAL(false)
+void PeerConnector::prepareSocket() STUB
 bool PeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
 void PeerConnector::negotiate() STUB
 bool PeerConnector::sslFinalized() STUB_RETVAL(false)

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -50,14 +50,15 @@ namespace Security
 {
 PeerConnector::PeerConnector(const Comm::ConnectionPointer &, AsyncCall::Pointer &, const AccessLogEntryPointer &, const time_t) :
     AsyncJob("Security::PeerConnector") {STUB}
-PeerConnector::~PeerConnector() {STUB}
 void PeerConnector::start() STUB
 bool PeerConnector::doneAll() const STUB_RETVAL(true)
 void PeerConnector::swanSong() STUB
+void PeerConnector::callException(const std::exception &) STUB
+void PeerConnector::handleException(const std::exception &) STUB
 const char *PeerConnector::status() const STUB_RETVAL("")
 void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB
+void PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &) STUB
 void PeerConnector::connectionClosed(const char *) STUB
-void PeerConnector::prepareSocket() STUB
 bool PeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
 void PeerConnector::negotiate() STUB
 bool PeerConnector::sslFinalized() STUB_RETVAL(false)
@@ -67,7 +68,9 @@ void PeerConnector::noteWantWrite() STUB
 void PeerConnector::noteNegotiationError(const int, const int, const int) STUB
 //    virtual Security::ContextPointer getTlsContext() = 0;
 void PeerConnector::bail(ErrorState *) STUB
+void PeerConnector::sendSuccess() STUB
 void PeerConnector::callBack() STUB
+void PeerConnector::disconnect() STUB
 void PeerConnector::recordNegotiationDetails() STUB
 }
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -56,7 +56,6 @@ void PeerConnector::swanSong() STUB
 const char *PeerConnector::status() const STUB_RETVAL("")
 void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB
 void PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &) STUB
-void PeerConnector::connectionClosed(const char *) STUB
 bool PeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
 void PeerConnector::negotiate() STUB
 bool PeerConnector::sslFinalized() STUB_RETVAL(false)

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -53,8 +53,6 @@ PeerConnector::PeerConnector(const Comm::ConnectionPointer &, AsyncCall::Pointer
 void PeerConnector::start() STUB
 bool PeerConnector::doneAll() const STUB_RETVAL(true)
 void PeerConnector::swanSong() STUB
-void PeerConnector::callException(const std::exception &) STUB
-void PeerConnector::handleException(const std::exception &) STUB
 const char *PeerConnector::status() const STUB_RETVAL("")
 void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB
 void PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &) STUB

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1096,7 +1096,8 @@ TunnelStateData::advanceDestination(const char *stepDescription, const Comm::Con
     } catch (...) {
         debugs (26, 2, "exception while trying to " << stepDescription << ": " << CurrentException);
         closePendingConnection(conn, "connection preparation exception");
-        saveError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al));
+        if (!savedError)
+            saveError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al));
         retryOrBail();
     }
 }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -941,18 +941,13 @@ tunnelErrorComplete(int fd/*const Comm::ConnectionPointer &*/, void *data, size_
 void
 TunnelStateData::retryOrBail()
 {
-    assert(!serverDestinations.empty());
-    debugs(26, 4, "removing the failed one from " << serverDestinations.size() <<
-           " destinations: " << serverDestinations.front());
-    serverDestinations.erase(serverDestinations.begin());
-
     // Since no TCP payload has been passed to client or server, we may
     // TCP-connect to other destinations (including alternate IPs).
 
     if (!FwdState::EnoughTimeToReForward(startTime))
         return sendError(savedError, "forwarding timeout");
 
-    if (!serverDestinations.empty())
+    if (!destinations->empty())
         return startConnecting();
 
     if (!PeerSelectionInitiator::subscribed)

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1121,6 +1121,7 @@ TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answ
 
     if (!Comm::IsConnOpen(answer.conn) || fd_table[answer.conn->fd].closing()) {
         sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al), "connecion gone");
+        closePendingConnection(answer.conn, "conn was closed while waiting for noteSecurityPeerConnectorAnswer");
         return;
     }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -182,7 +182,7 @@ public:
     void copyRead(Connection &from, IOCB *completion);
 
     /// continue to set up connection to a peer, going async for SSL peers
-    void connectToPeer(const Comm::ConnectionPointer &conn);
+    void connectToPeer(const Comm::ConnectionPointer &);
     void secureConnectionToPeer(const Comm::ConnectionPointer &);
 
     /* PeerSelectionInitiator API */
@@ -238,10 +238,10 @@ private:
     void usePinned();
 
     /// callback handler for the Security::PeerConnector encryptor
-    void noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answer);
+    void noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &);
 
     /// called after connection setup (including any encryption)
-    void connectedToPeer(const Comm::ConnectionPointer &conn);
+    void connectedToPeer(const Comm::ConnectionPointer &);
     void establishTunnelThruProxy(const Comm::ConnectionPointer &);
 
     template <typename StepStart>

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -962,6 +962,7 @@ TunnelStateData::noteConnection(HappyConnOpener::Answer &answer)
 
     ErrorState *error = nullptr;
     if ((error = answer.error.get())) {
+        Must(!Comm::IsConnOpen(answer.conn));
         syncHierNote(answer.conn, request->url.host());
         answer.error.clear();
     } else if (!Comm::IsConnOpen(answer.conn) || fd_table[answer.conn->fd].closing()) {

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1079,8 +1079,7 @@ TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
 void
 TunnelStateData::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
 {
-    AsyncCall::Pointer callback = asyncCall(5,4,
-                                            "TunnelStateData::ConnectedToPeer",
+    AsyncCall::Pointer callback = asyncCall(5,4, "TunnelStateData::noteSecurityPeerConnectorAnswer",
                                             MyAnswerDialer(&TunnelStateData::noteSecurityPeerConnectorAnswer, this));
     const auto connector = new Security::BlindPeerConnector(request, conn, callback, al);
     AsyncJob::Start(connector); // will call our callback

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1079,15 +1079,11 @@ TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
 void
 TunnelStateData::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
 {
-    { // TODO: Remove this diff reduction before commit
-        { // TODO: Remove this diff reduction before commit
-            AsyncCall::Pointer callback = asyncCall(5,4,
-                                                    "TunnelStateData::ConnectedToPeer",
-                                                    MyAnswerDialer(&TunnelStateData::noteSecurityPeerConnectorAnswer, this));
-            const auto connector = new Security::BlindPeerConnector(request, conn, callback, al);
-            AsyncJob::Start(connector); // will call our callback
-        }
-    }
+    AsyncCall::Pointer callback = asyncCall(5,4,
+                                            "TunnelStateData::ConnectedToPeer",
+                                            MyAnswerDialer(&TunnelStateData::noteSecurityPeerConnectorAnswer, this));
+    const auto connector = new Security::BlindPeerConnector(request, conn, callback, al);
+    AsyncJob::Start(connector); // will call our callback
 }
 
 /// starts a preparation step for an established connection; retries on failures

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1223,8 +1223,6 @@ TunnelStateData::cancelOpening(const char *reason)
 void
 TunnelStateData::startConnecting()
 {
-    TunnelStateEnterThrowingCode();
-
     if (request)
         request->hier.startPeerClock();
 
@@ -1238,8 +1236,6 @@ TunnelStateData::startConnecting()
     destinations->notificationPending = true; // start() is async
     connOpener = cs;
     AsyncJob::Start(cs);
-
-    TunnelStateExitThrowingCode([] { /* no conn to cleanup yet */ });
 }
 
 /// send request on an existing connection dedicated to the requesting client

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1100,6 +1100,7 @@ TunnelStateData::advanceDestination(const char *stepDescription, const Comm::Con
     } catch (...) {
         debugs (26, 2, "exception while trying to " << stepDescription << ": " << CurrentException);
         closePendingConnection(conn, "connection preparation exception");
+        saveError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al));
         retryOrBail();
     }
 }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1133,7 +1133,7 @@ TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answ
 void
 TunnelStateData::connectedToPeer(const Comm::ConnectionPointer &conn)
 {
-    advanceDestination("establish tunnel thru proxy", conn, [this,&conn] {
+    advanceDestination("establish tunnel through proxy", conn, [this,&conn] {
         establishTunnelThruProxy(conn);
     });
 }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1029,7 +1029,7 @@ TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
     connectedToPeer(conn);
 }
 
-    /// callback handler for the connection encryptor
+/// callback handler for the connection encryptor
 void
 TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answer)
 {

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1115,6 +1115,7 @@ void
 TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answer)
 {
     if (ErrorState *error = answer.error.get()) {
+        Must(!Comm::IsConnOpen(answer.conn));
         answer.error.clear(); // sendError() will own the error
         sendError(error, "TLS peer connection error");
         return;

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1039,6 +1039,11 @@ TunnelStateData::noteSecurityPeerConnectorAnswer(Security::EncryptorAnswer &answ
         return;
     }
 
+    if (!Comm::IsConnOpen(answer.conn) || fd_table[answer.conn->fd].closing()) {
+        sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scServiceUnavailable, request.getRaw(), al), "connecion gone");
+        return;
+    }
+
     connectedToPeer(answer.conn);
 }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -980,11 +980,7 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
         ResetMarkingsToServer(request.getRaw(), *conn);
     // else Comm::ConnOpener already applied proper/current markings
 
-    syncHierNote(server.conn, request->url.host());
-
-    request->hier.resetPeerNotes(conn, origin);
-    if (al)
-        al->hier.resetPeerNotes(conn, origin);
+    syncHierNote(conn, origin);
 
 #if USE_DELAY_POOLS
     /* no point using the delayIsNoDelay stuff since tunnel is nice and simple */

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1125,9 +1125,6 @@ TunnelStateData::connectedToPeer(const Comm::ConnectionPointer &conn)
     advanceDestination("establish tunnel thru proxy", conn, [this,&conn] {
         establishTunnelThruProxy(conn);
     });
-    // XXX: In tests, if establishTunnelThruProxy() throws and
-    // advanceDestination() does not close, then conn remains open forever(?).
-    // The expected outcome is a "BUG #3329" warning in ~Connection.
 }
 
 void

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -116,7 +116,7 @@ public:
     void retryOrBail();
 
     /// called when negotiations with the peer have been successfully completed
-    void notePeerReadyToShovel(const Comm::ConnectionPointer &conn);
+    void notePeerReadyToShovel(const Comm::ConnectionPointer &);
 
     class Connection
     {
@@ -863,7 +863,7 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 
     waitingForConnectExchange = false;
 
-    bool sawProblem = false;
+    auto sawProblem = false;
 
     if (!answer.positive()) {
         sawProblem = true;
@@ -1057,7 +1057,7 @@ tunnelStart(ClientHttpRequest * http)
 void
 TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
 {
-    if (const auto *p = conn->getPeer()) {
+    if (const auto p = conn->getPeer()) {
         if (p->secure.encryptTransport)
             return advanceDestination("secure connection to peer", conn, [this,&conn] {
                 secureConnectionToPeer(conn);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1338,6 +1338,9 @@ TunnelStateData::notifyConnOpener()
 void
 switchToTunnel(HttpRequest *request, Comm::ConnectionPointer &clientConn, Comm::ConnectionPointer &srvConn)
 {
+    Must(Comm::IsConnOpen(clientConn));
+    Must(Comm::IsConnOpen(srvConn));
+
     debugs(26,5, "Revert to tunnel FD " << clientConn->fd << " with FD " << srvConn->fd);
 
     /* Create state structure. */


### PR DESCRIPTION
Before PeerConnector and Tunneler were introduced, FwdState and
TunnelStateData naturally owned their to-server connection. When CONNECT
and TLS negotiation were outsourced, we kept that ownership to minimize
changes and simplify negotiation code. That was wrong because FwdState
and TunnelStateData, as connection owners, had to monitor for connection
closures but could not distinguish basic TCP peer closures from complex
CONNECT/TLS negotiation failures that required further detailing. The
user got generic error messages instead of details known to negotiators.

Now, Ssl::PeerConnector and Http::Tunneler jobs own the connection they
work with and, hence, are responsible for monitoring it and, upon
successful negotiation, returning it to the initiators. In case of
problems, these jobs send detailed errors to the initiators instead.

Passing connection ownership to and from a helper job is difficult
because the connection may be either closed or begin to close (e.g. by
shutdown) while the callback is pending without working close handlers.
Many changes focus on keeping Connection::fd in sync with Comm.

Also improved tunnel.cc mimicking of (better) FwdState code: Partially
open connections after Comm::ConnOpener failures are now closed, and
Http::Tunneler failures are now retried.

This is a Measurement Factory project.