### PR TITLE
Add missing libsystemd build logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2008,22 +2008,7 @@ esac
 AC_SUBST(LDAPLIB)
 AC_SUBST(LBERLIB)
 
-AC_ARG_WITH(systemd,
-  AS_HELP_STRING([--without-systemd],
-                 [Do not use systemd API to send start-up completion
-                  notification. Default: auto-detect]), [
-case "$with_systemd" in
-  yes|no)
-    : # Nothing special to do here
-    ;;
-  *)
-    if test ! -d "$withval" ; then
-      AC_MSG_ERROR([--with-systemd path does not point to a directory])
-    fi
-    SYSTEMD_PATH="-L$with_systemd/lib"
-    CPPFLAGS="-I$with_systemd/include $CPPFLAGS"
-  esac
-])
+SQUID_AUTO_LIB(systemd,[systemd API for start-up notification],[SYSTEMD])
 AH_TEMPLATE(USE_SYSTEMD,[systemd support is available])
 if test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"; then
   SQUID_STATE_SAVE(squid_systemd_state)
@@ -2046,7 +2031,7 @@ if test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"; then
   fi
   if test "x$SYSTEMD_LIBS" != "x" ; then
     CXXFLAGS="$SYSTEMD_CFLAGS $CXXFLAGS"
-    LDFLAGS="$SYSTEMD_LIBS $LDFLAGS"
+    LDFLAGS="$SYSTEMD_PATH $SYSTEMD_LIBS $LDFLAGS"
     AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
   else
     with_systemd=no

--- a/configure.ac
+++ b/configure.ac
@@ -2046,6 +2046,7 @@ if test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"; then
   fi
   if test "x$SYSTEMD_LIBS" != "x" ; then
     CXXFLAGS="$SYSTEMD_CFLAGS $CXXFLAGS"
+    LDFLAGS="$SYSTEMD_LIBS $LDFLAGS"
     AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
   else
     with_systemd=no

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -107,6 +107,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--without-gnutls \
 	--without-openssl \
 	--without-po2html \
+	--without-systemd \
 	--without-tdb \
 	"
 


### PR DESCRIPTION
* "Minimum build" test should run --without-systemd

* Add -lsystemd to linker flags

Completes the changes added in GitHub PR 539 (commit
6fa8c66435d55a2e713db0222cdca3a9dccf5bbe).
