### PR TITLE
Bug 5048: ResolvedPeers.cc:35: "found != paths_.end()" assertion

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -484,7 +484,7 @@ FwdState::fail(ErrorState * errorState)
         debugs(17, 5, HERE << "pconn race happened");
         pconnRace = raceHappened;
         if (destinationReceipt) {
-            destinations->returnPath(destinationReceipt);
+            destinations->reinstatePath(destinationReceipt);
             destinationReceipt = nullptr;
         }
     }

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -21,6 +21,7 @@
 #include "http/StatusCode.h"
 #include "ip/Address.h"
 #include "PeerSelectState.h"
+#include "ResolvedPeers.h"
 #include "security/forward.h"
 #if USE_OPENSSL
 #include "ssl/support.h"
@@ -197,6 +198,7 @@ private:
     HappyConnOpenerPointer connOpener; ///< current connection opening job
     ResolvedPeersPointer destinations; ///< paths for forwarding the request
     Comm::ConnectionPointer serverConn; ///< a successfully opened connection to a server.
+    PeerConnectionPointer destinationReceipt; ///< peer selection result (or nil)
 
     AsyncCall::Pointer closeHandler; ///< The serverConn close handler
 

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -484,7 +484,7 @@ void
 HappyConnOpener::cancelAttempt(Attempt &attempt, const char *reason)
 {
     Must(attempt);
-    destinations->returnPath(attempt.path); // before attempt.cancel() clears path
+    destinations->reinstatePath(attempt.path); // before attempt.cancel() clears path
     attempt.cancel(reason);
 }
 

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -726,7 +726,7 @@ HappyConnOpener::checkForNewConnection()
             debugs(17, 7, "new peer " << *currentPeer);
             primeStart = current_dtime;
             startConnecting(prime, newPrime);
-            // XXX: if reuseOldConnection() in startConnecting() above succeeds,
+            // TODO: if reuseOldConnection() in startConnecting() above succeeds,
             // then we should not get here, and Must(prime) below will fail.
             maybeGivePrimeItsChance();
             Must(prime); // entering state #1.1

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -14,13 +14,13 @@
 #include "comm/ConnOpener.h"
 #include "http/forward.h"
 #include "log/forward.h"
+#include "ResolvedPeers.h"
 
 #include <iosfwd>
 
 class HappyConnOpener;
 class HappyOrderEnforcer;
 class JobGapEnforcer;
-class ResolvedPeers;
 typedef RefCount<ResolvedPeers> ResolvedPeersPointer;
 
 /// A FIFO queue of HappyConnOpener jobs waiting to open a spare connection.
@@ -79,7 +79,7 @@ public:
 
     /// on success: an open, ready-to-use Squid-to-peer connection
     /// on failure: either a closed failed Squid-to-peer connection or nil
-    Comm::ConnectionPointer conn;
+    PeerConnectionPointer conn;
 
     // answer recipients must clear the error member in order to keep its info
     // XXX: We should refcount ErrorState instead of cbdata-protecting it.
@@ -164,7 +164,7 @@ private:
         /// aborts an in-progress attempt
         void cancel(const char *reason);
 
-        Comm::ConnectionPointer path; ///< the destination we are connecting to
+        PeerConnectionPointer path; ///< the destination we are connecting to
         AsyncCall::Pointer connector; ///< our opener callback
         Comm::ConnOpener::Pointer opener; ///< connects to path and calls us
 
@@ -186,9 +186,9 @@ private:
     void stopWaitingForSpareAllowance();
     void maybeOpenSpareConnection();
 
-    void startConnecting(Attempt &, Comm::ConnectionPointer &);
-    void openFreshConnection(Attempt &, Comm::ConnectionPointer &);
-    bool reuseOldConnection(const Comm::ConnectionPointer &);
+    void startConnecting(Attempt &, PeerConnectionPointer &);
+    void openFreshConnection(Attempt &, PeerConnectionPointer &);
+    bool reuseOldConnection(PeerConnectionPointer &);
 
     void connectDone(const CommConnectCbParams &);
 
@@ -201,8 +201,8 @@ private:
     bool ranOutOfTimeOrAttempts() const;
 
     ErrorState *makeError(const err_type type) const;
-    Answer *futureAnswer(const Comm::ConnectionPointer &);
-    void sendSuccess(const Comm::ConnectionPointer &conn, bool reused, const char *connKind);
+    Answer *futureAnswer(const PeerConnectionPointer &);
+    void sendSuccess(const PeerConnectionPointer &conn, bool reused, const char *connKind);
     void sendFailure();
     void cancelAttempt(Attempt &, const char *reason);
 
@@ -230,7 +230,7 @@ private:
     AccessLogEntryPointer ale; ///< transaction details
 
     ErrorState *lastError = nullptr; ///< last problem details (or nil)
-    Comm::ConnectionPointer lastFailedConnection; ///< nil if none has failed
+    PeerConnectionPointer lastFailedConnection; ///< nil if none has failed
 
     /// whether spare connection attempts disregard happy_eyeballs_* settings
     bool ignoreSpareRestrictions = false;

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -13,8 +13,6 @@
 #include "ResolvedPeers.h"
 #include "SquidConfig.h"
 
-/* ResolvedPeers */
-
 ResolvedPeers::ResolvedPeers()
 {
     if (Config.forward_max_tries > 0)

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -22,7 +22,7 @@ ResolvedPeers::ResolvedPeers()
 }
 
 void
-ResolvedPeers::returnPath(const PeerConnectionPointer &path)
+ResolvedPeers::reinstatePath(const PeerConnectionPointer &path)
 {
     debugs(17, 4, path);
     assert(path);

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -13,6 +13,8 @@
 #include "ResolvedPeers.h"
 #include "SquidConfig.h"
 
+/* ResolvedPeers */
+
 ResolvedPeers::ResolvedPeers()
 {
     if (Config.forward_max_tries > 0)
@@ -20,25 +22,20 @@ ResolvedPeers::ResolvedPeers()
 }
 
 void
-ResolvedPeers::retryPath(const Comm::ConnectionPointer &path)
+ResolvedPeers::returnPath(const PeerConnectionPointer &path)
 {
     debugs(17, 4, path);
     assert(path);
-    // Cannot use pathsToSkip for a faster (reverse) search because there
-    // may be unavailable paths past pathsToSkip. We could remember
-    // the last extraction index, but, to completely avoid a linear search,
-    // extract*() methods should return the path index.
-    const auto found = std::find_if(paths_.begin(), paths_.end(),
-    [path](const ResolvedPeerPath &candidate) {
-        return candidate.connection == path; // (refcounted) pointer comparison
-    });
-    assert(found != paths_.end());
-    assert(!found->available);
-    found->available = true;
+
+    const auto pos = path.position_;
+    assert(pos < paths_.size());
+
+    assert(!paths_[pos].available);
+    paths_[pos].available = true;
     increaseAvailability();
 
     // if we restored availability of a path that we used to skip, update
-    const auto pathsToTheLeft = static_cast<size_type>(found - paths_.begin());
+    const auto pathsToTheLeft = pos;
     if (pathsToTheLeft < pathsToSkip) {
         pathsToSkip = pathsToTheLeft;
     } else {
@@ -112,14 +109,14 @@ ResolvedPeers::findPeer(const Comm::Connection &currentPeer)
     return makeFinding(path, foundNext);
 }
 
-Comm::ConnectionPointer
+PeerConnectionPointer
 ResolvedPeers::extractFront()
 {
     Must(!empty());
     return extractFound("first: ", start());
 }
 
-Comm::ConnectionPointer
+PeerConnectionPointer
 ResolvedPeers::extractPrime(const Comm::Connection &currentPeer)
 {
     const auto found = findPrime(currentPeer).first;
@@ -130,7 +127,7 @@ ResolvedPeers::extractPrime(const Comm::Connection &currentPeer)
     return nullptr;
 }
 
-Comm::ConnectionPointer
+PeerConnectionPointer
 ResolvedPeers::extractSpare(const Comm::Connection &currentPeer)
 {
     const auto found = findSpare(currentPeer).first;
@@ -142,7 +139,7 @@ ResolvedPeers::extractSpare(const Comm::Connection &currentPeer)
 }
 
 /// convenience method to finish a successful extract*() call
-Comm::ConnectionPointer
+PeerConnectionPointer
 ResolvedPeers::extractFound(const char *description, const Paths::iterator &found)
 {
     auto &path = *found;
@@ -156,7 +153,8 @@ ResolvedPeers::extractFound(const char *description, const Paths::iterator &foun
         while (++pathsToSkip < paths_.size() && !paths_[pathsToSkip].available) {}
     }
 
-    return path.connection;
+    const auto cleanPath = path.connection->cloneDestinationDetails();
+    return PeerConnectionPointer(cleanPath, found - paths_.begin());
 }
 
 bool
@@ -227,3 +225,19 @@ operator <<(std::ostream &os, const ResolvedPeers &peers)
     return os << peers.size() << (peers.destinationsFinalized ? "" : "+") << " paths";
 }
 
+/* PeerConnectionPointer */
+
+void
+PeerConnectionPointer::print(std::ostream &os) const
+{
+    // We should see no combinations of a nil connection and a set position
+    // because assigning nullptr (to our smart pointer) naturally erases both
+    // fields. We report such unexpected combinations for debugging sake, but do
+    // not complicate this code to report them beautifully.
+
+    if (connection_)
+        os << connection_;
+
+    if (position_ != npos)
+        os << " @" << position_;
+}

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -13,6 +13,7 @@
 #include "comm/forward.h"
 
 #include <iosfwd>
+#include <limits>
 #include <utility>
 
 class ResolvedPeerPath
@@ -23,6 +24,8 @@ public:
     Comm::ConnectionPointer connection; ///< (the address of) a path
     bool available; ///< whether this path may be used (i.e., has not been tried already)
 };
+
+class PeerConnectionPointer;
 
 /// cache_peer and origin server addresses (a.k.a. paths)
 /// selected and resolved by the peering code
@@ -44,19 +47,20 @@ public:
     /// add a candidate path to try after all the existing paths
     void addPath(const Comm::ConnectionPointer &);
 
-    /// re-inserts the previously extracted address into the same position
-    void retryPath(const Comm::ConnectionPointer &);
+    /// makes the previously extracted path available for extraction at its
+    /// original position
+    void returnPath(const PeerConnectionPointer &);
 
     /// extracts and returns the first queued address
-    Comm::ConnectionPointer extractFront();
+    PeerConnectionPointer extractFront();
 
     /// extracts and returns the first same-peer same-family address
     /// \returns nil if it cannot find the requested address
-    Comm::ConnectionPointer extractPrime(const Comm::Connection &currentPeer);
+    PeerConnectionPointer extractPrime(const Comm::Connection &currentPeer);
 
     /// extracts and returns the first same-peer different-family address
     /// \returns nil if it cannot find the requested address
-    Comm::ConnectionPointer extractSpare(const Comm::Connection &currentPeer);
+    PeerConnectionPointer extractSpare(const Comm::Connection &currentPeer);
 
     /// whether extractSpare() would return a non-nil path right now
     bool haveSpare(const Comm::Connection &currentPeer);
@@ -91,7 +95,7 @@ private:
     Finding findSpare(const Comm::Connection &currentPeer);
     Finding findPrime(const Comm::Connection &currentPeer);
     Finding findPeer(const Comm::Connection &currentPeer);
-    Comm::ConnectionPointer extractFound(const char *description, const Paths::iterator &found);
+    PeerConnectionPointer extractFound(const char *description, const Paths::iterator &found);
     Finding makeFinding(const Paths::iterator &found, bool foundOther);
 
     bool doneWith(const Finding &findings) const;
@@ -110,8 +114,53 @@ private:
     size_type availablePaths = 0;
 };
 
+/// An invasive reference-counting Comm::Connection pointer that also keeps an
+/// (optional) ResolvedPeers position for the ResolvedPeers::returnPath() usage.
+/// Reference counting mechanism is compatible with Comm::ConnectionPointer.
+class PeerConnectionPointer
+{
+public:
+    using size_type = ResolvedPeers::size_type;
+
+    PeerConnectionPointer() = default;
+    PeerConnectionPointer(nullptr_t): PeerConnectionPointer() {} ///< implicit nullptr conversion
+    PeerConnectionPointer(const Comm::ConnectionPointer &conn, const size_type pos): connection_(conn), position_(pos) {}
+
+    /* read-only pointer API; for Connection assignment, see finalize() */
+    explicit operator bool() const { return static_cast<bool>(connection_); }
+    Comm::Connection *operator->() const { assert(connection_); return connection_.getRaw(); }
+    Comm::Connection &operator *() const { assert(connection_); return *connection_; }
+
+    /// convenience conversion to Comm::ConnectionPointer
+    operator const Comm::ConnectionPointer&() const { return connection_; }
+
+    /// upgrade stored peer selection details with a matching actual connection
+    void finalize(const Comm::ConnectionPointer &conn) { connection_ = conn; }
+
+    /// debugging dump
+    void print(std::ostream &) const;
+
+private:
+    /// non-existent position for nil connection
+    static constexpr auto npos = std::numeric_limits<size_type>::max();
+
+    /// half-baked, open, failed, or closed Comm::Connection (or nil)
+    Comm::ConnectionPointer connection_;
+
+    /// ResolvedPeers-maintained membership index (or npos)
+    size_type position_ = npos;
+    friend class ResolvedPeers;
+};
+
 /// summarized ResolvedPeers (for debugging)
 std::ostream &operator <<(std::ostream &, const ResolvedPeers &);
+
+inline std::ostream &
+operator <<(std::ostream &os, const PeerConnectionPointer &dest)
+{
+    dest.print(os);
+    return os;
+}
 
 #endif /* SQUID_RESOLVEDPEERS_H */
 

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -123,7 +123,7 @@ public:
     using size_type = ResolvedPeers::size_type;
 
     PeerConnectionPointer() = default;
-    PeerConnectionPointer(nullptr_t): PeerConnectionPointer() {} ///< implicit nullptr conversion
+    PeerConnectionPointer(std::nullptr_t): PeerConnectionPointer() {} ///< implicit nullptr conversion
     PeerConnectionPointer(const Comm::ConnectionPointer &conn, const size_type pos): connection_(conn), position_(pos) {}
 
     /* read-only pointer API; for Connection assignment, see finalize() */

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -49,7 +49,7 @@ public:
 
     /// makes the previously extracted path available for extraction at its
     /// original position
-    void returnPath(const PeerConnectionPointer &);
+    void reinstatePath(const PeerConnectionPointer &);
 
     /// extracts and returns the first queued address
     PeerConnectionPointer extractFront();
@@ -115,7 +115,7 @@ private:
 };
 
 /// An invasive reference-counting Comm::Connection pointer that also keeps an
-/// (optional) ResolvedPeers position for the ResolvedPeers::returnPath() usage.
+/// (optional) ResolvedPeers position for the ResolvedPeers::reinstatePath() usage.
 /// Reference counting mechanism is compatible with Comm::ConnectionPointer.
 class PeerConnectionPointer
 {

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -30,7 +30,7 @@ class CachePeer;
 
 CBDATA_NAMESPACED_CLASS_INIT(Comm, ConnOpener);
 
-Comm::ConnOpener::ConnOpener(Comm::ConnectionPointer &c, const AsyncCall::Pointer &handler, time_t ctimeout) :
+Comm::ConnOpener::ConnOpener(const Comm::ConnectionPointer &c, const AsyncCall::Pointer &handler, time_t ctimeout) :
     AsyncJob("Comm::ConnOpener"),
     host_(NULL),
     temporaryFd_(-1),

--- a/src/comm/ConnOpener.h
+++ b/src/comm/ConnOpener.h
@@ -33,7 +33,7 @@ public:
 
     virtual bool doneAll() const;
 
-    ConnOpener(Comm::ConnectionPointer &, const AsyncCall::Pointer &handler, time_t connect_timeout);
+    ConnOpener(const Comm::ConnectionPointer &, const AsyncCall::Pointer &handler, time_t connect_timeout);
     ~ConnOpener();
 
     void setHost(const char *);    ///< set the hostname note for this connection

--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -60,24 +60,25 @@ Comm::Connection::~Connection()
 }
 
 Comm::ConnectionPointer
-Comm::Connection::copyDetails() const
+Comm::Connection::cloneDestinationDetails() const
 {
-    ConnectionPointer c = new Comm::Connection;
-
+    const ConnectionPointer c = new Comm::Connection;
     c->setAddrs(local, remote);
     c->peerType = peerType;
+    c->flags = flags;
+    c->peer_ = cbdataReference(getPeer());
+    assert(!c->isOpen());
+    return c;
+}
+
+Comm::ConnectionPointer
+Comm::Connection::cloneIdentDetails() const
+{
+    auto c = cloneDestinationDetails();
     c->tos = tos;
     c->nfmark = nfmark;
     c->nfConnmark = nfConnmark;
-    c->flags = flags;
     c->startTime_ = startTime_;
-
-    // ensure FD is not open in the new copy.
-    c->fd = -1;
-
-    // ensure we have a cbdata reference to peer_ not a straight ptr copy.
-    c->peer_ = cbdataReference(getPeer());
-
     return c;
 }
 

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -77,10 +77,13 @@ public:
     /** Clear the connection properties and close any open socket. */
     virtual ~Connection();
 
-    /** Copy an existing connections IP and properties.
-     * This excludes the FD. The new copy will be a closed connection.
-     */
-    ConnectionPointer copyDetails() const;
+    /// Create a new (closed) IDENT Connection object based on our from-Squid
+    /// connection properties.
+    ConnectionPointer cloneIdentDetails() const;
+
+    /// Create a new (closed) Connection object pointing to the same destination
+    /// as this from-Squid connection.
+    ConnectionPointer cloneDestinationDetails() const;
 
     /// close the still-open connection when its last reference is gone
     void enterOrphanage() { flags |= COMM_ORPHANED; }
@@ -137,12 +140,9 @@ public:
     virtual ScopedId codeContextGist() const override;
     virtual std::ostream &detailCodeContext(std::ostream &os) const override;
 
-private:
-    /** These objects may not be exactly duplicated. Use copyDetails() instead. */
-    Connection(const Connection &c);
-
-    /** These objects may not be exactly duplicated. Use copyDetails() instead. */
-    Connection & operator =(const Connection &c);
+    // TODO: Declare and use (here and elsewhere) NonCopyable, NonMovable, etc.
+    /// no C++ copying/moving; see clone*() methods for custom/partial copies
+    Connection &operator =(Connection &&) = delete;
 
 public:
     /** Address/Port for the Squid end of a TCP link. */

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -140,9 +140,16 @@ public:
     virtual ScopedId codeContextGist() const override;
     virtual std::ostream &detailCodeContext(std::ostream &os) const override;
 
-    // TODO: Declare and use (here and elsewhere) NonCopyable, NonMovable, etc.
-    /// no C++ copying/moving; see clone*() methods for custom/partial copies
-    Connection &operator =(Connection &&) = delete;
+private:
+    /** These objects may not be exactly duplicated. Use cloneIdentDetails() or
+     * cloneDestinationDetails() instead.
+     */
+    Connection(const Connection &c);
+
+    /** These objects may not be exactly duplicated. Use cloneIdentDetails() or
+     * cloneDestinationDetails() instead.
+     */
+    Connection & operator =(const Connection &c);
 
 public:
     /** Address/Port for the Squid end of a TCP link. */

--- a/src/ident/Ident.cc
+++ b/src/ident/Ident.cc
@@ -259,7 +259,7 @@ Ident::Start(const Comm::ConnectionPointer &conn, IDCB * callback, void *data)
     state->hash.key = xstrdup(key);
 
     // copy the conn details. We do not want the original FD to be re-used by IDENT.
-    state->conn = conn->copyDetails();
+    state->conn = conn->cloneIdentDetails();
     // NP: use random port for secure outbound to IDENT_PORT
     state->conn->local.port(0);
     state->conn->remote.port(IDENT_PORT);

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -1083,6 +1083,8 @@ PeerSelector::addSelection(CachePeer *peer, const hier_code code)
         // There can be at most one PINNED destination.
         // Non-PINNED destinations are uniquely identified by their CachePeer
         // (even though a DIRECT destination might match a cache_peer address).
+        // XXX: We may still add duplicates because the same peer could have
+        // been removed from `servers` already (and given to the requestor).
         const bool duplicate = (server->code == PINNED) ?
                                (code == PINNED) : (server->_peer == peer);
         if (duplicate) {

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -1083,7 +1083,7 @@ PeerSelector::addSelection(CachePeer *peer, const hier_code code)
         // There can be at most one PINNED destination.
         // Non-PINNED destinations are uniquely identified by their CachePeer
         // (even though a DIRECT destination might match a cache_peer address).
-        // XXX: We may still add duplicates because the same peer could have
+        // TODO: We may still add duplicates because the same peer could have
         // been removed from `servers` already (and given to the requestor).
         const bool duplicate = (server->code == PINNED) ?
                                (code == PINNED) : (server->_peer == peer);

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -22,7 +22,8 @@ void Comm::AcceptLimiter::kick() STUB
 #include "comm/Connection.h"
 Comm::Connection::Connection() STUB
 Comm::Connection::~Connection() STUB
-Comm::ConnectionPointer Comm::Connection::copyDetails() const STUB_RETVAL(NULL)
+Comm::ConnectionPointer Comm::Connection::cloneIdentDetails() const STUB_RETVAL(nullptr)
+Comm::ConnectionPointer Comm::Connection::cloneDestinationDetails() const STUB_RETVAL(nullptr)
 void Comm::Connection::close() STUB
 CachePeer * Comm::Connection::getPeer() const STUB_RETVAL(NULL)
 void Comm::Connection::setPeer(CachePeer * p) STUB
@@ -35,7 +36,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Comm, ConnOpener);
 bool Comm::ConnOpener::doneAll() const STUB_RETVAL(false)
 void Comm::ConnOpener::start() STUB
 void Comm::ConnOpener::swanSong() STUB
-Comm::ConnOpener::ConnOpener(Comm::ConnectionPointer &, const AsyncCall::Pointer &, time_t) : AsyncJob("STUB Comm::ConnOpener") STUB
+Comm::ConnOpener::ConnOpener(const Comm::ConnectionPointer &, const AsyncCall::Pointer &, time_t) : AsyncJob("STUB Comm::ConnOpener") STUB
     Comm::ConnOpener::~ConnOpener() STUB
     void Comm::ConnOpener::setHost(const char *) STUB
     const char * Comm::ConnOpener::getHost() const STUB_RETVAL(NULL)


### PR DESCRIPTION
This bug was caused by a4d576d. ResolvedPeers::retryPath() used
connection object pointers to find the original path location under the
incorrect assumption that the Connection pointers never change. That
assumption was wrong for persistent connections: ResolvedPeers stores a
half-baked Connection object rather than the corresponding open
Connection object that the unfortunate caller got from fwdPconnPool and
passed to ResolvedPeers::retryPath().

While working on a fix, we discovered a second reason why the pointer
comparison was a bad idea (and why a simpler fix of comparing addresses
rather than pointers was also a bad idea): The peer selection code
promises to deliver unique destinations, but we now suspect that, under
presumably rare circumstances, it may deliver duplicates. This broken
promise is now an out-of-scope XXX in PeerSelector::addSelection().

Squid now eliminates the search (and the previously documented concern
about its slow speed) by remembering Connection's position in the
destination array. The position is remembered in a smart Connection
pointer (compatible with Comm::ConnectionPointer) so that the rest of
the code (that does not really care about all this) is preserved largely
unchanged. Most changes are just renaming the pointer type.

Also freshened a FwdState call and comment made stale by 25b0ce4.

Also marked an out-of-scope problem in maybeGivePrimeItsChance() caller.