### PR TITLE
Simplify parsing of domain names from the /etc/hosts file

### DIFF
--- a/src/tools.cc
+++ b/src/tools.cc
@@ -972,11 +972,11 @@ parseEtcHosts(void)
             debugs(1, 5, "etc_hosts: got hostname '" << lt << "'");
 
             /* For IPV6 addresses also check for a colon */
-            if (Config.appendDomain && !strchr(lt, '.') && !strchr(lt, ':')) {
+            if (Config.appendDomain && strlen(Config.appendDomain)<sizeof(buf2)-2 && !strchr(lt, '.') && !strchr(lt, ':')) {
                 /* I know it's ugly, but it's only at reconfig */
-                strncpy(buf2, lt, sizeof(buf2)-1);
-                strncat(buf2, Config.appendDomain, sizeof(buf2) - strlen(lt) - 1);
-                buf2[sizeof(buf2)-1] = '\0';
+                memset(buf2,0,sizeof(buf2));
+                strncpy(buf2, lt, sizeof(buf2)-strlen(Config.appendDomain)-2);
+                strncat(buf2, Config.appendDomain,  sizeof(buf2) - strlen(buf2) );
                 host = buf2;
             } else {
                 host = lt;

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -970,8 +970,8 @@ parseEtcHosts(void)
             *nt = '\0';
             debugs(1, 5, "etc_hosts: got hostname '" << lt << "'");
 
-            (void)urlAppendDomain(lt);
-            host = lt;
+            if(urlAppendDomain(lt))
+                host = lt;
             if (ipcacheAddEntryFromHosts(host, addr) != 0) {
                 /* invalid address, continuing is useless */
                 hosts.clear();

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -911,7 +911,6 @@ void
 parseEtcHosts(void)
 {
     char buf[1024];
-    char buf2[512];
     char *nt = buf;
     char *lt = buf;
 
@@ -971,17 +970,8 @@ parseEtcHosts(void)
             *nt = '\0';
             debugs(1, 5, "etc_hosts: got hostname '" << lt << "'");
 
-            /* For IPV6 addresses also check for a colon */
-            if (Config.appendDomain && strlen(Config.appendDomain)<sizeof(buf2)-2 && !strchr(lt, '.') && !strchr(lt, ':')) {
-                /* I know it's ugly, but it's only at reconfig */
-                memset(buf2,0,sizeof(buf2));
-                strncpy(buf2, lt, sizeof(buf2)-strlen(Config.appendDomain)-2);
-                strncat(buf2, Config.appendDomain,  sizeof(buf2) - strlen(buf2) );
-                host = buf2;
-            } else {
-                host = lt;
-            }
-
+            (void)urlAppendDomain(lt);
+            host = lt;
             if (ipcacheAddEntryFromHosts(host, addr) != 0) {
                 /* invalid address, continuing is useless */
                 hosts.clear();


### PR DESCRIPTION
For different lengths of domain names, access situations outside
the allocated buffer buf2 are possible. At the same time, the
fix eliminates the possibility of losing the terminator after
executing the strncpy function.