### PR TITLE
Bug 5076: WCCP Security Info incorrect

### DIFF
--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -584,7 +584,7 @@ wccp2_update_md5_security(char *password, char *ptr, char *packet, int len)
 
     SquidMD5Init(&M);
 
-    SquidMD5Update(&M, pwd, sizeof(pwd));
+    SquidMD5Update(&M, pwd, sizeof(pwd) - 1);  // Remove the trailing nul
 
     SquidMD5Update(&M, packet, len);
 
@@ -638,7 +638,7 @@ wccp2_check_security(struct wccp2_service_list_t *srv, char *security, char *pac
 
     SquidMD5Init(&M);
 
-    SquidMD5Update(&M, pwd, sizeof(pwd));
+    SquidMD5Update(&M, pwd, sizeof(pwd) - 1);  // Remove the trailing nul
 
     SquidMD5Update(&M, packet, len);
 

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -584,7 +584,9 @@ wccp2_update_md5_security(char *password, char *ptr, char *packet, int len)
 
     SquidMD5Init(&M);
 
-    SquidMD5Update(&M, pwd, sizeof(pwd) - 1);  // Remove the trailing nul
+    static_assert(sizeof(pwd) - 1 == 8, "WCCP2 password has exactly 8 (padded) octets, excluding storage-terminating NUL");
+
+    SquidMD5Update(&M, pwd, sizeof(pwd) - 1);
 
     SquidMD5Update(&M, packet, len);
 
@@ -638,7 +640,9 @@ wccp2_check_security(struct wccp2_service_list_t *srv, char *security, char *pac
 
     SquidMD5Init(&M);
 
-    SquidMD5Update(&M, pwd, sizeof(pwd) - 1);  // Remove the trailing nul
+    static_assert(sizeof(pwd) - 1 == 8, "WCCP2 password has exactly 8 (padded) octets, excluding storage-terminating NUL");
+
+    SquidMD5Update(&M, pwd, sizeof(pwd) - 1);
 
     SquidMD5Update(&M, packet, len);
 


### PR DESCRIPTION
When generating and validating WCCP2 Security Info use only an
8 byte password.