### PR TITLE
Honor on_unsupported_protocol for intercepted https_port

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4068,8 +4068,8 @@ ConnStateData::shouldPreserveClientData() const
         return true;
 #endif
 
-    // the 1st HTTP request on a connection to a plain intercepting port
-    if (!pipeline.nrequests && !port->secure.encryptTransport && transparent())
+    // the 1st HTTP(S) request on a connection to an intercepting port
+    if (!pipeline.nrequests && transparent())
         return true;
 
     return false;


### PR DESCRIPTION
... when Squid discovers a non-TLS client while parsing its handshake.

For https_port traffic, ConnStateData::switchToHttps() relies on start()
to set preservingClientData_ correctly, but shouldPreserveClientData(),
called by start() to set preservingClientData_, was not preserving TLS
bytes in the https_port start() context. Typical debug messages:

    parseTlsHandshake: Got something other than TLS ... Cannot SslBump
    tunnelOnError: may have forgotten client data; send error: 40