### PR TITLE
test-builds.sh: in case of error dump full log

### DIFF
--- a/test-builds.sh
+++ b/test-builds.sh
@@ -139,8 +139,10 @@ buildtest() {
 	fi
     else
         if test "${verbose}" != "yes" ; then
-            echo "Build Failed. Full log dump:"
+            echo "Build Failed."
+            echo "Log start: ${log}"
             cat ${log}
+            echo "Log end: ${log}"
         else
             echo "Build FAILED."
         fi

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -139,8 +139,8 @@ buildtest() {
 	fi
     else
         if test "${verbose}" != "yes" ; then
-            echo "Build Failed. Last log lines are:"
-            tail -20 ${log}
+            echo "Build Failed. Full log dump:"
+            cat ${log}
         else
             echo "Build FAILED."
         fi


### PR DESCRIPTION
Change behaviour of the test-builds script to
dump the full output of the current layer's log in
case of error. This will help better diagnose errors
as the root cause of an error may have exited the 20-lines
buffer we currently use