### PR TITLE
Fix PoolingAllocator build errors with older GCCs

### DIFF
--- a/src/mem/PoolingAllocator.h
+++ b/src/mem/PoolingAllocator.h
@@ -22,6 +22,23 @@ public:
     template <class Other> PoolingAllocator(const PoolingAllocator<Other> &) noexcept {}
     value_type *allocate(std::size_t n) { return static_cast<value_type*>(memAllocRigid(n*sizeof(value_type))); }
     void deallocate(value_type *vp, std::size_t n) noexcept { memFreeRigid(vp, n*sizeof(value_type)); }
+
+    // The following declarations are only necessary for compilers that do not
+    // fully support C++11 Allocator-related APIs, such as GCC v4.8.
+    // TODO: Remove after dropping support for such compilers.
+
+    using size_type = size_t;
+    using pointer = Value*;
+    using const_pointer = const Value*;
+    using reference = Value&;
+    using const_reference = const Value&;
+
+    template <class OtherValue>
+    struct rebind {
+      typedef PoolingAllocator<OtherValue> other;
+    };
+
+    template<typename OtherValue> void destroy(OtherValue *p) { p->~OtherValue(); }
 };
 
 template <class L, class R>


### PR DESCRIPTION
    error: no class template named rebind in class PoolingAllocator

GCC v4.8.4 (at least) does not fully implement C++11 Allocator-related
APIs, forcing the developer to manually provide Allocator traits that
are supposed to come automatically via std::allocator_traits.

The problem may only manifest itself when using a custom allocator with
types such as std::map<T> and std::list<T> that allocate wrapper
objects instead of Ts. For example, std::vector is unaffected.