### PR TITLE
Bug 5016: systemd thinks Squid is ready before Squid listens

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2102,6 +2102,51 @@ esac
 AC_SUBST(LDAPLIB)
 AC_SUBST(LBERLIB)
 
+AC_ARG_WITH(systemd,
+  AS_HELP_STRING([--without-systemd],
+                 [Do not use systemd API to send start-up completion
+                  notification. Default: auto-detect]), [
+case "$with_systemd" in
+  yes|no)
+    : # Nothing special to do here
+    ;;
+  *)
+    if test ! -d "$withval" ; then
+      AC_MSG_ERROR([--with-systemd path does not point to a directory])
+    fi
+    SYSTEMD_PATH="-L$with_systemd/lib"
+    CPPFLAGS="-I$with_systemd/include $CPPFLAGS"
+  esac
+])
+AH_TEMPLATE(USE_SYSTEMD,[systemd support is available])
+if test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"; then
+  SQUID_STATE_SAVE(squid_systemd_state)
+
+  # User may have provided a custom location for systemd. Otherwise...
+  LIBS="$LIBS $SYSTEMD_PATH"
+
+  # auto-detect using pkg-config
+  PKG_CHECK_MODULES(SYSTEMD,[libsystemd],,[
+    # systemd < 209
+    PKG_CHECK_MODULES(SYSTEMD,[libsystemd-daemon],,[:])
+  ])
+
+  AC_CHECK_HEADERS(systemd/sd-daemon.h)
+
+  SQUID_STATE_ROLLBACK(squid_systemd_state) #de-pollute LIBS
+
+  if test "x$with_systemd" = "xyes" -a "x$SYSTEMD_LIBS" = "x"; then
+    AC_MSG_ERROR([Required systemd library not found])
+  fi
+  if test "x$SYSTEMD_LIBS" != "x" ; then
+    CXXFLAGS="$SYSTEMD_CFLAGS $CXXFLAGS"
+    AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
+  else
+    with_systemd=no
+  fi
+fi
+AC_MSG_NOTICE([systemd library support: ${with_systemd:=auto} ${SYSTEMD_PATH} ${SYSTEMD_LIBS}])
+
 AC_ARG_ENABLE(forw-via-db,
   AS_HELP_STRING([--enable-forw-via-db],[Enable Forw/Via database]), [
   SQUID_YESNO([$enableval],[unrecognized argument to --enable-forw-via-db: $enableval])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -581,6 +581,7 @@ squid_LDADD = \
 	$(EPOLL_LIBS) \
 	$(MINGW_LIBS) \
 	$(KRB5LIBS) \
+	$(SYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(XTRA_LIBS)
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3488,8 +3488,13 @@ clientListenerConnectionOpened(AnyP::PortCfgPointer &s, const Ipc::FdNoteId port
     // Subsequent sd_notify() calls, including calls during reconfiguration,
     // do nothing because the first call parameter is 1.
     // XXX: Send the notification only after opening all configured ports.
-    if ((opt_foreground || opt_no_daemon) && (sd_notify(1, "READY=1") < 0))
-        debugs(1, DBG_IMPORTANT, "WARNING: failed to send start-up notification to systemd");
+    if (opt_foreground || opt_no_daemon) {
+        const auto result = sd_notify(1, "READY=1");
+        if (result < 0) {
+            debugs(1, DBG_IMPORTANT, "WARNING: failed to send start-up notification to systemd" <<
+                   Debug::Extra << "sd_notify() error: " << xstrerr(-result));
+        }
+    }
 #endif
 }
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -139,6 +139,10 @@
 #include <cmath>
 #include <limits>
 
+#if HAVE_SYSTEMD_SD_DAEMON_H
+#include <systemd/sd-daemon.h>
+#endif
+
 #if LINGERING_CLOSE
 #define comm_close comm_lingering_close
 #endif
@@ -3478,6 +3482,15 @@ clientListenerConnectionOpened(AnyP::PortCfgPointer &s, const Ipc::FdNoteId port
            << s->listenConn);
 
     Must(AddOpenedHttpSocket(s->listenConn)); // otherwise, we have received a fd we did not ask for
+
+#if USE_SYSTEMD
+    // When the very first port opens, tell systemd we are able to serve connections.
+    // Subsequent sd_notify() calls, including calls during reconfiguration,
+    // do nothing because the first call parameter is 1.
+    // XXX: Send the notification only after opening all configured ports.
+    if ((opt_foreground || opt_no_daemon) && (sd_notify(1, "READY=1") < 0))
+        debugs(1, DBG_IMPORTANT, "WARNING: failed to send start-up notification to systemd");
+#endif
 }
 
 void

--- a/tools/systemd/squid.service
+++ b/tools/systemd/squid.service
@@ -11,12 +11,13 @@ Documentation=man:squid(8)
 After=network.target network-online.target nss-lookup.target
 
 [Service]
-Type=forking
+Type=notify
 PIDFile=/var/run/squid.pid
 ExecStartPre=/usr/sbin/squid --foreground -z
-ExecStart=/usr/sbin/squid -sYC
+ExecStart=/usr/sbin/squid --foreground -sYC
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
+NotifyAccess=all
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use systemd API to send start-up completion notification if built
with libsystemd support. New configure option --with-systemd
can be used to force enable or disable the feature (default:
auto-detect on Linux platforms).