### PR TITLE
Add --progress option to test-builds.sh

### DIFF
--- a/test-builds.sh
+++ b/test-builds.sh
@@ -33,6 +33,10 @@ while [ $# -ge 1 ]; do
 	verbose="yes"
 	shift
 	;;
+    --progress)
+    verbose="progress"
+    shift
+    ;;
     --keep-going)
 	keepGoing="yes"
 	shift
@@ -64,11 +68,16 @@ while [ $# -ge 1 ]; do
 done
 
 logtee() {
-    if [ $verbose = yes ]; then
-	tee $1
-    else
-	cat >$1
-    fi
+    case $verbose in
+    yes)
+        tee $1
+        ;;
+    progress)
+        tee $1 | awk '{printf "."} END {print "\n"}'
+        ;;
+    *)
+        cat >$1
+    esac
 }
 
 buildtest() {

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -73,7 +73,7 @@ logtee() {
         tee $1
         ;;
     progress)
-        tee $1 | awk '{printf "."} END {print "\n"}'
+        tee $1 | awk '{printf "."; n++; if (!(n % 80)) print "" } END {print ""}'
         ;;
     *)
         cat >$1


### PR DESCRIPTION
Add an option to test-builds.sh to emit dots
to enable tracking progress in the test without
being fully verbose

In the context of the build farm, this will save storage
and bandwidth on the build nodes, while still showing
issues if anything were to occur, and showing whether
progress is being made or a build is stuck.