### PR TITLE
Squid-to-client write_timeout triggers client_lifetime timeout

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1607,6 +1607,7 @@ checkTimeouts(void)
             Comm::SetSelect(fd, COMM_SELECT_WRITE, NULL, NULL, 0);
             COMMIO_FD_WRITECB(fd)->finish(Comm::COMM_ERROR, ETIMEDOUT);
             CodeContext::Reset();
+            continue;
 #if USE_DELAY_POOLS
         } else if (F->writeQuotaHandler != nullptr && COMMIO_FD_WRITECB(fd)->conn != nullptr) {
             // TODO: Move and extract quota() call to place it inside F->codeContext.


### PR DESCRIPTION
Since commit 5ef5e5c, a socket write timeout triggers two things:
* reporting of a write error to the socket writer (as designed/expected)
* reporting of a socket read timeout to the socket reader (unexpected).

The exact outcome probably depends on the transaction state, but one
known manifestation of this bug is the following level-1 message in
cache.log, combined with an access.log record showing a
much-shorter-than-client_lifetime transaction response time.

    WARNING: Closing client connection due to lifetime timeout