### PR TITLE
Preserve caller context across tunnelDelayed*Read

### DIFF
--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -206,6 +206,7 @@ Http::Tunneler::handleReadyRead(const CommIoCbParams &io)
 #else
     rd.size = readBuf.spaceSize();
 #endif
+    // XXX: defer read if rd.size <= 0
 
     switch (Comm::ReadNow(rd, readBuf)) {
     case Comm::INPROGRESS:


### PR DESCRIPTION
tunnel.cc code approximates delay pools functionality using event.h API
that is not meant for transaction-specific events. We (temporary) add a
transaction context data member to TunnelStateData until the class
switches to using transaction-specific deferred reads API.
