### PR TITLE
Fix Linux build with glibc v2.30 which deprecated sys/sysctl.h

### DIFF
--- a/src/eui/Eui48.cc
+++ b/src/eui/Eui48.cc
@@ -45,8 +45,10 @@ struct arpreq {
 /* required by Solaris */
 #include <sys/sockio.h>
 #endif
+#if _SQUID_FREEBSD_ || _SQUID_NETBSD_ || _SQUID_OPENBSD_ || _SQUID_DRAGONFLY_ || _SQUID_KFREEBSD_
 #if HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
+#endif
 #endif
 #if HAVE_NET_ROUTE_H
 #include <net/route.h>


### PR DESCRIPTION
    error: #warning "The <sys/sysctl.h> header is deprecated and
    will be removed." [-Werror=cpp]

Squid only uses sysctl() on FreeBSD and friends so let's not #include
sys/sysctl.h in other environments. The existing compat/shm.cc already
uses a similar condition for including this header.

Glibc recommends using /proc instead of the sysctl.h they deprecated,
but that is probably not an option for FreeBSD anyway.