### PR TITLE
Maintenance: Remove FIXME and \todo labels

### DIFF
--- a/compat/os/os2.h
+++ b/compat/os/os2.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /*
-*  FIXME: the os2 port of bash seems to have problems checking
+*  XXX: the os2 port of bash seems to have problems checking
 *  the return codes of programs in if statements.  These options
 *  need to be overridden.
 */

--- a/configure.ac
+++ b/configure.ac
@@ -3043,7 +3043,7 @@ else
       AC_MSG_NOTICE([skipping libmalloc check for $host])
       ;;
     *)
-      #used later. FIXME
+      # XXX: used later
       AC_CHECK_LIB(malloc, main)
       ;;
   esac

--- a/doc/Programming-Guide/03_MajorComponents.dox
+++ b/doc/Programming-Guide/03_MajorComponents.dox
@@ -22,7 +22,7 @@
 	state information is stored in the clientSocketContext
 	structure. With HTTP/1.1 we may have multiple requests from
 	a single TCP connection.
-\todo DOCS: find out what has replaced clientSocketContext since it seems to not exist now.
+TODO: find out what has replaced clientSocketContext since it seems to not exist now.
 
 \section ClientSideRequest Client Side Request
 \par
@@ -31,7 +31,7 @@
 	and setup the initial client stream for internal requests.
 	Temporary state for this processing is held in a 
 	clientRequestContext.
-\todo DOCS: find out what has replaced clientRequestContext since it seems not to exist now.
+TODO: find out what has replaced clientRequestContext since it seems not to exist now.
 
 \section ClientSideReply Client Side Reply	
 \par
@@ -112,7 +112,7 @@
 	network sockets.  These routines do not support queuing
 	multiple blocks of data for writing.  Consequently, a
 	callback occurs for every write request.
-\todo DOCS: decide what to do for comm_poll() since its either obsolete or uses other names.
+TODO: decide what to do for comm_poll() since its either obsolete or uses other names.
 
 \section FileDiskIO File/Disk I/O
 \par
@@ -153,7 +153,7 @@
 	The cache manager provides essentially "read-only" access
 	to information.  It does not provide a method for configuring
 	Squid while it is running.
-\todo DOCS: get cachemgr.cgi documenting
+TODO: get cachemgr.cgi documenting
 
 \section NetworkMeasurementDB Network Measurement Database
 \par
@@ -195,12 +195,12 @@
 \par
 	The primary configuration file specification is in the file
 	cf.data.pre.  A simple utility program, cf_gen,
-	reads the cf.data.pre file and generates cf_parser.c
-	and squid.conf.  cf_parser.c is included directly
-	into cache_cf.c at compile time.
-\todo DOCS: get cf.data.pre documenting
-\todo DOCS: get squid.conf documenting
-\todo DOCS: get cf_gen documenting and linking.
+	reads the cf.data.pre file and generates cf_parser.cci
+	and squid.conf.  cf_parser.cci is included directly
+	into cache_cf.cc at compile time.
+TODO: get cf.data.pre documenting
+TODO: get squid.conf documenting
+TODO: get cf_gen documenting and linking.
 
 \section Callback Data Allocator
 \par
@@ -210,7 +210,7 @@
 	the callback function is executed.  The routines in cbdata.c
 	provide a uniform method for managing callback data memory,
 	canceling callbacks, and preventing erroneous memory accesses.
-\todo DOCS: get callback_data (object?) linking or replacement named.
+TODO: get callback_data (object?) linking or replacement named.
 
 \section RefCountDataAllocator Refcount Data Allocator
 \since Squid 3.0
@@ -220,7 +220,7 @@
 	allows us to create automatic reference counting pointers, that will
 	free objects when they are no longer needed. With some care these 
 	objects can be passed to functions needed Callback Data pointers.
-\todo DOCS: get cbdata documenting and linking.
+TODO: get cbdata documenting and linking.
 
 \section Debugging Debugging
 \par
@@ -237,7 +237,7 @@
 	level for that section, it will be shown.  This description
 	probably sounds more complicated than it really is.
 	File: debug.c.  Note that debugs() itself is a macro.
-\todo DOCS: get debugs() documenting as if it was a function.
+TODO: get debugs() documenting as if it was a function.
 
 \section ErrorGeneration Error Generation
 \par
@@ -290,7 +290,7 @@
 	ICP queries from Netcache/Netapp caches; they use
 	a different version number and a slightly different message
 	format.
-\todo DOCS: get RFCs linked from ietf
+TODO: get RFCs linked from ietf
 
 \section IdentLookups Ident Lookups
 \par

--- a/doc/Programming-Guide/Groups.dox
+++ b/doc/Programming-Guide/Groups.dox
@@ -74,13 +74,13 @@
 
 /**
  \defgroup Timeouts		Timeouts
- \todo DOCS: document Timeouts.
+ * TODO: Write Documentation about Timeouts.
  */
 
 /**
  \defgroup ServerProtocolHTTP HTTP
  \ingroup ServerProtocol
- \todo Write Documentation about HTTP
+ * TODO: Write Documentation about HTTP.
  */
 
 /**
@@ -91,11 +91,11 @@
 /**
  \defgroup ServerProtocolWAIS WAIS
  \ingroup ServerProtocol
- \todo Write Documentation about Wais
+ * TODO: Write Documentation about Wais.
  */
 
 /**
  \defgroup ServerProtocolPassthru Passthru
  \ingroup ServerProtocol
- \todo Write Documentation about Passthru
+ * TODO: Write Documentation about Passthru.
  */

--- a/include/base64.h
+++ b/include/base64.h
@@ -104,8 +104,8 @@ base64_encode_final(struct base64_encode_ctx *ctx,
 
 /* Encodes a string in one go, including any padding at the end.
  * Generates exactly BASE64_ENCODE_RAW_LENGTH(length) bytes of output.
- * Supports overlapped operation, if src <= dst. FIXME: Use of overlap
- * is deprecated, if needed there should be a separate public function
+ * Supports overlapped operation, if src <= dst.
+ * TODO: Use of overlap is deprecated, if needed there should be a separate public function
  * to do that.*/
 void
 base64_encode_raw(char *dst, size_t length, const uint8_t *src);

--- a/lib/rfcnb/ReadMe.1st
+++ b/lib/rfcnb/ReadMe.1st
@@ -53,3 +53,4 @@ rfcnb-io.c:           all IO to network occurs here
 test_rfcnb.c:         a small test program
 
 session.c:            all session routine code is here
+

--- a/lib/rfcnb/ReadMe.1st
+++ b/lib/rfcnb/ReadMe.1st
@@ -53,8 +53,3 @@ rfcnb-io.c:           all IO to network occurs here
 test_rfcnb.c:         a small test program
 
 session.c:            all session routine code is here
-
-todo:                 a list of things I would like to do ...
-
-
-

--- a/squid.dox
+++ b/squid.dox
@@ -620,7 +620,7 @@ STRICT_PROTO_MATCHING  = NO
 # list. This list is created by putting \todo commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TODOLIST      = YES
+GENERATE_TODOLIST      = NO
 
 # The GENERATE_TESTLIST tag can be used to enable (YES) or disable (NO) the test
 # list. This list is created by putting \test commands in the documentation.
@@ -848,6 +848,7 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */CVS/* \
+                         */.git* \
                          */lib/libTrie/* \
                          */libltdl/* \
                          */Programming-Guide/html/* \

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -79,8 +79,8 @@ public:
     // are stored in hier.tcpServer
 
     /** \brief This subclass holds log info for HTTP protocol
-     * \todo Inner class declarations should be moved outside
-     * \todo details of HTTP held in the parent class need moving into here.
+     * TODO: Inner class declarations should be moved outside
+     * TODO: details of HTTP held in the parent class need moving into here.
      */
     class HttpDetails
     {
@@ -104,7 +104,7 @@ public:
     } http;
 
     /** \brief This subclass holds log info for ICP protocol
-     * \todo Inner class declarations should be moved outside
+     * TODO: Inner class declarations should be moved outside
      */
     class IcpDetails
     {
@@ -113,7 +113,7 @@ public:
     } icp;
 
     /** \brief This subclass holds log info for HTCP protocol
-     * \todo Inner class declarations should be moved outside
+     * TODO: Inner class declarations should be moved outside
      */
     class HtcpDetails
     {
@@ -132,9 +132,9 @@ public:
 #endif
 
     /** \brief This subclass holds log info for Squid internal stats
-     * \todo Inner class declarations should be moved outside
-     * \todo some details relevant to particular protocols need shuffling to other sub-classes
-     * \todo this object field need renaming to 'squid' or something.
+     * TODO: Inner class declarations should be moved outside
+     * TODO: some details relevant to particular protocols need shuffling to other sub-classes
+     * TODO: this object field need renaming to 'squid' or something.
      */
     class CacheDetails
     {
@@ -161,7 +161,7 @@ public:
     } cache;
 
     /** \brief This subclass holds log info for various headers in raw format
-     * \todo shuffle this to the relevant protocol section.
+     * TODO: shuffle this to the relevant protocol section.
      */
     class Headers
     {
@@ -172,7 +172,7 @@ public:
 
 #if USE_ADAPTATION
     /** \brief This subclass holds general adaptation log info.
-     * \todo Inner class declarations should be moved outside.
+     * TODO: Inner class declarations should be moved outside.
      */
     class AdaptationDetails
     {
@@ -199,7 +199,7 @@ public:
 
 #if ICAP_CLIENT
     /** \brief This subclass holds log info for ICAP part of request
-     *  \todo Inner class declarations should be moved outside
+     *  TODO: Inner class declarations should be moved outside
      */
     class IcapLogEntry
     {

--- a/src/CommonPool.h
+++ b/src/CommonPool.h
@@ -18,7 +18,7 @@
 /*
  \ingroup DelayPoolsAPI
  *
- \todo Next steps: make this a composite, and TypeLabel a composite method.
+ * TODO: Next steps: make this a composite, and TypeLabel a composite method.
  * Then we have a legacy composite which returns class 1/2/3, and new
  * composites which return a descriptor of some sort.
  */

--- a/src/DelayPool.cc
+++ b/src/DelayPool.cc
@@ -75,7 +75,7 @@ DelayPool::freeData()
     pool = NULL;
 }
 
-/** \todo XXX create DelayIdComposite.cc */
+// XXX create DelayIdComposite.cc */
 void
 CompositePoolNode::delayRead(DeferredRead const &aRead)
 {

--- a/src/DelayPool.cc
+++ b/src/DelayPool.cc
@@ -75,7 +75,7 @@ DelayPool::freeData()
     pool = NULL;
 }
 
-// XXX create DelayIdComposite.cc */
+// TODO: create DelayIdComposite.cc
 void
 CompositePoolNode::delayRead(DeferredRead const &aRead)
 {

--- a/src/DescriptorSet.cc
+++ b/src/DescriptorSet.cc
@@ -37,13 +37,12 @@ DescriptorSet::~DescriptorSet()
 bool
 DescriptorSet::add(int fd)
 {
-    Must(0 <= fd);
-    Must(fd < capacity_);
+    assert(0 <= fd && fd < capacity_); // TODO: replace with Must()
 
     if (has(fd))
         return false; // already have it
 
-    Must(size_ < capacity_);
+    assert(size_ < capacity_); // TODO: replace with Must()
     const int pos = size_;
     ++size_;
     index_[fd] = pos;
@@ -55,21 +54,20 @@ DescriptorSet::add(int fd)
 bool
 DescriptorSet::del(int fd)
 {
-    Must(0 <= fd && fd < capacity_);
+    assert(0 <= fd && fd < capacity_); // TODO: here and below, use Must()
 
     if (!has(fd))
         return false; // we do not have it
 
-    Must(!empty());
+    assert(!empty());
     const int delPos = index_[fd];
-    Must(0 <= delPos);
-    Must(delPos < capacity_);
+    assert(0 <= delPos && delPos < capacity_);
 
     // move the last descriptor to the deleted fd position
     // to avoid skipping deleted descriptors in pop()
     const int lastPos = size_-1;
     const int lastFd = descriptors_[lastPos];
-    Must(delPos <= lastPos); // may be the same
+    assert(delPos <= lastPos); // may be the same
     descriptors_[delPos] = lastFd;
     index_[lastFd] = delPos;
 

--- a/src/DescriptorSet.cc
+++ b/src/DescriptorSet.cc
@@ -37,12 +37,13 @@ DescriptorSet::~DescriptorSet()
 bool
 DescriptorSet::add(int fd)
 {
-    assert(0 <= fd && fd < capacity_); // \todo: replace with Must()
+    Must(0 <= fd);
+    Must(fd < capacity_);
 
     if (has(fd))
         return false; // already have it
 
-    assert(size_ < capacity_); // \todo: replace with Must()
+    Must(size_ < capacity_);
     const int pos = size_;
     ++size_;
     index_[fd] = pos;
@@ -54,20 +55,21 @@ DescriptorSet::add(int fd)
 bool
 DescriptorSet::del(int fd)
 {
-    assert(0 <= fd && fd < capacity_); // \todo: here and below, use Must()
+    Must(0 <= fd && fd < capacity_);
 
     if (!has(fd))
         return false; // we do not have it
 
-    assert(!empty());
+    Must(!empty());
     const int delPos = index_[fd];
-    assert(0 <= delPos && delPos < capacity_);
+    Must(0 <= delPos);
+    Must(delPos < capacity_);
 
     // move the last descriptor to the deleted fd position
     // to avoid skipping deleted descriptors in pop()
     const int lastPos = size_-1;
     const int lastFd = descriptors_[lastPos];
-    assert(delPos <= lastPos); // may be the same
+    Must(delPos <= lastPos); // may be the same
     descriptors_[delPos] = lastFd;
     index_[lastFd] = delPos;
 
@@ -97,7 +99,7 @@ DescriptorSet::pop()
 void
 DescriptorSet::print(std::ostream &os) const
 {
-    // \todo add "name" if the set is used for more than just half-closed FDs
+    // TODO: add "name" if the set is used for more than just half-closed FDs
     os << size_ << " FDs";
 }
 

--- a/src/DescriptorSet.h
+++ b/src/DescriptorSet.h
@@ -11,12 +11,10 @@
 
 #include <iosfwd>
 
-/** \ingroup Comm
-
-    \todo: Should we use std::set<int> with its flexibility? Our implementation
+/* TODO: Should we use std::set<int> with its flexibility? Our implementation
     has constant overhead, which is smaller than log(n) of std::set.
-
-an unordered collection of unique descriptors with O(1) add/del/has ops */
+*/
+/// An unordered collection of unique descriptors with O(1) add/del/has ops
 class DescriptorSet
 {
 public:

--- a/src/DiskIO/AIO/AIODiskFile.cc
+++ b/src/DiskIO/AIO/AIODiskFile.cc
@@ -95,7 +95,7 @@ AIODiskFile::read(ReadRequest *request)
 
     if (slot < 0) {
         /* No free slot? Callback error, and return */
-        fatal("Aiee! out of aiocb slots! - FIXME and wrap file_read\n");
+        fatal("Aiee! out of aiocb slots! - TODO fix and wrap file_read\n");
         debugs(79, DBG_IMPORTANT, "WARNING: out of aiocb slots!");
         /* fall back to blocking method */
         //        file_read(fd, request->buf, request->len, request->offset, callback, data);
@@ -133,7 +133,7 @@ AIODiskFile::read(ReadRequest *request)
     /* Initiate aio */
     if (aio_read(&qe->aq_e_aiocb) < 0) {
         int xerrno = errno;
-        fatalf("Aiee! aio_read() returned error (%d)  FIXME and wrap file_read !\n", xerrno);
+        fatalf("Aiee! aio_read() returned error (%d) TODO fix and wrap file_read !\n", xerrno);
         debugs(79, DBG_IMPORTANT, "WARNING: aio_read() returned error: " << xstrerr(xerrno));
         /* fall back to blocking method */
         //        file_read(fd, request->buf, request->len, request->offset, callback, data);
@@ -154,7 +154,7 @@ AIODiskFile::write(WriteRequest *request)
 
     if (slot < 0) {
         /* No free slot? Callback error, and return */
-        fatal("Aiee! out of aiocb slots FIXME and wrap file_write !\n");
+        fatal("Aiee! out of aiocb slots TODO fix and wrap file_write !\n");
         debugs(79, DBG_IMPORTANT, "WARNING: out of aiocb slots!");
         /* fall back to blocking method */
         //        file_write(fd, offset, buf, len, callback, data, freefunc);
@@ -192,7 +192,7 @@ AIODiskFile::write(WriteRequest *request)
     /* Initiate aio */
     if (aio_write(&qe->aq_e_aiocb) < 0) {
         int xerrno = errno;
-        fatalf("Aiee! aio_write() returned error (%d) FIXME and wrap file_write !\n", xerrno);
+        fatalf("Aiee! aio_write() returned error (%d) TODO fix and wrap file_write !\n", xerrno);
         debugs(79, DBG_IMPORTANT, "WARNING: aio_write() returned error: " << xstrerr(xerrno));
         /* fall back to blocking method */
         //       file_write(fd, offset, buf, len, callback, data, freefunc);

--- a/src/HttpHdrContRange.h
+++ b/src/HttpHdrContRange.h
@@ -25,7 +25,7 @@ public:
     int64_t elength;        /**< entity length, not content length */
 };
 
-/** \todo CLEANUP: Move httpHdrContRange* functions into the class methods */
+// TODO: move httpHdrContRange* functions into the class methods
 
 HttpHdrContRange *httpHdrContRangeCreate(void);
 HttpHdrContRange *httpHdrContRangeParseCreate(const char *crange_spec);

--- a/src/HttpHdrRange.cc
+++ b/src/HttpHdrRange.cc
@@ -391,7 +391,7 @@ HttpHdrRange::canonize (int64_t newClen)
     merge (goods);
     debugs(64, 3, "HttpHdrRange::canonize: finished with " << specs.size() <<
            " specs");
-    return specs.size() > 0; // fixme, should return bool
+    return specs.size() > 0; // TODO: should return bool
 }
 
 /* hack: returns true if range specs are too "complex" for Squid to handle */

--- a/src/HttpHdrSc.cc
+++ b/src/HttpHdrSc.cc
@@ -25,7 +25,7 @@
 
 /* this table is used for parsing surrogate control header */
 /* order must match that of enum http_hdr_sc_type. The constraint is verified at initialization time */
-//todo: implement constraint
+// TODO: implement constraint
 static const LookupTable<http_hdr_sc_type>::Record ScAttrs[] {
     {"no-store", SC_NO_STORE},
     {"no-store-remote", SC_NO_STORE_REMOTE},

--- a/src/HttpHdrSc.h
+++ b/src/HttpHdrSc.h
@@ -40,7 +40,7 @@ public:
     bool parse(const String *str);
     void packInto(Packable * p) const;
     void updateStats(StatHist *) const;
-    HttpHdrScTarget * getMergedTarget (const char *ourtarget); //todo: make const?
+    HttpHdrScTarget * getMergedTarget(const char *ourtarget); // TODO: make const?
     void setMaxAge(char const *target, int max_age);
     void addTarget(HttpHdrScTarget *t);
     void addTargetAtTail(HttpHdrScTarget *t);

--- a/src/ICP.h
+++ b/src/ICP.h
@@ -57,10 +57,7 @@ public:
     static icp_common_t *CreateMessage(icp_opcode opcode, int flags, const char *url, int reqnum, int pad);
 };
 
-/**
- \ingroup ServerProtocolICPAPI
- \todo mempool this
- */
+// TODO: mempool this
 class ICPState: public StoreClient
 {
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -781,7 +781,7 @@ cf_gen_defines.cci: $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre $(top_builddi
 	$(AWK) -f $(srcdir)/cf_gen_defines <$(srcdir)/cf.data.pre >$@ || ($(RM) -f $@ && exit 1)
 
 
-## FIXME: generate a sed command file from configure. Then this doesn't
+## TODO: generate a sed command file from configure. Then this doesn't
 ## depend on the Makefile.
 cf.data: cf.data.pre Makefile
 	sed \

--- a/src/ProfStats.cc
+++ b/src/ProfStats.cc
@@ -250,10 +250,9 @@ xprofRegisterWithCacheManager(void)
     Mgr::RegisterAction("cpu_profile", "CPU Profiling Stats", xprof_summary, 0, 1);
 }
 
-// FIXME:
-// this gets colled once per event. This doesn't seem to make much sense,
-// does it?
 static hrtime_t now;
+
+// TODO: this gets called once per event. Make it only happen when enabling xprof.
 static void
 xprof_Init(void)
 {

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -240,7 +240,7 @@ public:
         Ip::Address snmp_incoming;
         Ip::Address snmp_outgoing;
 #endif
-        /* FIXME INET6 : this should really be a CIDR value */
+        // TODO: this should really be a CIDR value
         Ip::Address client_netmask;
     } Addrs;
     size_t tcpRcvBufsz;

--- a/src/StatCounters.h
+++ b/src/StatCounters.h
@@ -21,7 +21,7 @@ public:
     int falseHits = 0;
     int trueMisses = 0;
     int falseMisses = 0;
-    int closeHits = 0;     /// \todo: temporary remove it later
+    int closeHits = 0;     // TODO: temporary. remove it later
 };
 #endif
 

--- a/src/StatHist.h
+++ b/src/StatHist.h
@@ -29,9 +29,9 @@ public:
      * \note the default constructor doesn't fully initialize.
      *       you have to call one of the *init functions to specialize the
      *       histogram
-     * \todo merge functionality from the *init functions to the constructor and
+     * TODO: merge functionality from the *init functions to the constructor and
      *       drop these
-     * \todo specialize the class in a small hierarchy so that all
+     * TODO: specialize the class in a small hierarchy so that all
      *       relevant initializations are done at build-time
      */
     StatHist() = default;

--- a/src/Store.h
+++ b/src/Store.h
@@ -116,7 +116,7 @@ public:
     /// for eventual removal from the Store.
     void releaseRequest(const bool shareable = false);
     void negativeCache();
-    bool cacheNegatively();     /** \todo argh, why both? */
+    bool cacheNegatively();     // TODO: why both negativeCache() and cacheNegatively() ?
     void invokeHandlers();
     void cacheInMemory(); ///< start or continue storing in memory cache
     void swapOut();

--- a/src/StoreFileSystem.h
+++ b/src/StoreFileSystem.h
@@ -42,8 +42,8 @@
  * configure.ac must be updated to autogenerate a Makefile in
  * \em src/fs/foo/ from a Makefile.in file.
  *
- \todo DOCS: add template addition to configure.ac for storage module addition.
- \todo DOCS: add template Makefile.am for storage module addition.
+ * TODO: DOCS: add template addition to configure.ac for storage module addition.
+ * TODO: DOCS: add template Makefile.am for storage module addition.
  *
  \par
  * configure will take a list of storage types through the

--- a/src/StoreMeta.h
+++ b/src/StoreMeta.h
@@ -16,7 +16,7 @@ typedef class StoreMeta tlv;
 
 /**
  \ingroup SwapStoreAPI
- \todo AYJ: for critical lists like this we should use A=64,B=65 etc to enforce and reserve values.
+ * XXX: for critical lists like this we should use A=64,B=65 etc to enforce and reserve values.
  \note NOTE!  We must preserve the order of this list!
  *
  \section StoreSwapMeta Store "swap meta" Description
@@ -87,7 +87,7 @@ enum {
      */
     STORE_META_HITMETERING,
 
-    /// \todo DOCS: document.
+    // TODO: document this TLV type code
     STORE_META_VALID,
 
     /**
@@ -101,10 +101,11 @@ enum {
      */
     STORE_META_STD_LFS,
 
+    // TODO: document this TLV type code
     STORE_META_OBJSIZE,
 
-    STORE_META_STOREURL,    /* the store url, if different to the normal URL */
-    STORE_META_VARY_ID,     /* Unique ID linking variants */
+    STORE_META_STOREURL,    /**< the Store-ID url, if different to the normal URL */
+    STORE_META_VARY_ID,     /**< Unique ID linking variants */
     STORE_META_END
 };
 

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -89,7 +89,7 @@ ACLDestinationDomainStrategy::match (ACLData<MatchType> * &data, ACLFilledCheckl
         checklist->dst_rdns = xstrdup(fqdn);
         return data->match(fqdn);
     } else if (!checklist->destinationDomainChecked()) {
-        /* FIXME: Using AclMatchedName here is not OO correct. Should find a way to the current acl */
+        // TODO: Using AclMatchedName here is not OO correct. Should find a way to the current acl
         debugs(28, 3, "Can't yet compare '" << AclMatchedName << "' ACL for " << checklist->request->url.host());
         if (checklist->goAsync(DestinationDomainLookup::Instance()))
             return -1;

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -32,7 +32,7 @@ public:
 
     Ip::Address addr2;
 
-    Ip::Address mask; /**< \todo This should perhapse be stored as a CIDR range now instead of a full IP mask. */
+    Ip::Address mask; // TODO: should use a CIDR range
 
     acl_ip_data *next;      /**< used for parsing, not for storing */
 

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -49,7 +49,7 @@ ACLSourceDomainStrategy::match (ACLData<MatchType> * &data, ACLFilledChecklist *
     if (fqdn) {
         return data->match(fqdn);
     } else if (!checklist->sourceDomainChecked()) {
-        /* FIXME: Using AclMatchedName here is not OO correct. Should find a way to the current acl */
+        // TODO: Using AclMatchedName here is not OO correct. Should find a way to the current acl
         debugs(28, 3, "aclMatchAcl: Can't yet compare '" << AclMatchedName << "' ACL for '" << checklist->src_addr << "'");
         if (checklist->goAsync(SourceDomainLookup::Instance()))
             return -1;

--- a/src/acl/external/helpers.m4
+++ b/src/acl/external/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_external_acl_helpers list containing double entries.
+# TODO: de-duplicate $enable_external_acl_helpers list containing double entries.
 
 #define list of modules to build
 auto_ext_acl_modules=no

--- a/src/adaptation/AccessCheck.cc
+++ b/src/adaptation/AccessCheck.cc
@@ -154,7 +154,7 @@ Adaptation::AccessCheck::AccessCheckCallbackWrapper(Acl::Answer answer, void *da
     debugs(93, 8, HERE << "callback answer=" << answer);
     AccessCheck *ac = (AccessCheck*)data;
 
-    /** \todo AYJ 2008-06-12: If answer == ACCESS_AUTH_REQUIRED
+    /* TODO: AYJ 2008-06-12: If answer == ACCESS_AUTH_REQUIRED
      * we should be kicking off an authentication before continuing
      * with this request. see bug 2400 for details.
      */

--- a/src/adaptation/Message.h
+++ b/src/adaptation/Message.h
@@ -42,7 +42,7 @@ public:
     Header *header;   // parsed HTTP status/request line and headers
 
     /// Copy of header->body_pipe, in case somebody moves the original.
-    /// \todo Find and fix the code that moves (if any) and remove this.
+    /// TODO: Find and fix the code that moves (if any) and remove this.
     BodyPipePointer body_pipe;
 
 private:

--- a/src/adaptation/ServiceGroups.cc
+++ b/src/adaptation/ServiceGroups.cc
@@ -129,7 +129,7 @@ Adaptation::ServicePointer Adaptation::ServiceGroup::at(const Pos pos) const
     return FindService(services[pos]);
 }
 
-/// \todo: optimize to cut search short instead of looking for the best svc
+// TODO: optimize to cut search short instead of looking for the best svc
 bool
 Adaptation::ServiceGroup::wants(const ServiceFilter &filter) const
 {

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -571,7 +571,7 @@ AnyP::Uri::absolute() const
     return absolute_;
 }
 
-/** \todo AYJ: Performance: This is an *almost* duplicate of HttpRequest::effectiveRequestUri(). But elides the query-string.
+/* XXX: Performance: This is an *almost* duplicate of HttpRequest::effectiveRequestUri(). But elides the query-string.
  *        After copying it on in the first place! Would be less code to merge the two with a flag parameter.
  *        and never copy the query-string part in the first place
  */

--- a/src/auth/SchemeConfig.h
+++ b/src/auth/SchemeConfig.h
@@ -82,7 +82,7 @@ public:
      * If a singleton, delete will not occur. if not a singleton (future),
      * delete will occur when no references are held.
      *
-     \todo we need a 'done for reconfigure' and a 'done permanently' concept.
+     * TODO: need a 'done for reconfigure' and a 'done permanently' concept.
      */
     virtual void done();
 

--- a/src/auth/basic/SMB_LM/msntauth.cc
+++ b/src/auth/basic/SMB_LM/msntauth.cc
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <iostream>
 #include <string>
-#include <vector> //todo: turn into multimap
+#include <vector>
 #include <syslog.h>
 
 #include "auth/basic/SMB_LM/msntauth.h"

--- a/src/auth/basic/helpers.m4
+++ b/src/auth/basic/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_auth_basic list containing double entries.
+# TODO: de-duplicate $enable_auth_basic list containing double entries.
 
 #not specified. Inherit global
 if test "x$enable_auth_basic" = "x"; then

--- a/src/auth/digest/helpers.m4
+++ b/src/auth/digest/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_auth_digest list containing double entries.
+# TODO: de-duplicate $enable_auth_digest list containing double entries.
 
 #not specified. Inherit global
 if test "x$enable_auth_digest" = "x"; then

--- a/src/auth/negotiate/helpers.m4
+++ b/src/auth/negotiate/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_auth_negotiate list containing double entries.
+# TODO: de-duplicate $enable_auth_negotiate list containing double entries.
 
 #not specified. Inherit global
 if test "x$enable_auth_negotiate" = "x"; then

--- a/src/auth/ntlm/helpers.m4
+++ b/src/auth/ntlm/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_auth_ntlm list containing double entries.
+# TODO: de-duplicate $enable_auth_ntlm list containing double entries.
 
 #not specified. Inherit global
 if test "x$enable_auth_ntlm" = "x"; then

--- a/src/base/AsyncCall.cc
+++ b/src/base/AsyncCall.cc
@@ -69,7 +69,7 @@ AsyncCall::canFire()
     return !isCanceled;
 }
 
-/// \todo make this method const by providing a const getDialer()
+// TODO: make this method const by providing a const getDialer()
 void
 AsyncCall::print(std::ostream &os)
 {

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -37,7 +37,6 @@
 class CallDialer;
 class AsyncCallQueue;
 
-// TODO: support CBDATA_CLASS kids
 class AsyncCall: public RefCountable
 {
 public:
@@ -167,4 +166,3 @@ bool ScheduleCall(const char *fileName, int fileLine, AsyncCall::Pointer &call);
 #define ScheduleCallHere(call) ScheduleCall(__FILE__, __LINE__, (call))
 
 #endif /* SQUID_ASYNCCALL_H */
-

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -166,3 +166,4 @@ bool ScheduleCall(const char *fileName, int fileLine, AsyncCall::Pointer &call);
 #define ScheduleCallHere(call) ScheduleCall(__FILE__, __LINE__, (call))
 
 #endif /* SQUID_ASYNCCALL_H */
+

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -37,11 +37,7 @@
 class CallDialer;
 class AsyncCallQueue;
 
-/**
- \todo add unique call IDs
- \todo CBDATA_CLASS kids
- \ingroup AsyncCallsAPI
- */
+// TODO: support CBDATA_CLASS kids
 class AsyncCall: public RefCountable
 {
 public:

--- a/src/base/InstanceId.h
+++ b/src/base/InstanceId.h
@@ -40,7 +40,7 @@ typedef unsigned int InstanceIdDefaultValueType;
  *   - useful for debugging and insecure request/response matching;
  *   - sequential IDs within a class except when wrapping;
  *   - always positive IDs.
- *  \todo: add creation/destruction debugging?
+ * TODO: add creation/destruction debugging?
  */
 template <class Class, class ValueType = InstanceIdDefaultValueType>
 class InstanceId

--- a/src/cbdata.cc
+++ b/src/cbdata.cc
@@ -71,7 +71,7 @@ public:
     MEMPROXY_CLASS(cbdata);
 #endif
 
-    /** \todo examine making cbdata templated on this - so we get type
+    /* TODO: examine making cbdata templated on this - so we get type
      * safe access to data - RBC 20030902 */
 public:
 #if USE_CBDATA_DEBUG

--- a/src/clientStream.cc
+++ b/src/clientStream.cc
@@ -78,7 +78,7 @@
    return;
  \endcode
  *
- \todo rather than each node undeleting the next, have a clientStreamDelete that walks the list.
+ * TODO: rather than each node undeleting the next, have a clientStreamDelete that walks the list.
  */
 
 CBDATA_CLASS_INIT(clientStreamNode);

--- a/src/clientStream.h
+++ b/src/clientStream.h
@@ -49,7 +49,6 @@
  \li             satisfies the read request, or
  \li             inserts a new node above it and calls clientStreamRead(), or
  \li             calls clientStreamRead()
- \todo DOCS: make the above list nested.
  *
  \par
  *    There is no requirement for the Read parameters from different
@@ -58,7 +57,7 @@
  *
  \section WhatsInANode Whats in a node
  *
- \todo ClientStreams: These details should really be codified as a class which all ClientStream nodes inherit from.
+ * TODO: ClientStreams: These details should really be codified as a class which all ClientStream nodes inherit from.
  *
  \par   Each node must have:
  \li    read method - to allow loose coupling in the pipeline. (The reader may

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1549,7 +1549,7 @@ clientReplyContext::buildReplyHeader()
               reply->sline.status() == Http::scUnauthorized)
        ) {
         /* Add authentication header */
-        /*! \todo alter errorstate to be accel on|off aware. The 0 on the next line
+        /* TODO: alter errorstate to be accel on|off aware. The 0 on the next line
          * depends on authenticate behaviour: all schemes to date send no extra
          * data on 407/401 responses, and do not check the accel state on 401/407
          * responses

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1108,7 +1108,7 @@ clientReplyContext::purgeDoPurgeHead(StoreEntry *newEntry)
      * Make a new entry to hold the reply to be written
      * to the client.
      */
-    /* FIXME: This doesn't need to go through the store. Simply
+    /* TODO: This doesn't need to go through the store. Simply
      * push down the client chain
      */
     createStoreEntry(http->request->method, RequestFlags());

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -372,10 +372,7 @@ clientBeginRequest(const HttpRequestMethod& method, char const *url, CSCB * stre
     /* this is an internally created
      * request, not subject to acceleration
      * target overrides */
-    /*
-     * FIXME? Do we want to detect and handle internal requests of internal
-     * objects ?
-     */
+    // TODO: detect and handle internal requests of internal objects?
 
     /* Internally created requests cannot have bodies today */
     request->content_length = 0;
@@ -1298,7 +1295,7 @@ ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
     break;
     }
 
-    /* FIXME PIPELINE: This is inaccurate during pipelining */
+    /* XXX PIPELINE: This is inaccurate during pipelining */
 
     if (http->getConn() != NULL && Comm::IsConnOpen(http->getConn()->clientConnection))
         fd_note(http->getConn()->clientConnection->fd, http->uri);

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1928,7 +1928,7 @@ Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
         data.listenConn->close();
         data.listenConn = NULL;
         debugs(9, DBG_IMPORTANT, "FTP AcceptDataConnection: " << io.conn << ": " << xstrerr(io.xerrno));
-        /** \todo Need to send error message on control channel*/
+        // TODO: need to send error message on control channel
         ftpFail(this);
         return;
     }
@@ -2680,7 +2680,7 @@ Ftp::Gateway::writeReplyBody(const char *dataToWrite, size_t dataLength)
 /**
  * A hack to ensure we do not double-complete on the forward entry.
  *
- \todo Ftp::Gateway logic should probably be rewritten to avoid
+ * TODO: Ftp::Gateway logic should probably be rewritten to avoid
  *  double-completion or FwdState should be rewritten to allow it.
  */
 void

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -261,7 +261,7 @@ Ftp::Relay::serverState(const Ftp::ServerState newState)
  * (but we may still be waiting for 226 from the FTP server) and
  * also when we get that 226 from the server (and adaptation is done).
  *
- \todo Rewrite FwdState to ignore double completion?
+ * TODO: Rewrite FwdState to ignore double completion?
  */
 void
 Ftp::Relay::completeForwarding()

--- a/src/clients/forward.h
+++ b/src/clients/forward.h
@@ -41,7 +41,7 @@ AsyncJobPointer StartRelay(FwdState *const fwdState);
  *  We use standard URI-encoding on the second / making it
  *  ftp:host:port/%2froot/path  AKA 'the FTP %2f hack'.
  *
- * \todo Should be a URL class API call.
+ * TODO: Should be an AnyP::Uri member
  */
 const SBuf &UrlWith2f(HttpRequest *);
 

--- a/src/esi/Context.h
+++ b/src/esi/Context.h
@@ -128,8 +128,8 @@ public:
     private:
         bool inited_;
     }
+    parserState; // TODO: refactor this to somewhere else
 
-    parserState; /* todo factor this off somewhere else; */
     ESIVarState *varState;
     ESIElement::Pointer tree;
 

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -802,7 +802,7 @@ esiProcessStream (clientStreamNode *thisNode, ClientHttpRequest *http, HttpReply
     }
 
     /* ok.. no data sent, try to pull more data in from upstream.
-     * FIXME: Don't try thisNode if we have finished reading the template
+     * TODO: Don't try thisNode if we have finished reading the template
      */
     if (!context->flags.finishedtemplate && !context->reading()
             && !context->cachedASTInUse) {
@@ -1263,7 +1263,7 @@ ESIContext::parse()
             while (buffered.getRaw() && !flags.error)
                 parseOneBuffer();
 
-        } catch (Esi::ErrorDetail &errMsg) { // FIXME: non-const for c_str()
+        } catch (Esi::ErrorDetail &errMsg) { // XXX: non-const for c_str()
             // level-2: these are protocol/syntax errors from upstream
             debugs(86, 2, "WARNING: ESI syntax error: " << errMsg);
             setError();

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -335,7 +335,7 @@ ESIInclude::ESIInclude(esiTreeParentPtr aParent, int attrcount, char const **att
              */
             debugs(86, 5, "ESIIncludeNew: Requesting alternate '" << attr[i+1] << "'");
 
-            assert (alt.getRaw() == NULL); /* TODO: FIXME */
+            assert (alt.getRaw() == NULL); /* TODO: fix? */
             alt = ESIStreamContextNew (this);
             assert (alt.getRaw() != NULL);
             alturl = xstrdup(attr[i+1]);

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -335,8 +335,9 @@ ESIInclude::ESIInclude(esiTreeParentPtr aParent, int attrcount, char const **att
              */
             debugs(86, 5, "ESIIncludeNew: Requesting alternate '" << attr[i+1] << "'");
 
-            assert(!alt.getRaw());
+            assert (alt.getRaw() == NULL); /* TODO: FIXME */
             alt = ESIStreamContextNew (this);
+            assert (alt.getRaw() != NULL);
             alturl = xstrdup(attr[i+1]);
         } else if (!strcmp(attr[i],"onerror")) {
             if (!strcmp(attr[i+1], "continue")) {

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -335,9 +335,8 @@ ESIInclude::ESIInclude(esiTreeParentPtr aParent, int attrcount, char const **att
              */
             debugs(86, 5, "ESIIncludeNew: Requesting alternate '" << attr[i+1] << "'");
 
-            assert (alt.getRaw() == NULL); /* TODO: FIXME */
+            assert(!alt.getRaw());
             alt = ESIStreamContextNew (this);
-            assert (alt.getRaw() != NULL);
             alturl = xstrdup(attr[i+1]);
         } else if (!strcmp(attr[i],"onerror")) {
             if (!strcmp(attr[i+1], "continue")) {

--- a/src/esi/Sequence.cc
+++ b/src/esi/Sequence.cc
@@ -90,7 +90,7 @@ esiSequence::render(ESISegment::Pointer output)
     for (size_t i = 0; i < processedcount; ++i) {
         elements[i]->render(output);
         FinishAnElement(elements[i], i);
-        /* FIXME: pass a ESISegment ** ? */
+        // TODO: pass an "ESISegment **" ?
         output = output->tail();
     }
 

--- a/src/esi/VarState.cc
+++ b/src/esi/VarState.cc
@@ -805,6 +805,7 @@ ESIVariableProcessor::~ESIVariableProcessor()
     delete currentFunction;
 }
 
+/* XXX FIXME: this should be comma delimited, no? */
 void
 ESIVarState::buildVary (HttpReply *rep)
 {
@@ -812,24 +813,24 @@ ESIVarState::buildVary (HttpReply *rep)
     tempstr[0]='\0';
 
     if (flags.language)
-        strcat(tempstr, "Accept-Language, ");
+        strcat (tempstr, "Accept-Language ");
 
     if (flags.cookie)
-        strcat(tempstr, "Cookie, ");
+        strcat (tempstr, "Cookie ");
 
     if (flags.host)
-        strcat(tempstr, "Host, ");
+        strcat (tempstr, "Host ");
 
     if (flags.referer)
-        strcat(tempstr, "Referer, ");
+        strcat (tempstr, "Referer ");
 
     if (flags.useragent)
-        strcat(tempstr, "User-Agent, ");
+        strcat (tempstr, "User-Agent ");
 
     if (!tempstr[0])
         return;
 
-    String strVary(rep->header.getList (Http::HdrType::VARY));
+    String strVary (rep->header.getList (Http::HdrType::VARY));
 
     if (!strVary.size() || strVary[0] != '*') {
         rep->header.putStr (Http::HdrType::VARY, tempstr);

--- a/src/esi/VarState.cc
+++ b/src/esi/VarState.cc
@@ -805,7 +805,6 @@ ESIVariableProcessor::~ESIVariableProcessor()
     delete currentFunction;
 }
 
-/* XXX FIXME: this should be comma delimited, no? */
 void
 ESIVarState::buildVary (HttpReply *rep)
 {
@@ -813,24 +812,24 @@ ESIVarState::buildVary (HttpReply *rep)
     tempstr[0]='\0';
 
     if (flags.language)
-        strcat (tempstr, "Accept-Language ");
+        strcat(tempstr, "Accept-Language, ");
 
     if (flags.cookie)
-        strcat (tempstr, "Cookie ");
+        strcat(tempstr, "Cookie, ");
 
     if (flags.host)
-        strcat (tempstr, "Host ");
+        strcat(tempstr, "Host, ");
 
     if (flags.referer)
-        strcat (tempstr, "Referer ");
+        strcat(tempstr, "Referer, ");
 
     if (flags.useragent)
-        strcat (tempstr, "User-Agent ");
+        strcat(tempstr, "User-Agent, ");
 
     if (!tempstr[0])
         return;
 
-    String strVary (rep->header.getList (Http::HdrType::VARY));
+    String strVary(rep->header.getList (Http::HdrType::VARY));
 
     if (!strVary.size() || strVary[0] != '*') {
         rep->header.putStr (Http::HdrType::VARY, tempstr);

--- a/src/esi/VarState.cc
+++ b/src/esi/VarState.cc
@@ -805,7 +805,7 @@ ESIVariableProcessor::~ESIVariableProcessor()
     delete currentFunction;
 }
 
-/* XXX FIXME: this should be comma delimited, no? */
+/* XXX: this should be comma delimited, no? */
 void
 ESIVarState::buildVary (HttpReply *rep)
 {

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -69,8 +69,9 @@ static ExternalACLEntryPointer external_acl_cache_add(external_acl * def, const 
 
 class external_acl
 {
-    /* FIXME: These are not really cbdata, but it is an easy way
+    /* XXX: These are not really cbdata, but it is an easy way
      * to get them pooled, refcounted, accounted and freed properly...
+     * Use RefCountable MEMPROXY_CLASS instead
      */
     CBDATA_CLASS(external_acl);
 

--- a/src/format/ByteCode.h
+++ b/src/format/ByteCode.h
@@ -113,10 +113,10 @@ typedef enum {
     /*LFT_REQUEST_SIZE_BODY_NO_TE, */
 
     /* original Status-Line details received from server */
-    // XXX: todo
+    // TODO: implement server detail logging
 
     /* Status-Line details sent to the client */
-    // XXX: todo
+    // TODO: implement server detail logging
 
     /* response Status-Line details (legacy, filtered) */
     LFT_HTTP_SENT_STATUS_CODE_OLD_30,

--- a/src/format/Token.h
+++ b/src/format/Token.h
@@ -68,7 +68,7 @@ public:
     bool space;
     bool zero;
     int divisor;    // class invariant: MUST NOT be zero.
-    Token *next;    /* todo: move from linked list to array */
+    Token *next;    // TODO: move from linked list to array
 
 private:
     const char *scanForToken(TokenTableEntry const table[], const char *cur);

--- a/src/fs/ufs/StoreSearchUFS.h
+++ b/src/fs/ufs/StoreSearchUFS.h
@@ -25,7 +25,7 @@ public:
     StoreSearchUFS(RefCount<UFSSwapDir> sd);
     virtual ~StoreSearchUFS();
 
-    /** \todo Iterator API - garh, wrong place */
+    // TODO: misplaced Iterator API
     /**
      * callback the client when a new StoreEntry is available
      * or an error occurs

--- a/src/fs/ufs/UFSStoreState.h
+++ b/src/fs/ufs/UFSStoreState.h
@@ -100,7 +100,7 @@ protected:
     };
     std::queue<Ufs::UFSStoreState::_queued_write> pending_writes;
 
-    /** \todo These should be in the IO strategy */
+    // TODO: These should be in the IO strategy
 
     struct {
         /**

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -173,7 +173,7 @@ Http::Stream::getNextRangeOffset() const
 
     } else if (reply && reply->contentRange()) {
         /* request does not have ranges, but reply does */
-        /** \todo FIXME: should use range_iter_pos on reply, as soon as reply->content_range
+        /* TODO: should use range_iter_pos on reply, as soon as reply->content_range
          *        becomes HttpHdrRange rather than HttpHdrRangeSpec.
          */
         return http->out.offset + reply->contentRange()->spec.offset;

--- a/src/http/url_rewriters/helpers.m4
+++ b/src/http/url_rewriters/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_url_rewrite_helpers list containing double entries.
+# TODO: de-duplicate $enable_url_rewrite_helpers list containing double entries.
 
 #define list of modules to build
 auto_urlrewrite_modules=no

--- a/src/icmp/Icmp6.cc
+++ b/src/icmp/Icmp6.cc
@@ -241,7 +241,7 @@ Icmp6::Recv(void)
 
     debugs(42, 8, HERE << n << " bytes from " << preply.from);
 
-// FIXME INET6 : The IPv6 Header (ip6_hdr) is not available directly >:-(
+// XXX: The IPv6 Header (ip6_hdr) is not available directly
 //
 // TTL still has to come from the IP header somewhere.
 //  still need to strip and process it properly.
@@ -258,7 +258,7 @@ Icmp6::Recv(void)
     #define ip6_hops    // HOPS!!!  (can it be true??)
 
         ip = (struct ip6_hdr *) pkt;
-        FIXME  += sizeof(ip6_hdr);
+        //  += sizeof(ip6_hdr);
 
     debugs(42, DBG_CRITICAL, HERE << "ip6_nxt=" << ip->ip6_nxt <<
             ", ip6_plen=" << ip->ip6_plen <<
@@ -302,9 +302,9 @@ Icmp6::Recv(void)
     preply.rtt = tvSubMsec(tv, now);
 
     /*
-     * FIXME INET6: Without access to the IPv6-Hops header we must rely on the total RTT
-     *      and could calculate the hops from that, but it produces some weird value mappings using ipHops
-     *  for now everything is 1 v6 hop away with variant RTT
+     * Without access to the IPv6-Hops header we must rely on the total RTT
+     * and could calculate the hops from that, but it produces some weird value mappings using ipHops
+     * for now everything is 1 v6 hop away with variant RTT
      * WANT:    preply.hops = ip->ip6_hops; // ipHops(ip->ip_hops);
      */
     preply.hops = 1;

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -282,3 +282,4 @@ IcmpSquid::Close(void)
 
 #endif
 }
+

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -71,7 +71,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
     else if (payload && len == 0)
         len = strlen(payload);
 
-    // BUG: If length specified or auto-detected is greater than the possible payload squid will die with an assert.
+    // XXX: If length specified or auto-detected is greater than the possible payload squid will die with an assert.
     // TODO: This should perhapse be reduced to a truncated payload? or no payload. A WARNING is due anyway.
     assert(len <= PINGER_PAYLOAD_SZ);
 
@@ -282,4 +282,3 @@ IcmpSquid::Close(void)
 
 #endif
 }
-

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -71,10 +71,8 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
     else if (payload && len == 0)
         len = strlen(payload);
 
-    /** \li
-     \bug If length specified or auto-detected is greater than the possible payload squid will die with an assert.
-     \todo This should perhapse be reduced to a truncated payload? or no payload. A WARNING is due anyway.
-     */
+    // BUG: If length specified or auto-detected is greater than the possible payload squid will die with an assert.
+    // TODO: This should perhapse be reduced to a truncated payload? or no payload. A WARNING is due anyway.
     assert(len <= PINGER_PAYLOAD_SZ);
 
     pecho.to = to;
@@ -97,7 +95,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
         debugs(37, DBG_IMPORTANT, MYNAME << "send: " << xstrerr(xerrno));
 
         /** \li  If the send results in ECONNREFUSED or EPIPE errors from helper, will cleanly shutdown the module. */
-        /** \todo This should try restarting the helper a few times?? before giving up? */
+        // TODO: try restarting the helper a few times before giving up?
         if (xerrno == ECONNREFUSED || xerrno == EPIPE) {
             Close();
             return;

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -786,7 +786,7 @@ netdbExchangeHandleReply(void *data, StoreIOBuffer receivedData)
 
             case NETDB_EX_NETWORK:
                 ++o;
-                /* FIXME INET6 : NetDB can still only send IPv4 */
+                // XXX: NetDB can still only send IPv4
                 memcpy(&line_addr, p + o, sizeof(struct in_addr));
                 addr = line_addr;
                 o += sizeof(struct in_addr);
@@ -1211,7 +1211,7 @@ netdbBinaryExchange(StoreEntry * s)
         if (! (addr = n->network) )
             continue;
 
-        /* FIXME INET6 : NetDB cannot yet handle IPv6 addresses. Ensure only IPv4 get sent. */
+        // XXX: NetDB cannot yet handle IPv6 addresses
         if ( !addr.isIPv4() )
             continue;
 

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -936,9 +936,9 @@ Ip::Address::getSockAddr(struct sockaddr_storage &addr, const int family) const
     struct sockaddr_in *sin = NULL;
 
     if ( family == AF_INET && !isIPv4()) {
-        // FIXME INET6: caller using the wrong socket type!
+        // XXX: caller using the wrong socket type!
         debugs(14, DBG_CRITICAL, HERE << "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this);
-        assert(false);
+        assert(family == AF_INET && !isIPv4());
     }
 
     if ( family == AF_INET6 || (family == AF_UNSPEC && isIPv6()) ) {

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -936,7 +936,7 @@ Ip::Address::getSockAddr(struct sockaddr_storage &addr, const int family) const
     struct sockaddr_in *sin = NULL;
 
     if ( family == AF_INET && !isIPv4()) {
-        // FIXME INET6: caller using the wrong socket type!
+        // TODO INET6: caller using the wrong socket type!
         debugs(14, DBG_CRITICAL, HERE << "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this);
         assert(false);
     }

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -936,9 +936,9 @@ Ip::Address::getSockAddr(struct sockaddr_storage &addr, const int family) const
     struct sockaddr_in *sin = NULL;
 
     if ( family == AF_INET && !isIPv4()) {
-        // XXX: caller using the wrong socket type!
+        // FIXME INET6: caller using the wrong socket type!
         debugs(14, DBG_CRITICAL, HERE << "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this);
-        assert(family == AF_INET && !isIPv4());
+        assert(false);
     }
 
     if ( family == AF_INET6 || (family == AF_UNSPEC && isIPv6()) ) {

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -299,7 +299,7 @@ public:
     bool GetHostByName(const char *s);
 
 public:
-    /* FIXME: When C => C++ conversion is done will be fully private.
+    /* XXX: When C => C++ conversion is done will be fully private.
      * Legacy Transition Methods.
      * These are here solely to simplify the transition
      * when moving from converted code to unconverted

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -41,14 +41,12 @@
  *  mechanisms that allow non-blocking access to these mappings.
  *  The IP cache usually doesn't block on a request except for
  *  special cases where this is desired (see below).
- *
- \todo IP Cache should have its own API *.h header file.
  */
 
 /**
  \defgroup IPCacheInternal IP Cache Internals
  \ingroup IPCacheAPI
- \todo  when IP cache is provided as a class. These sub-groups will be obsolete
+ \note  when IP cache is provided as a class. These sub-groups will be obsolete
  *  for now they are used to separate the public and private functions.
  *  with the private ones all being in IPCachInternal and public in IPCacheAPI
  *

--- a/src/log/helpers.m4
+++ b/src/log/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_log_daemon_helpers list containing double entries.
+# TODO: de-duplicate $enable_log_daemon_helpers list containing double entries.
 
 #define list of modules to build
 auto_logdaemon_modules=no

--- a/src/mem/Pool.cc
+++ b/src/mem/Pool.cc
@@ -253,7 +253,7 @@ memPoolGetGlobalStats(MemPoolGlobalStats * stats)
     MemAllocator *pool;
     MemPoolIterator *iter;
 
-    *stats = MemPoolGlobalStats();
+    memset(stats, 0, sizeof(MemPoolGlobalStats));
     memset(&pp_stats, 0, sizeof(MemPoolStats));
 
     MemPools::GetInstance().flushMeters(); /* recreate TheMeter */

--- a/src/mem/Pool.cc
+++ b/src/mem/Pool.cc
@@ -253,7 +253,7 @@ memPoolGetGlobalStats(MemPoolGlobalStats * stats)
     MemAllocator *pool;
     MemPoolIterator *iter;
 
-    memset(stats, 0, sizeof(MemPoolGlobalStats));
+    *stats = MemPoolGlobalStats();
     memset(&pp_stats, 0, sizeof(MemPoolStats));
 
     MemPools::GetInstance().flushMeters(); /* recreate TheMeter */

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -62,7 +62,7 @@ class MemImplementingAllocator;
 class MemPoolStats;
 
 /// \ingroup MemPoolsAPI
-/// \todo Kill this typedef for C++
+/// TODO: Kill this typedef for C++
 typedef struct _MemPoolGlobalStats MemPoolGlobalStats;
 
 /// \ingroup MemPoolsAPI
@@ -156,7 +156,7 @@ public:
      * Suitable frequency for cleanup is in range of few tens of seconds to
      * few minutes, depending of memory activity.
      *
-     \todo DOCS: Re-write this shorter!
+     * TODO: DOCS: Re-write this shorter!
      *
      \param maxage   Release all totally idle chunks that
      *               have not been referenced for maxage seconds.
@@ -299,7 +299,7 @@ public:
 };
 
 /// \ingroup MemPoolsAPI
-/// \todo Classify and add constructor/destructor to initialize properly.
+/// TODO: Classify and add constructor/destructor to initialize properly.
 struct _MemPoolGlobalStats {
     MemPoolMeter *TheMeter;
 
@@ -346,7 +346,6 @@ extern void memPoolIterateDone(MemPoolIterator ** iter);
 
 /**
  \ingroup MemPoolsAPI
- \todo Stats API - not sured how to refactor yet
  *
  * Fills a MemPoolGlobalStats with statistical data about overall
  * usage for all pools.

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -62,6 +62,10 @@ class MemImplementingAllocator;
 class MemPoolStats;
 
 /// \ingroup MemPoolsAPI
+/// \todo Kill this typedef for C++
+typedef struct _MemPoolGlobalStats MemPoolGlobalStats;
+
+/// \ingroup MemPoolsAPI
 class MemPoolIterator
 {
 public:
@@ -139,17 +143,20 @@ public:
      * chunks, cleans up internal states and checks for releasable chunks.
      *
      \par
-     * Sorts chunks in suitable order as to reduce free memory
-     * fragmentation and increase chunk utilisation.
-     * Suitable frequency for cleanup is in range of few tens of seconds to
-     * few minutes, depending of memory activity.
-     *
-     \par
      * Between the calls to this function objects are placed onto internal
      * cache instead of returning to their home chunks, mainly for speedup
      * purpose. During that time state of chunk is not known, it is not
      * known whether chunk is free or in use. This call returns all objects
      * to their chunks and restores consistency.
+     *
+     \par
+     * Should be called relatively often, as it sorts chunks in suitable
+     * order as to reduce free memory fragmentation and increase chunk
+     * utilisation.
+     * Suitable frequency for cleanup is in range of few tens of seconds to
+     * few minutes, depending of memory activity.
+     *
+     \todo DOCS: Re-write this shorter!
      *
      \param maxage   Release all totally idle chunks that
      *               have not been referenced for maxage seconds.
@@ -292,26 +299,25 @@ public:
 };
 
 /// \ingroup MemPoolsAPI
-class MemPoolGlobalStats
-{
-public:
-    MemPoolMeter *TheMeter = nullptr;
+/// \todo Classify and add constructor/destructor to initialize properly.
+struct _MemPoolGlobalStats {
+    MemPoolMeter *TheMeter;
 
-    int tot_pools_alloc = 0;
-    int tot_pools_inuse = 0;
-    int tot_pools_mempid = 0;
+    int tot_pools_alloc;
+    int tot_pools_inuse;
+    int tot_pools_mempid;
 
-    int tot_chunks_alloc = 0;
-    int tot_chunks_inuse = 0;
-    int tot_chunks_partial = 0;
-    int tot_chunks_free = 0;
+    int tot_chunks_alloc;
+    int tot_chunks_inuse;
+    int tot_chunks_partial;
+    int tot_chunks_free;
 
-    int tot_items_alloc = 0;
-    int tot_items_inuse = 0;
-    int tot_items_idle = 0;
+    int tot_items_alloc;
+    int tot_items_inuse;
+    int tot_items_idle;
 
-    int tot_overhead = 0;
-    ssize_t mem_idle_limit = 0;
+    int tot_overhead;
+    ssize_t mem_idle_limit;
 };
 
 /// \ingroup MemPoolsAPI
@@ -340,6 +346,7 @@ extern void memPoolIterateDone(MemPoolIterator ** iter);
 
 /**
  \ingroup MemPoolsAPI
+ \todo Stats API - not sured how to refactor yet
  *
  * Fills a MemPoolGlobalStats with statistical data about overall
  * usage for all pools.

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -62,10 +62,6 @@ class MemImplementingAllocator;
 class MemPoolStats;
 
 /// \ingroup MemPoolsAPI
-/// \todo Kill this typedef for C++
-typedef struct _MemPoolGlobalStats MemPoolGlobalStats;
-
-/// \ingroup MemPoolsAPI
 class MemPoolIterator
 {
 public:
@@ -143,20 +139,17 @@ public:
      * chunks, cleans up internal states and checks for releasable chunks.
      *
      \par
+     * Sorts chunks in suitable order as to reduce free memory
+     * fragmentation and increase chunk utilisation.
+     * Suitable frequency for cleanup is in range of few tens of seconds to
+     * few minutes, depending of memory activity.
+     *
+     \par
      * Between the calls to this function objects are placed onto internal
      * cache instead of returning to their home chunks, mainly for speedup
      * purpose. During that time state of chunk is not known, it is not
      * known whether chunk is free or in use. This call returns all objects
      * to their chunks and restores consistency.
-     *
-     \par
-     * Should be called relatively often, as it sorts chunks in suitable
-     * order as to reduce free memory fragmentation and increase chunk
-     * utilisation.
-     * Suitable frequency for cleanup is in range of few tens of seconds to
-     * few minutes, depending of memory activity.
-     *
-     \todo DOCS: Re-write this shorter!
      *
      \param maxage   Release all totally idle chunks that
      *               have not been referenced for maxage seconds.
@@ -299,25 +292,26 @@ public:
 };
 
 /// \ingroup MemPoolsAPI
-/// \todo Classify and add constructor/destructor to initialize properly.
-struct _MemPoolGlobalStats {
-    MemPoolMeter *TheMeter;
+class MemPoolGlobalStats
+{
+public:
+    MemPoolMeter *TheMeter = nullptr;
 
-    int tot_pools_alloc;
-    int tot_pools_inuse;
-    int tot_pools_mempid;
+    int tot_pools_alloc = 0;
+    int tot_pools_inuse = 0;
+    int tot_pools_mempid = 0;
 
-    int tot_chunks_alloc;
-    int tot_chunks_inuse;
-    int tot_chunks_partial;
-    int tot_chunks_free;
+    int tot_chunks_alloc = 0;
+    int tot_chunks_inuse = 0;
+    int tot_chunks_partial = 0;
+    int tot_chunks_free = 0;
 
-    int tot_items_alloc;
-    int tot_items_inuse;
-    int tot_items_idle;
+    int tot_items_alloc = 0;
+    int tot_items_inuse = 0;
+    int tot_items_idle = 0;
 
-    int tot_overhead;
-    ssize_t mem_idle_limit;
+    int tot_overhead = 0;
+    ssize_t mem_idle_limit = 0;
 };
 
 /// \ingroup MemPoolsAPI
@@ -346,7 +340,6 @@ extern void memPoolIterateDone(MemPoolIterator ** iter);
 
 /**
  \ingroup MemPoolsAPI
- \todo Stats API - not sured how to refactor yet
  *
  * Fills a MemPoolGlobalStats with statistical data about overall
  * usage for all pools.

--- a/src/mgr/BasicActions.h
+++ b/src/mgr/BasicActions.h
@@ -93,7 +93,7 @@ protected:
     OfflineToggleAction(const CommandPointer &cmd);
 };
 
-/// Registers profiles for the actions above; \todo move elsewhere?
+/// Registers profiles for the actions above; TODO: move elsewhere?
 void RegisterBasics();
 
 } // namespace Mgr

--- a/src/mgr/BasicActions.h
+++ b/src/mgr/BasicActions.h
@@ -93,7 +93,7 @@ protected:
     OfflineToggleAction(const CommandPointer &cmd);
 };
 
-/// Registers profiles for the actions above.
+/// Registers profiles for the actions above; \todo move elsewhere?
 void RegisterBasics();
 
 } // namespace Mgr

--- a/src/mgr/BasicActions.h
+++ b/src/mgr/BasicActions.h
@@ -93,7 +93,7 @@ protected:
     OfflineToggleAction(const CommandPointer &cmd);
 };
 
-/// Registers profiles for the actions above; \todo move elsewhere?
+/// Registers profiles for the actions above.
 void RegisterBasics();
 
 } // namespace Mgr

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -410,8 +410,9 @@ getWeightedRoundRobinParent(PeerSelector *ps)
  * period. The larger the number of requests between cycled resets the
  * more balanced the operations.
  *
- \param data    unused.
- \todo Make the reset timing a selectable parameter in squid.conf
+ * \param data    unused
+ *
+ * TODO: Make the reset timing a selectable parameter in squid.conf
  */
 static void
 peerClearRRLoop(void *data)

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -232,7 +232,7 @@ Parser::Tokenizer::int64(int64_t & result, int base, bool allowSign, const SBuf:
 
     const SBuf range(buf_.substr(0,limit));
 
-    //fixme: account for buf_.size()
+    // XXX: account for buf_.size()
     bool neg = false;
     const char *s = range.rawContent();
     const char *end = range.rawContent() + range.length();

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -18,8 +18,6 @@
 /**
  \defgroup PConnAPI Persistent Connection API
  \ingroup Component
- *
- \todo CLEANUP: Break multiple classes out of the generic pconn.h header
  */
 
 class PconnPool;

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -408,7 +408,7 @@ redirectInit(void)
 void
 redirectShutdown(void)
 {
-    /** FIXME: Temporary unified helpers Shutdown
+    /** TODO: Temporary unified helpers Shutdown
      * When and if needed for more helpers a separated shutdown
      * method will be added for each of them.
      */

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -282,7 +282,7 @@ refreshCheck(const StoreEntry * entry, HttpRequest * request, time_t delta)
     if (check_time > entry->timestamp)
         age = check_time - entry->timestamp;
 
-    // FIXME: what to do when age < 0 or counter overflow?
+    // XXX: what to do when age < 0 or counter overflow?
     assert(age >= 0);
 
     /* We need a refresh rule. In order of preference:

--- a/src/security/cert_generators/helpers.m4
+++ b/src/security/cert_generators/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_security_cert_generators list containing double entries.
+# TODO: de-duplicate $enable_security_cert_generators list containing double entries.
 
 #define list of modules to build
 auto_security_modules=no

--- a/src/security/cert_validators/helpers.m4
+++ b/src/security/cert_validators/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_security_cert_validators list containing double entries.
+# TODO: de-duplicate $enable_security_cert_validators list containing double entries.
 
 #define list of modules to build
 auto_security_certv_modules=no

--- a/src/snmp_agent.cc
+++ b/src/snmp_agent.cc
@@ -208,7 +208,7 @@ snmp_meshPtblFn(variable_list * Var, snint * ErrP)
     }
 
     switch (Var->name[LEN_SQ_MESH + 2]) {
-    case MESH_PTBL_INDEX: { // FIXME INET6: Should be visible?
+    case MESH_PTBL_INDEX: { // XXX: Should be visible?
         Answer = snmp_var_new_integer(Var->name, Var->name_length,
                                       (snint)p->index, SMI_INTEGER);
     }

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1919,7 +1919,7 @@ statGraphDump(StoreEntry * e)
     GENGRAPH(client_http.kbytes_in.kb, "client_http.kbytes_in", "Client HTTP kbytes_in/sec");
     GENGRAPH(client_http.kbytes_out.kb, "client_http.kbytes_out", "Client HTTP kbytes_out/sec");
 
-    /* XXX todo: http median service times */
+    // TODO: http median service times
 
     GENGRAPH(server.all.requests, "server.all.requests", "Server requests/sec");
     GENGRAPH(server.all.errors, "server.all.errors", "Server errors/sec");
@@ -1946,8 +1946,8 @@ statGraphDump(StoreEntry * e)
     GENGRAPH(icp.kbytes_sent.kb, "icp.kbytes_sent", "ICP kbytes_sent/sec");
     GENGRAPH(icp.kbytes_recv.kb, "icp.kbytes_recv", "ICP kbytes_received/sec");
 
-    /* XXX todo: icp median service times */
-    /* XXX todo: dns median service times */
+    // TODO: icp median service times
+    // TODO: dns median service times
 
     GENGRAPH(unlink.requests, "unlink.requests", "Cache File unlink requests/sec");
     GENGRAPH(page_faults, "page_faults", "System Page Faults/sec");

--- a/src/stmem.cc
+++ b/src/stmem.cc
@@ -215,7 +215,7 @@ mem_hdr::debugDump() const
     debugs (19, 0, "mem_hdr::debugDump: Current available data is: " << result.str() << ".");
 }
 
-/* FIXME: how do we deal with sparse results -
+/* XXX: how do we deal with sparse results -
  * where we have (say)
  * 0-500 and 1000-1500, but are asked for
  * 0-2000

--- a/src/store.cc
+++ b/src/store.cc
@@ -63,7 +63,7 @@
 
 #define STORE_IN_MEM_BUCKETS            (229)
 
-/** \todo Convert these string constants to enum string-arrays generated */
+// TODO: Convert these string constants to enum string-arrays generated
 
 const char *memStatusStr[] = {
     "NOT_IN_MEMORY",

--- a/src/store/Disk.h
+++ b/src/store/Disk.h
@@ -38,7 +38,7 @@ public:
 
     /**
      * Notify this disk that it is full.
-     \todo XXX move into a protected api call between store files and their stores, rather than a top level api call
+     * XXX move into a protected api call between store files and their stores, rather than a top level api call
      */
     virtual void diskFull();
 

--- a/src/store/Storage.h
+++ b/src/store/Storage.h
@@ -55,7 +55,7 @@ public:
 
     /**
      * Output stats to the provided store entry.
-     \todo make these calls asynchronous
+     * TODO: make these calls asynchronous
      */
     virtual void stat(StoreEntry &e) const = 0;
 

--- a/src/store/id_rewriters/helpers.m4
+++ b/src/store/id_rewriters/helpers.m4
@@ -8,7 +8,7 @@
 # This file is supposed to run all the tests required to identify which
 # configured modules are able to be built in this environment
 
-# FIXME: de-duplicate $enable_storeid_rewrite_helpers list containing double entries.
+# TODO: de-duplicate $enable_storeid_rewrite_helpers list containing double entries.
 
 #define list of modules to build
 auto_storeid_modules=no

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -14,7 +14,7 @@
 #include "globals.h"
 #include "Store.h"
 #include "StoreClient.h"
-/* FIXME: Abstract the use of this more */
+// TODO: Abstract the use of this more
 #include "mem_node.h"
 #include "MemObject.h"
 #include "SquidConfig.h"
@@ -287,7 +287,7 @@ storeSwapOutFileClosed(void *data, int errflag, StoreIOState::Pointer self)
                e->swap_filen << ", errflag=" << errflag);
 
         if (errflag == DISK_NO_SPACE_LEFT) {
-            /* FIXME: this should be handle by the link from store IO to
+            /* TODO: this should be handle by the link from store IO to
              * Store, rather than being a top level API call.
              */
             e->disk().diskFull();

--- a/src/tests/testStatHist.cc
+++ b/src/tests/testStatHist.cc
@@ -79,7 +79,7 @@ testStatHist::testStatHistLog()
     CPPUNIT_ASSERT(test.counter(max)==1);
     test=raw;
     test.count(max);
-    //CPPUNIT_ASSERT(test.val(capacity-1)==1); //FIXME: val() returns a density
+    //CPPUNIT_ASSERT(test.val(capacity-1)==1); // XXX: val() returns a density
 }
 
 void

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -39,8 +39,6 @@ addSwapDir(MySwapDirPointer aStore)
     ++Config.cacheSwap.n_configured;
 }
 
-/* TODO make this a cbdata class */
-
 static bool cbcalled;
 
 static void
@@ -208,7 +206,7 @@ testUfs::testUfsSearch()
 
     free_cachedir(&Config.cacheSwap);
 
-    /* todo: here we should test a dirty rebuild */
+    // TODO: here we should test a dirty rebuild
 
     safe_free(Config.replPolicy->type);
     delete Config.replPolicy;

--- a/src/tests/test_http_range.cc
+++ b/src/tests/test_http_range.cc
@@ -6,14 +6,12 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-/* DEBUG: section 64    HTTP Range Header */
-
 #include "squid.h"
 #include "fatal.h"
 #include "HttpHeader.h"
 #include "HttpHeaderRange.h"
 
-/** \todo CLEANUP: This file should be called something_stub.cc */
+// TODO: refactor as cppunit test
 
 void httpHeaderPutStr(HttpHeader * hdr, Http::HdrType type, const char *str)
 {

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -1155,7 +1155,7 @@ wccp2HandleUdp(int sock, void *)
 
     Comm::SetSelect(sock, COMM_SELECT_READ, wccp2HandleUdp, NULL, 0);
 
-    /* FIXME INET6 : drop conversion boundary */
+    // TODO: drop conversion boundary
     Ip::Address from_tmp;
     from_tmp.setIPv4();
 
@@ -1174,7 +1174,7 @@ wccp2HandleUdp(int sock, void *)
     if (ntohl(wccp2_i_see_you.type) != WCCP2_I_SEE_YOU)
         return;
 
-    /* FIXME INET6 : drop conversion boundary */
+    // XXX: drop conversion boundary
     from_tmp.getSockAddr(from);
 
     debugs(80, 3, "Incoming WCCPv2 I_SEE_YOU length " << ntohs(wccp2_i_see_you.length) << ".");
@@ -1964,7 +1964,7 @@ wccp2AssignBuckets(void *)
             if (ntohl(router_list_ptr->num_caches)) {
                 /* send packet */
 
-                /* FIXME INET6 : drop temp conversion */
+                // XXX: drop temp conversion
                 Ip::Address tmp_rtr(router);
 
                 if (wccp2_numrouters > 1) {

--- a/tools/purge/conffile.cc
+++ b/tools/purge/conffile.cc
@@ -86,7 +86,7 @@ readConfigFile( CacheDirVector& cachedir, const char* fn, FILE* debug )
     char *s, line[1024];
     CacheDir cd;
     while ( cfgin.getline( line, sizeof(line)) ) {
-        // FIXME: overly long lines
+        // TODO: overly long lines
 
         // terminate line at start of comment
         if ( (s = (char*) memchr( line, '#', sizeof(line) )) ) *s = '\0';

--- a/tools/purge/copyout.cc
+++ b/tools/purge/copyout.cc
@@ -180,7 +180,7 @@ copy_out( size_t filesize, size_t metasize, unsigned debug,
     }
 
     // find double CRLF sequence (actually, look at the FSM below)
-    // FIXME: this only looks at the already known buffer read previously,
+    // XXX: this only looks at the already known buffer read previously,
     // which is globally passed (yuck)! As a limitation, the content data
     // *must* begin within the buffer size (that is: 16k)!
     if ( ! copyHdr ) {

--- a/tools/purge/purge.cc
+++ b/tools/purge/purge.cc
@@ -463,7 +463,7 @@ match( const char* fn, const REList* list )
 
             // "meta" will be deleted when exiting from this block
         } else {
-            // weird file, FIXME: stat() it!
+            // weird file, TODO: stat() it!
             struct stat st;
             long size = ( fstat(fd,&st) == -1 ? -1 : st.st_size );
             if ( ::verbose ) flag = ( log_extended( fn, -1, size, 0 ) >= 0 );


### PR DESCRIPTION
Update old ad-hoc FIXME labels and experimental use of doxygen \todo
listings to use XXX or TODO labels for consistency sake.

Approximate current definitions (to be formalized elsewhere):
 * XXX - a problem, often a serious one
 * TODO - a problem, often a minor one
 * BUG - a problem that is worth informing admin about

Existing TODO, XXX, and BUG labels may not fit the above definitions.

Some old marks were edited or purged.
