### PR TITLE
WIP: fast shutdown sequence

### DIFF
--- a/src/base/RunnersRegistry.h
+++ b/src/base/RunnersRegistry.h
@@ -73,6 +73,12 @@ public:
     /// Meant for cleanup and state saving that may require other modules.
     virtual void startShutdown() {}
 
+    /// Called once per second after receiving a shutdown request and before
+    /// stopping the main loop. At least one main loop iteration is guaranteed
+    /// after this call.
+    /// Meant for cleanup and state saving that may require other modules.
+    virtual void checkShutdown() {}
+
     /// Called after shutdown_lifetime grace period ends and before stopping
     /// the main loop. At least one main loop iteration is guaranteed after
     /// this call.

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -845,6 +845,7 @@ comm_close_complete(const FdeCbParams &params)
     fde *F = &fd_table[params.fd];
     F->ssl.reset();
     F->dynamicTlsContext.reset();
+    F->flags.client_connection = false; // reset
     fd_close(params.fd);        /* update fdstat */
     close(params.fd);
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -436,6 +436,7 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
     F->remote_port = details->remote.port();
     F->local_addr = details->local;
     F->sock_family = details->local.isIPv6()?AF_INET6:AF_INET;
+    F->flags.client_connection = true;
 
     // set socket flags
     commSetCloseOnExec(sock);

--- a/src/fde.h
+++ b/src/fde.h
@@ -129,6 +129,7 @@ public:
         bool read_pending = false;
         //bool write_pending; //XXX seems not to be used
         bool transparent = false;
+        bool client_connection = false;
     } flags;
 
     int64_t bytes_read = 0;


### PR DESCRIPTION
Add a 'shutdown tick' to the shutdown period where registered
runners can be polled for early completion of their shutdown.

Also, flag which FD are open client connections so shutdown
process finish can be triggered as soon as no clients are
waiting for transaction completion.

Turns shutdown_timeout into a proper timeout instead of a
minimum delay for shutdown.
