### PR TITLE
Removed StoreClient::created() and improved PURGE code quality

### DIFF
--- a/src/ICP.h
+++ b/src/ICP.h
@@ -65,22 +65,21 @@ public:
     ICPState(icp_common_t &aHeader, HttpRequest *aRequest);
     virtual ~ICPState();
 
+    /// either confirms and starts processing a cache hit or returns false
+    bool confirmAndPrepHit(const StoreEntry &);
+
     icp_common_t header;
     HttpRequest *request;
     int fd;
 
     Ip::Address from;
     char *url;
+    mutable AccessLogEntryPointer al;
 
 protected:
     /* StoreClient API */
     virtual LogTags *loggingTags() override;
     virtual void fillChecklist(ACLFilledChecklist &) const override;
-
-    /// either confirms and starts processing a cache hit or returns false
-    bool confirmAndPrepHit(const StoreEntry &);
-
-    mutable AccessLogEntryPointer al;
 };
 
 extern Comm::ConnectionPointer icpIncomingConn;

--- a/src/ICP.h
+++ b/src/ICP.h
@@ -65,8 +65,8 @@ public:
     ICPState(icp_common_t &aHeader, HttpRequest *aRequest);
     virtual ~ICPState();
 
-    /// either confirms and starts processing a cache hit or returns false
-    bool confirmAndPrepHit(const StoreEntry &);
+    /// whether the cache contains the requested entry
+    bool isHit();
 
     icp_common_t header;
     HttpRequest *request;
@@ -80,6 +80,9 @@ protected:
     /* StoreClient API */
     virtual LogTags *loggingTags() override;
     virtual void fillChecklist(ACLFilledChecklist &) const override;
+
+    /// either confirms and starts processing a cache hit or returns false
+    bool confirmAndPrepHit(const StoreEntry &);
 };
 
 extern Comm::ConnectionPointer icpIncomingConn;

--- a/src/ICP.h
+++ b/src/ICP.h
@@ -66,7 +66,7 @@ public:
     virtual ~ICPState();
 
     /// whether the cache contains the requested entry
-    bool isHit();
+    bool isHit() const;
 
     icp_common_t header;
     HttpRequest *request;
@@ -78,11 +78,11 @@ public:
 
 protected:
     /* StoreClient API */
-    virtual LogTags *loggingTags() override;
+    virtual LogTags *loggingTags() const override;
     virtual void fillChecklist(ACLFilledChecklist &) const override;
 
     /// either confirms and starts processing a cache hit or returns false
-    bool confirmAndPrepHit(const StoreEntry &);
+    bool confirmAndPrepHit(const StoreEntry &) const;
 };
 
 extern Comm::ConnectionPointer icpIncomingConn;

--- a/src/Store.h
+++ b/src/Store.h
@@ -239,9 +239,6 @@ public:
 
 public:
     static size_t inUseCount();
-    static void getPublicByRequestMethod(StoreClient * aClient, HttpRequest * request, const HttpRequestMethod& method);
-    static void getPublicByRequest(StoreClient * aClient, HttpRequest * request);
-    static void getPublic(StoreClient * aClient, const char *uri, const HttpRequestMethod& method);
 
     void *operator new(size_t byteCount);
     void operator delete(void *address);

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -20,7 +20,7 @@ class StoreEntry;
 class ACLFilledChecklist;
 class LogTags;
 
-/// TODO: rename
+/// a storeGetPublic*() caller
 class StoreClient
 {
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -28,7 +28,7 @@ public:
     virtual ~StoreClient () {}
 
     /// \return LogTags (if the class logs transactions) or nil (otherwise)
-    virtual LogTags *loggingTags() = 0;
+    virtual LogTags *loggingTags() const = 0;
 
 protected:
     /// configure the ACL checklist with the current transaction state
@@ -37,7 +37,7 @@ protected:
     /// \returns whether the caller must collapse on the given entry
     /// Before returning true, updates common collapsing-related stats.
     /// See also: StoreEntry::hittingRequiresCollapsing().
-    bool startCollapsingOn(const StoreEntry &, const bool doingRevalidation);
+    bool startCollapsingOn(const StoreEntry &, const bool doingRevalidation) const;
 
     // These methods only interpret Squid configuration. Their allowances are
     // provisional -- other factors may prevent collapsed forwarding. The first

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -20,18 +20,12 @@ class StoreEntry;
 class ACLFilledChecklist;
 class LogTags;
 
-/// A StoreEntry::getPublic*() caller.
+/// TODO: rename
 class StoreClient
 {
 
 public:
     virtual ~StoreClient () {}
-
-    // TODO: Remove? Probably added to make lookups asynchronous, but they are
-    // still blocking. A lot more is needed to support async callbacks.
-    /// Handle a StoreEntry::getPublic*() result.
-    /// A nil entry indicates a cache miss.
-    virtual void created(StoreEntry *) = 0;
 
     /// \return LogTags (if the class logs transactions) or nil (otherwise)
     virtual LogTags *loggingTags() = 0;

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1674,7 +1674,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
         assert (repContext);
         repContext->setReplyToError(ERR_UNSUP_REQ, Http::scNotImplemented, request->method, NULL,
-                                    conn->clientConnection, request.getRaw(), nullptr, nullptr);
+                                    conn, request.getRaw(), nullptr, nullptr);
         assert(context->http->out.offset == 0);
         context->pullData();
         clientProcessRequestFinished(conn, request);
@@ -1689,7 +1689,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         conn->quitAfterError(request.getRaw());
         repContext->setReplyToError(ERR_INVALID_REQ,
                                     Http::scLengthRequired, request->method, NULL,
-                                    conn->clientConnection, request.getRaw(), nullptr, nullptr);
+                                    conn, request.getRaw(), nullptr, nullptr);
         assert(context->http->out.offset == 0);
         context->pullData();
         clientProcessRequestFinished(conn, request);
@@ -1725,7 +1725,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
             conn->quitAfterError(request.getRaw());
             repContext->setReplyToError(ERR_TOO_BIG,
                                         Http::scPayloadTooLarge, Http::METHOD_NONE, NULL,
-                                        conn->clientConnection, http->request, nullptr, nullptr);
+                                        conn, http->request, nullptr, nullptr);
             assert(context->http->out.offset == 0);
             context->pullData();
             clientProcessRequestFinished(conn, request);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1674,7 +1674,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
         assert (repContext);
         repContext->setReplyToError(ERR_UNSUP_REQ, Http::scNotImplemented, request->method, NULL,
-                                    conn->clientConnection->remote, request.getRaw(), NULL, NULL);
+                                    conn->clientConnection, request.getRaw(), nullptr, nullptr);
         assert(context->http->out.offset == 0);
         context->pullData();
         clientProcessRequestFinished(conn, request);
@@ -1689,7 +1689,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         conn->quitAfterError(request.getRaw());
         repContext->setReplyToError(ERR_INVALID_REQ,
                                     Http::scLengthRequired, request->method, NULL,
-                                    conn->clientConnection->remote, request.getRaw(), NULL, NULL);
+                                    conn->clientConnection, request.getRaw(), nullptr, nullptr);
         assert(context->http->out.offset == 0);
         context->pullData();
         clientProcessRequestFinished(conn, request);
@@ -1725,7 +1725,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
             conn->quitAfterError(request.getRaw());
             repContext->setReplyToError(ERR_TOO_BIG,
                                         Http::scPayloadTooLarge, Http::METHOD_NONE, NULL,
-                                        conn->clientConnection->remote, http->request, NULL, NULL);
+                                        conn->clientConnection, http->request, nullptr, nullptr);
             assert(context->http->out.offset == 0);
             context->pullData();
             clientProcessRequestFinished(conn, request);

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1029,7 +1029,7 @@ clientReplyContext::purgeDoPurge()
 }
 
 void
-clientReplyContext::purgeEntry(StoreEntry &entry, const Http::MethodType &methodType, const char *descriptionPrefix)
+clientReplyContext::purgeEntry(StoreEntry &entry, const Http::MethodType methodType, const char *descriptionPrefix)
 {
     debugs(88, 4, descriptionPrefix << Http::MethodStr(methodType) << " '" << entry.url() << "'" );
 #if USE_HTCP

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -956,7 +956,7 @@ clientReplyContext::purgeDoPurge()
             http->logType.update(LOG_TCP_DENIED);
             Ip::Address tmp_noaddr;
             tmp_noaddr.setNoAddr(); // TODO: make a global const
-            auto err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, nullptr,
+            const auto err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, nullptr,
                                         http->getConn() ? http->getConn()->clientConnection->remote : tmp_noaddr,
                                         http->request, http->al);
             startError(err);
@@ -1591,7 +1591,7 @@ clientReplyContext::identifyStoreObject()
     // client sent CC:no-cache or some other condition has been
     // encountered which prevents delivering a public/cached object.
     if (!r->flags.noCache || r->flags.internal) {
-        auto e = storeGetPublicByRequest(r);
+        const auto e = storeGetPublicByRequest(r);
         identifyFoundObject(e, storeLookupString(bool(e)));
     } else {
         // "external" no-cache requests skip Store lookups

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -989,15 +989,15 @@ clientReplyContext::purgeRequest()
 void
 clientReplyContext::purgeDoPurge()
 {
-    bool firstFound = false;
-    if (auto entry = storeGetPublicByRequestMethod(http->request, Http::METHOD_GET)) {
+    auto firstFound = false;
+    if (const auto entry = storeGetPublicByRequestMethod(http->request, Http::METHOD_GET)) {
         firstFound = true;
         purgeEntry(*entry, Http::METHOD_GET);
     }
 
     detailStoreLookup(storeLookupString(firstFound));
 
-    if (auto entry = storeGetPublicByRequestMethod(http->request, Http::METHOD_HEAD))
+    if (const auto entry = storeGetPublicByRequestMethod(http->request, Http::METHOD_HEAD))
         purgeEntry(*entry, Http::METHOD_HEAD);
 
     /* And for Vary, release the base URI if none of the headers was included in the request */
@@ -1006,10 +1006,10 @@ clientReplyContext::purgeDoPurge()
         // XXX: performance regression, c_str() reallocates
         SBuf tmp(http->request->effectiveRequestUri());
 
-        if (auto entry = storeGetPublic(tmp.c_str(), Http::METHOD_GET))
+        if (const auto entry = storeGetPublic(tmp.c_str(), Http::METHOD_GET))
             purgeEntry(*entry, Http::METHOD_GET, "Vary ");
 
-        if (auto entry = storeGetPublic(tmp.c_str(), Http::METHOD_HEAD))
+        if (const auto entry = storeGetPublic(tmp.c_str(), Http::METHOD_HEAD))
             purgeEntry(*entry, Http::METHOD_HEAD, "Vary ");
     }
 
@@ -1612,7 +1612,7 @@ clientReplyContext::identifyStoreObject()
     // encountered which prevents delivering a public/cached object.
     if (!r->flags.noCache || r->flags.internal) {
         auto e = storeGetPublicByRequest(r);
-        identifyFoundObject(e, storeLookupString(e));
+        identifyFoundObject(e, storeLookupString(bool(e)));
     } else {
         // "external" no-cache requests skip Store lookups
         identifyFoundObject(nullptr, "no-cache");

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -914,12 +914,6 @@ clientReplyContext::purgeAllCached()
     purgeEntriesByUrl(http->request, url.c_str());
 }
 
-void
-clientReplyContext::created(StoreEntry *newEntry)
-{
-    detailStoreLookup(newEntry ? "match" : "mismatch");
-}
-
 LogTags *
 clientReplyContext::loggingTags()
 {

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -2229,7 +2229,7 @@ clientBuildError(err_type page_id, Http::StatusCode status, char const *url,
                  const ConnStateData *conn, HttpRequest *request, const AccessLogEntry::Pointer &al)
 {
     const auto err = new ErrorState(page_id, status, request, al);
-    err->src_addr = conn && conn->clientConnection ? conn->clientConnection->remote : Ip::Address::v6_noaddr;
+    err->src_addr = conn && conn->clientConnection ? conn->clientConnection->remote : Ip::Address::NoAddr();
 
     if (url)
         err->url = xstrdup(url);

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -990,10 +990,10 @@ void
 clientReplyContext::purgeDoPurge()
 {
     if (auto entry = storeGetPublicByRequestMethod(http->request, Http::METHOD_GET))
-        purgeEntry(entry, Http::METHOD_GET);
+        purgeEntry(*entry, Http::METHOD_GET);
 
     if (auto entry = storeGetPublicByRequestMethod(http->request, Http::METHOD_HEAD))
-        purgeEntry(entry, Http::METHOD_HEAD);
+        purgeEntry(*entry, Http::METHOD_HEAD);
 
     /* And for Vary, release the base URI if none of the headers was included in the request */
     if (!http->request->vary_headers.isEmpty()
@@ -1002,10 +1002,10 @@ clientReplyContext::purgeDoPurge()
         SBuf tmp(http->request->effectiveRequestUri());
 
         if (auto entry = storeGetPublic(tmp.c_str(), Http::METHOD_GET))
-            purgeEntry(entry, Http::METHOD_GET, "Vary ");
+            purgeEntry(*entry, Http::METHOD_GET, "Vary ");
 
         if (auto entry = storeGetPublic(tmp.c_str(), Http::METHOD_HEAD))
-            purgeEntry(entry, Http::METHOD_HEAD, "Vary ");
+            purgeEntry(*entry, Http::METHOD_HEAD, "Vary ");
     }
 
     if (purgeStatus == Http::scNone)
@@ -1029,14 +1029,13 @@ clientReplyContext::purgeDoPurge()
 }
 
 void
-clientReplyContext::purgeEntry(StoreEntry *entry, const Http::MethodType &methodType, const char *descriptionPrefix)
+clientReplyContext::purgeEntry(StoreEntry &entry, const Http::MethodType &methodType, const char *descriptionPrefix)
 {
-    assert(entry);
-    debugs(88, 4, descriptionPrefix << Http::MethodStr(methodType) << " '" << entry->url() << "'" );
+    debugs(88, 4, descriptionPrefix << Http::MethodStr(methodType) << " '" << entry.url() << "'" );
 #if USE_HTCP
-    neighborsHtcpClear(entry, http->request, HttpRequestMethod(methodType), HTCP_CLR_PURGE);
+    neighborsHtcpClear(&entry, http->request, HttpRequestMethod(methodType), HTCP_CLR_PURGE);
 #endif
-    entry->release(true);
+    entry.release(true);
     purgeStatus = Http::scOkay;
 }
 

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -910,7 +910,7 @@ clientReplyContext::purgeAllCached()
 }
 
 LogTags *
-clientReplyContext::loggingTags()
+clientReplyContext::loggingTags() const
 {
     // XXX: clientReplyContext code assumes that http cbdata is always valid.
     // TODO: Either add cbdataReferenceValid(http) checks in all the relevant

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -937,9 +937,7 @@ clientReplyContext::created(StoreEntry *newEntry)
     else if (lookingforstore == 2)
         purgeFoundHead(newEntry);
     else if (lookingforstore == 3)
-        purgeDoPurgeGet(newEntry);
-    else if (lookingforstore == 4)
-        purgeDoPurgeHead(newEntry);
+        purgeDoPurge(newEntry);
     else if (lookingforstore == 5)
         identifyFoundObject(newEntry);
 }
@@ -1046,17 +1044,12 @@ clientReplyContext::purgeDoMissPurge()
 }
 
 void
-clientReplyContext::purgeDoPurgeGet(StoreEntry *newEntry)
+clientReplyContext::purgeDoPurge(StoreEntry *getEntry)
 {
-    purgeEntry(newEntry, Http::METHOD_GET);
-    lookingforstore = 4;
-    StoreEntry::getPublicByRequestMethod(this, http->request, Http::METHOD_HEAD);
-}
+    purgeEntry(getEntry, Http::METHOD_GET);
 
-void
-clientReplyContext::purgeDoPurgeHead(StoreEntry *newEntry)
-{
-    purgeEntry(newEntry, Http::METHOD_HEAD);
+    auto headEntry = storeGetPublicByRequestMethod(http->request, Http::METHOD_HEAD);
+    purgeEntry(headEntry, Http::METHOD_HEAD);
 
     /* And for Vary, release the base URI if none of the headers was included in the request */
     if (!http->request->vary_headers.isEmpty()

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -948,7 +948,7 @@ clientReplyContext::purgeDoPurge()
         if (EBIT_TEST(entry->flags, ENTRY_SPECIAL)) {
             http->logType.update(LOG_TCP_DENIED);
             const auto err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, nullptr,
-                                        http->getConn(), http->request, http->al);
+                                              http->getConn(), http->request, http->al);
             startError(err);
             entry->abandon(__FUNCTION__);
             return;

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -802,8 +802,7 @@ clientReplyContext::processOnlyIfCachedMiss()
     debugs(88, 4, http->request->method << ' ' << http->uri);
     http->al->http.code = Http::scGatewayTimeout;
     ErrorState *err = clientBuildError(ERR_ONLY_IF_CACHED_MISS, Http::scGatewayTimeout, NULL,
-                                       http->getConn() ? http->getConn() : nullptr,
-                                       http->request, http->al);
+                                       http->getConn(), http->request, http->al);
     removeClientStoreReference(&sc, http);
     startError(err);
 }

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -120,7 +120,7 @@ private:
     void sendClientOldEntry();
     void purgeAllCached();
     /// releases the cached entry
-    void purgeEntry(StoreEntry &, const Http::MethodType &, const char *descriptionPrefix = "");
+    void purgeEntry(StoreEntry &, const Http::MethodType, const char *descriptionPrefix = "");
     /// releases both cached GET and HEAD entries
     void purgeDoPurge();
     void forgetHit();

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -127,6 +127,8 @@ private:
     void triggerInitialStoreRead();
     void sendClientOldEntry();
     void purgeAllCached();
+    /// releases the cached entry
+    void purgeEntry(StoreEntry *, const Http::MethodType &, const char *descriptionPrefix = "");
     void forgetHit();
     bool blockedHit() const;
     void detailStoreLookup(const char *detail);

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -40,8 +40,6 @@ public:
     void purgeFoundHead(StoreEntry *newEntry);
     void purgeFoundObject(StoreEntry *entry);
     void sendClientUpstreamResponse();
-    void purgeDoPurgeGet(StoreEntry *entry);
-    void purgeDoPurgeHead(StoreEntry *entry);
     void doGetMoreData();
     void identifyStoreObject();
     void identifyFoundObject(StoreEntry *entry);
@@ -129,6 +127,8 @@ private:
     void purgeAllCached();
     /// releases the cached entry
     void purgeEntry(StoreEntry *, const Http::MethodType &, const char *descriptionPrefix = "");
+    /// releases both cached GET and HEAD entries
+    void purgeDoPurge(StoreEntry *);
     void forgetHit();
     bool blockedHit() const;
     void detailStoreLookup(const char *detail);

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -69,7 +69,6 @@ public:
     Http::StatusCode purgeStatus;
 
     /* StoreClient API */
-    virtual void created (StoreEntry *newEntry);
     virtual LogTags *loggingTags();
 
     ClientHttpRequest *http;

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -34,7 +34,6 @@ public:
     void saveState();
     void restoreState();
     void purgeRequest ();
-    void purgeFoundObject(StoreEntry *entry);
     void sendClientUpstreamResponse();
     void doGetMoreData();
     void identifyStoreObject();
@@ -117,8 +116,9 @@ private:
     void triggerInitialStoreRead();
     void sendClientOldEntry();
     void purgeAllCached();
-    /// releases the cached entry
-    void purgeEntry(StoreEntry &, const Http::MethodType, const char *descriptionPrefix = "");
+    /// attempts to release the cached entry
+    /// \returns whether the entry was released
+    bool purgeEntry(StoreEntry &, const Http::MethodType, const char *descriptionPrefix = "");
     /// releases both cached GET and HEAD entries
     void purgeDoPurge();
     void forgetHit();

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -34,8 +34,6 @@ public:
     void saveState();
     void restoreState();
     void purgeRequest ();
-    void purgeFoundGet(StoreEntry *newEntry);
-    void purgeFoundHead(StoreEntry *newEntry);
     void purgeFoundObject(StoreEntry *entry);
     void sendClientUpstreamResponse();
     void doGetMoreData();

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -43,7 +43,7 @@ public:
     /// replaces current response store entry with the given one
     void setReplyToStoreEntry(StoreEntry *e, const char *reason);
     /// builds error using clientBuildError() and calls setReplyToError() below
-    void setReplyToError(err_type, Http::StatusCode, const HttpRequestMethod&, char const *, const Comm::ConnectionPointer &, HttpRequest *, const char *,
+    void setReplyToError(err_type, Http::StatusCode, const HttpRequestMethod&, char const *, const ConnStateData *, HttpRequest *, const char *,
 #if USE_AUTH
                          Auth::UserRequest::Pointer);
 #else

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -43,7 +43,7 @@ public:
     /// replaces current response store entry with the given one
     void setReplyToStoreEntry(StoreEntry *e, const char *reason);
     /// builds error using clientBuildError() and calls setReplyToError() below
-    void setReplyToError(err_type, Http::StatusCode, const HttpRequestMethod&, char const *, Ip::Address &, HttpRequest *, const char *,
+    void setReplyToError(err_type, Http::StatusCode, const HttpRequestMethod&, char const *, const Comm::ConnectionPointer &, HttpRequest *, const char *,
 #if USE_AUTH
                          Auth::UserRequest::Pointer);
 #else

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -66,7 +66,7 @@ public:
     Http::StatusCode purgeStatus;
 
     /* StoreClient API */
-    virtual LogTags *loggingTags();
+    virtual LogTags *loggingTags() const;
 
     ClientHttpRequest *http;
     /// Base reply header bytes received from Store.

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -34,8 +34,6 @@ public:
     void saveState();
     void restoreState();
     void purgeRequest ();
-    void purgeRequestFindObjectToPurge();
-    void purgeDoMissPurge();
     void purgeFoundGet(StoreEntry *newEntry);
     void purgeFoundHead(StoreEntry *newEntry);
     void purgeFoundObject(StoreEntry *entry);
@@ -69,9 +67,6 @@ public:
     const char *storeId() const { return (http->store_id.size() > 0 ? http->store_id.termedBuf() : http->uri); }
 
     Http::StatusCode purgeStatus;
-
-    /* state variable - replace with class to handle storeentries at some point */
-    int lookingforstore;
 
     /* StoreClient API */
     virtual void created (StoreEntry *newEntry);
@@ -128,7 +123,7 @@ private:
     /// releases the cached entry
     void purgeEntry(StoreEntry *, const Http::MethodType &, const char *descriptionPrefix = "");
     /// releases both cached GET and HEAD entries
-    void purgeDoPurge(StoreEntry *);
+    void purgeDoPurge();
     void forgetHit();
     bool blockedHit() const;
     void detailStoreLookup(const char *detail);

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -120,7 +120,7 @@ private:
     void sendClientOldEntry();
     void purgeAllCached();
     /// releases the cached entry
-    void purgeEntry(StoreEntry *, const Http::MethodType &, const char *descriptionPrefix = "");
+    void purgeEntry(StoreEntry &, const Http::MethodType &, const char *descriptionPrefix = "");
     /// releases both cached GET and HEAD entries
     void purgeDoPurge();
     void forgetHit();

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -40,7 +40,7 @@ public:
     void sendClientUpstreamResponse();
     void doGetMoreData();
     void identifyStoreObject();
-    void identifyFoundObject(StoreEntry *entry);
+    void identifyFoundObject(StoreEntry *entry, const char *detail);
     int storeOKTransferDone() const;
     int storeNotOKTransferDone() const;
     /// replaces current response store entry with the given one
@@ -125,6 +125,7 @@ private:
     void purgeDoPurge();
     void forgetHit();
     bool blockedHit() const;
+    const char *storeLookupString(bool found) const { return found ? "match" : "mismatch"; }
     void detailStoreLookup(const char *detail);
 
     void sendBodyTooLargeError();

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -132,12 +132,11 @@ public:
     AccessLogEntry::Pointer al; ///< access.log entry
 
     struct Flags {
-        Flags() : accel(false), internal(false), done_copying(false), purging(false) {}
+        Flags() : accel(false), internal(false), done_copying(false) {}
 
         bool accel;
         bool internal;
         bool done_copying;
-        bool purging;
     } flags;
 
     struct Redirect {

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1421,7 +1421,7 @@ ESIContext::freeResources ()
     /* don't touch incoming, it's a pointer into buffered anyway */
 }
 
-ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, const Comm::ConnectionPointer &, HttpRequest *, const AccessLogEntry::Pointer &);
+ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, const ConnStateData *, HttpRequest *, const AccessLogEntry::Pointer &);
 
 /* This can ONLY be used before we have sent *any* data to the client */
 void
@@ -1439,7 +1439,7 @@ ESIContext::fail ()
     flags.error = 1;
     /* create an error object */
     // XXX: with the in-direction on remote IP. does the http->getConn()->clientConnection exist?
-    const auto err = clientBuildError(errorpage, errorstatus, nullptr, http->getConn()->clientConnection, http->request, http->al);
+    const auto err = clientBuildError(errorpage, errorstatus, nullptr, http->getConn(), http->request, http->al);
     err->err_msg = errormessage;
     errormessage = NULL;
     rep = err->BuildHttpReply();

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1421,7 +1421,7 @@ ESIContext::freeResources ()
     /* don't touch incoming, it's a pointer into buffered anyway */
 }
 
-ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, Ip::Address &, HttpRequest *, const AccessLogEntry::Pointer &);
+ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, const Comm::ConnectionPointer &, HttpRequest *, const AccessLogEntry::Pointer &);
 
 /* This can ONLY be used before we have sent *any* data to the client */
 void
@@ -1439,7 +1439,7 @@ ESIContext::fail ()
     flags.error = 1;
     /* create an error object */
     // XXX: with the in-direction on remote IP. does the http->getConn()->clientConnection exist?
-    const auto err = clientBuildError(errorpage, errorstatus, nullptr, http->getConn()->clientConnection->remote, http->request, http->al);
+    const auto err = clientBuildError(errorpage, errorstatus, nullptr, http->getConn()->clientConnection, http->request, http->al);
     err->err_msg = errormessage;
     errormessage = NULL;
     rep = err->BuildHttpReply();

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -139,7 +139,6 @@ public:
     virtual std::ostream &detailCodeContext(std::ostream &os) const; // override
 
     /* StoreClient API */
-    void created(StoreEntry *);
     virtual LogTags *loggingTags();
     virtual void fillChecklist(ACLFilledChecklist &) const;
 
@@ -969,24 +968,18 @@ htcpSpecifier::checkHit()
         return;
     }
 
-    StoreEntry::getPublicByRequest(this, checkHitRequest.getRaw());
-}
-
-void
-htcpSpecifier::created(StoreEntry *e)
-{
+    const auto e = storeGetPublicByRequest(checkHitRequest.getRaw());
     StoreEntry *hit = nullptr;
-
     if (!e) {
-        debugs(31, 3, "htcpCheckHit: NO; public object not found");
+        debugs(31, 3, "NO; public object not found");
     } else if (!e->validToSend()) {
-        debugs(31, 3, "htcpCheckHit: NO; entry not valid to send" );
+        debugs(31, 3, "NO; entry not valid to send" );
     } else if (refreshCheckHTCP(e, checkHitRequest.getRaw())) {
-        debugs(31, 3, "htcpCheckHit: NO; cached response is stale");
+        debugs(31, 3, "NO; cached response is stale");
     } else if (e->hittingRequiresCollapsing() && !startCollapsingOn(*e, false)) {
-        debugs(31, 3, "htcpCheckHit: NO; prohibited CF hit: " << *e);
+        debugs(31, 3, " NO; prohibited CF hit: " << *e);
     } else {
-        debugs(31, 3, "htcpCheckHit: YES!?");
+        debugs(31, 3, "YES!?");
         hit = e;
     }
 

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -970,6 +970,7 @@ htcpSpecifier::checkHit()
 
     const auto e = storeGetPublicByRequest(checkHitRequest.getRaw());
     StoreEntry *hit = nullptr;
+
     if (!e) {
         debugs(31, 3, "NO; public object not found");
     } else if (!e->validToSend()) {
@@ -977,7 +978,7 @@ htcpSpecifier::checkHit()
     } else if (refreshCheckHTCP(e, checkHitRequest.getRaw())) {
         debugs(31, 3, "NO; cached response is stale");
     } else if (e->hittingRequiresCollapsing() && !startCollapsingOn(*e, false)) {
-        debugs(31, 3, " NO; prohibited CF hit: " << *e);
+        debugs(31, 3, "NO; prohibited CF hit: " << *e);
     } else {
         debugs(31, 3, "YES!?");
         hit = e;

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -139,7 +139,7 @@ public:
     virtual std::ostream &detailCodeContext(std::ostream &os) const; // override
 
     /* StoreClient API */
-    virtual LogTags *loggingTags();
+    virtual LogTags *loggingTags() const;
     virtual void fillChecklist(ACLFilledChecklist &) const;
 
 public:
@@ -992,7 +992,7 @@ htcpSpecifier::checkHit()
 }
 
 LogTags *
-htcpSpecifier::loggingTags()
+htcpSpecifier::loggingTags() const
 {
     // calling htcpSyncAle() here would not change cache.code
     if (!al)

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -583,7 +583,7 @@ icpHandleIcpV2(int fd, Ip::Address &from, char *buf, int len)
         return;
     }
 
-    debugs(12, 5, "OPCODE " << icp_opcode_str[header.opcode]);
+    debugs(12, 5, "OPCODE " << icp_opcode_str[header.getOpCode()] << '=' << uint8_t(header.opcode));
 
     switch (header.opcode) {
 

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -155,7 +155,7 @@ ICPState::~ICPState()
 }
 
 bool
-ICPState::isHit()
+ICPState::isHit() const
 {
     const auto e = storeGetPublic(url, Http::METHOD_GET);
 
@@ -168,7 +168,7 @@ ICPState::isHit()
 }
 
 bool
-ICPState::confirmAndPrepHit(const StoreEntry &e)
+ICPState::confirmAndPrepHit(const StoreEntry &e) const
 {
     if (!e.validToSend())
         return false;
@@ -183,7 +183,7 @@ ICPState::confirmAndPrepHit(const StoreEntry &e)
 }
 
 LogTags *
-ICPState::loggingTags()
+ICPState::loggingTags() const
 {
     // calling icpSyncAle(LOG_TAG_NONE) here would not change cache.code
     if (!al)

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -518,9 +518,9 @@ doV2Query(int fd, Ip::Address &from, char *buf, icp_common_t header)
         codeToSend = ICP_HIT;
     } else {
 #if USE_ICMP
-        if (Config.onoff.test_reachability && rtt == 0) {
-            if ((rtt = netdbHostRtt(request->url.host())) == 0)
-                netdbPingSite(request->url.host());
+        if (Config.onoff.test_reachability && state.rtt == 0) {
+            if ((state.rtt = netdbHostRtt(state.request->url.host())) == 0)
+                netdbPingSite(state.request->url.host());
         }
 #endif /* USE_ICMP */
 

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -27,7 +27,7 @@ public:
     ICP3State(icp_common_t &aHeader, HttpRequest *aRequest) :
         ICPState(aHeader, aRequest) {}
 
-    ~ICP3State();
+    ~ICP3State() = default;
 };
 
 /// \ingroup ServerProtocolICPInternal3
@@ -70,9 +70,6 @@ doV3Query(int fd, Ip::Address &from, char *buf, icp_common_t header)
         e->abandon(__FUNCTION__);
 
 }
-
-ICP3State::~ICP3State()
-{}
 
 /// \ingroup ServerProtocolICPInternal3
 /* Currently Harvest cached-2.x uses ICP_VERSION_3 */

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -85,7 +85,7 @@ icpHandleIcpV3(int fd, Ip::Address &from, char *buf, int len)
         return;
     }
 
-    debugs(12, 5, "OPCODE " << icp_opcode_str[header.opcode]);
+    debugs(12, 5, "OPCODE " << icp_opcode_str[header.getOpCode()] << '=' << uint8_t(header.opcode));
 
     switch (header.opcode) {
 

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -53,11 +53,9 @@ doV3Query(int fd, Ip::Address &from, char *buf, icp_common_t header)
     state.from = from;
     state.url = xstrdup(url);
 
-    const auto e = storeGetPublic(url, Http::METHOD_GET);
-
     icp_opcode codeToSend;
 
-    if (e && state.confirmAndPrepHit(*e)) {
+    if (state.isHit()) {
         codeToSend = ICP_HIT;
     } else if (icpGetCommonOpcode() == ICP_ERR)
         codeToSend = ICP_MISS;
@@ -65,10 +63,6 @@ doV3Query(int fd, Ip::Address &from, char *buf, icp_common_t header)
         codeToSend = icpGetCommonOpcode();
 
     icpCreateAndSend(codeToSend, 0, url, header.reqnum, 0, fd, from, state.al);
-
-    if (e)
-        e->abandon(__FUNCTION__);
-
 }
 
 /// \ingroup ServerProtocolICPInternal3

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -298,7 +298,9 @@ public:
      */
     bool GetHostByName(const char *s);
 
-    static const struct in6_addr v6_noaddr;
+    /// \returns an object containing the specific IP case NO_ADDR (format-neutral).
+    /// see isNoAddr() for more detail.
+    static const Address &NoAddr() { static const Address noAddr(v6_noaddr); return noAddr; }
 
 public:
     /* XXX: When C => C++ conversion is done will be fully private.
@@ -347,6 +349,7 @@ private:
     static const struct in6_addr v4_localhost;
     static const struct in6_addr v4_anyaddr;
     static const struct in6_addr v4_noaddr;
+    static const struct in6_addr v6_noaddr;
 };
 
 inline std::ostream &

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -298,8 +298,8 @@ public:
      */
     bool GetHostByName(const char *s);
 
-    /// \returns an object containing the specific IP case NO_ADDR (format-neutral).
-    /// see isNoAddr() for more detail.
+    /// \returns an Address with true isNoAddr()
+    /// \see isNoAddr() for more details
     static const Address &NoAddr() { static const Address noAddr(v6_noaddr); return noAddr; }
 
 public:

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -298,6 +298,8 @@ public:
      */
     bool GetHostByName(const char *s);
 
+    static const struct in6_addr v6_noaddr;
+
 public:
     /* XXX: When C => C++ conversion is done will be fully private.
      * Legacy Transition Methods.
@@ -345,7 +347,6 @@ private:
     static const struct in6_addr v4_localhost;
     static const struct in6_addr v4_anyaddr;
     static const struct in6_addr v4_noaddr;
-    static const struct in6_addr v6_noaddr;
 };
 
 inline std::ostream &

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -356,7 +356,7 @@ MimeIcon::load()
         fatal("Unknown icon format while reading mime.conf\n");
 
     if (const auto e = storeGetPublic(url_, Http::METHOD_GET)) {
-        /* if the icon is already in the store, do nothing */
+        // do not overwrite an already stored icon
         e->abandon(__FUNCTION__);
         return;
     }

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -45,7 +45,6 @@ public:
     void load();
 
     /* StoreClient API */
-    virtual void created(StoreEntry *);
     virtual LogTags *loggingTags() { return nullptr; } // no access logging/ACLs
     virtual void fillChecklist(ACLFilledChecklist &) const;
 
@@ -356,15 +355,12 @@ MimeIcon::load()
     if (type == NULL)
         fatal("Unknown icon format while reading mime.conf\n");
 
-    StoreEntry::getPublic(this, url_, Http::METHOD_GET);
-}
-
-void
-MimeIcon::created(StoreEntry *newEntry)
-{
-    /* if the icon is already in the store, do nothing */
-    if (newEntry)
+    if (const auto e = storeGetPublic(url_, Http::METHOD_GET)) {
+        /* if the icon is already in the store, do nothing */
+        e->abandon(__FUNCTION__);
         return;
+    }
+
     // XXX: if a 204 is cached due to earlier load 'failure' we should try to reload.
 
     // default is a 200 object with image data.

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -45,7 +45,7 @@ public:
     void load();
 
     /* StoreClient API */
-    virtual LogTags *loggingTags() { return nullptr; } // no access logging/ACLs
+    virtual LogTags *loggingTags() const { return nullptr; } // no access logging/ACLs
     virtual void fillChecklist(ACLFilledChecklist &) const;
 
 private:

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -260,7 +260,7 @@ constructHelperQuery(const char *name, helper *hlp, HLPCB *replyHandler, ClientH
         assert (repContext);
         repContext->setReplyToError(ERR_GATEWAY_FAILURE, status,
                                     http->request->method, NULL,
-                                    http->getConn() ? http->getConn()->clientConnection : nullptr,
+                                    http->getConn(),
                                     http->request,
                                     NULL,
 #if USE_AUTH

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -258,12 +258,9 @@ constructHelperQuery(const char *name, helper *hlp, HLPCB *replyHandler, ClientH
         clientStreamNode *node = (clientStreamNode *)http->client_stream.tail->prev->data;
         clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
         assert (repContext);
-        Ip::Address tmpnoaddr;
-        tmpnoaddr.setNoAddr();
         repContext->setReplyToError(ERR_GATEWAY_FAILURE, status,
                                     http->request->method, NULL,
-                                    http->getConn() != NULL && http->getConn()->clientConnection != NULL ?
-                                    http->getConn()->clientConnection->remote : tmpnoaddr,
+                                    http->getConn() ? http->getConn()->clientConnection : nullptr,
                                     http->request,
                                     NULL,
 #if USE_AUTH

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -220,7 +220,7 @@ Http::One::Server::setReplyError(Http::StreamPointer &context, HttpRequest::Poin
     clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
     assert (repContext);
 
-    repContext->setReplyToError(requestError, errStatusCode, method, context->http->uri, clientConnection->remote, nullptr, requestErrorBytes, nullptr);
+    repContext->setReplyToError(requestError, errStatusCode, method, context->http->uri, clientConnection, nullptr, requestErrorBytes, nullptr);
 
     assert(context->http->out.offset == 0);
     context->pullData();
@@ -264,7 +264,7 @@ Http::One::Server::processParsedRequest(Http::StreamPointer &context)
             clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
             assert (repContext);
             repContext->setReplyToError(ERR_INVALID_REQ, Http::scExpectationFailed, request->method, http->uri,
-                                        clientConnection->remote, request.getRaw(), NULL, NULL);
+                                        clientConnection, request.getRaw(), nullptr, nullptr);
             assert(context->http->out.offset == 0);
             context->pullData();
             clientProcessRequestFinished(this, request);

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -220,7 +220,7 @@ Http::One::Server::setReplyError(Http::StreamPointer &context, HttpRequest::Poin
     clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
     assert (repContext);
 
-    repContext->setReplyToError(requestError, errStatusCode, method, context->http->uri, clientConnection, nullptr, requestErrorBytes, nullptr);
+    repContext->setReplyToError(requestError, errStatusCode, method, context->http->uri, this, nullptr, requestErrorBytes, nullptr);
 
     assert(context->http->out.offset == 0);
     context->pullData();
@@ -264,7 +264,7 @@ Http::One::Server::processParsedRequest(Http::StreamPointer &context)
             clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
             assert (repContext);
             repContext->setReplyToError(ERR_INVALID_REQ, Http::scExpectationFailed, request->method, http->uri,
-                                        clientConnection, request.getRaw(), nullptr, nullptr);
+                                        this, request.getRaw(), nullptr, nullptr);
             assert(context->http->out.offset == 0);
             context->pullData();
             clientProcessRequestFinished(this, request);

--- a/src/store.cc
+++ b/src/store.cc
@@ -517,27 +517,6 @@ StoreEntry::doAbandon(const char *context)
     Store::Root().handleIdleEntry(*this); // may delete us
 }
 
-void
-StoreEntry::getPublicByRequestMethod  (StoreClient *aClient, HttpRequest * request, const HttpRequestMethod& method)
-{
-    assert (aClient);
-    aClient->created(storeGetPublicByRequestMethod(request, method));
-}
-
-void
-StoreEntry::getPublicByRequest (StoreClient *aClient, HttpRequest * request)
-{
-    assert (aClient);
-    aClient->created(storeGetPublicByRequest(request));
-}
-
-void
-StoreEntry::getPublic (StoreClient *aClient, const char *uri, const HttpRequestMethod& method)
-{
-    assert (aClient);
-    aClient->created(storeGetPublic(uri, method));
-}
-
 StoreEntry *
 storeGetPublic(const char *uri, const HttpRequestMethod& method)
 {

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -63,7 +63,7 @@ StoreClient::onCollapsingPath() const
 }
 
 bool
-StoreClient::startCollapsingOn(const StoreEntry &e, const bool doingRevalidation)
+StoreClient::startCollapsingOn(const StoreEntry &e, const bool doingRevalidation) const
 {
     if (!e.hittingRequiresCollapsing())
         return false; // collapsing is impossible due to the entry state

--- a/src/tests/stub_icp.cc
+++ b/src/tests/stub_icp.cc
@@ -21,8 +21,8 @@ icp_common_t *icp_common_t::CreateMessage(icp_opcode opcode, int flags, const ch
 icp_opcode icp_common_t::getOpCode() const STUB_RETVAL(ICP_INVALID)
 ICPState::ICPState(icp_common_t &aHeader, HttpRequest *aRequest) STUB
 ICPState::~ICPState() STUB
-bool ICPState::confirmAndPrepHit(const StoreEntry &) STUB_RETVAL(false)
-LogTags *ICPState::loggingTags() STUB_RETVAL(nullptr)
+bool ICPState::confirmAndPrepHit(const StoreEntry &) const STUB_RETVAL(false)
+LogTags *ICPState::loggingTags() const STUB_RETVAL(nullptr)
 void ICPState::fillChecklist(ACLFilledChecklist&) const STUB
 
 Comm::ConnectionPointer icpIncomingConn;

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -71,9 +71,6 @@ bool StoreEntry::hasIfMatchEtag(const HttpRequest &request) const STUB_RETVAL(fa
 bool StoreEntry::hasIfNoneMatchEtag(const HttpRequest &request) const STUB_RETVAL(false)
 Store::Disk &StoreEntry::disk() const STUB_RETREF(Store::Disk)
 size_t StoreEntry::inUseCount() STUB_RETVAL(0)
-void StoreEntry::getPublicByRequestMethod(StoreClient * aClient, HttpRequest * request, const HttpRequestMethod& method) STUB
-void StoreEntry::getPublicByRequest(StoreClient * aClient, HttpRequest * request) STUB
-void StoreEntry::getPublic(StoreClient * aClient, const char *uri, const HttpRequestMethod& method) STUB
 void *StoreEntry::operator new(size_t byteCount)
 {
     STUB

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -54,7 +54,7 @@ public:
 
 private:
     /* StoreClient API */
-    virtual LogTags *loggingTags() { return ale ? &ale->cache.code : nullptr; }
+    virtual LogTags *loggingTags() const { return ale ? &ale->cache.code : nullptr; }
     virtual void fillChecklist(ACLFilledChecklist &) const;
 
     char *urlres = nullptr;

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -37,7 +37,6 @@ class UrnState : public StoreClient
 public:
     explicit UrnState(const AccessLogEntry::Pointer &anAle): ale(anAle) {}
 
-    void created (StoreEntry *newEntry);
     void start (HttpRequest *, StoreEntry *);
     void setUriResFromRequest(HttpRequest *);
 
@@ -175,29 +174,17 @@ UrnState::start(HttpRequest * r, StoreEntry * e)
     if (urlres_r == NULL)
         return;
 
-    StoreEntry::getPublic (this, urlres, Http::METHOD_GET);
-}
+    const auto urlEntry = storeGetPublic(urlres, Http::METHOD_GET);
 
-void
-UrnState::fillChecklist(ACLFilledChecklist &checklist) const
-{
-    checklist.setRequest(request.getRaw());
-    checklist.al = ale;
-}
-
-void
-UrnState::created(StoreEntry *e)
-{
-    if (!e || (e->hittingRequiresCollapsing() && !startCollapsingOn(*e, false))) {
+    if (!urlEntry || (urlEntry->hittingRequiresCollapsing() && !startCollapsingOn(*urlEntry, false))) {
         urlres_e = storeCreateEntry(urlres, urlres, RequestFlags(), Http::METHOD_GET);
         sc = storeClientListAdd(urlres_e, this);
         FwdState::Start(Comm::ConnectionPointer(), urlres_e, urlres_r.getRaw(), ale);
-        // TODO: StoreClients must either store/lock or abandon found entries.
-        //if (e)
-        //    e->abandon();
+        if (urlEntry)
+            urlEntry->abandon(__FUNCTION__);
     } else {
-        urlres_e = e;
-        urlres_e->lock("UrnState::created");
+        urlres_e = urlEntry;
+        urlres_e->lock("UrnState::start");
         sc = storeClientListAdd(urlres_e, this);
     }
 
@@ -210,6 +197,13 @@ UrnState::created(StoreEntry *e)
                     tempBuffer,
                     urnHandleReply,
                     this);
+}
+
+void
+UrnState::fillChecklist(ACLFilledChecklist &checklist) const
+{
+    checklist.setRequest(request.getRaw());
+    checklist.al = ale;
 }
 
 void

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -174,14 +174,16 @@ UrnState::start(HttpRequest * r, StoreEntry * e)
     if (urlres_r == NULL)
         return;
 
-    const auto urlEntry = storeGetPublic(urlres, Http::METHOD_GET);
+    auto urlEntry = storeGetPublic(urlres, Http::METHOD_GET);
 
     if (!urlEntry || (urlEntry->hittingRequiresCollapsing() && !startCollapsingOn(*urlEntry, false))) {
         urlres_e = storeCreateEntry(urlres, urlres, RequestFlags(), Http::METHOD_GET);
         sc = storeClientListAdd(urlres_e, this);
         FwdState::Start(Comm::ConnectionPointer(), urlres_e, urlres_r.getRaw(), ale);
-        if (urlEntry)
+        if (urlEntry) {
             urlEntry->abandon(__FUNCTION__);
+            urlEntry = nullptr;
+        }
     } else {
         urlres_e = urlEntry;
         urlres_e->lock("UrnState::start");


### PR DESCRIPTION
The StoreClient::created() callback method was probably added in hope to
make Store lookups asynchronous, but that functionality has not been
implemented, leaving convoluted and dangerous synchronous created() call
chains behind. Moreover, properly supporting asynchronous Store lookups
in modern code is likely to require a very different API.

Removal of created() allowed to greatly simplify PURGE processing,
eliminating some tricky state, such as `purging` and `lookingforstore`.

Also removed all Store::getPublic*() methods as no longer used.
