### PR TITLE
Avoid corruption of source files when astyle cannot start

### DIFF
--- a/scripts/formater.pl
+++ b/scripts/formater.pl
@@ -58,6 +58,8 @@ while($out){
         next;
     }
 
+    die("Cannot format a non-existent file: $out\n") unless -e $out;
+
     my $in= "$out.astylebak";
     my($new_in) = $in;
     my($i) = 0;


### PR DESCRIPTION
    $ export ASTYLE=/no/such/file
    $ ./scripts/formater.pl src/tunnel.cc
    open2: exec of /no/such/file ... failed: No such file or directory

    # for debugging; most admins will just fix the ASTYLE value
    $ file src/tunnel.cc
    src/tunnel.cc: cannot open `src/tunnel.cc' (No such file or ...)

    $ export ASTYLE=/usr/bin/astyle
    $ ./scripts/formater.pl src/tunnel.cc
    Can not open input file: src/tunnel.cc.astylebak.2

    $ xxd -C src/tunnel.cc
    00000000: 00

Also avoids creation of new source files, as (poorly) illustrated by the
single-byte src/tunnel.cc file created (after being removed) above.

Also improves diagnostic when dealing with misspelled file names:

    $ ./scripts/formater.pl src/tunnel.ccsrc/FwdState.cc
    Can not open input file: src/tunnel.ccsrc/FwdState.cc.astylebak
    Can't open output file: src/tunnel.ccsrc/FwdState.cc