### PR TITLE
Bug 5051: Some collapsed revalidation responses never expire

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -493,6 +493,10 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
         http->logType = LOG_TCP_REFRESH_FAIL_ERR;
         debugs(88, 3, "origin replied with error " << status <<
                ", forwarding to client due to fail_on_validation_err");
+
+        if (collapsedRevalidation)
+            http->storeEntry()->clearPublicKeyScope();
+
         sendClientUpstreamResponse();
     } else {
         // ignore and let client have old entry

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -367,6 +367,10 @@ clientReplyContext::sendClientUpstreamResponse()
 {
     StoreIOBuffer tempresult;
     removeStoreReference(&old_sc, &old_entry);
+
+    if (collapsedRevalidation)
+        http->storeEntry()->clearPublicKeyScope();
+
     /* here the data to send is the data we just received */
     tempBuffer.offset = 0;
     old_reqsize = 0;
@@ -480,10 +484,6 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
             http->logType = LOG_TCP_REFRESH_MODIFIED;
             debugs(88, 3, "origin replied " << status <<
                    ", replacing existing entry and forwarding to client");
-
-            if (collapsedRevalidation)
-                http->storeEntry()->clearPublicKeyScope();
-
             sendClientUpstreamResponse();
         }
     }
@@ -493,10 +493,6 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
         http->logType = LOG_TCP_REFRESH_FAIL_ERR;
         debugs(88, 3, "origin replied with error " << status <<
                ", forwarding to client due to fail_on_validation_err");
-
-        if (collapsedRevalidation)
-            http->storeEntry()->clearPublicKeyScope();
-
         sendClientUpstreamResponse();
     } else {
         // ignore and let client have old entry


### PR DESCRIPTION
Since negative caching support was repaired in master commit 91870bf, it
has been found to last indefinitely when cache revalidation happens.

New revalidation requests were collapsing on a negatively cached
response forever because handleIMS() logic does not validate response
freshness (still assuming that the reply came in response to the current
request even though that assumption could be false since collapsed
revalidation support was added in master commit 1a210de).

Clearing the ENTRY_REQUIRES_COLLAPSING flag when hitting the negatively
cached collapsed revalidaiton response for the first time works around
this "lack of freshness check" problem. The same solution existed in the
official code for positive responses. However, this solution is partial
and unreliable because there is no guarantee that the clearing code will
be reached (and reached while the cached response is still fresh).