### PR TITLE
Always send port in request-target of CONNECT requests to peers

### DIFF
--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -43,7 +43,7 @@ Http::Tunneler::Tunneler(const Comm::ConnectionPointer &conn, const HttpRequest:
     assert(connection);
     assert(callback);
     assert(dynamic_cast<Http::TunnelerAnswer *>(callback->getDialer()));
-    url = request->url.authority();
+    url = request->url.authority(true);
     watchForClosures();
 }
 


### PR DESCRIPTION
Broken since commit f5e1794 (Peering support for SslBump).