### PR TITLE
Preserve half-closed transaction context

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1667,7 +1667,7 @@ commHalfClosedCheck(void *)
         Comm::ConnectionPointer c = new Comm::Connection; // XXX: temporary. make HalfClosed a list of these.
         c->fd = *i;
         if (!fd_table[c->fd].halfClosedReader) { // not reading already
-            CallBack(fd_table[c->fd].codeContext, [c] {
+            CallBack(fd_table[c->fd].codeContext, [&c] {
                 AsyncCall::Pointer call = commCbCall(5,4, "commHalfClosedReader",
                                                      CommIoCbPtrFun(&commHalfClosedReader, nullptr));
                 Comm::Read(c, call);


### PR DESCRIPTION
The code monitoring half-closed connections (with half_closed_clients
"on") did not save and did not restore transaction contexts.