### PR TITLE
Remove pointer from the input of Digest nonce hashes

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -157,10 +157,10 @@ authenticateDigestNonceNew(void)
      * really bad timing with expiry and creation).  Using a random
      * component in the nonce allows us to loop to find a unique nonce.
      * We use H(nonce_data) so the nonce is meaningless to the reciever.
-     * So our nonce looks like hex(H(timestamp,pointertohash,randomdata))
+     * So our nonce looks like hex(H(timestamp,randomdata))
      * And even if our randomness is not very random we don't really care
-     * - the timestamp and memory pointer also guarantee local uniqueness
-     * in the input to the hash function.
+     * - the timestamp also guarantees local uniqueness in the input to
+     * the hash function.
      */
     // NP: this will likely produce the same randomness sequences for each worker
     // since they should all start within the 1-second resolution of seed value.
@@ -170,7 +170,6 @@ authenticateDigestNonceNew(void)
     /* create a new nonce */
     newnonce->nc = 0;
     newnonce->flags.valid = true;
-    newnonce->noncedata.self = newnonce;
     newnonce->noncedata.creationtime = current_time.tv_sec;
     newnonce->noncedata.randomdata = newRandomData(mt);
 

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -32,8 +32,6 @@ typedef struct _digest_nonce_h digest_nonce_h;
 /* data to be encoded into the nonce's hex representation */
 struct _digest_nonce_data {
     time_t creationtime;
-    /* in memory address of the nonce struct (similar purpose to an ETag) */
-    digest_nonce_h *self;
     uint32_t randomdata;
 };
 


### PR DESCRIPTION
This is a follow-up to #491 (b20ce97), which hashed what was previously
revealed as plaintext. Removing the pointer from the input to the hash
removes the possibility that someone could recover a pointer by
reversing a hash. Having the pointer as input was not adding anything:
Squid remembers all outstanding nonces, so it really only requires
uniqueness, which is already guaranteed by the
authenticateDigestNonceFindNonce loop.