### PR TITLE
Cleanup: convert ACL::name to SBuf

### DIFF
--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -111,8 +111,6 @@ AccessLogEntry::~AccessLogEntry()
     safe_free(headers.adapted_request);
     HTTPMSGUNLOCK(adapted_request);
 
-    safe_free(lastAclName);
-
     HTTPMSGUNLOCK(request);
 #if ICAP_CLIENT
     HTTPMSGUNLOCK(icap.reply);

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -182,7 +182,7 @@ public:
     } adapt;
 #endif
 
-    const char *lastAclName = nullptr; ///< string for external_acl_type %ACL format code
+    SBuf lastAclName; ///< string for external_acl_type %ACL format code
     SBuf lastAclData; ///< string for external_acl_type %DATA format code
 
     HierarchyLogEntry hier;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1822,7 +1822,8 @@ nodist_tests_testACLMaxUserIP_SOURCES = \
 	tests/stub_libauth.cc \
 	tests/stub_libhttp.cc \
 	tests/stub_libmem.cc \
-	tests/stub_libsecurity.cc
+	tests/stub_libsecurity.cc \
+	tests/stub_time.cc
 tests_testACLMaxUserIP_LDADD = \
 	$(AUTH_ACL_LIBS) \
 	acl/libapi.la \

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -27,7 +27,7 @@
 #include <algorithm>
 #include <map>
 
-const char *AclMatchedName = NULL;
+SBuf AclMatchedName;
 
 namespace Acl {
 
@@ -90,26 +90,17 @@ ACL::operator delete (void *)
 }
 
 ACL *
-ACL::FindByName(const char *name)
+ACL::FindByName(const SBuf &name)
 {
-    ACL *a;
     debugs(28, 9, "ACL::FindByName '" << name << "'");
 
-    for (a = Config.aclList; a; a = a->next)
-        if (!strcasecmp(a->name, name))
+    for (auto *a = Config.aclList; a; a = a->next)
+        if (a->name.caseCmp(name) == 0)
             return a;
 
     debugs(28, 9, "ACL::FindByName found no match");
 
     return NULL;
-}
-
-ACL::ACL() :
-    cfgline(nullptr),
-    next(nullptr),
-    registered(false)
-{
-    *name = 0;
 }
 
 bool ACL::valid () const
@@ -154,11 +145,9 @@ ACL::matches(ACLChecklist *checklist) const
 }
 
 void
-ACL::context(const char *aName, const char *aCfgLine)
+ACL::context(const SBuf &aName, const char *aCfgLine)
 {
-    name[0] = '\0';
-    if (aName)
-        xstrncpy(name, aName, ACL_NAME_SZ-1);
+    name = aName;
     safe_free(cfgline);
     if (aCfgLine)
         cfgline = xstrdup(aCfgLine);
@@ -170,7 +159,6 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
     /* we're already using strtok() to grok the line */
     char *t = NULL;
     ACL *A = NULL;
-    LOCAL_ARRAY(char, aclname, ACL_NAME_SZ);
     int new_acl = 0;
 
     /* snarf the ACL name */
@@ -188,7 +176,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
         return;
     }
 
-    xstrncpy(aclname, t, ACL_NAME_SZ);
+    SBuf aclname(t);
     /* snarf the ACL type */
     const char *theType;
 
@@ -220,7 +208,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
         }
         theType = "localport";
         debugs(28, DBG_IMPORTANT, "UPGRADE: ACL 'myport' type is has been renamed to 'localport' and matches the port the client connected to.");
-    } else if (strcmp(theType, "proto") == 0 && strcmp(aclname, "manager") == 0) {
+    } else if (strcmp(theType, "proto") == 0 && aclname.cmp("manager") == 0) {
         // ACL manager is now a built-in and has a different type.
         debugs(28, DBG_PARSE_NOTE(DBG_IMPORTANT), "UPGRADE: ACL 'manager' is now a built-in ACL. Remove it from your config file.");
         return; // ignore the line
@@ -338,7 +326,8 @@ ACL::~ACL()
 {
     debugs(28, 3, "freeing ACL " << name);
     safe_free(cfgline);
-    AclMatchedName = NULL; // in case it was pointing to our name
+    if (AclMatchedName == name)
+        AclMatchedName.clear();
 }
 
 void

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -312,17 +312,6 @@ ACL::dumpOptions()
     return result;
 }
 
-/* ACL result caching routines */
-
-int
-ACL::matchForCache(ACLChecklist *)
-{
-    /* This is a fatal to ensure that cacheMatchAcl calls are _only_
-     * made for supported acl types */
-    fatal("aclCacheMatchAcl: unknown or unexpected ACL type");
-    return 0;       /* NOTREACHED */
-}
-
 bool
 ACL::requiresAle() const
 {

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -323,39 +323,6 @@ ACL::matchForCache(ACLChecklist *)
     return 0;       /* NOTREACHED */
 }
 
-/*
- * we lookup an acl's cached results, and if we cannot find the acl being
- * checked we check it and cache the result. This function is a template
- * method to support caching of multiple acl types.
- * Note that caching of time based acl's is not
- * wise in long lived caches (i.e. the auth_user proxy match cache)
- * RBC
- * TODO: does a dlink_list perform well enough? Kinkie
- */
-int
-ACL::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
-{
-    acl_proxy_auth_match_cache *auth_match;
-    dlink_node *link;
-    link = cache->head;
-
-    while (link) {
-        auth_match = (acl_proxy_auth_match_cache *)link->data;
-
-        if (auth_match->acl_data == this) {
-            debugs(28, 4, "ACL::cacheMatchAcl: cache hit on acl '" << name << "' (" << this << ")");
-            return auth_match->matchrv;
-        }
-
-        link = link->next;
-    }
-
-    auth_match = new acl_proxy_auth_match_cache(matchForCache(checklist), this);
-    dlinkAddTail(auth_match, &auth_match->link, cache);
-    debugs(28, 4, "ACL::cacheMatchAcl: miss for '" << name << "'. Adding result " << auth_match->matchrv);
-    return auth_match->matchrv;
-}
-
 bool
 ACL::requiresAle() const
 {

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -356,24 +356,6 @@ ACL::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
     return auth_match->matchrv;
 }
 
-void
-aclCacheMatchFlush(dlink_list * cache)
-{
-    acl_proxy_auth_match_cache *auth_match;
-    dlink_node *link, *tmplink;
-    link = cache->head;
-
-    debugs(28, 8, "aclCacheMatchFlush called for cache " << cache);
-
-    while (link) {
-        auth_match = (acl_proxy_auth_match_cache *)link->data;
-        tmplink = link;
-        link = link->next;
-        dlinkDelete(tmplink, cache);
-        delete auth_match;
-    }
-}
-
 bool
 ACL::requiresAle() const
 {

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -73,7 +73,6 @@ public:
     virtual bool empty() const = 0;
     virtual bool valid() const;
 
-    int cacheMatchAcl(dlink_list * cache, ACLChecklist *);
     virtual int matchForCache(ACLChecklist *checklist);
 
     virtual void prepareForUse() {}

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -14,7 +14,7 @@
 #include "cbdata.h"
 #include "defines.h"
 #include "dlink.h"
-#include "sbuf/forward.h"
+#include "sbuf/SBuf.h"
 
 #include <algorithm>
 #include <ostream>
@@ -45,13 +45,12 @@ public:
 
     static void ParseAclLine(ConfigParser &parser, ACL ** head);
     static void Initialize();
-    static ACL *FindByName(const char *name);
+    static ACL *FindByName(const SBuf &name);
 
-    ACL();
     virtual ~ACL();
 
     /// sets user-specified ACL name and squid.conf context
-    void context(const char *name, const char *configuration);
+    void context(const SBuf &name, const char *configuration);
 
     /// Orchestrates matching checklist against the ACL using match(),
     /// after checking preconditions and while providing debugging.
@@ -77,10 +76,10 @@ public:
 
     SBufList dumpOptions(); ///< \returns approximate options configuration
 
-    char name[ACL_NAME_SZ];
-    char *cfgline;
-    ACL *next; // XXX: remove or at least use refcounting
-    bool registered; ///< added to the global list of ACLs via aclRegister()
+    SBuf name;
+    char *cfgline = nullptr;
+    ACL *next = nullptr; // XXX: remove or at least use refcounting
+    bool registered = false; ///< added to the global list of ACLs via aclRegister()
 
 private:
     /// Matches the actual data in checklist against this ACL.
@@ -197,7 +196,7 @@ public:
 
 /// \ingroup ACLAPI
 /// XXX: find a way to remove or at least use a refcounted ACL pointer
-extern const char *AclMatchedName;  /* NULL */
+extern SBuf AclMatchedName;
 
 #endif /* SQUID_ACL_H */
 

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -73,8 +73,6 @@ public:
     virtual bool empty() const = 0;
     virtual bool valid() const;
 
-    virtual int matchForCache(ACLChecklist *checklist);
-
     virtual void prepareForUse() {}
 
     SBufList dumpOptions(); ///< \returns approximate options configuration

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -11,7 +11,6 @@
 #include "acl/BoolOps.h"
 #include "acl/Checklist.h"
 #include "globals.h"
-#include "MemBuf.h"
 
 char const *
 Acl::AllOf::typeString() const
@@ -60,13 +59,11 @@ Acl::AllOf::parse()
     } else if (oldNode) {
         // this acl saw a single line before; create a new OR inner node
 
-        MemBuf wholeCtx;
-        wholeCtx.init();
-        wholeCtx.appendf("(%s lines)", name);
-        wholeCtx.terminate();
+        SBuf wholeCtx;
+        wholeCtx.appendf("(" SQUIDSBUFPH " lines)", SQUIDSBUFPRINT(name));
 
         Acl::OrNode *newWhole = new Acl::OrNode;
-        newWhole->context(wholeCtx.content(), oldNode->cfgline);
+        newWhole->context(wholeCtx, oldNode->cfgline);
         newWhole->add(oldNode); // old (i.e. first) line
         nodes.front() = whole = newWhole;
     } else {
@@ -77,13 +74,11 @@ Acl::AllOf::parse()
     assert(whole);
     const int lineId = whole->childrenCount() + 1;
 
-    MemBuf lineCtx;
-    lineCtx.init();
-    lineCtx.appendf("(%s line #%d)", name, lineId);
-    lineCtx.terminate();
+    SBuf lineCtx;
+    lineCtx.appendf("(" SQUIDSBUFPH " line #%d)", SQUIDSBUFPRINT(name), lineId);
 
     Acl::AndNode *line = new AndNode;
-    line->context(lineCtx.content(), config_input_line);
+    line->context(lineCtx, config_input_line);
     line->lineParse();
 
     whole->add(line);

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -17,10 +17,8 @@
 Acl::NotNode::NotNode(ACL *acl)
 {
     assert(acl);
-    Must(strlen(acl->name) <= sizeof(name)-2);
-    name[0] = '!';
-    name[1] = '\0';
-    xstrncpy(&name[1], acl->name, sizeof(name)-1); // -1 for '!'
+    name.append(typeString());
+    name.append(acl->name);
     add(acl);
 }
 
@@ -66,7 +64,7 @@ SBufList
 Acl::NotNode::dump() const
 {
     SBufList text;
-    text.push_back(SBuf(name));
+    text.push_back(name);
     return text;
 }
 

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -11,6 +11,7 @@
 
 #include "acl/forward.h"
 #include "err_type.h"
+#include "sbuf/forward.h"
 
 #include <sstream>
 
@@ -46,9 +47,9 @@ void aclParseAclList(ConfigParser &parser, Acl::Tree **tree, const Any any)
 }
 
 /// \ingroup ACLAPI
-int aclIsProxyAuth(const char *name);
+int aclIsProxyAuth(const SBuf &name);
 /// \ingroup ACLAPI
-err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const char *name, int redirect_allowed);
+err_type aclGetDenyInfoPage(AclDenyInfoList ** head, const SBuf &name, int redirect_allowed);
 /// \ingroup ACLAPI
 void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -56,8 +56,6 @@ void aclDestroyDenyInfoList(AclDenyInfoList **);
 /// \ingroup ACLAPI
 wordlist *aclDumpGeneric(const ACL *);
 /// \ingroup ACLAPI
-void aclCacheMatchFlush(dlink_list * cache);
-/// \ingroup ACLAPI
 void dump_acl_access(StoreEntry * entry, const char *name, acl_access * head);
 /// \ingroup ACLAPI
 void dump_acl_list(StoreEntry * entry, ACLList * head);

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -56,7 +56,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        ACL *a = ACL::FindByName(t);
+        auto *a = ACL::FindByName(SBuf(t));
 
         if (a == NULL) {
             debugs(28, DBG_CRITICAL, "ACL not found: " << t);
@@ -79,7 +79,7 @@ Acl::InnerNode::dump() const
 {
     SBufList rv;
     for (Nodes::const_iterator i = nodes.begin(); i != nodes.end(); ++i)
-        rv.push_back(SBuf((*i)->name));
+        rv.push_back((*i)->name);
     return rv;
 }
 

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -178,9 +178,7 @@ ACLProxyAuth::matchProxyAuth(ACLChecklist *cl)
     /* check to see if we have matched the user-acl before */
     auto &cache = checklist->auth_user_request->user()->proxyAuthAclCache;
 
-    SBuf key;
-    key.appendf("ACL %s(%" PRIX64 ")", name, this);
-
+    SBuf key(name);
     if (const auto *v = cache.get(key)) {
         debugs(28, 4, "cache hit on acl " << key << "=" << *v);
         checklist->auth_user_request = nullptr;

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -161,14 +161,6 @@ ACLProxyAuth::clone() const
     return new ACLProxyAuth(*this);
 }
 
-int
-ACLProxyAuth::matchForCache(ACLChecklist *cl)
-{
-    ACLFilledChecklist *checklist = Filled(cl);
-    assert (checklist->auth_user_request != NULL);
-    return data->match(checklist->auth_user_request->username());
-}
-
 /* aclMatchProxyAuth can return two exit codes:
  * 0 : Authorisation for this ACL failed. (Did not match)
  * 1 : Authorisation OK. (Matched)
@@ -182,9 +174,23 @@ ACLProxyAuth::matchProxyAuth(ACLChecklist *cl)
             return 0;
         }
     }
+
     /* check to see if we have matched the user-acl before */
-    int result = cacheMatchAcl(&checklist->auth_user_request->user()->proxy_match_cache, checklist);
-    checklist->auth_user_request = NULL;
+    auto &cache = checklist->auth_user_request->user()->proxyAuthAclCache;
+
+    SBuf key;
+    key.appendf("ACL %s(%" PRIX64 ")", name, this);
+
+    if (const auto *v = cache.get(key)) {
+        debugs(28, 4, "cache hit on acl " << key << "=" << *v);
+        checklist->auth_user_request = nullptr;
+        return *v;
+    }
+
+    const auto result = data->match(checklist->auth_user_request->username());
+    debugs(28, 4, "cache miss on acl " << key << ". Adding " << result);
+    cache.add(key, result, (checklist->auth_user_request->user()->expiretime - squid_curtime));
+    checklist->auth_user_request = nullptr;
     return result;
 }
 

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -48,7 +48,6 @@ public:
     virtual bool empty() const;
     virtual bool requiresRequest() const {return true;}
     virtual ACL *clone() const;
-    virtual int matchForCache(ACLChecklist *checklist);
 
 private:
     int matchProxyAuth(ACLChecklist *);

--- a/src/auth/CredentialsCache.cc
+++ b/src/auth/CredentialsCache.cc
@@ -141,9 +141,9 @@ CredentialsCache::doConfigChangeCleanup()
 {
     // purge expired entries entirely
     cleanup();
-    // purge the ACL match data stored in the credentials
+    // purge the proxy_auth ACL data stored in the credentials
     for (auto i : store_) {
-        aclCacheMatchFlush(&i.second->proxy_match_cache);
+        i.second->proxyAuthAclCache.clear();
     }
 }
 

--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -24,13 +24,13 @@
 Auth::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm) :
     auth_type(Auth::AUTH_UNKNOWN),
     config(aConfig),
+    proxyAuthAclCache(1024),
     ipcount(0),
     expiretime(0),
     credentials_state(Auth::Unchecked),
     username_(nullptr),
     requestRealm_(aRequestRealm)
 {
-    proxy_match_cache.head = proxy_match_cache.tail = NULL;
     ip_list.head = ip_list.tail = NULL;
     debugs(29, 5, HERE << "Initialised auth_user '" << this << "'.");
 }
@@ -61,7 +61,7 @@ Auth::User::absorb(Auth::User::Pointer from)
 {
     /*
      * XXX Incomplete: it should merge in hash references too and ask the module to merge in scheme data
-     *  dlink_list proxy_match_cache;
+     *  CacheType proxyAuthAclCache;
      */
 
     debugs(29, 5, HERE << "auth_user '" << from << "' into auth_user '" << this << "'.");
@@ -122,9 +122,6 @@ Auth::User::~User()
 {
     debugs(29, 5, HERE << "Freeing auth_user '" << this << "'.");
     assert(LockCount() == 0);
-
-    /* free cached acl results */
-    aclCacheMatchFlush(&proxy_match_cache);
 
     /* free seen ip address's */
     clearIp();

--- a/src/auth/User.h
+++ b/src/auth/User.h
@@ -15,11 +15,12 @@
 #include "auth/forward.h"
 #include "auth/Type.h"
 #include "base/CbcPointer.h"
+#include "base/ClpMap.h"
 #include "base/RefCount.h"
 #include "dlink.h"
 #include "ip/Address.h"
 #include "Notes.h"
-#include "sbuf/SBuf.h"
+#include "sbuf/Algorithms.h"
 
 class StoreEntry;
 
@@ -48,7 +49,8 @@ public:
     Auth::Type auth_type;
     /** the config for this user */
     Auth::SchemeConfig *config;
-    dlink_list proxy_match_cache;
+    using CacheType = ClpMap<SBuf, int>;
+    CacheType proxyAuthAclCache;    ///< Cache of results from proxy_auth ACL tests for these credentials
     size_t ipcount;
     long expiretime;
 

--- a/src/base/ClpMap.h
+++ b/src/base/ClpMap.h
@@ -69,6 +69,9 @@ public:
     /// Remove the corresponding entry (if any)
     void del(const Key &);
 
+    /// Remove all entries in this cache
+    void clear() noexcept;
+
     /// Reset the memory capacity for this map, purging if needed
     void setMemLimit(uint64_t newLimit);
 
@@ -258,6 +261,15 @@ ClpMap<Key, Value, MemoryUsedBy>::del(const Key &key)
     const auto i = find(key);
     if (i != index_.end())
         erase(i);
+}
+
+template <class Key, class Value, uint64_t MemoryUsedBy(const Value &)>
+void
+ClpMap<Key, Value, MemoryUsedBy>::clear() noexcept
+{
+    index_.clear();
+    entries_.clear();
+    memUsed_ = 0;
 }
 
 /// purges entries to make free memory large enough to fit wantSpace bytes

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2086,9 +2086,10 @@ clientReplyContext::ProcessReplyAccessResult(Acl::Answer rv, void *voidMe)
 void
 clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
 {
+    static const SBuf noAcls("NO ACL's");
     debugs(88, 2, "The reply for " << http->request->method
            << ' ' << http->uri << " is " << accessAllowed << ", because it matched "
-           << (AclMatchedName ? AclMatchedName : "NO ACL's"));
+           << (AclMatchedName.isEmpty() ? noAcls : AclMatchedName));
 
     if (!accessAllowed.allowed()) {
         ErrorState *err;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -742,9 +742,10 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
     acl_checklist = NULL;
     err_type page_id;
     Http::StatusCode status;
+    static const SBuf none("[none]");
     debugs(85, 2, "The request " << http->request->method << ' ' <<
            http->uri << " is " << answer <<
-           "; last ACL checked: " << (AclMatchedName ? AclMatchedName : "[none]"));
+           "; last ACL checked: " << (AclMatchedName.isEmpty() ? none : AclMatchedName));
 
 #if USE_AUTH
     char const *proxy_auth_msg = "<null>";
@@ -761,7 +762,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
         // XXX: do we still need aclIsProxyAuth() ?
         bool auth_challenge = (answer == ACCESS_AUTH_REQUIRED || aclIsProxyAuth(AclMatchedName));
         debugs(85, 5, "Access Denied: " << http->uri);
-        debugs(85, 5, "AclMatchedName = " << (AclMatchedName ? AclMatchedName : "<null>"));
+        debugs(85, 5, "AclMatchedName = " << (AclMatchedName.isEmpty() ? none : AclMatchedName));
 #if USE_AUTH
         if (auth_challenge)
             debugs(33, 5, "Proxy Auth Message = " << (proxy_auth_msg ? proxy_auth_msg : "<null>"));

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -20,6 +20,7 @@
 #include "HttpHdrContRange.h"
 #include "HttpReply.h"
 #include "HttpRequest.h"
+#include "sbuf/StringConvert.h"
 #include "SquidConfig.h"
 #include "SquidTime.h"
 #include "StatCounters.h"
@@ -900,8 +901,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
 
     debugs(11,7, HERE << "creating adaptation block response");
 
-    err_type page_id =
-        aclGetDenyInfoPage(&Config.denyInfoList, answer.ruleId.termedBuf(), 1);
+    auto page_id = aclGetDenyInfoPage(&Config.denyInfoList, StringToSBuf(answer.ruleId), 1);
     if (page_id == ERR_NONE)
         page_id = ERR_ACCESS_DENIED;
 

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -489,19 +489,18 @@ class external_acl_data
     CBDATA_CLASS(external_acl_data);
 
 public:
-    explicit external_acl_data(external_acl *aDef) : def(cbdataReference(aDef)), name(NULL), arguments(NULL) {}
+    explicit external_acl_data(external_acl *aDef) : def(cbdataReference(aDef)) {}
     ~external_acl_data();
 
-    external_acl *def;
-    const char *name;
-    wordlist *arguments;
+    external_acl *def = nullptr;
+    SBuf name;
+    wordlist *arguments = nullptr;
 };
 
 CBDATA_CLASS_INIT(external_acl_data);
 
 external_acl_data::~external_acl_data()
 {
-    xfree(name);
     wordlistDestroy(&arguments);
     cbdataReferenceDone(def);
 }
@@ -531,7 +530,7 @@ ACLExternal::parse()
 
     // def->name is the name of the external_acl_type.
     // this is the name of the 'acl' directive being tested
-    data->name = xstrdup(AclMatchedName);
+    data->name = AclMatchedName;
 
     while ((token = ConfigParser::strtokFile())) {
         wordlistAdd(&data->arguments, token);
@@ -770,8 +769,7 @@ makeExternalAclKey(ACLFilledChecklist * ch, external_acl_data * acl_data)
 
         if (t->type == Format::LFT_EXT_ACL_NAME) {
             // setup for %ACL
-            safe_free(ch->al->lastAclName);
-            ch->al->lastAclName = xstrdup(acl_data->name);
+            ch->al->lastAclName = acl_data->name;
         }
 
         if (t->type == Format::LFT_EXT_ACL_DATA) {

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1433,7 +1433,8 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
             break;
 
         case LFT_EXT_ACL_NAME:
-            out = al->lastAclName;
+            if (!al->lastAclName.isEmpty())
+                out = al->lastAclName.c_str();
             break;
 
         case LFT_EXT_ACL_DATA:

--- a/src/tests/stub_libauth.cc
+++ b/src/tests/stub_libauth.cc
@@ -40,7 +40,7 @@ void Auth::Scheme::FreeAll() STUB
 void Auth::SchemesConfig::expand() STUB
 
 #include "auth/User.h"
-Auth::User::User(Auth::SchemeConfig *, const char *) STUB
+Auth::User::User(Auth::SchemeConfig *, const char *) : proxyAuthAclCache(0) {STUB}
 Auth::CredentialState Auth::User::credentials() const STUB_RETVAL(credentials_state)
 void Auth::User::credentials(CredentialState) STUB
 void Auth::User::absorb(Auth::User::Pointer) STUB

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -44,7 +44,6 @@ ProxyAuthLookup * ProxyAuthLookup::Instance() STUB_RETVAL(NULL)
 void ProxyAuthLookup::checkForAsync(ACLChecklist *) const STUB
 void ProxyAuthLookup::LookupDone(void *) STUB
 ACL * ACLProxyAuth::clone() const STUB_RETVAL(NULL)
-int ACLProxyAuth::matchForCache(ACLChecklist *) STUB_RETVAL(0)
 int ACLProxyAuth::matchProxyAuth(ACLChecklist *) STUB_RETVAL(0)
 void ACLProxyAuth::parseFlags() STUB
 


### PR DESCRIPTION
Optimizes memory storage and re-use for ACL names.

Reduces string copying in several instances for improved
performance with PR #697 changes and cachemgr report generation.