### PR TITLE
Fix clang-6.0 build on FreeBSD 12 [-Wformat]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3012,7 +3012,6 @@ AC_CHECK_TYPE([bool])
 #need the defines for PRId64
 AC_CHECK_SIZEOF(int64_t)
 AC_CHECK_SIZEOF(long)
-AC_CHECK_SIZEOF(long long)
 #need the defines for PRIuSIZE
 AC_CHECK_SIZEOF(size_t)
 #need the define for overflow checks

--- a/configure.ac
+++ b/configure.ac
@@ -3012,6 +3012,7 @@ AC_CHECK_TYPE([bool])
 #need the defines for PRId64
 AC_CHECK_SIZEOF(int64_t)
 AC_CHECK_SIZEOF(long)
+AC_CHECK_SIZEOF(long long)
 #need the defines for PRIuSIZE
 AC_CHECK_SIZEOF(size_t)
 #need the define for overflow checks

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3072,8 +3072,8 @@ free_time_msec(time_msec_t * var)
 static void
 dump_time_nanoseconds(StoreEntry *entry, const char *name, const std::chrono::nanoseconds &var)
 {
-    // This assumes that nothing in C++ is larger than long long. TODO: Avoid printf().
-    storeAppendPrintf(entry, "%s %lld nanoseconds\n", name, static_cast<long long>(var.count()));
+    // std::chrono::nanoseconds::rep is unknown a priori so we cast to (and print) the largest supported integer
+    storeAppendPrintf(entry, "%s %jd nanoseconds\n", name, static_cast<intmax_t>(var.count()));
 }
 
 static void
@@ -5110,4 +5110,3 @@ free_on_unsupported_protocol(acl_access **access)
 {
     free_acl_access(access);
 }
-

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3072,7 +3072,7 @@ free_time_msec(time_msec_t * var)
 static void
 dump_time_nanoseconds(StoreEntry *entry, const char *name, const std::chrono::nanoseconds &var)
 {
-    storeAppendPrintf(entry, "%s %" PRId64 " nanoseconds\n", name, var.count());
+    storeAppendPrintf(entry, "%s %" PRId64 " nanoseconds\n", name, static_cast<int64_t>(var.count()));
 }
 
 static void

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3072,7 +3072,8 @@ free_time_msec(time_msec_t * var)
 static void
 dump_time_nanoseconds(StoreEntry *entry, const char *name, const std::chrono::nanoseconds &var)
 {
-    storeAppendPrintf(entry, "%s %" PRId64 " nanoseconds\n", name, static_cast<int64_t>(var.count()));
+    // This assumes that nothing in C++ is larger than long long. TODO: Avoid printf().
+    storeAppendPrintf(entry, "%s %lld nanoseconds\n", name, static_cast<long long>(var.count()));
 }
 
 static void
@@ -5109,4 +5110,3 @@ free_on_unsupported_protocol(acl_access **access)
 {
     free_acl_access(access);
 }
-

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -5110,3 +5110,4 @@ free_on_unsupported_protocol(acl_access **access)
 {
     free_acl_access(access);
 }
+


### PR DESCRIPTION
Cast and print std::chrono:nanoseconds::count() as intmax_t because its
actual type might be larger than the 64 bytes expected by %PRId64.

The problem was not, technically, specific to clang or FreeBSD.

The error message says "long" because %PRId64 is %ld on platforms where
"long" is 64 bits:

    format specifies type 'long' but the argument has type [...]
    'long long' [-Wformat]
