### PR TITLE
Bug 5022: Reconfigure kills Coordinator in SMP+ufs configurations

### DIFF
--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -728,6 +728,9 @@ Fs::Ufs::UFSSwapDir::logFile(char const *ext) const
 void
 Fs::Ufs::UFSSwapDir::openLog()
 {
+    if (!IamWorkerProcess())
+        return;
+
     assert(NumberOfUFSDirs || !UFSDirToGlobalDirMapping);
     ++NumberOfUFSDirs;
     assert(NumberOfUFSDirs <= Config.cacheSwap.n_configured);

--- a/src/main.cc
+++ b/src/main.cc
@@ -1010,8 +1010,7 @@ mainReconfigureFinish(void *)
 
     neighbors_init();
 
-    if (!IamCoordinatorProcess())
-        storeDirOpenSwapLogs();
+    storeDirOpenSwapLogs();
 
     mimeInit(Config.mimeTablePathname);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1010,7 +1010,8 @@ mainReconfigureFinish(void *)
 
     neighbors_init();
 
-    storeDirOpenSwapLogs();
+    if (!IamCoordinatorProcess())
+        storeDirOpenSwapLogs();
 
     mimeInit(Config.mimeTablePathname);
 


### PR DESCRIPTION
In these unsupported SMP+ufs configurations, depending on the deployment
specifics, the Coordinator process could exit due to swap state file
opening errors:

    kid11| FATAL: UFSSwapDir::openLog: Failed to open swap log.

