### PR TITLE
Avoid null pointer dereferences when dynamic_cast'ing to SwapDir

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1503,6 +1503,7 @@ tests_testStore_SOURCES = \
 	StatCounters.h \
 	StatHist.cc \
 	StatHist.h \
+	StoreFileSystem.cc \
 	tests/testStore.cc \
 	tests/testStore.h \
 	tests/testStoreController.cc \
@@ -1781,7 +1782,6 @@ tests_testDiskIO_LDADD = \
 	dns/libdns.la \
 	base/libbase.la \
 	mem/libmem.la \
-	store/libstore.la \
 	sbuf/libsbuf.la \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \

--- a/src/StoreFileSystem.cc
+++ b/src/StoreFileSystem.cc
@@ -70,6 +70,16 @@ StoreFileSystem::FreeAllFs()
     }
 }
 
+StoreFileSystem *
+StoreFileSystem::FindByType(const char *type)
+{
+    for (const auto fs: FileSystems()) {
+        if (strcasecmp(type, fs->type()) == 0)
+            return fs;
+    }
+    return nullptr;
+}
+
 /* no filesystem is required to export statistics */
 void
 StoreFileSystem::registerWithCacheManager(void)

--- a/src/StoreFileSystem.h
+++ b/src/StoreFileSystem.h
@@ -93,6 +93,7 @@ public:
     static void SetupAllFs();
     static void FsAdd(StoreFileSystem &);
     static void FreeAllFs();
+    static StoreFileSystem *FindByType(const char *type);
     static std::vector<StoreFileSystem*> const &FileSystems();
     typedef std::vector<StoreFileSystem*>::iterator iterator;
     typedef std::vector<StoreFileSystem*>::const_iterator const_iterator;

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -62,9 +62,7 @@
 #include "SquidString.h"
 #include "ssl/ProxyCerts.h"
 #include "Store.h"
-#include "store/Disk.h"
 #include "store/Disks.h"
-#include "StoreFileSystem.h"
 #include "tools.h"
 #include "util.h"
 #include "wordlist.h"
@@ -642,19 +640,6 @@ configDoConfigure(void)
     /* init memory as early as possible */
     memConfigure();
     /* Sanity checks */
-
-    Config.cacheSwap.n_strands = 0; // no diskers by default
-    if (Config.cacheSwap.swapDirs == NULL) {
-        /* Memory-only cache probably in effect. */
-        /* turn off the cache rebuild delays... */
-        StoreController::store_dirs_rebuilding = 0;
-    } else if (InDaemonMode()) { // no diskers in non-daemon mode
-        for (int i = 0; i < Config.cacheSwap.n_configured; ++i) {
-            const RefCount<SwapDir> sd = Config.cacheSwap.swapDirs[i];
-            if (sd->needsDiskStrand())
-                sd->disker = Config.workers + (++Config.cacheSwap.n_strands);
-        }
-    }
 
     if (Debug::rotateNumber < 0) {
         Debug::rotateNumber = Config.Log.rotateNumber;
@@ -1853,17 +1838,8 @@ parse_http_header_replace(HeaderManglers **pm)
 static void
 dump_cachedir(StoreEntry * entry, const char *name, const Store::DiskConfig &swap)
 {
-    SwapDir *s;
-    int i;
-    assert (entry);
-
-    for (i = 0; i < swap.n_configured; ++i) {
-        s = dynamic_cast<SwapDir *>(swap.swapDirs[i].getRaw());
-        if (!s) continue;
-        storeAppendPrintf(entry, "%s %s %s", name, s->type(), s->path);
-        s->dump(*entry);
-        storeAppendPrintf(entry, "\n");
-    }
+    assert(entry);
+    Store::Disks::Dump(swap, *entry, name);
 }
 
 static int
@@ -1981,84 +1957,11 @@ ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *d
     (*access)->add(rule, action);
 }
 
-/* TODO: just return the object, the # is irrelevant */
-static int
-find_fstype(char *type)
-{
-    for (size_t i = 0; i < StoreFileSystem::FileSystems().size(); ++i)
-        if (strcasecmp(type, StoreFileSystem::FileSystems().at(i)->type()) == 0)
-            return (int)i;
-
-    return (-1);
-}
-
 static void
 parse_cachedir(Store::DiskConfig *swap)
 {
-    char *type_str = ConfigParser::NextToken();
-    if (!type_str) {
-        self_destruct();
-        return;
-    }
-
-    char *path_str = ConfigParser::NextToken();
-    if (!path_str) {
-        self_destruct();
-        return;
-    }
-
-    int fs = find_fstype(type_str);
-    if (fs < 0) {
-        debugs(3, DBG_PARSE_NOTE(DBG_IMPORTANT), "ERROR: This proxy does not support the '" << type_str << "' cache type. Ignoring.");
-        return;
-    }
-
-    /* reconfigure existing dir */
-
-    RefCount<SwapDir> sd;
-    for (int i = 0; i < swap->n_configured; ++i) {
-        assert (swap->swapDirs[i].getRaw());
-
-        if ((strcasecmp(path_str, dynamic_cast<SwapDir *>(swap->swapDirs[i].getRaw())->path)) == 0) {
-            /* this is specific to on-fs Stores. The right
-             * way to handle this is probably to have a mapping
-             * from paths to stores, and have on-fs stores
-             * register with that, and lookip in that in their
-             * own setup logic. RBC 20041225. TODO.
-             */
-
-            sd = dynamic_cast<SwapDir *>(swap->swapDirs[i].getRaw());
-
-            if (strcmp(sd->type(), StoreFileSystem::FileSystems().at(fs)->type()) != 0) {
-                debugs(3, DBG_CRITICAL, "ERROR: Can't change type of existing cache_dir " <<
-                       sd->type() << " " << sd->path << " to " << type_str << ". Restart required");
-                return;
-            }
-
-            sd->reconfigure();
-            return;
-        }
-    }
-
-    /* new cache_dir */
-    if (swap->n_configured > 63) {
-        /* 7 bits, signed */
-        debugs(3, DBG_CRITICAL, "WARNING: There is a fixed maximum of 63 cache_dir entries Squid can handle.");
-        debugs(3, DBG_CRITICAL, "WARNING: '" << path_str << "' is one to many.");
-        self_destruct();
-        return;
-    }
-
-    allocate_new_swapdir(swap);
-
-    swap->swapDirs[swap->n_configured] = StoreFileSystem::FileSystems().at(fs)->createSwapDir();
-
-    sd = dynamic_cast<SwapDir *>(swap->swapDirs[swap->n_configured].getRaw());
-
-    /* parse the FS parameters and options */
-    sd->parse(swap->n_configured, path_str);
-
-    ++swap->n_configured;
+    assert(swap);
+    Store::Disks::Parse(*swap);
 }
 
 static const char *

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1838,7 +1838,6 @@ parse_http_header_replace(HeaderManglers **pm)
 static void
 dump_cachedir(StoreEntry * entry, const char *name, const Store::DiskConfig &swap)
 {
-    assert(entry);
     Store::Disks::Dump(swap, *entry, name);
 }
 

--- a/src/store.cc
+++ b/src/store.cc
@@ -1324,7 +1324,7 @@ storeInit(void)
 void
 storeConfigure(void)
 {
-    Store::Root().updateLimits();
+    Store::Root().configure();
 }
 
 bool

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -199,8 +199,6 @@ Store::Controller::configure()
 {
     swapDir->configure();
 
-    // update limits
-
     store_swap_high = (long) (((float) maxSize() *
                                (float) Config.Swap.highWaterMark) / (float) 100);
     store_swap_low = (long) (((float) maxSize() *

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -195,9 +195,11 @@ Store::Controller::maxObjectSize() const
 }
 
 void
-Store::Controller::updateLimits()
+Store::Controller::configure()
 {
-    swapDir->updateLimits();
+    swapDir->configure();
+
+    // update limits
 
     store_swap_high = (long) (((float) maxSize() *
                                (float) Config.Swap.highWaterMark) / (float) 100);

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -74,8 +74,8 @@ public:
     /// reduce the risk of selecting the wrong disk cache for the growing entry.
     int64_t accumulateMore(StoreEntry &) const;
 
-    /// slowly calculate (and cache) hi/lo watermarks and similar limits
-    void updateLimits();
+    /// update configuration, including limits (re)calculation
+    void configure();
 
     /// called when the entry is no longer needed by any transaction
     void handleIdleEntry(StoreEntry &);

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -458,7 +458,6 @@ Store::Disks::Parse(DiskConfig &swap)
         throw TextException(ToSBuf("Squid cannot handle more than ", cacheDirCountLimit, " cache_dir directives"), Here());
 
     // create a new cache_dir
-
     allocate_new_swapdir(swap);
     swap.swapDirs[swap.n_configured] = fs->createSwapDir();
     auto &disk = Dir(swap.n_configured);
@@ -856,4 +855,3 @@ storeDirSwapLog(const StoreEntry * e, int op)
 
     e->disk().logEntry(*e, op);
 }
-

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -53,6 +53,7 @@ objectSizeForDirSelection(const StoreEntry &entry)
     return minSize;
 }
 
+/// TODO: Remove when cache_dir-iterating functions are converted to Disks methods
 static SwapDir &
 SwapDirByIndex(const int i)
 {

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -9,16 +9,23 @@
 /* DEBUG: section 47    Store Directory Routines */
 
 #include "squid.h"
+#include "cache_cf.h"
+#include "ConfigParser.h"
 #include "Debug.h"
 #include "globals.h"
 #include "profiler/Profiler.h"
+#include "sbuf/Stream.h"
 #include "SquidConfig.h"
 #include "Store.h"
 #include "store/Disk.h"
 #include "store/Disks.h"
+#include "StoreFileSystem.h"
 #include "store_rebuild.h"
 #include "swap_log_op.h"
+#include "tools.h"
 #include "util.h" // for tvSubDsec() which should be in SquidTime.h
+
+typedef SwapDir *STDIRSELECT(const StoreEntry *e);
 
 static STDIRSELECT storeDirSelectSwapDirRoundRobin;
 static STDIRSELECT storeDirSelectSwapDirLeastLoad;
@@ -26,7 +33,7 @@ static STDIRSELECT storeDirSelectSwapDirLeastLoad;
  * This function pointer is set according to 'store_dir_select_algorithm'
  * in squid.conf.
  */
-STDIRSELECT *storeDirSelectSwapDir = storeDirSelectSwapDirLeastLoad;
+static STDIRSELECT *storeDirSelectSwapDir = storeDirSelectSwapDirLeastLoad;
 
 /// The entry size to use for Disk::canStore() size limit checks.
 /// This is an optimization to avoid similar calculations in every cache_dir.
@@ -46,12 +53,20 @@ objectSizeForDirSelection(const StoreEntry &entry)
     return minSize;
 }
 
+static SwapDir &
+SwapDirByIndex(const int i)
+{
+    const auto sd = INDEXSD(i);
+    assert(sd);
+    return *sd;
+}
+
 /**
  * This new selection scheme simply does round-robin on all SwapDirs.
  * A SwapDir is skipped if it is over the max_size (100%) limit, or
  * overloaded.
  */
-static int
+static SwapDir *
 storeDirSelectSwapDirRoundRobin(const StoreEntry * e)
 {
     const int64_t objsize = objectSizeForDirSelection(*e);
@@ -64,20 +79,20 @@ storeDirSelectSwapDirRoundRobin(const StoreEntry * e)
 
     for (int i = 0; i < Config.cacheSwap.n_configured; ++i) {
         const int dirn = (firstCandidate + i) % Config.cacheSwap.n_configured;
-        const SwapDir *sd = dynamic_cast<SwapDir*>(INDEXSD(dirn));
+        auto &dir = SwapDirByIndex(dirn);
 
         int load = 0;
-        if (!sd->canStore(*e, objsize, load))
+        if (!dir.canStore(*e, objsize, load))
             continue;
 
         if (load < 0 || load > 1000) {
             continue;
         }
 
-        return dirn;
+        return &dir;
     }
 
-    return -1;
+    return nullptr;
 }
 
 /**
@@ -93,24 +108,23 @@ storeDirSelectSwapDirRoundRobin(const StoreEntry * e)
  * ALL swapdirs, regardless of state. Again, this is a hack while
  * we sort out the real usefulness of this algorithm.
  */
-static int
+static SwapDir *
 storeDirSelectSwapDirLeastLoad(const StoreEntry * e)
 {
     int64_t most_free = 0;
     int64_t best_objsize = -1;
     int least_load = INT_MAX;
     int load;
-    int dirn = -1;
+    SwapDir *selectedDir = nullptr;
     int i;
-    RefCount<SwapDir> SD;
 
     const int64_t objsize = objectSizeForDirSelection(*e);
 
     for (i = 0; i < Config.cacheSwap.n_configured; ++i) {
-        SD = dynamic_cast<SwapDir *>(INDEXSD(i));
-        SD->flags.selected = false;
+        auto &sd = SwapDirByIndex(i);
+        sd.flags.selected = false;
 
-        if (!SD->canStore(*e, objsize, load))
+        if (!sd.canStore(*e, objsize, load))
             continue;
 
         if (load < 0 || load > 1000)
@@ -119,7 +133,7 @@ storeDirSelectSwapDirLeastLoad(const StoreEntry * e)
         if (load > least_load)
             continue;
 
-        const int64_t cur_free = SD->maxSize() - SD->currentSize();
+        const int64_t cur_free = sd.maxSize() - sd.currentSize();
 
         /* If the load is equal, then look in more details */
         if (load == least_load) {
@@ -127,8 +141,8 @@ storeDirSelectSwapDirLeastLoad(const StoreEntry * e)
             if (best_objsize != -1) {
                 // cache_dir with the smallest max-size gets the known-size object
                 // cache_dir with the largest max-size gets the unknown-size object
-                if ((objsize != -1 && SD->maxObjectSize() > best_objsize) ||
-                        (objsize == -1 && SD->maxObjectSize() < best_objsize))
+                if ((objsize != -1 && sd.maxObjectSize() > best_objsize) ||
+                        (objsize == -1 && sd.maxObjectSize() < best_objsize))
                     continue;
             }
 
@@ -138,15 +152,15 @@ storeDirSelectSwapDirLeastLoad(const StoreEntry * e)
         }
 
         least_load = load;
-        best_objsize = SD->maxObjectSize();
+        best_objsize = sd.maxObjectSize();
         most_free = cur_free;
-        dirn = i;
+        selectedDir = &sd;
     }
 
-    if (dirn >= 0)
-        dynamic_cast<SwapDir *>(INDEXSD(dirn))->flags.selected = true;
+    if (selectedDir)
+        selectedDir->flags.selected = true;
 
-    return dirn;
+    return selectedDir;
 }
 
 Store::Disks::Disks():
@@ -165,9 +179,7 @@ Store::Disks::store(int const x) const
 SwapDir &
 Store::Disks::Dir(const int i)
 {
-    SwapDir *sd = INDEXSD(i);
-    assert(sd);
-    return *sd;
+    return SwapDirByIndex(i);
 }
 
 int
@@ -225,11 +237,11 @@ Store::Disks::get(const cache_key *key)
         static int idx = 0;
         for (int n = 0; n < cacheDirs; ++n) {
             idx = (idx + 1) % cacheDirs;
-            SwapDir *sd = dynamic_cast<SwapDir*>(INDEXSD(idx));
-            if (!sd->active())
+            auto &sd = Dir(idx);
+            if (!sd.active())
                 continue;
 
-            if (StoreEntry *e = sd->get(key)) {
+            if (auto e = sd.get(key)) {
                 debugs(20, 7, "cache_dir " << idx << " has: " << *e);
                 return e;
             }
@@ -363,16 +375,26 @@ Store::Disks::maxObjectSize() const
 }
 
 void
-Store::Disks::updateLimits()
+Store::Disks::configure()
 {
+    if (!Config.cacheSwap.swapDirs)
+        Controller::store_dirs_rebuilding = 0; // nothing to index
+
     largestMinimumObjectSize = -1;
     largestMaximumObjectSize = -1;
     secondLargestMaximumObjectSize = -1;
 
     for (int i = 0; i < Config.cacheSwap.n_configured; ++i) {
-        const auto &disk = Dir(i);
+        auto &disk = Dir(i);
+        if (disk.needsDiskStrand()) {
+            assert(InDaemonMode());
+            disk.disker = Config.workers + (++Config.cacheSwap.n_strands);
+        }
+
         if (!disk.active())
             continue;
+
+        // update limits
 
         if (disk.minObjectSize() > largestMinimumObjectSize)
             largestMinimumObjectSize = disk.minObjectSize();
@@ -384,6 +406,70 @@ Store::Disks::updateLimits()
             largestMaximumObjectSize = diskMaxObjectSize;
         }
     }
+}
+
+void
+Store::Disks::Parse(Store::DiskConfig &swap)
+{
+    const auto typeStr = ConfigParser::NextToken();
+    if (!typeStr)
+        throw TextException("missing cache_dir parameter: storage type", Here());
+
+    const auto pathStr = ConfigParser::NextToken();
+    if (!pathStr)
+        throw TextException("missing cache_dir parameter: directory name", Here());
+
+    const auto fs = StoreFileSystem::FindByType(typeStr);
+    if (!fs) {
+        debugs(3, DBG_PARSE_NOTE(DBG_IMPORTANT), "ERROR: This proxy does not support the '" << typeStr << "' cache type. Ignoring.");
+        return;
+    }
+
+    const auto fsType = fs->type();
+
+    // check for the existing cache_dir
+    for (int i = 0; i < swap.n_configured; ++i) {
+        auto &disk = Dir(i);
+        if ((strcasecmp(pathStr, disk.path)) == 0) {
+            /* this is specific to on-fs Stores. The right
+             * way to handle this is probably to have a mapping
+             * from paths to stores, and have on-fs stores
+             * register with that, and lookip in that in their
+             * own setup logic. RBC 20041225. TODO.
+             */
+
+            if (strcmp(disk.type(), fsType) == 0)
+                disk.reconfigure();
+            else
+                debugs(3, DBG_CRITICAL, "ERROR: Can't change type of existing cache_dir " <<
+                       disk.type() << " " << disk.path << " to " << fsType << ". Restart required");
+
+            return;
+        }
+    }
+
+    const int cacheDirCountLimit = 64; // StoreEntry::swap_dirn is a signed 7-bit integer
+    if (swap.n_configured >= cacheDirCountLimit)
+        throw TextException(ToSBuf("Squid cannot handle more than ", cacheDirCountLimit, " cache_dir directives"), Here());
+
+    // create a new cache_dir
+
+    allocate_new_swapdir(swap);
+    swap.swapDirs[swap.n_configured] = fs->createSwapDir();
+    auto &disk = Dir(swap.n_configured);
+    disk.parse(swap.n_configured, pathStr);
+    ++swap.n_configured;
+}
+
+void
+Store::Disks::Dump(const Store::DiskConfig &swap, StoreEntry &entry, const char *name)
+{
+   for (int i = 0; i < swap.n_configured; ++i) {
+       const auto &disk = SwapDirByIndex(i);
+       storeAppendPrintf(&entry, "%s %s %s", name, disk.type(), disk.path);
+       disk.dump(entry);
+       storeAppendPrintf(&entry, "\n");
+   }
 }
 
 int64_t
@@ -565,6 +651,12 @@ Store::Disks::SmpAware()
     return false;
 }
 
+SwapDir *
+Store::Disks::SelectSwapDir(const StoreEntry *e)
+{
+    return storeDirSelectSwapDir(e);
+}
+
 bool
 Store::Disks::hasReadableEntry(const StoreEntry &e) const
 {
@@ -605,7 +697,6 @@ storeDirWriteCleanLogs(int reopen)
 
     struct timeval start;
     double dt;
-    RefCount<SwapDir> sd;
     int dirn;
     int notdone = 1;
 
@@ -623,10 +714,10 @@ storeDirWriteCleanLogs(int reopen)
     start = current_time;
 
     for (dirn = 0; dirn < Config.cacheSwap.n_configured; ++dirn) {
-        sd = dynamic_cast<SwapDir *>(INDEXSD(dirn));
+        auto &sd = *INDEXSD(dirn);
 
-        if (sd->writeCleanStart() < 0) {
-            debugs(20, DBG_IMPORTANT, "log.clean.start() failed for dir #" << sd->index);
+        if (sd.writeCleanStart() < 0) {
+            debugs(20, DBG_IMPORTANT, "log.clean.start() failed for dir #" << sd.index);
             continue;
         }
     }
@@ -640,22 +731,22 @@ storeDirWriteCleanLogs(int reopen)
         notdone = 0;
 
         for (dirn = 0; dirn < Config.cacheSwap.n_configured; ++dirn) {
-            sd = dynamic_cast<SwapDir *>(INDEXSD(dirn));
+            auto &sd = SwapDirByIndex(dirn);
 
-            if (NULL == sd->cleanLog)
+            if (!sd.cleanLog)
                 continue;
 
-            e = sd->cleanLog->nextEntry();
+            e = sd.cleanLog->nextEntry();
 
             if (!e)
                 continue;
 
             notdone = 1;
 
-            if (!sd->canLog(*e))
+            if (!sd.canLog(*e))
                 continue;
 
-            sd->cleanLog->write(*e);
+            sd.cleanLog->write(*e);
 
             if ((++n & 0xFFFF) == 0) {
                 getCurrentTime();
@@ -667,7 +758,7 @@ storeDirWriteCleanLogs(int reopen)
 
     /* Flush */
     for (dirn = 0; dirn < Config.cacheSwap.n_configured; ++dirn)
-        dynamic_cast<SwapDir *>(INDEXSD(dirn))->writeCleanDone();
+        SwapDirByIndex(dirn).writeCleanDone();
 
     if (reopen)
         storeDirOpenSwapLogs();
@@ -686,21 +777,21 @@ storeDirWriteCleanLogs(int reopen)
 /* Globals that should be converted to static Store::Disks methods */
 
 void
-allocate_new_swapdir(Store::DiskConfig *swap)
+allocate_new_swapdir(Store::DiskConfig &swap)
 {
-    if (!swap->swapDirs) {
-        swap->n_allocated = 4;
-        swap->swapDirs = new SwapDir::Pointer[swap->n_allocated];
+    if (!swap.swapDirs) {
+        swap.n_allocated = 4;
+        swap.swapDirs = new SwapDir::Pointer[swap.n_allocated];
     }
 
-    if (swap->n_allocated == swap->n_configured) {
-        swap->n_allocated <<= 1;
-        const auto tmp = new SwapDir::Pointer[swap->n_allocated];
-        for (int i = 0; i < swap->n_configured; ++i) {
-            tmp[i] = swap->swapDirs[i];
+    if (swap.n_allocated == swap.n_configured) {
+        swap.n_allocated <<= 1;
+        const auto tmp = new SwapDir::Pointer[swap.n_allocated];
+        for (int i = 0; i < swap.n_configured; ++i) {
+            tmp[i] = swap.swapDirs[i];
         }
-        delete[] swap->swapDirs;
-        swap->swapDirs = tmp;
+        delete[] swap.swapDirs;
+        swap.swapDirs = tmp;
     }
 }
 
@@ -758,6 +849,6 @@ storeDirSwapLog(const StoreEntry * e, int op)
            e->swap_dirn << " " <<
            std::hex << std::uppercase << std::setfill('0') << std::setw(8) << e->swap_filen);
 
-    dynamic_cast<SwapDir *>(INDEXSD(e->swap_dirn))->logEntry(*e, op);
+    SwapDirByIndex(e->swap_dirn).logEntry(*e, op);
 }
 

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -855,3 +855,4 @@ storeDirSwapLog(const StoreEntry * e, int op)
 
     e->disk().logEntry(*e, op);
 }
+

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -42,14 +42,19 @@ public:
     virtual void evictIfFound(const cache_key *) override;
     virtual int callback() override;
 
-    /// slowly calculate (and cache) hi/lo watermarks and similar limits
-    void updateLimits();
+    /// update configuration, including limits (re)calculation
+    void configure();
+    /// parses a single cache_dir configuration line
+    static void Parse(Store::DiskConfig &);
+    /// prints the configuration into the provided StoreEntry
+    static void Dump(const Store::DiskConfig &, StoreEntry &, const char *name);
 
     /// Additional unknown-size entry bytes required by disks in order to
     /// reduce the risk of selecting the wrong disk cache for the growing entry.
     int64_t accumulateMore(const StoreEntry&) const;
     /// whether any disk cache is SMP-aware
     static bool SmpAware();
+    static SwapDir *SelectSwapDir(const StoreEntry *);
     /// whether any of disk caches has entry with e.key
     bool hasReadableEntry(const StoreEntry &) const;
 
@@ -71,12 +76,9 @@ int storeDirWriteCleanLogs(int reopen);
 void storeDirCloseSwapLogs(void);
 
 /* Globals that should be converted to static Store::Disks methods */
-void allocate_new_swapdir(Store::DiskConfig *swap);
+void allocate_new_swapdir(Store::DiskConfig &swap);
 void free_cachedir(Store::DiskConfig *swap);
 
-/* Globals that should be converted to Store::Disks private data members */
-typedef int STDIRSELECT(const StoreEntry *e);
-extern STDIRSELECT *storeDirSelectSwapDir;
 
 /* Globals that should be moved to some Store::UFS-specific logging module */
 void storeDirSwapLog(const StoreEntry *e, int op);

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -45,9 +45,9 @@ public:
     /// update configuration, including limits (re)calculation
     void configure();
     /// parses a single cache_dir configuration line
-    static void Parse(Store::DiskConfig &);
+    static void Parse(DiskConfig &);
     /// prints the configuration into the provided StoreEntry
-    static void Dump(const Store::DiskConfig &, StoreEntry &, const char *name);
+    static void Dump(const DiskConfig &, StoreEntry &, const char *name);
 
     /// Additional unknown-size entry bytes required by disks in order to
     /// reduce the risk of selecting the wrong disk cache for the growing entry.

--- a/src/store_io.cc
+++ b/src/store_io.cc
@@ -32,19 +32,16 @@ storeCreate(StoreEntry * e, StoreIOState::STFNCB * file_callback, StoreIOState::
      * Pick the swapdir
      * We assume that the header has been packed by now ..
      */
-    const sdirno dirn = storeDirSelectSwapDir(e);
+    const auto sd = Store::Disks::SelectSwapDir(e);
 
-    if (dirn == -1) {
+    if (!sd) {
         debugs(20, 2, "storeCreate: no swapdirs for " << *e);
         ++store_io_stats.create.select_fail;
         return NULL;
     }
 
-    debugs(20, 2, "storeCreate: Selected dir " << dirn << " for " << *e);
-    SwapDir *SD = dynamic_cast<SwapDir *>(INDEXSD(dirn));
-
     /* Now that we have a fs to use, call its storeCreate function */
-    StoreIOState::Pointer sio = SD->createStoreIO(*e, file_callback, close_callback, callback_data);
+    StoreIOState::Pointer sio = sd->createStoreIO(*e, file_callback, close_callback, callback_data);
 
     if (sio == NULL)
         ++store_io_stats.create.create_fail;

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -50,8 +50,7 @@ StoreRebuildData::updateStartTime(const timeval &dirStartTime)
 static int
 storeCleanupDoubleCheck(StoreEntry * e)
 {
-    SwapDir *SD = dynamic_cast<SwapDir *>(INDEXSD(e->swap_dirn));
-    return (SD->doubleCheck(*e));
+    return e->disk().doubleCheck(*e);
 }
 
 static void

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -47,12 +47,6 @@ StoreRebuildData::updateStartTime(const timeval &dirStartTime)
     startTime = started() ? std::min(startTime, dirStartTime) : dirStartTime;
 }
 
-static int
-storeCleanupDoubleCheck(StoreEntry * e)
-{
-    return e->disk().doubleCheck(*e);
-}
-
 static void
 storeCleanup(void *)
 {
@@ -85,7 +79,7 @@ storeCleanup(void *)
             continue;
 
         if (opt_store_doublecheck)
-            if (storeCleanupDoubleCheck(e))
+            if (e->disk().doubleCheck(*e))
                 ++store_errors;
 
         EBIT_SET(e->flags, ENTRY_VALIDATED);

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -37,7 +37,7 @@ bool Controller::markedForDeletion(const cache_key *) const STUB_RETVAL(false)
 bool Controller::markedForDeletionAndAbandoned(const StoreEntry &) const STUB_RETVAL(false)
 bool Controller::hasReadableDiskEntry(const StoreEntry &) const STUB_RETVAL(false)
 int64_t Controller::accumulateMore(StoreEntry &) const STUB_RETVAL(0)
-void Controller::updateLimits() STUB
+void Controller::configure() STUB
 void Controller::handleIdleEntry(StoreEntry &) STUB
 void Controller::freeMemorySpace(const int) STUB
 void Controller::memoryOut(StoreEntry &, const bool) STUB
@@ -122,17 +122,19 @@ bool Disks::updateAnchored(StoreEntry &) STUB_RETVAL(false)
 void Disks::evictCached(StoreEntry &) STUB
 void Disks::evictIfFound(const cache_key *) STUB
 int Disks::callback() STUB_RETVAL(0)
-void Disks::updateLimits() STUB
+void Disks::configure() STUB
 int64_t Disks::accumulateMore(const StoreEntry&) const STUB_RETVAL(0)
 bool Disks::SmpAware() STUB_RETVAL(false)
 bool Disks::hasReadableEntry(const StoreEntry &) const STUB_RETVAL(false)
+void Disks::Parse(Store::DiskConfig &) STUB
+void Disks::Dump(const Store::DiskConfig &, StoreEntry &, const char *name) STUB
+SwapDir *Store::Disks::SelectSwapDir(const StoreEntry *) STUB_RETVAL(nullptr)
 }
 void storeDirOpenSwapLogs(void) STUB
 int storeDirWriteCleanLogs(int) STUB_RETVAL(0)
 void storeDirCloseSwapLogs(void) STUB
-void allocate_new_swapdir(Store::DiskConfig *) STUB
-void free_cachedir(Store::DiskConfig *) STUB
-STDIRSELECT *storeDirSelectSwapDir = nullptr;
+void allocate_new_swapdir(Store::DiskConfig &) STUB
+void free_cachedir(Store::DiskConfig *) STUB;
 void storeDirSwapLog(const StoreEntry *, int) STUB
 
 #include "store/LocalSearch.h"

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -126,9 +126,9 @@ void Disks::configure() STUB
 int64_t Disks::accumulateMore(const StoreEntry&) const STUB_RETVAL(0)
 bool Disks::SmpAware() STUB_RETVAL(false)
 bool Disks::hasReadableEntry(const StoreEntry &) const STUB_RETVAL(false)
-void Disks::Parse(Store::DiskConfig &) STUB
-void Disks::Dump(const Store::DiskConfig &, StoreEntry &, const char *name) STUB
-SwapDir *Store::Disks::SelectSwapDir(const StoreEntry *) STUB_RETVAL(nullptr)
+void Disks::Parse(DiskConfig &) STUB
+void Disks::Dump(const DiskConfig &, StoreEntry &, const char *name) STUB
+SwapDir *Disks::SelectSwapDir(const StoreEntry *) STUB_RETVAL(nullptr)
 }
 void storeDirOpenSwapLogs(void) STUB
 int storeDirWriteCleanLogs(int) STUB_RETVAL(0)

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -45,7 +45,7 @@ static char cwd[MAXPATHLEN];
 static void
 addSwapDir(testRock::SwapDirPointer aStore)
 {
-    allocate_new_swapdir(&Config.cacheSwap);
+    allocate_new_swapdir(Config.cacheSwap);
     Config.cacheSwap.swapDirs[Config.cacheSwap.n_configured] = aStore.getRaw();
     ++Config.cacheSwap.n_configured;
 }

--- a/src/tests/testStoreController.cc
+++ b/src/tests/testStoreController.cc
@@ -21,7 +21,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( testStoreController );
 static void
 addSwapDir(TestSwapDirPointer aStore)
 {
-    allocate_new_swapdir(&Config.cacheSwap);
+    allocate_new_swapdir(Config.cacheSwap);
     Config.cacheSwap.swapDirs[Config.cacheSwap.n_configured] = aStore.getRaw();
     ++Config.cacheSwap.n_configured;
 }

--- a/src/tests/testStoreHashIndex.cc
+++ b/src/tests/testStoreHashIndex.cc
@@ -21,7 +21,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( testStoreHashIndex );
 static void
 addSwapDir(TestSwapDirPointer aStore)
 {
-    allocate_new_swapdir(&Config.cacheSwap);
+    allocate_new_swapdir(Config.cacheSwap);
     Config.cacheSwap.swapDirs[Config.cacheSwap.n_configured] = aStore.getRaw();
     ++Config.cacheSwap.n_configured;
 }

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -34,7 +34,7 @@ extern REMOVALPOLICYCREATE createRemovalPolicy_lru; /* XXX fails with --enable-r
 static void
 addSwapDir(MySwapDirPointer aStore)
 {
-    allocate_new_swapdir(&Config.cacheSwap);
+    allocate_new_swapdir(Config.cacheSwap);
     Config.cacheSwap.swapDirs[Config.cacheSwap.n_configured] = aStore.getRaw();
     ++Config.cacheSwap.n_configured;
 }


### PR DESCRIPTION
Detected by Coverity. CID 1461158: Null pointer dereferences
(FORWARD_NULL).

When fixing these problems, we moved a few cache_dir iterations into
Disks.cc by applying the "Only Store::Disks can iterate cache_dirs"
design principle to the changed code. The Disks class is responsible for
maintaining (and will eventually encapsulate all the knowledge of) the
set of cache_dirs. Adjusted cache_cf.cc no longer depends on Disk.h.