### PR TITLE
Restore PURGE miss replies to be "404 Not Found", not "0 Init"

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1047,9 +1047,6 @@ clientReplyContext::purgeDoMissPurge()
 void
 clientReplyContext::purgeDoPurgeGet(StoreEntry *newEntry)
 {
-    /* Move to new() when that is created */
-    purgeStatus = Http::scNotFound;
-
     if (newEntry) {
         /* Release the cached URI */
         debugs(88, 4, "clientPurgeRequest: GET '" << newEntry->url() << "'" );
@@ -1103,6 +1100,9 @@ clientReplyContext::purgeDoPurgeHead(StoreEntry *newEntry)
             purgeStatus = Http::scOkay;
         }
     }
+
+    if (purgeStatus == Http::scNone)
+        purgeStatus = Http::scNotFound;
 
     /*
      * Make a new entry to hold the reply to be written

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1047,9 +1047,10 @@ clientReplyContext::purgeDoMissPurge()
 void
 clientReplyContext::purgeDoPurgeGet(StoreEntry *newEntry)
 {
+    /* Move to new() when that is created */
+    purgeStatus = Http::scNotFound;
+
     if (newEntry) {
-        /* Move to new() when that is created */
-        purgeStatus = Http::scNotFound;
         /* Release the cached URI */
         debugs(88, 4, "clientPurgeRequest: GET '" << newEntry->url() << "'" );
 #if USE_HTCP

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -48,14 +48,16 @@ Http::StatusLine::packInto(Packable * p) const
     assert(p);
 
     auto packedStatus = status();
+    auto packedReason = reason();
+
     if (packedStatus == Http::scNone) {
         static unsigned int reports = 0;
         if (++reports <= 100)
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
         packedStatus = Http::scInternalServerError;
+        packedReason = Http::StatusCodeString(packedStatus);
         // and ignore custom reason_ (if any)
     }
-    const auto packedReason = Http::StatusCodeString(packedStatus);
 
     /* local constants */
     /* AYJ: see bug 2469 - RFC2616 confirms stating 'SP characters' plural! */

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -53,6 +53,7 @@ Http::StatusLine::packInto(Packable * p) const
         if (++reports <= 100)
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
         packedStatus = Http::scInternalServerError;
+        // and ignore custom reason_ (if any)
     }
     const auto packedReason = Http::StatusCodeString(packedStatus);
 

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -49,7 +49,7 @@ Http::StatusLine::packInto(Packable * p) const
 
     auto useStatus = status();
     if (!useStatus) {
-        static int zeroStatusCount = 0;
+        static unsigned int zeroStatusCount = 0;
         if (++zeroStatusCount < 100) {
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
         }

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -47,6 +47,21 @@ Http::StatusLine::packInto(Packable * p) const
 {
     assert(p);
 
+    Http::StatusCode useStatus;
+    const char *useReason;
+
+    if (!status()) {
+        static int zeroStatusCount = 0;
+        if (++zeroStatusCount < 100) {
+            debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
+        }
+        useStatus = Http::scInternalServerError;
+        useReason = Http::StatusCodeString(useStatus);
+    } else {
+        useStatus = status();
+        useReason = reason();
+    }
+
     /* local constants */
     /* AYJ: see bug 2469 - RFC2616 confirms stating 'SP characters' plural! */
     static const char *Http1StatusLineFormat = "HTTP/%d.%d %3d %s\r\n";
@@ -56,15 +71,15 @@ Http::StatusLine::packInto(Packable * p) const
     if (protocol == AnyP::PROTO_ICY) {
         debugs(57, 9, "packing sline " << this << " using " << p << ":");
         debugs(57, 9, "FORMAT=" << IcyStatusLineFormat );
-        debugs(57, 9, "ICY " << status() << " " << reason());
-        p->appendf(IcyStatusLineFormat, status(), reason());
+        debugs(57, 9, "ICY " << useStatus << " " << useReason);
+        p->appendf(IcyStatusLineFormat, useStatus, useReason);
         return;
     }
 
     debugs(57, 9, "packing sline " << this << " using " << p << ":");
     debugs(57, 9, "FORMAT=" << Http1StatusLineFormat );
-    debugs(57, 9, "HTTP/" << version.major << "." << version.minor << " " << status() << " " << reason());
-    p->appendf(Http1StatusLineFormat, version.major, version.minor, status(), reason());
+    debugs(57, 9, "HTTP/" << version.major << "." << version.minor << " " << useStatus << " " << useReason);
+    p->appendf(Http1StatusLineFormat, version.major, version.minor, useStatus, useReason);
 }
 
 /*

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -55,8 +55,7 @@ Http::StatusLine::packInto(Packable * p) const
         if (++reports <= 100)
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
         packedStatus = Http::scInternalServerError;
-        packedReason = Http::StatusCodeString(packedStatus);
-        // and ignore custom reason_ (if any)
+        packedReason = Http::StatusCodeString(packedStatus); // ignore custom reason_ (if any)
     }
 
     /* local constants */

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -47,20 +47,15 @@ Http::StatusLine::packInto(Packable * p) const
 {
     assert(p);
 
-    Http::StatusCode useStatus;
-    const char *useReason;
-
-    if (!status()) {
+    auto useStatus = status();
+    if (!useStatus) {
         static int zeroStatusCount = 0;
         if (++zeroStatusCount < 100) {
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
         }
         useStatus = Http::scInternalServerError;
-        useReason = Http::StatusCodeString(useStatus);
-    } else {
-        useStatus = status();
-        useReason = reason();
     }
+    const auto useReason = Http::StatusCodeString(useStatus);
 
     /* local constants */
     /* AYJ: see bug 2469 - RFC2616 confirms stating 'SP characters' plural! */

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -47,15 +47,14 @@ Http::StatusLine::packInto(Packable * p) const
 {
     assert(p);
 
-    auto useStatus = status();
-    if (!useStatus) {
-        static unsigned int zeroStatusCount = 0;
-        if (++zeroStatusCount <= 100) {
+    auto packedStatus = status();
+    if (!packedStatus) {
+        static unsigned int reports = 0;
+        if (++reports <= 100)
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
-        }
-        useStatus = Http::scInternalServerError;
+        packedStatus = Http::scInternalServerError;
     }
-    const auto useReason = Http::StatusCodeString(useStatus);
+    const auto packedReason = Http::StatusCodeString(packedStatus);
 
     /* local constants */
     /* AYJ: see bug 2469 - RFC2616 confirms stating 'SP characters' plural! */
@@ -66,15 +65,15 @@ Http::StatusLine::packInto(Packable * p) const
     if (protocol == AnyP::PROTO_ICY) {
         debugs(57, 9, "packing sline " << this << " using " << p << ":");
         debugs(57, 9, "FORMAT=" << IcyStatusLineFormat );
-        debugs(57, 9, "ICY " << useStatus << " " << useReason);
-        p->appendf(IcyStatusLineFormat, useStatus, useReason);
+        debugs(57, 9, "ICY " << packedStatus << " " << packedReason);
+        p->appendf(IcyStatusLineFormat, packedStatus, packedReason);
         return;
     }
 
     debugs(57, 9, "packing sline " << this << " using " << p << ":");
     debugs(57, 9, "FORMAT=" << Http1StatusLineFormat );
-    debugs(57, 9, "HTTP/" << version.major << "." << version.minor << " " << useStatus << " " << useReason);
-    p->appendf(Http1StatusLineFormat, version.major, version.minor, useStatus, useReason);
+    debugs(57, 9, "HTTP/" << version.major << "." << version.minor << " " << packedStatus << " " << packedReason);
+    p->appendf(Http1StatusLineFormat, version.major, version.minor, packedStatus, packedReason);
 }
 
 /*

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -50,7 +50,7 @@ Http::StatusLine::packInto(Packable * p) const
     auto useStatus = status();
     if (!useStatus) {
         static unsigned int zeroStatusCount = 0;
-        if (++zeroStatusCount < 100) {
+        if (++zeroStatusCount <= 100) {
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");
         }
         useStatus = Http::scInternalServerError;

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -48,7 +48,7 @@ Http::StatusLine::packInto(Packable * p) const
     assert(p);
 
     auto packedStatus = status();
-    if (!packedStatus) {
+    if (packedStatus == Http::scNone) {
         static unsigned int reports = 0;
         if (++reports <= 100)
             debugs(57, DBG_IMPORTANT, "BUG: Generated response lacks status code");


### PR DESCRIPTION
Since commit 6956579, PURGE requests resulted in invalid HTTP responses
with zero status code when Store lacked both GET and HEAD entries with
the requested URI.

Also adjusted Http::StatusLine packing code to avoid generating similar
invalid responses in the future (and to attract developer attention to
their presence in the code logic with a BUG message).

This is a Measurement Factory project.