### PR TITLE
Cleanup HERE usage

### DIFF
--- a/scripts/maintenance/deprecated-wrappers
+++ b/scripts/maintenance/deprecated-wrappers
@@ -1,0 +1,16 @@
+#!/usr/bin/gawk -f
+#
+## Copyright (C) 1996-2020 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+/HERE/ {
+  # HERE is deprecated by debugs() internal logic
+  sub(/[ ]*HERE[ ]*<<[ ]*":[ ]/, " \"", $0);
+  sub(/[ ]*HERE[ ]*<<[ ]*/, " ", $0);
+}
+
+{ print }


### PR DESCRIPTION
Draft rules to drop over 90% of HERE macros automatically.
The remaining HERE need manual attention to replace with
useful debug texts.

This PR is scope is the maintenance script rules. As a transitional
update to reduce the removal pains. eg old patches containing
HERE can still be tested during the transition period and even
(if QA allows) merged.