### PR TITLE
Remove dlink from HttpHdrSc

### DIFF
--- a/src/HttpHdrSc.cc
+++ b/src/HttpHdrSc.cc
@@ -189,32 +189,7 @@ HttpHdrSc::parse(const String * str)
         }
     }
 
-    return sc->targets.head != NULL;
-}
-
-HttpHdrSc::~HttpHdrSc()
-{
-    if (targets.head) {
-        dlink_node *sct = targets.head;
-
-        while (sct) {
-            HttpHdrScTarget *t = static_cast<HttpHdrScTarget *>(sct->data);
-            sct = sct->next;
-            dlinkDelete (&t->node, &targets);
-            delete t;
-        }
-    }
-}
-
-HttpHdrSc::HttpHdrSc(const HttpHdrSc &sc)
-{
-    dlink_node *node = sc.targets.head;
-
-    while (node) {
-        HttpHdrScTarget *dupsct = new HttpHdrScTarget(*static_cast<HttpHdrScTarget *>(node->data));
-        addTargetAtTail(dupsct);
-        node = node->next;
-    }
+    return !sc->targets.empty();
 }
 
 void
@@ -249,13 +224,9 @@ HttpHdrScTarget::packInto(Packable * p) const
 void
 HttpHdrSc::packInto(Packable * p) const
 {
-    dlink_node *node;
     assert(p);
-    node = targets.head;
-
-    while (node) {
-        static_cast<HttpHdrScTarget *>(node->data)->packInto(p);
-        node = node->next;
+    for (const auto &t : targets) {
+        t.packInto(p);
     }
 }
 
@@ -266,8 +237,8 @@ HttpHdrSc::setMaxAge(char const *target, int max_age)
     HttpHdrScTarget *sct = findTarget(target);
 
     if (!sct) {
-        sct = new HttpHdrScTarget(target);
-        dlinkAddTail (sct, &sct->node, &targets);
+        targets.emplace_back(target);
+        sct = &targets.back();
     }
 
     sct->maxAge(max_age);
@@ -276,11 +247,8 @@ HttpHdrSc::setMaxAge(char const *target, int max_age)
 void
 HttpHdrSc::updateStats(StatHist * hist) const
 {
-    dlink_node *sct = targets.head;
-
-    while (sct) {
-        static_cast<HttpHdrScTarget *>(sct->data)->updateStats(hist);
-        sct = sct->next;
+    for (auto &t : targets) {
+        t.updateStats(hist);
     }
 }
 
@@ -313,18 +281,9 @@ httpHdrScStatDumper(StoreEntry * sentry, int, double val, double, int count)
 HttpHdrScTarget *
 HttpHdrSc::findTarget(const char *target)
 {
-    dlink_node *node;
-    node = targets.head;
-
-    while (node) {
-        HttpHdrScTarget *sct = (HttpHdrScTarget *)node->data;
-
-        if (target && sct->target.size() > 0 && !strcmp(target, sct->target.termedBuf()))
-            return sct;
-        else if (!target && sct->target.size() == 0)
-            return sct;
-
-        node = node->next;
+    for (auto &sct : targets) {
+        if (sct.target.cmp(target) == 0)
+            return &sct;
     }
 
     return NULL;
@@ -352,12 +311,14 @@ HttpHdrSc::getMergedTarget(const char *ourtarget)
 }
 
 void
-HttpHdrSc::addTarget(HttpHdrScTarget *t) {
-    dlinkAdd(t, &t->node, &targets);
+HttpHdrSc::addTarget(HttpHdrScTarget *t)
+{
+    targets.emplace_front(std::move(*t));
 }
 
 void
-HttpHdrSc::addTargetAtTail(HttpHdrScTarget *t) {
-    dlinkAddTail (t, &t->node, &targets);
+HttpHdrSc::addTargetAtTail(HttpHdrScTarget *t)
+{
+    targets.emplace_back(std::move(*t));
 }
 

--- a/src/HttpHdrSc.cc
+++ b/src/HttpHdrSc.cc
@@ -124,8 +124,8 @@ HttpHdrSc::parse(const String * str)
         sct = sc->findTarget(target);
 
         if (!sct) {
-            sct = new HttpHdrScTarget(target);
-            addTarget(sct);
+            targets.emplace_front(target);
+            sct = &targets.front();
         }
 
         safe_free (temp);
@@ -309,16 +309,3 @@ HttpHdrSc::getMergedTarget(const char *ourtarget)
 
     return NULL;
 }
-
-void
-HttpHdrSc::addTarget(HttpHdrScTarget *t)
-{
-    targets.emplace_front(std::move(*t));
-}
-
-void
-HttpHdrSc::addTargetAtTail(HttpHdrScTarget *t)
-{
-    targets.emplace_back(std::move(*t));
-}
-

--- a/src/HttpHdrSc.h
+++ b/src/HttpHdrSc.h
@@ -11,7 +11,6 @@
 
 #include "http/forward.h"
 #include "HttpHdrScTarget.h"
-#include "mem/PoolingAllocator.h"
 #include "SquidString.h"
 
 #include <list>

--- a/src/HttpHdrSc.h
+++ b/src/HttpHdrSc.h
@@ -31,8 +31,6 @@ public:
     void updateStats(StatHist *) const;
     HttpHdrScTarget * getMergedTarget(const char *ourtarget); // TODO: make const?
     void setMaxAge(char const *target, int max_age);
-    void addTarget(HttpHdrScTarget *t);
-    void addTargetAtTail(HttpHdrScTarget *t);
 
 private:
     HttpHdrScTarget * findTarget (const char *target);

--- a/src/HttpHdrSc.h
+++ b/src/HttpHdrSc.h
@@ -11,7 +11,7 @@
 
 #include "http/forward.h"
 #include "HttpHdrScTarget.h"
-#include "mem/forward.h"
+#include "mem/PoolingAllocator.h"
 #include "SquidString.h"
 
 #include <list>
@@ -35,7 +35,7 @@ public:
 private:
     HttpHdrScTarget * findTarget (const char *target);
 
-    std::list<HttpHdrScTarget> targets;
+    std::list<HttpHdrScTarget, PoolingAllocator<HttpHdrScTarget>> targets;
 };
 
 /* Http Surrogate Control Header Field */

--- a/src/HttpHdrSc.h
+++ b/src/HttpHdrSc.h
@@ -9,23 +9,16 @@
 #ifndef SQUID_HTTPHDRSURROGATECONTROL_H
 #define SQUID_HTTPHDRSURROGATECONTROL_H
 
-#include "dlink.h"
+#include "http/forward.h"
+#include "HttpHdrScTarget.h"
 #include "mem/forward.h"
 #include "SquidString.h"
 
-class HttpHdrScTarget;
+#include <list>
+
 class Packable;
 class StatHist;
 class StoreEntry;
-
-typedef enum {
-    SC_NO_STORE,
-    SC_NO_STORE_REMOTE,
-    SC_MAX_AGE,
-    SC_CONTENT,
-    SC_OTHER,
-    SC_ENUM_END /* also used to mean "invalid" */
-} http_hdr_sc_type;
 
 /* http surogate control header field */
 class HttpHdrSc
@@ -33,10 +26,6 @@ class HttpHdrSc
     MEMPROXY_CLASS(HttpHdrSc);
 
 public:
-    HttpHdrSc(const HttpHdrSc &);
-    HttpHdrSc() {}
-    ~HttpHdrSc();
-
     bool parse(const String *str);
     void packInto(Packable * p) const;
     void updateStats(StatHist *) const;
@@ -45,10 +34,10 @@ public:
     void addTarget(HttpHdrScTarget *t);
     void addTargetAtTail(HttpHdrScTarget *t);
 
-    dlink_list targets;
 private:
     HttpHdrScTarget * findTarget (const char *target);
 
+    std::list<HttpHdrScTarget> targets;
 };
 
 /* Http Surrogate Control Header Field */

--- a/src/HttpHdrScTarget.h
+++ b/src/HttpHdrScTarget.h
@@ -10,8 +10,10 @@
 #define SQUID_HTTPHDRSURROGATECONTROLTARGET_H
 
 #include "defines.h" //for bit mask operations
-#include "HttpHdrSc.h"
+#include "http/forward.h"
+#include "SquidString.h"
 
+class HttpHdrSc;
 class Packable;
 class StatHist;
 class StoreEntry;
@@ -30,11 +32,11 @@ public:
     static const int MAX_AGE_UNSET=-1; //max-age is unset
     static const int MAX_STALE_UNSET=0; //max-stale is unset
 
-    HttpHdrScTarget(const char *target_):
+    explicit HttpHdrScTarget(const char *target_) :
         mask(0), max_age(MAX_AGE_UNSET), max_stale(MAX_STALE_UNSET),target(target_) {}
-    HttpHdrScTarget(const String &target_):
+    explicit HttpHdrScTarget(const String &target_) :
         mask(0), max_age(MAX_AGE_UNSET), max_stale(MAX_STALE_UNSET),target(target_) {}
-    HttpHdrScTarget(const HttpHdrScTarget &t):
+    explicit HttpHdrScTarget(const HttpHdrScTarget &t) :
         mask(t.mask), max_age(t.max_age), max_stale(t.max_stale),
         content_(t.content_), target(t.target) {}
 
@@ -98,7 +100,6 @@ private:
     int max_stale;
     String content_;
     String target;
-    dlink_node node;
 };
 
 void httpHdrScTargetStatDumper(StoreEntry * sentry, int idx, double val, double size, int count);

--- a/src/HttpHdrScTarget.h
+++ b/src/HttpHdrScTarget.h
@@ -13,7 +13,6 @@
 #include "http/forward.h"
 #include "SquidString.h"
 
-class HttpHdrSc;
 class Packable;
 class StatHist;
 class StoreEntry;

--- a/src/HttpHdrScTarget.h
+++ b/src/HttpHdrScTarget.h
@@ -32,13 +32,8 @@ public:
     static const int MAX_AGE_UNSET=-1; //max-age is unset
     static const int MAX_STALE_UNSET=0; //max-stale is unset
 
-    explicit HttpHdrScTarget(const char *target_) :
-        mask(0), max_age(MAX_AGE_UNSET), max_stale(MAX_STALE_UNSET),target(target_) {}
-    explicit HttpHdrScTarget(const String &target_) :
-        mask(0), max_age(MAX_AGE_UNSET), max_stale(MAX_STALE_UNSET),target(target_) {}
-    explicit HttpHdrScTarget(const HttpHdrScTarget &t) :
-        mask(t.mask), max_age(t.max_age), max_stale(t.max_stale),
-        content_(t.content_), target(t.target) {}
+    explicit HttpHdrScTarget(const char *target_) : target(target_) {}
+    explicit HttpHdrScTarget(const String &target_) : target(target_) {}
 
     bool hasNoStore() const {return isSet(SC_NO_STORE); }
     void noStore(bool v) { setMask(SC_NO_STORE,v); }
@@ -95,9 +90,9 @@ private:
         else EBIT_CLR(mask,id);
     }
 
-    int mask;
-    int max_age;
-    int max_stale;
+    int mask = 0;
+    int max_age = MAX_AGE_UNSET;
+    int max_stale = MAX_STALE_UNSET;
     String content_;
     String target;
 };

--- a/src/HttpHdrScTarget.h
+++ b/src/HttpHdrScTarget.h
@@ -29,8 +29,8 @@ public:
     static const int MAX_AGE_UNSET=-1; //max-age is unset
     static const int MAX_STALE_UNSET=0; //max-stale is unset
 
-    explicit HttpHdrScTarget(const char *target_) : target(target_) {}
-    explicit HttpHdrScTarget(const String &target_) : target(target_) {}
+    explicit HttpHdrScTarget(const char *aTarget): target(aTarget) {}
+    explicit HttpHdrScTarget(const String &aTarget): target(aTarget) {}
     explicit HttpHdrScTarget(const HttpHdrScTarget &) = delete; // avoid accidental string copies
     HttpHdrScTarget &operator =(const HttpHdrScTarget &) = delete; // avoid accidental string copies
 

--- a/src/HttpHdrScTarget.h
+++ b/src/HttpHdrScTarget.h
@@ -23,8 +23,6 @@ class StoreEntry;
  */
 class HttpHdrScTarget
 {
-    MEMPROXY_CLASS(HttpHdrScTarget);
-
     // parsing is done in HttpHdrSc, need to grant them access.
     friend class HttpHdrSc;
 public:
@@ -33,6 +31,8 @@ public:
 
     explicit HttpHdrScTarget(const char *target_) : target(target_) {}
     explicit HttpHdrScTarget(const String &target_) : target(target_) {}
+    explicit HttpHdrScTarget(const HttpHdrScTarget &) = delete; // avoid accidental string copies
+    HttpHdrScTarget &operator =(const HttpHdrScTarget &) = delete; // avoid accidental string copies
 
     bool hasNoStore() const {return isSet(SC_NO_STORE); }
     void noStore(bool v) { setMask(SC_NO_STORE,v); }

--- a/src/http/forward.h
+++ b/src/http/forward.h
@@ -35,6 +35,8 @@ typedef enum {
     SC_ENUM_END /* also used to mean "invalid" */
 } http_hdr_sc_type;
 
+class HttpHdrSc;
+
 class HttpRequestMethod;
 typedef RefCount<HttpRequestMethod> HttpRequestMethodPointer;
 

--- a/src/http/forward.h
+++ b/src/http/forward.h
@@ -24,7 +24,17 @@ typedef RefCount<Http::Stream> StreamPointer;
 
 } // namespace Http
 
-// TODO move these classes into Http namespace
+// TODO move these into Http namespace
+
+typedef enum {
+    SC_NO_STORE,
+    SC_NO_STORE_REMOTE,
+    SC_MAX_AGE,
+    SC_CONTENT,
+    SC_OTHER,
+    SC_ENUM_END /* also used to mean "invalid" */
+} http_hdr_sc_type;
+
 class HttpRequestMethod;
 typedef RefCount<HttpRequestMethod> HttpRequestMethodPointer;
 


### PR DESCRIPTION
Resolves Coverity issue 1461128 Resource leak. Which is a false positive
due to analysis inability to track dlink pointers.