### PR TITLE
Bug 5045: ext_edirectory_userip_acl is missing include files

### DIFF
--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -69,6 +69,12 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
 
 #ifdef HELPER_INPUT_BUFFER
 #define EDUI_MAXLEN     HELPER_INPUT_BUFFER


### PR DESCRIPTION
Discovered on FreeBSD v12.1 running on amd64 with clang v8.0.1.

    error: use of undeclared identifier 'AF_INET6'
    error: member access into incomplete type 'struct sockaddr_in6'
    ...

Co-Authored-By: Pavel Timofeev <timp87@gmail.com>