### PR TITLE
Fix std::ostream precision settings leak in Progress::print()

### DIFF
--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -247,7 +247,7 @@ Progress::print(std::ostream &os) const
         const auto savedPrecision = os.precision(2);
         const auto percent = 100.0 * completed / goal;
         os << percent << "% (" << completed << " out of " << goal << ")";
-        os.precision(savedPrecision);
+       (void)os.precision(savedPrecision);
     } else if (!completed && !goal) {
         os << "nothing to do";
     } else {
@@ -389,4 +389,3 @@ storeRebuildParseEntry(MemBuf &buf, StoreEntry &tmpe, cache_key *key,
 
     return true;
 }
-

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -389,3 +389,4 @@ storeRebuildParseEntry(MemBuf &buf, StoreEntry &tmpe, cache_key *key,
 
     return true;
 }
+

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -244,9 +244,10 @@ void
 Progress::print(std::ostream &os) const
 {
     if (goal > 0) {
+        const auto savedPrecision = os.precision(2);
         const auto percent = 100.0 * completed / goal;
-        os << std::setprecision(2) << percent << "% (" <<
-            completed << " out of " << goal << ")";
+        os << percent << "% (" << completed << " out of " << goal << ")";
+        os.precision(savedPrecision);
     } else if (!completed && !goal) {
         os << "nothing to do";
     } else {


### PR DESCRIPTION
No functionality changes expected.

Broken since inception (commit 8ecbe78d).

Detected by Coverity. CID 1468264: API usage errors(STREAM_FORMAT_STATE)