### PR TITLE
Cycling ip addresses to enable loadbalancing

### DIFF
--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -648,6 +648,8 @@ ipcache_nbgethostbyname_(const char *name, IpCacheLookupForwarder handler)
         /* hit */
         debugs(14, 4, "ipcache_nbgethostbyname: HIT for '" << name << "'");
 
+        ipcacheCycleAddr(name, &i->addrs);
+
         if (i->flags.negcached)
             ++IpcacheStats.negative_hits;
         else


### PR DESCRIPTION
When an FQDN which resolves to more than one IP address is
being used, squid always uses the first IP from the list.
This contribution would rotate the list of IP addresses,
thus enabling loadbalancing.