### PR TITLE
Change time_units test to also work on 32bit systems

### DIFF
--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -15,18 +15,16 @@ dns_timeout 1 millisecond
 dns_timeout 0.001 second
 
 # check support for the maximum value (expressed in each supported time unit)
-# XXX: Use a 32-bit maximum to avoid breaking tests on 32-bit platforms.
-# TODO: Generate these test lines based on the target build platform.
-dns_timeout 2147483647854 milliseconds
-dns_timeout 2147483647 seconds # 2^31-1
-dns_timeout 35791394 minutes # floor(dns_timeout seconds/60)
-dns_timeout 596523 hours # floor(dns_timeout minutes/60)
-dns_timeout 24855 days # floor(dns_timeout hours/24)
-dns_timeout 3550 weeks # floor(dns_timeout days/7)
-dns_timeout 1775 fortnights # floor(dns_timeout weeks/2)
-dns_timeout 828.5 months # dns_timeout days/30
-dns_timeout 68.095 years # approx(dns_timeout days/365)
-dns_timeout 6.8095 decades
+dns_timeout 9223372036854 milliseconds
+dns_timeout 9223372036 seconds
+dns_timeout 153722867 minutes
+dns_timeout 2562047 hours
+dns_timeout 106751 days
+dns_timeout 15250 weeks
+dns_timeout 7625 fortnights
+dns_timeout 3558 months
+dns_timeout 292.27 years
+dns_timeout 29.227 decades
 # a second-precision parameter (time-units)
 
 # minimum checks
@@ -34,6 +32,8 @@ max_stale 1 second
 max_stale 0.0167 minute
 
 # maximum checks (see similar dns_timeout checks for details)
+# XXX: Use a 32-bit maximum to avoid breaking tests on 32-bit platforms.
+# TODO: Generate these test lines based on the target build platform.
 max_stale 2147483647 seconds # 2^31-1
 max_stale 35791394 minutes # floor(max_stale seconds/60)
 max_stale 596523 hours # floor(max_stale minutes/60)

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -41,8 +41,8 @@ max_stale 24855 days # floor(max_stale hours/24)
 max_stale 3550 weeks # floor(max_stale days/7)
 max_stale 1775 fortnights # floor(max_stale weeks/2)
 max_stale 828.5 months # max_stale days/30
-max_stale 68 years # approx(max_stale days/365)
-max_stale 6.8 decades
+max_stale 68.04 years # approx(max_stale days/365.2522)
+max_stale 6.804 decades # max_stale years/10
 
 # a multiple-options parameter
 

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -15,17 +15,16 @@ dns_timeout 1 millisecond
 dns_timeout 0.001 second
 
 # maximum checks
-dns_timeout 9223372036854 milliseconds
-dns_timeout 9223372036 seconds
-dns_timeout 153722867 minutes
-dns_timeout 2562047 hours
-dns_timeout 106751 days
-dns_timeout 15250 weeks
-dns_timeout 7625 fortnights
-dns_timeout 3558 months
-dns_timeout 292.27 years
-dns_timeout 29.227 decades
-
+dns_timeout 2147483647854 milliseconds
+dns_timeout 2147483647 seconds
+dns_timeout 2562047 minutes
+dns_timeout 42700 hours
+dns_timeout 1779 days
+dns_timeout 254 weeks
+dns_timeout 127 fortnights
+dns_timeout 63 months
+dns_timeout 5.27 years
+dns_timeout 0.727 decades
 
 # a second-precision parameter (time-units)
 
@@ -34,15 +33,15 @@ max_stale 1 second
 max_stale 0.0167 minute
 
 # maximum checks
-max_stale 9223372036 seconds
-max_stale 153722867 minutes
-max_stale 2562047 hours
-max_stale 106751 days
-max_stale 15250 weeks
-max_stale 7625 fortnights
-max_stale 3558 months
-max_stale 292.27 years
-max_stale 29.227 decades
+max_stale 2147483647 seconds
+max_stale 2562047 minutes
+max_stale 42700 hours
+max_stale 1779 days
+max_stale 254 weeks
+max_stale 127 fortnights
+max_stale 63 months
+max_stale 5.27 years
+max_stale 0.727 decades
 
 # a multiple-options parameter
 

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -33,7 +33,7 @@ dns_timeout 29.227 decades
 max_stale 1 second
 max_stale 0.0167 minute
 
-# maximum checks (see similar dns_timeout checks for details)
+# check support for the maximum value (expressed in each supported time unit)
 # XXX: Use a 32-bit maximum to avoid breaking tests on 32-bit platforms.
 # TODO: Generate these test lines based on the target build platform.
 max_stale 2147483647 seconds # 2^31-1

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -18,16 +18,15 @@ dns_timeout 0.001 second
 # XXX: Use a 32-bit maximum to avoid breaking tests on 32-bit platforms.
 # TODO: Generate these test lines based on the target build platform.
 dns_timeout 2147483647854 milliseconds
-dns_timeout 2147483647 seconds
-dns_timeout 2562047 minutes
-dns_timeout 42700 hours
-dns_timeout 1779 days
-dns_timeout 254 weeks
-dns_timeout 127 fortnights
-dns_timeout 63 months
-dns_timeout 5.27 years
-dns_timeout 0.727 decades
-
+dns_timeout 2147483647 seconds # 2^31-1
+dns_timeout 35791394 minutes # floor(dns_timeout seconds/60)
+dns_timeout 596523 hours # floor(dns_timeout minutes/60)
+dns_timeout 24855 days # floor(dns_timeout hours/24)
+dns_timeout 3550 weeks # floor(dns_timeout days/7)
+dns_timeout 1775 fortnights # floor(dns_timeout weeks/2)
+dns_timeout 828.5 months # dns_timeout days/30
+dns_timeout 68.095 years # approx(dns_timeout days/365)
+dns_timeout 6.8095 decades
 # a second-precision parameter (time-units)
 
 # minimum checks
@@ -35,15 +34,15 @@ max_stale 1 second
 max_stale 0.0167 minute
 
 # maximum checks (see similar dns_timeout checks for details)
-max_stale 2147483647 seconds
-max_stale 2562047 minutes
-max_stale 42700 hours
-max_stale 1779 days
-max_stale 254 weeks
-max_stale 127 fortnights
-max_stale 63 months
-max_stale 5.27 years
-max_stale 0.727 decades
+max_stale 2147483647 seconds # 2^31-1
+max_stale 35791394 minutes # floor(max_stale seconds/60)
+max_stale 596523 hours # floor(max_stale minutes/60)
+max_stale 24855 days # floor(max_stale hours/24)
+max_stale 3550 weeks # floor(max_stale days/7)
+max_stale 1775 fortnights # floor(max_stale weeks/2)
+max_stale 828.5 months # max_stale days/30
+max_stale 68 years # approx(max_stale days/365)
+max_stale 6.8 decades
 
 # a multiple-options parameter
 

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -34,7 +34,7 @@ dns_timeout 0.727 decades
 max_stale 1 second
 max_stale 0.0167 minute
 
-# maximum checks
+# maximum checks (see similar dns_timeout checks for details)
 max_stale 2147483647 seconds
 max_stale 2562047 minutes
 max_stale 42700 hours

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -14,7 +14,9 @@
 dns_timeout 1 millisecond
 dns_timeout 0.001 second
 
-# maximum checks
+# check support for the maximum value (expressed in each supported time unit)
+# XXX: Use a 32-bit maximum to avoid breaking tests on 32-bit platforms.
+# TODO: Generate these test lines based on the target build platform.
 dns_timeout 2147483647854 milliseconds
 dns_timeout 2147483647 seconds
 dns_timeout 2562047 minutes
@@ -53,4 +55,3 @@ url_rewrite_timeout 292 year on_timeout=bypass
 url_rewrite_timeout 1 on_timeout=bypass
 
 # TODO: a nanosecond-precison parameter (time-units-small)
-

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -25,6 +25,8 @@ dns_timeout 7625 fortnights
 dns_timeout 3558 months
 dns_timeout 292.27 years
 dns_timeout 29.227 decades
+
+
 # a second-precision parameter (time-units)
 
 # minimum checks
@@ -54,3 +56,4 @@ url_rewrite_timeout 292 year on_timeout=bypass
 url_rewrite_timeout 1 on_timeout=bypass
 
 # TODO: a nanosecond-precison parameter (time-units-small)
+


### PR DESCRIPTION
With a 64-bit maximum value, "make check" failed on 32-bit platforms
(e.g., arm7l) with:

    configuration error: directive supports time values up to 2147483647
    but is given 9223372036 seconds
