### PR TITLE
Supply ALE to request_header_add/reply_header_add

### DIFF
--- a/src/HttpHeaderTools.cc
+++ b/src/HttpHeaderTools.cc
@@ -477,6 +477,12 @@ httpHdrAdd(HttpHeader *heads, HttpRequest *request, const AccessLogEntryPointer 
 {
     ACLFilledChecklist checklist(NULL, request, NULL);
 
+    checklist.al = al;
+    if (al && al->reply) {
+        checklist.reply = al->reply;
+        HTTPMSGLOCK(checklist.reply);
+    }
+
     for (HeaderWithAclList::const_iterator hwa = headersAdd.begin(); hwa != headersAdd.end(); ++hwa) {
         if (!hwa->aclList || checklist.fastCheck(hwa->aclList).allowed()) {
             const char *fieldValue = NULL;


### PR DESCRIPTION
Supply ALE to request_header_add and reply_header_add ACLs that need it
(e.g., external, annotate_client, and annotate_transaction ACLs). Fixes
"ACL is used in context without an ALE state" errors when external ACLs
are used in the same context (other ACLs do not yet properly disclose
that they need ALE).

Also provides HTTP reply to reply_header_add ACLs.

This is a Measurement Factory project.

This is a v4 port of master commit b6f3c19a9.