### PR TITLE
Bug 5073: Compile error: index was not declared in this scope

### DIFF
--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -498,12 +498,6 @@ write(int fd, const void * buf, size_t siz)
         return _write(fd, buf, siz);
 }
 
-inline char *
-index(const char *s, int c)
-{
-    return (char *)strchr(s,c);
-}
-
 // stdlib <functional> definitions are required before std API redefinitions.
 #include <functional>
 

--- a/src/esi/VarState.cc
+++ b/src/esi/VarState.cc
@@ -150,7 +150,7 @@ ESIVariableUserAgent::getProductVersion (char const *s)
 {
     char const *t;
     int len;
-    t = index(s,'/');
+    t = strchr(s, '/');
 
     if (!t || !*(++t))
         return xstrdup("");
@@ -328,12 +328,12 @@ ESIVariableUserAgent::ESIVariableUserAgent(ESIVarState &state)
 
         if ((t = strstr (s, "MSIE"))) {
             browser = ESI_BROWSER_MSIE;
-            t = index (t, ' ');
+            t = strchr(t, ' ');
 
             if (!t)
                 browserversion = xstrdup("");
             else {
-                t1 = index(t, ';');
+                t1 = strchr(t, ';');
 
                 if (!t1)
                     browserversion = xstrdup(t + 1);


### PR DESCRIPTION
Use strchr(3) instead of a legacy POSIX.1-2001 index(3) API.

Also removed the index() implementation on MS Windows as no longer used.
