### PR TITLE
Cleanup: remove self_destruct() wrapper function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3133,6 +3133,7 @@ AC_CONFIG_FILES([
 	src/auth/ntlm/SMB_LM/Makefile
 	src/auth/ntlm/SSPI/Makefile
 	src/base/Makefile
+	src/cfg/Makefile
 	src/clients/Makefile
 	src/comm/Makefile
 	src/debug/Makefile

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -217,6 +217,13 @@ ConfigParser::CurrentLocation()
     return ToSBuf(SourceLocation(cfg_directive, cfg_filename, config_lineno));
 }
 
+ConfigParser &
+ConfigParser::LegacyInstance()
+{
+    static ConfigParser legacyParser = ConfigParser();
+    return legacyParser;
+}
+
 char *
 ConfigParser::TokenParse(const char * &nextToken, ConfigParser::TokenType &type)
 {

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -159,6 +159,9 @@ public:
      */
     static bool StrictMode;
 
+    /// a ConfigParser instance Squid-2 model config parse code can use
+    static ConfigParser &LegacyInstance();
+
 protected:
     /**
      * Class used to store required information for the current

--- a/src/DelaySpec.cc
+++ b/src/DelaySpec.cc
@@ -15,7 +15,6 @@
 #include "cfg/Exceptions.h"
 #include "DelaySpec.h"
 #include "Parsing.h"
-#include "sbuf/Stream.h"
 #include "Store.h"
 
 DelaySpec::DelaySpec() : restore_bps(-1), max_bytes (-1)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1120,8 +1120,7 @@ nodist_tests_testRock_SOURCES = \
 	SquidMath.cc \
 	SquidMath.h \
 	hier_code.cc \
-	swap_log_op.cc \
-	tests/stub_libcfg.cc
+	swap_log_op.cc
 tests_testRock_LDADD = \
 	http/libhttp.la \
 	parser/libparser.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1142,6 +1142,7 @@ tests_testRock_LDADD = \
 	mem/libmem.la \
 	store/libstore.la \
 	$(ADAPTATION_LIBS) \
+	cfg/libcfg.la \
 	sbuf/libsbuf.la \
 	time/libtime.la \
 	$(top_builddir)/lib/libmisccontainers.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,7 @@ LOADABLE_MODULES_SOURCES = \
 	LoadableModules.cc \
 	LoadableModules.h
 
-SUBDIRS = mem time debug base anyp helper dns ftp parser comm error eui acl format clients sbuf servers fs repl store DiskIO proxyp
+SUBDIRS	= mem base cfg anyp helper dns ftp parser comm eui acl format clients sbuf servers fs repl store DiskIO proxyp
 
 if ENABLE_AUTH
 SUBDIRS += auth

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,7 @@ LOADABLE_MODULES_SOURCES = \
 	LoadableModules.cc \
 	LoadableModules.h
 
-SUBDIRS	= mem base cfg anyp helper dns ftp parser comm eui acl format clients sbuf servers fs repl store DiskIO proxyp
+SUBDIRS = mem base cfg anyp helper dns ftp parser comm eui acl format clients sbuf servers fs repl store DiskIO proxyp
 
 if ENABLE_AUTH
 SUBDIRS += auth
@@ -515,6 +515,7 @@ squid_LDADD = \
 	mem/libmem.la \
 	store/libstore.la \
 	time/libtime.la \
+	cfg/libcfg.la \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
@@ -1119,7 +1120,8 @@ nodist_tests_testRock_SOURCES = \
 	SquidMath.cc \
 	SquidMath.h \
 	hier_code.cc \
-	swap_log_op.cc
+	swap_log_op.cc \
+	tests/stub_libcfg.cc
 tests_testRock_LDADD = \
 	http/libhttp.la \
 	parser/libparser.la \
@@ -1292,7 +1294,8 @@ nodist_tests_testUfs_SOURCES = \
 	SquidMath.cc \
 	SquidMath.h \
 	hier_code.cc \
-	swap_log_op.cc
+	swap_log_op.cc \
+	tests/stub_libcfg.cc
 tests_testUfs_LDADD = \
 	http/libhttp.la \
 	parser/libparser.la \
@@ -1462,7 +1465,8 @@ nodist_tests_testStore_SOURCES = \
 	SquidMath.cc \
 	SquidMath.h \
 	tests/stub_libtime.cc \
-	swap_log_op.cc
+	swap_log_op.cc \
+	tests/stub_libcfg.cc
 tests_testStore_LDADD= \
 	libsquid.la \
 	http/libhttp.la \
@@ -1634,7 +1638,8 @@ nodist_tests_testDiskIO_SOURCES = \
 	SquidMath.h \
 	hier_code.cc \
 	tests/stub_libtime.cc \
-	swap_log_op.cc
+	swap_log_op.cc \
+	tests/stub_libcfg.cc
 tests_testDiskIO_LDADD = \
 	libsquid.la \
 	http/libhttp.la \
@@ -1696,6 +1701,7 @@ nodist_tests_testACLMaxUserIP_SOURCES = \
 	tests/stub_fatal.cc \
 	globals.cc \
 	tests/stub_libauth.cc \
+	tests/stub_libcfg.cc \
 	tests/stub_libcomm.cc \
 	tests/stub_libhttp.cc \
 	tests/stub_libmem.cc \
@@ -1909,6 +1915,7 @@ tests_test_http_range_SOURCES = \
 	wordlist.h
 nodist_tests_test_http_range_SOURCES = \
 	$(BUILT_SOURCES) \
+	tests/stub_libcfg.cc \
 	tests/stub_libtime.cc
 tests_test_http_range_LDADD = \
 	libsquid.la \
@@ -2083,6 +2090,7 @@ tests_testHttpReply_SOURCES = \
 nodist_tests_testHttpReply_SOURCES = \
 	$(TESTSOURCES) \
 	hier_code.cc \
+	tests/stub_libcfg.cc \
 	tests/stub_libtime.cc
 tests_testHttpReply_LDADD=\
 	CommCalls.o \
@@ -2292,6 +2300,7 @@ tests_testHttpRequest_SOURCES = \
 	wordlist.h
 nodist_tests_testHttpRequest_SOURCES = \
 	$(BUILT_SOURCES) \
+	tests/stub_libcfg.cc \
 	tests/stub_libtime.cc
 tests_testHttpRequest_LDADD = \
 	libsquid.la \
@@ -2585,6 +2594,7 @@ tests_testCacheManager_SOURCES = \
 	wordlist.h
 nodist_tests_testCacheManager_SOURCES = \
 	$(BUILT_SOURCES) \
+	tests/stub_libcfg.cc \
 	tests/stub_libtime.cc
 # comm.cc only requires comm/libcomm.la until fdc_table is dead.
 tests_testCacheManager_LDADD = \
@@ -2707,6 +2717,7 @@ nodist_tests_testEvent_SOURCES = \
 	tests/stub_cbdata.cc \
 	tests/stub_debug.cc \
 	event.cc \
+	tests/stub_libcfg.cc \
 	tests/stub_libmem.cc \
 	tests/stub_libtime.cc \
 	tests/stub_tools.cc
@@ -2725,6 +2736,7 @@ nodist_tests_testEventLoop_SOURCES = \
 	tests/stub_SBuf.cc \
 	tests/stub_debug.cc \
 	tests/stub_fatal.cc \
+	tests/stub_libcfg.cc \
 	tests/stub_libtime.cc
 tests_testEventLoop_LDADD = \
 	base/libbase.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,7 @@ LOADABLE_MODULES_SOURCES = \
 	LoadableModules.cc \
 	LoadableModules.h
 
-SUBDIRS = mem base cfg anyp helper dns ftp parser comm eui acl format clients sbuf servers fs repl store DiskIO proxyp
+SUBDIRS = mem time debug base cfg anyp helper dns ftp parser comm error eui acl format clients sbuf servers fs repl store DiskIO proxyp
 
 if ENABLE_AUTH
 SUBDIRS += auth
@@ -2699,6 +2699,7 @@ nodist_tests_testConfigParser_SOURCES = \
 	tests/stub_libmem.cc \
 	tests/stub_neighbors.cc
 tests_testConfigParser_LDADD = \
+	cfg/libcfg.la \
 	base/libbase.la \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \

--- a/src/MessageDelayPools.cc
+++ b/src/MessageDelayPools.cc
@@ -136,8 +136,7 @@ MessageDelayConfig::parseResponseDelayPool()
     char *key = nullptr;
     char *value = nullptr;
     while (ConfigParser::NextKvPair(key, value)) {
-        if (!value)
-            throw Cfg::FatalError(ToSBuf("option '", key, "'  missing value"));
+        Cfg::RequireValue(key, value);
         auto it = params.find(SBuf(key));
         if (it == params.end())
             throw Cfg::FatalError(ToSBuf("unknown option '", key, "'"));

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -37,12 +37,7 @@ Note::Value::Value(const char *aVal, const bool quoted, const char *descr, const
 {
     if (quoted) {
         valueFormat = new Format::Format(descr ? descr : "Notes");
-        if (!valueFormat->parse(theValue.c_str())) {
-            delete valueFormat;
-            SBuf exceptionMsg;
-            exceptionMsg.Printf("failed to parse annotation value %s", theValue.c_str());
-            throw TexcHere(exceptionMsg.c_str());
-        }
+        valueFormat->parse(theValue.c_str());
     }
 }
 

--- a/src/Parsing.cc
+++ b/src/Parsing.cc
@@ -40,38 +40,21 @@ int
 xatoi(const char *token)
 {
     int64_t input = xatoll(token, 10);
-    int ret = (int) input;
-
-    if (input != static_cast<int64_t>(ret))
-        throw Cfg::FatalError(ToSBuf("invalid value: '", token, "' is larger than the type 'int'"));
-
-    return ret;
+    return Cfg::DownsizeValue<int>(token, input);
 }
 
 unsigned int
 xatoui(const char *token, char eov)
 {
     int64_t input = xatoll(token, 10, eov);
-    if (input < 0)
-        throw Cfg::FatalError(ToSBuf("invalid value: '", token, "' cannot be less than 0"));
-
-    unsigned int ret = (unsigned int) input;
-    if (input != static_cast<int64_t>(ret))
-        throw Cfg::FatalError(ToSBuf("invalid value: '", token, "' is larger than the type 'unsigned int'"));
-
-    return ret;
+    return Cfg::DownsizeValue<unsigned int>(token, input);
 }
 
 long
 xatol(const char *token)
 {
     int64_t input = xatoll(token, 10);
-    long ret = (long) input;
-
-    if (input != static_cast<int64_t>(ret))
-        throw Cfg::FatalError(ToSBuf("invalid value: '", token, "' is larger than the type 'long'"));
-
-    return ret;
+    return Cfg::DownsizeValue<long>(token, input);
 }
 
 int64_t
@@ -101,15 +84,8 @@ xatoull(const char *token, int base, char eov)
 unsigned short
 xatos(const char *token)
 {
-    long port = xatol(token);
-
-    if (port < 0)
-        throw Cfg::FatalError(ToSBuf("invalid value: '", token, "' cannot be less than 0"));
-
-    if ((port & ~0xFFFF) != 0)
-        throw Cfg::FatalError(ToSBuf("invalid value: '", token, "' is larger than the type 'short'"));
-
-    return port;
+    long input = xatol(token);
+    return Cfg::DownsizeValue<unsigned short>(token, input);
 }
 
 int64_t
@@ -135,12 +111,7 @@ GetInteger(void)
 
     // The conversion must honor 0 and 0x prefixes, which are important for things like umask
     int64_t ret = xatoll(token, 0);
-
-    int i = (int) ret;
-    if (ret != static_cast<int64_t>(i))
-        throw Cfg::FatalError(ToSBuf("invalid value: '", token, "' is larger than the type 'int'"));
-
-    return i;
+    return Cfg::DownsizeValue<int>(token, ret);
 }
 
 /*

--- a/src/Parsing.cc
+++ b/src/Parsing.cc
@@ -16,7 +16,6 @@
 #include "debug/Stream.h"
 #include "globals.h"
 #include "Parsing.h"
-#include "sbuf/Stream.h"
 
 /*
  * These functions is the same as atoi/l/f, except that they check for errors

--- a/src/Parsing.h
+++ b/src/Parsing.h
@@ -29,7 +29,7 @@ int64_t GetInteger64(void);
 /**
  * Parses an integer value.
  * Uses a method that obeys hexadecimal 0xN syntax needed for certain bitmasks.
- * self_destruct() will be called to abort when invalid tokens are encountered.
+ * A Cfg::FatalError exception will be thrown when invalid tokens are encountered.
  */
 int GetInteger(void);
 

--- a/src/XactionInitiator.cc
+++ b/src/XactionInitiator.cc
@@ -7,8 +7,8 @@
  */
 
 #include "squid.h"
-#include "cache_cf.h"
-#include "debug/Stream.h"
+#include "cfg/Exceptions.h"
+#include "sbuf/Stream.h"
 #include "XactionInitiator.h"
 
 #include <map>
@@ -37,11 +37,8 @@ XactionInitiator::ParseInitiators(const char *name)
         {"all", AllInitiators()}
     };
     const auto it = SupportedInitiators.find(name);
-    if (it != SupportedInitiators.cend())
-        return it->second;
-
-    debugs(28, DBG_CRITICAL, "FATAL: Invalid transaction_initiator value near " << name);
-    self_destruct();
-    return 0;
+    if (it == SupportedInitiators.cend())
+        throw Cfg::FatalError(ToSBuf("invalid transaction_initiator '", name, "'"));
+    return it->second;
 }
 

--- a/src/XactionInitiator.cc
+++ b/src/XactionInitiator.cc
@@ -8,7 +8,6 @@
 
 #include "squid.h"
 #include "cfg/Exceptions.h"
-#include "sbuf/Stream.h"
 #include "XactionInitiator.h"
 
 #include <map>

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -21,7 +21,6 @@
 #include "fatal.h"
 #include "globals.h"
 #include "sbuf/List.h"
-#include "sbuf/Stream.h"
 #include "SquidConfig.h"
 
 #include <algorithm>

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -57,8 +57,7 @@ Make(TypeName typeName)
         throw Cfg::FatalError(ToSBuf("unknown ACL type '", typeName, "'"));
     ACL *result = (pos->second)(pos->first);
     debugs(28, 4, typeName << '=' << result);
-    if (!result)
-        throw Cfg::FatalError(ToSBuf("BUG: could not find maker for ACL type '", typeName, "'"));
+    assert(result);
     return result;
 }
 

--- a/src/acl/AdaptationServiceData.cc
+++ b/src/acl/AdaptationServiceData.cc
@@ -15,6 +15,7 @@
 #include "adaptation/Service.h"
 #include "adaptation/ServiceGroups.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 
@@ -31,8 +32,7 @@ ACLAdaptationServiceData::parse()
             Adaptation::Icap::TheConfig.findServiceConfig(t) == nullptr &&
 #endif
             Adaptation::FindGroup(t) == nullptr) {
-            debugs(28, DBG_CRITICAL, "FATAL: Adaptation service/group " << t << " in adaptation_service acl is not defined");
-            self_destruct();
+            throw Cfg::FatalError(ToSBuf("adaptation service/group ", t, " in adaptation_service acl is not defined"));
         }
         insert(t);
     }

--- a/src/acl/AnnotationData.cc
+++ b/src/acl/AnnotationData.cc
@@ -11,10 +11,12 @@
 #include "acl/AnnotationData.h"
 #include "acl/Checklist.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "format/Format.h"
 #include "sbuf/Algorithms.h"
+#include "sbuf/Stream.h"
 
 ACLAnnotationData::ACLAnnotationData()
     : notes(new Notes("annotation_data")) {}
@@ -32,11 +34,8 @@ void
 ACLAnnotationData::parse()
 {
     notes->parseKvPair();
-    if (char *t = ConfigParser::PeekAtToken()) {
-        debugs(29, DBG_CRITICAL, "FATAL: Unexpected argument '" << t << "' after annotation specification");
-        self_destruct();
-        return;
-    }
+    if (const auto *t = ConfigParser::PeekAtToken())
+        throw Cfg::FatalError(ToSBuf("unexpected value '", t, "' after annotation specification"));
 }
 
 void

--- a/src/acl/AnnotationData.cc
+++ b/src/acl/AnnotationData.cc
@@ -16,7 +16,6 @@
 #include "debug/Stream.h"
 #include "format/Format.h"
 #include "sbuf/Algorithms.h"
-#include "sbuf/Stream.h"
 
 ACLAnnotationData::ACLAnnotationData()
     : notes(new Notes("annotation_data")) {}

--- a/src/acl/CertificateData.cc
+++ b/src/acl/CertificateData.cc
@@ -12,6 +12,7 @@
 #include "acl/CertificateData.h"
 #include "acl/Checklist.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "wordlist.h"
@@ -79,10 +80,8 @@ ACLCertificateData::parse()
         char *newAttribute = ConfigParser::strtokFile();
 
         if (!newAttribute) {
-            if (!attributeIsOptional) {
-                debugs(28, DBG_CRITICAL, "FATAL: required attribute argument missing");
-                self_destruct();
-            }
+            if (!attributeIsOptional)
+                throw Cfg::FatalError("required attribute argument is missing");
             return;
         }
 
@@ -99,11 +98,8 @@ ACLCertificateData::parse()
                 }
             }
 
-            if (!valid) {
-                debugs(28, DBG_CRITICAL, "FATAL: Unknown option. Supported option(s) are: " << validAttributesStr);
-                self_destruct();
-                return;
-            }
+            if (!valid)
+                throw Cfg::FatalError(ToSBuf("unknown option. Supported option(s) are: ", validAttributesStr));
 
             // If attribute has been set already, then we do not need to call OBJ_create()
             // below because either we did that for the same attribute when we set it, or
@@ -124,11 +120,8 @@ ACLCertificateData::parse()
                             debugs(28, 7, "New SSL certificate attribute created with name: " << newAttribute << " and nid: " << nid);
                         }
                     }
-                    if (nid == 0) {
-                        debugs(28, DBG_CRITICAL, "FATAL: Not valid SSL certificate attribute name or numerical OID: " << newAttribute);
-                        self_destruct();
-                        return;
-                    }
+                    if (nid == 0)
+                        throw Cfg::FatalError(ToSBuf("Not valid SSL certificate attribute name or numerical OID: ", newAttribute));
                 }
             }
 

--- a/src/acl/DomainData.cc
+++ b/src/acl/DomainData.cc
@@ -13,6 +13,7 @@
 #include "acl/DomainData.h"
 #include "anyp/Uri.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "util.h"
@@ -93,9 +94,8 @@ aclDomainCompare(T const &a, T const &b)
         // discarding the wildcard is critically bad.
         // or Maybe even both are wildcards. Things are very weird in those cases.
         bool d1big = (strlen(d1) > strlen(d2)); // Always suggest removing the longer one.
-        debugs(28, DBG_CRITICAL, "ERROR: '" << (d1big?d1:d2) << "' is a subdomain of '" << (d1big?d2:d1) << "'");
-        debugs(28, DBG_CRITICAL, "ERROR: You need to remove '" << (d1big?d1:d2) << "' from the ACL named '" << AclMatchedName << "'");
-        self_destruct();
+        throw Cfg::FatalError(ToSBuf((d1big?d1:d2), " is a subdomain of ", (d1big?d2:d1),
+                                     "\nYou need to remove ", (d1big?d1:d2), " from the ACL named ", AclMatchedName));
     }
 
     return ret;

--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -12,7 +12,6 @@
 #include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "sbuf/Algorithms.h"
-#include "sbuf/Stream.h"
 
 const SBuf ACLHasComponentData::RequestStr("request");
 const SBuf ACLHasComponentData::ResponseStr("response");

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -13,9 +13,12 @@
 #include "acl/Gadgets.h"
 #include "acl/InnerNode.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "globals.h"
+#include "sbuf/Stream.h"
+
 #include <algorithm>
 
 void
@@ -58,11 +61,8 @@ Acl::InnerNode::lineParse()
         debugs(28, 3, "looking for ACL " << t);
         ACL *a = ACL::FindByName(t);
 
-        if (a == nullptr) {
-            debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);
-            self_destruct();
-            return count; // not reached
-        }
+        if (!a)
+            throw Cfg::FatalError(ToSBuf("ACL not found: ", t));
 
         // append(negated ? new NotNode(a) : a);
         if (negated)

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -17,7 +17,6 @@
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "globals.h"
-#include "sbuf/Stream.h"
 
 #include <algorithm>
 

--- a/src/acl/IntRange.cc
+++ b/src/acl/IntRange.cc
@@ -16,7 +16,6 @@
 #include "debug/Stream.h"
 #include "fatal.h"
 #include "Parsing.h"
-#include "sbuf/Stream.h"
 
 void
 ACLIntRange::parse()

--- a/src/acl/IntRange.cc
+++ b/src/acl/IntRange.cc
@@ -11,10 +11,12 @@
 #include "squid.h"
 #include "acl/IntRange.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "fatal.h"
 #include "Parsing.h"
+#include "sbuf/Stream.h"
 
 void
 ACLIntRange::parse()
@@ -35,13 +37,10 @@ ACLIntRange::parse()
         else
             port2 = port1;
 
-        if (port2 >= port1) {
-            RangeType temp(port1, port2+1);
-            ranges.push_back(temp);
-        } else {
-            debugs(28, DBG_CRITICAL, "ERROR: ACLIntRange::parse: Invalid port value");
-            self_destruct();
-        }
+        if (port2 < port1)
+            throw Cfg::FatalError(ToSBuf("invalid port range: ", port1, '-', port2));
+
+        ranges.emplace_back(port1, port2+1);
     }
 }
 
@@ -84,4 +83,3 @@ ACLIntRange::dump() const
 
     return sl;
 }
-

--- a/src/acl/Ip.cc
+++ b/src/acl/Ip.cc
@@ -17,7 +17,6 @@
 #include "debug/Stream.h"
 #include "ip/tools.h"
 #include "MemBuf.h"
-#include "sbuf/Stream.h"
 #include "wordlist.h"
 
 void *

--- a/src/acl/SquidErrorData.cc
+++ b/src/acl/SquidErrorData.cc
@@ -10,10 +10,12 @@
 #include "acl/Data.h"
 #include "acl/SquidErrorData.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "error/Error.h"
 #include "fatal.h"
+#include "sbuf/Stream.h"
 #include "wordlist.h"
 
 bool
@@ -52,11 +54,8 @@ ACLSquidErrorData::parse()
 
         if (err < ERR_MAX)
             errors.push_back(err);
-        else {
-            debugs(28, DBG_CRITICAL, "FATAL: Invalid squid error name");
-            if (!opt_parse_cfg_only)
-                self_destruct();
-        }
+        else
+            throw Cfg::FatalError(ToSBuf("invalid Squid error name ", token));
     }
 }
 

--- a/src/acl/SquidErrorData.cc
+++ b/src/acl/SquidErrorData.cc
@@ -15,7 +15,6 @@
 #include "debug/Stream.h"
 #include "error/Error.h"
 #include "fatal.h"
-#include "sbuf/Stream.h"
 #include "wordlist.h"
 
 bool

--- a/src/acl/TimeData.cc
+++ b/src/acl/TimeData.cc
@@ -12,6 +12,7 @@
 #include "acl/Checklist.h"
 #include "acl/TimeData.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "wordlist.h"
@@ -153,13 +154,9 @@ ACLTimeData::parse()
             /* assume its time-of-day spec */
 
             if ((sscanf(t, "%d:%d-%d:%d", &h1, &m1, &h2, &m2) < 4) || (!((h1 >= 0 && h1 < 24) && ((h2 >= 0 && h2 < 24) || (h2 == 24 && m2 == 0)) && (m1 >= 0 && m1 < 60) && (m2 >= 0 && m2 < 60)))) {
-                debugs(28, DBG_CRITICAL, "ERROR: aclParseTimeSpec: Bad time range '" << t << "'");
-                self_destruct();
-
                 if (q != this)
                     delete q;
-
-                return;
+                throw Cfg::FatalError(ToSBuf("bad time range '", t, "'"));
             }
 
             if ((parsed_weekbits == 0) && (start == 0) && (stop == 0))
@@ -176,13 +173,9 @@ ACLTimeData::parse()
             parsed_weekbits = 0;
 
             if (q->start > q->stop) {
-                debugs(28, DBG_CRITICAL, "aclParseTimeSpec: Reversed time range");
-                self_destruct();
-
                 if (q != this)
                     delete q;
-
-                return;
+                throw Cfg::FatalError("reversed time range");
             }
 
             if (q->weekbits == 0)

--- a/src/auth/SchemeConfig.cc
+++ b/src/auth/SchemeConfig.cc
@@ -111,8 +111,7 @@ Auth::SchemeConfig::parse(Auth::SchemeConfig * scheme, int, char *param_str)
     } else if (strcmp(param_str, "key_extras") == 0) {
         keyExtrasLine = ConfigParser::NextQuotedToken();
         Format::Format *nlf =  new ::Format::Format(scheme->type());
-        if (!nlf->parse(keyExtrasLine.termedBuf()))
-            throw Cfg::FatalError("failed parsing key_extras formatting value");
+        nlf->parse(keyExtrasLine.termedBuf()); // XXX: throws and leaks nlf on errors
         if (keyExtras)
             delete keyExtras;
 

--- a/src/auth/SchemeConfig.cc
+++ b/src/auth/SchemeConfig.cc
@@ -20,7 +20,6 @@
 #include "errorpage.h"
 #include "format/Format.h"
 #include "globals.h"
-#include "sbuf/Stream.h"
 #include "Store.h"
 #include "wordlist.h"
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1378,11 +1378,7 @@ parseBytesOptionValue(size_t * bptr, const char *units, char const * value)
     number.assign(number_begin, number_end - number_begin);
 
     int d = xatoi(number.termedBuf());
-    int m;
-    if ((m = parseBytesUnits(number_end)) == 0) {
-        self_destruct();
-        return;
-    }
+    int m = parseBytesUnits(number_end);
 
     *bptr = static_cast<size_t>(m * d / u);
     if (static_cast<double>(*bptr) * 2 != (m * d / u) * 2)

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -565,7 +565,11 @@ parseOneConfigFile(const char *file_name, unsigned int depth)
                     }
                 } catch (const Cfg::FatalError &e) {
                     debugs(3, DBG_CRITICAL, e.what());
-                    self_destruct();
+                    // when -k parse is used try to report as many admin mistakes as possible before terminating
+                    if (opt_parse_cfg_only)
+                        ++err_count;
+                    else
+                        self_destruct();
                 } catch (...) {
                     // fatal for now
                     debugs(3, DBG_CRITICAL, "FATAL: configuration error: " << CurrentException);

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -25,6 +25,7 @@
 #include "base/RunnersRegistry.h"
 #include "cache_cf.h"
 #include "CachePeer.h"
+#include "cfg/Exceptions.h"
 #include "ConfigOption.h"
 #include "ConfigParser.h"
 #include "CpuAffinityMap.h"
@@ -562,9 +563,12 @@ parseOneConfigFile(const char *file_name, unsigned int depth)
                         debugs(3, DBG_CRITICAL, ConfigParser::CurrentLocation() << ": unrecognized: '" << tmp_line << "'");
                         ++err_count;
                     }
+                } catch (const Cfg::FatalError &e) {
+                    debugs(3, DBG_CRITICAL, e.what());
+                    self_destruct();
                 } catch (...) {
                     // fatal for now
-                    debugs(3, DBG_CRITICAL, "ERROR: configuration failure: " << CurrentException);
+                    debugs(3, DBG_CRITICAL, "FATAL: configuration error: " << CurrentException);
                     self_destruct();
                 }
             }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -624,8 +624,12 @@ parseConfigFileOrThrow(const char *file_name)
      * We must call configDoConfigure() before leave_suid() because
      * configDoConfigure() is where we turn username strings into
      * uid values.
+     *
+     * For -k parse skip these checks until the config has no errors
+     * to avoid false log warnings due to incomplete config.
      */
-    configDoConfigure();
+    if (!opt_parse_cfg_only || err_count == 0)
+        configDoConfigure();
 
     if (opt_send_signal == -1) {
         Mgr::RegisterAction("config",

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3322,7 +3322,7 @@ parsePortSpecification(const AnyP::PortCfgPointer &s, char *token)
         port = xatos(token);
         debugs(3, 3, portType << "_port: found Listen on Port: " << port);
     } else {
-        throw Cfg::FatalError(ToSBuf("missing Port in: ", token));
+        throw Cfg::FatalError(ToSBuf("missing port in: ", token));
     }
 
     if (port == 0 && host)
@@ -3581,7 +3581,7 @@ parsePortCfg(AnyP::PortCfgPointer *head, const char *optionName)
     else if (strcmp(optionName, "ftp_port") == 0)
         protoName = "FTP";
     if (protoName.isEmpty())
-        throw Cfg::FatalError("unsupported *_port directive");
+        throw Cfg::FatalError(ToSBuf("unsupported ", optionName, " directive"));
 
     char *token = ConfigParser::NextToken();
 
@@ -4716,4 +4716,3 @@ free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuardsPtr)
     delete protoGuards;
     protoGuards = nullptr;
 }
-

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -623,7 +623,7 @@ parseConfigFileOrThrow(const char *file_name)
     if (!opt_parse_cfg_only || err_count == 0)
         configDoConfigure();
 
-    if (opt_send_signal == -1) {
+    if (opt_send_signal == -1 && err_count == 0) {
         Mgr::RegisterAction("config",
                             "Current Squid Configuration",
                             dump_config,

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -62,7 +62,6 @@
 #include "RefreshPattern.h"
 #include "rfc1738.h"
 #include "sbuf/List.h"
-#include "sbuf/Stream.h"
 #include "SquidConfig.h"
 #include "SquidString.h"
 #include "ssl/ProxyCerts.h"

--- a/src/cache_cf.h
+++ b/src/cache_cf.h
@@ -14,7 +14,6 @@
 class wordlist;
 
 void configFreeMemory(void);
-void self_destruct(void);
 void add_http_port(char *portspec);
 
 /* extra functions from cache_cf.c useful for lib modules */

--- a/src/cfg/Exceptions.cc
+++ b/src/cfg/Exceptions.cc
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 1996-2020 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "cfg/Exceptions.h"
+
+const char *
+Cfg::FatalError::what() const throw()
+{
+    static const SBuf prefix("FATAL: ");
+    static SBuf result;
+    result = prefix;
+    result.append(message);
+    return result.c_str();
+}

--- a/src/cfg/Exceptions.cc
+++ b/src/cfg/Exceptions.cc
@@ -8,7 +8,6 @@
 
 #include "squid.h"
 #include "cfg/Exceptions.h"
-#include "sbuf/Stream.h"
 
 const char *
 Cfg::FatalError::what() const throw()

--- a/src/cfg/Exceptions.cc
+++ b/src/cfg/Exceptions.cc
@@ -8,6 +8,7 @@
 
 #include "squid.h"
 #include "cfg/Exceptions.h"
+#include "sbuf/Stream.h"
 
 const char *
 Cfg::FatalError::what() const throw()
@@ -17,4 +18,11 @@ Cfg::FatalError::what() const throw()
     result = prefix;
     result.append(message);
     return result.c_str();
+}
+
+void
+Cfg::RequireValue(const char *key, const char *value)
+{
+    if (!value)
+        throw Cfg::FatalError(ToSBuf("option ", key, " missing value"));
 }

--- a/src/cfg/Exceptions.h
+++ b/src/cfg/Exceptions.h
@@ -60,9 +60,9 @@ T
 DownsizeValue(const char *str, const int64_t &input, const T low = std::numeric_limits<T>::min(), const T high = std::numeric_limits<T>::max())
 {
     // check this is actually a downsize, not upgrade
-    static_assert(std::numeric_limits<int64_t>::min() <= std::numeric_limits<T>::min());
-    static_assert(std::numeric_limits<int64_t>::max() >= std::numeric_limits<T>::max());
-    static_assert(sizeof(int64_t) >= sizeof(T));
+    static_assert(std::numeric_limits<int64_t>::min() <= std::numeric_limits<T>::min(), "T min limit too small");
+    static_assert(std::numeric_limits<int64_t>::max() >= std::numeric_limits<T>::max(), "T max limit too large");
+    static_assert(sizeof(int64_t) >= sizeof(T),"destination type larger than 64-bit");
 
     if (input < low)
         throw Cfg::FatalError(ToSBuf("invalid value: ", str, " must be above ", low));

--- a/src/cfg/Exceptions.h
+++ b/src/cfg/Exceptions.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 1996-2020 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID__SRC_CFG_EXCEPTIONS_H
+#define SQUID__SRC_CFG_EXCEPTIONS_H
+
+#include "sbuf/SBuf.h"
+
+#include <stdexcept>
+
+namespace Cfg
+{
+
+/**
+ * Helper class to distinguish serious parsing errors which need
+ * Administrative attention before Squid can operate.
+ */
+class FatalError : public std::exception
+{
+public:
+    /// NP: use ToSBuf(...) if the error message is complex
+    explicit FatalError(const SBuf &m) :
+        message(m)
+    {}
+    explicit FatalError(const char *m) :
+        message(m)
+    {}
+
+    /* std::exception API */
+    const char *what() const throw() override;
+
+public:
+    /// the error message text to display
+    SBuf message;
+};
+
+} // namespace Cfg
+
+#endif /* SQUID__SRC_CFG_EXCEPTIONS_H */

--- a/src/cfg/Exceptions.h
+++ b/src/cfg/Exceptions.h
@@ -60,9 +60,9 @@ T
 DownsizeValue(const char *str, const int64_t &input, const T low = std::numeric_limits<T>::min(), const T high = std::numeric_limits<T>::max())
 {
     // check this is actually a downsize, not upgrade
-    static_assert(std::numeric_limits<int64_t>::min() <= std::numeric_limits<T>::min(), "T min limit too small");
-    static_assert(std::numeric_limits<int64_t>::max() >= std::numeric_limits<T>::max(), "T max limit too large");
-    static_assert(sizeof(int64_t) >= sizeof(T),"destination type larger than 64-bit");
+    static_assert(std::numeric_limits<int64_t>::min() <= std::numeric_limits<T>::min(), "std::numeric_limits<int64_t>::min() <= std::numeric_limits<T>::min()");
+    static_assert(std::numeric_limits<int64_t>::max() >= std::numeric_limits<T>::max(), "std::numeric_limits<int64_t>::max() >= std::numeric_limits<T>::max()");
+    static_assert(sizeof(int64_t) >= sizeof(T), "sizeof(int64_t) >= sizeof(T)");
 
     if (input < low)
         throw Cfg::FatalError(ToSBuf("invalid value: ", str, " must be above ", low));

--- a/src/cfg/Exceptions.h
+++ b/src/cfg/Exceptions.h
@@ -9,8 +9,9 @@
 #ifndef SQUID__SRC_CFG_EXCEPTIONS_H
 #define SQUID__SRC_CFG_EXCEPTIONS_H
 
-#include "sbuf/SBuf.h"
+#include "sbuf/Stream.h"
 
+#include <limits>
 #include <stdexcept>
 
 namespace Cfg
@@ -38,6 +39,29 @@ public:
     /// the error message text to display
     SBuf message;
 };
+
+// Gadgets to throw consistent error messages on common squid.conf requirements.
+
+/// throws a Cfg::FatalError if value is unset
+void RequireValue(const char *key, const char *value);
+
+/// throws a Cfg::FatalError if value is zero or negative
+template<typename T>
+void
+RequirePositiveInt(const char *key, const T &value)
+{
+    if (value <= 0)
+        throw Cfg::FatalError(ToSBuf("option ", key, " value must be a positive number. Got: ", value));
+}
+
+/// throws a Cfg::FatalError if value is outside the given range
+template<typename T>
+void
+RequireRangedInt(const char *key, const char *value, T &result, const int low = 0, const int high = std::numeric_limits<T>::max())
+{
+    if (!xstrtoui(value, nullptr, &result, low, high))
+        throw Cfg::FatalError(ToSBuf("invalid value for ", key, value));
+}
 
 } // namespace Cfg
 

--- a/src/cfg/Exceptions.h
+++ b/src/cfg/Exceptions.h
@@ -48,9 +48,9 @@ void RequireValue(const char *key, const char *value);
 /// throws a Cfg::FatalError if value is zero or negative
 template<typename T>
 void
-RequirePositiveInt(const char *key, const T &value)
+RequirePositiveValue(const char *key, const T &value)
 {
-    if (value <= 0)
+    if (!std::is_unsigned<T>() && value <= 0)
         throw Cfg::FatalError(ToSBuf("option ", key, " value must be a positive number. Got: ", value));
 }
 

--- a/src/cfg/Makefile.am
+++ b/src/cfg/Makefile.am
@@ -1,0 +1,13 @@
+## Copyright (C) 1996-2020 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+include $(top_srcdir)/src/Common.am
+include $(top_srcdir)/src/TestHeaders.am
+
+noinst_LTLIBRARIES = libcfg.la
+
+libcfg_la_SOURCES=

--- a/src/cfg/Makefile.am
+++ b/src/cfg/Makefile.am
@@ -10,4 +10,7 @@ include $(top_srcdir)/src/TestHeaders.am
 
 noinst_LTLIBRARIES = libcfg.la
 
-libcfg_la_SOURCES=
+libcfg_la_SOURCES= \
+	Exceptions.cc \
+	Exceptions.h \
+	forward.h

--- a/src/cfg/forward.h
+++ b/src/cfg/forward.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 1996-2020 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID__SRC_CFG_FORWARD_H
+#define SQUID__SRC_CFG_FORWARD_H
+
+namespace Cfg
+{
+
+class FatalError;
+
+}
+
+#endif /* SQUID__SRC_CFG_FORWARD_H */

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "AccessLogEntry.h"
 #include "base64.h"
+#include "cfg/Exceptions.h"
 #include "client_side.h"
 #include "comm/Connection.h"
 #include "error/Detail.h"
@@ -22,7 +23,6 @@
 #include "MemBuf.h"
 #include "proxyp/Header.h"
 #include "rfc1738.h"
-#include "sbuf/Stream.h"
 #include "sbuf/StringConvert.h"
 #include "security/CertError.h"
 #include "security/Certificate.h"
@@ -62,7 +62,7 @@ Format::Format::~Format()
     delete format;
 }
 
-bool
+void
 Format::Format::parse(const char *def)
 {
     const char *cur, *eos;
@@ -71,10 +71,8 @@ Format::Format::parse(const char *def)
 
     debugs(46, 2, "got definition '" << def << "'");
 
-    if (format) {
-        debugs(46, DBG_IMPORTANT, "WARNING: existing format for '" << name << " " << def << "'");
-        return false;
-    }
+    if (format)
+        throw Cfg::FatalError(ToSBuf("existing format for '", name, " ", def, "'"));
 
     /* very inefficient parser, but who cares, this needs to be simple */
     /* First off, let's tokenize, we'll optimize in a second pass.
@@ -91,8 +89,6 @@ Format::Format::parse(const char *def)
         last_lt = new_lt;
         cur += new_lt->parse(cur, &quote);
     }
-
-    return true;
 }
 
 size_t

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -48,7 +48,7 @@ public:
     /* First off, let's tokenize, we'll optimize in a second pass.
      * A token can either be a %-prefixed sequence (usually a dynamic
      * token but it can be an escaped sequence), or a string. */
-    bool parse(const char *def);
+    void parse(const char *def);
 
     /// assemble the state information into a formatted line.
     void assemble(MemBuf &mb, const AccessLogEntryPointer &al, int logSequenceNumber) const;

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -514,8 +514,6 @@ Rock::SwapDir::dumpSizeOption(StoreEntry * e) const
 void
 Rock::SwapDir::validateOptions()
 {
-    assert(slotSize >= 0); // validated by parseSizeOption()
-
     const int64_t maxSizeRoundingWaste = 1024 * 1024; // size is configured in MB
     const int64_t slotSizeRoundingWaste = slotSize;
     const int64_t maxRoundingWaste =

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -514,7 +514,7 @@ Rock::SwapDir::dumpSizeOption(StoreEntry * e) const
 void
 Rock::SwapDir::validateOptions()
 {
-    assert(slotSize <= 0); // validated by parseSizeOption()
+    assert(slotSize >= 0); // validated by parseSizeOption()
 
     const int64_t maxSizeRoundingWaste = 1024 * 1024; // size is configured in MB
     const int64_t slotSizeRoundingWaste = slotSize;

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -411,8 +411,8 @@ Rock::SwapDir::parseTimeOption(char const *option, const char *value, int reconf
     const int64_t parsedValue = strtoll(value, nullptr, 10);
     Cfg::RequirePositiveValue(option, parsedValue);
 
-    static_assert(std::numeric_limits<time_msec_t>::max() >= std::numeric_limits<decltype(parsedValue)>::max());
-    static_assert(sizeof(time_msec_t) >= sizeof(decltype(parsedValue)));
+    static_assert(std::numeric_limits<time_msec_t>::max() >= std::numeric_limits<decltype(parsedValue)>::max(), "time_msec_t less than 64-bit");
+    static_assert(sizeof(time_msec_t) >= sizeof(decltype(parsedValue)), "time_msec_t bit size too small to cast");
     const auto newTime = static_cast<time_msec_t>(parsedValue);
 
     if (!reconfig)

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -409,10 +409,10 @@ Rock::SwapDir::parseTimeOption(char const *option, const char *value, int reconf
 
     // TODO: handle time units and detect parsing errors better
     const int64_t parsedValue = strtoll(value, nullptr, 10);
-    Cfg::RequirePositiveInt(option, parsedValue);
+    Cfg::RequirePositiveValue(option, parsedValue);
 
     const time_msec_t newTime = static_cast<time_msec_t>(parsedValue);
-    Cfg::RequirePositiveInt(option, newTime);
+    Cfg::RequirePositiveValue(option, newTime);
 
     if (!reconfig)
         *storedTime = newTime;
@@ -448,10 +448,10 @@ Rock::SwapDir::parseRateOption(char const *option, const char *value, int isaRec
 
     // TODO: handle time units and detect parsing errors better
     const int64_t parsedValue = strtoll(value, nullptr, 10);
-    Cfg::RequirePositiveInt(option, parsedValue);
+    Cfg::RequirePositiveValue(option, parsedValue);
 
     const int newRate = static_cast<int>(parsedValue);
-    Cfg::RequirePositiveInt(option, newRate);
+    Cfg::RequirePositiveValue(option, newRate);
 
     if (!isaReconfig)
         *storedRate = newRate;
@@ -486,7 +486,7 @@ Rock::SwapDir::parseSizeOption(char const *option, const char *value, int reconf
 
     // TODO: handle size units and detect parsing errors better
     const uint64_t newSize = strtoll(value, nullptr, 10);
-    Cfg::RequirePositiveInt(option, newSize);
+    Cfg::RequirePositiveValue(option, newSize);
 
     if (newSize <= sizeof(DbCellHeader))
         throw Cfg::FatalError(ToSBuf("cache_dir ", path, ' ', option, " must exceed ", sizeof(DbCellHeader), "; got: ", newSize));

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -13,6 +13,7 @@
 #include "squid.h"
 #include "base/Random.h"
 #include "cache_cf.h"
+#include "cfg/Exceptions.h"
 #include "ConfigOption.h"
 #include "DiskIO/DiskIOModule.h"
 #include "DiskIO/DiskIOStrategy.h"
@@ -222,17 +223,12 @@ Fs::Ufs::UFSSwapDir::optionIOParse(char const *option, const char *value, int is
         /* silently ignore this */
         return true;
 
-    if (!value) {
-        self_destruct();
-        return false;
-    }
+    Cfg::RequireValue(option, value);
 
     DiskIOModule *module = DiskIOModule::Find(value);
 
-    if (!module) {
-        self_destruct();
-        return false;
-    }
+    if (!module)
+        throw Cfg::FatalError(ToSBuf("unknown DiskIO module: ", value));
 
     changeIO(module);
 

--- a/src/icmp/IcmpConfig.cc
+++ b/src/icmp/IcmpConfig.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 
 #if USE_ICMP
+#include "cfg/Exceptions.h"
 #include "ConfigParser.h"
 #include "IcmpConfig.h"
 
@@ -23,7 +24,7 @@ IcmpConfig::parse()
         program.clear();
         program.append(token);
     } else
-        self_destruct();
+        throw Cfg::FatalError("missing ICMP helper parameter");
 }
 
 #endif /* USE_ICMP */

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -297,7 +297,7 @@ void
 Ip::Qos::Config::parseConfigLine()
 {
 #if !USE_QOS_TOS
-    throw Cfg::FatalError("invalid option 'qos_flows'. QOS features not enabled in this build");
+    throw Cfg::FatalError("QOS features not enabled in this build");
 #endif
 
     /* parse options ... */

--- a/src/main.cc
+++ b/src/main.cc
@@ -900,14 +900,14 @@ mainReconfigureFinish(void *)
     const int oldWorkers = Config.workers;
     try {
         if (parseConfigFile(ConfigFile) != 0) {
-            // for now any errors are a fatal condition...
-            self_destruct();
+            // for now any errors that reach here are a fatal condition...
+            ConfigParser::LegacyInstance().destruct();
         }
     } catch (...) {
         // for now any errors are a fatal condition...
         debugs(1, DBG_CRITICAL, "FATAL: Unhandled exception parsing config file. " <<
                " Run squid -k parse and check for errors.");
-        self_destruct();
+            ConfigParser::LegacyInstance().destruct();
     }
 
     if (oldWorkers != Config.workers) {

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -390,13 +390,13 @@ redirectInit(void)
     if (Config.redirector_extras) {
         delete redirectorExtrasFmt;
         redirectorExtrasFmt = new ::Format::Format("url_rewrite_extras");
-        (void)redirectorExtrasFmt->parse(Config.redirector_extras);
+        redirectorExtrasFmt->parse(Config.redirector_extras); // XXX: throws and leaks format on errors
     }
 
     if (Config.storeId_extras) {
         delete storeIdExtrasFmt;
         storeIdExtrasFmt = new ::Format::Format("store_id_extras");
-        (void)storeIdExtrasFmt->parse(Config.storeId_extras);
+        storeIdExtrasFmt->parse(Config.storeId_extras); // XXX: throws and leaks format on errors
     }
 
     init = true;

--- a/src/tests/Stub.am
+++ b/src/tests/Stub.am
@@ -58,6 +58,7 @@ STUB_SOURCE = \
 	tests/stub_libanyp.cc \
 	tests/stub_libauth.cc \
 	tests/stub_libauth_acls.cc \
+	tests/stub_libcfg.cc \
 	tests/stub_libcomm.cc \
 	tests/stub_libdiskio.cc \
 	tests/stub_liberror.cc \

--- a/src/tests/stub_cache_cf.cc
+++ b/src/tests/stub_cache_cf.cc
@@ -22,7 +22,6 @@ const char *cfg_directive = nullptr;
 const char *cfg_filename = nullptr;
 int config_lineno = 0;
 char config_input_line[BUFSIZ] = {};
-void self_destruct(void) STUB
 void parse_int(int *) STUB
 void parse_onoff(int *) STUB
 void parse_eol(char *volatile *) STUB

--- a/src/tests/stub_libcfg.cc
+++ b/src/tests/stub_libcfg.cc
@@ -8,11 +8,12 @@
 
 #include "squid.h"
 
-#define STUB_API "lcfg/libcfg.la"
+#define STUB_API "cfg/libcfg.la"
 #include "tests/STUB.h"
 
 #include "cfg/Exceptions.h"
 namespace Cfg
 {
 const char *FatalError::what() const throw() STUB_RETVAL("")
+void RequireValue(const char *, const char *) STUB
 }

--- a/src/tests/stub_libcfg.cc
+++ b/src/tests/stub_libcfg.cc
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 1996-2020 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#define STUB_API "lcfg/libcfg.la"
+#include "tests/STUB.h"
+
+#include "cfg/Exceptions.h"
+namespace Cfg
+{
+const char *FatalError::what() const throw() STUB_RETVAL("")
+}

--- a/src/tests/stub_libformat.cc
+++ b/src/tests/stub_libformat.cc
@@ -13,7 +13,7 @@
 #include "tests/STUB.h"
 
 void Format::Format::assemble(MemBuf &, const AccessLogEntryPointer &, int) const STUB
-bool Format::Format::parse(char const*) STUB_RETVAL(false)
+void Format::Format::parse(char const*) STUB
 Format::Format::Format(char const*) STUB
 Format::Format::~Format() STUB
 

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -22,7 +22,6 @@
 #include "ip/Address.h"
 #include "md5.h"
 #include "Parsing.h"
-#include "sbuf/Stream.h"
 #include "SquidConfig.h"
 #include "Store.h"
 #include "wccp2.h"


### PR DESCRIPTION
The self_destruct() function is a legacy wrapper used to shutdown
Squid somewhat gracefully on squid.conf parsing problems. It was
supposed to only be used by old Squid-2 code while the transition
to Squid-3 ConfigParser design took place, but more uses have
kept being added and the ConfigParser work stalled.

Each call to this function needed to be preceded by a high level
debugs() statement with FATAL label to explain properly what the
'Bungled config' claim meant, and followed by a return statement
to make static analysis happy. These requirements were not always
being followed, particularly the first one. Use of exceptions
removes these requirements and simplifies the resulting code.

This update replaces the self_destruct() and some fatal*() calls
with an exception customized to describe squid.conf parsing
errors. The exceptions thrown are caught in two places;
 * throws' during config file I/O operations and global macro
   processing are caught and handled by main.cc.
 * throws' by the config syntax parsing are caught on a per-line
   basis and preceded by an optional (level 3) "Processing: "
   display of the config line where the error occured.

Several gadgets are supplied to validate config settings and
throw a consistent error message for the type of failure
detected.

The new exception definition and code is integrated as
cfg/libcfg.la in accordance with the SourceLayout project plan.

The output from `-k parse` configuration testing will now
report and continue checking after many errors which would
previously have halted the test immediately.