### PR TITLE
Happy Eyeballs: Do not discard viable reforwarding destinations

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -470,7 +470,7 @@ FwdState::fail(ErrorState * errorState)
     if (pconnRace == racePossible) {
         debugs(17, 5, HERE << "pconn race happened");
         pconnRace = raceHappened;
-        destinations->retryPath(serverConn);
+        destinations->retryPrimePath(serverConn);
     }
 
     if (ConnStateData *pinned_connection = request->pinnedConnection()) {

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -470,7 +470,7 @@ FwdState::fail(ErrorState * errorState)
     if (pconnRace == racePossible) {
         debugs(17, 5, HERE << "pconn race happened");
         pconnRace = raceHappened;
-        destinations->retryPrimePath(serverConn);
+        destinations->retryPath(serverConn);
     }
 
     if (ConnStateData *pinned_connection = request->pinnedConnection()) {

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -486,7 +486,7 @@ void
 HappyConnOpener::cancelPrimeAttempt(Attempt &attempt, const char *reason)
 {
     Must(attempt);
-    destinations->retryPrimePath(attempt.path);
+    destinations->retryPath(attempt.path);
     attempt.cancel(reason);
 }
 
@@ -496,7 +496,7 @@ void
 HappyConnOpener::cancelSpareAttempt(Attempt &attempt, const char *reason)
 {
     Must(attempt);
-    destinations->retrySparePath(attempt.path);
+    destinations->retryPath(attempt.path);
     attempt.cancel(reason);
 }
 

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -480,8 +480,7 @@ HappyConnOpener::sendSuccess(const Comm::ConnectionPointer &conn, bool reused, c
     callback_ = nullptr;
 }
 
-/// if the given spare attempt is in progress, cancels it and re-inserts
-/// the path into the candidates list
+/// cancels the being in-progress attempt and re-inserts the path into the candidates list
 void
 HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -480,7 +480,7 @@ HappyConnOpener::sendSuccess(const Comm::ConnectionPointer &conn, bool reused, c
     callback_ = nullptr;
 }
 
-/// cancels the being in-progress attempt and re-inserts the path into the candidates list
+/// cancels the in-progress attempt, making its path a future candidate
 void
 HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {
@@ -584,9 +584,9 @@ HappyConnOpener::connectDone(const CommConnectCbParams &params)
     Must(itWasPrime != itWasSpare);
 
     if (itWasPrime) {
-        prime.clear();
+        prime.finish();
     } else {
-        spare.clear();
+        spare.finish();
         if (gotSpareAllowance) {
             TheSpareAllowanceGiver.jobUsedAllowance();
             gotSpareAllowance = false;

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -396,17 +396,16 @@ HappyConnOpener::swanSong()
 
     // TODO: Find an automated, faster way to kill no-longer-needed jobs.
 
+    if (prime) {
+        cancelPrimeAttempt(prime, "job finished during a prime attempt");
+    }
+
     if (spare) {
-        // cancel the spare attempt first to preserve destination order
-        cancelAttempt(spare, "job finished during a spare attempt");
+        cancelSpareAttempt(spare, "job finished during a spare attempt");
         if (gotSpareAllowance) {
             TheSpareAllowanceGiver.jobDroppedAllowance();
             gotSpareAllowance = false;
         }
-    }
-
-    if (prime) {
-        cancelAttempt(prime, "job finished during a prime attempt");
     }
 
     AsyncJob::swanSong();
@@ -481,13 +480,23 @@ HappyConnOpener::sendSuccess(const Comm::ConnectionPointer &conn, bool reused, c
     callback_ = nullptr;
 }
 
-/// if the given attempt is in progress, cancels it and re-inserts
+/// if the given prime attempt is in progress, cancels it and re-inserts
 /// the path into the beginning of candidates list
 void
-HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
+HappyConnOpener::cancelPrimeAttempt(Attempt &attempt, const char *reason)
 {
     Must(attempt);
-    destinations->retryPath(attempt.path);
+    destinations->retryPrimePath(attempt.path);
+    attempt.cancel(reason);
+}
+
+/// if the given spare attempt is in progress, cancels it and re-inserts
+/// the path into the candidates list
+void
+HappyConnOpener::cancelSpareAttempt(Attempt &attempt, const char *reason)
+{
+    Must(attempt);
+    destinations->retrySparePath(attempt.path);
     attempt.cancel(reason);
 }
 

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -568,7 +568,7 @@ HappyConnOpener::openFreshConnection(Attempt &attempt, Comm::ConnectionPointer &
 
     attempt.path = dest;
     attempt.connector = callConnect;
-    attempt.connOpener = cs;
+    attempt.opener = cs;
 
     AsyncJob::Start(cs);
 }
@@ -880,7 +880,7 @@ HappyConnOpener::Attempt::cancel(const char *reason)
 {
     if (connector) {
         connector->cancel(reason);
-        CallJobHere(17, 3, connOpener, Comm::ConnOpener, noteAbort);
+        CallJobHere(17, 3, opener, Comm::ConnOpener, noteAbort);
     }
     clear();
 }

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -397,11 +397,11 @@ HappyConnOpener::swanSong()
     // TODO: Find an automated, faster way to kill no-longer-needed jobs.
 
     if (prime) {
-        cancelPrimeAttempt(prime, "job finished during a prime attempt");
+        cancelAttempt(prime, "job finished during a prime attempt");
     }
 
     if (spare) {
-        cancelSpareAttempt(spare, "job finished during a spare attempt");
+        cancelAttempt(spare, "job finished during a spare attempt");
         if (gotSpareAllowance) {
             TheSpareAllowanceGiver.jobDroppedAllowance();
             gotSpareAllowance = false;
@@ -480,20 +480,10 @@ HappyConnOpener::sendSuccess(const Comm::ConnectionPointer &conn, bool reused, c
     callback_ = nullptr;
 }
 
-/// if the given prime attempt is in progress, cancels it and re-inserts
-/// the path into the beginning of candidates list
-void
-HappyConnOpener::cancelPrimeAttempt(Attempt &attempt, const char *reason)
-{
-    Must(attempt);
-    destinations->retryPath(attempt.path);
-    attempt.cancel(reason);
-}
-
 /// if the given spare attempt is in progress, cancels it and re-inserts
 /// the path into the candidates list
 void
-HappyConnOpener::cancelSpareAttempt(Attempt &attempt, const char *reason)
+HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {
     Must(attempt);
     destinations->retryPath(attempt.path);

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -485,7 +485,7 @@ void
 HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {
     Must(attempt);
-    destinations->retryPath(attempt.path);
+    destinations->retryPath(attempt.path); // before attempt.cancel() clears path
     attempt.cancel(reason);
 }
 

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -157,13 +157,20 @@ private:
     class Attempt {
     public:
         explicit operator bool() const { return static_cast<bool>(path); }
-        void clear() { path = nullptr; connector = nullptr; connOpener = nullptr; }
-        /// cancels the attempt
+
+        /// reacts to a natural attempt completion (successful or otherwise)
+        void finish() { clear(); }
+
+        /// aborts an in-progress attempt
         void cancel(const char *reason);
 
         Comm::ConnectionPointer path; ///< the destination we are connecting to
         AsyncCall::Pointer connector; ///< our Comm::ConnOpener callback
         Comm::ConnOpener::Pointer connOpener; ///< our Comm::ConnOpener job
+
+    private:
+        /// cleans up after the attempt ends (successfully or otherwise)
+        void clear() { path = nullptr; connector = nullptr; connOpener = nullptr; }
     };
 
     /* AsyncJob API */

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -197,7 +197,8 @@ private:
     Answer *futureAnswer(const Comm::ConnectionPointer &);
     void sendSuccess(const Comm::ConnectionPointer &conn, bool reused, const char *connKind);
     void sendFailure();
-    void cancelAttempt(Attempt &, const char *reason);
+    void cancelPrimeAttempt(Attempt &, const char *reason);
+    void cancelSpareAttempt(Attempt &, const char *reason);
 
     const time_t fwdStart; ///< requestor start time
 

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -197,8 +197,7 @@ private:
     Answer *futureAnswer(const Comm::ConnectionPointer &);
     void sendSuccess(const Comm::ConnectionPointer &conn, bool reused, const char *connKind);
     void sendFailure();
-    void cancelPrimeAttempt(Attempt &, const char *reason);
-    void cancelSpareAttempt(Attempt &, const char *reason);
+    void cancelAttempt(Attempt &, const char *reason);
 
     const time_t fwdStart; ///< requestor start time
 

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -157,10 +157,13 @@ private:
     class Attempt {
     public:
         explicit operator bool() const { return static_cast<bool>(path); }
-        void clear() { path = nullptr; connector = nullptr; }
+        void clear() { path = nullptr; connector = nullptr; connOpener = nullptr; }
+        /// cancels the attempt
+        void cancel(const char *reason);
 
         Comm::ConnectionPointer path; ///< the destination we are connecting to
         AsyncCall::Pointer connector; ///< our Comm::ConnOpener callback
+        Comm::ConnOpener::Pointer connOpener; ///< our Comm::ConnOpener job
     };
 
     /* AsyncJob API */
@@ -194,6 +197,7 @@ private:
     Answer *futureAnswer(const Comm::ConnectionPointer &);
     void sendSuccess(const Comm::ConnectionPointer &conn, bool reused, const char *connKind);
     void sendFailure();
+    void cancelAttempt(Attempt &, const char *reason);
 
     const time_t fwdStart; ///< requestor start time
 

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -165,12 +165,12 @@ private:
         void cancel(const char *reason);
 
         Comm::ConnectionPointer path; ///< the destination we are connecting to
-        AsyncCall::Pointer connector; ///< our Comm::ConnOpener callback
-        Comm::ConnOpener::Pointer connOpener; ///< our Comm::ConnOpener job
+        AsyncCall::Pointer connector; ///< our opener callback
+        Comm::ConnOpener::Pointer opener; ///< connects to path and calls us
 
     private:
         /// cleans up after the attempt ends (successfully or otherwise)
-        void clear() { path = nullptr; connector = nullptr; connOpener = nullptr; }
+        void clear() { path = nullptr; connector = nullptr; opener = nullptr; }
     };
 
     /* AsyncJob API */

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -70,10 +70,10 @@ ResolvedPeers::extractFront()
 
 /// helps to optimize find*() searches, caching the 'current peer' iterator
 const ConnectionList::iterator &
-ResolvedPeers::cachedCurrent(const CachePeer *currentPeer)
+ResolvedPeers::cachedCurrent(const Comm::Connection *currentPeer)
 {
     Must(!paths_.empty()); // guarantees that lastCurrentPeer was initialized
-    if (!currentPeer || (currentPeer != lastCurrentPeer->connection->getPeer())) {
+    if (!currentPeer || (currentPeer->getPeer() != lastCurrentPeer->connection->getPeer())) {
         lastCurrentPeer = std::find_if(paths_.begin(), paths_.end(),
         [](const ResolvedPeerPath &path) {
             return path.available;
@@ -92,7 +92,7 @@ ResolvedPeers::findPrime(const Comm::Connection &currentPeer, bool *hasNext)
     const auto peerToMatch = currentPeer.getPeer();
     const auto familyToMatch = ConnectionFamily(currentPeer);
     bool foundSpareOrNext = false;
-    auto found = std::find_if(cachedCurrent(peerToMatch), paths_.end(),
+    auto found = std::find_if(cachedCurrent(&currentPeer), paths_.end(),
     [&](const ResolvedPeerPath &path) {
         if (!path.available) // skip unavailable
             return false;
@@ -114,7 +114,7 @@ ResolvedPeers::findSpare(const Comm::Connection &currentPeer, bool *hasNext)
     const auto peerToMatch = currentPeer.getPeer();
     const auto familyToAvoid = ConnectionFamily(currentPeer);
     bool foundNext = false;
-    auto found = std::find_if(cachedCurrent(peerToMatch), paths_.end(),
+    auto found = std::find_if(cachedCurrent(&currentPeer), paths_.end(),
     [&](const ResolvedPeerPath &path) {
         if (!path.available || familyToAvoid == ConnectionFamily(*path.connection)) // skip unavailable and prime
             return false;
@@ -135,7 +135,7 @@ ResolvedPeers::findPeer(const Comm::Connection &currentPeer, bool *hasNext)
 {
     const auto peerToMatch = currentPeer.getPeer();
     bool foundNext = false;
-    auto found = std::find_if(cachedCurrent(peerToMatch), paths_.end(),
+    auto found = std::find_if(cachedCurrent(&currentPeer), paths_.end(),
     [&](const ResolvedPeerPath &path) {
         if (!path.available) // skip unavailable
             return false;

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -106,21 +106,13 @@ ResolvedPeers::findSpare(const Comm::Connection &currentPeer, bool *foundOther)
 }
 
 /// \returns the first available same-peer address iterator or end()
-/// If not found and there is an other-peer address, the optional *foundOther becomes true
+/// \param foundOther (optional) filled with "found other-peer address"
 ConnectionList::iterator
 ResolvedPeers::findPeer(const Comm::Connection &currentPeer, bool *foundOther)
 {
-    const auto peerToMatch = currentPeer.getPeer();
-    bool foundNext = false;
-    const auto found = std::find_if(start(), paths_.end(),
-    [&](const ResolvedPeerPath &path) {
-        if (!path.available) // skip unavailable
-            return false;
-        // an other-peer address means that there are no current peer addresses left
-        if (peerToMatch != path.connection->getPeer())
-            foundNext = true;
-        return true;
-    });
+    const auto found = start();
+    const auto foundNext = found != paths_.end() &&
+        currentPeer.getPeer() != found->connection->getPeer();
     if (foundOther)
         *foundOther = foundNext;
     return foundNext ? paths_.end() : found;

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -61,8 +61,12 @@ ResolvedPeers::addPath(const Comm::ConnectionPointer &path)
 Comm::ConnectionPointer
 ResolvedPeers::extractFront()
 {
-    Must(!empty());
-    return extractFound("first: ", paths_.begin());
+    auto found = std::find_if(paths_.begin(), paths_.end(),
+    [](const ResolvedPeerPath &path) {
+         return path.available;
+    });
+    Must(found != paths_.end());
+    return extractFound("first: ", found);
 }
 
 /// \returns the first available same-peer same-family address iterator or end()

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -173,16 +173,17 @@ ResolvedPeers::extractSpare(const Comm::Connection &currentPeer)
 Comm::ConnectionPointer
 ResolvedPeers::extractFound(const char *description, const ConnectionList::iterator &found)
 {
-    assert(found->available);
-    found->available = false;
-    debugs(17, 7, description << found->connection);
+    auto &path = *found;
+    debugs(17, 7, description << path.connection);
+    assert(path.available);
+    path.available = false;
 
     // if we extracted the left-most available candidate, find the next one
     if (static_cast<size_type>(found - paths_.begin()) == candidatesToSkip) {
         while (++candidatesToSkip < paths_.size() && !paths_[candidatesToSkip].available) {}
     }
 
-    return found->connection;
+    return path.connection;
 }
 
 bool

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -33,7 +33,7 @@ ResolvedPeers::retryPath(const Comm::ConnectionPointer &path)
         return candidate.connection == path; // (refcounted) pointer comparison
     });
     assert(found != paths_.end());
-    assert(found->available == false);
+    assert(!found->available);
     found->available = true;
 
     // if we restored availability of a candidate that we used to skip, update

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -72,7 +72,7 @@ ResolvedPeers::makeFinding(const ConnectionList::iterator &candidate, bool found
     return std::make_pair((foundOther ? paths_.end() : candidate), foundOther);
 }
 
-/// \returns the first available same-peer same-family address iterator or end()
+/// \returns the first available same-peer same-family Finding or <end,...>
 ResolvedPeers::Finding
 ResolvedPeers::findPrime(const Comm::Connection &currentPeer)
 {
@@ -83,7 +83,7 @@ ResolvedPeers::findPrime(const Comm::Connection &currentPeer)
     return makeFinding(candidate, foundNextOrSpare);
 }
 
-/// \returns the first available same-peer different-family address iterator or end()
+/// \returns the first available same-peer different-family Finding or <end,...>
 ResolvedPeers::Finding
 ResolvedPeers::findSpare(const Comm::Connection &currentPeer)
 {
@@ -101,7 +101,7 @@ ResolvedPeers::findSpare(const Comm::Connection &currentPeer)
     return makeFinding(candidate, foundNext);
 }
 
-/// \returns the first available same-peer address iterator or end()
+/// \returns the first available same-peer Finding or <end,...>
 ResolvedPeers::Finding
 ResolvedPeers::findPeer(const Comm::Connection &currentPeer)
 {
@@ -174,7 +174,7 @@ ResolvedPeers::doneWith(const Finding &findings) const
         return false; // not done because the caller found a viable candidate X
 
     // The caller did not find any candidate X. If the caller found any "other"
-    // candidates, then we are doing with candidates X. If there are no
+    // candidates, then we are done with candidates X. If there are no
     // candidates in paths_, then destinationsFinalized is the answer.
     return findings.second ? true : destinationsFinalized;
 }

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -32,7 +32,6 @@ ResolvedPeers::retrySparePath(const Comm::ConnectionPointer &spare)
 {
     debugs(17, 4, spare);
     assert(spare);
-    paths_.emplace(paths_.begin(), spare);
     const auto peerToAvoid = spare->getPeer();
     const auto familyToMatch = ConnectionFamily(*spare);
     const auto spareOrNextPeer = std::find_if(paths_.begin(), paths_.end(),

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -62,13 +62,6 @@ ResolvedPeers::addPath(const Comm::ConnectionPointer &path)
     Must(paths_.back().available); // no candidatesToSkip updates are needed
 }
 
-Comm::ConnectionPointer
-ResolvedPeers::extractFront()
-{
-    Must(!empty());
-    return extractFound("first: ", start());
-}
-
 /// \returns the beginning iterator for any available-path search
 ConnectionList::iterator
 ResolvedPeers::start()
@@ -141,6 +134,13 @@ ResolvedPeers::findPeer(const Comm::Connection &currentPeer, bool *hasNext)
     if (hasNext)
         *hasNext = foundNext;
     return foundNext ? paths_.end() : found;
+}
+
+Comm::ConnectionPointer
+ResolvedPeers::extractFront()
+{
+    Must(!empty());
+    return extractFound("first: ", start());
 }
 
 Comm::ConnectionPointer

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -76,13 +76,7 @@ ResolvedPeers::start()
 ConnectionList::iterator
 ResolvedPeers::findPrime(const Comm::Connection &currentPeer, bool *hasNext)
 {
-    const auto found = std::find_if(start(), paths_.end(),
-    [&](const ResolvedPeerPath &path) {
-        if (!path.available)
-            return false;
-        // prime, spare, or next peer
-        return true;
-    });
+    const auto found = start();
     const auto peerToMatch = currentPeer.getPeer();
     const auto familyToMatch = ConnectionFamily(currentPeer);
     const auto foundSpareOrNext = found != paths_.end() &&

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -20,13 +20,13 @@ ResolvedPeers::ResolvedPeers()
 }
 
 void
-ResolvedPeers::retryPath(const Comm::ConnectionPointer &conn)
+ResolvedPeers::retryPath(const Comm::ConnectionPointer &path)
 {
-    debugs(17, 4, conn);
-    assert(conn);
+    debugs(17, 4, path);
+    assert(path);
     const auto found = std::find_if(paths_.begin(), paths_.end(),
-    [conn](const ResolvedPeerPath &path) {
-        return path.connection == conn;
+    [path](const ResolvedPeerPath &candidate) {
+        return candidate.connection == path; // (refcounted) pointer comparison
     });
     assert(found != paths_.end());
     assert(found->available == false);

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -58,7 +58,7 @@ ResolvedPeers::addPath(const Comm::ConnectionPointer &path)
 }
 
 /// \returns the beginning iterator for any available-path search
-ConnectionList::iterator
+ResolvedPeers::Paths::iterator
 ResolvedPeers::start()
 {
     Must(candidatesToSkip <= paths_.size());
@@ -67,7 +67,7 @@ ResolvedPeers::start()
 
 /// finalizes the iterator part of the given preliminary find*() result
 ResolvedPeers::Finding
-ResolvedPeers::makeFinding(const ConnectionList::iterator &candidate, bool foundOther)
+ResolvedPeers::makeFinding(const Paths::iterator &candidate, bool foundOther)
 {
     return std::make_pair((foundOther ? paths_.end() : candidate), foundOther);
 }
@@ -142,7 +142,7 @@ ResolvedPeers::extractSpare(const Comm::Connection &currentPeer)
 
 /// convenience method to finish a successful extract*() call
 Comm::ConnectionPointer
-ResolvedPeers::extractFound(const char *description, const ConnectionList::iterator &found)
+ResolvedPeers::extractFound(const char *description, const Paths::iterator &found)
 {
     auto &path = *found;
     debugs(17, 7, description << path.connection);

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -36,11 +36,10 @@ ResolvedPeers::retryPath(const Comm::ConnectionPointer &conn)
 bool
 ResolvedPeers::empty() const
 {
-    const auto anyPath = std::find_if(paths_.begin(), paths_.end(),
+    return !std::any_of(paths_.begin(), paths_.end(),
     [](const ResolvedPeerPath &path) {
         return path.available;
     });
-    return anyPath == paths_.end();
 }
 
 ConnectionList::size_type

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -55,7 +55,11 @@ ResolvedPeers::size() const
 void
 ResolvedPeers::addPath(const Comm::ConnectionPointer &path)
 {
+    const auto oldCapacity = paths_.capacity();
     paths_.emplace_back(path);
+    const auto iteratorsInvalidated = oldCapacity < paths_.size();
+    if (paths_.size() == 1 || iteratorsInvalidated)
+        lastCurrentPeer = paths_.begin();
 }
 
 Comm::ConnectionPointer
@@ -68,6 +72,7 @@ ResolvedPeers::extractFront()
 const ConnectionList::iterator &
 ResolvedPeers::cachedCurrent(const CachePeer *currentPeer)
 {
+    Must(!paths_.empty()); // guarantees that lastCurrentPeer was initialized
     if (!currentPeer || (currentPeer != lastCurrentPeer->connection->getPeer())) {
         lastCurrentPeer = std::find_if(paths_.begin(), paths_.end(),
         [](const ResolvedPeerPath &path) {

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -24,6 +24,10 @@ ResolvedPeers::retryPath(const Comm::ConnectionPointer &path)
 {
     debugs(17, 4, path);
     assert(path);
+    // Cannot use candidatesToSkip for a faster (reverse) search because there
+    // may be unavailable candidates past candidatesToSkip. We could remember
+    // the last extraction index, but, to completely avoid a linear search,
+    // extract*() methods should return the candidate index.
     const auto found = std::find_if(paths_.begin(), paths_.end(),
     [path](const ResolvedPeerPath &candidate) {
         return candidate.connection == path; // (refcounted) pointer comparison

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -20,11 +20,26 @@ ResolvedPeers::ResolvedPeers()
 }
 
 void
-ResolvedPeers::retryPath(const Comm::ConnectionPointer &path)
+ResolvedPeers::retryPrimePath(const Comm::ConnectionPointer &path)
 {
     debugs(17, 4, path);
     assert(path);
     paths_.emplace(paths_.begin(), path);
+}
+
+void
+ResolvedPeers::retrySparePath(const Comm::ConnectionPointer &spare)
+{
+    debugs(17, 4, spare);
+    assert(spare);
+    paths_.emplace(paths_.begin(), spare);
+    const auto peerToAvoid = spare->getPeer();
+    const auto familyToMatch = ConnectionFamily(*spare);
+    const auto spareOrNextPeer = std::find_if(paths_.begin(), paths_.end(),
+    [peerToAvoid, familyToMatch](const Comm::ConnectionPointer &conn) {
+        return peerToAvoid != conn->getPeer() || familyToMatch == ConnectionFamily(*conn);
+    });
+    paths_.emplace(spareOrNextPeer, spare);
 }
 
 void

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -49,7 +49,7 @@ ResolvedPeers::retryPath(const Comm::ConnectionPointer &path)
 ConnectionList::size_type
 ResolvedPeers::size() const
 {
-    return std::count_if(paths_.begin(), paths_.end(),
+    return std::count_if(start(), paths_.end(),
     [](const ResolvedPeerPath &path) {
         return path.available;
     });

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -65,7 +65,7 @@ ResolvedPeers::extractFront()
 }
 
 /// helps to optimize find*() searches, caching the 'current peer' iterator
-ConnectionList::iterator
+const ConnectionList::iterator &
 ResolvedPeers::cachedCurrent(const CachePeer *currentPeer)
 {
     if (!currentPeer || (currentPeer != lastCurrentPeer->connection->getPeer())) {

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -88,16 +88,19 @@ ResolvedPeers::Finding
 ResolvedPeers::findSpare(const Comm::Connection &currentPeer)
 {
     const auto primeFamily = ConnectionFamily(currentPeer);
+    const auto primePeer = currentPeer.getPeer();
     const auto candidate = std::find_if(start(), paths_.end(),
-    [primeFamily](const ResolvedPeerPath &path) {
+    [primeFamily, primePeer](const ResolvedPeerPath &path) {
         if (!path.available)
             return false;
-        if (primeFamily == ConnectionFamily(*path.connection))
-            return false;
-        return true; // found either spare or next peer
+        if (primePeer != path.connection->getPeer())
+            return true; // found next peer
+        if (primeFamily != ConnectionFamily(*path.connection))
+            return true; // found spare
+        return false;
     });
     const auto foundNext = candidate != paths_.end() &&
-        currentPeer.getPeer() != candidate->connection->getPeer();
+        primePeer != candidate->connection->getPeer();
     return makeFinding(candidate, foundNext);
 }
 

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -75,13 +75,13 @@ ResolvedPeers::start()
 ConnectionList::iterator
 ResolvedPeers::findPrime(const Comm::Connection &currentPeer, bool *foundOther)
 {
-    const auto found = start();
-    const auto foundNextOrSpare = found != paths_.end() &&
-        (currentPeer.getPeer() != found->connection->getPeer() || // next peer
-            ConnectionFamily(currentPeer) != ConnectionFamily(*found->connection));
+    const auto candidate = start();
+    const auto foundNextOrSpare = candidate != paths_.end() &&
+        (currentPeer.getPeer() != candidate->connection->getPeer() || // next peer
+            ConnectionFamily(currentPeer) != ConnectionFamily(*candidate->connection));
     if (foundOther)
         *foundOther = foundNextOrSpare;
-    return foundNextOrSpare ? paths_.end() : found;
+    return foundNextOrSpare ? paths_.end() : candidate;
 }
 
 /// \returns the first available same-peer different-family address iterator or end()
@@ -90,19 +90,19 @@ ConnectionList::iterator
 ResolvedPeers::findSpare(const Comm::Connection &currentPeer, bool *foundOther)
 {
     const auto primeFamily = ConnectionFamily(currentPeer);
-    const auto found = std::find_if(start(), paths_.end(),
-    [&](const ResolvedPeerPath &path) {
+    const auto candidate = std::find_if(start(), paths_.end(),
+    [primeFamily](const ResolvedPeerPath &path) {
         if (!path.available)
             return false;
         if (primeFamily == ConnectionFamily(*path.connection))
             return false;
         return true; // found either spare or next peer
     });
-    const auto foundNext = found != paths_.end() &&
-        currentPeer.getPeer() != found->connection->getPeer();
+    const auto foundNext = candidate != paths_.end() &&
+        currentPeer.getPeer() != candidate->connection->getPeer();
     if (foundOther)
         *foundOther = foundNext;
-    return foundNext ? paths_.end() : found;
+    return foundNext ? paths_.end() : candidate;
 }
 
 /// \returns the first available same-peer address iterator or end()
@@ -110,12 +110,12 @@ ResolvedPeers::findSpare(const Comm::Connection &currentPeer, bool *foundOther)
 ConnectionList::iterator
 ResolvedPeers::findPeer(const Comm::Connection &currentPeer, bool *foundOther)
 {
-    const auto found = start();
-    const auto foundNext = found != paths_.end() &&
-        currentPeer.getPeer() != found->connection->getPeer();
+    const auto candidate = start();
+    const auto foundNext = candidate != paths_.end() &&
+        currentPeer.getPeer() != candidate->connection->getPeer();
     if (foundOther)
         *foundOther = foundNext;
-    return foundNext ? paths_.end() : found;
+    return foundNext ? paths_.end() : candidate;
 }
 
 Comm::ConnectionPointer

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -46,15 +46,6 @@ ResolvedPeers::retryPath(const Comm::ConnectionPointer &path)
     }
 }
 
-bool
-ResolvedPeers::empty() const
-{
-    return !std::any_of(paths_.begin(), paths_.end(),
-    [](const ResolvedPeerPath &path) {
-        return path.available;
-    });
-}
-
 ConnectionList::size_type
 ResolvedPeers::size() const
 {
@@ -74,6 +65,7 @@ ResolvedPeers::addPath(const Comm::ConnectionPointer &path)
 Comm::ConnectionPointer
 ResolvedPeers::extractFront()
 {
+    Must(!empty());
     return extractFound("first: ", start());
 }
 

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -20,8 +20,8 @@ class ResolvedPeerPath
 public:
     explicit ResolvedPeerPath(const Comm::ConnectionPointer &conn) : connection(conn), available(true) {}
 
-    Comm::ConnectionPointer connection; ///< a path(address) candidate
-    bool available; ///< whether this address may be used (i.e., has not been tried already)
+    Comm::ConnectionPointer connection; ///< (the address of) a path candidate
+    bool available; ///< whether this path may be used (i.e., has not been tried already)
 };
 
 typedef std::vector<ResolvedPeerPath> ConnectionList;

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -32,7 +32,11 @@ public:
     void addPath(const Comm::ConnectionPointer &);
 
     /// add a candidate path to try before all the existing paths
-    void retryPath(const Comm::ConnectionPointer &);
+    void retryPrimePath(const Comm::ConnectionPointer &);
+
+    /// add a candidate spare path just after prime paths (if any)
+    /// or before all existing paths
+    void retrySparePath(const Comm::ConnectionPointer &spare);
 
     /// extracts and returns the first queued address
     Comm::ConnectionPointer extractFront();
@@ -73,7 +77,7 @@ private:
     Comm::ConnectionList::iterator findSpareOrNextPeer(const Comm::Connection &currentPeer);
     Comm::ConnectionPointer extractFound(const char *description, const Comm::ConnectionList::iterator &found);
 
-    Comm::ConnectionList paths_;
+    Comm::ConnectionList paths_; ///< resolved addresses in (peer, family) order
 };
 
 /// summarized ResolvedPeers (for debugging)

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -13,6 +13,7 @@
 #include "comm/forward.h"
 
 #include <iosfwd>
+#include <utility>
 
 class ResolvedPeerPath
 {
@@ -80,18 +81,22 @@ public:
 private:
     using size_type = ConnectionList::size_type;
 
+    /// A find*() result: An iterator of the found path (or paths_.end()) and
+    /// whether the "other" path was found instead.
+    typedef std::pair<ConnectionList::iterator, bool> Finding;
+
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
     ConnectionList::const_iterator start() const { return const_cast<ResolvedPeers*>(this)->start(); }
     ConnectionList::iterator start();
-    ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
-    ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
-    ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
+    Finding findSpare(const Comm::Connection &currentPeer);
+    Finding findPrime(const Comm::Connection &currentPeer);
+    Finding findPeer(const Comm::Connection &currentPeer);
     Comm::ConnectionPointer extractFound(const char *description, const ConnectionList::iterator &found);
+    Finding makeFinding(const ConnectionList::iterator &found, bool foundOther);
 
-    typedef ConnectionList::iterator (ResolvedPeers::*findSmthFun)(const Comm::Connection &, bool *);
-    bool doneWith(const Comm::Connection &currentPeer, findSmthFun);
+    bool doneWith(const Finding &findings) const;
 
     ConnectionList paths_; ///< resolved addresses in (peer, family) order
     /// the number of leading paths_ elements that are all currently unavailable

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -81,7 +81,7 @@ private:
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
-    const ConnectionList::iterator &cachedCurrent(const CachePeer *currentPeer = nullptr);
+    const ConnectionList::iterator &cachedCurrent(const Comm::Connection *currentPeer = nullptr);
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -81,7 +81,7 @@ private:
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
-    ConnectionList::iterator cachedCurrent(const CachePeer *currentPeer = nullptr);
+    const ConnectionList::iterator &cachedCurrent(const CachePeer *currentPeer = nullptr);
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -83,6 +83,7 @@ private:
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
+    ConnectionList::const_iterator start() const { return const_cast<ResolvedPeers*>(this)->start(); }
     ConnectionList::iterator start();
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -78,11 +78,12 @@ public:
     bool notificationPending = false;
 
 private:
+    using size_type = ConnectionList::size_type;
+
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
-    ConnectionList::iterator cacheFront();
-    ConnectionList::iterator cachedCurrent(const Comm::Connection *currentPeer);
+    ConnectionList::iterator start();
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
@@ -92,9 +93,10 @@ private:
     bool doneWith(const Comm::Connection &currentPeer, findSmthFun);
 
     ConnectionList paths_; ///< resolved addresses in (peer, family) order
-    /// The index in paths_, calculated by the last cacheFront() call.
-    /// Do not use directly - use cachedCurrent() instead.
-    uint64_t currentPeerIndex = 0;
+    /// the number of leading paths_ elements that are all currently unavailable
+    /// i.e. the size of the front paths_ segment comprised of unavailable items
+    /// i.e. the position of the first available candidate (or paths_.size())
+    size_type candidatesToSkip = 0;
 };
 
 /// summarized ResolvedPeers (for debugging)

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -14,13 +14,14 @@
 
 #include <iosfwd>
 
+
 class ResolvedPeerPath
 {
 public:
     explicit ResolvedPeerPath(const Comm::ConnectionPointer &conn) : connection(conn), available(true) {}
 
-    Comm::ConnectionPointer connection;
-    bool available;
+    Comm::ConnectionPointer connection; ///< a path(address) candidate
+    bool available; ///< whether this address may be used (i.e., has not been tried already)
 };
 
 typedef std::vector<ResolvedPeerPath> ConnectionList;

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -20,7 +20,7 @@ class ResolvedPeerPath
 public:
     explicit ResolvedPeerPath(const Comm::ConnectionPointer &conn) : connection(conn), available(true) {}
 
-    Comm::ConnectionPointer connection; ///< (the address of) a path candidate
+    Comm::ConnectionPointer connection; ///< (the address of) a path
     bool available; ///< whether this path may be used (i.e., has not been tried already)
 };
 
@@ -39,7 +39,7 @@ public:
     ResolvedPeers();
 
     /// whether we lack any known candidate paths
-    bool empty() const { return !availableCandidates; }
+    bool empty() const { return !availablePaths; }
 
     /// add a candidate path to try after all the existing paths
     void addPath(const Comm::ConnectionPointer &);
@@ -71,7 +71,7 @@ public:
     bool doneWithPeer(const Comm::Connection &currentPeer);
 
     /// the current number of candidate paths
-    size_type size() const { return availableCandidates; }
+    size_type size() const { return availablePaths; }
 
     /// whether all of the available candidate paths received from DNS
     bool destinationsFinalized = false;
@@ -103,11 +103,11 @@ private:
 
     /// the number of leading paths_ elements that are all currently unavailable
     /// i.e. the size of the front paths_ segment comprised of unavailable items
-    /// i.e. the position of the first available candidate (or paths_.size())
-    size_type candidatesToSkip = 0;
+    /// i.e. the position of the first available path (or paths_.size())
+    size_type pathsToSkip = 0;
 
-    /// the total number of currently available candidates in paths_
-    size_type availableCandidates = 0;
+    /// the total number of currently available elements in paths_
+    size_type availablePaths = 0;
 };
 
 /// summarized ResolvedPeers (for debugging)

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -93,6 +93,8 @@ private:
     ConnectionList paths_; ///< resolved addresses in (peer, family) order
     /// The value returned by the last cachedCurrent() call.
     /// Do not use directly - use cachedCurrent() instead.
+    // The validity of this iterator should be guaranteed by absence of
+    // any container modifying operations, except appendings, see addPath().
     ConnectionList::iterator lastCurrentPeer;
 };
 

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -77,10 +77,10 @@ public:
     /// whether HappyConnOpener::noteCandidatesChange() is scheduled to fire
     bool notificationPending = false;
 
-private:
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
+private:
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer);
     ConnectionList::iterator findPeer(const Comm::Connection &currentPeer);

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -96,6 +96,9 @@ private:
 
     bool doneWith(const Finding &findings) const;
 
+    void increaseAvailability();
+    void decreaseAvailability();
+
     Paths paths_; ///< resolved addresses in (peer, family) order
 
     /// the number of leading paths_ elements that are all currently unavailable

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -37,7 +37,7 @@ public:
     ResolvedPeers();
 
     /// whether we lack any known candidate paths
-    bool empty() const;
+    bool empty() const { return candidatesToSkip == paths_.size(); }
 
     /// add a candidate path to try after all the existing paths
     void addPath(const Comm::ConnectionPointer &);

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -81,6 +81,7 @@ private:
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
+    ConnectionList::iterator cachedCurrent(const CachePeer *currentPeer = nullptr);
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
@@ -90,6 +91,9 @@ private:
     bool doneWith(const Comm::Connection &currentPeer, findSmthFun);
 
     ConnectionList paths_; ///< resolved addresses in (peer, family) order
+    /// The value returned by the last cachedCurrent() call.
+    /// Do not use directly - use cachedCurrent() instead.
+    ConnectionList::iterator lastCurrentPeer;
 };
 
 /// summarized ResolvedPeers (for debugging)

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -14,7 +14,6 @@
 
 #include <iosfwd>
 
-
 class ResolvedPeerPath
 {
 public:

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -24,8 +24,6 @@ public:
     bool available; ///< whether this path may be used (i.e., has not been tried already)
 };
 
-typedef std::vector<ResolvedPeerPath> ConnectionList;
-
 /// cache_peer and origin server addresses (a.k.a. paths)
 /// selected and resolved by the peering code
 class ResolvedPeers: public RefCountable
@@ -33,7 +31,9 @@ class ResolvedPeers: public RefCountable
     MEMPROXY_CLASS(ResolvedPeers);
 
 public:
-    using size_type = ConnectionList::size_type;
+    // ResolvedPeerPaths in addPath() call order
+    typedef std::vector<ResolvedPeerPath> Paths;
+    using size_type = Paths::size_type;
     typedef RefCount<ResolvedPeers> Pointer;
 
     ResolvedPeers();
@@ -82,21 +82,21 @@ public:
 private:
     /// A find*() result: An iterator of the found path (or paths_.end()) and
     /// whether the "other" path was found instead.
-    typedef std::pair<ConnectionList::iterator, bool> Finding;
+    typedef std::pair<Paths::iterator, bool> Finding;
 
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
-    ConnectionList::iterator start();
+    Paths::iterator start();
     Finding findSpare(const Comm::Connection &currentPeer);
     Finding findPrime(const Comm::Connection &currentPeer);
     Finding findPeer(const Comm::Connection &currentPeer);
-    Comm::ConnectionPointer extractFound(const char *description, const ConnectionList::iterator &found);
-    Finding makeFinding(const ConnectionList::iterator &found, bool foundOther);
+    Comm::ConnectionPointer extractFound(const char *description, const Paths::iterator &found);
+    Finding makeFinding(const Paths::iterator &found, bool foundOther);
 
     bool doneWith(const Finding &findings) const;
 
-    ConnectionList paths_; ///< resolved addresses in (peer, family) order
+    Paths paths_; ///< resolved addresses in (peer, family) order
 
     /// the number of leading paths_ elements that are all currently unavailable
     /// i.e. the size of the front paths_ segment comprised of unavailable items

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -81,10 +81,13 @@ public:
     static int ConnectionFamily(const Comm::Connection &conn);
 
 private:
-    ConnectionList::iterator findSpare(const Comm::Connection &currentPeer);
-    ConnectionList::iterator findPrime(const Comm::Connection &currentPeer);
-    ConnectionList::iterator findPeer(const Comm::Connection &currentPeer);
+    ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
+    ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
+    ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     Comm::ConnectionPointer extractFound(const char *description, const ConnectionList::iterator &found);
+
+    typedef ConnectionList::iterator (ResolvedPeers::*findSmthFun)(const Comm::Connection &, bool *);
+    bool doneWith(const Comm::Connection &currentPeer, findSmthFun);
 
     ConnectionList paths_; ///< resolved addresses in (peer, family) order
 };

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -77,10 +77,10 @@ public:
     /// whether HappyConnOpener::noteCandidatesChange() is scheduled to fire
     bool notificationPending = false;
 
+private:
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
-private:
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -81,7 +81,8 @@ private:
     /// The protocol family of the given path, AF_INET or AF_INET6
     static int ConnectionFamily(const Comm::Connection &conn);
 
-    const ConnectionList::iterator &cachedCurrent(const Comm::Connection *currentPeer = nullptr);
+    ConnectionList::iterator cacheFront();
+    ConnectionList::iterator cachedCurrent(const Comm::Connection *currentPeer);
     ConnectionList::iterator findSpare(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPrime(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
     ConnectionList::iterator findPeer(const Comm::Connection &currentPeer, bool *hasNext = nullptr);
@@ -91,11 +92,9 @@ private:
     bool doneWith(const Comm::Connection &currentPeer, findSmthFun);
 
     ConnectionList paths_; ///< resolved addresses in (peer, family) order
-    /// The value returned by the last cachedCurrent() call.
+    /// The index in paths_, calculated by the last cacheFront() call.
     /// Do not use directly - use cachedCurrent() instead.
-    // The validity of this iterator should be guaranteed by absence of
-    // any container modifying operations, except appendings, see addPath().
-    ConnectionList::iterator lastCurrentPeer;
+    uint64_t currentPeerIndex = 0;
 };
 
 /// summarized ResolvedPeers (for debugging)

--- a/src/comm/forward.h
+++ b/src/comm/forward.h
@@ -26,8 +26,6 @@ class ConnOpener;
 
 typedef RefCount<Comm::Connection> ConnectionPointer;
 
-typedef std::vector<Comm::ConnectionPointer> ConnectionList;
-
 bool IsConnOpen(const Comm::ConnectionPointer &conn);
 
 // callback handler to process an FD which is available for writing.


### PR DESCRIPTION
When HappyConnOpener starts opening two connections, both destinations
are removed from the shared destinations list. As soon as one connection
(X) succeeded, the other destination (Y) was essentially forgotten. If
FwdState, after using X, decided to reforward the request, then the
request was never reforwarded to Y. We now return Y to the list.

Also abort the still-active ConnOpener job upon the termination of its
"parent" HappyConnOpener job. Without an explicit termination, those
abandoned child jobs wasted OS and Squid resources while the OS was
trying to open the requested connection. They would terminate on a
timeout or when the connection was finally opened (and discarded).

Waiting for the child ConnOpener job to end is a useful optimization,
but it remains a TODO. It requires complex accumulation avoidance logic.

Also fixed retrying via FwdState::fail() which could reorder addresses.
It incorrectly assumed that only the prime connections were retried.