### PR TITLE
Fix: cannot stat tests/STUB.h No such file or directory

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -719,6 +719,7 @@ EXTRA_DIST = \
 	mk-string-arrays.awk \
 	repl_modules.sh \
 	$(STUB_SOURCE) \
+	tests/STUB.h \
 	mib.txt \
 	mime.conf.default
 

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -40,11 +40,11 @@ COPIED_SOURCE= \
 	globals.cc \
 	SquidConfig.cc \
 	SquidNew.cc \
-	stub_fd.cc \
-	stub_HelperChildConfig.cc \
-	stub_libmem.cc \
-	stub_SBuf.cc \
-	STUB.h \
+	tests/stub_fd.cc \
+	tests/stub_HelperChildConfig.cc \
+	tests/stub_libmem.cc \
+	tests/stub_SBuf.cc \
+	tests/STUB.h \
 	time.cc
 
 # ICMP lookup helper
@@ -99,17 +99,17 @@ SquidConfig.cc: $(top_srcdir)/src/SquidConfig.cc
 SquidNew.cc: $(top_srcdir)/src/SquidNew.cc
 	cp $(top_srcdir)/src/SquidNew.cc $@
 
-stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc
+tests/stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc
 	cp $(top_srcdir)/src/tests/stub_HelperChildConfig.cc $@
 
-stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc STUB.h
+tests/stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc
 	cp $(top_srcdir)/src/tests/stub_fd.cc $@
 
-stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc STUB.h
+tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 
-stub_SBuf.cc: $(top_srcdir)/src/tests/stub_SBuf.cc STUB.h
+tests/stub_SBuf.cc: $(top_srcdir)/src/tests/stub_SBuf.cc
 	cp $(top_srcdir)/src/tests/stub_SBuf.cc $@
 
-STUB.h: $(top_srcdir)/src/tests/STUB.h
+tests/STUB.h: $(top_srcdir)/src/tests/STUB.h
 	cp $(top_srcdir)/src/tests/STUB.h $@

--- a/src/tests/Stub.am
+++ b/src/tests/Stub.am
@@ -6,7 +6,7 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-STUB_SOURCE= tests/STUB.h \
+STUB_SOURCE= \
 	tests/stub_access_log.cc \
 	tests/stub_acl.cc \
 	tests/stub_cache_cf.cc \


### PR DESCRIPTION
Since 2b5ebbe (PR #670), we have been seeing "random" build failures.

The tests/Stub.am generated by source-maintenance.sh has not included
the tests/STUB.h file for explicit distribution. The source file was
built and included only when seen as a dependency of the files using it.

When stubs are copied for use by the extra binaries from tools/
directory, there is a secondary side effect from "make -j":

* When the -j concurrency is small, tests/STUB.h gets copied during the
  first cycle, and parallel builds compiling other copied files succeed.

* When the -j concurrency is large, tests/STUB.h may be deferred to a
  later copy cycle, and the first actual compile task needing it fails
  with `cannot stat 'src/tests/STUB.h': No such file or directory`.

Add tests/STUB.h to src/Makefile.am EXTRA_DIST to restore the previous
distribution behavior (when STUB_SOURCE contained it explicitly).

Update the pinger source paths that were omitted in 2b5ebbe.
