### PR TITLE
Update ipcache_size and cache_log documentation

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -5473,7 +5473,9 @@ DOC_START
 
 	This is where general information about Squid behavior goes. You can
 	increase the amount of data logged to this file and how often it is
-	rotated with "debug_options"
+	rotated with "debug_options".
+	Caching the general information would introduce extra I/O and may cause performance issue 
+	when the workload is heavy. The cache_log can be disabled by setting the configuration to cache_log /dev/null 
 DOC_END
 
 NAME: debug_options

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -10070,7 +10070,7 @@ TYPE: int
 DEFAULT: 1024
 LOC: Config.ipcache.size
 DOC_START
-	Maximum number of DNS IP cache entries.
+	Maximum number of DNS IP cache entries. A large ipcache size may improve performance because it avoid more address lookups but excessively large values would waste memory. Since the entry only takes very small amounts of memory and the default value is relatively small, the developer may need to set a large size in production.
 DOC_END
 
 NAME: ipcache_low


### PR DESCRIPTION
The squid website's description of ipcache_size configuration is rather outdated. It says that 

> The ipcache_size defines the maximum number of DNS IP cache entries 

The description doesn't mention the performance impact of tunning the ipcache_size. While increasing the ipcache_size would increase the memory usage, each entry takes really small amounts of memory usage but can avoid DNS lookup. Since the amount of available main memory is enormous these days, it seems to me that we can increase the default value in most scenarios. 

Detail:
I run squid 4.1 on Ubuntu 18.04 as a proxy to visit other web server. The result shows that by increasing the ipcache_size to larger than the averge latency is about 54.458ms. If the ipcache_size is smaller than the total number of dns name, the latency is about 71.428ms. Thus, there is a 31% performance benefit by increasing the ipcache_size.  

The squid website's description about cache_log mentions that :

> The cache_log is squid administrative logging file. This is where general information about Squid behavior goes. You can increase the amount of data logged to this file and how often it is rotated with "debug_options".

The description doesn't clarify the performance impact of cache_log. While it is nice to cache the log information, cache_log would add extra I/O operation and thus would cause performance problem. Therefore, I think it would be great to elaborate the description about the preformance impact.  

Detail:
I run squid 4.1 on Ubuntu 18.04 as a proxy to visit other web server.  I test the cache_log with a heavy benchmarking. The result shows that the average latency is 51ms when enabling the cache_log and the average latency when disabling cache_log is about 43ms. Thus, disabling cache_log would gain about 24% performance benefit.   