### PR TITLE
Fix whitespace shell bugs in configure library detection

### DIFF
--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -175,10 +175,10 @@ AC_DEFUN([SQUID_AUTO_LIB],[
   AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
     AS_CASE(["$withval"],[yes|no],,[
       AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
-      set with_$squid_auto_lib = yes
-      AS_IF([test -d "$withval/lib64"],[$3_PATH += "-L$withval/lib64"])
-      AS_IF([test -d "$withval/lib"],[$3_PATH += "-L$withval/lib"])
-      $3_CFLAGS="-I$withval/include"
+      set with_$squid_auto_lib=yes
+      AS_IF([test -d "$withval/lib64"],[$3_PATH+="-L$withval/lib64"])
+      AS_IF([test -d "$withval/lib"],[$3_PATH+="-L$withval/lib"])
+      AS_IF([test -d "$withval/include"],[$3_CFLAGS+="-I$withval/include"])
     ])
   ])
   unset squid_auto_lib
@@ -186,14 +186,14 @@ AC_DEFUN([SQUID_AUTO_LIB],[
 dnl same as SQUID_AUTO_LIB but for default-disabled libraries
 AC_DEFUN([SQUID_OPTIONAL_LIB],[
   squid_auto_lib=`echo $1|tr "\-" "_"`
-  set with_$squid_auto_lib = no
+  set with_$squid_auto_lib=no
   AC_ARG_WITH([$1],AS_HELP_STRING([--with-$1],[Compile with the $2 library.]),[
-    AS_CASE(["$with_$1"],[yes|no],,[
-      AS_IF([test ! -d "$with_$1"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
-      with_$squid_auto_lib=yes
-      AS_IF([test -d "$withval/lib64"],[$3_PATH += "-L$withval/lib64"])
-      AS_IF([test -d "$withval/lib"],[$3_PATH += "-L$withval/lib"])
-      $3_CFLAGS="-I$withval/include"
+    AS_CASE(["$withval"],[yes|no],,[
+      AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
+      set with_$squid_auto_lib=yes
+      AS_IF([test -d "$withval/lib64"],[$3_PATH+="-L$withval/lib64"])
+      AS_IF([test -d "$withval/lib"],[$3_PATH+="-L$withval/lib"])
+      AS_IF([test -d "$withval/include"],[$3_CFLAGS+="-I$withval/include"])
     ])
   ])
   unset squid_auto_lib

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -171,32 +171,28 @@ dnl 1) binary library name (without 'lib' prefix)
 dnl 2) name of the library for human reading
 dnl 3) prefix used for pkg-check macros
 AC_DEFUN([SQUID_AUTO_LIB],[
-  squid_auto_lib=`echo $1|tr "\-" "_"`
   AC_ARG_WITH([$1],AS_HELP_STRING([--without-$1],[Compile without the $2 library.]),[
     AS_CASE(["$withval"],[yes|no],,[
       AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
-      set with_$squid_auto_lib=yes
+      m4_translit([with_$1], [-+.], [___])=yes
       AS_IF([test -d "$withval/lib64"],[$3_PATH+="-L$withval/lib64"])
       AS_IF([test -d "$withval/lib"],[$3_PATH+="-L$withval/lib"])
       AS_IF([test -d "$withval/include"],[$3_CFLAGS+="-I$withval/include"])
     ])
   ])
-  unset squid_auto_lib
 ])
 dnl same as SQUID_AUTO_LIB but for default-disabled libraries
 AC_DEFUN([SQUID_OPTIONAL_LIB],[
-  squid_auto_lib=`echo $1|tr "\-" "_"`
-  set with_$squid_auto_lib=no
   AC_ARG_WITH([$1],AS_HELP_STRING([--with-$1],[Compile with the $2 library.]),[
     AS_CASE(["$withval"],[yes|no],,[
       AS_IF([test ! -d "$withval"],AC_MSG_ERROR([--with-$1 path does not point to a directory]))
-      set with_$squid_auto_lib=yes
+      m4_translit([with_$1], [-+.], [___])=yes
       AS_IF([test -d "$withval/lib64"],[$3_PATH+="-L$withval/lib64"])
       AS_IF([test -d "$withval/lib"],[$3_PATH+="-L$withval/lib"])
       AS_IF([test -d "$withval/include"],[$3_CFLAGS+="-I$withval/include"])
     ])
   ])
-  unset squid_auto_lib
+  AS_IF([test "x$withval" = "x"],[m4_translit([with_$1], [-+.], [___])=no])
 ])
 
 AC_DEFUN([SQUID_EMBED_BUILD_INFO],[


### PR DESCRIPTION
Whitespace around shell variable assign and append operators
results in those operations not being performed.
This caused the with_*, *_PATH and *_LIBS variables to not
be set to the correct path when a custom path is used.

Also, lack of condition on the *_CFLAGS assign can pollute
the compiler parameters with non-existent directories.
It should also have been an append like PATH and LIBS to
add the auto-detected value after any user-provided value
instead of overwriting.

Broken since master commit 2453140.