### PR TITLE
Cleanup helper.h classes

### DIFF
--- a/src/helper.cc
+++ b/src/helper.cc
@@ -155,6 +155,7 @@ helper_server::helper_server(helper *hlp, int aPid, void *aIpc, int rfd, int wfd
     HelperServerBase(hlp->cmdline->key, hlp->addr, aPid, aIpc, rfd, wfd),
     parent(cbdataReference(hlp))
 {
+    wqueue = new MemBuf;
 }
 
 helper_server::~helper_server()

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -131,9 +131,10 @@ HelperServerBase::HelperServerBase(const char *desc, Ip::Address &ip, int aPid, 
     addr(ip),
     readPipe(new Comm::Connection),
     writePipe(new Comm::Connection),
-    hIpc(aIpc),
-    rbuf(static_cast<char *>(memAllocBuf(ReadBufSize, &rbuf_sz)))
+    hIpc(aIpc)
 {
+    rbuf = static_cast<char *>(memAllocBuf(ReadBufSize, &rbuf_sz));
+
     readPipe->fd = rfd;
     readPipe->noteStart();
     fd_note(readPipe->fd, desc);

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -60,16 +60,6 @@ CBDATA_CLASS_INIT(helper_stateful_server);
 InstanceIdDefinitions(HelperServerBase, "Hlpr");
 
 void
-HelperServerBase::initStats()
-{
-    stats.uses=0;
-    stats.replies=0;
-    stats.pending=0;
-    stats.releases=0;
-    stats.timedout = 0;
-}
-
-void
 HelperServerBase::closePipesSafely(const char *id_name)
 {
 #if _SQUID_WINDOWS_
@@ -136,12 +126,35 @@ HelperServerBase::dropQueued()
     }
 }
 
+HelperServerBase::HelperServerBase(const char *desc, Ip::Address &ip, int aPid, void *aIpc, int rfd, int wfd) :
+    pid(aPid),
+    addr(ip),
+    readPipe(new Comm::Connection),
+    writePipe(new Comm::Connection),
+    hIpc(aIpc),
+    rbuf(static_cast<char *>(memAllocBuf(ReadBufSize, &rbuf_sz)))
+{
+    readPipe->fd = rfd;
+    readPipe->noteStart();
+    fd_note(readPipe->fd, desc);
+
+    writePipe->fd = wfd;
+    writePipe->noteStart();
+    fd_note(writePipe->fd, desc);
+}
+
 HelperServerBase::~HelperServerBase()
 {
     if (rbuf) {
         memFreeBuf(rbuf_sz, rbuf);
         rbuf = NULL;
     }
+}
+
+helper_server::helper_server(helper *hlp, int aPid, void *aIpc, int rfd, int wfd) :
+    HelperServerBase(hlp->cmdline->key, hlp->addr, aPid, aIpc, rfd, wfd),
+    parent(cbdataReference(hlp))
+{
 }
 
 helper_server::~helper_server()
@@ -174,6 +187,12 @@ helper_server::dropQueued()
     requestsIndex.clear();
 }
 
+helper_stateful_server::helper_stateful_server(statefulhelper *hlp, int aPid, void *aIpc, int rfd, int wfd) :
+    HelperServerBase(hlp->cmdline->key, hlp->addr, aPid, aIpc, rfd, wfd),
+    parent(cbdataReference(hlp))
+{
+}
+
 helper_stateful_server::~helper_stateful_server()
 {
     /* TODO: walk the local queue of requests and carry them all out */
@@ -201,7 +220,6 @@ helperOpenServers(helper * hlp)
     char *procname;
     const char *args[HELPER_MAX_ARGS+1]; // save space for a NULL terminator
     char fd_note_buf[FD_DESC_SZ];
-    helper_server *srv;
     int nargs = 0;
     int k;
     pid_t pid;
@@ -265,22 +283,7 @@ helperOpenServers(helper * hlp)
 
         ++ hlp->childs.n_running;
         ++ hlp->childs.n_active;
-        srv = new helper_server;
-        srv->hIpc = hIpc;
-        srv->pid = pid;
-        srv->initStats();
-        srv->addr = hlp->addr;
-        srv->readPipe = new Comm::Connection;
-        srv->readPipe->fd = rfd;
-        srv->writePipe = new Comm::Connection;
-        srv->writePipe->fd = wfd;
-        srv->rbuf = (char *)memAllocBuf(ReadBufSize, &srv->rbuf_sz);
-        srv->wqueue = new MemBuf;
-        srv->roffset = 0;
-        srv->nextRequestId = 0;
-        srv->replyXaction = NULL;
-        srv->ignoreToEom = false;
-        srv->parent = cbdataReference(hlp);
+        auto *srv = new helper_server(hlp, pid, hIpc, rfd, wfd);
         dlinkAddTail(srv, &srv->link, &hlp->servers);
 
         if (rfd == wfd) {
@@ -392,20 +395,7 @@ helperStatefulOpenServers(statefulhelper * hlp)
 
         ++ hlp->childs.n_running;
         ++ hlp->childs.n_active;
-        helper_stateful_server *srv = new helper_stateful_server;
-        srv->hIpc = hIpc;
-        srv->pid = pid;
-        srv->initStats();
-        srv->addr = hlp->addr;
-        srv->readPipe = new Comm::Connection;
-        srv->readPipe->fd = rfd;
-        srv->writePipe = new Comm::Connection;
-        srv->writePipe->fd = wfd;
-        srv->rbuf = (char *)memAllocBuf(ReadBufSize, &srv->rbuf_sz);
-        srv->roffset = 0;
-        srv->parent = cbdataReference(hlp);
-        srv->reservationStart = 0;
-
+        auto *srv = new helper_stateful_server(hlp, pid, hIpc, rfd, wfd);
         dlinkAddTail(srv, &srv->link, &hlp->servers);
 
         if (rfd == wfd) {

--- a/src/security/cert_generators/file/security_file_certgen.cc
+++ b/src/security/cert_generators/file/security_file_certgen.cc
@@ -336,7 +336,13 @@ int main(int argc, char *argv[])
                 if (fgets(request, HELPER_INPUT_BUFFER, stdin) == NULL)
                     exit(EXIT_FAILURE);
                 size_t gcount = strlen(request);
+                if (debug_enabled) {
+                    std::cerr << argv[0] << ": received " << gcount << " bytes from Squid" << std::endl << " " << request << std::endl;
+                }
                 parse_result = request_message.parse(request, gcount);
+                if (debug_enabled) {
+                    std::cerr << argv[0] << ": parsed result=" << parse_result << std::endl;
+                }
             }
 
             if (parse_result == Ssl::CrtdMessage::ERROR) {


### PR DESCRIPTION
Polish up the classes in helper.h to use proper constructors as the
caller API for creation + initialization. Use C++11 initialization for
default values.

* no "virtual" in helper class destructor declaration could create
  memory leaks in future (poorly) refactored code; the gained protection
  is probably worth adding the (currently unused) virtual table to the
  helper class; resolves Coverity issue CID 1461141 (VIRTUAL_DTOR)
* missing Comm::Connection timers initialization on helper startup
* multiple initialization of values used for state accounting
* initialization of booleans to non-0 integer values
* initialization of char using numeric values
* missing mgr:filedescriptors description for helper sockets