### PR TITLE
Bug 4735: Truncated chunked responses cached as whole

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -1505,6 +1505,9 @@ HttpStateData::processReplyBody()
 
         case COMPLETE_NONPERSISTENT_MSG:
             debugs(11, 5, "processReplyBody: COMPLETE_NONPERSISTENT_MSG from " << serverConnection);
+            if (flags.chunked && !lastChunk)
+                entry->lengthWentBad("missing last-chunk");
+
             serverComplete();
             return;
         }


### PR DESCRIPTION
Mark responses received without the last chunk as responses that have
bad (and, hence, unknown) message body length (i.e. ENTRY_BAD_LENGTH).
If they were being cached, such responses will be released and will stop
being shareable.