### PR TITLE
Create and preserve code context in peerCountMcastPeers* events

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -63,6 +63,8 @@ static CNCB peerProbeConnectDone;
 static void peerCountMcastPeersDone(void *data);
 static void peerCountMcastPeersStart(void *data);
 static void peerCountMcastPeersSchedule(CachePeer * p, time_t when);
+static void peerCountMcastPeersAbort(PeerSelector *);
+static void peerCountMcastPeersCreateAndSend(CachePeer *p);
 static IRCB peerCountHandleIcpReply;
 
 static void neighborIgnoreNonPeer(const Ip::Address &, icp_opcode);
@@ -1393,9 +1395,19 @@ peerCountMcastPeersSchedule(CachePeer * p, time_t when)
 static void
 peerCountMcastPeersStart(void *data)
 {
+    const auto peer = static_cast<CachePeer*>(data);
+    CallContextCreator([peer] {
+        peerCountMcastPeersCreateAndSend(peer);
+    });
+    peerCountMcastPeersSchedule(peer, MCAST_COUNT_RATE);
+}
+
+/// initiates an ICP transaction to a multicast peer
+static void
+peerCountMcastPeersCreateAndSend(CachePeer * const p)
+{
     // XXX: Do not create lots of complex fake objects (while abusing their
     // APIs) to pass around a few basic data points like start_ping and ping!
-    CachePeer *p = (CachePeer *)data;
     MemObject *mem;
     int reqnum;
     // TODO: use class AnyP::Uri instead of constructing and re-parsing a string
@@ -1408,6 +1420,9 @@ peerCountMcastPeersStart(void *data)
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initPeerMcast);
     auto *req = HttpRequest::FromUrlXXX(url, mx);
     assert(req != nullptr);
+    const AccessLogEntry::Pointer ale = new AccessLogEntry;
+    ale->request = req;
+    CodeContext::Reset(ale);
     StoreEntry *fake = storeCreateEntry(url, url, RequestFlags(), Http::METHOD_GET);
     const auto psstate = new PeerSelector(nullptr);
     psstate->request = req;
@@ -1415,6 +1430,7 @@ peerCountMcastPeersStart(void *data)
     psstate->entry = fake;
     psstate->peerCountMcastPeerXXX = cbdataReference(p);
     psstate->ping.start = current_time;
+    psstate->al = ale;
     mem = fake->mem_obj;
     mem->request = psstate->request;
     mem->start_ping = current_time;
@@ -1431,13 +1447,23 @@ peerCountMcastPeersStart(void *data)
              psstate,
              Config.Timeout.mcast_icp_query / 1000.0, 1);
     p->mcast.flags.counting = true;
-    peerCountMcastPeersSchedule(p, MCAST_COUNT_RATE);
 }
 
 static void
 peerCountMcastPeersDone(void *data)
 {
     const auto psstate = static_cast<PeerSelector*>(data);
+    CallBack(psstate->al, [psstate] {
+        peerCountMcastPeersAbort(psstate);
+        delete psstate;
+    });
+}
+
+/// ends counting of multicast ICP replies
+/// to the ICP query initiated by peerCountMcastPeersCreateAndSend()
+static void
+peerCountMcastPeersAbort(PeerSelector * const psstate)
+{
     StoreEntry *fake = psstate->entry;
 
     if (cbdataReferenceValid(psstate->peerCountMcastPeerXXX)) {
@@ -1455,7 +1481,6 @@ peerCountMcastPeersDone(void *data)
     fake->abort(); // sets ENTRY_ABORTED and initiates releated cleanup
     fake->mem_obj->request = nullptr;
     fake->unlock("peerCountMcastPeersDone");
-    delete psstate;
 }
 
 static void


### PR DESCRIPTION
These event handlers initiate multicast cache peer pinging and collect
multicast statistics for the peer in CachePeer::mcast. Before the fix,
both handlers ran without any context, ignoring the existing
ICP transaction context.