### PR TITLE
Replaced X-Cache and X-Cache-Lookup headers with Cache-Status

### DIFF
--- a/src/LogTags.cc
+++ b/src/LogTags.cc
@@ -101,3 +101,77 @@ LogTags::isTcpHit() const
         (oldType == LOG_TCP_OFFLINE_HIT);
 }
 
+const char *
+LogTags::cacheStatusSource() const
+{
+    // see draft-ietf-httpbis-cache-header for the (quoted below) specs
+    switch (oldType) {
+    case LOG_TAG_NONE:
+        return nullptr;
+
+    case LOG_TCP_HIT:
+    case LOG_TCP_IMS_HIT:
+    case LOG_TCP_INM_HIT:
+    case LOG_TCP_REFRESH_FAIL_OLD:
+    case LOG_TCP_REFRESH_UNMODIFIED:
+    case LOG_TCP_NEGATIVE_HIT:
+    case LOG_TCP_MEM_HIT:
+    case LOG_TCP_OFFLINE_HIT:
+        // We put LOG_TCP_REFRESH_UNMODIFIED and LOG_TCP_REFRESH_FAIL_OLD here
+        // because the specs probably classify master transactions where the
+        // client request did "go forward" but the to-client response was
+        // ultimately "obtained from the cache" as "hit" transactions.
+        return ";hit";
+
+    case LOG_TCP_MISS:
+#if USE_DELAY_POOLS
+        // do not lie until we get a better solution for bugs 1000, 2096
+        return nullptr;
+#else
+        // TODO: "distinguish between uri-miss and vary-miss"
+        return ";fwd=miss";
+#endif
+
+    case LOG_TCP_REFRESH_MODIFIED:
+    case LOG_TCP_REFRESH:
+        return ";fwd=stale";
+
+    case LOG_TCP_CLIENT_REFRESH_MISS:
+        return ";fwd=request";
+
+    case LOG_TCP_REFRESH_FAIL_ERR:
+    case LOG_TCP_SWAPFAIL_MISS:
+        // Ignore "to be used when the implementation cannot distinguish between
+        // uri-miss and vary-miss" specs condition as being too restrictive,
+        // especially when there is no fwd=other or a more suitable parameter.
+        return ";fwd=miss";
+
+    case LOG_TCP_DENIED:
+    case LOG_TCP_DENIED_REPLY:
+    case LOG_TCP_REDIRECT:
+        // We served a Squid-generated response (with or without forwarding).
+        // The response itself should provide enough classification clues.
+        return nullptr;
+
+    case LOG_TCP_TUNNEL:
+        // could use fwd=bypass, but the CONNECT request was not really bypassed
+        return nullptr;
+
+    case LOG_UDP_HIT:
+    case LOG_UDP_MISS:
+    case LOG_UDP_DENIED:
+    case LOG_UDP_INVALID:
+    case LOG_UDP_MISS_NOFETCH:
+    case LOG_ICP_QUERY:
+        // do not bother classifying these non-HTTP outcomes for now
+        return nullptr;
+
+    case LOG_TYPE_MAX:
+        // should not happen
+        return nullptr;
+    }
+
+    // should not happen
+    return nullptr;
+}
+

--- a/src/LogTags.h
+++ b/src/LogTags.h
@@ -62,6 +62,9 @@ public:
     /// determine if the log tag code indicates a cache HIT
     bool isTcpHit() const;
 
+    /// \returns Cache-Status "hit" or "fwd=..." parameter (or nil)
+    const char *cacheStatusSource() const;
+
     /// Things that may happen to a transaction while it is being
     /// processed according to its LOG_* category. Logged as _SUFFIX(es).
     /// Unlike LOG_* categories, these flags may not be mutually exclusive.

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1562,8 +1562,8 @@ clientReplyContext::buildReplyHeader()
 #endif
 
     SBuf cacheStatus(uniqueHostname());
-    if (is_hit)
-        cacheStatus.append(";hit");
+    if (const auto hitOrFwd = http->logType.cacheStatusSource())
+        cacheStatus.append(hitOrFwd);
     if (firstStoreLookup_) {
         cacheStatus.append(";detail=");
         cacheStatus.append(firstStoreLookup_);

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -81,9 +81,6 @@ clientReplyContext::clientReplyContext(ClientHttpRequest *clientContext) :
     old_reqsize(0),
     reqsize(0),
     reqofs(0),
-#if USE_CACHE_DIGESTS
-    lookup_type(NULL),
-#endif
     ourNode(NULL),
     reply(NULL),
     old_entry(NULL),
@@ -1567,14 +1564,6 @@ clientReplyContext::buildReplyHeader()
                      (is_hit ? "hit" : "fwd=miss")
                      );
 
-#if USE_CACHE_DIGESTS
-    /* Append X-Cache-Lookup: -- temporary hack, to be removed @?@ @?@ */
-    httpHeaderPutStrf(hdr, Http::HdrType::X_CACHE_LOOKUP, "%s from %s:%d",
-                      lookup_type ? lookup_type : "NONE",
-                      getMyHostname(), getMyPort());
-
-#endif
-
     const bool maySendChunkedReply = !request->multipartRangeRequest() &&
                                      reply->sline.protocol == AnyP::PROTO_HTTP && // response is HTTP
                                      (request->http_ver >= Http::ProtocolVersion(1,1));
@@ -1718,10 +1707,6 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry)
       */
     if (r->flags.noCache || r->flags.noCacheHack())
         ipcacheInvalidateNegative(r->url.host());
-
-#if USE_CACHE_DIGESTS
-    lookup_type = e ? "HIT" : "MISS";
-#endif
 
     if (!e) {
         /** \li If no StoreEntry object is current assume this object isn't in the cache set MISS*/

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1562,10 +1562,9 @@ clientReplyContext::buildReplyHeader()
         Auth::UserRequest::AddReplyAuthHeader(reply, request->auth_user_request, request, http->flags.accel, 0);
 #endif
 
-    httpHeaderPutStrf(hdr, Http::HdrType::CACHE_STATUS, "%s;%s%s",
+    httpHeaderPutStrf(hdr, Http::HdrType::CACHE_STATUS, "%s;%s",
                      uniqueHostname(),
-                     (is_hit ? "hit" : "fwd=miss"),
-                     (collapsedRevalidation != crNone ? ";collapsed" : "")
+                     (is_hit ? "hit" : "fwd=miss")
                      );
 
 #if USE_CACHE_DIGESTS

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1562,7 +1562,6 @@ clientReplyContext::buildReplyHeader()
         Auth::UserRequest::AddReplyAuthHeader(reply, request->auth_user_request, request, http->flags.accel, 0);
 #endif
 
-    /* Append Cache-Status */
     httpHeaderPutStrf(hdr, Http::HdrType::CACHE_STATUS, "%s;%s%s",
                      uniqueHostname(),
                      (is_hit ? "hit" : "fwd=miss"),
@@ -2348,4 +2347,3 @@ clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
 
     return err;
 }
-

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2346,3 +2346,4 @@ clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
 
     return err;
 }
+

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1562,9 +1562,12 @@ clientReplyContext::buildReplyHeader()
         Auth::UserRequest::AddReplyAuthHeader(reply, request->auth_user_request, request, http->flags.accel, 0);
 #endif
 
-    /* Append X-Cache */
-    httpHeaderPutStrf(hdr, Http::HdrType::X_CACHE, "%s from %s",
-                      is_hit ? "HIT" : "MISS", getMyHostname());
+    /* Append Cache-Status */
+    httpHeaderPutStrf(hdr, Http::HdrType::CACHE_STATUS, "%s;%s%s",
+                     uniqueHostname(),
+                     (is_hit ? "hit" : "fwd=miss"),
+                     (collapsedRevalidation != crNone ? ";collapsed" : "")
+                     );
 
 #if USE_CACHE_DIGESTS
     /* Append X-Cache-Lookup: -- temporary hack, to be removed @?@ @?@ */

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1562,7 +1562,8 @@ clientReplyContext::buildReplyHeader()
 #endif
 
     SBuf cacheStatus(uniqueHostname());
-    cacheStatus.append(is_hit ? ";hit" : ";fwd=miss");
+    if (is_hit)
+        cacheStatus.append(";hit");
     if (firstStoreLookup_) {
         cacheStatus.append(";detail=");
         cacheStatus.append(firstStoreLookup_);

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -129,11 +129,17 @@ private:
     void purgeAllCached();
     void forgetHit();
     bool blockedHit() const;
+    void detailStoreLookup(const char *detail);
 
     void sendBodyTooLargeError();
     void sendPreconditionFailedError();
     void sendNotModified();
     void sendNotModifiedOrPreconditionFailedError();
+
+    /// Classification of the initial Store lookup.
+    /// This very first lookup happens without the Vary-driven key augmentation.
+    /// TODO: Exclude internal Store match bans from the "mismatch" category.
+    const char *firstStoreLookup_ = nullptr;
 
     StoreEntry *old_entry;
     /* ... for entry to be validated */

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -90,10 +90,6 @@ public:
     size_t reqsize;
     size_t reqofs;
     char tempbuf[HTTP_REQBUF_SZ];   ///< a temporary buffer if we need working storage
-#if USE_CACHE_DIGESTS
-
-    const char *lookup_type;    /* temporary hack: storeGet() result: HIT/MISS/NONE */
-#endif
 
     struct Flags {
         Flags() : storelogiccomplete(0), complete(0), headersSent(false) {}

--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -105,7 +105,6 @@ enum HdrType {
     VIA,                            /**< RFC 7230 */
     WARNING,                        /**< RFC 7234 */
     WWW_AUTHENTICATE,               /**< RFC 7235, 4559 */
-    X_CACHE,                        /**< obsolete Squid custom header draft-ietf-httpbis-cache-header */
     X_CACHE_LOOKUP,                 /**< obsolete Squid custom header, draft-ietf-httpbis-cache-header */
     X_FORWARDED_FOR,                /**< obsolete Squid custom header, RFC 7239 */
     X_REQUEST_URI,                  /**< Squid custom header appended if ADD_X_REQUEST_URI is defined */

--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -105,7 +105,6 @@ enum HdrType {
     VIA,                            /**< RFC 7230 */
     WARNING,                        /**< RFC 7234 */
     WWW_AUTHENTICATE,               /**< RFC 7235, 4559 */
-    X_CACHE_LOOKUP,                 /**< obsolete Squid custom header, draft-ietf-httpbis-cache-header */
     X_FORWARDED_FOR,                /**< obsolete Squid custom header, RFC 7239 */
     X_REQUEST_URI,                  /**< Squid custom header appended if ADD_X_REQUEST_URI is defined */
     X_SQUID_ERROR,                  /**< Squid custom header on generated error responses */

--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -32,6 +32,7 @@ enum HdrType {
     AUTHENTICATION_INFO,            /**< RFC 2617 */
     AUTHORIZATION,                  /**< RFC 7235, 4559 */
     CACHE_CONTROL,                  /**< RFC 7234 */
+    CACHE_STATUS,                   /**< draft-ietf-httpbis-cache-header */
     CDN_LOOP,                       /**< RFC 8586 */
     CONNECTION,                     /**< RFC 7230 */
     CONTENT_BASE,                   /**< obsoleted RFC 2068 */
@@ -104,8 +105,8 @@ enum HdrType {
     VIA,                            /**< RFC 7230 */
     WARNING,                        /**< RFC 7234 */
     WWW_AUTHENTICATE,               /**< RFC 7235, 4559 */
-    X_CACHE,                        /**< Squid custom header */
-    X_CACHE_LOOKUP,                 /**< Squid custom header. temporary hack that became de-facto. TODO remove */
+    X_CACHE,                        /**< obsolete Squid custom header draft-ietf-httpbis-cache-header */
+    X_CACHE_LOOKUP,                 /**< obsolete Squid custom header, draft-ietf-httpbis-cache-header */
     X_FORWARDED_FOR,                /**< obsolete Squid custom header, RFC 7239 */
     X_REQUEST_URI,                  /**< Squid custom header appended if ADD_X_REQUEST_URI is defined */
     X_SQUID_ERROR,                  /**< Squid custom header on generated error responses */

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -1,35 +1,35 @@
 /* C++ code produced by gperf version 3.1 */
-/* Command-line: gperf -m 100000 src/http/RegisteredHeadersHash.gperf  */
+/* Command-line: gperf -m 100000 RegisteredHeadersHash.gperf  */
 /* Computed positions: -k'3,9,$' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
-      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
-      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
-      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
-      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
-      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
-      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
-      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
-      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
-      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
-      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
-      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
-      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
-      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
-      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
-      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
-      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
-      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
-      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
-      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
-      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
-      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
-      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
+&& ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+&& (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
+&& ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
+&& ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
+&& ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
+&& ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
+&& ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
+&& ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
+&& ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
+&& ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
+&& ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
+&& ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
+&& ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
+&& ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
+&& ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
+&& ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
+&& ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
+&& ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
+&& ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
+&& ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
+&& ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
+&& ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
 /* The character set is not based on ISO-646.  */
 #error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
 #endif
 
-#line 1 "src/http/RegisteredHeadersHash.gperf"
+#line 1 "RegisteredHeadersHash.gperf"
 
 /* AUTO GENERATED FROM RegisteredHeadersHash.gperf. DO NOT EDIT */
 
@@ -40,28 +40,28 @@
  * contributions from numerous individuals and organizations.
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
-#line 24 "src/http/RegisteredHeadersHash.gperf"
+#line 24 "RegisteredHeadersHash.gperf"
 struct HeaderTableRecord;
-enum
-  {
+        enum
+{
     TOTAL_KEYWORDS = 88,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 25,
     MIN_HASH_VALUE = 5,
     MAX_HASH_VALUE = 109
-  };
+};
 
 /* maximum key range = 105, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
 static unsigned char gperf_downcase[256] =
-  {
-      0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
-     15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
-     30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
-     45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
-     60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
+{
+    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
+    15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+    30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+    45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+    60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
     107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
     122,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104,
     105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
@@ -75,7 +75,7 @@ static unsigned char gperf_downcase[256] =
     225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
     240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254,
     255
-  };
+};
 #endif
 
 #ifndef GPERF_CASE_MEMCMP
@@ -83,303 +83,303 @@ static unsigned char gperf_downcase[256] =
 static int
 gperf_case_memcmp (const char *s1, const char *s2, size_t n)
 {
-  for (; n > 0;)
+    for (; n > 0;)
     {
-      unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
-      unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
-      if (c1 == c2)
+        unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
+        unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
+        if (c1 == c2)
         {
-          n--;
-          continue;
+            n--;
+            continue;
         }
-      return (int)c1 - (int)c2;
+        return (int)c1 - (int)c2;
     }
-  return 0;
+    return 0;
 }
 #endif
 
 class HttpHeaderHashTable
 {
 private:
-  static inline unsigned int HttpHeaderHash (const char *str, size_t len);
+    static inline unsigned int HttpHeaderHash (const char *str, size_t len);
 public:
-  static const struct HeaderTableRecord *lookup (const char *str, size_t len);
+    static const struct HeaderTableRecord *lookup (const char *str, size_t len);
 };
 
 inline unsigned int
 HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 {
-  static const unsigned char asso_values[] =
+    static const unsigned char asso_values[] =
     {
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110,   0, 110, 110,  13, 110, 110, 110, 110,
-       12, 110, 110,  41, 110, 110, 110, 110,  26, 110,
-      110, 110, 110, 110, 110,  16,  10,  10,  20,   4,
-       10,  47,  50,  62, 110,   0,  38,  30,   1,   2,
-       33,  30,  32,  14,   0,  21,   5,  23,  19,  36,
-      110, 110, 110, 110, 110, 110, 110,  16,  10,  10,
-       20,   4,  10,  47,  50,  62, 110,   0,  38,  30,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110,   0, 110, 110,  13, 110, 110, 110, 110,
+        12, 110, 110,  41, 110, 110, 110, 110,  26, 110,
+        110, 110, 110, 110, 110,  16,  10,  10,  20,   4,
+        10,  47,  50,  62, 110,   0,  38,  30,   1,   2,
+        33,  30,  32,  14,   0,  21,   5,  23,  19,  36,
+        110, 110, 110, 110, 110, 110, 110,  16,  10,  10,
+        20,   4,  10,  47,  50,  62, 110,   0,  38,  30,
         1,   2,  33,  30,  32,  14,   0,  21,   5,  23,
-       19,  36, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-      110, 110, 110, 110, 110, 110
+        19,  36, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+        110, 110, 110, 110, 110, 110
     };
-  unsigned int hval = len;
+    unsigned int hval = len;
 
-  switch (hval)
+    switch (hval)
     {
-      default:
+    default:
         hval += asso_values[static_cast<unsigned char>(str[8])];
-      /*FALLTHROUGH*/
-      case 8:
-      case 7:
-      case 6:
-      case 5:
-      case 4:
-      case 3:
+    /*FALLTHROUGH*/
+    case 8:
+    case 7:
+    case 6:
+    case 5:
+    case 4:
+    case 3:
         hval += asso_values[static_cast<unsigned char>(str[2])];
-      /*FALLTHROUGH*/
-      case 2:
+    /*FALLTHROUGH*/
+    case 2:
         break;
     }
-  return hval + asso_values[static_cast<unsigned char>(str[len - 1])];
+    return hval + asso_values[static_cast<unsigned char>(str[len - 1])];
 }
 
 static const unsigned char lengthtable[] =
-  {
-     0,  0,  0,  0,  0,  4,  2,  0,  4,  5,  5,  3,  6,  0,
+{
+    0,  0,  0,  0,  0,  4,  2,  0,  4,  5,  5,  3,  6,  0,
     10, 10,  6, 12,  4,  8, 16,  7, 19, 10, 18,  8,  6, 12,
     14, 25, 13, 19,  0,  9, 15,  3,  4, 10,  6,  6,  0, 19,
-     8, 11,  7, 15, 10, 16, 13,  7, 13, 15, 12, 13,  7,  7,
+    8, 11,  7, 15, 10, 16, 13,  7, 13, 15, 12, 13,  7,  7,
     16, 12,  7, 16, 18, 12, 13, 13,  9, 21,  5,  4, 16,  6,
-     6,  8,  4, 15, 14,  3, 10, 15, 10, 13, 11,  9,  6, 11,
-     0, 11,  7,  0,  0,  0, 13, 17, 20, 17,  0,  0, 17,  0,
+    6,  8,  4, 15, 14,  3, 10, 15, 10, 13, 11,  9,  6, 11,
+    0, 11,  7,  0,  0,  0, 13, 17, 20, 17,  0,  0, 17,  0,
     19,  0,  0,  0, 18, 14,  0,  0, 13, 13,  0, 13
-  };
+};
 
 static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
-  {
+{
     {""}, {""}, {""}, {""}, {""},
-#line 67 "src/http/RegisteredHeadersHash.gperf"
+#line 67 "RegisteredHeadersHash.gperf"
     {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 87 "src/http/RegisteredHeadersHash.gperf"
+#line 87 "RegisteredHeadersHash.gperf"
     {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
     {""},
-#line 51 "src/http/RegisteredHeadersHash.gperf"
+#line 51 "RegisteredHeadersHash.gperf"
     {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
-#line 88 "src/http/RegisteredHeadersHash.gperf"
+#line 88 "RegisteredHeadersHash.gperf"
     {"Title", Http::HdrType::TITLE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 80 "src/http/RegisteredHeadersHash.gperf"
+#line 80 "RegisteredHeadersHash.gperf"
     {"Range", Http::HdrType::RANGE, Http::HdrFieldType::ftPRange, HdrKind::RequestHeader},
-#line 31 "src/http/RegisteredHeadersHash.gperf"
+#line 31 "RegisteredHeadersHash.gperf"
     {"Age", Http::HdrType::AGE, Http::HdrFieldType::ftInt, HdrKind::ReplyHeader},
-#line 49 "src/http/RegisteredHeadersHash.gperf"
+#line 49 "RegisteredHeadersHash.gperf"
     {"Cookie", Http::HdrType::COOKIE, Http::HdrFieldType::ftStr, HdrKind::None},
     {""},
-#line 39 "src/http/RegisteredHeadersHash.gperf"
+#line 39 "RegisteredHeadersHash.gperf"
     {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 94 "src/http/RegisteredHeadersHash.gperf"
+#line 94 "RegisteredHeadersHash.gperf"
     {"User-Agent", Http::HdrType::USER_AGENT, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 26 "src/http/RegisteredHeadersHash.gperf"
+#line 26 "RegisteredHeadersHash.gperf"
     {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 48 "src/http/RegisteredHeadersHash.gperf"
+#line 48 "RegisteredHeadersHash.gperf"
     {"Content-Type", Http::HdrType::CONTENT_TYPE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 57 "src/http/RegisteredHeadersHash.gperf"
+#line 57 "RegisteredHeadersHash.gperf"
     {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 68 "src/http/RegisteredHeadersHash.gperf"
+#line 68 "RegisteredHeadersHash.gperf"
     {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 77 "src/http/RegisteredHeadersHash.gperf"
+#line 77 "RegisteredHeadersHash.gperf"
     {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 50 "src/http/RegisteredHeadersHash.gperf"
+#line 50 "RegisteredHeadersHash.gperf"
     {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 76 "src/http/RegisteredHeadersHash.gperf"
+#line 76 "RegisteredHeadersHash.gperf"
     {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 64 "src/http/RegisteredHeadersHash.gperf"
+#line 64 "RegisteredHeadersHash.gperf"
     {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 74 "src/http/RegisteredHeadersHash.gperf"
+#line 74 "RegisteredHeadersHash.gperf"
     {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 62 "src/http/RegisteredHeadersHash.gperf"
+#line 62 "RegisteredHeadersHash.gperf"
     {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
-#line 79 "src/http/RegisteredHeadersHash.gperf"
+#line 79 "RegisteredHeadersHash.gperf"
     {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 40 "src/http/RegisteredHeadersHash.gperf"
+#line 40 "RegisteredHeadersHash.gperf"
     {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 58 "src/http/RegisteredHeadersHash.gperf"
+#line 58 "RegisteredHeadersHash.gperf"
     {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 75 "src/http/RegisteredHeadersHash.gperf"
+#line 75 "RegisteredHeadersHash.gperf"
     {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 35 "src/http/RegisteredHeadersHash.gperf"
+#line 35 "RegisteredHeadersHash.gperf"
     {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 34 "src/http/RegisteredHeadersHash.gperf"
+#line 34 "RegisteredHeadersHash.gperf"
     {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
     {""},
-#line 91 "src/http/RegisteredHeadersHash.gperf"
+#line 91 "RegisteredHeadersHash.gperf"
     {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 103 "src/http/RegisteredHeadersHash.gperf"
+#line 103 "RegisteredHeadersHash.gperf"
     {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 96 "src/http/RegisteredHeadersHash.gperf"
+#line 96 "RegisteredHeadersHash.gperf"
     {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 56 "src/http/RegisteredHeadersHash.gperf"
+#line 56 "RegisteredHeadersHash.gperf"
     {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 113 "src/http/RegisteredHeadersHash.gperf"
+#line 113 "RegisteredHeadersHash.gperf"
     {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
-#line 73 "src/http/RegisteredHeadersHash.gperf"
+#line 73 "RegisteredHeadersHash.gperf"
     {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 53 "src/http/RegisteredHeadersHash.gperf"
+#line 53 "RegisteredHeadersHash.gperf"
     {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
     {""},
-#line 41 "src/http/RegisteredHeadersHash.gperf"
+#line 41 "RegisteredHeadersHash.gperf"
     {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 38 "src/http/RegisteredHeadersHash.gperf"
+#line 38 "RegisteredHeadersHash.gperf"
     {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 83 "src/http/RegisteredHeadersHash.gperf"
+#line 83 "RegisteredHeadersHash.gperf"
     {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 109 "src/http/RegisteredHeadersHash.gperf"
+#line 109 "RegisteredHeadersHash.gperf"
     {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 29 "src/http/RegisteredHeadersHash.gperf"
+#line 29 "RegisteredHeadersHash.gperf"
     {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 111 "src/http/RegisteredHeadersHash.gperf"
+#line 111 "RegisteredHeadersHash.gperf"
     {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 98 "src/http/RegisteredHeadersHash.gperf"
+#line 98 "RegisteredHeadersHash.gperf"
     {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 78 "src/http/RegisteredHeadersHash.gperf"
+#line 78 "RegisteredHeadersHash.gperf"
     {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 81 "src/http/RegisteredHeadersHash.gperf"
+#line 81 "RegisteredHeadersHash.gperf"
     {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 47 "src/http/RegisteredHeadersHash.gperf"
+#line 47 "RegisteredHeadersHash.gperf"
     {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
-#line 106 "src/http/RegisteredHeadersHash.gperf"
+#line 106 "RegisteredHeadersHash.gperf"
     {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 37 "src/http/RegisteredHeadersHash.gperf"
+#line 37 "RegisteredHeadersHash.gperf"
     {"Cache-Status", Http::HdrType::CACHE_STATUS, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 30 "src/http/RegisteredHeadersHash.gperf"
+#line 30 "RegisteredHeadersHash.gperf"
     {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 54 "src/http/RegisteredHeadersHash.gperf"
+#line 54 "RegisteredHeadersHash.gperf"
     {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 89 "src/http/RegisteredHeadersHash.gperf"
+#line 89 "RegisteredHeadersHash.gperf"
     {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 45 "src/http/RegisteredHeadersHash.gperf"
+#line 45 "RegisteredHeadersHash.gperf"
     {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 70 "src/http/RegisteredHeadersHash.gperf"
+#line 70 "RegisteredHeadersHash.gperf"
     {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
-#line 93 "src/http/RegisteredHeadersHash.gperf"
+#line 93 "RegisteredHeadersHash.gperf"
     {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 43 "src/http/RegisteredHeadersHash.gperf"
+#line 43 "RegisteredHeadersHash.gperf"
     {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 33 "src/http/RegisteredHeadersHash.gperf"
+#line 33 "RegisteredHeadersHash.gperf"
     {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 69 "src/http/RegisteredHeadersHash.gperf"
+#line 69 "RegisteredHeadersHash.gperf"
     {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
-#line 36 "src/http/RegisteredHeadersHash.gperf"
+#line 36 "RegisteredHeadersHash.gperf"
     {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 101 "src/http/RegisteredHeadersHash.gperf"
+#line 101 "RegisteredHeadersHash.gperf"
     {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 71 "src/http/RegisteredHeadersHash.gperf"
+#line 71 "RegisteredHeadersHash.gperf"
     {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 92 "src/http/RegisteredHeadersHash.gperf"
+#line 92 "RegisteredHeadersHash.gperf"
     {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 32 "src/http/RegisteredHeadersHash.gperf"
+#line 32 "RegisteredHeadersHash.gperf"
     {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 52 "src/http/RegisteredHeadersHash.gperf"
+#line 52 "RegisteredHeadersHash.gperf"
     {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
-#line 42 "src/http/RegisteredHeadersHash.gperf"
+#line 42 "RegisteredHeadersHash.gperf"
     {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 72 "src/http/RegisteredHeadersHash.gperf"
+#line 72 "RegisteredHeadersHash.gperf"
     {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 84 "src/http/RegisteredHeadersHash.gperf"
+#line 84 "RegisteredHeadersHash.gperf"
     {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 59 "src/http/RegisteredHeadersHash.gperf"
+#line 59 "RegisteredHeadersHash.gperf"
     {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 95 "src/http/RegisteredHeadersHash.gperf"
+#line 95 "RegisteredHeadersHash.gperf"
     {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 28 "src/http/RegisteredHeadersHash.gperf"
+#line 28 "RegisteredHeadersHash.gperf"
     {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
-#line 27 "src/http/RegisteredHeadersHash.gperf"
+#line 27 "RegisteredHeadersHash.gperf"
     {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 65 "src/http/RegisteredHeadersHash.gperf"
+#line 65 "RegisteredHeadersHash.gperf"
     {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 85 "src/http/RegisteredHeadersHash.gperf"
+#line 85 "RegisteredHeadersHash.gperf"
     {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 99 "src/http/RegisteredHeadersHash.gperf"
+#line 99 "RegisteredHeadersHash.gperf"
     {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 110 "src/http/RegisteredHeadersHash.gperf"
+#line 110 "RegisteredHeadersHash.gperf"
     {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
-#line 82 "src/http/RegisteredHeadersHash.gperf"
+#line 82 "RegisteredHeadersHash.gperf"
     {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
-#line 107 "src/http/RegisteredHeadersHash.gperf"
+#line 107 "RegisteredHeadersHash.gperf"
     {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 55 "src/http/RegisteredHeadersHash.gperf"
+#line 55 "RegisteredHeadersHash.gperf"
     {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 112 "src/http/RegisteredHeadersHash.gperf"
+#line 112 "RegisteredHeadersHash.gperf"
     {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 46 "src/http/RegisteredHeadersHash.gperf"
+#line 46 "RegisteredHeadersHash.gperf"
     {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
     {""},
-#line 86 "src/http/RegisteredHeadersHash.gperf"
+#line 86 "RegisteredHeadersHash.gperf"
     {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 97 "src/http/RegisteredHeadersHash.gperf"
+#line 97 "RegisteredHeadersHash.gperf"
     {"Warning", Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
     {""}, {""}, {""},
-#line 108 "src/http/RegisteredHeadersHash.gperf"
+#line 108 "RegisteredHeadersHash.gperf"
     {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 105 "src/http/RegisteredHeadersHash.gperf"
+#line 105 "RegisteredHeadersHash.gperf"
     {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 104 "src/http/RegisteredHeadersHash.gperf"
+#line 104 "RegisteredHeadersHash.gperf"
     {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 90 "src/http/RegisteredHeadersHash.gperf"
+#line 90 "RegisteredHeadersHash.gperf"
     {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
     {""}, {""},
-#line 60 "src/http/RegisteredHeadersHash.gperf"
+#line 60 "RegisteredHeadersHash.gperf"
     {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
     {""},
-#line 63 "src/http/RegisteredHeadersHash.gperf"
+#line 63 "RegisteredHeadersHash.gperf"
     {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
     {""}, {""}, {""},
-#line 102 "src/http/RegisteredHeadersHash.gperf"
+#line 102 "RegisteredHeadersHash.gperf"
     {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 44 "src/http/RegisteredHeadersHash.gperf"
+#line 44 "RegisteredHeadersHash.gperf"
     {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
     {""}, {""},
-#line 61 "src/http/RegisteredHeadersHash.gperf"
+#line 61 "RegisteredHeadersHash.gperf"
     {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 100 "src/http/RegisteredHeadersHash.gperf"
+#line 100 "RegisteredHeadersHash.gperf"
     {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
     {""},
-#line 66 "src/http/RegisteredHeadersHash.gperf"
+#line 66 "RegisteredHeadersHash.gperf"
     {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader}
-  };
+};
 
 const struct HeaderTableRecord *
 HttpHeaderHashTable::lookup (const char *str, size_t len)
 {
-  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
+    if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      unsigned int key = HttpHeaderHash (str, len);
+        unsigned int key = HttpHeaderHash (str, len);
 
-      if (key <= MAX_HASH_VALUE)
-        if (len == lengthtable[key])
-          {
-            const char *s = HttpHeaderDefinitionsTable[key].name;
+        if (key <= MAX_HASH_VALUE)
+            if (len == lengthtable[key])
+            {
+                const char *s = HttpHeaderDefinitionsTable[key].name;
 
-            if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_memcmp (str, s, len))
-              return &HttpHeaderDefinitionsTable[key];
-          }
+                if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_memcmp (str, s, len))
+                    return &HttpHeaderDefinitionsTable[key];
+            }
     }
-  return 0;
+    return 0;
 }
-#line 114 "src/http/RegisteredHeadersHash.gperf"
+#line 114 "RegisteredHeadersHash.gperf"
 

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -44,14 +44,14 @@
 struct HeaderTableRecord;
 enum
   {
-    TOTAL_KEYWORDS = 90,
+    TOTAL_KEYWORDS = 89,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 25,
-    MIN_HASH_VALUE = 5,
-    MAX_HASH_VALUE = 106
+    MIN_HASH_VALUE = 7,
+    MAX_HASH_VALUE = 113
   };
 
-/* maximum key range = 102, duplicates = 0 */
+/* maximum key range = 107, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
@@ -111,32 +111,32 @@ HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 {
   static const unsigned char asso_values[] =
     {
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107,  51, 107, 107,  15, 107, 107, 107, 107,
-       19, 107, 107,  42, 107, 107, 107, 107,  27, 107,
-      107, 107, 107, 107, 107,  16,  56,  10,  25,   4,
-        2,  45,  44,  45, 107,   0,  26,  34,   1,   2,
-       28,  19,  40,  22,   0,  10,   0,   1,   5,  10,
-      107, 107, 107, 107, 107, 107, 107,  16,  56,  10,
-       25,   4,   2,  45,  44,  45, 107,   0,  26,  34,
-        1,   2,  28,  19,  40,  22,   0,  10,   0,   1,
-        5,  10, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
-      107, 107, 107, 107, 107, 107
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114,  44, 114, 114,  17, 114, 114, 114, 114,
+       31, 114, 114,  42, 114, 114, 114, 114,  35, 114,
+      114, 114, 114, 114, 114,  17,  62,  12,  15,   5,
+       10,  47,  48,  45, 114,   2,  23,  35,   2,   3,
+       14,   4,  38,  23,   1,   1,  14,  43,   2,  32,
+      114, 114, 114, 114, 114, 114, 114,  17,  62,  12,
+       15,   5,  10,  47,  48,  45, 114,   2,  23,  35,
+        2,   3,  14,   4,  38,  23,   1,   1,  14,  43,
+        2,  32, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
+      114, 114, 114, 114, 114, 114
     };
   unsigned int hval = len;
 
@@ -161,23 +161,24 @@ HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 
 static const unsigned char lengthtable[] =
   {
-     0,  0,  0,  0,  0,  4,  2,  0,  4,  5,  5,  3,  6,  0,
-    10, 10,  6, 12, 10,  8, 16,  7, 19,  3, 18, 16,  4,  8,
-     7, 25, 13, 19,  5,  9,  6,  3, 14,  8,  6,  7,  4, 10,
-    15, 13, 16, 15, 19, 16, 18,  7, 13, 11,  6, 21,  4, 12,
-     7,  7, 13, 10, 12, 13,  9,  7, 15,  4, 16,  8, 14, 12,
-    10, 15,  6, 12, 20, 11, 13,  6, 14, 13, 11, 17, 15, 19,
-    18, 14,  6, 17, 11, 10,  0,  0,  7, 17,  0,  0,  0, 13,
-    13,  9,  0,  0,  0,  0,  0, 13, 13
+     0,  0,  0,  0,  0,  0,  0,  2,  4,  0,  4,  5,  5,  3,
+     6,  0,  0, 10, 10,  6, 12,  6,  8, 16,  8, 19,  7, 18,
+     4, 10,  8, 13, 25, 13, 10, 19,  9,  3, 19, 14,  6,  7,
+     4, 16,  7, 15, 16, 18, 10, 15, 13, 11, 21,  6, 12,  7,
+    15, 11, 13,  7, 13, 10,  7, 14, 12, 13,  9,  3,  4, 16,
+    16,  5, 12,  8,  4, 14, 15,  9, 15, 13,  6, 12,  6, 17,
+    17, 13, 19, 14, 11,  6, 11, 10,  7,  0,  0, 20, 13, 13,
+    17,  0,  0,  0,  0,  0,  0, 18,  0,  0,  0,  0,  0,  0,
+     0, 13
   };
 
 static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
   {
-    {""}, {""}, {""}, {""}, {""},
-#line 67 "src/http/RegisteredHeadersHash.gperf"
-    {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
 #line 87 "src/http/RegisteredHeadersHash.gperf"
     {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 67 "src/http/RegisteredHeadersHash.gperf"
+    {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
     {""},
 #line 51 "src/http/RegisteredHeadersHash.gperf"
     {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
@@ -189,7 +190,7 @@ static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Age", Http::HdrType::AGE, Http::HdrFieldType::ftInt, HdrKind::ReplyHeader},
 #line 49 "src/http/RegisteredHeadersHash.gperf"
     {"Cookie", Http::HdrType::COOKIE, Http::HdrFieldType::ftStr, HdrKind::None},
-    {""},
+    {""}, {""},
 #line 39 "src/http/RegisteredHeadersHash.gperf"
     {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
 #line 94 "src/http/RegisteredHeadersHash.gperf"
@@ -198,165 +199,163 @@ static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 48 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Type", Http::HdrType::CONTENT_TYPE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 64 "src/http/RegisteredHeadersHash.gperf"
-    {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+#line 53 "src/http/RegisteredHeadersHash.gperf"
+    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 68 "src/http/RegisteredHeadersHash.gperf"
     {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 77 "src/http/RegisteredHeadersHash.gperf"
     {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 99 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Cache", Http::HdrType::X_CACHE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 38 "src/http/RegisteredHeadersHash.gperf"
+    {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 76 "src/http/RegisteredHeadersHash.gperf"
     {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 65 "src/http/RegisteredHeadersHash.gperf"
-    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 110 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 74 "src/http/RegisteredHeadersHash.gperf"
     {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 98 "src/http/RegisteredHeadersHash.gperf"
-    {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 57 "src/http/RegisteredHeadersHash.gperf"
     {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 112 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 62 "src/http/RegisteredHeadersHash.gperf"
     {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
-#line 50 "src/http/RegisteredHeadersHash.gperf"
-    {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 78 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
 #line 75 "src/http/RegisteredHeadersHash.gperf"
     {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
 #line 35 "src/http/RegisteredHeadersHash.gperf"
     {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 64 "src/http/RegisteredHeadersHash.gperf"
+    {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
 #line 34 "src/http/RegisteredHeadersHash.gperf"
     {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 32 "src/http/RegisteredHeadersHash.gperf"
-    {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
 #line 91 "src/http/RegisteredHeadersHash.gperf"
     {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 53 "src/http/RegisteredHeadersHash.gperf"
-    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 96 "src/http/RegisteredHeadersHash.gperf"
     {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 58 "src/http/RegisteredHeadersHash.gperf"
-    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 38 "src/http/RegisteredHeadersHash.gperf"
-    {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 73 "src/http/RegisteredHeadersHash.gperf"
-    {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 111 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 56 "src/http/RegisteredHeadersHash.gperf"
-    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 113 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 105 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 78 "src/http/RegisteredHeadersHash.gperf"
-    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 45 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 29 "src/http/RegisteredHeadersHash.gperf"
-    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 41 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 58 "src/http/RegisteredHeadersHash.gperf"
+    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 73 "src/http/RegisteredHeadersHash.gperf"
+    {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 50 "src/http/RegisteredHeadersHash.gperf"
+    {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 56 "src/http/RegisteredHeadersHash.gperf"
+    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 45 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 54 "src/http/RegisteredHeadersHash.gperf"
+    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 104 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 43 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
 #line 33 "src/http/RegisteredHeadersHash.gperf"
     {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 81 "src/http/RegisteredHeadersHash.gperf"
-    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 111 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
+#line 29 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 36 "src/http/RegisteredHeadersHash.gperf"
     {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
 #line 83 "src/http/RegisteredHeadersHash.gperf"
     {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 72 "src/http/RegisteredHeadersHash.gperf"
-    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 92 "src/http/RegisteredHeadersHash.gperf"
     {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 95 "src/http/RegisteredHeadersHash.gperf"
-    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 72 "src/http/RegisteredHeadersHash.gperf"
+    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 69 "src/http/RegisteredHeadersHash.gperf"
     {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
-#line 93 "src/http/RegisteredHeadersHash.gperf"
-    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 54 "src/http/RegisteredHeadersHash.gperf"
-    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 81 "src/http/RegisteredHeadersHash.gperf"
+    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 107 "src/http/RegisteredHeadersHash.gperf"
+    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 108 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 47 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
+#line 93 "src/http/RegisteredHeadersHash.gperf"
+    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+#line 82 "src/http/RegisteredHeadersHash.gperf"
+    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
 #line 85 "src/http/RegisteredHeadersHash.gperf"
     {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 89 "src/http/RegisteredHeadersHash.gperf"
+    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+#line 99 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Cache-Lookup", Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 37 "src/http/RegisteredHeadersHash.gperf"
     {"Cache-Status", Http::HdrType::CACHE_STATUS, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 30 "src/http/RegisteredHeadersHash.gperf"
     {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 71 "src/http/RegisteredHeadersHash.gperf"
     {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 89 "src/http/RegisteredHeadersHash.gperf"
-    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 108 "src/http/RegisteredHeadersHash.gperf"
-    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 65 "src/http/RegisteredHeadersHash.gperf"
+    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 52 "src/http/RegisteredHeadersHash.gperf"
     {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
+#line 98 "src/http/RegisteredHeadersHash.gperf"
+    {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 42 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 59 "src/http/RegisteredHeadersHash.gperf"
-    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 27 "src/http/RegisteredHeadersHash.gperf"
-    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 32 "src/http/RegisteredHeadersHash.gperf"
+    {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
 #line 70 "src/http/RegisteredHeadersHash.gperf"
     {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
-#line 112 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
+#line 59 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 95 "src/http/RegisteredHeadersHash.gperf"
+    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 27 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 28 "src/http/RegisteredHeadersHash.gperf"
     {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
+#line 55 "src/http/RegisteredHeadersHash.gperf"
+    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 100 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 102 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 79 "src/http/RegisteredHeadersHash.gperf"
     {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 40 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 106 "src/http/RegisteredHeadersHash.gperf"
-    {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 86 "src/http/RegisteredHeadersHash.gperf"
-    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 82 "src/http/RegisteredHeadersHash.gperf"
-    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
-#line 114 "src/http/RegisteredHeadersHash.gperf"
-    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 100 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Cache-Lookup", Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 103 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 109 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 60 "src/http/RegisteredHeadersHash.gperf"
-    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
-#line 101 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 63 "src/http/RegisteredHeadersHash.gperf"
-    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
-#line 104 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 44 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
 #line 84 "src/http/RegisteredHeadersHash.gperf"
     {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 107 "src/http/RegisteredHeadersHash.gperf"
+#line 106 "src/http/RegisteredHeadersHash.gperf"
     {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 60 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
+#line 109 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 63 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
+#line 44 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
+#line 86 "src/http/RegisteredHeadersHash.gperf"
+    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 113 "src/http/RegisteredHeadersHash.gperf"
+    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
 #line 46 "src/http/RegisteredHeadersHash.gperf"
     {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 115 "src/http/RegisteredHeadersHash.gperf"
+#line 114 "src/http/RegisteredHeadersHash.gperf"
     {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
-    {""}, {""},
 #line 97 "src/http/RegisteredHeadersHash.gperf"
     {"Warning", Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 90 "src/http/RegisteredHeadersHash.gperf"
-    {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-    {""}, {""}, {""},
-#line 110 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 102 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 55 "src/http/RegisteredHeadersHash.gperf"
-    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-    {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 105 "src/http/RegisteredHeadersHash.gperf"
+    {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 66 "src/http/RegisteredHeadersHash.gperf"
     {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 101 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 90 "src/http/RegisteredHeadersHash.gperf"
+    {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 103 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
 #line 61 "src/http/RegisteredHeadersHash.gperf"
     {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader}
   };
@@ -379,5 +378,5 @@ HttpHeaderHashTable::lookup (const char *str, size_t len)
     }
   return 0;
 }
-#line 116 "src/http/RegisteredHeadersHash.gperf"
+#line 115 "src/http/RegisteredHeadersHash.gperf"
 

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -1,35 +1,35 @@
 /* C++ code produced by gperf version 3.1 */
-/* Command-line: gperf -m 100000 RegisteredHeadersHash.gperf  */
-/* Computed positions: -k'1,9,$' */
+/* Command-line: gperf -m 100000 src/http/RegisteredHeadersHash.gperf  */
+/* Computed positions: -k'3,9,$' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
-&& ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
-&& (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
-&& ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
-&& ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
-&& ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
-&& ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
-&& ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
-&& ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
-&& ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
-&& ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
-&& ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
-&& ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
-&& ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
-&& ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
-&& ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
-&& ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
-&& ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
-&& ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
-&& ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
-&& ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
-&& ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
-&& ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
+      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
+      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
+      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
+      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
+      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
+      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
+      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
+      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
+      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
+      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
+      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
+      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
+      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
+      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
+      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
+      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
+      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
+      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
+      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
+      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
+      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
 /* The character set is not based on ISO-646.  */
 #error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
 #endif
 
-#line 1 "RegisteredHeadersHash.gperf"
+#line 1 "src/http/RegisteredHeadersHash.gperf"
 
 /* AUTO GENERATED FROM RegisteredHeadersHash.gperf. DO NOT EDIT */
 
@@ -40,28 +40,28 @@
  * contributions from numerous individuals and organizations.
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
-#line 24 "RegisteredHeadersHash.gperf"
+#line 24 "src/http/RegisteredHeadersHash.gperf"
 struct HeaderTableRecord;
-        enum
-{
-    TOTAL_KEYWORDS = 89,
+enum
+  {
+    TOTAL_KEYWORDS = 90,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 25,
-    MIN_HASH_VALUE = 13,
-    MAX_HASH_VALUE = 114
-};
+    MIN_HASH_VALUE = 5,
+    MAX_HASH_VALUE = 106
+  };
 
 /* maximum key range = 102, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
 static unsigned char gperf_downcase[256] =
-{
-    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
-    15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
-    30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
-    45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
-    60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
+  {
+      0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
+     15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+     30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+     45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+     60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
     107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
     122,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104,
     105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
@@ -75,7 +75,7 @@ static unsigned char gperf_downcase[256] =
     225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
     240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254,
     255
-};
+  };
 #endif
 
 #ifndef GPERF_CASE_MEMCMP
@@ -83,305 +83,301 @@ static unsigned char gperf_downcase[256] =
 static int
 gperf_case_memcmp (const char *s1, const char *s2, size_t n)
 {
-    for (; n > 0;)
+  for (; n > 0;)
     {
-        unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
-        unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
-        if (c1 == c2)
+      unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
+      unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
+      if (c1 == c2)
         {
-            n--;
-            continue;
+          n--;
+          continue;
         }
-        return (int)c1 - (int)c2;
+      return (int)c1 - (int)c2;
     }
-    return 0;
+  return 0;
 }
 #endif
 
 class HttpHeaderHashTable
 {
 private:
-    static inline unsigned int HttpHeaderHash (const char *str, size_t len);
+  static inline unsigned int HttpHeaderHash (const char *str, size_t len);
 public:
-    static const struct HeaderTableRecord *lookup (const char *str, size_t len);
+  static const struct HeaderTableRecord *lookup (const char *str, size_t len);
 };
 
 inline unsigned int
 HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 {
-    static const unsigned char asso_values[] =
+  static const unsigned char asso_values[] =
     {
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115,  27, 115, 115,   4, 115, 115, 115, 115,
-        26, 115, 115,  33, 115, 115, 115, 115,  25, 115,
-        115, 115, 115, 115, 115,  15,   7,   7,  10,   4,
-        33,  66,  42,  22, 115,  63,  10,  33,  18,  44,
-        11, 115,   4,  28,  10,  42,  23,  26,  31,  30,
-        115, 115, 115, 115, 115, 115, 115,  15,   7,   7,
-        10,   4,  33,  66,  42,  22, 115,  63,  10,  33,
-        18,  44,  11, 115,   4,  28,  10,  42,  23,  26,
-        31,  30, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
-        115, 115, 115, 115, 115, 115
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107,  51, 107, 107,  15, 107, 107, 107, 107,
+       19, 107, 107,  42, 107, 107, 107, 107,  27, 107,
+      107, 107, 107, 107, 107,  16,  56,  10,  25,   4,
+        2,  45,  44,  45, 107,   0,  26,  34,   1,   2,
+       28,  19,  40,  22,   0,  10,   0,   1,   5,  10,
+      107, 107, 107, 107, 107, 107, 107,  16,  56,  10,
+       25,   4,   2,  45,  44,  45, 107,   0,  26,  34,
+        1,   2,  28,  19,  40,  22,   0,  10,   0,   1,
+        5,  10, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107, 107, 107, 107, 107,
+      107, 107, 107, 107, 107, 107
     };
-    unsigned int hval = len;
+  unsigned int hval = len;
 
-    switch (hval)
+  switch (hval)
     {
-    default:
+      default:
         hval += asso_values[static_cast<unsigned char>(str[8])];
-    /*FALLTHROUGH*/
-    case 8:
-    case 7:
-    case 6:
-    case 5:
-    case 4:
-    case 3:
-    case 2:
-    case 1:
-        hval += asso_values[static_cast<unsigned char>(str[0])];
+      /*FALLTHROUGH*/
+      case 8:
+      case 7:
+      case 6:
+      case 5:
+      case 4:
+      case 3:
+        hval += asso_values[static_cast<unsigned char>(str[2])];
+      /*FALLTHROUGH*/
+      case 2:
         break;
     }
-    return hval + asso_values[static_cast<unsigned char>(str[len - 1])];
+  return hval + asso_values[static_cast<unsigned char>(str[len - 1])];
 }
 
 static const unsigned char lengthtable[] =
-{
-    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  5,
-    0,  7,  2,  6,  4,  5,  6,  7,  3,  0,  6, 13,  8,  9,
-    13, 11, 12,  6,  6, 12,  8,  9,  8, 16,  6,  7,  7,  3,
-    7, 18,  7, 13,  5, 18, 13, 15, 16, 16, 13,  7, 19, 13,
-    4,  4, 19, 17, 15, 13,  9, 16, 10, 17, 14, 19,  6, 11,
-    4, 13,  8, 14,  4,  6, 13,  4, 15, 10, 10, 14, 20, 18,
-    11, 19, 15, 11, 12, 10, 25, 12,  0, 16, 14,  0,  3, 17,
-    0,  7, 10,  0,  0,  0,  0, 10,  0, 13,  0,  0, 13, 21,
-    0, 10, 15
-};
+  {
+     0,  0,  0,  0,  0,  4,  2,  0,  4,  5,  5,  3,  6,  0,
+    10, 10,  6, 12, 10,  8, 16,  7, 19,  3, 18, 16,  4,  8,
+     7, 25, 13, 19,  5,  9,  6,  3, 14,  8,  6,  7,  4, 10,
+    15, 13, 16, 15, 19, 16, 18,  7, 13, 11,  6, 21,  4, 12,
+     7,  7, 13, 10, 12, 13,  9,  7, 15,  4, 16,  8, 14, 12,
+    10, 15,  6, 12, 20, 11, 13,  6, 14, 13, 11, 17, 15, 19,
+    18, 14,  6, 17, 11, 10,  0,  0,  7, 17,  0,  0,  0, 13,
+    13,  9,  0,  0,  0,  0,  0, 13, 13
+  };
 
 static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
-{
-    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-    {""}, {""}, {""}, {""},
-#line 79 "RegisteredHeadersHash.gperf"
-    {"Range", Http::HdrType::RANGE, Http::HdrFieldType::ftPRange, HdrKind::RequestHeader},
-    {""},
-#line 80 "RegisteredHeadersHash.gperf"
-    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 86 "RegisteredHeadersHash.gperf"
-    {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 48 "RegisteredHeadersHash.gperf"
-    {"Cookie", Http::HdrType::COOKIE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 50 "RegisteredHeadersHash.gperf"
-    {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
-#line 87 "RegisteredHeadersHash.gperf"
-    {"Title", Http::HdrType::TITLE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 52 "RegisteredHeadersHash.gperf"
-    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 88 "RegisteredHeadersHash.gperf"
-    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 31 "RegisteredHeadersHash.gperf"
-    {"Age", Http::HdrType::AGE, Http::HdrFieldType::ftInt, HdrKind::ReplyHeader},
-    {""},
-#line 78 "RegisteredHeadersHash.gperf"
-    {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 81 "RegisteredHeadersHash.gperf"
-    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
-#line 37 "RegisteredHeadersHash.gperf"
-    {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 90 "RegisteredHeadersHash.gperf"
-    {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 46 "RegisteredHeadersHash.gperf"
-    {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
-#line 82 "RegisteredHeadersHash.gperf"
-    {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 39 "RegisteredHeadersHash.gperf"
-    {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 26 "RegisteredHeadersHash.gperf"
-    {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 72 "RegisteredHeadersHash.gperf"
-    {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 47 "RegisteredHeadersHash.gperf"
-    {"Content-Type", Http::HdrType::CONTENT_TYPE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 61 "RegisteredHeadersHash.gperf"
-    {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
-#line 70 "RegisteredHeadersHash.gperf"
-    {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 67 "RegisteredHeadersHash.gperf"
-    {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 42 "RegisteredHeadersHash.gperf"
-    {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 83 "RegisteredHeadersHash.gperf"
-    {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 53 "RegisteredHeadersHash.gperf"
-    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 49 "RegisteredHeadersHash.gperf"
-    {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 95 "RegisteredHeadersHash.gperf"
-    {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 98 "RegisteredHeadersHash.gperf"
-    {"X-Cache", Http::HdrType::X_CACHE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 73 "RegisteredHeadersHash.gperf"
-    {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 110 "RegisteredHeadersHash.gperf"
-    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 77 "RegisteredHeadersHash.gperf"
-    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 32 "RegisteredHeadersHash.gperf"
-    {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 33 "RegisteredHeadersHash.gperf"
-    {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 36 "RegisteredHeadersHash.gperf"
-    {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 29 "RegisteredHeadersHash.gperf"
-    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 97 "RegisteredHeadersHash.gperf"
-    {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 44 "RegisteredHeadersHash.gperf"
-    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 102 "RegisteredHeadersHash.gperf"
-    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 92 "RegisteredHeadersHash.gperf"
-    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 40 "RegisteredHeadersHash.gperf"
-    {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 65 "RegisteredHeadersHash.gperf"
-    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 56 "RegisteredHeadersHash.gperf"
-    {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 94 "RegisteredHeadersHash.gperf"
-    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 75 "RegisteredHeadersHash.gperf"
-    {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 106 "RegisteredHeadersHash.gperf"
-    {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 100 "RegisteredHeadersHash.gperf"
-    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 35 "RegisteredHeadersHash.gperf"
-    {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 54 "RegisteredHeadersHash.gperf"
-    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 76 "RegisteredHeadersHash.gperf"
-    {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 84 "RegisteredHeadersHash.gperf"
-    {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 59 "RegisteredHeadersHash.gperf"
-    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
-#line 99 "RegisteredHeadersHash.gperf"
-    {"X-Cache-Lookup", Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 62 "RegisteredHeadersHash.gperf"
-    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
-#line 71 "RegisteredHeadersHash.gperf"
-    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 108 "RegisteredHeadersHash.gperf"
-    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 55 "RegisteredHeadersHash.gperf"
-    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 30 "RegisteredHeadersHash.gperf"
-    {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 58 "RegisteredHeadersHash.gperf"
-    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 43 "RegisteredHeadersHash.gperf"
-    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
-#line 51 "RegisteredHeadersHash.gperf"
-    {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
-#line 113 "RegisteredHeadersHash.gperf"
-    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 101 "RegisteredHeadersHash.gperf"
-    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 66 "RegisteredHeadersHash.gperf"
+  {
+    {""}, {""}, {""}, {""}, {""},
+#line 67 "src/http/RegisteredHeadersHash.gperf"
     {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 104 "RegisteredHeadersHash.gperf"
-    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 38 "RegisteredHeadersHash.gperf"
+#line 87 "src/http/RegisteredHeadersHash.gperf"
+    {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+    {""},
+#line 51 "src/http/RegisteredHeadersHash.gperf"
+    {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
+#line 88 "src/http/RegisteredHeadersHash.gperf"
+    {"Title", Http::HdrType::TITLE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 80 "src/http/RegisteredHeadersHash.gperf"
+    {"Range", Http::HdrType::RANGE, Http::HdrFieldType::ftPRange, HdrKind::RequestHeader},
+#line 31 "src/http/RegisteredHeadersHash.gperf"
+    {"Age", Http::HdrType::AGE, Http::HdrFieldType::ftInt, HdrKind::ReplyHeader},
+#line 49 "src/http/RegisteredHeadersHash.gperf"
+    {"Cookie", Http::HdrType::COOKIE, Http::HdrFieldType::ftStr, HdrKind::None},
+    {""},
+#line 39 "src/http/RegisteredHeadersHash.gperf"
     {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 93 "RegisteredHeadersHash.gperf"
+#line 94 "src/http/RegisteredHeadersHash.gperf"
     {"User-Agent", Http::HdrType::USER_AGENT, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 27 "RegisteredHeadersHash.gperf"
-    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 105 "RegisteredHeadersHash.gperf"
-    {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 103 "RegisteredHeadersHash.gperf"
-    {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 45 "RegisteredHeadersHash.gperf"
-    {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 34 "RegisteredHeadersHash.gperf"
-    {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 107 "RegisteredHeadersHash.gperf"
-    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 85 "RegisteredHeadersHash.gperf"
-    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 68 "RegisteredHeadersHash.gperf"
-    {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
-#line 114 "RegisteredHeadersHash.gperf"
-    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
-#line 74 "RegisteredHeadersHash.gperf"
-    {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 69 "RegisteredHeadersHash.gperf"
-    {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
-    {""},
-#line 41 "RegisteredHeadersHash.gperf"
-    {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 57 "RegisteredHeadersHash.gperf"
-    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-    {""},
-#line 64 "RegisteredHeadersHash.gperf"
-    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 89 "RegisteredHeadersHash.gperf"
-    {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-    {""},
-#line 96 "RegisteredHeadersHash.gperf"
-    {"Warning", Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 63 "RegisteredHeadersHash.gperf"
+#line 26 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 48 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Type", Http::HdrType::CONTENT_TYPE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 64 "src/http/RegisteredHeadersHash.gperf"
     {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-    {""}, {""}, {""}, {""},
-#line 112 "RegisteredHeadersHash.gperf"
+#line 68 "src/http/RegisteredHeadersHash.gperf"
+    {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 77 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+#line 99 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Cache", Http::HdrType::X_CACHE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 76 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 65 "src/http/RegisteredHeadersHash.gperf"
+    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 74 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 98 "src/http/RegisteredHeadersHash.gperf"
+    {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 57 "src/http/RegisteredHeadersHash.gperf"
+    {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 62 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
+#line 50 "src/http/RegisteredHeadersHash.gperf"
+    {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 75 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+#line 35 "src/http/RegisteredHeadersHash.gperf"
+    {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 34 "src/http/RegisteredHeadersHash.gperf"
+    {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+#line 32 "src/http/RegisteredHeadersHash.gperf"
+    {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 91 "src/http/RegisteredHeadersHash.gperf"
+    {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 53 "src/http/RegisteredHeadersHash.gperf"
+    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 96 "src/http/RegisteredHeadersHash.gperf"
+    {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 58 "src/http/RegisteredHeadersHash.gperf"
+    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 38 "src/http/RegisteredHeadersHash.gperf"
+    {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 73 "src/http/RegisteredHeadersHash.gperf"
+    {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 111 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 56 "src/http/RegisteredHeadersHash.gperf"
+    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 113 "src/http/RegisteredHeadersHash.gperf"
     {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
-    {""},
-#line 109 "RegisteredHeadersHash.gperf"
-    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
-    {""}, {""},
-#line 60 "RegisteredHeadersHash.gperf"
-    {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 91 "RegisteredHeadersHash.gperf"
+#line 105 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 78 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+#line 45 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 29 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 41 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 43 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 33 "src/http/RegisteredHeadersHash.gperf"
+    {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+#line 81 "src/http/RegisteredHeadersHash.gperf"
+    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 36 "src/http/RegisteredHeadersHash.gperf"
+    {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 83 "src/http/RegisteredHeadersHash.gperf"
+    {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 72 "src/http/RegisteredHeadersHash.gperf"
+    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 92 "src/http/RegisteredHeadersHash.gperf"
     {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
-    {""},
-#line 111 "RegisteredHeadersHash.gperf"
+#line 95 "src/http/RegisteredHeadersHash.gperf"
+    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 69 "src/http/RegisteredHeadersHash.gperf"
+    {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
+#line 93 "src/http/RegisteredHeadersHash.gperf"
+    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+#line 54 "src/http/RegisteredHeadersHash.gperf"
+    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 47 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
+#line 85 "src/http/RegisteredHeadersHash.gperf"
+    {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 37 "src/http/RegisteredHeadersHash.gperf"
+    {"Cache-Status", Http::HdrType::CACHE_STATUS, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 30 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 71 "src/http/RegisteredHeadersHash.gperf"
+    {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 89 "src/http/RegisteredHeadersHash.gperf"
+    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+#line 108 "src/http/RegisteredHeadersHash.gperf"
+    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 52 "src/http/RegisteredHeadersHash.gperf"
+    {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
+#line 42 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 59 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 27 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 70 "src/http/RegisteredHeadersHash.gperf"
+    {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
+#line 112 "src/http/RegisteredHeadersHash.gperf"
     {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
-#line 28 "RegisteredHeadersHash.gperf"
-    {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader}
-};
+#line 28 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
+#line 79 "src/http/RegisteredHeadersHash.gperf"
+    {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 40 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 106 "src/http/RegisteredHeadersHash.gperf"
+    {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 86 "src/http/RegisteredHeadersHash.gperf"
+    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 82 "src/http/RegisteredHeadersHash.gperf"
+    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
+#line 114 "src/http/RegisteredHeadersHash.gperf"
+    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 100 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Cache-Lookup", Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 103 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 109 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 60 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
+#line 101 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 63 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
+#line 104 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 44 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
+#line 84 "src/http/RegisteredHeadersHash.gperf"
+    {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 107 "src/http/RegisteredHeadersHash.gperf"
+    {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 46 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 115 "src/http/RegisteredHeadersHash.gperf"
+    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
+    {""}, {""},
+#line 97 "src/http/RegisteredHeadersHash.gperf"
+    {"Warning", Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 90 "src/http/RegisteredHeadersHash.gperf"
+    {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+    {""}, {""}, {""},
+#line 110 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 102 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 55 "src/http/RegisteredHeadersHash.gperf"
+    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+    {""}, {""}, {""}, {""}, {""},
+#line 66 "src/http/RegisteredHeadersHash.gperf"
+    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 61 "src/http/RegisteredHeadersHash.gperf"
+    {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader}
+  };
 
 const struct HeaderTableRecord *
 HttpHeaderHashTable::lookup (const char *str, size_t len)
 {
-    if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
+  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-        unsigned int key = HttpHeaderHash (str, len);
+      unsigned int key = HttpHeaderHash (str, len);
 
-        if (key <= MAX_HASH_VALUE)
-            if (len == lengthtable[key])
-            {
-                const char *s = HttpHeaderDefinitionsTable[key].name;
+      if (key <= MAX_HASH_VALUE)
+        if (len == lengthtable[key])
+          {
+            const char *s = HttpHeaderDefinitionsTable[key].name;
 
-                if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_memcmp (str, s, len))
-                    return &HttpHeaderDefinitionsTable[key];
-            }
+            if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_memcmp (str, s, len))
+              return &HttpHeaderDefinitionsTable[key];
+          }
     }
-    return 0;
+  return 0;
 }
-#line 115 "RegisteredHeadersHash.gperf"
+#line 116 "src/http/RegisteredHeadersHash.gperf"
 

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -44,14 +44,14 @@
 struct HeaderTableRecord;
 enum
   {
-    TOTAL_KEYWORDS = 89,
+    TOTAL_KEYWORDS = 88,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 25,
-    MIN_HASH_VALUE = 7,
-    MAX_HASH_VALUE = 113
+    MIN_HASH_VALUE = 5,
+    MAX_HASH_VALUE = 109
   };
 
-/* maximum key range = 107, duplicates = 0 */
+/* maximum key range = 105, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
@@ -111,32 +111,32 @@ HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 {
   static const unsigned char asso_values[] =
     {
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114,  44, 114, 114,  17, 114, 114, 114, 114,
-       31, 114, 114,  42, 114, 114, 114, 114,  35, 114,
-      114, 114, 114, 114, 114,  17,  62,  12,  15,   5,
-       10,  47,  48,  45, 114,   2,  23,  35,   2,   3,
-       14,   4,  38,  23,   1,   1,  14,  43,   2,  32,
-      114, 114, 114, 114, 114, 114, 114,  17,  62,  12,
-       15,   5,  10,  47,  48,  45, 114,   2,  23,  35,
-        2,   3,  14,   4,  38,  23,   1,   1,  14,  43,
-        2,  32, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-      114, 114, 114, 114, 114, 114
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110,   0, 110, 110,  13, 110, 110, 110, 110,
+       12, 110, 110,  41, 110, 110, 110, 110,  26, 110,
+      110, 110, 110, 110, 110,  16,  10,  10,  20,   4,
+       10,  47,  50,  62, 110,   0,  38,  30,   1,   2,
+       33,  30,  32,  14,   0,  21,   5,  23,  19,  36,
+      110, 110, 110, 110, 110, 110, 110,  16,  10,  10,
+       20,   4,  10,  47,  50,  62, 110,   0,  38,  30,
+        1,   2,  33,  30,  32,  14,   0,  21,   5,  23,
+       19,  36, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+      110, 110, 110, 110, 110, 110
     };
   unsigned int hval = len;
 
@@ -161,24 +161,23 @@ HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 
 static const unsigned char lengthtable[] =
   {
-     0,  0,  0,  0,  0,  0,  0,  2,  4,  0,  4,  5,  5,  3,
-     6,  0,  0, 10, 10,  6, 12,  6,  8, 16,  8, 19,  7, 18,
-     4, 10,  8, 13, 25, 13, 10, 19,  9,  3, 19, 14,  6,  7,
-     4, 16,  7, 15, 16, 18, 10, 15, 13, 11, 21,  6, 12,  7,
-    15, 11, 13,  7, 13, 10,  7, 14, 12, 13,  9,  3,  4, 16,
-    16,  5, 12,  8,  4, 14, 15,  9, 15, 13,  6, 12,  6, 17,
-    17, 13, 19, 14, 11,  6, 11, 10,  7,  0,  0, 20, 13, 13,
-    17,  0,  0,  0,  0,  0,  0, 18,  0,  0,  0,  0,  0,  0,
-     0, 13
+     0,  0,  0,  0,  0,  4,  2,  0,  4,  5,  5,  3,  6,  0,
+    10, 10,  6, 12,  4,  8, 16,  7, 19, 10, 18,  8,  6, 12,
+    14, 25, 13, 19,  0,  9, 15,  3,  4, 10,  6,  6,  0, 19,
+     8, 11,  7, 15, 10, 16, 13,  7, 13, 15, 12, 13,  7,  7,
+    16, 12,  7, 16, 18, 12, 13, 13,  9, 21,  5,  4, 16,  6,
+     6,  8,  4, 15, 14,  3, 10, 15, 10, 13, 11,  9,  6, 11,
+     0, 11,  7,  0,  0,  0, 13, 17, 20, 17,  0,  0, 17,  0,
+    19,  0,  0,  0, 18, 14,  0,  0, 13, 13,  0, 13
   };
 
 static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
   {
-    {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 87 "src/http/RegisteredHeadersHash.gperf"
-    {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+    {""}, {""}, {""}, {""}, {""},
 #line 67 "src/http/RegisteredHeadersHash.gperf"
     {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 87 "src/http/RegisteredHeadersHash.gperf"
+    {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
     {""},
 #line 51 "src/http/RegisteredHeadersHash.gperf"
     {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
@@ -190,7 +189,7 @@ static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Age", Http::HdrType::AGE, Http::HdrFieldType::ftInt, HdrKind::ReplyHeader},
 #line 49 "src/http/RegisteredHeadersHash.gperf"
     {"Cookie", Http::HdrType::COOKIE, Http::HdrFieldType::ftStr, HdrKind::None},
-    {""}, {""},
+    {""},
 #line 39 "src/http/RegisteredHeadersHash.gperf"
     {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
 #line 94 "src/http/RegisteredHeadersHash.gperf"
@@ -199,165 +198,169 @@ static const struct HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 48 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Type", Http::HdrType::CONTENT_TYPE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 53 "src/http/RegisteredHeadersHash.gperf"
-    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 57 "src/http/RegisteredHeadersHash.gperf"
+    {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 68 "src/http/RegisteredHeadersHash.gperf"
     {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 77 "src/http/RegisteredHeadersHash.gperf"
     {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 38 "src/http/RegisteredHeadersHash.gperf"
-    {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 76 "src/http/RegisteredHeadersHash.gperf"
-    {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 110 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 74 "src/http/RegisteredHeadersHash.gperf"
-    {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 57 "src/http/RegisteredHeadersHash.gperf"
-    {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 112 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 62 "src/http/RegisteredHeadersHash.gperf"
-    {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
-#line 78 "src/http/RegisteredHeadersHash.gperf"
-    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 75 "src/http/RegisteredHeadersHash.gperf"
-    {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 35 "src/http/RegisteredHeadersHash.gperf"
-    {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 64 "src/http/RegisteredHeadersHash.gperf"
-    {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 34 "src/http/RegisteredHeadersHash.gperf"
-    {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 91 "src/http/RegisteredHeadersHash.gperf"
-    {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 96 "src/http/RegisteredHeadersHash.gperf"
-    {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 41 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 58 "src/http/RegisteredHeadersHash.gperf"
-    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 73 "src/http/RegisteredHeadersHash.gperf"
-    {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
 #line 50 "src/http/RegisteredHeadersHash.gperf"
     {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 56 "src/http/RegisteredHeadersHash.gperf"
-    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 45 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 54 "src/http/RegisteredHeadersHash.gperf"
-    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 104 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 43 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 33 "src/http/RegisteredHeadersHash.gperf"
-    {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 111 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
-#line 29 "src/http/RegisteredHeadersHash.gperf"
-    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 36 "src/http/RegisteredHeadersHash.gperf"
-    {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 83 "src/http/RegisteredHeadersHash.gperf"
-    {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 92 "src/http/RegisteredHeadersHash.gperf"
-    {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 72 "src/http/RegisteredHeadersHash.gperf"
-    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 69 "src/http/RegisteredHeadersHash.gperf"
-    {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
-#line 81 "src/http/RegisteredHeadersHash.gperf"
-    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 107 "src/http/RegisteredHeadersHash.gperf"
-    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 108 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 47 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
-#line 93 "src/http/RegisteredHeadersHash.gperf"
-    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 82 "src/http/RegisteredHeadersHash.gperf"
-    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
-#line 85 "src/http/RegisteredHeadersHash.gperf"
-    {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 89 "src/http/RegisteredHeadersHash.gperf"
-    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 99 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Cache-Lookup", Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 37 "src/http/RegisteredHeadersHash.gperf"
-    {"Cache-Status", Http::HdrType::CACHE_STATUS, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 30 "src/http/RegisteredHeadersHash.gperf"
-    {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 71 "src/http/RegisteredHeadersHash.gperf"
-    {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 65 "src/http/RegisteredHeadersHash.gperf"
-    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 52 "src/http/RegisteredHeadersHash.gperf"
-    {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
-#line 98 "src/http/RegisteredHeadersHash.gperf"
-    {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 42 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 32 "src/http/RegisteredHeadersHash.gperf"
-    {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 70 "src/http/RegisteredHeadersHash.gperf"
-    {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
-#line 59 "src/http/RegisteredHeadersHash.gperf"
-    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 95 "src/http/RegisteredHeadersHash.gperf"
-    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 27 "src/http/RegisteredHeadersHash.gperf"
-    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 28 "src/http/RegisteredHeadersHash.gperf"
-    {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
-#line 55 "src/http/RegisteredHeadersHash.gperf"
-    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 100 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 102 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 76 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 64 "src/http/RegisteredHeadersHash.gperf"
+    {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+#line 74 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 62 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
 #line 79 "src/http/RegisteredHeadersHash.gperf"
     {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 40 "src/http/RegisteredHeadersHash.gperf"
     {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 58 "src/http/RegisteredHeadersHash.gperf"
+    {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
+#line 75 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+#line 35 "src/http/RegisteredHeadersHash.gperf"
+    {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 34 "src/http/RegisteredHeadersHash.gperf"
+    {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+    {""},
+#line 91 "src/http/RegisteredHeadersHash.gperf"
+    {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 103 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 96 "src/http/RegisteredHeadersHash.gperf"
+    {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 56 "src/http/RegisteredHeadersHash.gperf"
+    {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 113 "src/http/RegisteredHeadersHash.gperf"
+    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
+#line 73 "src/http/RegisteredHeadersHash.gperf"
+    {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 53 "src/http/RegisteredHeadersHash.gperf"
+    {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+    {""},
+#line 41 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 38 "src/http/RegisteredHeadersHash.gperf"
+    {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 83 "src/http/RegisteredHeadersHash.gperf"
+    {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 109 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 29 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 111 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 98 "src/http/RegisteredHeadersHash.gperf"
+    {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 78 "src/http/RegisteredHeadersHash.gperf"
+    {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+#line 81 "src/http/RegisteredHeadersHash.gperf"
+    {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
+#line 47 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
+#line 106 "src/http/RegisteredHeadersHash.gperf"
+    {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 37 "src/http/RegisteredHeadersHash.gperf"
+    {"Cache-Status", Http::HdrType::CACHE_STATUS, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 30 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 54 "src/http/RegisteredHeadersHash.gperf"
+    {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+#line 89 "src/http/RegisteredHeadersHash.gperf"
+    {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+#line 45 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 70 "src/http/RegisteredHeadersHash.gperf"
+    {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
+#line 93 "src/http/RegisteredHeadersHash.gperf"
+    {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
+#line 43 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 33 "src/http/RegisteredHeadersHash.gperf"
+    {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
+#line 69 "src/http/RegisteredHeadersHash.gperf"
+    {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
+#line 36 "src/http/RegisteredHeadersHash.gperf"
+    {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 101 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 71 "src/http/RegisteredHeadersHash.gperf"
+    {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 92 "src/http/RegisteredHeadersHash.gperf"
+    {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 32 "src/http/RegisteredHeadersHash.gperf"
+    {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 52 "src/http/RegisteredHeadersHash.gperf"
+    {"ETag", Http::HdrType::ETAG, Http::HdrFieldType::ftETag, HdrKind::EntityHeader},
+#line 42 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
+#line 72 "src/http/RegisteredHeadersHash.gperf"
+    {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 84 "src/http/RegisteredHeadersHash.gperf"
     {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 106 "src/http/RegisteredHeadersHash.gperf"
-    {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 60 "src/http/RegisteredHeadersHash.gperf"
-    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
-#line 109 "src/http/RegisteredHeadersHash.gperf"
-    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 63 "src/http/RegisteredHeadersHash.gperf"
-    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
-#line 44 "src/http/RegisteredHeadersHash.gperf"
-    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
-#line 86 "src/http/RegisteredHeadersHash.gperf"
-    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 113 "src/http/RegisteredHeadersHash.gperf"
+#line 59 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 95 "src/http/RegisteredHeadersHash.gperf"
+    {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 28 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
+#line 27 "src/http/RegisteredHeadersHash.gperf"
+    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 65 "src/http/RegisteredHeadersHash.gperf"
+    {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 85 "src/http/RegisteredHeadersHash.gperf"
+    {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 99 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 110 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
+#line 82 "src/http/RegisteredHeadersHash.gperf"
+    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
+#line 107 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
+#line 55 "src/http/RegisteredHeadersHash.gperf"
+    {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 112 "src/http/RegisteredHeadersHash.gperf"
     {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
 #line 46 "src/http/RegisteredHeadersHash.gperf"
     {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 114 "src/http/RegisteredHeadersHash.gperf"
-    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
+    {""},
+#line 86 "src/http/RegisteredHeadersHash.gperf"
+    {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 97 "src/http/RegisteredHeadersHash.gperf"
     {"Warning", Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-    {""}, {""},
+    {""}, {""}, {""},
+#line 108 "src/http/RegisteredHeadersHash.gperf"
+    {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 105 "src/http/RegisteredHeadersHash.gperf"
+    {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
+#line 104 "src/http/RegisteredHeadersHash.gperf"
     {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 66 "src/http/RegisteredHeadersHash.gperf"
-    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 101 "src/http/RegisteredHeadersHash.gperf"
-    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 90 "src/http/RegisteredHeadersHash.gperf"
     {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-    {""}, {""}, {""}, {""}, {""}, {""},
-#line 103 "src/http/RegisteredHeadersHash.gperf"
+    {""}, {""},
+#line 60 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
+    {""},
+#line 63 "src/http/RegisteredHeadersHash.gperf"
+    {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
+    {""}, {""}, {""},
+#line 102 "src/http/RegisteredHeadersHash.gperf"
     {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 44 "src/http/RegisteredHeadersHash.gperf"
+    {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
+    {""}, {""},
 #line 61 "src/http/RegisteredHeadersHash.gperf"
-    {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader}
+    {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
+#line 100 "src/http/RegisteredHeadersHash.gperf"
+    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+    {""},
+#line 66 "src/http/RegisteredHeadersHash.gperf"
+    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader}
   };
 
 const struct HeaderTableRecord *
@@ -378,5 +381,5 @@ HttpHeaderHashTable::lookup (const char *str, size_t len)
     }
   return 0;
 }
-#line 115 "src/http/RegisteredHeadersHash.gperf"
+#line 114 "src/http/RegisteredHeadersHash.gperf"
 

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -96,7 +96,6 @@ Vary, Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKin
 Via, Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
 Warning, Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader
 WWW-Authenticate, Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader
-X-Cache-Lookup, Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader
 X-Forwarded-For, Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
 X-Request-URI, Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader
 X-Squid-Error, Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -34,6 +34,7 @@ Alternate-Protocol, Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr
 Authentication-Info, Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader
 Authorization, Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader
 Cache-Control, Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader
+Cache-Status, Http::HdrType::CACHE_STATUS, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader
 CDN-Loop, Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader
 Connection, Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader
 Content-Base, Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -96,7 +96,6 @@ Vary, Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKin
 Via, Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
 Warning, Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader
 WWW-Authenticate, Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader
-X-Cache, Http::HdrType::X_CACHE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader
 X-Cache-Lookup, Http::HdrType::X_CACHE_LOOKUP, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader
 X-Forwarded-For, Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
 X-Request-URI, Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader


### PR DESCRIPTION
See https://tools.ietf.org/html/draft-ietf-httpbis-cache-header

Also switched to identifying Squid instance in the header using
unique_hostname(), fixing a bug affecting proxies that share the same
visible_hostname in a cluster. The Cache-Status field values will now
point to a specific proxy in such a cluster.

The new initial lookup reporting (formally X-Cache-Lookup)
implementation has several differences:

* The reporting of the lookup is now unconditional, just like the
  Cache-Status reporting itself. The dropped X-Cache-Lookup required
  --enable-cache-digests. We removed that precondition because
  Cache-Status already relays quite a bit of information, and sharing
  lookup details is unlikely to tilt the balance in most environments.
  The original lookup reporting code was conditional because the feature
  was added for Cache Digests debugging, not because we wanted to hide
  the info. Folks later discovered that the info is useful in many other
  cases. If we do want to hide this information, it should be done
  directly rather than via a (no) Cache Digests side effect.

* The initial lookup classification can no longer be overwritten by
  additional Store lookups. Official code allowed such rewrites due to
  implementation bugs. If we only report one lookup, the first lookup
  classification is the most valuable one and almost eliminates doubts
  about the the cache state at the request time. Ideally, we should also
  exclude various internal Store lookup checks that may hide a matching
  cache entry, but that exclusion is difficult to implement with the
  current needlessly asynchronous create() Store API.

* Lookup reporting now covers more use cases. The official code probably
  missed or mishandled various PURGE/DELETE use cases and did not
  distinguish absence of Store lookup because of CC:no-cache from other
  lookup bypass cases (e.g., errors). More work is probably needed to
  cover every lookup-avoiding case.
