### PR TITLE
compat/cpu.h: remove obsolete bits

### DIFF
--- a/compat/cpu.h
+++ b/compat/cpu.h
@@ -27,10 +27,6 @@ inline int sched_setaffinity(int, size_t, cpu_set_t *) { return ENOTSUP; }
 inline int sched_getaffinity(int, size_t, cpu_set_t *) { return ENOTSUP; }
 #endif /* HAVE_CPU_AFFINITY */
 
-#if !defined(CPU_SETSIZE)
-#define CPU_SETSIZE 0
-#endif
-
 #if !defined(CPU_ZERO)
 #define CPU_ZERO(set) (void)0
 #endif
@@ -39,45 +35,4 @@ inline int sched_getaffinity(int, size_t, cpu_set_t *) { return ENOTSUP; }
 #define CPU_SET(cpu, set) (void)0
 #endif
 
-#if !defined(CPU_CLR)
-#define CPU_CLR(cpu, set) (void)0
-#endif
-
-#if !defined(CPU_ISSET)
-#define CPU_ISSET(cpu, set) false
-#endif
-
-// glibc prior to 2.6 lacks CPU_COUNT
-#ifndef CPU_COUNT
-#define CPU_COUNT(set) CpuCount(set)
-/// CPU_COUNT replacement
-inline int
-CpuCount(const cpu_set_t *set)
-{
-    int count = 0;
-    for (int i = 0; i < CPU_SETSIZE; ++i) {
-        if (CPU_ISSET(i, set))
-            ++count;
-    }
-    return count;
-}
-#endif /* CPU_COUNT */
-
-// glibc prior to 2.7 lacks CPU_AND
-#ifndef CPU_AND
-#define CPU_AND(destset, srcset1, srcset2) CpuAnd((destset), (srcset1), (srcset2))
-/// CPU_AND replacement
-inline void
-CpuAnd(cpu_set_t *destset, const cpu_set_t *srcset1, const cpu_set_t *srcset2)
-{
-    for (int i = 0; i < CPU_SETSIZE; ++i) {
-        if (CPU_ISSET(i, srcset1) && CPU_ISSET(i, srcset2))
-            CPU_SET(i, destset);
-        else
-            CPU_CLR(i, destset);
-    }
-}
-#endif /* CPU_AND */
-
 #endif /* SQUID_COMPAT_CPU_H */
-


### PR DESCRIPTION
some compatibility bits in cpu.h are for
glibc versions that are older than the oldest
supported OS by now. Remove them