### PR TITLE
Streamline ./configure handling of optional libraries

### DIFF
--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -169,18 +169,16 @@ dnl check the build parameters for a library to auto-enable
 dnl Parameters for this macro are:
 dnl 1) binary library name (without 'lib' prefix)
 dnl 2) name of the library for human reading
-dnl 3) actions when a valid PATH is given
-dnl 4) prefix used for pkg-check macros
+dnl 3) prefix used for pkg-check macros
 AC_DEFUN([SQUID_AUTO_LIB],[
   squid_auto_lib=`echo $$1|tr "\-" "_"`
   AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
     AS_CASE(["$withval"],[yes|no],,[
       AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
       with_$squid_auto_lib=yes
-      AS_IF([test -d "$withval/lib64"],[$4_PATH += "-L$withval/lib64"])
-      AS_IF([test -d "$withval/lib"],[$4_PATH += "-L$withval/lib"])
-      $4_CFLAGS="-I$withval/include"
-      $3
+      AS_IF([test -d "$withval/lib64"],[$3_PATH += "-L$withval/lib64"])
+      AS_IF([test -d "$withval/lib"],[$3_PATH += "-L$withval/lib"])
+      $3_CFLAGS="-I$withval/include"
     ])
   ])
   unset squid_auto_lib
@@ -193,10 +191,9 @@ AC_DEFUN([SQUID_OPTIONAL_LIB],[
     AS_CASE(["$with_$1"],[yes|no],,[
       AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
       with_$squid_auto_lib=yes
-      AS_IF([test -d "$withval/lib64"],[$4_PATH += "-L$withval/lib64"])
-      AS_IF([test -d "$withval/lib"],[$4_PATH += "-L$withval/lib"])
-      $4_CFLAGS="-I$withval/include"
-      $3
+      AS_IF([test -d "$withval/lib64"],[$3_PATH += "-L$withval/lib64"])
+      AS_IF([test -d "$withval/lib"],[$3_PATH += "-L$withval/lib"])
+      $3_CFLAGS="-I$withval/include"
     ])
   ])
   unset squid_auto_lib

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -171,11 +171,11 @@ dnl 1) binary library name (without 'lib' prefix)
 dnl 2) name of the library for human reading
 dnl 3) prefix used for pkg-check macros
 AC_DEFUN([SQUID_AUTO_LIB],[
-  squid_auto_lib=`echo $$1|tr "\-" "_"`
+  squid_auto_lib=`echo $1|tr "\-" "_"`
   AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
     AS_CASE(["$withval"],[yes|no],,[
       AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
-      with_$squid_auto_lib=yes
+      set with_$squid_auto_lib = yes
       AS_IF([test -d "$withval/lib64"],[$3_PATH += "-L$withval/lib64"])
       AS_IF([test -d "$withval/lib"],[$3_PATH += "-L$withval/lib"])
       $3_CFLAGS="-I$withval/include"
@@ -185,8 +185,8 @@ AC_DEFUN([SQUID_AUTO_LIB],[
 ])
 dnl same as SQUID_AUTO_LIB but for default-disabled libraries
 AC_DEFUN([SQUID_OPTIONAL_LIB],[
-  squid_auto_lib=`echo $$1|tr "\-" "_"`
-  with_$squid_auto_lib=no
+  squid_auto_lib=`echo $1|tr "\-" "_"`
+  set with_$squid_auto_lib = no
   AC_ARG_WITH([$1],AS_HELP_STRING([--with-$1],[Compile with the $2 library.]),[
     AS_CASE(["$with_$1"],[yes|no],,[
       AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -165,6 +165,22 @@ if test "$1" != "yes" -a "$1" != "no" ; then
 fi
 ])
 
+dnl check the build parameters for a library to auto-enable
+dnl Parameters for this macro are:
+dnl 1) binary library name (without 'lib' prefix)
+dnl 2) name of the library for human reading
+dnl 3) actions when a valid PATH is given
+AC_DEFUN([SQUID_AUTO_LIB],[
+  SQUID_TOLOWER_VAR_CONTENTS([1])
+  AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
+    AS_CASE([$with_$1],[yes|no],,[
+      AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
+      with_$1=yes
+      $3
+    ])
+  ])
+])
+
 AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
   AC_ARG_ENABLE([build-info],
     AS_HELP_STRING([--enable-build-info="build info string"],

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -171,10 +171,20 @@ dnl 1) binary library name (without 'lib' prefix)
 dnl 2) name of the library for human reading
 dnl 3) actions when a valid PATH is given
 AC_DEFUN([SQUID_AUTO_LIB],[
-  SQUID_TOLOWER_VAR_CONTENTS([1])
   AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
-    AS_CASE([$with_$1],[yes|no],,[
-      AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
+    AS_CASE(["$with_$1"],[yes|no],,[
+      AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
+      with_$1=yes
+      $3
+    ])
+  ])
+])
+dnl same as SQUID_AUTO_LIB but for default-disabled libraries
+AC_DEFUN([SQUID_OPTIONAL_LIB],[
+  with_$1=no
+  AC_ARG_WITH([$1],AS_HELP_STRING([--with-$1],[Compile with the $2 library.]),[
+    AS_CASE(["$with_$1"],[yes|no],,[
+      AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
       with_$1=yes
       $3
     ])

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -171,24 +171,28 @@ dnl 1) binary library name (without 'lib' prefix)
 dnl 2) name of the library for human reading
 dnl 3) actions when a valid PATH is given
 AC_DEFUN([SQUID_AUTO_LIB],[
+  squid_auto_lib=`echo $$1|tr "\-" "_"`
   AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
-    AS_CASE(["$with_$1"],[yes|no],,[
-      AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
-      with_$1=yes
+    AS_CASE(["$withval"],[yes|no],,[
+      AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
+      with_$squid_auto_lib=yes
       $3
     ])
   ])
+  unset squid_auto_lib
 ])
 dnl same as SQUID_AUTO_LIB but for default-disabled libraries
 AC_DEFUN([SQUID_OPTIONAL_LIB],[
-  with_$1=no
+  squid_auto_lib=`echo $$1|tr "\-" "_"`
+  with_$squid_auto_lib=no
   AC_ARG_WITH([$1],AS_HELP_STRING([--with-$1],[Compile with the $2 library.]),[
     AS_CASE(["$with_$1"],[yes|no],,[
       AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
-      with_$1=yes
+      with_$squid_auto_lib=yes
       $3
     ])
   ])
+  unset squid_auto_lib
 ])
 
 AC_DEFUN([SQUID_EMBED_BUILD_INFO],[

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -170,12 +170,16 @@ dnl Parameters for this macro are:
 dnl 1) binary library name (without 'lib' prefix)
 dnl 2) name of the library for human reading
 dnl 3) actions when a valid PATH is given
+dnl 4) prefix used for pkg-check macros
 AC_DEFUN([SQUID_AUTO_LIB],[
   squid_auto_lib=`echo $$1|tr "\-" "_"`
   AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
     AS_CASE(["$withval"],[yes|no],,[
       AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
       with_$squid_auto_lib=yes
+      AS_IF([test -d "$withval/lib64"],[$4_PATH += "-L$withval/lib64"])
+      AS_IF([test -d "$withval/lib"],[$4_PATH += "-L$withval/lib"])
+      $4_CFLAGS="-I$withval/include"
       $3
     ])
   ])
@@ -189,6 +193,9 @@ AC_DEFUN([SQUID_OPTIONAL_LIB],[
     AS_CASE(["$with_$1"],[yes|no],,[
       AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
       with_$squid_auto_lib=yes
+      AS_IF([test -d "$withval/lib64"],[$4_PATH += "-L$withval/lib64"])
+      AS_IF([test -d "$withval/lib"],[$4_PATH += "-L$withval/lib"])
+      $4_CFLAGS="-I$withval/include"
       $3
     ])
   ])

--- a/configure.ac
+++ b/configure.ac
@@ -1173,13 +1173,11 @@ AM_CONDITIONAL(ENABLE_HTCP, [test "x$enable_htcp" = "xyes"])
 AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 
 # Cryptograhic libraries
-SQUID_AUTO_LIB(nettle,[Nettle crypto],[
-    NETTLELIBDIR="-L$with_nettle/lib"
-    CPPFLAGS="-I$with_nettle/include $CPPFLAGS"
-],[LIBNETTLE])
+SQUID_AUTO_LIB(nettle,[Nettle crypto],[],[LIBNETTLE])
 if test "x$with_nettle" != "xno" ; then
+  CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
   AC_CHECK_LIB(nettle, nettle_md5_init,[
-    NETTLELIB="$NETTLELIBDIR -lnettle"
+    NETTLELIB="$LIBNETTLE_PATH -lnettle"
     AC_CHECK_HEADERS(nettle/md5.h)
   ],[with_nettle=no])
   if test "x$with_nettle" != "xno" ; then
@@ -1221,14 +1219,13 @@ AC_SUBST(CRYPTLIB)
 
 SSLLIB=""
 
-SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[
-    CPPFLAGS="-I$with_gnutls/include $CPPFLAGS"
-],[LIBGNUTLS])
+SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[],[LIBGNUTLS])
 AH_TEMPLATE(USE_GNUTLS,[GnuTLS support is available])
 if test "x$with_gnutls" != "xno"; then
   SQUID_STATE_SAVE(squid_gnutls_state)
 
   # User may have provided a custom location for GnuTLS. Otherwise...
+  CPPFLAGS="$LIBGNUTLS_CFLAGS $CPPFLAGS"
   LIBS="$LIBS $LIBGNUTLS_PATH"
 
   # auto-detect using pkg-config
@@ -1258,12 +1255,11 @@ fi
 AC_MSG_NOTICE([GnuTLS library support: ${with_gnutls:=auto} ${LIBGNUTLS_PATH} ${LIBGNUTLS_LIBS}])
 
 dnl User may specify OpenSSL is needed from a non-standard location
-SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[
-  CPPFLAGS="-I$with_openssl/include $CPPFLAGS"
-],[LIBOPENSSL])
+SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[],[LIBOPENSSL])
 AH_TEMPLATE(USE_OPENSSL,[OpenSSL support is available])
 ## OpenSSL is default disable due to licensing issues on some OS
 if test "x$with_openssl" = "xyes"; then
+  CPPFLAGS="$LIBOPENSSL_CFLAGS $CPPFLAGS"
   AC_CHECK_HEADERS( \
     openssl/asn1.h \
     openssl/bio.h \
@@ -1352,16 +1348,15 @@ AM_CONDITIONAL(ENABLE_SSL,[ test "x$with_openssl" = "xyes" ])
 AC_SUBST(SSLLIB)
 
 dnl User may specify MIT Kerberos is needed from a non-standard location
-SQUID_AUTO_LIB(mit-krb5,[MIT Kerberos],[
-    CXXFLAGS="-I$with_mit_krb5/include $CXXFLAGS"
-    krb5confpath="$with_mit_krb5/bin"
-],[LIB_KRB5])
+SQUID_AUTO_LIB(mit-krb5,[MIT Kerberos],[],[LIB_KRB5])
 AH_TEMPLATE(USE_APPLE_KRB5,[Apple Kerberos support is available])
 AH_TEMPLATE(USE_MIT_KRB5,[MIT Kerberos support is available])
 AH_TEMPLATE(USE_SOLARIS_KRB5,[Solaris Kerberos support is available])
 
 ## find out if pkg-config or krb5-config will work
 if test "x$with_mit_krb5" != "xno"; then
+  CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
+  krb5confpath="$with_mit_krb5/bin"
   # find installed libs via pkg-config or krb5-config
   squid_pc_krb5_name=
   PKG_CHECK_EXISTS(mit-krb5-gssapi mit-krb5, [squid_pc_krb5_name="mit-krb5-gssapi mit-krb5"],[
@@ -1572,13 +1567,11 @@ if test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
 fi
 
 dnl User may specify Heimdal Kerberos is needed from a non-standard location
-SQUID_AUTO_LIB(heimdal-krb5,[Heimdal Kerberos],[
-    CXXFLAGS="-I$with_heimdal_krb5/include $CXXFLAGS"
-    krb5confpath="$with_heimdal_krb5/bin"
-    with_heimdal_krb5=yes
-],[LIB_KRB5])
+SQUID_AUTO_LIB(heimdal-krb5,[Heimdal Kerberos],[],[LIB_KRB5])
 AH_TEMPLATE(USE_HEIMDAL_KRB5,[Heimdal Kerberos support is available])
 if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
+  CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
+  krb5confpath="$with_heimdal_krb5/bin"
   # find installed libs via pkg-config or krb5-config
   PKG_CHECK_EXISTS(heimdal-krb5, [squid_pc_krb5_name="heimdal-krb5"])
   if test "x$squid_pc_krb5_name" = "x"; then
@@ -1725,13 +1718,11 @@ if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
 fi
 
 dnl User may specify GNU gss is needed from a non-standard location
-SQUID_AUTO_LIB(gnugss,[GNU gss],[
-    CXXFLAGS="-I$with_gnugss/include $CXXFLAGS"
-    krb5confpath=
-    with_gnugss=yes
-],[LIB_KRB5])
+SQUID_AUTO_LIB(gnugss,[GNU gss],[],[LIB_KRB5])
 AH_TEMPLATE(USE_GNUGSS,[GNU gss support is available])
 if test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"; then
+  CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
+  krb5confpath=
   SQUID_STATE_SAVE([squid_krb5_save])
   LIBS="$LIBS $LIB_KRB5_PATH"
 
@@ -2272,15 +2263,11 @@ AC_MSG_NOTICE([Linux Netfilter support requested: ${enable_linux_netfilter:=auto
 
 
 dnl Look for libnetfilter_conntrack options (needed for QOS netfilter marking)
-dnl squid_opt_netfilterconntrack is set only when option is explicity specified
-SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[
-    squid_opt_netfilterconntrackpath=$withval
-    LDFLAGS="-L$squid_opt_netfilterconntrackpath/lib $LDFLAGS"
-    CPPFLAGS="-I$squid_opt_netfilterconntrackpath/include $CPPFLAGS"
-],[LIBNETFILTER_CONNTRACK])
-squid_opt_netfilterconntrack=$with_netfilter_conntrack
+SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[],[LIBNETFILTER_CONNTRACK])
 AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_conntrack:=auto}])
 if test "x$with_netfilter_conntrack" != "xno"; then
+    LDFLAGS="$LIBNETFILTER_CONNTRACK_PATH $LDFLAGS"
+    CPPFLAGS="$LIBNETFILTER_CONNTRACK_CFLAGS $CPPFLAGS"
     AC_SEARCH_LIBS([nfct_query], [netfilter_conntrack],,[
         if test x"$with_netfilter_conntrack" = "xyes"; then
             AC_MSG_ERROR([--with-netfilter-conntrack specified but libnetfilter-conntrack library not found])
@@ -2681,10 +2668,9 @@ SQUID_DEFINE_BOOL(X_ACCELERATOR_VARY,${enable_x_accelerator_vary:=no},
                       [Enable support for the X-Accelerator-Vary HTTP header])
 AC_MSG_NOTICE([X-Accelerator-Vary support enabled: $enable_x_accelerator_vary])
 
-SQUID_AUTO_LIB(cppunit,[cppunit test framework],[
-  LIBCPPUNIT_LIBS="-L$with_cppunit/lib -lcppunit"
-],[LIBCPPUNIT])
+SQUID_AUTO_LIB(cppunit,[cppunit test framework],[],[LIBCPPUNIT])
 AS_IF([test "x$with_cppunit" != "xno"],[
+  LIBCPPUNIT_LIBS="$LIBCPPUNIT_PATH -lcppunit"
   PKG_CHECK_MODULES([LIBCPPUNIT],[cppunit],[
     squid_cv_cppunit_version="`pkg-config cppunit --version`"
     AC_MSG_NOTICE([using system installed cppunit version $squid_cv_cppunit_version])
@@ -2967,10 +2953,10 @@ AC_FUNC_ALLOCA
 
 
 # TODO: remove this 'lib' prefix to match coding standard
-SQUID_AUTO_LIB(libcap,[Linux capabilities],[
-  AC_MSG_ERROR([unrecognized argument to --with-libcap : $withval])
-],[LIBCAP])
+SQUID_AUTO_LIB(libcap,[Linux capabilities],[],[LIBCAP])
 if test "x$with_libcap" != "xno"; then
+  CXXFLAGS="$LIBCAP_CFLAGS $CXXFLAGS"
+  LDFLAGS="$LIBCAP_PATH $LDFLAGS"
   # cap_clear_flag is the most recent libcap function we require
   AC_CHECK_HEADERS(sys/capability.h)
   AC_CHECK_LIB(cap, cap_clear_flag)
@@ -3520,16 +3506,12 @@ if test "x$enable_linux_netfilter" = "xyes" -a "x$with_libcap" != "xyes" ; then
     AC_MSG_WARN([Reduced support to NAT Interception Proxy])
     # AC_DEFINEd later
 fi
-
-if test "x$squid_opt_netfilterconntrack" = "xyes" -a "x$with_libcap" != "xyes" ; then
-    AC_MSG_ERROR([Linux netfilter conntrack requires libcap support (libcap 2.09+)])
-fi
 if test "x$with_netfilter_conntrack" = "xyes" -a "x$with_libcap" != "xyes" ; then
     AC_MSG_WARN([Missing needed capabilities (libcap 2.09+) for netfilter mark support])
     AC_MSG_WARN([Linux netfilter marking support WILL NOT be enabled])
     with_netfilter_conntrack=no
 fi
-AC_MSG_NOTICE([Linux Netfilter Conntrack support enabled: ${with_netfilter_conntrack} ${squid_opt_netfilterconntrackpath}])
+AC_MSG_NOTICE([Linux Netfilter Conntrack support enabled: ${with_netfilter_conntrack}])
 
 
 AC_ARG_ENABLE(zph-qos,

--- a/configure.ac
+++ b/configure.ac
@@ -1259,24 +1259,9 @@ fi
 AC_MSG_NOTICE([GnuTLS library support: ${with_gnutls:=auto} ${LIBGNUTLS_PATH} ${LIBGNUTLS_LIBS}])
 
 dnl User may specify OpenSSL is needed from a non-standard location
-AC_ARG_WITH(openssl,
-  AS_HELP_STRING([--with-openssl=PATH],
-                 [Compile with the OpenSSL libraries. The path to
-                  the OpenSSL development libraries and headers
-                  installation can be specified if outside of the
-                  system standard directories]), [ 
-case "$with_openssl" in
-  yes|no)
-    : # Nothing special to do here
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-openssl path does not point to a directory])
-    fi
-    LIBOPENSSL_PATH="-L$with_openssl/lib"
-    CPPFLAGS="-I$with_openssl/include $CPPFLAGS"
-    with_openssl=yes
-  esac
+SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[
+  LIBOPENSSL_PATH="-L$with_openssl/lib"
+  CPPFLAGS="-I$with_openssl/include $CPPFLAGS"
 ])
 AH_TEMPLATE(USE_OPENSSL,[OpenSSL support is available])
 ## OpenSSL is default disable due to licensing issues on some OS

--- a/configure.ac
+++ b/configure.ac
@@ -882,7 +882,7 @@ HAVE_LIBXML2=0
 XMLLIB=
 
 # ESI support libraries: expat
-SQUID_AUTO_LIB(expat,[ESI expat],[],[LIBEXPAT])
+SQUID_AUTO_LIB(expat,[ESI expat],[LIBEXPAT])
 if test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno" ; then
   AC_CHECK_LIB([expat], [main], [EXPATLIB="-lexpat"; HAVE_LIBEXPAT=1])
   AC_CHECK_HEADERS([expat.h])
@@ -899,7 +899,7 @@ if test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno" ; then
 fi
 
 # TODO: remove this 'lib' prefix to match coding standard
-SQUID_AUTO_LIB(libxml2,[ESI libxml2],[],[LIBXML2])
+SQUID_AUTO_LIB(libxml2,[ESI libxml2],[LIBXML2])
 if test "x$squid_opt_use_esi" != "xno" -a "x$with_libxml2" != "xno" ; then
   SQUID_STATE_SAVE([squid_libxml2_save])
   PKG_CHECK_MODULES([LIBXML2],[libxml-2.0],[],[
@@ -1173,7 +1173,7 @@ AM_CONDITIONAL(ENABLE_HTCP, [test "x$enable_htcp" = "xyes"])
 AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 
 # Cryptograhic libraries
-SQUID_AUTO_LIB(nettle,[Nettle crypto],[],[LIBNETTLE])
+SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
 if test "x$with_nettle" != "xno" ; then
   CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
   AC_CHECK_LIB(nettle, nettle_md5_init,[
@@ -1219,7 +1219,7 @@ AC_SUBST(CRYPTLIB)
 
 SSLLIB=""
 
-SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[],[LIBGNUTLS])
+SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[LIBGNUTLS])
 AH_TEMPLATE(USE_GNUTLS,[GnuTLS support is available])
 if test "x$with_gnutls" != "xno"; then
   SQUID_STATE_SAVE(squid_gnutls_state)
@@ -1255,7 +1255,7 @@ fi
 AC_MSG_NOTICE([GnuTLS library support: ${with_gnutls:=auto} ${LIBGNUTLS_PATH} ${LIBGNUTLS_LIBS}])
 
 dnl User may specify OpenSSL is needed from a non-standard location
-SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[],[LIBOPENSSL])
+SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[LIBOPENSSL])
 AH_TEMPLATE(USE_OPENSSL,[OpenSSL support is available])
 ## OpenSSL is default disable due to licensing issues on some OS
 if test "x$with_openssl" = "xyes"; then
@@ -1348,7 +1348,7 @@ AM_CONDITIONAL(ENABLE_SSL,[ test "x$with_openssl" = "xyes" ])
 AC_SUBST(SSLLIB)
 
 dnl User may specify MIT Kerberos is needed from a non-standard location
-SQUID_AUTO_LIB(mit-krb5,[MIT Kerberos],[],[LIB_KRB5])
+SQUID_AUTO_LIB(mit-krb5,[MIT Kerberos],[LIB_KRB5])
 AH_TEMPLATE(USE_APPLE_KRB5,[Apple Kerberos support is available])
 AH_TEMPLATE(USE_MIT_KRB5,[MIT Kerberos support is available])
 AH_TEMPLATE(USE_SOLARIS_KRB5,[Solaris Kerberos support is available])
@@ -1567,7 +1567,7 @@ if test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
 fi
 
 dnl User may specify Heimdal Kerberos is needed from a non-standard location
-SQUID_AUTO_LIB(heimdal-krb5,[Heimdal Kerberos],[],[LIB_KRB5])
+SQUID_AUTO_LIB(heimdal-krb5,[Heimdal Kerberos],[LIB_KRB5])
 AH_TEMPLATE(USE_HEIMDAL_KRB5,[Heimdal Kerberos support is available])
 if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
   CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
@@ -1718,7 +1718,7 @@ if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
 fi
 
 dnl User may specify GNU gss is needed from a non-standard location
-SQUID_AUTO_LIB(gnugss,[GNU gss],[],[LIB_KRB5])
+SQUID_AUTO_LIB(gnugss,[GNU gss],[LIB_KRB5])
 AH_TEMPLATE(USE_GNUGSS,[GNU gss support is available])
 if test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"; then
   CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
@@ -2263,7 +2263,7 @@ AC_MSG_NOTICE([Linux Netfilter support requested: ${enable_linux_netfilter:=auto
 
 
 dnl Look for libnetfilter_conntrack options (needed for QOS netfilter marking)
-SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[],[LIBNETFILTER_CONNTRACK])
+SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[LIBNETFILTER_CONNTRACK])
 AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_conntrack:=auto}])
 if test "x$with_netfilter_conntrack" != "xno"; then
     LDFLAGS="$LIBNETFILTER_CONNTRACK_PATH $LDFLAGS"
@@ -2668,7 +2668,7 @@ SQUID_DEFINE_BOOL(X_ACCELERATOR_VARY,${enable_x_accelerator_vary:=no},
                       [Enable support for the X-Accelerator-Vary HTTP header])
 AC_MSG_NOTICE([X-Accelerator-Vary support enabled: $enable_x_accelerator_vary])
 
-SQUID_AUTO_LIB(cppunit,[cppunit test framework],[],[LIBCPPUNIT])
+SQUID_AUTO_LIB(cppunit,[cppunit test framework],[LIBCPPUNIT])
 AS_IF([test "x$with_cppunit" != "xno"],[
   LIBCPPUNIT_LIBS="$LIBCPPUNIT_PATH -lcppunit"
   PKG_CHECK_MODULES([LIBCPPUNIT],[cppunit],[
@@ -2953,7 +2953,7 @@ AC_FUNC_ALLOCA
 
 
 # TODO: remove this 'lib' prefix to match coding standard
-SQUID_AUTO_LIB(libcap,[Linux capabilities],[],[LIBCAP])
+SQUID_AUTO_LIB(libcap,[Linux capabilities],[LIBCAP])
 if test "x$with_libcap" != "xno"; then
   CXXFLAGS="$LIBCAP_CFLAGS $CXXFLAGS"
   LDFLAGS="$LIBCAP_PATH $LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -435,9 +435,12 @@ if test "x$squid_opt_aufs_threads" != "x"; then
                  [Defines how many threads aufs uses for I/O])
 fi
 
-AC_ARG_WITH(dl, AS_HELP_STRING([--with-dl],[Use dynamic linking]))
-if test "x$with_dl" = "xyes"; then
-  AC_MSG_NOTICE([With dl])
+## TODO check if this is necessary, LT_INIT does these checks
+SQUID_AUTO_LIB(dl,[dynamic linking],[LIBDL])
+if test "x$with_dl" != "xno"; then
+  CXXFLAGS="$LIBDL_CFLAGS $CXXFLAGS"
+  LDFLAGS="$LIBDL_PATH $LDFLAGS"
+  AC_CHECK_LIB(dl, dlopen)
 fi
 
 ## check for atomics library before anything that might need it
@@ -3100,11 +3103,6 @@ fi
 SQUID_CHECK_SS_LEN_IN_SOCKADDR_STORAGE
 SQUID_CHECK_SIN_LEN_IN_SOCKADDR_IN
 
-
-dnl Check for libdl, used by auth_modules/PAM
-if test "x$with_dl" = "xyes"; then
-    AC_CHECK_LIB(dl, dlopen)
-fi
 
 dnl -lintl is needed on SCO version 3.2v4.2 for strftime()
 dnl Robert Side <rside@aiinc.bc.ca>

--- a/configure.ac
+++ b/configure.ac
@@ -882,7 +882,7 @@ HAVE_LIBXML2=0
 XMLLIB=
 
 # ESI support libraries: expat
-AC_ARG_WITH(expat, AS_HELP_STRING([--without-expat],[Do not use expat for ESI. Default: auto-detect]))
+SQUID_AUTO_LIB(expat,[ESI expat],[])
 if test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno" ; then
   AC_CHECK_LIB([expat], [main], [EXPATLIB="-lexpat"; HAVE_LIBEXPAT=1])
   AC_CHECK_HEADERS([expat.h])
@@ -898,7 +898,8 @@ if test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno" ; then
   ])
 fi
 
-AC_ARG_WITH(libxml2, AS_HELP_STRING([--without-libxml2],[Do not use libxml2 for ESI. Default: auto-detect]))
+# TODO: remove this 'lib' prefix to match coding standard
+SQUID_AUTO_LIB(libxml2,[ESI libxml2],[])
 if test "x$squid_opt_use_esi" != "xno" -a "x$with_libxml2" != "xno" ; then
   SQUID_STATE_SAVE([squid_libxml2_save])
   PKG_CHECK_MODULES([LIBXML2],[libxml-2.0],[],[
@@ -1172,20 +1173,9 @@ AM_CONDITIONAL(ENABLE_HTCP, [test "x$enable_htcp" = "xyes"])
 AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 
 # Cryptograhic libraries
-AC_ARG_WITH(nettle,
-  AS_HELP_STRING([--without-nettle],[Compile without the Nettle crypto library.]),[
-case "$with_nettle" in
-  yes|no)
-    : # Nothing special to do here
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-nettle path does not point to a directory])
-    fi
+SQUID_AUTO_LIB(nettle,[Nettle crypto],[
     NETTLELIBDIR="-L$with_nettle/lib"
     CPPFLAGS="-I$with_nettle/include $CPPFLAGS"
-    with_nettle=yes
-  esac
 ])
 if test "x$with_nettle" != "xno" ; then
   AC_CHECK_LIB(nettle, nettle_md5_init,[
@@ -1231,21 +1221,9 @@ AC_SUBST(CRYPTLIB)
 
 SSLLIB=""
 
-dnl User may want to disable GnuTLS
-AC_ARG_WITH(gnutls,
-  AS_HELP_STRING([--without-gnutls],
-                 [Do not use GnuTLS for SSL. Default: auto-detect]), [ 
-case "$with_gnutls" in
-  yes|no)
-    : # Nothing special to do here
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-gnutls path does not point to a directory])
-    fi
+SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[
     LIBGNUTLS_PATH="-L$with_gnutls/lib"
     CPPFLAGS="-I$with_gnutls/include $CPPFLAGS"
-  esac
 ])
 AH_TEMPLATE(USE_GNUTLS,[GnuTLS support is available])
 if test "x$with_gnutls" != "xno"; then
@@ -1391,17 +1369,7 @@ AM_CONDITIONAL(ENABLE_SSL,[ test "x$with_openssl" = "xyes" ])
 AC_SUBST(SSLLIB)
 
 dnl User may specify MIT Kerberos is needed from a non-standard location
-AC_ARG_WITH(mit-krb5,
-  AS_HELP_STRING([--without-mit-krb5],
-		 [Compile without MIT Kerberos support.]), [
-case "$with_mit_krb5" in
-  yes|no)
-    : # Nothing special to do here
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-mit-krb5 path does not point to a directory])
-    fi
+SQUID_AUTO_LIB(mit-krb5,[MIT Kerberos],[
     if test -d "$with_mit_krb5/lib64" ; then
       LIB_KRB5_PATH="-L$with_mit_krb5/lib64 -L$with_mit_krb5/lib"
     else
@@ -1409,8 +1377,6 @@ case "$with_mit_krb5" in
     fi
     CXXFLAGS="-I$with_mit_krb5/include $CXXFLAGS"
     krb5confpath="$with_mit_krb5/bin"
-    with_mit_krb5=yes
-esac
 ])
 AH_TEMPLATE(USE_APPLE_KRB5,[Apple Kerberos support is available])
 AH_TEMPLATE(USE_MIT_KRB5,[MIT Kerberos support is available])
@@ -1628,17 +1594,7 @@ if test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
 fi
 
 dnl User may specify Heimdal Kerberos is needed from a non-standard location
-AC_ARG_WITH(heimdal-krb5,
-  AS_HELP_STRING([--without-heimdal-krb5],
-		 [Compile without Heimdal Kerberos support.]), [
-case "$with_heimdal_krb5" in
-  yes|no)
-    : # Nothing special to do here
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-heimdal-krb5 path does not point to a directory])
-    fi
+SQUID_AUTO_LIB(heimdal-krb5,[Heimdal Kerberos],[
     if test -d "$with_heimdal_krb5/lib64" ; then
       LIB_KRB5_PATH="-L$with_heimdal_krb5/lib64 -L$with_heimdal_krb5/lib"
     else 
@@ -1647,7 +1603,6 @@ case "$with_heimdal_krb5" in
     CXXFLAGS="-I$with_heimdal_krb5/include $CXXFLAGS"
     krb5confpath="$with_heimdal_krb5/bin"
     with_heimdal_krb5=yes
-esac
 ])
 AH_TEMPLATE(USE_HEIMDAL_KRB5,[Heimdal Kerberos support is available])
 if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
@@ -1797,17 +1752,7 @@ if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
 fi
 
 dnl User may specify GNU gss is needed from a non-standard location
-AC_ARG_WITH(gnugss,
-  AS_HELP_STRING([--without-gnugss],
-		 [Compile without the GNU gss libraries.]), [
-case "$with_gnugss" in
-  yes|no)
-    : # Nothing special to do here
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-gnugss path does not point to a directory])
-    fi
+SQUID_AUTO_LIB(gnugss,[GNU gss],[
     if test ! -d "$with_gnugss/lib64" ; then
       LIB_KRB5_PATH="-L$with_gnugss/lib64 -L$with_gnugss/lib"
     else
@@ -1816,7 +1761,6 @@ case "$with_gnugss" in
     CXXFLAGS="-I$with_gnugss/include $CXXFLAGS"
     krb5confpath=
     with_gnugss=yes
-esac
 ])
 AH_TEMPLATE(USE_GNUGSS,[GNU gss support is available])
 if test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"; then
@@ -2361,26 +2305,12 @@ AC_MSG_NOTICE([Linux Netfilter support requested: ${enable_linux_netfilter:=auto
 
 dnl Look for libnetfilter_conntrack options (needed for QOS netfilter marking)
 dnl squid_opt_netfilterconntrack is set only when option is explicity specified
-AC_ARG_WITH(netfilter-conntrack,
-  AS_HELP_STRING([--without-netfilter-conntrack],
-                 [Do not use Netfilter conntrack libraries for packet marking.
-                  A path to alternative library location may be specified by
-                  using --with-netfilter-conntrack=PATH. Default: auto-detect.]), [
-case "$with_netfilter_conntrack" in
-  yes|no)
-    squid_opt_netfilterconntrack=$with_netfilter_conntrack
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-netfilter-conntrack path does not point to a directory])
-    fi
+SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[
     squid_opt_netfilterconntrackpath=$withval
     LDFLAGS="-L$squid_opt_netfilterconntrackpath/lib $LDFLAGS"
     CPPFLAGS="-I$squid_opt_netfilterconntrackpath/include $CPPFLAGS"
-    with_netfilter_conntrack=yes
-    squid_opt_netfilterconntrack=yes
-  esac
 ])
+squid_opt_netfilterconntrack=$with_netfilter_conntrack
 AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_conntrack:=auto}])
 if test "x$with_netfilter_conntrack" != "xno"; then
     AC_SEARCH_LIBS([nfct_query], [netfilter_conntrack],,[
@@ -2783,13 +2713,9 @@ SQUID_DEFINE_BOOL(X_ACCELERATOR_VARY,${enable_x_accelerator_vary:=no},
                       [Enable support for the X-Accelerator-Vary HTTP header])
 AC_MSG_NOTICE([X-Accelerator-Vary support enabled: $enable_x_accelerator_vary])
 
-AC_ARG_WITH([cppunit], AS_HELP_STRING([--without-cppunit],[Do not use cppunit test framework]),[
-  AS_CASE($with_cppunit, [yes|no],[],
-   [
-    AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-cppunit PATH does not point to a directory]))
-    LIBCPPUNIT_CFLAGS="-I$with_cppunit/include"
-    LIBCPPUNIT_LIBS="-L$with_cppunit/lib -lcppunit"
-  ])
+SQUID_AUTO_LIB(cppunit,[cppunit test framework],[
+  LIBCPPUNIT_CFLAGS="-I$with_cppunit/include"
+  LIBCPPUNIT_LIBS="-L$with_cppunit/lib -lcppunit"
 ])
 AS_IF([test "x$with_cppunit" != "xno"],[
   PKG_CHECK_MODULES([LIBCPPUNIT],[cppunit],[
@@ -3073,12 +2999,10 @@ dnl Check for special functions
 AC_FUNC_ALLOCA
 
 
-dnl Check for libcap header (assume its not broken unless 
-AC_ARG_WITH(libcap, AS_HELP_STRING([--without-libcap],
-       [disable usage of Linux capabilities library to control privileges]), [
-SQUID_YESNO([$withval],[unrecognized argument to --without-libcap: $withval])
-],[with_libcap=auto])
-
+# TODO: remove this 'lib' prefix to match coding standard
+SQUID_AUTO_LIB(libcap,[Linux capabilities],[
+  AC_MSG_ERROR([unrecognized argument to --with-libcap : $withval])
+])
 if test "x$with_libcap" != "xno"; then
   # cap_clear_flag is the most recent libcap function we require
   AC_CHECK_HEADERS(sys/capability.h)

--- a/configure.ac
+++ b/configure.ac
@@ -882,7 +882,7 @@ HAVE_LIBXML2=0
 XMLLIB=
 
 # ESI support libraries: expat
-SQUID_AUTO_LIB(expat,[ESI expat],[])
+SQUID_AUTO_LIB(expat,[ESI expat],[],[LIBEXPAT])
 if test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno" ; then
   AC_CHECK_LIB([expat], [main], [EXPATLIB="-lexpat"; HAVE_LIBEXPAT=1])
   AC_CHECK_HEADERS([expat.h])
@@ -899,7 +899,7 @@ if test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno" ; then
 fi
 
 # TODO: remove this 'lib' prefix to match coding standard
-SQUID_AUTO_LIB(libxml2,[ESI libxml2],[])
+SQUID_AUTO_LIB(libxml2,[ESI libxml2],[],[LIBXML2])
 if test "x$squid_opt_use_esi" != "xno" -a "x$with_libxml2" != "xno" ; then
   SQUID_STATE_SAVE([squid_libxml2_save])
   PKG_CHECK_MODULES([LIBXML2],[libxml-2.0],[],[
@@ -1176,7 +1176,7 @@ AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 SQUID_AUTO_LIB(nettle,[Nettle crypto],[
     NETTLELIBDIR="-L$with_nettle/lib"
     CPPFLAGS="-I$with_nettle/include $CPPFLAGS"
-])
+],[LIBNETTLE])
 if test "x$with_nettle" != "xno" ; then
   AC_CHECK_LIB(nettle, nettle_md5_init,[
     NETTLELIB="$NETTLELIBDIR -lnettle"
@@ -1222,9 +1222,8 @@ AC_SUBST(CRYPTLIB)
 SSLLIB=""
 
 SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[
-    LIBGNUTLS_PATH="-L$with_gnutls/lib"
     CPPFLAGS="-I$with_gnutls/include $CPPFLAGS"
-])
+],[LIBGNUTLS])
 AH_TEMPLATE(USE_GNUTLS,[GnuTLS support is available])
 if test "x$with_gnutls" != "xno"; then
   SQUID_STATE_SAVE(squid_gnutls_state)
@@ -1260,9 +1259,8 @@ AC_MSG_NOTICE([GnuTLS library support: ${with_gnutls:=auto} ${LIBGNUTLS_PATH} ${
 
 dnl User may specify OpenSSL is needed from a non-standard location
 SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[
-  LIBOPENSSL_PATH="-L$with_openssl/lib"
   CPPFLAGS="-I$with_openssl/include $CPPFLAGS"
-])
+],[LIBOPENSSL])
 AH_TEMPLATE(USE_OPENSSL,[OpenSSL support is available])
 ## OpenSSL is default disable due to licensing issues on some OS
 if test "x$with_openssl" = "xyes"; then
@@ -1355,14 +1353,9 @@ AC_SUBST(SSLLIB)
 
 dnl User may specify MIT Kerberos is needed from a non-standard location
 SQUID_AUTO_LIB(mit-krb5,[MIT Kerberos],[
-    if test -d "$with_mit_krb5/lib64" ; then
-      LIB_KRB5_PATH="-L$with_mit_krb5/lib64 -L$with_mit_krb5/lib"
-    else
-      LIB_KRB5_PATH="-L$with_mit_krb5/lib"
-    fi
     CXXFLAGS="-I$with_mit_krb5/include $CXXFLAGS"
     krb5confpath="$with_mit_krb5/bin"
-])
+],[LIB_KRB5])
 AH_TEMPLATE(USE_APPLE_KRB5,[Apple Kerberos support is available])
 AH_TEMPLATE(USE_MIT_KRB5,[MIT Kerberos support is available])
 AH_TEMPLATE(USE_SOLARIS_KRB5,[Solaris Kerberos support is available])
@@ -1580,15 +1573,10 @@ fi
 
 dnl User may specify Heimdal Kerberos is needed from a non-standard location
 SQUID_AUTO_LIB(heimdal-krb5,[Heimdal Kerberos],[
-    if test -d "$with_heimdal_krb5/lib64" ; then
-      LIB_KRB5_PATH="-L$with_heimdal_krb5/lib64 -L$with_heimdal_krb5/lib"
-    else 
-      LIB_KRB5_PATH="-L$with_heimdal_krb5/lib"
-    fi
     CXXFLAGS="-I$with_heimdal_krb5/include $CXXFLAGS"
     krb5confpath="$with_heimdal_krb5/bin"
     with_heimdal_krb5=yes
-])
+],[LIB_KRB5])
 AH_TEMPLATE(USE_HEIMDAL_KRB5,[Heimdal Kerberos support is available])
 if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
   # find installed libs via pkg-config or krb5-config
@@ -1738,15 +1726,10 @@ fi
 
 dnl User may specify GNU gss is needed from a non-standard location
 SQUID_AUTO_LIB(gnugss,[GNU gss],[
-    if test ! -d "$with_gnugss/lib64" ; then
-      LIB_KRB5_PATH="-L$with_gnugss/lib64 -L$with_gnugss/lib"
-    else
-      LIB_KRB5_PATH="-L$with_gnugss/lib"
-    fi
     CXXFLAGS="-I$with_gnugss/include $CXXFLAGS"
     krb5confpath=
     with_gnugss=yes
-])
+],[LIB_KRB5])
 AH_TEMPLATE(USE_GNUGSS,[GNU gss support is available])
 if test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"; then
   SQUID_STATE_SAVE([squid_krb5_save])
@@ -2294,7 +2277,7 @@ SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[
     squid_opt_netfilterconntrackpath=$withval
     LDFLAGS="-L$squid_opt_netfilterconntrackpath/lib $LDFLAGS"
     CPPFLAGS="-I$squid_opt_netfilterconntrackpath/include $CPPFLAGS"
-])
+],[LIBNETFILTER_CONNTRACK])
 squid_opt_netfilterconntrack=$with_netfilter_conntrack
 AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_conntrack:=auto}])
 if test "x$with_netfilter_conntrack" != "xno"; then
@@ -2699,9 +2682,8 @@ SQUID_DEFINE_BOOL(X_ACCELERATOR_VARY,${enable_x_accelerator_vary:=no},
 AC_MSG_NOTICE([X-Accelerator-Vary support enabled: $enable_x_accelerator_vary])
 
 SQUID_AUTO_LIB(cppunit,[cppunit test framework],[
-  LIBCPPUNIT_CFLAGS="-I$with_cppunit/include"
   LIBCPPUNIT_LIBS="-L$with_cppunit/lib -lcppunit"
-])
+],[LIBCPPUNIT])
 AS_IF([test "x$with_cppunit" != "xno"],[
   PKG_CHECK_MODULES([LIBCPPUNIT],[cppunit],[
     squid_cv_cppunit_version="`pkg-config cppunit --version`"
@@ -2987,7 +2969,7 @@ AC_FUNC_ALLOCA
 # TODO: remove this 'lib' prefix to match coding standard
 SQUID_AUTO_LIB(libcap,[Linux capabilities],[
   AC_MSG_ERROR([unrecognized argument to --with-libcap : $withval])
-])
+],[LIBCAP])
 if test "x$with_libcap" != "xno"; then
   # cap_clear_flag is the most recent libcap function we require
   AC_CHECK_HEADERS(sys/capability.h)


### PR DESCRIPTION
Squid macros to simplify most AC_ARG_WITH behaviour. 

These macros perform the necessary checks for on/off and
custom library path validation for Squid coding policy.

Usage:
* When the parameter is for a build value rather than a
  library to link. Use AC_ARG_WITH.

* When a library is experimental and should default disable.
   Use SQUID_OPTIONAL_LIB to detect the --with parameter.

* When a library is expected to be available and default enable.
  Use SQUID_AUTO_LIB to detect --without parameter.



Sets pkg-config variables to enable more consistent configure.ac
logic for libraries even if pkg-config is not used or supported
for any specific library.

Fixes several trivial bugs where unnecessary or duplicate
library entries were injected into CXXFLAGS, LDFLAGS and similar.
Followup logic for some libraries is adjusted to inject the
pkg-config variables to retain build behaviour for now.
