### PR TITLE
Fix auth digest refcount integer overflow

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -96,9 +96,6 @@ static void authenticateDigestNonceDelete(digest_nonce_h * nonce);
 static void authenticateDigestNonceSetup(void);
 static void authDigestNonceEncode(digest_nonce_h * nonce);
 static void authDigestNonceLink(digest_nonce_h * nonce);
-#if NOT_USED
-static int authDigestNonceLinks(digest_nonce_h * nonce);
-#endif
 static void authDigestNonceUserUnlink(digest_nonce_h * nonce);
 
 static void
@@ -291,20 +288,9 @@ authDigestNonceLink(digest_nonce_h * nonce)
 {
     assert(nonce != NULL);
     ++nonce->references;
+    assert(nonce->references != 0); // no overflows
     debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
 }
-
-#if NOT_USED
-static int
-authDigestNonceLinks(digest_nonce_h * nonce)
-{
-    if (!nonce)
-        return -1;
-
-    return nonce->references;
-}
-
-#endif
 
 void
 authDigestNonceUnlink(digest_nonce_h * nonce)

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -43,7 +43,6 @@
  */
 #include "mem/Pool.h"
 
-#include <climits>
 #include <random>
 
 static AUTHSSTATS authenticateDigestStats;
@@ -291,13 +290,8 @@ static void
 authDigestNonceLink(digest_nonce_h * nonce)
 {
     assert(nonce != NULL);
-    if (nonce->references != UINT_MAX) {
-        ++nonce->references;
-        debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
-    }
-    else {
-        debugs(29, 9, "nonce '" << nonce << "' refcount at maximum value!");
-    }
+    ++nonce->references;
+    debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
 }
 
 #if NOT_USED

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -43,6 +43,7 @@
  */
 #include "mem/Pool.h"
 
+#include <climits>
 #include <random>
 
 static AUTHSSTATS authenticateDigestStats;
@@ -290,8 +291,13 @@ static void
 authDigestNonceLink(digest_nonce_h * nonce)
 {
     assert(nonce != NULL);
-    ++nonce->references;
-    debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
+    if (nonce->references != UINT_MAX) {
+        ++nonce->references;
+        debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
+    }
+    else {
+        debugs(29, 9, "nonce '" << nonce << "' refcount at maximum value!");
+    }
 }
 
 #if NOT_USED

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -42,7 +42,7 @@ struct _digest_nonce_h : public hash_link {
     /* number of uses we've seen of this nonce */
     unsigned long nc;
     /* reference count */
-    unsigned int references;
+    uint64_t references;
     /* the auth_user this nonce has been tied to */
     Auth::Digest::User *user;
     /* has this nonce been invalidated ? */

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -42,7 +42,7 @@ struct _digest_nonce_h : public hash_link {
     /* number of uses we've seen of this nonce */
     unsigned long nc;
     /* reference count */
-    short references;
+    unsigned int references;
     /* the auth_user this nonce has been tied to */
     Auth::Digest::User *user;
     /* has this nonce been invalidated ? */


### PR DESCRIPTION
This fixes a possible overflow of the nonce reference counter in the 
digest authentication scheme, found by security researchers 
@synacktiv.

It changes `references` to be an 64 bits unsigned integer. This makes 
overflowing the counter impossible in practice.