### PR TITLE
Fix Squid V4-Bug 4992

### DIFF
--- a/src/stat.cc
+++ b/src/stat.cc
@@ -352,6 +352,7 @@ statObjects(void *data)
     if (state->theSearch->isDone()) {
         if (UsingSmp())
             storeAppendPrintf(state->sentry, "} by kid%d\n\n", KidIdentifier);
+        state->sentry->flush();
         state->sentry->complete();
         state->sentry->unlock("statObjects+isDone");
         delete state;


### PR DESCRIPTION
mgr:objects response stalls fix.
Missing "state->sentry->flush();" statement at line no 355 of src/stat.cc, was causing halt state in mgr:objects command.