### PR TITLE
Preserve caller context in commHandleWriteHelper()

### DIFF
--- a/src/ClientInfo.h
+++ b/src/ClientInfo.h
@@ -78,6 +78,8 @@ public:
     unsigned int quotaPeekReserv() const; ///< returns the next reserv. to pop
     void quotaDequeue(); ///< pops queue head from queue
     void kickQuotaQueue(); ///< schedule commHandleWriteHelper call
+    /// either selects the head descriptor for writing or calls quotaDequeue()
+    void writeOrDequeue();
 
     /* BandwidthBucket API */
     virtual int quota() override; ///< allocate quota for a just dequeued client

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1284,7 +1284,7 @@ commHandleWriteHelper(void * data)
             return;
     } while (clientInfo->hasQueue());
 
-    debugs(77,3, "emptied queue");
+    debugs(77, 3, "emptied queue");
 }
 
 void


### PR DESCRIPTION
This event handler resumes write operations for descriptors,
queued due to delay pool restraints. Before this fix, the enqueuing
code did not save and the dequeuing code did not restore transaction
contexts.