### PR TITLE
Translations: Update integration

### DIFF
--- a/doc/manuals/language.am
+++ b/doc/manuals/language.am
@@ -18,4 +18,4 @@ TRANSLATE_LANGUAGES = \
     oc.lang \
     pt.lang \
     ro.lang \
-    ru.lang 
+    ru.lang

--- a/errors/TRANSLATORS
+++ b/errors/TRANSLATORS
@@ -21,6 +21,7 @@ and ideas to make Squid available as multi-langual software.
 	George Machitidze <giomac@gmail.com>
 	Henrik Nordström
 	Ivan Masár <helix84@centrum.sk>
+	Javier Pacheco <javier@aex.mx>
 	John 'Profic' Ustiuzhanin
 	Leandro Cesar Nardini Frasson
 	liuyongbing

--- a/errors/aliases
+++ b/errors/aliases
@@ -14,7 +14,8 @@ da	da-dk
 de	de-at de-ch de-de de-li de-lu
 el	el-gr
 en	en-au en-bz en-ca en-cn en-gb en-ie en-in en-jm en-nz en-ph en-sg en-tt en-uk en-us en-za en-zw
-es	es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-gt es-hn es-mx es-ni es-pa es-pe es-pr es-py es-sv es-us es-uy es-ve es-xl
+es	es-ar es-bo es-cl es-cu es-co es-do es-ec es-es es-pe es-pr es-py es-us es-uy es-ve es-xl spq
+es-mx	es-bz es-cr es-gt es-hn es-ni es-pa es-sv
 et	et-ee
 fa	fa-fa fa-ir
 fi	fi-fi

--- a/errors/language.am
+++ b/errors/language.am
@@ -17,6 +17,7 @@ TRANSLATE_LANGUAGES = \
     de.lang \
     el.lang \
     en.lang \
+    es-mx.lang \
     es.lang \
     et.lang \
     fa.lang \
@@ -51,4 +52,4 @@ TRANSLATE_LANGUAGES = \
     uz.lang \
     vi.lang \
     zh-hans.lang \
-    zh-hant.lang 
+    zh-hant.lang

--- a/errors/template.am
+++ b/errors/template.am
@@ -48,4 +48,4 @@ ERROR_TEMPLATES = \
     templates/ERR_UNSUP_REQ \
     templates/ERR_URN_RESOLVE \
     templates/ERR_WRITE_ERROR \
-    templates/ERR_ZERO_SIZE_OBJECT 
+    templates/ERR_ZERO_SIZE_OBJECT


### PR DESCRIPTION
* Add credits for es-mx translation moderator
* Use es-mx for default of all Spanish (Central America) texts
* Update translation related .am files