### PR TITLE
WIP: Preserve caller context across event.h callbacks

### DIFF
--- a/src/event.cc
+++ b/src/event.cc
@@ -95,6 +95,7 @@ ev_entry::ev_entry(char const * aName, EVH * aFunction, void * aArgument, double
     when(evWhen),
     weight(aWeight),
     cbdata(haveArg),
+    codeContext(CodeContext::Current()),
     next(NULL)
 {
 }
@@ -238,6 +239,8 @@ EventScheduler::checkEvents(int)
         /* XXX assumes event->name is static memory! */
         AsyncCall::Pointer call = asyncCall(41,5, event->name,
                                             EventDialer(event->func, event->arg, event->cbdata));
+        call->codeContext = event->codeContext;
+
         ScheduleCallHere(call);
 
         last_event_ran = event->name; // XXX: move this to AsyncCallQueue

--- a/src/event.h
+++ b/src/event.h
@@ -10,6 +10,7 @@
 #define SQUID_EVENT_H
 
 #include "AsyncEngine.h"
+#include "base/CodeContext.h"
 #include "mem/forward.h"
 
 class StoreEntry;
@@ -40,6 +41,7 @@ public:
     int weight;
     bool cbdata;
 
+    CodeContext::Pointer codeContext; ///< event creator's context
     ev_entry *next;
 };
 


### PR DESCRIPTION
eventAdd*() API queues callbacks without saving the call context. Thus,
EventScheduler::checkEvents() schedules event callbacks (via AsyncCall
API) without restoring the original recipient context. We must
preserve the code context across events.