### PR TITLE
Bug 5030: Negative responses are never cached

### DIFF
--- a/src/store.cc
+++ b/src/store.cc
@@ -1028,8 +1028,8 @@ storeCheckCachableStats(StoreEntry *sentry)
                       store_check_cachable_hist.no.not_entry_cachable);
     storeAppendPrintf(sentry, "no.wrong_content_length\t%d\n",
                       store_check_cachable_hist.no.wrong_content_length);
-    /* for backward compatibility */
-    storeAppendPrintf(sentry, "no.negative_cached\t0\n");
+    storeAppendPrintf(sentry, "no.negative_cached\t%d\n",
+                      0); // TODO: Remove this backward compatibility hack.
     storeAppendPrintf(sentry, "no.missing_parts\t%d\n",
                       store_check_cachable_hist.no.missing_parts);
     storeAppendPrintf(sentry, "no.too_big\t%d\n",

--- a/src/store.cc
+++ b/src/store.cc
@@ -899,7 +899,7 @@ struct _store_check_cachable_hist {
         int non_get;
         int not_entry_cachable;
         int wrong_content_length;
-        int negative_cached;
+        int expired_negative_cached;
         int too_big;
         int too_small;
         int private_key;
@@ -910,6 +910,7 @@ struct _store_check_cachable_hist {
 
     struct {
         int Default;
+        int unexpired_negative_cached;
     } yes;
 } store_check_cachable_hist;
 
@@ -980,8 +981,13 @@ StoreEntry::checkCachable()
             debugs(20, 2, "StoreEntry::checkCachable: NO: wrong content-length");
             ++store_check_cachable_hist.no.wrong_content_length;
         } else if (EBIT_TEST(flags, ENTRY_NEGCACHED)) {
-            debugs(20, 3, "StoreEntry::checkCachable: NO: negative cached");
-            ++store_check_cachable_hist.no.negative_cached;
+            if (squid_curtime < expires) {
+                debugs(20, 3, "StoreEntry::checkCachable: YES: unexpired negative cached");
+                ++store_check_cachable_hist.yes.unexpired_negative_cached;
+                return 1;
+            }
+            debugs(20, 3, "StoreEntry::checkCachable: NO: expired negative cached");
+            ++store_check_cachable_hist.no.expired_negative_cached;
             return 0;           /* avoid release call below */
         } else if (!mem_obj) {
             // XXX: In bug 4131, we forgetHit() without mem_obj, so we need
@@ -1033,8 +1039,8 @@ storeCheckCachableStats(StoreEntry *sentry)
                       store_check_cachable_hist.no.not_entry_cachable);
     storeAppendPrintf(sentry, "no.wrong_content_length\t%d\n",
                       store_check_cachable_hist.no.wrong_content_length);
-    storeAppendPrintf(sentry, "no.negative_cached\t%d\n",
-                      store_check_cachable_hist.no.negative_cached);
+    storeAppendPrintf(sentry, "no.expired_negative_cached\t%d\n",
+                      store_check_cachable_hist.no.expired_negative_cached);
     storeAppendPrintf(sentry, "no.missing_parts\t%d\n",
                       store_check_cachable_hist.no.missing_parts);
     storeAppendPrintf(sentry, "no.too_big\t%d\n",
@@ -1047,6 +1053,8 @@ storeCheckCachableStats(StoreEntry *sentry)
                       store_check_cachable_hist.no.too_many_open_files);
     storeAppendPrintf(sentry, "no.too_many_open_fds\t%d\n",
                       store_check_cachable_hist.no.too_many_open_fds);
+    storeAppendPrintf(sentry, "yes.unexpired_negative_cached\t%d\n",
+                      store_check_cachable_hist.yes.unexpired_negative_cached);
     storeAppendPrintf(sentry, "yes.default\t%d\n",
                       store_check_cachable_hist.yes.Default);
 }
@@ -1374,6 +1382,7 @@ StoreEntry::negativeCache()
 #else
         expires = squid_curtime;
 #endif
+    debugs(20, 6, "expires = " << expires << ", curtime = " << squid_curtime);
     EBIT_SET(flags, ENTRY_NEGCACHED);
 }
 

--- a/src/store.cc
+++ b/src/store.cc
@@ -908,7 +908,6 @@ struct _store_check_cachable_hist {
     } no;
 
     struct {
-        int negative_cached;
         int Default;
     } yes;
 } store_check_cachable_hist;
@@ -1005,10 +1004,6 @@ StoreEntry::checkCachable()
         } else if (fdNFree() < RESERVED_FD) {
             debugs(20, 2, "StoreEntry::checkCachable: NO: too many FD's open");
             ++store_check_cachable_hist.no.too_many_open_fds;
-        } else if (EBIT_TEST(flags, ENTRY_NEGCACHED)) {
-            debugs(20, 3, "StoreEntry::checkCachable: YES: negative cached");
-            ++store_check_cachable_hist.yes.negative_cached;
-            return 1;
         } else {
             ++store_check_cachable_hist.yes.Default;
             return 1;
@@ -1033,6 +1028,8 @@ storeCheckCachableStats(StoreEntry *sentry)
                       store_check_cachable_hist.no.not_entry_cachable);
     storeAppendPrintf(sentry, "no.wrong_content_length\t%d\n",
                       store_check_cachable_hist.no.wrong_content_length);
+    /* for backward compatibility */
+    storeAppendPrintf(sentry, "no.negative_cached\t0\n");
     storeAppendPrintf(sentry, "no.missing_parts\t%d\n",
                       store_check_cachable_hist.no.missing_parts);
     storeAppendPrintf(sentry, "no.too_big\t%d\n",
@@ -1045,8 +1042,6 @@ storeCheckCachableStats(StoreEntry *sentry)
                       store_check_cachable_hist.no.too_many_open_files);
     storeAppendPrintf(sentry, "no.too_many_open_fds\t%d\n",
                       store_check_cachable_hist.no.too_many_open_fds);
-    storeAppendPrintf(sentry, "yes.negative_cached\t%d\n",
-                      store_check_cachable_hist.yes.negative_cached);
     storeAppendPrintf(sentry, "yes.default\t%d\n",
                       store_check_cachable_hist.yes.Default);
 }
@@ -2157,3 +2152,4 @@ Store::EntryGuard::onException() noexcept
         entry_->unlock(context_);
     });
 }
+

--- a/src/store.cc
+++ b/src/store.cc
@@ -1374,9 +1374,10 @@ StoreEntry::negativeCache()
 #else
         expires = squid_curtime;
 #endif
-    debugs(20, 6, "expires = " << expires << ", curtime = " << squid_curtime);
-    if (expires > squid_curtime)
+    if (expires > squid_curtime) {
         EBIT_SET(flags, ENTRY_NEGCACHED);
+        debugs(20, 6, "expires = " << expires << " +" << (expires-squid_curtime) << ' ' << *this);
+    }
 }
 
 void
@@ -2156,4 +2157,3 @@ Store::EntryGuard::onException() noexcept
         entry_->unlock(context_);
     });
 }
-


### PR DESCRIPTION
Negative caching was blocked by checkCachable().

Since 3e98df2, Squid cached ENTRY_NEGCACHED entries in memory cache
only. Back then, storeCheckSwapable() prevented what later became
ENTRY_NEGCACHED entries from going to disk. The design was obscured by
8350fe9 that renamed storeCheckSwapable() to storeCheckCachable().

Commit 97754f5 violated that (obscured) design by adding a
checkCachable() call to StoreEntry::memoryCachable(), effectively
blocking ENTRY_NEGCACHED entries from the memory cache as well. That
call should have been added, but checkCachable() should not have denied
caching rights to ENTRY_NEGCACHED -- the corresponding check should have
been moved into StoreEntry::mayStartSwapOut().

By removing ENTRY_NEGCACHED from checkCachable(), we now allow
ENTRY_NEGCACHED entries into both memory and disk caches, subject to all
the other checks. We allow ENTRY_NEGCACHED to be cached on disk because
negative responses are fundamentally no different than positive ones:
HTTP allows caching of 4xx and 5xx responses expiring in the future.
Hopefully, the increased disk cache traffic will not be a problem.
