### PR TITLE
Restored support for non-lowercase Transfer-Encoding values

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -551,9 +551,9 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         delById(Http::HdrType::CONTENT_LENGTH);
         // and clen state becomes irrelevant
 
-        if (rawTe.caseCmp("chunked")) {
+        if (rawTe.caseCmp("chunked") == 0) {
             ; // leave header present for chunked() method
-        } else if (rawTe.caseCmp("identity")) { // deprecated. no coding
+        } else if (rawTe.caseCmp("identity") == 0) { // deprecated. no coding
             delById(Http::HdrType::TRANSFER_ENCODING);
         } else {
             // This also rejects multiple encodings until we support them properly.

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -551,9 +551,9 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
         delById(Http::HdrType::CONTENT_LENGTH);
         // and clen state becomes irrelevant
 
-        if (rawTe == "chunked") {
+        if (rawTe.caseCmp("chunked")) {
             ; // leave header present for chunked() method
-        } else if (rawTe == "identity") { // deprecated. no coding
+        } else if (rawTe.caseCmp("identity")) { // deprecated. no coding
             delById(Http::HdrType::TRANSFER_ENCODING);
         } else {
             // This also rejects multiple encodings until we support them properly.


### PR DESCRIPTION
... after "Improve Transfer-Encoding handling" commit f6dd87e.

Folks are reporting Chunked Transfer-Encoding values in real
traffic. HTTP requires case-insensitve treatment of codings.