### PR TITLE
Preserve caller context across Store data delivery

### DIFF
--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_STORECLIENT_H
 #define SQUID_STORECLIENT_H
 
+#include "base/forward.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
 #include "StoreIOState.h"
@@ -124,6 +125,7 @@ public:
         bool pending() const;
         STCB *callback_handler;
         void *callback_data;
+        CodeContextPointer codeContext; ///< Store client context
     } _callback;
 };
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "acl/FilledChecklist.h"
+#include "base/CodeContext.h"
 #include "event.h"
 #include "globals.h"
 #include "HttpReply.h"
@@ -772,13 +773,13 @@ StoreEntry::invokeHandlers()
 
     PROF_start(InvokeHandlers);
 
-    debugs(90, 3, "InvokeHandlers: " << getMD5Text()  );
+    debugs(90, 3, mem_obj->nclients << " clients; " << *this << ' ' << getMD5Text());
     /* walk the entire list looking for valid callbacks */
 
+    const auto savedContext = CodeContext::Current();
     for (node = mem_obj->clients.head; node; node = nx) {
         sc = (store_client *)node->data;
         nx = node->next;
-        debugs(90, 3, "StoreEntry::InvokeHandlers: checking client #" << i  );
         ++i;
 
         if (!sc->_callback.pending())
@@ -787,8 +788,11 @@ StoreEntry::invokeHandlers()
         if (sc->flags.disk_io_pending)
             continue;
 
+        CodeContext::Reset(sc->_callback.codeContext);
+        debugs(90, 3, "checking client #" << i);
         storeClientCopy2(this, sc);
     }
+    CodeContext::Reset(savedContext);
     PROF_stop(InvokeHandlers);
 }
 
@@ -931,7 +935,12 @@ store_client::Callback::pending() const
     return callback_handler && callback_data;
 }
 
-store_client::Callback::Callback(STCB *function, void *data) : callback_handler(function), callback_data (data) {}
+store_client::Callback::Callback(STCB *function, void *data):
+    callback_handler(function),
+    callback_data(data),
+    codeContext(CodeContext::Current())
+{
+}
 
 #if USE_DELAY_POOLS
 void


### PR DESCRIPTION
StoreEntry::invokeHandlers() sends a recently loaded response data to
the waiting store_clients. During concurrent cache hits (including, but
not limited to collapsed ones), the response can be loaded into Store by
one transaction and delivered to several different transactions (i.e.
store_clients). This Store "hit sharing service" must restore the
context of the transactions it serves.