### PR TITLE
Reject different HTTP requests with unusual framing

### DIFF
--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -73,13 +73,19 @@ This section gives an account of those changes in three categories:
 	<p>Obsolete. Squid accepts an entity (aka payload, body) on
 	   HTTP/1.1 GET or HEAD requests when a Content-Length or
 	   Transfer-Encoding header is presented to clearly determine size.
-	<p>To retain the old behaviour use <em>http_access</em> rules:
+	<p>To retain the old behaviour of rejecting GET/HEAD payloads
+	   for HTTP/1.1 use <em>http_access</em> rules:
 <verb>
   acl fetch method GET HEAD
   acl entity req_header Content-Length .
   http_access deny fetch entity
 </verb>
-
+	<p>Squid will reject use of Content-Length header on HTTP/1.0
+	   messages with GET, HEAD, DELETE, LINK, UNLINK methods. Since
+	   the HTTP/1.0 specification defines those as not having entities.
+	   To deliver entities on these methods the chunked encoding
+	   feature defined by HTTP/1.1 must be used, or the request
+	   upgraded to an HTTP/1.1 message.
 </descrip>
 
 

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -69,7 +69,16 @@ This section gives an account of those changes in three categories:
 <sect1>Removed directives<label id="removeddirectives">
 <p>
 <descrip>
-	<p>There have been no directives changed.
+	<tag>request_entities</tag>
+	<p>Obsolete. Squid accepts an entity (aka payload, body) on
+	   HTTP/1.1 GET or HEAD requests when a Content-Length or
+	   Transfer-Encoding header is presented to clearly determine size.
+	<p>To retain the old behaviour use <em>http_access</em> rules:
+<verb>
+  acl fetch method GET HEAD
+  acl entity req_header Content-Length .
+  http_access deny fetch entity
+</verb>
 
 </descrip>
 

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -654,6 +654,14 @@ HttpRequest::canHandle1xx() const
 Http::StatusCode
 HttpRequest::checkEntityFraming() const
 {
+    // RFC 7230 section 3.3.1:
+    // "
+    //  A server that receives a request message with a transfer coding it
+    //  does not understand SHOULD respond with 501 (Not Implemented).
+    // "
+    if (header.unsupportedTe())
+        return Http::scNotImplemented;
+
     // RFC 7230 section 3.3.3 #3 paragraph 3:
     // Transfer-Encoding overrides Content-Length
     if (header.chunked())

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -652,8 +652,13 @@ HttpRequest::canHandle1xx() const
 }
 
 Http::StatusCode
-HttpRequest::canUseContentLength() const
+HttpRequest::checkEntityFraming() const
 {
+    // RFC 7230 section 3.3.3 #3 paragraph 3:
+    // Transfer-Encoding overrides Content-Length
+    if (header.chunked())
+        return Http::scNone;
+
     // RFC 7230 Section 3.3.3 #4:
     // conflicting Content-Length(s) mean a message framing error
     if (header.conflictingContentLength())

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -248,8 +248,9 @@ public:
 
     virtual void configureContentLengthInterpreter(Http::ContentLengthInterpreter &) {}
 
-    /// checks whether the Content-Length header (or lack of) is acceptible
-    Http::StatusCode canUseContentLength() const;
+    /// Check whether the message framing headers are valid.
+    /// \returns Http::scNone or an HTTP error status
+    Http::StatusCode checkEntityFraming() const;
 
     /// Parses request header using Parser.
     /// Use it in contexts where the Parser object is available.

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -249,7 +249,7 @@ public:
     virtual void configureContentLengthInterpreter(Http::ContentLengthInterpreter &) {}
 
     /// checks whether the Content-Length header (or lack of) is acceptible
-    bool canUseContentLength() const;
+    Http::StatusCode canUseContentLength() const;
 
     /// Parses request header using Parser.
     /// Use it in contexts where the Parser object is available.

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -248,6 +248,9 @@ public:
 
     virtual void configureContentLengthInterpreter(Http::ContentLengthInterpreter &) {}
 
+    /// checks whether the Content-Length header (or lack of) is acceptible
+    bool canUseContentLength() const;
+
     /// Parses request header using Parser.
     /// Use it in contexts where the Parser object is available.
     bool parseHeader(Http1::Parser &hp);

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -316,7 +316,6 @@ public:
 
         int vary_ignore_expire;
         int surrogate_is_remote;
-        int request_entities;
         int detect_broken_server_pconns;
         int relaxed_header_parser;
         int check_hostnames;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -181,6 +181,13 @@ DOC_START
 	This option is not yet supported by Squid-3.
 DOC_END
 
+# Options removed in 6.x
+NAME: request_entities
+TYPE: obsolete
+DOC_START
+	Remove this line. HTTP/1.1 defines per-message control over GET/HEAD message body using headers.
+DOC_END
+
 # Options removed in 5.x
 NAME: dns_v4_first
 TYPE: obsolete
@@ -6652,22 +6659,6 @@ DOC_START
 
 	WARNING: If turned on this may eventually cause some
 	varying objects not intended for caching to get cached.
-DOC_END
-
-NAME: request_entities
-TYPE: onoff
-LOC: Config.onoff.request_entities
-DEFAULT: off
-DOC_START
-	Squid defaults to deny GET and HEAD requests with request entities,
-	as the meaning of such requests are undefined in the HTTP standard
-	even if not explicitly forbidden.
-
-	Set this directive to on if you have clients which insists
-	on sending request entities in GET or HEAD requests. But be warned
-	that there is server software (both proxies and web servers) which
-	can fail to properly process this kind of request which may make you
-	vulnerable to cache pollution attacks if enabled.
 DOC_END
 
 NAME: request_header_access

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -185,7 +185,7 @@ DOC_END
 NAME: request_entities
 TYPE: obsolete
 DOC_START
-	Remove this line. HTTP/1.1 defines per-message control over GET/HEAD message body using headers.
+	Remove this line. Squid now accepts GET/HEAD message body by default.
 DOC_END
 
 # Options removed in 5.x

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -185,7 +185,8 @@ DOC_END
 NAME: request_entities
 TYPE: obsolete
 DOC_START
-	Remove this line. Squid now accepts GET/HEAD message body by default.
+	Remove this line. Squid now accepts HTTP/1.1 requests with bodies.
+	To simplify UI and code, Squid rejects certain HTTP/1.0 requests with bodies.
 DOC_END
 
 # Options removed in 5.x

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -700,7 +700,7 @@ clientSetKeepaliveFlag(ClientHttpRequest * http)
 
 /// checks body length of non-chunked requests
 static bool
-clientIsContentLengthValid(HttpRequest * r)
+clientIsContentLengthValid(const HttpRequestPointer &r)
 {
     // No Content-Length means this request just has no body, but conflicting
     // Content-Lengths mean a message framing error (RFC 7230 Section 3.3.3 #4).
@@ -1720,7 +1720,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
     }
 
     const auto chunked = request->header.chunked();
-    if (!chunked && !clientIsContentLengthValid(request.getRaw())) {
+    if (!chunked && !clientIsContentLengthValid(request)) {
         clientStreamNode *node = context->getClientReplyContext();
         clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
         assert (repContext);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -708,7 +708,7 @@ clientIsContentLengthValid(const HttpRequestPointer &r)
         return false;
 
     // RFC 7230 section 3.3 - Content-Length defines body exists regardless of method
-    if (r->content_length > 0)
+    if (r->content_length >= 0)
         return true;
 
     // We do not want a request entity on HTTP/1.0 GET/HEAD requests

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1697,18 +1697,19 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
     }
 
     const auto chunked = request->header.chunked();
-    if (!chunked && !request->canUseContentLength()) {
-        clientStreamNode *node = context->getClientReplyContext();
-        clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
-        assert (repContext);
-        conn->quitAfterError(request.getRaw());
-        repContext->setReplyToError(ERR_INVALID_REQ,
-                                    Http::scLengthRequired, request->method, NULL,
-                                    conn, request.getRaw(), nullptr, nullptr);
-        assert(context->http->out.offset == 0);
-        context->pullData();
-        clientProcessRequestFinished(conn, request);
-        return;
+    if (!chunked) {
+        const auto clResult = request->canUseContentLength();
+        if (clResult != Http::scNone) {
+            auto *node = context->getClientReplyContext();
+            auto *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
+            assert(repContext);
+            conn->quitAfterError(request.getRaw());
+            repContext->setReplyToError(ERR_INVALID_REQ, clResult, request->method, nullptr, conn, request.getRaw(), nullptr, nullptr);
+            assert(context->http->out.offset == 0);
+            context->pullData();
+            clientProcessRequestFinished(conn, request);
+            return;
+        }
     }
 
     clientSetKeepaliveFlag(http);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1679,11 +1679,9 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
         request->http_ver.minor = http_ver.minor;
     }
 
-    const auto unsupportedTe = request->header.unsupportedTe();
-
     mustReplyToOptions = (request->method == Http::METHOD_OPTIONS) &&
                          (request->header.getInt64(Http::HdrType::MAX_FORWARDS) == 0);
-    if (!urlCheckRequest(request.getRaw()) || mustReplyToOptions || unsupportedTe) {
+    if (!urlCheckRequest(request.getRaw()) || mustReplyToOptions) {
         clientStreamNode *node = context->getClientReplyContext();
         conn->quitAfterError(request.getRaw());
         clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1696,9 +1696,9 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
 
     const auto frameStatus = request->checkEntityFraming();
     if (frameStatus != Http::scNone) {
-        auto *node = context->getClientReplyContext();
-        auto *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
-        assert(repContext);
+        clientStreamNode *node = context->getClientReplyContext();
+        clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());
+        assert (repContext);
         conn->quitAfterError(request.getRaw());
         repContext->setReplyToError(ERR_INVALID_REQ, frameStatus, request->method, nullptr, conn, request.getRaw(), nullptr, nullptr);
         assert(context->http->out.offset == 0);

--- a/src/http/MethodType.h
+++ b/src/http/MethodType.h
@@ -31,11 +31,9 @@ typedef enum _method_t {
     METHOD_OPTIONS,
     METHOD_DELETE,
 
-#if NO_SPECIAL_HANDLING
     // RFC 2068
     METHOD_LINK,
     METHOD_UNLINK,
-#endif
 
     // RFC 3253
     METHOD_CHECKOUT,


### PR DESCRIPTION
... and remove support for request_entities.

Squid now follows the following (approximate) rules when checking HTTP
request framing. The first matching rule wins.

* HTTP requests with a Transfer-Encoding:chunked header, including GET
  and HEAD requests with that header, are accepted. No changes here.

* HTTP requests with unsupported Transfer-Encoding values are rejected
  (Squid replies with HTTP 501 "Not Implemented"). No changes here.

* HTTP requests having conflicting Content-Length values are rejected
  (Squid replies with HTTP 400 "Bad Request"). No changes here.

* HTTP/1.0 and HTTP/0.9 POST and PUT requests without a valid
  Content-Length header are now rejected (Squid replies with HTTP 411
  "Length Required"). All of these were allowed before.

* HTTP/1.0 GET and HEAD requests with a Content-Length:0 header are now
  rejected (Squid replies with HTTP 400 "Bad Request"). All of these
  were allowed before.

* HTTP/1.0 GET and HEAD requests with a positive Content-Length header
  are now rejected (Squid replies with HTTP 400 "Bad Request"). All of
  these were allowed before if and only if the request_entities
  directive was explicitly set to "on".

There are no other framing-related HTTP request restrictions. Prior to
these changes, HTTP/1.1 GET and HEAD requests with a positive
Content-Length header were rejected unless the request_entities
directive was explicitly set to "on". The following configuration sketch
keeps rejecting those requests:

    acl getOrHead method GET HEAD
    acl withContentLength req_header Content-Length .
    http_access deny getOrHead withContentLength

The new restrictions were added due to possibility of cache corruption
attacks and other security issues related to HTTP request framing.

The request_entities directive was removed to simplify decision logic.

Some developers believe that these changes should be accompanied by
configuration options that allow admins to bypass (most of) the
previously absent restrictions. However, these developers do not know of
any important use cases that these changes break, and such cases may not
even exist. The authors insist on these security-driven changes.
