### PR TITLE
Invalidate cache when last chunk missing from upstream

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -1493,6 +1493,9 @@ HttpStateData::processReplyBody()
 
         case COMPLETE_NONPERSISTENT_MSG:
             debugs(11, 5, "processReplyBody: COMPLETE_NONPERSISTENT_MSG from " << serverConnection);
+            if (flags.chunked && !lastChunk)
+                entry->lengthWentBad("missing last-chunk");
+
             serverComplete();
             return;
         }


### PR DESCRIPTION
See [bug 4735](https://bugs.squid-cache.org/show_bug.cgi?id=4735).  This implement's @rousskov's suggested fix, which worked perfectly in my testing. 