### PR TITLE
Do not send keep-alive in 101 (Switching Protocols) responses

### DIFF
--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -360,7 +360,8 @@ Http::One::Server::writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &ca
 
     if (switching && /* paranoid: */ upgradeHeader.size()) {
         rep->header.putStr(Http::HdrType::UPGRADE, upgradeHeader.termedBuf());
-        rep->header.putStr(Http::HdrType::CONNECTION, "upgrade, keep-alive");
+        rep->header.putStr(Http::HdrType::CONNECTION, "upgrade");
+        // keep-alive is redundant, breaks some 101 (Switching Protocols) recipients
     } else {
         rep->header.putStr(Http::HdrType::CONNECTION, "keep-alive");
     }


### PR DESCRIPTION
... because it breaks clients using websocket_client[1] library and is
redundant in our HTTP/1.1 control messages anyway.

I suspect that at least some buggy clients are confused by a multi-value
Connection field rather than the redundant keep-alive signal itself, but
let's try to follow RFC 7230 Upgrade example more closely this time and
send no keep-alive at all.

[1] https://pypi.org/project/websocket_client/