### PR TITLE
source-maintenance.sh: add command line options

### DIFF
--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -35,6 +35,14 @@ while [ $# -ge 1 ]; do
         KeepGoingDirective=$1
         shift
         ;;
+    --skip-astyle-version-check)
+        SkipAstyleVersionCheck=yes
+        shift
+        ;;
+    --verbose|-v)
+        Verbose=yes
+        shift
+        ;;
     *)
         echo "Usage: $0 [--keep-going|-k]"
         echo "Unsupported command-line option: $1"
@@ -67,6 +75,10 @@ if test "${ASVER}" != "2.04" ; then
 	ASVER=""
 else
 	echo "Found astyle ${ASVER}. Formatting..."
+fi
+if test "${SkipAstyleVersionCheck}" = "yes" && test -z "${ASVER}" ; then
+    echo "Ignoring astyle version mismatch as instrcuted"
+    ASVER="any"
 fi
 
 COPYRIGHT_YEARS=`date +"1996-%Y"`
@@ -115,6 +127,7 @@ applyPlugin ()
 
 srcFormat ()
 {
+test -n "${Verbose}" && echo "Source formatting"
 #
 # Scan for incorrect use of #ifdef/#ifndef
 #
@@ -128,6 +141,7 @@ git grep "ifn?def .*_SQUID_" |
 #
 for FILENAME in `git ls-files`; do
     skip_copyright_check=""
+    test -n "${Verbose}" && echo ${FILENAME}
 
     # skip subdirectories, git ls-files is recursive
     test -d $FILENAME && continue


### PR DESCRIPTION
Add --verbose to help track what's happening
Add --skip-astyle-version-check to accept any astyle
version installed on the system