### PR TITLE
Preserve caller context across IPC-related timeout events

### DIFF
--- a/src/ipc/Forwarder.cc
+++ b/src/ipc/Forwarder.cc
@@ -25,6 +25,7 @@ unsigned int Ipc::Forwarder::LastRequestId = 0;
 
 Ipc::Forwarder::Forwarder(Request::Pointer aRequest, double aTimeout):
     AsyncJob("Ipc::Forwarder"),
+    codeContext(CodeContext::Current()),
     request(aRequest), timeout(aTimeout)
 {
 }
@@ -101,7 +102,10 @@ Ipc::Forwarder::RequestTimedOut(void* param)
     Must(param != NULL);
     Forwarder* fwdr = static_cast<Forwarder*>(param);
     // use async call to enable job call protection that time events lack
-    CallJobHere(54, 5, fwdr, Forwarder, requestTimedOut);
+
+    CallBack(fwdr->codeContext, [&fwdr] {
+        CallJobHere(54, 5, fwdr, Forwarder, requestTimedOut);
+    });
 }
 
 /// called when Coordinator fails to start processing the request [in time]

--- a/src/ipc/Forwarder.h
+++ b/src/ipc/Forwarder.h
@@ -12,6 +12,7 @@
 #define SQUID_IPC_FORWARDER_H
 
 #include "base/AsyncJob.h"
+#include "base/forward.h"
 #include "cbdata.h"
 #include "ipc/Request.h"
 #include "mgr/ActionParams.h"
@@ -38,6 +39,8 @@ public:
 
     /* has-to-be-public AsyncJob API */
     virtual void callException(const std::exception& e);
+
+    CodeContextPointer codeContext;
 
 protected:
     /* AsyncJob API */

--- a/src/ipc/Inquirer.cc
+++ b/src/ipc/Inquirer.cc
@@ -33,6 +33,7 @@ LesserStrandByKidId(const Ipc::StrandCoord &c1, const Ipc::StrandCoord &c2)
 Ipc::Inquirer::Inquirer(Request::Pointer aRequest, const StrandCoords& coords,
                         double aTimeout):
     AsyncJob("Ipc::Inquirer"),
+    codeContext(CodeContext::Current()),
     request(aRequest), strands(coords), pos(strands.begin()), timeout(aTimeout)
 {
     debugs(54, 5, HERE);
@@ -181,7 +182,9 @@ Ipc::Inquirer::RequestTimedOut(void* param)
     Must(param != NULL);
     Inquirer* cmi = static_cast<Inquirer*>(param);
     // use async call to enable job call protection that time events lack
-    CallJobHere(54, 5, cmi, Inquirer, requestTimedOut);
+    CallBack(cmi->codeContext, [&cmi] {
+        CallJobHere(54, 5, cmi, Inquirer, requestTimedOut);
+    });
 }
 
 /// called when the strand failed to respond (or finish responding) in time

--- a/src/ipc/Inquirer.h
+++ b/src/ipc/Inquirer.h
@@ -13,6 +13,7 @@
 
 #include "base/AsyncJob.h"
 #include "base/AsyncJobCalls.h"
+#include "base/forward.h"
 #include "ipc/forward.h"
 #include "ipc/Request.h"
 #include "ipc/Response.h"
@@ -37,6 +38,8 @@ public:
 
     /* has-to-be-public AsyncJob API */
     virtual void callException(const std::exception& e);
+
+    CodeContextPointer codeContext;
 
 protected:
     /* AsyncJob API */

--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -83,6 +83,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Ipc, UdsSender);
 
 Ipc::UdsSender::UdsSender(const String& pathAddr, const TypedMsgHdr& aMessage):
     UdsOp(pathAddr),
+    codeContext(CodeContext::Current()),
     message(aMessage),
     retries(10), // TODO: make configurable?
     timeout(10), // TODO: make configurable?
@@ -161,10 +162,9 @@ void Ipc::UdsSender::DelayedRetry(void *data)
     Pointer *ptr = static_cast<Pointer*>(data);
     assert(ptr);
     if (UdsSender *us = dynamic_cast<UdsSender*>(ptr->valid())) {
-        // get back inside AsyncJob protection by scheduling an async job call
-        typedef NullaryMemFunT<Ipc::UdsSender> Dialer;
-        AsyncCall::Pointer call = JobCallback(54, 4, Dialer, us, Ipc::UdsSender::delayedRetry);
-        ScheduleCallHere(call);
+        CallBack(us->codeContext, [&us] {
+            CallJobHere(54, 4, us, UdsSender, delayedRetry);
+        });
     }
     delete ptr;
 }

--- a/src/ipc/UdsOp.h
+++ b/src/ipc/UdsOp.h
@@ -12,6 +12,7 @@
 #define SQUID_IPC_ASYNCUDSOP_H
 
 #include "base/AsyncJob.h"
+#include "base/forward.h"
 #include "cbdata.h"
 #include "comm/forward.h"
 #include "ipc/FdNotes.h"
@@ -70,6 +71,8 @@ class UdsSender: public UdsOp
 
 public:
     UdsSender(const String& pathAddr, const TypedMsgHdr& aMessage);
+
+    CodeContextPointer codeContext;
 
 protected:
     virtual void swanSong(); // UdsOp (AsyncJob) API


### PR DESCRIPTION
Before this fix, the transaction context was not saved/restored when
scheduling the following three events:

* Ipc::Forwarder::RequestTimedOut()
* Ipc::UdsSender::DelayedRetry()
* Ipc::Inquirer::RequestTimedOut()