### PR TITLE
Reduce Pointer refcounting in forwarding

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1353,7 +1353,7 @@ aclFindNfMarkConfig(acl_nfmark * head, ACLChecklist * ch)
 }
 
 void
-getOutgoingAddress(HttpRequest * request, Comm::ConnectionPointer conn)
+getOutgoingAddress(HttpRequest * request, const Comm::ConnectionPointer &conn)
 {
     // skip if an outgoing address is already set.
     if (!conn->local.isAnyAddr()) return;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -197,7 +197,7 @@ private:
     PconnRace pconnRace; ///< current pconn race state
 };
 
-void getOutgoingAddress(HttpRequest * request, Comm::ConnectionPointer conn);
+void getOutgoingAddress(HttpRequest * request, const Comm::ConnectionPointer &conn);
 
 /// a collection of previously used persistent Squid-to-peer HTTP(S) connections
 extern PconnPool *fwdPconnPool;


### PR DESCRIPTION
Remove temporary Pointer copy which confused Coverity scan
into thinking there is a double-free. Should resolve Issue #1461170
and maybe others.