### PR TITLE
Improve Transfer-Encoding handling

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -531,7 +531,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         // and clen state becomes irrelevant
 
         if (rawTe == "chunked") {
-            teChunked_ = true;
+            ; // NP: leave header present for chunked() method
         } else if (rawTe == "identity") { // deprecated. no coding
             delById(Http::HdrType::TRANSFER_ENCODING);
         } else {
@@ -1777,3 +1777,4 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
+

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1779,3 +1779,4 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
+

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -510,8 +510,8 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
 
     String rawTe;
     if (clen.prohibitedAndIgnored()) {
-        // NOTE: prohibitedAndIgnored() includes trailer header blocks
-        //       being parsed as a case to forbid/ignore these headers.
+        // prohibitedAndIgnored() includes trailer header blocks
+        // being parsed as a case to forbid/ignore these headers.
 
         // RFC 7230 section 3.3.2: A server MUST NOT send a Content-Length
         // header field in any response with a status code of 1xx (Informational)

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -533,7 +533,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         // and clen state becomes irrelevant
 
         if (rawTe == "chunked") {
-            ; // NP: leave header present for chunked() method
+            ; // leave header present for chunked() method
         } else if (rawTe == "identity") { // deprecated. no coding
             delById(Http::HdrType::TRANSFER_ENCODING);
         } else {
@@ -1779,4 +1779,3 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
-

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -181,6 +181,7 @@ HttpHeader::operator =(const HttpHeader &other)
         update(&other); // will update the mask as well
         len = other.len;
         conflictingContentLength_ = other.conflictingContentLength_;
+        teUnsupported_ = other.teUnsupported_;
     }
     return *this;
 }
@@ -229,6 +230,7 @@ HttpHeader::clean()
     httpHeaderMaskInit(&mask, 0);
     len = 0;
     conflictingContentLength_ = false;
+    teUnsupported_ = false;
     PROF_stop(HttpHeaderClean);
 }
 

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -506,6 +506,7 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
                Raw("header", header_start, hdrLen));
     }
 
+    String rawTe;
     if (clen.prohibitedAndIgnored()) {
         // RFC 7230 section 3.3.2: A server MUST NOT send a Content-Length
         // header field in any response with a status code of 1xx (Informational)
@@ -513,11 +514,29 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         // such Content-Lengths.
         if (delById(Http::HdrType::CONTENT_LENGTH))
             debugs(55, 3, "Content-Length is " << clen.prohibitedAndIgnored());
-    } else if (chunked()) {
+
+        // RFC 7230 section 3.3.1 has the same criteria forbid Transfer-Encoding
+        if (delById(Http::HdrType::TRANSFER_ENCODING)) {
+            debugs(55, 3, "Transfer-Encoding is " << clen.prohibitedAndIgnored());
+            teUnsupported_ = true;
+        }
+
+    } else if (getByIdIfPresent(Http::HdrType::TRANSFER_ENCODING, &rawTe)) {
         // RFC 2616 section 4.4: ignore Content-Length with Transfer-Encoding
         // RFC 7230 section 3.3.3 #3: Transfer-Encoding overwrites Content-Length
         delById(Http::HdrType::CONTENT_LENGTH);
         // and clen state becomes irrelevant
+
+        if (rawTe == "chunked") {
+            teChunked_ = true;
+        } else if (rawTe == "identity") { // deprecated. no coding
+            delById(Http::HdrType::TRANSFER_ENCODING);
+        } else {
+            // This also rejects multiple encodings until we support them properly.
+            debugs(55, warnOnError, "WARNING: unsupported Transfer-Encoding used by client: " << rawTe);
+            teUnsupported_ = true;
+        }
+
     } else if (clen.sawBad) {
         // ensure our callers do not accidentally see bad Content-Length values
         delById(Http::HdrType::CONTENT_LENGTH);
@@ -1755,4 +1774,3 @@ HttpHeader::removeConnectionHeaderEntries()
             refreshMask();
     }
 }
-

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -508,6 +508,9 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
 
     String rawTe;
     if (clen.prohibitedAndIgnored()) {
+        // NOTE: prohibitedAndIgnored() includes trailer header blocks
+        //       being parsed as a case to forbid/ignore these headers.
+
         // RFC 7230 section 3.3.2: A server MUST NOT send a Content-Length
         // header field in any response with a status code of 1xx (Informational)
         // or 204 (No Content). And RFC 7230 3.3.3#1 tells recipients to ignore

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -159,8 +159,9 @@ public:
     int hasListMember(Http::HdrType id, const char *member, const char separator) const;
     int hasByNameListMember(const char *name, const char *member, const char separator) const;
     void removeHopByHopEntries();
-    bool chunked() const { return teChunked_; };             ///< whether message uses chunked Transfer-Encoding
-    bool unsupportedTe() const { return teUnsupported_; }; ///< whether message uses unsupported Transfer-Encoding
+    inline bool chunked() const; ///< whether message uses chunked Transfer-Encoding
+    /// whether message used an unsupported (or invalid) Transfer-Encoding
+    bool unsupportedTe() const { return teUnsupported_; }
 
     /* protected, do not use these, use interface functions instead */
     std::vector<HttpHeaderEntry*, PoolingAllocator<HttpHeaderEntry*> > entries; /**< parsed fields in raw format */
@@ -184,7 +185,6 @@ protected:
 private:
     HttpHeaderEntry *findLastEntry(Http::HdrType id) const;
     bool conflictingContentLength_; ///< found different Content-Length fields
-    bool teChunked_ = false;        ///< found Transfer-Encoding:chunked
     bool teUnsupported_ = false;    ///< found unsupported Transfer-Encoding value(s)
 };
 
@@ -194,6 +194,14 @@ int httpHeaderParseQuotedString(const char *start, const int len, String *val);
 SBuf httpHeaderQuoteString(const char *raw);
 
 void httpHeaderCalcMask(HttpHeaderMask * mask, Http::HdrType http_hdr_type_enums[], size_t count);
+
+inline bool
+HttpHeader::chunked() const
+{
+    return has(Http::HdrType::TRANSFER_ENCODING) &&
+           hasListMember(Http::HdrType::TRANSFER_ENCODING, "chunked", ',');
+}
+
 void httpHeaderInitModule(void);
 
 #endif /* SQUID_HTTPHEADER_H */

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -200,8 +200,7 @@ void httpHeaderCalcMask(HttpHeaderMask * mask, Http::HdrType http_hdr_type_enums
 inline bool
 HttpHeader::chunked() const
 {
-    return has(Http::HdrType::TRANSFER_ENCODING) &&
-           hasListMember(Http::HdrType::TRANSFER_ENCODING, "chunked", ',');
+    return has(Http::HdrType::TRANSFER_ENCODING);
 }
 
 void httpHeaderInitModule(void);

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -160,7 +160,7 @@ public:
     int hasByNameListMember(const char *name, const char *member, const char separator) const;
     void removeHopByHopEntries();
     inline bool chunked() const; ///< whether message uses chunked Transfer-Encoding
-    /// whether message used an unsupported (or invalid) Transfer-Encoding
+    /// whether message used an unsupported and/or invalid Transfer-Encoding
     bool unsupportedTe() const { return teUnsupported_; }
 
     /* protected, do not use these, use interface functions instead */
@@ -185,7 +185,9 @@ protected:
 private:
     HttpHeaderEntry *findLastEntry(Http::HdrType id) const;
     bool conflictingContentLength_; ///< found different Content-Length fields
-    bool teUnsupported_ = false;    ///< found unsupported Transfer-Encoding value(s)
+    /// unsupported encoding, unnecessary syntax characters, and/or
+    /// invalid field-value found in Transfer-Encoding header
+    bool teUnsupported_ = false;
 };
 
 int httpHeaderParseQuotedString(const char *start, const int len, String *val);

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -159,7 +159,8 @@ public:
     int hasListMember(Http::HdrType id, const char *member, const char separator) const;
     int hasByNameListMember(const char *name, const char *member, const char separator) const;
     void removeHopByHopEntries();
-    inline bool chunked() const; ///< whether message uses chunked Transfer-Encoding
+    bool chunked() const { return teChunked_; };             ///< whether message uses chunked Transfer-Encoding
+    bool unsupportedTe() const { return teUnsupported_; }; ///< whether message uses unsupported Transfer-Encoding
 
     /* protected, do not use these, use interface functions instead */
     std::vector<HttpHeaderEntry*, PoolingAllocator<HttpHeaderEntry*> > entries; /**< parsed fields in raw format */
@@ -183,6 +184,8 @@ protected:
 private:
     HttpHeaderEntry *findLastEntry(Http::HdrType id) const;
     bool conflictingContentLength_; ///< found different Content-Length fields
+    bool teChunked_ = false;        ///< found Transfer-Encoding:chunked
+    bool teUnsupported_ = false;    ///< found unsupported Transfer-Encoding value(s)
 };
 
 int httpHeaderParseQuotedString(const char *start, const int len, String *val);
@@ -191,14 +194,6 @@ int httpHeaderParseQuotedString(const char *start, const int len, String *val);
 SBuf httpHeaderQuoteString(const char *raw);
 
 void httpHeaderCalcMask(HttpHeaderMask * mask, Http::HdrType http_hdr_type_enums[], size_t count);
-
-inline bool
-HttpHeader::chunked() const
-{
-    return has(Http::HdrType::TRANSFER_ENCODING) &&
-           hasListMember(Http::HdrType::TRANSFER_ENCODING, "chunked", ',');
-}
-
 void httpHeaderInitModule(void);
 
 #endif /* SQUID_HTTPHEADER_H */

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -159,7 +159,11 @@ public:
     int hasListMember(Http::HdrType id, const char *member, const char separator) const;
     int hasByNameListMember(const char *name, const char *member, const char separator) const;
     void removeHopByHopEntries();
-    inline bool chunked() const; ///< whether message uses chunked Transfer-Encoding
+
+    /// whether the message uses chunked Transfer-Encoding
+    /// optimized implementation relies on us rejecting/removing other codings
+    bool chunked() const { return has(Http::HdrType::TRANSFER_ENCODING); }
+
     /// whether message used an unsupported and/or invalid Transfer-Encoding
     bool unsupportedTe() const { return teUnsupported_; }
 
@@ -196,12 +200,6 @@ int httpHeaderParseQuotedString(const char *start, const int len, String *val);
 SBuf httpHeaderQuoteString(const char *raw);
 
 void httpHeaderCalcMask(HttpHeaderMask * mask, Http::HdrType http_hdr_type_enums[], size_t count);
-
-inline bool
-HttpHeader::chunked() const
-{
-    return has(Http::HdrType::TRANSFER_ENCODING);
-}
 
 void httpHeaderInitModule(void);
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1664,7 +1664,6 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         request->http_ver.minor = http_ver.minor;
     }
 
-    const auto chunked = request->header.chunked();
     const auto unsupportedTe = request->header.unsupportedTe();
 
     mustReplyToOptions = (request->method == Http::METHOD_OPTIONS) &&
@@ -1682,6 +1681,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         return;
     }
 
+    const auto chunked = request->header.chunked();
     if (!chunked && !clientIsContentLengthValid(request.getRaw())) {
         clientStreamNode *node = context->getClientReplyContext();
         clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1607,9 +1607,7 @@ void
 clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp, Http::Stream *context)
 {
     ClientHttpRequest *http = context->http;
-    bool chunked = false;
     bool mustReplyToOptions = false;
-    bool unsupportedTe = false;
     bool expectBody = false;
 
     // We already have the request parsed and checked, so we
@@ -1666,13 +1664,8 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         request->http_ver.minor = http_ver.minor;
     }
 
-    if (request->header.chunked()) {
-        chunked = true;
-    } else if (request->header.has(Http::HdrType::TRANSFER_ENCODING)) {
-        const String te = request->header.getList(Http::HdrType::TRANSFER_ENCODING);
-        // HTTP/1.1 requires chunking to be the last encoding if there is one
-        unsupportedTe = te.size() && te != "identity";
-    } // else implied identity coding
+    bool chunked = request->header.chunked();
+    bool unsupportedTe = request->header.unsupportedTe();
 
     mustReplyToOptions = (request->method == Http::METHOD_OPTIONS) &&
                          (request->header.getInt64(Http::HdrType::MAX_FORWARDS) == 0);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1664,8 +1664,8 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         request->http_ver.minor = http_ver.minor;
     }
 
-    bool chunked = request->header.chunked();
-    bool unsupportedTe = request->header.unsupportedTe();
+    const auto chunked = request->header.chunked();
+    const auto unsupportedTe = request->header.unsupportedTe();
 
     mustReplyToOptions = (request->method == Http::METHOD_OPTIONS) &&
                          (request->header.getInt64(Http::HdrType::MAX_FORWARDS) == 0);
@@ -4087,4 +4087,3 @@ operator <<(std::ostream &os, const ConnStateData::ServerConnectionContext &scc)
 {
     return os << scc.conn_ << ", srv_bytes=" << scc.preReadServerBytes.length();
 }
-

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -4087,3 +4087,4 @@ operator <<(std::ostream &os, const ConnStateData::ServerConnectionContext &scc)
 {
     return os << scc.conn_ << ", srv_bytes=" << scc.preReadServerBytes.length();
 }
+

--- a/src/http.cc
+++ b/src/http.cc
@@ -1380,6 +1380,9 @@ HttpStateData::continueAfterParsingHeader()
             } else if (vrep->header.conflictingContentLength()) {
                 fwd->dontRetry(true);
                 error = ERR_INVALID_RESP;
+            } else if (vrep->header.unsupportedTe()) {
+                fwd->dontRetry(true);
+                error = ERR_INVALID_RESP;
             } else {
                 return true; // done parsing, got reply, and no error
             }


### PR DESCRIPTION
Reject messages containing Transfer-Encoding header with coding other
than chunked or identity. Squid does not support other codings.

For simplicity and security sake, also reject messages where
Transfer-Encoding contains unnecessary complex values that are
technically equivalent to "chunked" or "identity" (e.g., ",,chunked" or
"identity, chunked").

RFC 7230 formally deprecated and removed identity coding, but it is
still used by some agents.