### PR TITLE
SslBump: Disable OpenSSL TLSv1.3 support for older TLS traffic

### DIFF
--- a/src/anyp/ProtocolVersion.h
+++ b/src/anyp/ProtocolVersion.h
@@ -40,6 +40,8 @@ public:
     unsigned int major;    ///< major version number
     unsigned int minor;    ///< minor version number
 
+    explicit operator bool() const { return protocol != PROTO_NONE; }
+
     bool operator==(const ProtocolVersion& that) const {
         if (this->protocol != that.protocol)
             return false;

--- a/src/anyp/ProtocolVersion.h
+++ b/src/anyp/ProtocolVersion.h
@@ -40,6 +40,7 @@ public:
     unsigned int major;    ///< major version number
     unsigned int minor;    ///< minor version number
 
+    /// whether the version is "known" (e.g., has been parsed or explicitly set)
     explicit operator bool() const { return protocol != PROTO_NONE; }
 
     bool operator==(const ProtocolVersion& that) const {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2187,6 +2187,7 @@ ConnStateData::ConnStateData(const MasterXaction::Pointer &xact) :
     bodyParser(nullptr),
 #if USE_OPENSSL
     sslBumpMode(Ssl::bumpEnd),
+    tlsParser(Security::HandshakeParser::fromClient),
 #endif
     needProxyProtocolHeader_(false),
 #if USE_OPENSSL

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -280,9 +280,12 @@ Security::HandshakeParser::parseChangeCipherCpecMessage()
     // We are currently ignoring Change Cipher Spec Protocol messages.
     skipMessage("ChangeCipherCpec msg [fragment]");
 
+    // This is a TLSv1.3 message or a resuming session
+    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3))
+        resumingSession = true;
+
     // Everything after the ChangeCipherCpec message may be encrypted.
     // Continuing parsing is pointless. Stop here.
-    resumingSession = true;
     done = "ChangeCipherCpec";
 }
 

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -336,7 +336,7 @@ Security::HandshakeParser::parseHandshakeMessage()
         state = atHelloReceived;
         // for TLSv1.3 and later, anything after the server Hello is encrypted
         if (Tls1p3orLater(details->tlsSupportedVersion))
-            done = "Tlsv13ServerHello in v1.3+";
+            done = "ServerHello in v1.3+";
         return;
     case HandshakeType::hskCertificate:
         Must(state < atCertificatesReceived);
@@ -521,7 +521,7 @@ Security::HandshakeParser::parseSniExtension(const SBuf &extensionData) const
     return SBuf(); // SNI extension lacks host_name
 }
 
-// RFC 8446 Section 4.2.1: SupportedVersions extension
+/// RFC 8446 Section 4.2.1: SupportedVersions extension
 void
 Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extensionData) const
 {
@@ -537,7 +537,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
     // (TLS 1.2).
     //
     // To reduce misdetection of legacy agents and mishandling of malformed
-    // traffic, ignore supported_versions senders that violate the above MUSTs:
+    // input, ignore supported_versions senders violating legacy_version MUSTs:
     if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2))
         return;
 
@@ -551,7 +551,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
         while (!tkVersions.atEnd()) {
             const auto version = ParseProtocolVersion(tkVersions, "supported_version");
             if (Tls1p3orLater(version) &&
-                (!supportedVersionMax || supportedVersionMax < version))
+                    (!supportedVersionMax || supportedVersionMax < version))
                 supportedVersionMax = version;
         }
     } else {

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -693,7 +693,7 @@ Security::SupportedExtensions()
 #if defined(TLSEXT_TYPE_next_proto_neg) // 13172
     extensions.insert(TLSEXT_TYPE_next_proto_neg);
 #endif
-#if defined(TLSEXT_TYPE_supported_versions)
+#if defined(TLSEXT_TYPE_supported_versions) // 43
     extensions.insert(TLSEXT_TYPE_supported_versions);
 #endif
 

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -555,8 +555,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
         Parser::BinaryTokenizer tkVersions(tkList.pstring8("SupportedVersions"));
         while (!tkVersions.atEnd()) {
             const auto version = ParseProtocolVersion(tkVersions, "supported_version");
-            // XXX: If versions have SSL vX, the operator "<" below may not work
-            if (!supportedVersionMax || supportedVersionMax < version)
+            if (!supportedVersionMax || TlsVersionEarlierThan(supportedVersionMax, version))
                 supportedVersionMax = version;
         }
 

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -292,7 +292,7 @@ Security::HandshakeParser::parseChangeCipherCpecMessage()
     // tlsSupportedVersion is already known) and indicates session resumption.
     // In later TLS versions, ChangeCipherSpec may be sent before and after
     // Hello, but it is unused for session resumption and should be ignored.
-    if (!details->tlsSupportedVersion || TlsVersion13OrLater(details->tlsSupportedVersion))
+    if (!details->tlsSupportedVersion || Tls1p3orLater(details->tlsSupportedVersion))
         return;
 
     resumingSession = true;
@@ -335,7 +335,7 @@ Security::HandshakeParser::parseHandshakeMessage()
         parseServerHelloHandshakeMessage(message.msg_body);
         state = atHelloReceived;
         // for TLSv1.3 and later, anything after the server Hello is encrypted
-        if (TlsVersion13OrLater(details->tlsSupportedVersion))
+        if (Tls1p3orLater(details->tlsSupportedVersion))
             done = "Tlsv13ServerHello in v1.3+";
         return;
     case HandshakeType::hskCertificate:
@@ -548,14 +548,14 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
         while (!tkVersions.atEnd()) {
             Parser::BinaryTokenizerContext version(tkVersions, "SupportedVersion");
             const auto aVersion = ParseProtocolVersion(tkVersions);
-            if (TlsVersion13OrLater(aVersion) &&
+            if (Tls1p3orLater(aVersion) &&
                 (!supportedVersionMax || supportedVersionMax < aVersion))
                 supportedVersionMax = aVersion;
         }
     } else if (messageSource == fromServer) {
         Parser::BinaryTokenizer tkVersion(extensionData);
         const auto aVersion = ParseProtocolVersion(tkVersion);
-        if (TlsVersion13OrLater(aVersion))
+        if (Tls1p3orLater(aVersion))
             supportedVersionMax = aVersion;
     }
 

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -106,14 +106,6 @@ static Extensions SupportedExtensions();
 
 } // namespace Security
 
-/// Whether the given version is TLSv1.3 or latter
-static bool
-TlsVersion13OrLater(const AnyP::ProtocolVersion &version)
-{
-    return version.protocol == AnyP::PROTO_TLS &&
-        version >= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
-}
-
 /// Convenience helper: We parse ProtocolVersion but store "int".
 static AnyP::ProtocolVersion
 ParseProtocolVersion(Parser::BinaryTokenizer &tk)

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -292,14 +292,13 @@ Security::HandshakeParser::parseChangeCipherCpecMessage()
     // tlsSupportedVersion is already known) and indicates session resumption.
     // In later TLS versions, ChangeCipherSpec may be sent before and after
     // Hello, but it is unused for session resumption and should be ignored.
-    const bool tls1p2orEarlier = details->tlsSupportedVersion &&
-                                 !TlsVersion13OrLater(details->tlsSupportedVersion);
-    if (tls1p2orEarlier) {
-        resumingSession = true;
+    if (!details->tlsSupportedVersion || TlsVersion13OrLater(details->tlsSupportedVersion))
+        return;
 
-        // Everything after the ChangeCipherSpec message may be encrypted. Stop.
-        done = "ChangeCipherSpec in v1.2-";
-    }
+    resumingSession = true;
+
+    // Everything after the ChangeCipherSpec message may be encrypted. Stop.
+    done = "ChangeCipherSpec in v1.2-";
 }
 
 void

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -515,13 +515,13 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
         Parser::BinaryTokenizer tkVersions(tkList.pstring8("SupportedVersionsList"));
         while (!tkVersions.atEnd()) {
             Parser::BinaryTokenizerContext version(tkVersions, "SupportedVersion");
-            const uint16_t aVersion = tkVersions.uint16(".version");
+            const auto aVersion = tkVersions.uint16(".version");
             if (aVersion == 0x0304)
                 details->tlsSupportedVersion = AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
         }
     } else if (handshakeType == hskServerHello) {
         Parser::BinaryTokenizer tkVersion(extensionData);
-        const uint16_t supportedVersion = tkVersion.uint16(".supported_version");
+        const auto supportedVersion = tkVersion.uint16(".supported_version");
         if (supportedVersion == 0x0304)
             details->tlsSupportedVersion = AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
     }

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -183,7 +183,7 @@ Security::HandshakeParser::HandshakeParser():
     details(new TlsDetails),
     state(atHelloNone),
     resumingSession(false),
-    handshakeType(hskNone),
+    handshakeType(hskOther),
     currentContentType(0),
     done(nullptr),
     expectingModernRecords(false)

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -527,7 +527,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
     //
     // For both Client and Server hello the legacy_version (highest supported
     // version for TLSv1.2 and earlier) must be set to 0x0303
-    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3))
+    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2))
         return;
 
     bool isHelloTLSv1_3 = false;

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -581,7 +581,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
     // We overwrite Hello-derived legacy_version because the following MUSTs
     // indicate that it is ignored in the presence of valid supported_versions
     // as far as the negotiated version is concerned. For simplicity sake, we
-    // also overwrite previous valid supported_versions extensions (if any).
+    // may also overwrite previous valid supported_versions extensions (if any).
     //
     // RFC 8446 Section 4.2.1:
     // If this extension is present in the ClientHello, servers MUST NOT use the

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -554,7 +554,8 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
                 (!supportedVersionMax || supportedVersionMax < version))
                 supportedVersionMax = version;
         }
-    } else if (messageSource == fromServer) {
+    } else {
+        assert(messageSource == fromServer);
         Parser::BinaryTokenizer tkVersion(extensionData, "selected_version");
         const auto version = ParseProtocolVersion(tkVersion);
         if (Tls1p3orLater(version))

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -546,8 +546,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
     // (TLS 1.2).
     //
     // Ignore supported_versions senders violating legacy_version MUSTs above:
-    static const AnyP::ProtocolVersion Tls1p2(AnyP::PROTO_TLS, 1, 2);
-    if (details->tlsSupportedVersion != Tls1p2)
+    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2))
         return;
 
     AnyP::ProtocolVersion supportedVersionMax;

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -187,7 +187,7 @@ Security::TlsDetails::TlsDetails():
 
 /* Security::HandshakeParser */
 
-Security::HandshakeParser::HandshakeParser(MessageSource source):
+Security::HandshakeParser::HandshakeParser(const MessageSource source):
     details(new TlsDetails),
     state(atHelloNone),
     resumingSession(false),

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -293,7 +293,7 @@ Security::HandshakeParser::parseChangeCipherCpecMessage()
     // In later TLS versions, ChangeCipherSpec may be sent before and after
     // Hello, but it is no longer used for session resumption and should be
     // ignored.
-    const bool tlsv12OrEarlier = details->tlsSupportedVersion.protocol != AnyP::PROTO_NONE &&
+    const bool tlsv12OrEarlier = details->tlsSupportedVersion &&
                                  !TlsVersion13OrLater(details->tlsSupportedVersion);
     if (tlsv12OrEarlier) {
         resumingSession = true;
@@ -553,7 +553,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
             Parser::BinaryTokenizerContext version(tkVersions, "SupportedVersion");
             const auto aVersion = ParseProtocolVersion(tkVersions);
             if (TlsVersion13OrLater(aVersion) &&
-                (fixSupportedVersion.protocol == AnyP::PROTO_NONE || fixSupportedVersion < aVersion))
+                (!fixSupportedVersion || fixSupportedVersion < aVersion))
                 fixSupportedVersion = aVersion;
         }
     } else if (messageSource == fromServer) {
@@ -563,7 +563,7 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
             fixSupportedVersion = aVersion;
     }
 
-    if (fixSupportedVersion.protocol != AnyP::PROTO_NONE) {
+    if (fixSupportedVersion) {
         // overwrite previously stored Hello-derived legacy_version
         details->tlsSupportedVersion = fixSupportedVersion;
     }

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -541,6 +541,9 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
     if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2))
         return;
 
+    // The code below ignores older protocol versions in supported_versions.
+    // TODO: Document why. For example, why leave tlsSupportedVersion at v1.2
+    // when a v1.3 server negotiates v1.1 using supported_versions?
     AnyP::ProtocolVersion supportedVersionMax;
     if (messageSource == fromClient) {
         Parser::BinaryTokenizer tkList(extensionData);

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -546,7 +546,8 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
     // (TLS 1.2).
     //
     // Ignore supported_versions senders violating legacy_version MUSTs above:
-    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2))
+    static const AnyP::ProtocolVersion Tls1p2(AnyP::PROTO_TLS, 1, 2);
+    if (details->tlsSupportedVersion != Tls1p2)
         return;
 
     AnyP::ProtocolVersion supportedVersionMax;

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -296,15 +296,17 @@ Security::HandshakeParser::parseChangeCipherCpecMessage()
     // We are currently ignoring Change Cipher Spec Protocol messages.
     skipMessage("ChangeCipherSpec msg [fragment]");
 
-    // In TLS v1.3, a dummy ChangeCipherSpec implies Middlebox Compatibility
-    // Mode. In earlier TLS versions, ChangeCipherSpec starts (encrypted)
+    // In earlier TLS v1.2 and earlier, ChangeCipherSpec starts (encrypted)
     // session resumption
-    if (!TlsVersion13OrLater(details->tlsSupportedVersion))
+    const bool tlsv12OrEarlier = details->tlsSupportedVersion.protocol != AnyP::PROTO_NONE &&
+                                 !TlsVersion13OrLater(details->tlsSupportedVersion);
+    if (tlsv12OrEarlier) {
         resumingSession = true;
 
-    // Everything after the ChangeCipherSpec message may be encrypted.
-    // Continuing parsing is pointless. Stop here.
-    done = "ChangeCipherSpec";
+        // Everything after the ChangeCipherSpec message may be encrypted.
+        // Continuing parsing is pointless. Stop here.
+        done = "ChangeCipherSpec";
+    }
 }
 
 void

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -296,8 +296,11 @@ Security::HandshakeParser::parseChangeCipherCpecMessage()
     // We are currently ignoring Change Cipher Spec Protocol messages.
     skipMessage("ChangeCipherSpec msg [fragment]");
 
-    // In earlier TLS v1.2 and earlier, ChangeCipherSpec starts (encrypted)
-    // session resumption
+    // In TLS v1.2 and earlier, ChangeCipherSpec is sent after Hello (so the
+    // version is known by now) and indicates session resumption.
+    // In later TLS versions, ChangeCipherSpec may be sent before and after
+    // Hello, but it is no longer used for session resumption and should be
+    // ignored.
     const bool tlsv12OrEarlier = details->tlsSupportedVersion.protocol != AnyP::PROTO_NONE &&
                                  !TlsVersion13OrLater(details->tlsSupportedVersion);
     if (tlsv12OrEarlier) {

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -278,15 +278,18 @@ Security::HandshakeParser::parseChangeCipherCpecMessage()
 {
     Must(currentContentType == ContentType::ctChangeCipherSpec);
     // We are currently ignoring Change Cipher Spec Protocol messages.
-    skipMessage("ChangeCipherCpec msg [fragment]");
+    skipMessage("ChangeCipherSpec msg [fragment]");
 
-    // This is a TLSv1.3 message or a resuming session
-    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3))
+    // In TLS v1.3, a dummy ChangeCipherSpec implies Middlebox Compatibility
+    // Mode. In earlier TLS versions, ChangeCipherSpec starts (encrypted)
+    // session resumption
+    const bool tlsv13OrLater = details->tlsSupportedVersion.protocol == AnyP::PROTO_TLS && details->tlsSupportedVersion >= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
+    if (!tlsv13OrLater)
         resumingSession = true;
 
-    // Everything after the ChangeCipherCpec message may be encrypted.
+    // Everything after the ChangeCipherSpec message may be encrypted.
     // Continuing parsing is pointless. Stop here.
-    done = "ChangeCipherCpec";
+    done = "ChangeCipherSpec";
 }
 
 void

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -559,14 +559,14 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
         Parser::BinaryTokenizer tkVersions(tkList.pstring8("SupportedVersionsList"));
         while (!tkVersions.atEnd()) {
             Parser::BinaryTokenizerContext version(tkVersions, "SupportedVersion");
-            auto aVersion = ParseProtocolVersion(tkVersions);
+            const auto aVersion = ParseProtocolVersion(tkVersions);
             if (TlsVersion13OrLater(aVersion) &&
                 (fixSupportedVersion.protocol == AnyP::PROTO_NONE || fixSupportedVersion < aVersion))
                 fixSupportedVersion = aVersion;
         }
     } else if (messageSource == fromServer) {
         Parser::BinaryTokenizer tkVersion(extensionData);
-        auto aVersion = ParseProtocolVersion(tkVersion);
+        const auto aVersion = ParseProtocolVersion(tkVersion);
         if (TlsVersion13OrLater(aVersion))
             fixSupportedVersion = aVersion;
     }

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -134,13 +134,23 @@ private:
 /// \returns true when the given protocol is TLS with v1.3 or a later version
 /// Negating the result of this function may be misleading. For example,
 /// !Tls1p3orLater(x) does not imply that x is TLS v1.2 or lower; x could also
-/// be unknown or even HTTP/2. If you do need negation, consider adding and
-/// using Tls1p2orEarlier() instead (which should also return true for SSL).
+/// be unknown or even HTTP/2. If you do need negation, consider using
+/// Tls1p2orEarlier() instead.
 inline bool
 Tls1p3orLater(const AnyP::ProtocolVersion &version)
 {
     return version.protocol == AnyP::PROTO_TLS &&
            version >= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
+}
+
+/// \returns true when the given protocol is SSL or TLS with v1.2 or a earlier version
+/// Negating the result of this function may be misleading.
+inline bool
+Tls1p2orEarlier(const AnyP::ProtocolVersion &version)
+{
+    return version.protocol == AnyP::PROTO_SSL ||
+           (version.protocol == AnyP::PROTO_TLS &&
+            version <= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2));
 }
 
 }

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -158,13 +158,13 @@ Tls1p2orEarlier(const AnyP::ProtocolVersion &version)
 inline bool
 TlsVersionEarlierThan(const AnyP::ProtocolVersion &va, const AnyP::ProtocolVersion &vb)
 {
-    Must(va.protocol == AnyP::PROTO_SSL || va.protocol == AnyP::PROTO_TLS);
-    Must(vb.protocol == AnyP::PROTO_SSL || vb.protocol == AnyP::PROTO_TLS);
+    Must(va.protocol == AnyP::PROTO_TLS || va.protocol == AnyP::PROTO_SSL);
+    Must(vb.protocol == AnyP::PROTO_TLS || vb.protocol == AnyP::PROTO_SSL);
 
     if (va.protocol == vb.protocol)
         return va < vb;
 
-    return va.protocol == AnyP::PROTO_SSL;
+    return va.protocol == AnyP::PROTO_SSL; // implies that vb is TLS
 }
 
 }

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -52,6 +52,15 @@ std::ostream &operator <<(std::ostream &os, Security::TlsDetails const &details)
     return details.print(os);
 }
 
+/// TLS Handshake protocol's handshake types from RFC 5246 Section 7.4
+enum HandshakeType {
+    hskClientHello = 1,
+    hskServerHello = 2,
+    hskCertificate = 11,
+    hskServerHelloDone = 14,
+    hskNone = 255
+};
+
 /// Incremental TLS/SSL Handshake parser.
 class HandshakeParser
 {
@@ -75,6 +84,7 @@ public:
 
     bool resumingSession; ///< True if this is a resuming session
 
+    HandshakeType handshakeType; ///< hskClientHello or hskServerHello
 private:
     bool isSslv2Record(const SBuf &raw) const;
     void parseRecord();
@@ -96,6 +106,7 @@ private:
     bool parseCompressionMethods(const SBuf &raw);
     void parseExtensions(const SBuf &raw);
     SBuf parseSniExtension(const SBuf &extensionData) const;
+    void parseSupportedVersionsExtension(const SBuf &extensionData) const;
 
     void parseCiphers(const SBuf &raw);
     void parseV23Ciphers(const SBuf &raw);

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -155,7 +155,8 @@ TlsVersionEarlierThan(const AnyP::ProtocolVersion &a, const AnyP::ProtocolVersio
 inline bool
 Tls1p2orEarlier(const AnyP::ProtocolVersion &p)
 {
-    return TlsVersionEarlierThan(p, AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3));
+    static const AnyP::ProtocolVersion Tls1p3(AnyP::PROTO_TLS, 1, 3);
+    return TlsVersionEarlierThan(p, Tls1p3);
 }
 
 /// whether the given TLS/SSL protocol is TLS v1.3 or later

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -52,7 +52,7 @@ std::ostream &operator <<(std::ostream &os, Security::TlsDetails const &details)
     return details.print(os);
 }
 
-/// TLS Handshake protocol's handshake types from RFC 5246 Section 7.4
+/// TLS Handshake protocol's handshake types from RFC 8446 Section B.3
 enum HandshakeType {
     hskClientHello = 1,
     hskServerHello = 2,

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -29,7 +29,11 @@ public:
     std::ostream & print(std::ostream &os) const;
 
     AnyP::ProtocolVersion tlsVersion; ///< The TLS hello message version
-    AnyP::ProtocolVersion tlsSupportedVersion; ///< The requested/used TLS version
+
+    /// For compliant TLS v1.3+ agents, this is supported_versions maximum.
+    /// For others agents, this is the legacy_version field.
+    AnyP::ProtocolVersion tlsSupportedVersion;
+
     bool compressionSupported; ///< The requested/used compressed  method
     SBuf serverName; ///< The SNI hostname, if any
     bool doHeartBeats;
@@ -125,7 +129,7 @@ private:
     YesNoNone expectingModernRecords;
 };
 
-/// Whether the given version is TLSv1.3 or latter
+/// whether the given protocol is TLS (v1.3 or later)
 inline bool
 TlsVersion13OrLater(const AnyP::ProtocolVersion &version)
 {

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -129,7 +129,11 @@ private:
     YesNoNone expectingModernRecords;
 };
 
-/// whether the given protocol is TLS (v1.3 or later)
+/// \returns true when the given protocol is TLS with v1.3 or a later version
+/// Negating the result of this function may be misleading. For example,
+/// !TlsVersion13OrLater(x) does not imply that x is TLS v1.2 or lower; x could
+/// also be unknown or even HTTP/2. If you do need negation, consider adding and
+/// using Tls1p2orEarlier() instead (which should also return true for SSL).
 inline bool
 TlsVersion13OrLater(const AnyP::ProtocolVersion &version)
 {

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -125,6 +125,14 @@ private:
     YesNoNone expectingModernRecords;
 };
 
+/// Whether the given version is TLSv1.3 or latter
+inline bool
+TlsVersion13OrLater(const AnyP::ProtocolVersion &version)
+{
+    return version.protocol == AnyP::PROTO_TLS &&
+           version >= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
+}
+
 }
 
 #endif // SQUID_SECURITY_HANDSHAKE_H

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -30,7 +30,7 @@ public:
 
     AnyP::ProtocolVersion tlsVersion; ///< The TLS hello message version
 
-    /// For compliant TLS v1.3+ agents, this is supported_versions maximum.
+    /// For most compliant TLS v1.3+ agents, this is supported_versions maximum.
     /// For others agents, this is the legacy_version field.
     AnyP::ProtocolVersion tlsSupportedVersion;
 
@@ -63,7 +63,8 @@ public:
     /// The parsing states
     typedef enum {atHelloNone = 0, atHelloStarted, atHelloReceived, atCertificatesReceived, atHelloDoneReceived, atNstReceived, atCcsReceived, atFinishReceived} ParserState;
 
-    typedef enum {fromClient = 0, fromServer} MessageSource;
+    /// the originator of the TLS handshake being parsed
+    typedef enum { fromClient = 0, fromServer } MessageSource;
 
     explicit HandshakeParser(MessageSource);
 
@@ -73,7 +74,7 @@ public:
     /// Throws on errors.
     bool parseHello(const SBuf &data);
 
-    TlsDetails::Pointer details; ///< TLS handshake meta info or nil.
+    TlsDetails::Pointer details; ///< TLS handshake meta info. Never nil.
 
     Security::CertList serverCertificates; ///< parsed certificates chain
 
@@ -83,6 +84,7 @@ public:
 
     ///< whether we are parsing Server or Client TLS handshake messages
     MessageSource messageSource;
+
 private:
     bool isSslv2Record(const SBuf &raw) const;
     void parseRecord();

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -131,11 +131,11 @@ private:
 
 /// \returns true when the given protocol is TLS with v1.3 or a later version
 /// Negating the result of this function may be misleading. For example,
-/// !TlsVersion13OrLater(x) does not imply that x is TLS v1.2 or lower; x could
-/// also be unknown or even HTTP/2. If you do need negation, consider adding and
+/// !Tls1p3orLater(x) does not imply that x is TLS v1.2 or lower; x could also
+/// be unknown or even HTTP/2. If you do need negation, consider adding and
 /// using Tls1p2orEarlier() instead (which should also return true for SSL).
 inline bool
-TlsVersion13OrLater(const AnyP::ProtocolVersion &version)
+Tls1p3orLater(const AnyP::ProtocolVersion &version)
 {
     return version.protocol == AnyP::PROTO_TLS &&
            version >= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -155,8 +155,7 @@ TlsVersionEarlierThan(const AnyP::ProtocolVersion &a, const AnyP::ProtocolVersio
 inline bool
 Tls1p2orEarlier(const AnyP::ProtocolVersion &p)
 {
-    static const AnyP::ProtocolVersion Tls1p3(AnyP::PROTO_TLS, 1, 3);
-    return TlsVersionEarlierThan(p, Tls1p3);
+    return TlsVersionEarlierThan(p, AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3));
 }
 
 /// whether the given TLS/SSL protocol is TLS v1.3 or later

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -58,7 +58,7 @@ enum HandshakeType {
     hskServerHello = 2,
     hskCertificate = 11,
     hskServerHelloDone = 14,
-    hskNone = 255
+    hskOther = 255
 };
 
 /// Incremental TLS/SSL Handshake parser.

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -153,6 +153,20 @@ Tls1p2orEarlier(const AnyP::ProtocolVersion &version)
             version <= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2));
 }
 
+/// \returns true when the TLS/SSL protocol va is earlier than vb
+/// Throws if the given protocols are not TLS or SSL.
+inline bool
+TlsVersionEarlierThan(const AnyP::ProtocolVersion &va, const AnyP::ProtocolVersion &vb)
+{
+    Must(va.protocol == AnyP::PROTO_SSL || va.protocol == AnyP::PROTO_TLS);
+    Must(vb.protocol == AnyP::PROTO_SSL || vb.protocol == AnyP::PROTO_TLS);
+
+    if (va.protocol == vb.protocol)
+        return va < vb;
+
+    return va.protocol == AnyP::PROTO_SSL;
+}
+
 }
 
 #endif // SQUID_SECURITY_HANDSHAKE_H

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -131,11 +131,10 @@ private:
     YesNoNone expectingModernRecords;
 };
 
-/// \returns true when the given protocol is TLS with v1.3 or a later version
+/// \returns true when the given protocol is TLS v1.3 or later
 /// Negating the result of this function may be misleading. For example,
 /// !Tls1p3orLater(x) does not imply that x is TLS v1.2 or lower; x could also
-/// be unknown or even HTTP/2. If you do need negation, consider using
-/// Tls1p2orEarlier() instead.
+/// be unknown or even HTTP/2. Use Tls1p2orEarlier() instead of negating.
 inline bool
 Tls1p3orLater(const AnyP::ProtocolVersion &version)
 {
@@ -143,8 +142,9 @@ Tls1p3orLater(const AnyP::ProtocolVersion &version)
            version >= AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
 }
 
-/// \returns true when the given protocol is SSL or TLS with v1.2 or a earlier version
-/// Negating the result of this function may be misleading.
+/// \returns true when the given protocol is TLS v1.2 or earlier, including SSL
+/// Negating the result of this function may be misleading. See Tls1p3orLater()
+/// for the discussion and a better alternative to negation.
 inline bool
 Tls1p2orEarlier(const AnyP::ProtocolVersion &version)
 {

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -52,15 +52,6 @@ std::ostream &operator <<(std::ostream &os, Security::TlsDetails const &details)
     return details.print(os);
 }
 
-/// TLS Handshake protocol's handshake types from RFC 8446 Section B.3
-enum HandshakeType {
-    hskClientHello = 1,
-    hskServerHello = 2,
-    hskCertificate = 11,
-    hskServerHelloDone = 14,
-    hskOther = 255
-};
-
 /// Incremental TLS/SSL Handshake parser.
 class HandshakeParser
 {
@@ -68,7 +59,9 @@ public:
     /// The parsing states
     typedef enum {atHelloNone = 0, atHelloStarted, atHelloReceived, atCertificatesReceived, atHelloDoneReceived, atNstReceived, atCcsReceived, atFinishReceived} ParserState;
 
-    HandshakeParser();
+    typedef enum {fromClient = 0, fromServer} MessageSource;
+
+    explicit HandshakeParser(MessageSource);
 
     /// Parses the initial sequence of raw bytes sent by the TLS/SSL agent.
     /// Returns true upon successful completion (e.g., got HelloDone).
@@ -84,7 +77,8 @@ public:
 
     bool resumingSession; ///< True if this is a resuming session
 
-    HandshakeType handshakeType; ///< hskClientHello or hskServerHello
+    ///< whether we are parsing Server or Client TLS handshake messages
+    MessageSource messageSource;
 private:
     bool isSslv2Record(const SBuf &raw) const;
     void parseRecord();

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -82,7 +82,7 @@ public:
 
     bool resumingSession; ///< True if this is a resuming session
 
-    ///< whether we are parsing Server or Client TLS handshake messages
+    /// whether we are parsing Server or Client TLS handshake messages
     MessageSource messageSource;
 
 private:
@@ -131,41 +131,38 @@ private:
     YesNoNone expectingModernRecords;
 };
 
-/// \returns true when the given version is a TLS/SSL protocol
+/// whether the given protocol belongs to the TLS/SSL group of protocols
 inline bool
-IsTlsProtocol(const AnyP::ProtocolVersion &version)
+TlsFamilyProtocol(const AnyP::ProtocolVersion &version)
 {
     return (version.protocol == AnyP::PROTO_TLS || version.protocol == AnyP::PROTO_SSL);
 }
 
-/// \returns true when the TLS/SSL protocol va is earlier than vb
-/// Throws if the given protocols are not TLS or SSL.
+/// whether TLS/SSL protocol `a` precedes TLS/SSL protocol `b`
 inline bool
-TlsVersionEarlierThan(const AnyP::ProtocolVersion &va, const AnyP::ProtocolVersion &vb)
+TlsVersionEarlierThan(const AnyP::ProtocolVersion &a, const AnyP::ProtocolVersion &b)
 {
-    Must(IsTlsProtocol(va));
-    Must(IsTlsProtocol(vb));
+    Must(TlsFamilyProtocol(a));
+    Must(TlsFamilyProtocol(b));
 
-    if (va.protocol == vb.protocol)
-        return va < vb;
+    if (a.protocol == b.protocol)
+        return a < b;
 
-    return va.protocol == AnyP::PROTO_SSL; // implies that vb is TLS
+    return a.protocol == AnyP::PROTO_SSL; // implies that b is TLS
 }
 
-/// \returns true when the given protocol is TLS v1.2 or earlier, including SSL
-/// Throws if the given protocol is not TLS or SSL.
+/// whether the given TLS/SSL protocol is TLS v1.2 or earlier, including SSL
 inline bool
-Tls1p2orEarlier(const AnyP::ProtocolVersion &version)
+Tls1p2orEarlier(const AnyP::ProtocolVersion &p)
 {
-    return TlsVersionEarlierThan(version, AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3));
+    return TlsVersionEarlierThan(p, AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3));
 }
 
-/// \returns true when the given protocol is TLS v1.3 or later
-/// Throws if the given protocol is not TLS or SSL.
+/// whether the given TLS/SSL protocol is TLS v1.3 or later
 inline bool
-Tls1p3orLater(const AnyP::ProtocolVersion &version)
+Tls1p3orLater(const AnyP::ProtocolVersion &p)
 {
-    return !Tls1p2orEarlier(version);
+    return !Tls1p2orEarlier(p);
 }
 
 }

--- a/src/security/NegotiationHistory.cc
+++ b/src/security/NegotiationHistory.cc
@@ -25,7 +25,7 @@ Security::NegotiationHistory::NegotiationHistory()
 const char *
 Security::NegotiationHistory::printTlsVersion(AnyP::ProtocolVersion const &v) const
 {
-    if (v.protocol != AnyP::PROTO_SSL && v.protocol != AnyP::PROTO_TLS)
+    if (!IsTlsProtocol(v))
         return nullptr;
 
     static char buf[512];

--- a/src/security/NegotiationHistory.cc
+++ b/src/security/NegotiationHistory.cc
@@ -25,7 +25,7 @@ Security::NegotiationHistory::NegotiationHistory()
 const char *
 Security::NegotiationHistory::printTlsVersion(AnyP::ProtocolVersion const &v) const
 {
-    if (!IsTlsProtocol(v))
+    if (!TlsFamilyProtocol(v))
         return nullptr;
 
     static char buf[512];

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -277,22 +277,22 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_
     Ssl::ServerBio *srvBio = static_cast<Ssl::ServerBio *>(BIO_get_data(b));
 
     if (srvBio->bumpMode() == Ssl::bumpPeek) {
-        bool bypassValidator = false;
-        // If the server selected TLSv1.3 protocol the server certificates
-        // are not available.
+        auto bypassValidator = false;
+        // If the server selected TLS v1.3 protocol, then we cannot peek at its
+        // (encrypted) certificates.
         if (srvBio->tlsv13OrLater()) {
-            // we currently splice all TLSv1.3 sessions unconditionally
-            // if (const bool spliceTLSv1_3 = true) {
+            // we currently splice all TLS v1.3 sessions unconditionally
+            // if (const auto spliceTLSv1_3 = true) {
             bypassValidator = true;
             // } // else fall through to find a matching ssl_bump action (with limited info)
         } else if (srvBio->resumingSession()) {
-            // In Peek mode, the ClientHello message sent to the server. If the
-            // server resuming a previous (spliced) SSL session with the client,
-            // then probably we are here because local SSL object does not know
-            // anything about the session being resumed.
+            // In peek mode, the ClientHello message is forwarded to the server.
+            // If the server is resuming a previous (spliced) SSL session with
+            // the client, then probably we are here because our local SSL
+            // object does not know anything about the session being resumed.
             //
             // we currently splice all resumed sessions unconditionally
-            // if (const bool spliceResumed = true) {
+            // if (const auto spliceResumed = true) {
             bypassValidator = true;
             // } // else fall through to find a matching ssl_bump action (with limited info)
         }

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -285,7 +285,7 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_
             // if (const bool spliceTLSv1_3 = true) {
             bypassValidator = true;
             // } // else fall through to find a matching ssl_bump action (with limited info)
-        } else if ((resumingSession = srvBio->resumingSession())) {
+        } else if (srvBio->resumingSession()) {
             // In Peek mode, the ClientHello message sent to the server. If the
             // server resuming a previous (spliced) SSL session with the client,
             // then probably we are here because local SSL object does not know

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -280,7 +280,7 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_
         bool bypassValidator = false;
         // If the server selected TLSv1.3 protocol the server certificates
         // are not available.
-        if (srvBio->tlsv1_3()) {
+        if (srvBio->tlsv13OrLater()) {
             // we currently splice all TLSv1.3 sessions unconditionally
             // if (const bool spliceTLSv1_3 = true) {
             bypassValidator = true;

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -278,11 +278,11 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_
 
     if (srvBio->bumpMode() == Ssl::bumpPeek) {
         auto bypassValidator = false;
-        // If the server selected TLS v1.3 protocol, then we cannot peek at its
-        // (encrypted) certificates.
-        if (srvBio->tls1p3orLater()) {
-            // we currently splice all TLS v1.3 sessions unconditionally
-            // if (const auto spliceTLSv1_3 = true) {
+        if (srvBio->encryptedCertificates()) {
+            // it is pointless to peek at encrypted certificates
+            //
+            // we currently splice all sessions with encrypted certificates
+            // if (const auto spliceEncryptedCertificates = true) {
             bypassValidator = true;
             // } // else fall through to find a matching ssl_bump action (with limited info)
         } else if (srvBio->resumingSession()) {
@@ -291,7 +291,7 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_
             // the client, then probably we are here because our local SSL
             // object does not know anything about the session being resumed.
             //
-            // we currently splice all resumed sessions unconditionally
+            // we currently splice all resumed sessions
             // if (const auto spliceResumed = true) {
             bypassValidator = true;
             // } // else fall through to find a matching ssl_bump action (with limited info)

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -280,7 +280,7 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_
         auto bypassValidator = false;
         // If the server selected TLS v1.3 protocol, then we cannot peek at its
         // (encrypted) certificates.
-        if (srvBio->tlsv13OrLater()) {
+        if (srvBio->tls1p3orLater()) {
             // we currently splice all TLS v1.3 sessions unconditionally
             // if (const auto spliceTLSv1_3 = true) {
             bypassValidator = true;

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -281,7 +281,7 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const int result, const int ssl_
         // If the server selected TLSv1.3 protocol the server certificates
         // are not available.
         if (srvBio->tlsv1_3()) {
-            // we currently splice all resumed sessions unconditionally
+            // we currently splice all TLSv1.3 sessions unconditionally
             // if (const bool spliceTLSv1_3 = true) {
             bypassValidator = true;
             // } // else fall through to find a matching ssl_bump action (with limited info)

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -30,7 +30,6 @@ public:
         Security::PeerConnector(aServerConn, aCallback, alp, timeout),
         clientConn(aClientConn),
         splice(false),
-        resumingSession(false),
         serverCertificateHandled(false)
     {
         request = aRequest;
@@ -75,7 +74,6 @@ private:
     Comm::ConnectionPointer clientConn; ///< TCP connection to the client
     AsyncCall::Pointer closeHandler; ///< we call this when the connection closed
     bool splice; ///< whether we are going to splice or not
-    bool resumingSession; ///< whether it is an SSL resuming session connection
     bool serverCertificateHandled; ///< whether handleServerCertificate() succeeded
 };
 

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -555,7 +555,7 @@ Ssl::ServerBio::resumingSession()
 }
 
 bool
-Ssl::ServerBio::tlsv1_3()
+Ssl::ServerBio::tlsv1_3() const
 {
     return parser_.details->tlsSupportedVersion == AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
 }

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -556,13 +556,10 @@ Ssl::ServerBio::resumingSession()
 }
 
 bool
-Ssl::ServerBio::tls1p3orLater() const
+Ssl::ServerBio::encryptedCertificates() const
 {
-    // Parsing may not be completed or aborted because of an error
-    if (!Security::IsTlsProtocol(parser_.details->tlsSupportedVersion))
-        return false;
-
-    return Security::Tls1p3orLater(parser_.details->tlsSupportedVersion);
+    return parser_.details->tlsSupportedVersion &&
+        Security::Tls1p3orLater(parser_.details->tlsSupportedVersion);
 }
 
 /// initializes BIO table after allocation

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -558,6 +558,10 @@ Ssl::ServerBio::resumingSession()
 bool
 Ssl::ServerBio::tls1p3orLater() const
 {
+    // Parsing may not be completed or aborted because of an error
+    if (!Security::IsTlsProtocol(parser_.details->tlsSupportedVersion))
+        return false;
+
     return Security::Tls1p3orLater(parser_.details->tlsSupportedVersion);
 }
 

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -730,7 +730,7 @@ applyTlsDetailsToSSL(SSL *ssl, Security::TlsDetails::Pointer const &details, Ssl
 
 #if defined(SSL_OP_NO_TLSv1_3)
     // avoid "inappropriate fallback" OpenSSL error messages
-    if (Security::Tls1p2orEarlier(details->tlsSupportedVersion))
+    if (details->tlsSupportedVersion && Security::Tls1p2orEarlier(details->tlsSupportedVersion))
         SSL_set_options(ssl, SSL_OP_NO_TLSv1_3);
 #endif
 

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -725,6 +725,7 @@ applyTlsDetailsToSSL(SSL *ssl, Security::TlsDetails::Pointer const &details, Ssl
 #endif
 
 #if defined(SSL_OP_NO_TLSv1_3)
+    // TODO: Explain why we should disable v1.3 support for, say, TLS v1.4.
     if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3))
         SSL_set_options(ssl, SSL_OP_NO_TLSv1_3);
 #endif

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -554,6 +554,12 @@ Ssl::ServerBio::resumingSession()
     return parser_.resumingSession;
 }
 
+bool
+Ssl::ServerBio::tlsv1_3()
+{
+    return parser_.details->tlsSupportedVersion == AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
+}
+
 /// initializes BIO table after allocation
 static int
 squid_bio_create(BIO *bi)

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -716,6 +716,8 @@ applyTlsDetailsToSSL(SSL *ssl, Security::TlsDetails::Pointer const &details, Ssl
     if (!details->compressionSupported)
         SSL_set_options(ssl, SSL_OP_NO_COMPRESSION);
 #endif
+    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3))
+        SSL_set_options(ssl, SSL_OP_NO_TLSv1_3);
 
 #if defined(TLSEXT_STATUSTYPE_ocsp)
     if (details->tlsStatusRequest)

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -722,8 +722,11 @@ applyTlsDetailsToSSL(SSL *ssl, Security::TlsDetails::Pointer const &details, Ssl
     if (!details->compressionSupported)
         SSL_set_options(ssl, SSL_OP_NO_COMPRESSION);
 #endif
+
+#if defined(SSL_OP_NO_TLSv1_3)
     if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3))
         SSL_set_options(ssl, SSL_OP_NO_TLSv1_3);
+#endif
 
 #if defined(TLSEXT_STATUSTYPE_ocsp)
     if (details->tlsStatusRequest)

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -556,9 +556,9 @@ Ssl::ServerBio::resumingSession()
 }
 
 bool
-Ssl::ServerBio::tlsv13OrLater() const
+Ssl::ServerBio::tls1p3orLater() const
 {
-    return Security::TlsVersion13OrLater(parser_.details->tlsSupportedVersion);
+    return Security::Tls1p3orLater(parser_.details->tlsSupportedVersion);
 }
 
 /// initializes BIO table after allocation

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -556,9 +556,9 @@ Ssl::ServerBio::resumingSession()
 }
 
 bool
-Ssl::ServerBio::tlsv1_3() const
+Ssl::ServerBio::tlsv13OrLater() const
 {
-    return parser_.details->tlsSupportedVersion == AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
+    return Security::TlsVersion13OrLater(parser_.details->tlsSupportedVersion);
 }
 
 /// initializes BIO table after allocation

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -725,8 +725,8 @@ applyTlsDetailsToSSL(SSL *ssl, Security::TlsDetails::Pointer const &details, Ssl
 #endif
 
 #if defined(SSL_OP_NO_TLSv1_3)
-    // TODO: Explain why we should disable v1.3 support for, say, TLS v1.4.
-    if (details->tlsSupportedVersion != AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3))
+    // avoid "inappropriate fallback" OpenSSL error messages
+    if (Security::Tls1p2orEarlier(details->tlsSupportedVersion))
         SSL_set_options(ssl, SSL_OP_NO_TLSv1_3);
 #endif
 

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -250,7 +250,8 @@ Ssl::ServerBio::ServerBio(const int anFd):
     parsedHandshake(false),
     parseError(false),
     bumpMode_(bumpNone),
-    rbufConsumePos(0)
+    rbufConsumePos(0),
+    parser_(Security::HandshakeParser::fromServer)
 {
 }
 

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -143,7 +143,7 @@ public:
 
     bool resumingSession();
 
-    bool tlsv13OrLater() const; ///< true if server choose the TLSv1.3 protocol
+    bool tlsv13OrLater() const; ///< whether the server chose TLS v1.3
 
     /// The write hold state
     bool holdWrite() const {return holdWrite_;}

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -143,9 +143,9 @@ public:
 
     bool resumingSession();
 
-    /// \returns true when the server chose TLS with v1.3 or a later version
-    /// avoid negating the result; \see Security::Tls1p3orLater()
-    bool tls1p3orLater() const;
+    /// whether the server encrypts its certificate (e.g., TLS v1.3)
+    /// \retval false the server uses plain certs or its intent is unknown
+    bool encryptedCertificates() const;
 
     /// The write hold state
     bool holdWrite() const {return holdWrite_;}

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -143,7 +143,7 @@ public:
 
     bool resumingSession();
 
-    bool tlsv1_3(); ///< true if server choose the TLSv1.3 protocol
+    bool tlsv1_3() const; ///< true if server choose the TLSv1.3 protocol
 
     /// The write hold state
     bool holdWrite() const {return holdWrite_;}

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -143,7 +143,7 @@ public:
 
     bool resumingSession();
 
-    bool tlsv1_3() const; ///< true if server choose the TLSv1.3 protocol
+    bool tlsv13OrLater() const; ///< true if server choose the TLSv1.3 protocol
 
     /// The write hold state
     bool holdWrite() const {return holdWrite_;}

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -143,6 +143,8 @@ public:
 
     bool resumingSession();
 
+    bool tlsv1_3(); ///< true if server choose the TLSv1.3 protocol
+
     /// The write hold state
     bool holdWrite() const {return holdWrite_;}
     /// Enables or disables the write hold state

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -143,7 +143,9 @@ public:
 
     bool resumingSession();
 
-    bool tlsv13OrLater() const; ///< whether the server chose TLS v1.3
+    /// \returns true when the server chose TLS with v1.3 or a later version
+    /// avoid negating the result; \see Security::Tls1p3orLater()
+    bool tls1p3orLater() const;
 
     /// The write hold state
     bool holdWrite() const {return holdWrite_;}

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -28,7 +28,7 @@ Security::EncryptorAnswer::~EncryptorAnswer() {}
 std::ostream &Security::operator <<(std::ostream &os, const Security::EncryptorAnswer &) STUB_RETVAL(os)
 
 #include "security/Handshake.h"
-Security::HandshakeParser::HandshakeParser() STUB
+Security::HandshakeParser::HandshakeParser(MessageSource) STUB
 bool Security::HandshakeParser::parseHello(const SBuf &) STUB_RETVAL(false)
 
 #include "security/KeyData.h"


### PR DESCRIPTION
This change fixes stalled peeked-at during step2 connections from IE11
and FireFox v56 running on Windows 10 (at least), producing "Handshake
with SSL server failed" cache.log errors with this OpenSSL detail:

`SSL routines:ssl_choose_client_version:inappropriate fallback`

Disabling TLS v1.3 support for older TLS connections is required
because, in the affected environments, OpenSSL detects and, for some
unknown reason, blocks a "downgrade" when a server claims support for
TLS v1.3 but then accepts a TLS v1.2 connection from an older client.

This is a Measurement Factory project