### PR TITLE
gcc-8+ build error: undefined reference to __atomic_is_lock_free

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -447,7 +447,7 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
   AC_LINK_IFELSE([
     AC_LANG_SOURCE([[
       #include <atomic>
-      struct LockRequired { char data[2]; };
+      struct LockRequired { char data[256]; };
       int
       main() {
           return std::atomic<LockRequired>{}.is_lock_free();

--- a/configure.ac
+++ b/configure.ac
@@ -467,7 +467,8 @@ AS_IF([test "x$libatomic_checker_result" = "xno"],[
   LIBS="$LIBS -latomic"
   LIBATOMIC_CHECKER(with)
   AS_IF([test "x$libatomic_checker_result" = "xyes"],[
-    ATOMICLIB="-latomic"
+    ATOMICLIB="-latomic"],[
+    AC_MSG_ERROR([Required library libatomic not found.])
 ])])
 SQUID_STATE_ROLLBACK(LIBATOMIC)
 AC_SUBST(ATOMICLIB)

--- a/configure.ac
+++ b/configure.ac
@@ -443,23 +443,34 @@ if test "x$with_dl" != "xno"; then
   AC_CHECK_LIB(dl, dlopen)
 fi
 
+AC_DEFUN([LIBATOMIC_CHECKER],[
+  AC_LINK_IFELSE([
+    AC_LANG_SOURCE([[
+      #include <atomic>
+      struct LockRequired { char data[2]; };
+      int
+      main() {
+          return std::atomic<LockRequired>{}.is_lock_free();
+      }
+  ]])],[
+    AC_MSG_RESULT(yes)
+    libatomic_checker_result="yes"],[
+    AC_MSG_RESULT(no)
+    libatomic_checker_result="no"
+])])
+
 ## check for atomics library before anything that might need it
 SQUID_STATE_SAVE(LIBATOMIC)
-AC_MSG_CHECKING(whether -latomic is a good idea)
-LIBS="$LIBS -latomic"
-AC_LINK_IFELSE(
-  [AC_LANG_SOURCE([[
-    #include <atomic>
-    struct LockRequired { char data[256]; };
-    int
-    main() {
-        return std::atomic<LockRequired>{}.is_lock_free();
-    }
-  ]])],
-  [AC_MSG_RESULT(yes)
-   ATOMICLIB='-latomic'],
-  [AC_MSG_RESULT(no)]
-)
+AC_MSG_CHECKING(whether linking without -latomic works)
+LIBATOMIC_CHECKER()
+if test "x$libatomic_checker_result" = "xno"; then
+  AC_MSG_CHECKING(whether linking with -latomic works)
+  LIBS="$LIBS -latomic"
+  LIBATOMIC_CHECKER()
+  if test "x$libatomic_checker_result" = "xyes"; then
+    ATOMICLIB="-latomic"
+  fi
+fi
 SQUID_STATE_ROLLBACK(LIBATOMIC)
 AC_SUBST(ATOMICLIB)
 

--- a/configure.ac
+++ b/configure.ac
@@ -448,10 +448,10 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
   AC_LINK_IFELSE([
     AC_LANG_SOURCE([[
 #include <atomic>
-      struct LockRequired { char data[256]; };
+#include <cstdint>
       int
       main(int, char **) {
-          return std::atomic<LockRequired>{}.is_lock_free();
+          return std::atomic<uint64_t>{}.is_lock_free() ? 0 : 1;
       }
   ]])],[
     AC_MSG_RESULT(yes)

--- a/configure.ac
+++ b/configure.ac
@@ -444,6 +444,7 @@ if test "x$with_dl" != "xno"; then
 fi
 
 AC_DEFUN([LIBATOMIC_CHECKER],[
+  AC_MSG_CHECKING(whether linking $1 -latomic works)
   AC_LINK_IFELSE([
     AC_LANG_SOURCE([[
       #include <atomic>
@@ -461,12 +462,10 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
 
 ## check for atomics library before anything that might need it
 SQUID_STATE_SAVE(LIBATOMIC)
-AC_MSG_CHECKING(whether linking without -latomic works)
-LIBATOMIC_CHECKER()
+LIBATOMIC_CHECKER(without)
 if test "x$libatomic_checker_result" = "xno"; then
-  AC_MSG_CHECKING(whether linking with -latomic works)
   LIBS="$LIBS -latomic"
-  LIBATOMIC_CHECKER()
+  LIBATOMIC_CHECKER(with)
   if test "x$libatomic_checker_result" = "xyes"; then
     ATOMICLIB="-latomic"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -447,10 +447,10 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
   AC_MSG_CHECKING(whether linking $1 -latomic works)
   AC_LINK_IFELSE([
     AC_LANG_SOURCE([[
-      #include <atomic>
+#include <atomic>
       struct LockRequired { char data[256]; };
       int
-      main() {
+      main(int, char **) {
           return std::atomic<LockRequired>{}.is_lock_free();
       }
   ]])],[
@@ -463,13 +463,12 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
 ## check for atomics library before anything that might need it
 SQUID_STATE_SAVE(LIBATOMIC)
 LIBATOMIC_CHECKER(without)
-if test "x$libatomic_checker_result" = "xno"; then
+AS_IF([test "x$libatomic_checker_result" = "xno"],[
   LIBS="$LIBS -latomic"
   LIBATOMIC_CHECKER(with)
-  if test "x$libatomic_checker_result" = "xyes"; then
+  AS_IF([test "x$libatomic_checker_result" = "xyes"],[
     ATOMICLIB="-latomic"
-  fi
-fi
+])])
 SQUID_STATE_ROLLBACK(LIBATOMIC)
 AC_SUBST(ATOMICLIB)
 

--- a/configure.ac
+++ b/configure.ac
@@ -444,10 +444,20 @@ if test "x$with_dl" != "xno"; then
 fi
 
 ## check for atomics library before anything that might need it
-# AC_SEARCH_LIBS pollutes LIBS
 SQUID_STATE_SAVE(LIBATOMIC)
-AC_SEARCH_LIBS([__atomic_load_8],[atomic],[
-  test "$ac_res" = "none required" || ATOMICLIB=$ac_res],[])
+AC_MSG_CHECKING(library containing __atomic_is_lock_free)
+LIBS="-latomic"
+AC_LINK_IFELSE(
+  [AC_LANG_SOURCE([[
+    int main(void) {
+        char lockRequired[256];
+        return __atomic_is_lock_free(sizeof(lockRequired),&lockRequired);
+    }
+  ]])],
+  [AC_MSG_RESULT(-latomic)
+   ATOMICLIB='-latomic'],
+  [AC_MSG_RESULT(no)]
+)
 SQUID_STATE_ROLLBACK(LIBATOMIC)
 AC_SUBST(ATOMICLIB)
 

--- a/configure.ac
+++ b/configure.ac
@@ -445,16 +445,18 @@ fi
 
 ## check for atomics library before anything that might need it
 SQUID_STATE_SAVE(LIBATOMIC)
-AC_MSG_CHECKING(library containing __atomic_is_lock_free)
-LIBS="-latomic"
+AC_MSG_CHECKING(whether -latomic is a good idea)
+LIBS="$LIBS -latomic"
 AC_LINK_IFELSE(
   [AC_LANG_SOURCE([[
-    int main(void) {
-        char lockRequired[256];
-        return __atomic_is_lock_free(sizeof(lockRequired),&lockRequired);
+    #include <atomic>
+    struct LockRequired { char data[256]; };
+    int
+    main() {
+        return std::atomic<LockRequired>{}.is_lock_free();
     }
   ]])],
-  [AC_MSG_RESULT(-latomic)
+  [AC_MSG_RESULT(yes)
    ATOMICLIB='-latomic'],
   [AC_MSG_RESULT(no)]
 )


### PR DESCRIPTION
Compilers warned about AC_SEARCH_LIBS(__atomic_load_8)-generated code.
Newer, stricter compilers (e.g., gcc-8), exit with an error, resulting
in AC_SEARCH_LIBS failure when determining whether libatomic is needed.

More at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=907277#30

It is unclear whether autoconf will ever handle this case better. Let's
use a custom-made test for now. The current test refuses to build Squid
on platforms where a program using std::atomic<T>::is_lock_free() cannot
be successfully linked (either with or without libatomic) for a the
largest atomic T used by Squid (i.e. a 64 bit integer).

Linking with libatomic may be required for many reasons that we do not
fully understand, but we know that std::atomic<T>::is_lock_free() does
require linking with libatomic in some environments, even where T is an
inlineable atomic. That is why we use that as a test case.