### PR TITLE
FtpGateway.cc: fix build on gcc-10 [-Werror=class-memaccess]

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -563,8 +563,6 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
 
     n_tokens = 0;
 
-    memset(tokens, 0, sizeof(tokens));
-
     xbuf = xstrdup(buf);
 
     if (flags.tried_nlst) {


### PR DESCRIPTION
Since a1c06c7, tokens initialization is done by FtpLineToken
constructor, and g++-10 complains about memsetting a nontrivial object:

    clearing an object of non-trivial type [-Werror=class-memaccess]
