### PR TITLE
Fix "make check" with GCC-10

### DIFF
--- a/src/tests/stub_HttpControlMsg.cc
+++ b/src/tests/stub_HttpControlMsg.cc
@@ -9,7 +9,7 @@
 #include "squid.h"
 
 #define STUB_API "HttpControlMsg.cc"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #include "HttpControlMsg.h"
 void HttpControlMsgSink::wroteControlMsg(CommIoCbParams const&) STUB

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -11,7 +11,7 @@
 #include "TimeOrTag.h"
 
 #define STUB_API "HttpHeader.cc"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #include "HttpHeader.h"
 HttpHeaderEntry::HttpHeaderEntry(Http::HdrType, const SBuf &, const char *) {STUB}

--- a/src/tests/stub_HttpUpgradeProtocolAccess.cc
+++ b/src/tests/stub_HttpUpgradeProtocolAccess.cc
@@ -10,7 +10,7 @@
 #include "ConfigParser.h"
 
 #define STUB_API "HttpUpgradeProtocolAccess.cc"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #include "HttpUpgradeProtocolAccess.h"
 ProtocolView::ProtocolView(const char * const, const size_t) STUB

--- a/src/tests/stub_StatHist.cc
+++ b/src/tests/stub_StatHist.cc
@@ -10,7 +10,7 @@
 #include "StatHist.h"
 
 #define STUB_API "StatHist.cc"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 class StoreEntry;
 

--- a/src/tests/stub_ipcache.cc
+++ b/src/tests/stub_ipcache.cc
@@ -10,7 +10,7 @@
 #include "ipcache.h"
 
 #define STUB_API "ipcache.cc"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 void ipcache_purgelru(void *) STUB
 void ipcache_nbgethostbyname(const char *name, IPH * handler, void *handlerData) STUB

--- a/src/tests/stub_libauth.cc
+++ b/src/tests/stub_libauth.cc
@@ -9,7 +9,7 @@
 #include "squid.h"
 
 #define STUB_API "auth/libauth.la"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #if USE_AUTH
 #include "auth/SchemeConfig.h"

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -9,7 +9,7 @@
 #include "squid.h"
 
 #define STUB_API "auth/libacls.la"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #if USE_AUTH
 #include "acl/Acl.h" /* for Acl::Answer */

--- a/src/tests/stub_libeui.cc
+++ b/src/tests/stub_libeui.cc
@@ -9,7 +9,7 @@
 #include "squid.h"
 
 #define STUB_API "eui/libeui.la"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #include "eui/Config.h"
 Eui::EuiConfig Eui::TheConfig;

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -12,7 +12,7 @@
 #include "SquidConfig.h"
 
 #define STUB_API "http/libhttp.la"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #include "http/ContentLengthInterpreter.h"
 namespace Http

--- a/src/tests/stub_libicmp.cc
+++ b/src/tests/stub_libicmp.cc
@@ -8,7 +8,7 @@
 
 #include "squid.h"
 #define STUB_API "icmp/libicmp.la"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #include "icmp/IcmpSquid.h"
 //IcmpSquid::IcmpSquid() STUB

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -9,7 +9,7 @@
 #include "squid.h"
 
 #define STUB_API "mem/libmem.la"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 #include "mem/AllocatorProxy.h"
 void *Mem::AllocatorProxy::alloc() {return xmalloc(64*1024);}

--- a/src/tests/stub_time.cc
+++ b/src/tests/stub_time.cc
@@ -10,7 +10,7 @@
 #include "SquidTime.h"
 
 #define STUB_API "time.cc"
-#include "STUB.h"
+#include "tests/STUB.h"
 
 struct timeval current_time;
 double current_dtime;

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -31,7 +31,7 @@ include $(top_srcdir)/doc/manuals/Substitute.am
 test_tools.cc: $(top_srcdir)/test-suite/test_tools.cc
 	cp $(top_srcdir)/test-suite/test_tools.cc $@
 
-stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc
+tests/stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc
 	cp $(top_srcdir)/src/tests/stub_debug.cc $@
 
 Here.cc: $(top_srcdir)/src/base/Here.cc
@@ -46,13 +46,13 @@ MemBuf.cc: $(top_srcdir)/src/MemBuf.cc
 time.cc: $(top_srcdir)/src/time.cc
 	cp $(top_srcdir)/src/time.cc $@
 
-stub_cbdata.cc: $(top_srcdir)/src/tests/stub_cbdata.cc
+tests/stub_cbdata.cc: $(top_srcdir)/src/tests/stub_cbdata.cc
 	cp $(top_srcdir)/src/tests/stub_cbdata.cc $@
 
-stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc STUB.h
+tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 
-STUB.h: $(top_srcdir)/src/tests/STUB.h
+tests/STUB.h: $(top_srcdir)/src/tests/STUB.h
 	cp $(top_srcdir)/src/tests/STUB.h $@
 
 # stock tools for unit tests - library independent versions of dlink_list
@@ -60,7 +60,7 @@ STUB.h: $(top_srcdir)/src/tests/STUB.h
 # globals.cc is needed by test_tools.cc.
 # Neither of these should be disted from here.
 TESTSOURCES= test_tools.cc
-CLEANFILES += test_tools.cc Here.cc CharacterSet.cc MemBuf.cc stub_debug.cc time.cc stub_cbdata.cc stub_libmem.cc STUB.h
+CLEANFILES += test_tools.cc Here.cc CharacterSet.cc MemBuf.cc tests/stub_debug.cc time.cc tests/stub_cbdata.cc tests/stub_libmem.cc tests/STUB.h
 
 ## Test Scripts
 EXTRA_DIST += helper-ok-dying.pl helper-ok.pl
@@ -75,13 +75,15 @@ cachemgr__CGIEXT__SOURCES = \
 	CharacterSet.cc \
 	Here.cc \
 	MemBuf.cc \
-	STUB.h \
 	cachemgr.cc \
-	stub_cbdata.cc \
-	stub_debug.cc \
-	stub_libmem.cc \
 	test_tools.cc \
 	time.cc
+
+nodist_cachemgr__CGIEXT__SOURCES = \
+	tests/STUB.h \
+	tests/stub_cbdata.cc \
+	tests/stub_debug.cc \
+	tests/stub_libmem.cc \
 
 cachemgr__CGIEXT__CXXFLAGS = -DDEFAULT_CACHEMGR_CONFIG=\"$(DEFAULT_CACHEMGR_CONFIG)\" $(AM_CXXFLAGS)
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -83,7 +83,7 @@ nodist_cachemgr__CGIEXT__SOURCES = \
 	tests/STUB.h \
 	tests/stub_cbdata.cc \
 	tests/stub_debug.cc \
-	tests/stub_libmem.cc \
+	tests/stub_libmem.cc
 
 cachemgr__CGIEXT__CXXFLAGS = -DDEFAULT_CACHEMGR_CONFIG=\"$(DEFAULT_CACHEMGR_CONFIG)\" $(AM_CXXFLAGS)
 

--- a/tools/squidclient/Makefile.am
+++ b/tools/squidclient/Makefile.am
@@ -57,7 +57,6 @@ squidclient_SOURCES = \
 	Parameters.h \
 	Ping.cc \
 	Ping.h \
-	STUB.h \
 	Transport.cc \
 	Transport.h \
 	gssapi_support.cc \

--- a/tools/squidclient/Makefile.am
+++ b/tools/squidclient/Makefile.am
@@ -30,25 +30,24 @@ include $(top_srcdir)/doc/manuals/Substitute.am
 test_tools.cc: $(top_srcdir)/test-suite/test_tools.cc
 	cp $(top_srcdir)/test-suite/test_tools.cc $@
 
-stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc
+tests/stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc
 	cp $(top_srcdir)/src/tests/stub_debug.cc $@
 
 time.cc: $(top_srcdir)/src/time.cc
 	cp $(top_srcdir)/src/time.cc $@
 
-stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc STUB.h
+tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
-	
-STUB.h: $(top_srcdir)/src/tests/STUB.h
+
+tests/STUB.h: $(top_srcdir)/src/tests/STUB.h
 	cp $(top_srcdir)/src/tests/STUB.h $@
-	
 
 # stock tools for unit tests - library independent versions of dlink_list
 # etc.
 # globals.cc is needed by test_tools.cc.
 # Neither of these should be disted from here.
 TESTSOURCES= test_tools.cc
-CLEANFILES += test_tools.cc stub_debug.cc time.cc stub_libmem.cc STUB.h
+CLEANFILES += test_tools.cc tests/stub_debug.cc time.cc tests/stub_libmem.cc tests/STUB.h
 
 ## ##### squidclient  #####
 
@@ -64,7 +63,10 @@ squidclient_SOURCES = \
 	gssapi_support.cc \
 	gssapi_support.h \
 	squidclient.cc \
-	stub_debug.cc \
-	stub_libmem.cc \
 	test_tools.cc \
 	time.cc
+
+nodist_squidclient_SOURCES = \
+	tests/stub_debug.cc \
+	tests/stub_libmem.cc \
+	tests/STUB.h


### PR DESCRIPTION
Latest GCC-10 release on some OS (Debian initially) no
longer locates files in "." by default. Fix Makefile hack
pulling tests/ files into tools/ for stub linking.

Also, Squid #includes under src/ are supposed to always
use path relative to src/. Fix wrong STUB.h references.