### PR TITLE
Adjust const-correctness in src/PingData.h

### DIFF
--- a/src/PingData.h
+++ b/src/PingData.h
@@ -16,7 +16,7 @@
 class PeerSelector;
 class PeerSelectorPingMonitor;
 
-typedef std::pair<timeval, PeerSelector *> WaitingPeerSelector;
+typedef std::pair<const timeval, PeerSelector *> WaitingPeerSelector;
 /// waiting PeerSelector objects, ordered by their absolute deadlines
 typedef std::multimap<timeval, PeerSelector *, std::less<timeval>, PoolingAllocator<WaitingPeerSelector> > WaitingPeerSelectors;
 typedef WaitingPeerSelectors::iterator WaitingPeerSelectorPosition;


### PR DESCRIPTION
libc++-based systems complain about const-correctness
in PingData.h from PR#635. Eduard root-caused, I tested his analysis
and cofirmed it builds.