### PR TITLE
Forbid obs-fold and bare CR whitespace in framing header fields

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -372,6 +372,9 @@ HttpHeader::parse(const char *buf, size_t buf_len, bool atEnd, size_t &hdr_sz, H
     return -1;
 }
 
+// XXX: callers treat this return as boolean.
+// XXX: A better mechanism is needed to signal different types of error.
+//      lexicon, syntax, semantics, validation, access policy - are all (ab)using 'return 0'
 int
 HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthInterpreter &clen)
 {

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -496,7 +496,8 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         if (lines > 1 || hasBareCr) {
             const auto framingHeader = (e->id == Http::HdrType::CONTENT_LENGTH || e->id == Http::HdrType::TRANSFER_ENCODING);
             if (framingHeader) {
-                debugs(55, warnOnError, "WARNING: " << (hasBareCr ? hasBareCr : "obs-fold") << " seen in framing-sensitive " << e->name << ": " << e->value);
+                if (!hasBareCr) // already warned about bare CRs
+                    debugs(55, warnOnError, "WARNING: " << "obs-fold in framing-sensitive " << e->name << ": " << e->value);
                 delete e;
                 PROF_stop(HttpHeaderParse);
                 clean();

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1773,3 +1773,4 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
+

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -443,7 +443,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
 
             /* Barf on stray CR characters */
             if (memchr(this_line, '\r', field_end - this_line)) {
-                hasBareCr = "bare-CR";
+                hasBareCr = "bare CR";
                 debugs(55, warnOnError, "WARNING: suspicious CR characters in HTTP header {" <<
                        getStringPrefix(field_start, field_end-field_start) << "}");
 
@@ -1773,4 +1773,3 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
-

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -400,11 +400,11 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         const char *field_start = field_ptr;
         const char *field_end;
 
-        int seenLines = 0;
+        size_t lines = 0;
         do {
             const char *this_line = field_ptr;
             field_ptr = (const char *)memchr(field_ptr, '\n', header_end - field_ptr);
-            ++seenLines;
+            ++lines;
 
             if (!field_ptr) {
                 // missing <LF>
@@ -488,8 +488,8 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             return 0;
         }
 
-        const bool frameHeader = (e->id == Http::HdrType::CONTENT_LENGTH || e->id == Http::HdrType::TRANSFER_ENCODING);
-        if (seenLines > 1 && frameHeader) {
+        const auto framingHeader = (e->id == Http::HdrType::CONTENT_LENGTH || e->id == Http::HdrType::TRANSFER_ENCODING);
+        if (lines > 1 && framingHeader) {
             debugs(55, warnOnError, "WARNING: obs-fold seen in " << e->name << ": " << e->value);
             delete e;
             PROF_stop(HttpHeaderParse);

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -498,7 +498,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         if (lines > 1 || hasBareCr) {
             const auto framingHeader = (e->id == Http::HdrType::CONTENT_LENGTH || e->id == Http::HdrType::TRANSFER_ENCODING);
             if (framingHeader) {
-                debugs(55, warnOnError, "WARNING: " << (lines > 1 ? "obs-fold" : hasBareCr) << " seen in " << e->name << ": " << e->value);
+                debugs(55, warnOnError, "WARNING: " << (hasBareCr ? hasBareCr : "obs-fold") << " seen in framing-sensitive " << e->name << ": " << e->value);
                 delete e;
                 PROF_stop(HttpHeaderParse);
                 clean();
@@ -1775,4 +1775,3 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
-

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1774,3 +1774,4 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
+

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -497,7 +497,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             const auto framingHeader = (e->id == Http::HdrType::CONTENT_LENGTH || e->id == Http::HdrType::TRANSFER_ENCODING);
             if (framingHeader) {
                 if (!hasBareCr) // already warned about bare CRs
-                    debugs(55, warnOnError, "WARNING: " << "obs-fold in framing-sensitive " << e->name << ": " << e->value);
+                    debugs(55, warnOnError, "WARNING: obs-fold in framing-sensitive " << e->name << ": " << e->value);
                 delete e;
                 PROF_stop(HttpHeaderParse);
                 clean();

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -488,13 +488,15 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
             return 0;
         }
 
-        const auto framingHeader = (e->id == Http::HdrType::CONTENT_LENGTH || e->id == Http::HdrType::TRANSFER_ENCODING);
-        if (lines > 1 && framingHeader) {
-            debugs(55, warnOnError, "WARNING: obs-fold seen in " << e->name << ": " << e->value);
-            delete e;
-            PROF_stop(HttpHeaderParse);
-            clean();
-            return 0;
+        if (lines > 1) {
+            const auto framingHeader = (e->id == Http::HdrType::CONTENT_LENGTH || e->id == Http::HdrType::TRANSFER_ENCODING);
+            if (framingHeader) {
+                debugs(55, warnOnError, "WARNING: obs-fold seen in " << e->name << ": " << e->value);
+                delete e;
+                PROF_stop(HttpHeaderParse);
+                clean();
+                return 0;
+            }
         }
 
         if (e->id == Http::HdrType::CONTENT_LENGTH && !clen.checkField(e->value)) {

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -429,8 +429,6 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
                     for (const char *p = this_line; p < field_end && cr_only; ++p) {
                         if (*p != '\r')
                             cr_only = false;
-                        else
-                            hasBareCr = "bare-CR";
                     }
                     if (cr_only) {
                         debugs(55, DBG_IMPORTANT, "SECURITY WARNING: Rejecting HTTP request with a CR+ "
@@ -445,6 +443,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
 
             /* Barf on stray CR characters */
             if (memchr(this_line, '\r', field_end - this_line)) {
+                hasBareCr = "bare-CR";
                 debugs(55, warnOnError, "WARNING: suspicious CR characters in HTTP header {" <<
                        getStringPrefix(field_start, field_end-field_start) << "}");
 
@@ -452,7 +451,6 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
                     char *p = (char *) this_line;   /* XXX Warning! This destroys original header content and violates specifications somewhat */
 
                     while ((p = (char *)memchr(p, '\r', field_end - p)) != NULL) {
-                        hasBareCr = "bare-CR";
                         *p = ' ';
                         ++p;
                     }


### PR DESCRIPTION
Header folding has been used for various attacks on HTTP proxies and
servers. RFC 7230 prohibits sending obs-fold (in any header field) and
allows the recipient to reject messages with folded headers. To reduce
the attack space, Squid now rejects messages with folded Content-Length
and Transfer-Encoding header field values. TODO: Follow RFC 7230 status
code recommendations when rejecting.

Bare CR is a CR character that is not followed by a LF character.
Similar to folding, bare CRs has been used for various attacks. HTTP
does not allow sending bare CRs in Content-Length and Transfer-Encoding
header field values. Squid now rejects messages with bare CR characters
in those framing-related field values.

When rejecting, Squid informs the admin with a level-1 WARNING such as

    obs-fold seen in framing-sensitive Content-Length: ...
