### PR TITLE
Cleanup: Remove legacy dlink_list from proxy_match_cache

### DIFF
--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -333,7 +333,8 @@ ACL::matchForCache(ACLChecklist *)
  * RBC
  * TODO: does a dlink_list perform well enough? Kinkie
  */
-int ACL::cacheMatchAcl(std::list<acl_proxy_auth_match_cache> &cache, ACLChecklist *checklist)
+int
+ACL::cacheMatchAcl(std::list<acl_proxy_auth_match_cache> &cache, ACLChecklist *checklist)
 {
     for (const auto &auth_match : cache) {
         if (auth_match.acl_data == this) {

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -334,17 +334,17 @@ ACL::matchForCache(ACLChecklist *)
  * TODO: does a dlink_list perform well enough? Kinkie
  */
 int
-ACL::cacheMatchAcl(std::list<acl_proxy_auth_match_cache> &cache, ACLChecklist *checklist)
+ACL::cacheMatchAcl(proxy_auth_match_cache &cache, ACLChecklist *checklist)
 {
     for (const auto &auth_match : cache) {
         if (auth_match.acl_data == this) {
-            debugs(28, 4, "ACL::cacheMatchAcl: cache hit on acl '" << name << "' (" << this << ")");
+            debugs(28, 4, "cache hit on acl '" << name << "' (" << this << ")");
             return auth_match.matchrv;
         }
     }
-    auto auth_match = acl_proxy_auth_match_cache(matchForCache(checklist), this);
+    auto auth_match = acl_proxy_auth_match_cache_entry(matchForCache(checklist), this);
     cache.emplace_back(auth_match);
-    debugs(28, 4, "ACL::cacheMatchAcl: miss for '" << name << "'. Adding result " << auth_match.matchrv);
+    debugs(28, 4, "miss for '" << name << "'. Adding result " << auth_match.matchrv);
     return auth_match.matchrv;
 }
 

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -331,10 +331,9 @@ ACL::matchForCache(ACLChecklist *)
  * Note that caching of time based acl's is not
  * wise in long lived caches (i.e. the auth_user proxy match cache)
  * RBC
- * TODO: does a dlink_list perform well enough? Kinkie
  */
 int
-ACL::cacheMatchAcl(proxy_auth_match_cache &cache, ACLChecklist *checklist)
+ACL::cacheMatchAcl(Acl::ProxyAuthMatchCache &cache, ACLChecklist *checklist)
 {
     for (const auto &auth_match : cache) {
         if (auth_match.acl_data == this) {
@@ -342,7 +341,7 @@ ACL::cacheMatchAcl(proxy_auth_match_cache &cache, ACLChecklist *checklist)
             return auth_match.matchrv;
         }
     }
-    auto auth_match = acl_proxy_auth_match_cache_entry(matchForCache(checklist), this);
+    auto auth_match = Acl::ProxyAuthMatchCacheEntry(matchForCache(checklist), this);
     cache.emplace_back(auth_match);
     debugs(28, 4, "miss for '" << name << "'. Adding result " << auth_match.matchrv);
     return auth_match.matchrv;

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -32,7 +32,7 @@ void RegisterMaker(TypeName typeName, Maker maker);
 
 } // namespace Acl
 
-class acl_proxy_auth_match_cache;
+class acl_proxy_auth_match_cache_entry;
 
 /// A configurable condition. A node in the ACL expression tree.
 /// Can evaluate itself in FilledChecklist context.
@@ -75,7 +75,8 @@ public:
     virtual bool empty() const = 0;
     virtual bool valid() const;
 
-    int cacheMatchAcl(std::list<acl_proxy_auth_match_cache> &cache, ACLChecklist *);
+    using proxy_auth_match_cache = std::list<acl_proxy_auth_match_cache_entry>;
+    int cacheMatchAcl(proxy_auth_match_cache &cache, ACLChecklist *);
     virtual int matchForCache(ACLChecklist *checklist);
 
     virtual void prepareForUse() {}
@@ -185,10 +186,10 @@ operator <<(std::ostream &o, const Acl::Answer a)
 }
 
 /// \ingroup ACLAPI
-class acl_proxy_auth_match_cache
+class acl_proxy_auth_match_cache_entry
 {
 public:
-    acl_proxy_auth_match_cache(int matchRv, void * aclData) :
+    acl_proxy_auth_match_cache_entry(int matchRv, void * aclData) :
         matchrv(matchRv),
         acl_data(aclData)
     {}

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -32,6 +32,8 @@ void RegisterMaker(TypeName typeName, Maker maker);
 
 } // namespace Acl
 
+class acl_proxy_auth_match_cache;
+
 /// A configurable condition. A node in the ACL expression tree.
 /// Can evaluate itself in FilledChecklist context.
 /// Does not change during evaluation.
@@ -73,7 +75,7 @@ public:
     virtual bool empty() const = 0;
     virtual bool valid() const;
 
-    int cacheMatchAcl(dlink_list * cache, ACLChecklist *);
+    int cacheMatchAcl(std::list<acl_proxy_auth_match_cache> &cache, ACLChecklist *);
     virtual int matchForCache(ACLChecklist *checklist);
 
     virtual void prepareForUse() {}
@@ -185,15 +187,12 @@ operator <<(std::ostream &o, const Acl::Answer a)
 /// \ingroup ACLAPI
 class acl_proxy_auth_match_cache
 {
-    MEMPROXY_CLASS(acl_proxy_auth_match_cache);
-
 public:
     acl_proxy_auth_match_cache(int matchRv, void * aclData) :
         matchrv(matchRv),
         acl_data(aclData)
     {}
 
-    dlink_node link;
     int matchrv;
     void *acl_data;
 };

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -44,6 +44,7 @@ public:
     void *acl_data;
 };
 
+/// LRU cache used for User ACL match
 using ProxyAuthMatchCache =
     std::list < ProxyAuthMatchCacheEntry, PoolingAllocator<ProxyAuthMatchCacheEntry> >;
 

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -56,8 +56,6 @@ void aclDestroyDenyInfoList(AclDenyInfoList **);
 /// \ingroup ACLAPI
 wordlist *aclDumpGeneric(const ACL *);
 /// \ingroup ACLAPI
-void aclCacheMatchFlush(dlink_list * cache);
-/// \ingroup ACLAPI
 void dump_acl_access(StoreEntry * entry, const char *name, acl_access * head);
 /// \ingroup ACLAPI
 void dump_acl_list(StoreEntry * entry, ACLList * head);

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -183,7 +183,7 @@ ACLProxyAuth::matchProxyAuth(ACLChecklist *cl)
         }
     }
     /* check to see if we have matched the user-acl before */
-    int result = cacheMatchAcl(&checklist->auth_user_request->user()->proxy_match_cache, checklist);
+    int result = cacheMatchAcl(checklist->auth_user_request->user()->proxy_match_cache, checklist);
     checklist->auth_user_request = NULL;
     return result;
 }

--- a/src/auth/CredentialsCache.cc
+++ b/src/auth/CredentialsCache.cc
@@ -141,6 +141,9 @@ CredentialsCache::doConfigChangeCleanup()
 {
     // purge expired entries entirely
     cleanup();
+    for (auto i : store_) {
+        i.second->proxy_match_cache.clear();
+    }
 }
 
 } /* namespace Auth */

--- a/src/auth/CredentialsCache.cc
+++ b/src/auth/CredentialsCache.cc
@@ -141,10 +141,6 @@ CredentialsCache::doConfigChangeCleanup()
 {
     // purge expired entries entirely
     cleanup();
-    // purge the ACL match data stored in the credentials
-    for (auto i : store_) {
-        aclCacheMatchFlush(&i.second->proxy_match_cache);
-    }
 }
 
 } /* namespace Auth */

--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -30,7 +30,6 @@ Auth::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm) :
     username_(nullptr),
     requestRealm_(aRequestRealm)
 {
-    proxy_match_cache.head = proxy_match_cache.tail = NULL;
     ip_list.head = ip_list.tail = NULL;
     debugs(29, 5, HERE << "Initialised auth_user '" << this << "'.");
 }
@@ -122,9 +121,6 @@ Auth::User::~User()
 {
     debugs(29, 5, HERE << "Freeing auth_user '" << this << "'.");
     assert(LockCount() == 0);
-
-    /* free cached acl results */
-    aclCacheMatchFlush(&proxy_match_cache);
 
     /* free seen ip address's */
     clearIp();

--- a/src/auth/User.h
+++ b/src/auth/User.h
@@ -52,7 +52,7 @@ public:
     /** the config for this user */
     Auth::SchemeConfig *config;
     // XXX would be better served by unordered_map<void*, int> ?
-    std::list<acl_proxy_auth_match_cache> proxy_match_cache;
+    ACL::proxy_auth_match_cache proxy_match_cache;
     size_t ipcount;
     long expiretime;
 

--- a/src/auth/User.h
+++ b/src/auth/User.h
@@ -51,8 +51,8 @@ public:
     Auth::Type auth_type;
     /** the config for this user */
     Auth::SchemeConfig *config;
-    // XXX would be better served by unordered_map<void*, int> ?
-    ACL::proxy_auth_match_cache proxy_match_cache;
+    /// cache mapping ACLs to their results
+    Acl::ProxyAuthMatchCache proxy_match_cache;
     size_t ipcount;
     long expiretime;
 

--- a/src/auth/User.h
+++ b/src/auth/User.h
@@ -11,6 +11,7 @@
 
 #if USE_AUTH
 
+#include "acl/Acl.h"
 #include "auth/CredentialState.h"
 #include "auth/forward.h"
 #include "auth/Type.h"
@@ -20,6 +21,8 @@
 #include "ip/Address.h"
 #include "Notes.h"
 #include "sbuf/SBuf.h"
+
+#include <list>
 
 class StoreEntry;
 
@@ -48,7 +51,8 @@ public:
     Auth::Type auth_type;
     /** the config for this user */
     Auth::SchemeConfig *config;
-    dlink_list proxy_match_cache;
+    // XXX would be better served by unordered_map<void*, int> ?
+    std::list<acl_proxy_auth_match_cache> proxy_match_cache;
     size_t ipcount;
     long expiretime;
 


### PR DESCRIPTION
Auth::User uses a dlink_list for proxy_match_cache
replace it with a std::list<acl_proxy_auth_match_cache>
to make the code cleaner and more readable.

Removing this dlink container should resolve Coverity
issue #1461172.