### PR TITLE
Bug 5046: FreeBSD lacks open(2) O_DSYNC flag

### DIFF
--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -144,7 +144,6 @@ static void init_db(void)
     db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, O_CREAT|O_DSYNC, 0666);
 #endif
     if (!db) {
-    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, , 0666);
         fprintf(stderr, "FATAL: %s: Failed to open session db '%s'\n", program_name, db_path);
         shutdown_db();
         exit(EXIT_FAILURE);

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -137,15 +137,14 @@ static void init_db(void)
         }
     }
 #elif USE_TRIVIALDB
-#if _SQUID_FREEBSD_
+#if _SQUID_FREEBSD_ && !defined(O_DSYNC)
     // FreeBSD lacks O_DSYNC, O_SYNC is closest to correct behaviour
-    const auto openFlags = O_CREAT|O_SYNC;
-#else
-    const auto openFlags = O_CREAT|O_DSYNC;
+#define O_DSYNC O_SYNC
 #endif
-    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, openFlags, 0666);
+    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, O_CREAT|O_DSYNC, 0666);
 #endif
     if (!db) {
+    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, , 0666);
         fprintf(stderr, "FATAL: %s: Failed to open session db '%s'\n", program_name, db_path);
         shutdown_db();
         exit(EXIT_FAILURE);

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -137,7 +137,12 @@ static void init_db(void)
         }
     }
 #elif USE_TRIVIALDB
+#if _SQUID_FREEBSD_
+    // FreeBSD lacks O_DSYNC, O_SYNC is closest to correct behaviour
+    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, O_CREAT|O_SYNC, 0666);
+#else
     db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, O_CREAT|O_DSYNC, 0666);
+#endif
 #endif
     if (!db) {
         fprintf(stderr, "FATAL: %s: Failed to open session db '%s'\n", program_name, db_path);

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -139,10 +139,11 @@ static void init_db(void)
 #elif USE_TRIVIALDB
 #if _SQUID_FREEBSD_
     // FreeBSD lacks O_DSYNC, O_SYNC is closest to correct behaviour
-    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, O_CREAT|O_SYNC, 0666);
+    const auto openFlags = O_CREAT|O_SYNC;
 #else
-    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, O_CREAT|O_DSYNC, 0666);
+    const auto openFlags = O_CREAT|O_DSYNC;
 #endif
+    db = tdb_open(db_path, 0, TDB_CLEAR_IF_FIRST, openFlags, 0666);
 #endif
     if (!db) {
         fprintf(stderr, "FATAL: %s: Failed to open session db '%s'\n", program_name, db_path);


### PR DESCRIPTION
ext_session_acl built with TrivialDB uses O_DSYNC to ensure
thread-safe manipulation of data within the TDB files in Squid
multi-process environment.

FreeBSD lacks this flag entirely. Use the O_SYNC flag as a
backup, which apparently provides file-level synchronization.
It is not clear whether this flag will prevent duplicate keys or
record overwrites in the case of process write race collisions.

NP: this appears to be FreeBSD specific. Other BSD either define
O_DSYNC or lack support for these POSIX flags entirely.
