### PR TITLE
Bug 5036: capital 'L's in logs when daemon queue overflows

### DIFF
--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -349,3 +349,4 @@ logfile_mod_daemon_flush(Logfile * lf)
         return;
     }
 }
+

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -301,10 +301,7 @@ logfile_mod_daemon_writeline(Logfile * lf, const char *buf, size_t len)
 
     /* Are we eol? If so, prefix with our logfile command byte */
     if (ll->eol) {
-	char tb[2];
-	tb[0] = 'L';
-	tb[1] = '\0';
-	logfile_mod_daemon_append(lf, tb, 1);
+	logfile_mod_daemon_append(lf, "L", 1);
 	ll->eol = 0;
     }
 
@@ -351,4 +348,3 @@ logfile_mod_daemon_flush(Logfile * lf)
         return;
     }
 }
-

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -312,6 +312,7 @@ logfile_mod_daemon_writeline(Logfile * lf, const char *buf, size_t len)
 static void
 logfile_mod_daemon_linestart(Logfile * lf)
 {
+    l_daemon_t *ll = static_cast<l_daemon_t *>(lf->data);
     assert(ll->eol == 1);
     // logfile_mod_daemon_writeline() sends the starting command
 }

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -320,6 +320,8 @@ logfile_mod_daemon_lineend(Logfile * lf)
 {
     l_daemon_t *ll = static_cast<l_daemon_t *>(lf->data);
     logfile_buffer_t *b;
+    if (ll->eol == 1) // logfile_mod_daemon_writeline() wrote nothing
+        return;
     ll->eol = 1;
     /* Kick a write off if the head buffer is -full- */
     if (ll->bufs.head != NULL) {

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -47,6 +47,7 @@ static void logfile_mod_daemon_append(Logfile * lf, const char *buf, int len);
 struct _l_daemon {
     int rfd, wfd;
     char eol;
+    char command_written;
     pid_t pid;
     int flush_pending;
     dlink_list bufs;
@@ -226,6 +227,7 @@ logfile_mod_daemon_open(Logfile * lf, const char *path, size_t, int)
     ll = static_cast<l_daemon_t*>(xcalloc(1, sizeof(*ll)));
     lf->data = ll;
     ll->eol = 1;
+    ll->command_written = 0;
     {
         Ip::Address localhost;
         args[0] = "(logfile-daemon)";
@@ -298,8 +300,16 @@ logfile_mod_daemon_writeline(Logfile * lf, const char *buf, size_t len)
         }
         return;
     }
+
+    if (!ll->command_written) {
+	char tb[2];
+	tb[0] = 'L';
+	tb[1] = '\0';
+	logfile_mod_daemon_append(lf, tb, 1);
+	ll->command_written = 1;
+    }
+
     /* Append this data to the end buffer; create a new one if needed */
-    /* Are we eol? If so, prefix with our logfile command byte */
     logfile_mod_daemon_append(lf, buf, len);
 }
 
@@ -307,12 +317,8 @@ static void
 logfile_mod_daemon_linestart(Logfile * lf)
 {
     l_daemon_t *ll = static_cast<l_daemon_t *>(lf->data);
-    char tb[2];
     assert(ll->eol == 1);
     ll->eol = 0;
-    tb[0] = 'L';
-    tb[1] = '\0';
-    logfile_mod_daemon_append(lf, tb, 1);
 }
 
 static void
@@ -322,6 +328,9 @@ logfile_mod_daemon_lineend(Logfile * lf)
     logfile_buffer_t *b;
     assert(ll->eol == 0);
     ll->eol = 1;
+    if (!ll->command_written)
+	return;
+    ll->command_written = 0;
     /* Kick a write off if the head buffer is -full- */
     if (ll->bufs.head != NULL) {
         b = static_cast<logfile_buffer_t*>(ll->bufs.head->data);

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -312,10 +312,7 @@ logfile_mod_daemon_writeline(Logfile * lf, const char *buf, size_t len)
 static void
 logfile_mod_daemon_linestart(Logfile * lf)
 {
-    /* 
-     * Sending the starting command byte has been moved to
-     * logfile_mod_daemon_writeline
-     */
+    // logfile_mod_daemon_writeline() sends the starting command
 }
 
 static void

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -300,7 +300,7 @@ logfile_mod_daemon_writeline(Logfile * lf, const char *buf, size_t len)
     }
 
     /* Are we eol? If so, prefix with our logfile command byte */
-    if (ll->eol) {
+    if (ll->eol == 1) {
 	logfile_mod_daemon_append(lf, "L", 1);
 	ll->eol = 0;
     }
@@ -312,6 +312,7 @@ logfile_mod_daemon_writeline(Logfile * lf, const char *buf, size_t len)
 static void
 logfile_mod_daemon_linestart(Logfile * lf)
 {
+    assert(ll->eol == 1);
     // logfile_mod_daemon_writeline() sends the starting command
 }
 


### PR DESCRIPTION
Varying number of capital 'L's have been observed in access logs
written by the daemon module.  The 'L's corresponded with the
cache log message:

  "queue is too large; some log messages have been lost."

This was caused by the fact that the 'L' command byte was
buffered even when the queue was too large to accept messages.

Deferring buffering the command byte until just before the
message itself is buffered.