### PR TITLE
Fixed TLS selected_version parsing and debugging

### DIFF
--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -568,8 +568,8 @@ Security::HandshakeParser::parseSupportedVersionsExtension(const SBuf &extension
         // v1.3 server by sending supported_versions containing just X.
     } else {
         assert(messageSource == fromServer);
-        Parser::BinaryTokenizer tkVersion(extensionData, "selected_version");
-        const auto version = ParseProtocolVersion(tkVersion);
+        Parser::BinaryTokenizer tkVersion(extensionData);
+        const auto version = ParseProtocolVersion(tkVersion, "selected_version");
         // RFC 8446 Section 4.2.1:
         // A server which negotiates a version of TLS prior to TLS 1.3 [...]
         // MUST NOT send the "supported_versions" extension.


### PR DESCRIPTION
The description of the expected input was given to the wrong parsing
function. This typo may have affected parsing because it told the TLS
version tokenizer that more data may be expected for the already fully
extracted extension. I believe that the lie could affect error
diagnostic when parsing malformed input, but had no effect on handling
well-formed TLS handshakes (other than less-specific debugging).

Detected by Coverity. CID 1462621: Incorrect expression (NO_EFFECT)

Broken by master commit cd29a42.