### PR TITLE
Bug 5041: Missing Debug::Extra breaks build on hosts with systemd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2162,6 +2162,7 @@ if test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"; then
   fi
   if test "x$SYSTEMD_LIBS" != "x" ; then
     CXXFLAGS="$SYSTEMD_CFLAGS $CXXFLAGS"
+    LDFLAGS="$SYSTEMD_LIBS $LDFLAGS"
     AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
   else
     with_systemd=no

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -99,6 +99,10 @@ public:
 
     /// configures the active debugging context to write syslog ALERT
     static void ForceAlert();
+
+    /// prefixes each grouped debugs() line after the first one in the group
+    static std::ostream& Extra(std::ostream &os) { return os << "\n    "; }
+
 private:
     static Context *Current; ///< deepest active context; nil outside debugs()
 };

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -108,6 +108,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--without-gnutls \
 	--without-openssl \
 	--without-po2html \
+	--without-systemd \
 	"
 
 # Fix the distclean testing.


### PR DESCRIPTION
Master commit 6fa8c66 (i.e. Bug 5016 fix) relied on Debug::Extra added
by master commit (ccfbe8f) that was not ported to v4. The port of the
former commit lacked the required piece of the latter commit, breaking
v4 build since v4 commit 62f38c1.

The problem is invisible on hosts without a systemd package (that Squid
can find/use) and with Squids explicitly ./configured --without-systemd.