### PR TITLE
Transactions exceeding client_lifetime are logged as _ABORTED

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2169,7 +2169,8 @@ clientLifetimeTimeout(const CommTimeoutCbParams &io)
     ClientHttpRequest *http = static_cast<ClientHttpRequest *>(io.data);
     debugs(33, DBG_IMPORTANT, "WARNING: Closing client connection due to lifetime timeout");
     debugs(33, DBG_IMPORTANT, "\t" << http->uri);
-    http->logType.err.timedout = true;
+    if (const auto conn = http->getConn())
+        conn->pipeline.terminateAll(ETIMEDOUT);
     if (Comm::IsConnOpen(io.conn))
         io.conn->close();
 }


### PR DESCRIPTION
... rather than timed out (_TIMEOUT).

To record the right cause of death, we have to call terminateAll()
rather than setting logType.err.timedout directly. Otherwise, when
ConnStateData::swanSong() calls terminateAll(0), it overwrites our
direct setting.