### PR TITLE
Bug 5038: Introduce allow_small_pids option

### DIFF
--- a/src/Instance.cc
+++ b/src/Instance.cc
@@ -80,7 +80,7 @@ GetOtherPid(File &pidFile)
 
     debugs(50, 7, "found PID " << rawPid << " in " << TheFile);
 
-    if (rawPid <= 1)
+    if ((rawPid <= 1 && !Config.onoff.allow_small_pids) || (rawPid < 1))
         throw TexcHere(ToSBuf("Bad ", TheFile, " contains unreasonably small PID value: ", rawPid));
     const auto finalPid = static_cast<pid_t>(rawPid);
     if (static_cast<int64_t>(finalPid) != rawPid)

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -277,6 +277,7 @@ public:
     } Netdb;
 
     struct {
+        int allow_small_pids;
         int log_udp;
         int res_defnames;
         int anonymizer;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2828,6 +2828,18 @@ DOC_START
 	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 DOC_END
 
+NAME: allow_small_pids
+TYPE: onoff
+DEFAULT: off
+LOC: Config.onoff.allow_small_pids
+DOC_START
+    If allow_small_pids is off (the default), "squid -k" actions will
+    fail if squid has a pid of 1. This prevents erroneously sending
+    signals to init. If you are running squid in a containerized 
+    environment where it is actually pid 1, set allow_small_pids on
+    to permit "squid -k" commands to operate as intended.
+DOC_END
+
 NAME: host_verify_strict
 TYPE: onoff
 DEFAULT: off


### PR DESCRIPTION
The allow_small_pids option permits commands like "squid -k rotate" to
operate correctly even when the squid process is PID 1 (as is commonly
found when running in containerized environments). The option
defaults to "off", preserving the existing behavior unless it is
explicitly enabled.