### PR TITLE
Turn hash_table into proper c++ class

### DIFF
--- a/include/hash.h
+++ b/include/hash.h
@@ -9,61 +9,55 @@
 #ifndef SQUID_HASH_H
 #define SQUID_HASH_H
 
+/*
+ * for hash_table size, it is recommended to use
+ * hash_table::hashPrime(desired_size) for optimal performance
+ */
+#define DEFAULT_HASH_SIZE 7951 /* prime number < 8192 */
+
 typedef void HASHFREE(void *);
 typedef int HASHCMP(const void *, const void *);
 typedef unsigned int HASHHASH(const void *, unsigned int);
 
 class hash_link {
 public:
-    hash_link() : key(nullptr), next(nullptr) {}
-    void *key;
-    hash_link *next;
+    hash_link() {}
+    const char *hashKeyStr() const {
+        return static_cast<const char *>(key);
+    };
+    void *key = nullptr;
+    hash_link *next = nullptr;
 };
 
 class hash_table {
 public:
-    hash_link **buckets;
-    HASHCMP *cmp;
-    HASHHASH *hash;
+    hash_table(HASHCMP *cmp_func, HASHHASH *hash_func,
+               int hash_sz = DEFAULT_HASH_SIZE);
+    ~hash_table();
+    void hash_join(hash_link *);
+    void hash_remove_link(hash_link *);
+    static uint32_t hashPrime(uint32_t n);
+    hash_link *hash_lookup(const void *);
+    hash_link *hash_next();
+    void hash_last();
+    void hash_first();
+    hash_link *hash_get_bucket(unsigned int);
+    void hashFreeItems(HASHFREE *);
+    int hash_count() const { return count; }
+
+private:
+    int count = 0;
+    hash_link *next = nullptr;
     unsigned int size;
-    unsigned int current_slot;
-    hash_link *next;
-    int count;
+    hash_link **buckets = nullptr;
+    unsigned int current_slot = 0;
+    HASHHASH *hash;
+    HASHCMP *cmp;
+    void hash_next_bucket();
 };
 
-SQUIDCEXTERN hash_table *hash_create(HASHCMP *, int, HASHHASH *);
-SQUIDCEXTERN void hash_join(hash_table *, hash_link *);
-SQUIDCEXTERN void hash_remove_link(hash_table *, hash_link *);
-SQUIDCEXTERN int hashPrime(int n);
-SQUIDCEXTERN hash_link *hash_lookup(hash_table *, const void *);
-SQUIDCEXTERN void hash_first(hash_table *);
-SQUIDCEXTERN hash_link *hash_next(hash_table *);
-SQUIDCEXTERN void hash_last(hash_table *);
-SQUIDCEXTERN hash_link *hash_get_bucket(hash_table *, unsigned int);
-SQUIDCEXTERN void hashFreeMemory(hash_table *);
-SQUIDCEXTERN void hashFreeItems(hash_table *, HASHFREE *);
 SQUIDCEXTERN HASHHASH hash_string;
 SQUIDCEXTERN HASHHASH hash4;
-SQUIDCEXTERN const char *hashKeyStr(const hash_link *);
-
-/*
- *  Here are some good prime number choices.  It's important not to
- *  choose a prime number that is too close to exact powers of 2.
- *
- *  HASH_SIZE 103               // prime number < 128
- *  HASH_SIZE 229               // prime number < 256
- *  HASH_SIZE 467               // prime number < 512
- *  HASH_SIZE 977               // prime number < 1024
- *  HASH_SIZE 1979              // prime number < 2048
- *  HASH_SIZE 4019              // prime number < 4096
- *  HASH_SIZE 6037              // prime number < 6144
- *  HASH_SIZE 7951              // prime number < 8192
- *  HASH_SIZE 12149             // prime number < 12288
- *  HASH_SIZE 16231             // prime number < 16384
- *  HASH_SIZE 33493             // prime number < 32768
- *  HASH_SIZE 65357             // prime number < 65536
- */
-#define  DEFAULT_HASH_SIZE 7951 /* prime number < 8192 */
 
 #endif /* SQUID_HASH_H */
 

--- a/src/DiskIO/DiskDaemon/diskd.cc
+++ b/src/DiskIO/DiskDaemon/diskd.cc
@@ -73,7 +73,7 @@ do_open(diomsg * r, int, const char *buf)
     fs->id = r->id;
     fs->key = &fs->id;          /* gack */
     fs->fd = fd;
-    hash_join(hash, (hash_link *) fs);
+    hash->hash_join((hash_link *) fs);
     DEBUG(2) {
         fprintf(stderr, "%d OPEN  id %d, FD %d, fs %p\n",
                 (int) mypid,
@@ -89,7 +89,7 @@ do_close(diomsg * r, int)
 {
     int fd;
     file_state *fs;
-    fs = (file_state *) hash_lookup(hash, &r->id);
+    fs = (file_state *)hash->hash_lookup(&r->id);
 
     if (NULL == fs) {
         errno = EBADF;
@@ -102,7 +102,7 @@ do_close(diomsg * r, int)
     }
 
     fd = fs->fd;
-    hash_remove_link(hash, (hash_link *) fs);
+    hash->hash_remove_link((hash_link *) fs);
     DEBUG(2) {
         fprintf(stderr, "%d CLOSE id %d, FD %d, fs %p\n",
                 (int) mypid,
@@ -120,7 +120,7 @@ do_read(diomsg * r, int, char *buf)
     int x;
     int readlen = r->size;
     file_state *fs;
-    fs = (file_state *) hash_lookup(hash, &r->id);
+    fs = (file_state *)hash->hash_lookup(&r->id);
 
     if (NULL == fs) {
         errno = EBADF;
@@ -170,7 +170,7 @@ do_write(diomsg * r, int, const char *buf)
     int wrtlen = r->size;
     int x;
     file_state *fs;
-    fs = (file_state *) hash_lookup(hash, &r->id);
+    fs = (file_state *)hash->hash_lookup(&r->id);
 
     if (NULL == fs) {
         errno = EBADF;
@@ -347,7 +347,7 @@ main(int argc, char *argv[])
         exit(EXIT_FAILURE);
     }
 
-    hash = hash_create(fsCmp, 1 << 4, fsHash);
+    hash = new hash_table(fsCmp, fsHash, 1 << 4);
     assert(hash);
     if (fcntl(0, F_SETFL, SQUID_NONBLOCK) < 0) {
         perror(xstrerr(errno));

--- a/src/auth/digest/file/text_backend.cc
+++ b/src/auth/digest/file/text_backend.cc
@@ -70,10 +70,10 @@ read_passwd_file(const char *passwordFile, int isHa1Mode)
     char *realm;
 
     if (hash != NULL) {
-        hashFreeItems(hash, my_free);
+        hash->hashFreeItems(my_free);
     }
     /* initial setup */
-    hash = hash_create((HASHCMP *) strcmp, 7921, hash_string);
+    hash = new hash_table((HASHCMP *)strcmp, hash_string, 7921 );
     if (NULL == hash) {
         fprintf(stderr, "digest_file_auth: cannot create hash table\n");
         exit(EXIT_FAILURE);
@@ -128,7 +128,7 @@ read_passwd_file(const char *passwordFile, int isHa1Mode)
                 u->ha1 = xstrdup(ha1);
             else
                 u->passwd = xstrdup(passwd);
-            hash_join(hash, &u->hash);
+            hash->hash_join(&u->hash);
         }
     }
     fclose(f);
@@ -174,10 +174,10 @@ GetPassword(RequestData * requestData)
     len = snprintf(buf, sizeof(buf), "%s:%s", requestData->user, requestData->realm);
     if (len >= static_cast<int>(sizeof(buf)))
         return NULL;
-    u = (user_data*)hash_lookup(hash, buf);
+    u = (user_data*)hash->hash_lookup(buf);
     if (u)
         return u;
-    u = (user_data*)hash_lookup(hash, requestData->user);
+    u = (user_data *)hash->hash_lookup(requestData->user);
     return u;
 }
 

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -94,7 +94,8 @@ Auth::Negotiate::Config::init(Auth::SchemeConfig *)
             negotiateauthenticators = new statefulhelper("negotiateauthenticator");
 
         if (!proxy_auth_cache)
-            proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
+            proxy_auth_cache =
+                new hash_table((HASHCMP *)strcmp, hash_string, 7921);
 
         assert(proxy_auth_cache);
 

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -93,7 +93,8 @@ Auth::Ntlm::Config::init(Auth::SchemeConfig *)
             ntlmauthenticators = new statefulhelper("ntlmauthenticator");
 
         if (!proxy_auth_cache)
-            proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
+            proxy_auth_cache =
+                new hash_table((HASHCMP *)strcmp, hash_string, 7921);
 
         assert(proxy_auth_cache);
 

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -14,8 +14,8 @@
 #include "CacheManager.h"
 #include "comm/Connection.h"
 #include "Debug.h"
-#include "errorpage.h"
 #include "error/ExceptionErrorDetail.h"
+#include "errorpage.h"
 #include "fde.h"
 #include "HttpReply.h"
 #include "HttpRequest.h"
@@ -487,3 +487,4 @@ CacheManager::GetInstance()
     }
     return instance;
 }
+

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -1145,7 +1145,7 @@ idnsCallback(idns_query *q, const char *error)
         return; // wait for more answers
 
     if (master->hash.key) {
-        hash_remove_link(idns_lookup_hash, &master->hash);
+        idns_lookup_hash->hash_remove_link(&master->hash);
         master->hash.key = nullptr;
     }
 
@@ -1612,7 +1612,7 @@ Dns::Init(void)
 
     if (!init) {
         memset(RcodeMatrix, '\0', sizeof(RcodeMatrix));
-        idns_lookup_hash = hash_create((HASHCMP *) strcmp, 103, hash_string);
+        idns_lookup_hash = new hash_table((HASHCMP *) strcmp, hash_string, 103);
         ++init;
     }
 
@@ -1671,7 +1671,7 @@ Dns::ConfigRr::startReconfigure()
 static int
 idnsCachedLookup(const char *key, IDNSCB * callback, void *data)
 {
-    idns_query *old = (idns_query *) hash_lookup(idns_lookup_hash, key);
+    idns_query *old = (idns_query *) idns_lookup_hash->hash_lookup(key);
 
     if (!old)
         return 0;
@@ -1706,7 +1706,7 @@ idnsStartQuery(idns_query *q, IDNSCB * callback, void *data)
     q->callback_data = cbdataReference(data);
 
     q->hash.key = q->orig;
-    hash_join(idns_lookup_hash, &q->hash);
+    idns_lookup_hash->hash_join(&q->hash);
 
     idnsSendQuery(q);
 }

--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -289,3 +289,4 @@ Http::Message::firstLineBuf(MemBuf &mb)
 {
     packFirstLineInto(&mb, true);
 }
+

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -446,8 +446,8 @@ accessLogInit(void)
 static void
 fvdbInit(void)
 {
-    via_table = hash_create((HASHCMP *) strcmp, 977, hash4);
-    forw_table = hash_create((HASHCMP *) strcmp, 977, hash4);
+    via_table = new hash_table((HASHCMP *) strcmp, hash4, 977);
+    forw_table = new hash_table((HASHCMP *)strcmp, hash4, 977);
 }
 
 static void
@@ -466,12 +466,12 @@ fvdbCount(hash_table * hash, const char *key)
     if (NULL == hash)
         return;
 
-    fv = (fvdb_entry *)hash_lookup(hash, key);
+    fv = (fvdb_entry *)hash->hash_lookup(key);
 
     if (NULL == fv) {
         fv = static_cast <fvdb_entry *>(xcalloc(1, sizeof(fvdb_entry)));
         fv->hash.key = xstrdup(key);
-        hash_join(hash, &fv->hash);
+        hash->hash_join(&fv->hash);
     }
 
     ++ fv->n;
@@ -498,11 +498,11 @@ fvdbDumpTable(StoreEntry * e, hash_table * hash)
     if (hash == NULL)
         return;
 
-    hash_first(hash);
+    hash->hash_first();
 
-    while ((h = hash_next(hash))) {
+    while ((h = hash->hash_next())) {
         fv = (fvdb_entry *) h;
-        storeAppendPrintf(e, "%9d %s\n", fv->n, hashKeyStr(&fv->hash));
+        storeAppendPrintf(e, "%9d %s\n", fv->n, fv->hash.hashKeyStr());
     }
 }
 
@@ -530,12 +530,12 @@ fvdbFreeEntry(void *data)
 static void
 fvdbClear(void)
 {
-    hashFreeItems(via_table, fvdbFreeEntry);
-    hashFreeMemory(via_table);
-    via_table = hash_create((HASHCMP *) strcmp, 977, hash4);
-    hashFreeItems(forw_table, fvdbFreeEntry);
-    hashFreeMemory(forw_table);
-    forw_table = hash_create((HASHCMP *) strcmp, 977, hash4);
+    via_table->hashFreeItems(fvdbFreeEntry);
+    delete via_table;
+    via_table = new hash_table((HASHCMP *) strcmp, hash4, 977);
+    forw_table->hashFreeItems(fvdbFreeEntry);
+    delete forw_table;
+    forw_table = new hash_table((HASHCMP *)strcmp, hash4, 977);
 }
 
 #endif

--- a/src/mgr/QueryParams.cc
+++ b/src/mgr/QueryParams.cc
@@ -157,3 +157,4 @@ Mgr::QueryParams::CreateParam(QueryParam::Type aType)
     }
     return NULL;
 }
+

--- a/src/store.cc
+++ b/src/store.cc
@@ -440,14 +440,14 @@ StoreEntry::hashInsert(const cache_key * someKey)
     debugs(20, 3, "StoreEntry::hashInsert: Inserting Entry " << *this << " key '" << storeKeyText(someKey) << "'");
     assert(!key);
     key = storeKeyDup(someKey);
-    hash_join(store_table, this);
+    store_table->hash_join(this);
 }
 
 void
 StoreEntry::hashDelete()
 {
     if (key) { // some test cases do not create keys and do not hashInsert()
-        hash_remove_link(store_table, this);
+        store_table->hash_remove_link(this);
         storeKeyFree((const cache_key *)key);
         key = NULL;
     }
@@ -582,7 +582,7 @@ StoreEntry::setPrivateKey(const bool shareable, const bool permanent)
         mem_obj->id = getKeyCounter();
     const cache_key *newkey = storeKeyPrivate();
 
-    assert(hash_lookup(store_table, newkey) == NULL);
+    assert(!store_table->hash_lookup(newkey));
     EBIT_SET(flags, KEY_PRIVATE);
     shareableWhenPrivate = shareable;
     hashInsert(newkey);
@@ -651,7 +651,7 @@ StoreEntry::forcePublicKey(const cache_key *newkey)
     debugs(20, 3, storeKeyText(newkey) << " for " << *this);
     assert(mem_obj);
 
-    if (StoreEntry *e2 = (StoreEntry *)hash_lookup(store_table, newkey)) {
+    if (StoreEntry *e2 = (StoreEntry *)store_table->hash_lookup(newkey)) {
         assert(e2 != this);
         debugs(20, 3, "releasing clashing " << *e2);
         e2->release(true);

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -49,8 +49,8 @@ Store::Controller::~Controller()
     delete swapDir;
 
     if (store_table) {
-        hashFreeItems(store_table, destroyStoreEntry);
-        hashFreeMemory(store_table);
+        store_table->hashFreeItems(destroyStoreEntry);
+        delete store_table;
         store_table = nullptr;
     }
 }
@@ -413,7 +413,7 @@ Store::Controller::findCallbackXXX(const cache_key *key)
     // member or use an HTCP/ICP-specific index rather than store_table.
 
     // cannot reuse peekAtLocal() because HTCP/ICP callbacks may use private keys
-    return static_cast<StoreEntry*>(hash_lookup(store_table, key));
+    return static_cast<StoreEntry *>(store_table->hash_lookup(key));
 }
 
 /// \returns either an existing local reusable StoreEntry object or nil
@@ -422,7 +422,7 @@ Store::Controller::findCallbackXXX(const cache_key *key)
 StoreEntry *
 Store::Controller::peekAtLocal(const cache_key *key)
 {
-    if (StoreEntry *e = static_cast<StoreEntry*>(hash_lookup(store_table, key))) {
+    if (StoreEntry *e = static_cast<StoreEntry*>(store_table->hash_lookup(key))) {
         // callers must only search for public entries
         assert(!EBIT_TEST(e->flags, KEY_PRIVATE));
         assert(e->publicKey());

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -281,8 +281,8 @@ Store::Disks::init()
            (Config.memShared ? " [shared]" : ""));
     debugs(20, DBG_IMPORTANT, "Max Swap size: " << (Store::Root().maxSize() >> 10) << " KB");
 
-    store_table = hash_create(storeKeyHashCmp,
-                              store_hash_buckets, storeKeyHashHash);
+    store_table =
+        new hash_table(storeKeyHashCmp, storeKeyHashHash, store_hash_buckets);
 
     // Increment _before_ any possible storeRebuildComplete() calls so that
     // storeRebuildComplete() can reliably detect when all disks are done. The

--- a/src/store/LocalSearch.cc
+++ b/src/store/LocalSearch.cc
@@ -94,7 +94,7 @@ Store::LocalSearch::copyBucket()
     assert (!entries.size());
     hash_link *link_ptr = NULL;
     hash_link *link_next = NULL;
-    link_next = hash_get_bucket(store_table, bucket);
+    link_next = store_table->hash_get_bucket(bucket);
 
     while (NULL != (link_ptr = link_next)) {
         link_next = link_ptr->next;

--- a/src/tests/testCacheManager.cc
+++ b/src/tests/testCacheManager.cc
@@ -218,3 +218,4 @@ testCacheManager::testParseUrl()
         }
     }
 }
+


### PR DESCRIPTION
We have two implementations of hash_table in our code. One has
bitrot, and the other needlessly tries to be C.
Remove the "pure C" one, remove the only bitrotten user of that
implementation, and implement a more C++-like facade in front of
the remaining implementation.

This is the first step towards the goal of using std::
containers in place of our custom hash table.