### PR TITLE
Deduplicating IPC strand messages

### DIFF
--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -144,7 +144,7 @@ IpcIoFile::open(int flags, mode_t mode, RefCount<IORequestor> callback)
 
         queue->localRateLimit().store(config.ioRate);
 
-        Ipc::StrandMessage::NotifyCoordinator(Ipc::mtRegistration, dbName.termedBuf());
+        Ipc::StrandMessage::NotifyCoordinator(Ipc::mtStrandRegistration, dbName.termedBuf());
 
         ioRequestor->ioCompletedNotification();
         return;

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -144,7 +144,7 @@ IpcIoFile::open(int flags, mode_t mode, RefCount<IORequestor> callback)
 
         queue->localRateLimit().store(config.ioRate);
 
-        Ipc::StrandMessage::NotifyCoordinator(Ipc::mtStrandRegistration, dbName.termedBuf());
+        Ipc::StrandMessage::NotifyCoordinator(Ipc::mtRegisterStrand, dbName.termedBuf());
 
         ioRequestor->ioCompletedNotification();
         return;

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -23,6 +23,7 @@
 #include "ipc/Messages.h"
 #include "ipc/Port.h"
 #include "ipc/Queue.h"
+#include "ipc/StrandCoord.h"
 #include "ipc/StrandSearch.h"
 #include "ipc/UdsOp.h"
 #include "sbuf/SBuf.h"
@@ -143,11 +144,7 @@ IpcIoFile::open(int flags, mode_t mode, RefCount<IORequestor> callback)
 
         queue->localRateLimit().store(config.ioRate);
 
-        Ipc::HereIamMessage ann(Ipc::StrandCoord(KidIdentifier, myPid));
-        ann.strand.tag = dbName;
-        Ipc::TypedMsgHdr message;
-        ann.pack(message);
-        SendMessage(Ipc::Port::CoordinatorAddr(), message);
+        Ipc::StrandMessage::NotifyCoordinator(Ipc::mtRegistration, dbName.termedBuf());
 
         ioRequestor->ioCompletedNotification();
         return;
@@ -168,7 +165,7 @@ IpcIoFile::open(int flags, mode_t mode, RefCount<IORequestor> callback)
 }
 
 void
-IpcIoFile::openCompleted(const Ipc::StrandSearchResponse *const response)
+IpcIoFile::openCompleted(const Ipc::StrandMessage *const response)
 {
     Must(diskId < 0); // we do not know our disker yet
 
@@ -455,7 +452,7 @@ IpcIoFile::canWait() const
 
 /// called when coordinator responds to worker open request
 void
-IpcIoFile::HandleOpenResponse(const Ipc::StrandSearchResponse &response)
+IpcIoFile::HandleOpenResponse(const Ipc::StrandMessage &response)
 {
     debugs(47, 7, HERE << "coordinator response to open request");
     for (IpcIoFileList::iterator i = WaitingForOpen.begin();

--- a/src/DiskIO/IpcIo/IpcIoFile.h
+++ b/src/DiskIO/IpcIo/IpcIoFile.h
@@ -87,7 +87,7 @@ public:
     virtual bool ioInProgress() const;
 
     /// handle open response from coordinator
-    static void HandleOpenResponse(const Ipc::StrandSearchResponse &response);
+    static void HandleOpenResponse(const Ipc::StrandMessage &);
 
     /// handle queue push notifications from worker or disker
     static void HandleNotification(const Ipc::TypedMsgHdr &msg);
@@ -99,7 +99,7 @@ public:
 
 protected:
     friend class IpcIoPendingRequest;
-    void openCompleted(const Ipc::StrandSearchResponse *const response);
+    void openCompleted(const Ipc::StrandMessage *);
     void readCompleted(ReadRequest *readRequest, IpcIoMsg *const response);
     void writeCompleted(WriteRequest *writeRequest, const IpcIoMsg *const response);
     bool canWait() const;

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -78,13 +78,13 @@ void Ipc::Coordinator::registerStrand(const StrandCoord& strand)
 
 void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 {
-    switch (message.type()) {
+    switch (message.rawType()) {
     case mtRegistration:
         debugs(54, 6, HERE << "Registration request");
-        handleRegistrationRequest(HereIamMessage(message));
+        handleRegistrationRequest(StrandMessage(message));
         break;
 
-    case mtStrandSearchRequest: {
+    case mtFindStrand: {
         const StrandSearchRequest sr(message);
         debugs(54, 6, HERE << "Strand search request: " << sr.requestorId <<
                " tag: " << sr.tag);
@@ -128,12 +128,12 @@ void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 #endif
 
     default:
-        debugs(54, DBG_IMPORTANT, HERE << "Unhandled message type: " << message.type());
+        debugs(54, DBG_IMPORTANT, "WARNING: Ignoring IPC message with an unknown type: " << message.rawType());
         break;
     }
 }
 
-void Ipc::Coordinator::handleRegistrationRequest(const HereIamMessage& msg)
+void Ipc::Coordinator::handleRegistrationRequest(const StrandMessage& msg)
 {
     registerStrand(msg.strand);
 
@@ -222,7 +222,7 @@ Ipc::Coordinator::notifySearcher(const Ipc::StrandSearchRequest &request,
 {
     debugs(54, 3, HERE << "tell kid" << request.requestorId << " that " <<
            request.tag << " is kid" << strand.kidId);
-    const StrandSearchResponse response(strand);
+    const StrandMessage response(Ipc::mtStrandReady, strand);
     TypedMsgHdr message;
     response.pack(message);
     SendMessage(MakeAddr(strandAddrLabel, request.requestorId), message);

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -139,7 +139,7 @@ void Ipc::Coordinator::handleRegistrationRequest(const StrandMessage& msg)
 
     // send back an acknowledgement; TODO: remove as not needed?
     TypedMsgHdr message;
-    msg.pack(message);
+    msg.pack(mtStrandRegistration, message);
     SendMessage(MakeAddr(strandAddrLabel, msg.strand.kidId), message);
 }
 
@@ -222,9 +222,9 @@ Ipc::Coordinator::notifySearcher(const Ipc::StrandSearchRequest &request,
 {
     debugs(54, 3, HERE << "tell kid" << request.requestorId << " that " <<
            request.tag << " is kid" << strand.kidId);
-    const StrandMessage response(Ipc::mtStrandReady, strand);
+    const StrandMessage response(strand);
     TypedMsgHdr message;
-    response.pack(message);
+    response.pack(mtStrandReady, message);
     SendMessage(MakeAddr(strandAddrLabel, request.requestorId), message);
 }
 

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -79,7 +79,7 @@ void Ipc::Coordinator::registerStrand(const StrandCoord& strand)
 void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 {
     switch (message.rawType()) {
-    case mtRegistration:
+    case mtStrandRegistration:
         debugs(54, 6, HERE << "Registration request");
         handleRegistrationRequest(StrandMessage(message));
         break;

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -79,7 +79,7 @@ void Ipc::Coordinator::registerStrand(const StrandCoord& strand)
 void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 {
     switch (message.rawType()) {
-    case mtStrandRegistration:
+    case mtRegisterStrand:
         debugs(54, 6, HERE << "Registration request");
         handleRegistrationRequest(StrandMessage(message));
         break;
@@ -139,7 +139,7 @@ void Ipc::Coordinator::handleRegistrationRequest(const StrandMessage& msg)
 
     // send back an acknowledgement; TODO: remove as not needed?
     TypedMsgHdr message;
-    msg.pack(mtStrandRegistration, message);
+    msg.pack(mtStrandRegistered, message);
     SendMessage(MakeAddr(strandAddrLabel, msg.strand.kidId), message);
 }
 

--- a/src/ipc/Coordinator.h
+++ b/src/ipc/Coordinator.h
@@ -47,7 +47,7 @@ protected:
 
     StrandCoord* findStrand(int kidId); ///< registered strand or NULL
     void registerStrand(const StrandCoord &); ///< adds or updates existing
-    void handleRegistrationRequest(const HereIamMessage &); ///< register,ACK
+    void handleRegistrationRequest(const StrandMessage &); ///< register,ACK
 
     /// answer the waiting search request
     void notifySearcher(const StrandSearchRequest &request, const StrandCoord&);

--- a/src/ipc/Messages.h
+++ b/src/ipc/Messages.h
@@ -18,22 +18,28 @@ namespace Ipc
 
 /// message class identifier
 typedef enum { mtNone = 0, ///< unspecified or unknown message kind; unused on the wire
+
                mtRegisterStrand, ///< notifies about our strand existence
                mtStrandRegistered, ///< acknowledges mtRegisterStrand acceptance
+
                mtFindStrand, ///< a worker requests a strand from Coordinator
-               mtStrandReady, ///< a mtFindStrand answer: the strand exists and should be usable
+               mtStrandReady, ///< an mtFindStrand answer: the strand exists and should be usable
+
                mtSharedListenRequest,
                mtSharedListenResponse,
+
                mtIpcIoNotification,
+
                mtCollapsedForwardingNotification,
+
                mtCacheMgrRequest,
-               mtCacheMgrResponse
+               mtCacheMgrResponse,
+
 #if SQUID_SNMP
-               ,
                mtSnmpRequest,
-               mtSnmpResponse
+               mtSnmpResponse,
 #endif
-               ,
+
                mtEnd ///< for message kind range checks; unused on the wire
              } MessageType;
 

--- a/src/ipc/Messages.h
+++ b/src/ipc/Messages.h
@@ -18,7 +18,8 @@ namespace Ipc
 
 /// message class identifier
 typedef enum { mtNone = 0, ///< unspecified or unknown message kind; unused on the wire
-               mtStrandRegistration, ///< strand registration with Coordinator (also used as an ACK)
+               mtRegisterStrand, ///< notifies about our strand existence
+               mtStrandRegistered, ///< acknowledges mtRegisterStrand acceptance
                mtFindStrand, ///< a worker requests a strand from Coordinator
                mtStrandReady, ///< a mtFindStrand answer: the strand exists and should be usable
                mtSharedListenRequest,

--- a/src/ipc/Messages.h
+++ b/src/ipc/Messages.h
@@ -17,16 +17,23 @@ namespace Ipc
 {
 
 /// message class identifier
-typedef enum { mtNone = 0, mtRegistration,
-               mtStrandSearchRequest, mtStrandSearchResponse,
-               mtSharedListenRequest, mtSharedListenResponse,
+typedef enum { enumBegin_ = 0,
+               mtRegistration, ///< strand registration with Coordinator (also used as an ACK)
+               mtFindStrand, ///< a worker requests a strand from Coordinator
+               mtStrandReady, ///< a mtFindStrand answer: the strand exists and should be usable
+               mtSharedListenRequest,
+               mtSharedListenResponse,
                mtIpcIoNotification,
                mtCollapsedForwardingNotification,
-               mtCacheMgrRequest, mtCacheMgrResponse
+               mtCacheMgrRequest,
+               mtCacheMgrResponse
 #if SQUID_SNMP
                ,
-               mtSnmpRequest, mtSnmpResponse
+               mtSnmpRequest,
+               mtSnmpResponse
 #endif
+               ,
+               enumEnd_
              } MessageType;
 
 } // namespace Ipc;

--- a/src/ipc/Messages.h
+++ b/src/ipc/Messages.h
@@ -17,8 +17,8 @@ namespace Ipc
 {
 
 /// message class identifier
-typedef enum { enumBegin_ = 0,
-               mtRegistration, ///< strand registration with Coordinator (also used as an ACK)
+typedef enum { mtNone = 0, ///< unspecified or unknown message kind; unused on the wire
+               mtStrandRegistration, ///< strand registration with Coordinator (also used as an ACK)
                mtFindStrand, ///< a worker requests a strand from Coordinator
                mtStrandReady, ///< a mtFindStrand answer: the strand exists and should be usable
                mtSharedListenRequest,
@@ -33,7 +33,7 @@ typedef enum { enumBegin_ = 0,
                mtSnmpResponse
 #endif
                ,
-               enumEnd_
+               mtEnd ///< for message kind range checks; unused on the wire
              } MessageType;
 
 } // namespace Ipc;

--- a/src/ipc/Port.cc
+++ b/src/ipc/Port.cc
@@ -79,7 +79,7 @@ void Ipc::Port::noteRead(const CommIoCbParams& params)
            " [" << this << ']');
     if (params.flag == Comm::OK) {
         assert(params.buf == buf.raw());
-        debugs(54, 6, "received message type: " << buf.rawType());
+        debugs(54, 6, "message type: " << buf.rawType());
         receive(buf);
     }
     // TODO: if there was a fatal error on our socket, close the socket before

--- a/src/ipc/Port.cc
+++ b/src/ipc/Port.cc
@@ -79,6 +79,7 @@ void Ipc::Port::noteRead(const CommIoCbParams& params)
            " [" << this << ']');
     if (params.flag == Comm::OK) {
         assert(params.buf == buf.raw());
+        debugs(54, 6, "received message type: " << buf.rawType());
         receive(buf);
     }
     // TODO: if there was a fatal error on our socket, close the socket before

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -53,7 +53,7 @@ void Ipc::Strand::registerSelf()
     debugs(54, 6, HERE);
     Must(!isRegistered);
 
-    StrandMessage::NotifyCoordinator(mtRegistration, nullptr);
+    StrandMessage::NotifyCoordinator(mtStrandRegistration, nullptr);
     setTimeout(6, "Ipc::Strand::timeoutHandler"); // TODO: make 6 configurable?
 }
 
@@ -61,7 +61,7 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 {
     switch (message.rawType()) {
 
-    case mtRegistration:
+    case mtStrandRegistration:
         handleRegistrationResponse(StrandMessage(message));
         break;
 

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -53,7 +53,7 @@ void Ipc::Strand::registerSelf()
     debugs(54, 6, HERE);
     Must(!isRegistered);
 
-    StrandMessage::NotifyCoordinator(mtStrandRegistration, nullptr);
+    StrandMessage::NotifyCoordinator(mtRegisterStrand, nullptr);
     setTimeout(6, "Ipc::Strand::timeoutHandler"); // TODO: make 6 configurable?
 }
 
@@ -61,7 +61,7 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 {
     switch (message.rawType()) {
 
-    case mtStrandRegistration:
+    case mtStrandRegistered:
         handleRegistrationResponse(StrandMessage(message));
         break;
 

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -53,20 +53,16 @@ void Ipc::Strand::registerSelf()
     debugs(54, 6, HERE);
     Must(!isRegistered);
 
-    HereIamMessage ann(StrandCoord(KidIdentifier, getpid()));
-    TypedMsgHdr message;
-    ann.pack(message);
-    SendMessage(Port::CoordinatorAddr(), message);
+    StrandMessage::NotifyCoordinator(mtRegistration, nullptr);
     setTimeout(6, "Ipc::Strand::timeoutHandler"); // TODO: make 6 configurable?
 }
 
 void Ipc::Strand::receive(const TypedMsgHdr &message)
 {
-    debugs(54, 6, HERE << message.type());
-    switch (message.type()) {
+    switch (message.rawType()) {
 
     case mtRegistration:
-        handleRegistrationResponse(HereIamMessage(message));
+        handleRegistrationResponse(StrandMessage(message));
         break;
 
     case mtSharedListenResponse:
@@ -74,8 +70,8 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
         break;
 
 #if HAVE_DISKIO_MODULE_IPCIO
-    case mtStrandSearchResponse:
-        IpcIoFile::HandleOpenResponse(StrandSearchResponse(message));
+    case mtStrandReady:
+        IpcIoFile::HandleOpenResponse(StrandMessage(message));
         break;
 
     case mtIpcIoNotification:
@@ -114,12 +110,13 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 #endif
 
     default:
-        debugs(54, DBG_IMPORTANT, HERE << "Unhandled message type: " << message.type());
+        debugs(54, DBG_IMPORTANT, "WARNING: Ignoring IPC message with an unknown type: " << message.rawType());
         break;
     }
 }
 
-void Ipc::Strand::handleRegistrationResponse(const HereIamMessage &msg)
+void
+Ipc::Strand::handleRegistrationResponse(const StrandMessage &msg)
 {
     // handle registration response from the coordinator; it could be stale
     if (msg.strand.kidId == KidIdentifier && msg.strand.pid == getpid()) {

--- a/src/ipc/Strand.h
+++ b/src/ipc/Strand.h
@@ -39,7 +39,7 @@ protected:
 
 private:
     void registerSelf(); /// let Coordinator know this strand exists
-    void handleRegistrationResponse(const HereIamMessage &msg);
+    void handleRegistrationResponse(const StrandMessage &);
     void handleCacheMgrRequest(const Mgr::Request& request);
     void handleCacheMgrResponse(const Mgr::Response& response);
 #if SQUID_SNMP

--- a/src/ipc/StrandCoord.cc
+++ b/src/ipc/StrandCoord.cc
@@ -47,7 +47,6 @@ Ipc::StrandMessage::StrandMessage(const MessageType msgType, const StrandCoord &
 Ipc::StrandMessage::StrandMessage(const TypedMsgHdr &hdrMsg):
     messageType(hdrMsg.type())
 {
-    hdrMsg.checkType(mtRegistration);
     strand.unpack(hdrMsg);
 }
 

--- a/src/ipc/StrandCoord.cc
+++ b/src/ipc/StrandCoord.cc
@@ -10,7 +10,8 @@
 
 #include "squid.h"
 #include "Debug.h"
-#include "ipc/Messages.h"
+#include "globals.h"
+#include "ipc/Port.h"
 #include "ipc/StrandCoord.h"
 #include "ipc/TypedMsgHdr.h"
 
@@ -37,20 +38,35 @@ void Ipc::StrandCoord::pack(TypedMsgHdr &hdrMsg) const
     hdrMsg.putString(tag);
 }
 
-Ipc::HereIamMessage::HereIamMessage(const StrandCoord &aStrand):
+Ipc::StrandMessage::StrandMessage(const MessageType msgType, const StrandCoord &aStrand):
+    messageType(msgType),
     strand(aStrand)
 {
 }
 
-Ipc::HereIamMessage::HereIamMessage(const TypedMsgHdr &hdrMsg)
+Ipc::StrandMessage::StrandMessage(const TypedMsgHdr &hdrMsg):
+    messageType(hdrMsg.type())
 {
     hdrMsg.checkType(mtRegistration);
     strand.unpack(hdrMsg);
 }
 
-void Ipc::HereIamMessage::pack(TypedMsgHdr &hdrMsg) const
+void
+Ipc::StrandMessage::pack(TypedMsgHdr &hdrMsg) const
 {
-    hdrMsg.setType(mtRegistration);
+    hdrMsg.setType(messageType);
     strand.pack(hdrMsg);
+}
+
+void
+Ipc::StrandMessage::NotifyCoordinator(const MessageType msgType, const char *tag)
+{
+    static const auto pid = getpid();
+    StrandMessage message(msgType, StrandCoord(KidIdentifier, pid));
+    if (tag)
+        message.strand.tag = tag;
+    TypedMsgHdr hdr;
+    message.pack(hdr);
+    SendMessage(Port::CoordinatorAddr(), hdr);
 }
 

--- a/src/ipc/StrandCoord.cc
+++ b/src/ipc/StrandCoord.cc
@@ -38,20 +38,18 @@ void Ipc::StrandCoord::pack(TypedMsgHdr &hdrMsg) const
     hdrMsg.putString(tag);
 }
 
-Ipc::StrandMessage::StrandMessage(const MessageType msgType, const StrandCoord &aStrand):
-    messageType(msgType),
+Ipc::StrandMessage::StrandMessage(const StrandCoord &aStrand):
     strand(aStrand)
 {
 }
 
-Ipc::StrandMessage::StrandMessage(const TypedMsgHdr &hdrMsg):
-    messageType(hdrMsg.type())
+Ipc::StrandMessage::StrandMessage(const TypedMsgHdr &hdrMsg)
 {
     strand.unpack(hdrMsg);
 }
 
 void
-Ipc::StrandMessage::pack(TypedMsgHdr &hdrMsg) const
+Ipc::StrandMessage::pack(const MessageType messageType, TypedMsgHdr &hdrMsg) const
 {
     hdrMsg.setType(messageType);
     strand.pack(hdrMsg);
@@ -61,11 +59,11 @@ void
 Ipc::StrandMessage::NotifyCoordinator(const MessageType msgType, const char *tag)
 {
     static const auto pid = getpid();
-    StrandMessage message(msgType, StrandCoord(KidIdentifier, pid));
+    StrandMessage message(StrandCoord(KidIdentifier, pid));
     if (tag)
         message.strand.tag = tag;
     TypedMsgHdr hdr;
-    message.pack(hdr);
+    message.pack(msgType, hdr);
     SendMessage(Port::CoordinatorAddr(), hdr);
 }
 

--- a/src/ipc/StrandCoord.h
+++ b/src/ipc/StrandCoord.h
@@ -10,6 +10,7 @@
 #define SQUID_IPC_STRAND_COORD_H
 
 #include "ipc/forward.h"
+#include "ipc/Messages.h"
 #include "SquidString.h"
 
 namespace Ipc
@@ -32,16 +33,20 @@ public:
     String tag; ///< optional unique well-known key (e.g., cache_dir path)
 };
 
-/// strand registration with Coordinator (also used as an ACK)
-class HereIamMessage
+/// an IPC message carrying just the kid coordinates and the message kind
+class StrandMessage
 {
 public:
-    explicit HereIamMessage(const StrandCoord &strand); ///< from registrant
-    explicit HereIamMessage(const TypedMsgHdr &hdrMsg); ///< from recvmsg()
-    void pack(TypedMsgHdr &hdrMsg) const; ///< prepare for sendmsg()
+    StrandMessage(MessageType, const StrandCoord &);
+    explicit StrandMessage(const TypedMsgHdr &);
+    void pack(TypedMsgHdr &) const;
+
+    /// creates and sends StrandMessage to Coordinator
+    static void NotifyCoordinator(MessageType, const char *tag);
 
 public:
-    StrandCoord strand; ///< registrant coordinates and related details
+    MessageType messageType; ///< overall message purpose or category
+    StrandCoord strand; ///< messageType-specific coordinates (e.g., sender)
 };
 
 } // namespace Ipc;

--- a/src/ipc/StrandCoord.h
+++ b/src/ipc/StrandCoord.h
@@ -33,19 +33,18 @@ public:
     String tag; ///< optional unique well-known key (e.g., cache_dir path)
 };
 
-/// an IPC message carrying just the kid coordinates and the message kind
+/// an IPC message carrying StrandCoord
 class StrandMessage
 {
 public:
-    StrandMessage(MessageType, const StrandCoord &);
+    explicit StrandMessage(const StrandCoord &);
     explicit StrandMessage(const TypedMsgHdr &);
-    void pack(TypedMsgHdr &) const;
+    void pack(MessageType, TypedMsgHdr &) const;
 
     /// creates and sends StrandMessage to Coordinator
     static void NotifyCoordinator(MessageType, const char *tag);
 
 public:
-    MessageType messageType; ///< overall message purpose or category
     StrandCoord strand; ///< messageType-specific coordinates (e.g., sender)
 };
 

--- a/src/ipc/StrandSearch.cc
+++ b/src/ipc/StrandSearch.cc
@@ -20,34 +20,15 @@ Ipc::StrandSearchRequest::StrandSearchRequest(): requestorId(-1)
 Ipc::StrandSearchRequest::StrandSearchRequest(const TypedMsgHdr &hdrMsg):
     requestorId(-1)
 {
-    hdrMsg.checkType(mtStrandSearchRequest);
+    hdrMsg.checkType(mtFindStrand);
     hdrMsg.getPod(requestorId);
     hdrMsg.getString(tag);
 }
 
 void Ipc::StrandSearchRequest::pack(TypedMsgHdr &hdrMsg) const
 {
-    hdrMsg.setType(mtStrandSearchRequest);
+    hdrMsg.setType(mtFindStrand);
     hdrMsg.putPod(requestorId);
     hdrMsg.putString(tag);
-}
-
-/* StrandSearchResponse */
-
-Ipc::StrandSearchResponse::StrandSearchResponse(const Ipc::StrandCoord &aStrand):
-    strand(aStrand)
-{
-}
-
-Ipc::StrandSearchResponse::StrandSearchResponse(const TypedMsgHdr &hdrMsg)
-{
-    hdrMsg.checkType(mtStrandSearchResponse);
-    strand.unpack(hdrMsg);
-}
-
-void Ipc::StrandSearchResponse::pack(TypedMsgHdr &hdrMsg) const
-{
-    hdrMsg.setType(mtStrandSearchResponse);
-    strand.pack(hdrMsg);
 }
 

--- a/src/ipc/StrandSearch.h
+++ b/src/ipc/StrandSearch.h
@@ -29,18 +29,6 @@ public:
     String tag; ///< set when looking for a matching StrandCoord::tag
 };
 
-/// asynchronous strand search response
-class StrandSearchResponse
-{
-public:
-    StrandSearchResponse(const StrandCoord &strand);
-    explicit StrandSearchResponse(const TypedMsgHdr &hdrMsg); ///< from recvmsg()
-    void pack(TypedMsgHdr &hdrMsg) const; ///< prepare for sendmsg()
-
-public:
-    StrandCoord strand; ///< answer matching StrandSearchRequest criteria
-};
-
 } // namespace Ipc;
 
 #endif /* SQUID_IPC_STRAND_SEARCH_H */

--- a/src/ipc/TypedMsgHdr.cc
+++ b/src/ipc/TypedMsgHdr.cc
@@ -81,15 +81,6 @@ void Ipc::TypedMsgHdr::sync()
     offset = 0;
 }
 
-Ipc::MessageType
-Ipc::TypedMsgHdr::type() const
-{
-    const auto uncheckedType = rawType();
-    Must(uncheckedType > MessageType::mtNone);
-    Must(uncheckedType < MessageType::mtEnd);
-    return static_cast<MessageType>(uncheckedType);
-}
-
 void
 Ipc::TypedMsgHdr::address(const struct sockaddr_un& addr)
 {

--- a/src/ipc/TypedMsgHdr.cc
+++ b/src/ipc/TypedMsgHdr.cc
@@ -81,11 +81,13 @@ void Ipc::TypedMsgHdr::sync()
     offset = 0;
 }
 
-int
+Ipc::MessageType
 Ipc::TypedMsgHdr::type() const
 {
-    Must(msg_iovlen == 1);
-    return data.type_;
+    const auto uncheckedType = rawType();
+    Must(uncheckedType >= MessageType::enumBegin_);
+    Must(uncheckedType <= MessageType::enumEnd_);
+    return static_cast<MessageType>(uncheckedType);
 }
 
 void
@@ -100,7 +102,7 @@ Ipc::TypedMsgHdr::address(const struct sockaddr_un& addr)
 void
 Ipc::TypedMsgHdr::checkType(int destType) const
 {
-    Must(type() == destType);
+    Must(rawType() == destType);
 }
 
 void

--- a/src/ipc/TypedMsgHdr.cc
+++ b/src/ipc/TypedMsgHdr.cc
@@ -85,8 +85,8 @@ Ipc::MessageType
 Ipc::TypedMsgHdr::type() const
 {
     const auto uncheckedType = rawType();
-    Must(uncheckedType >= MessageType::enumBegin_);
-    Must(uncheckedType <= MessageType::enumEnd_);
+    Must(uncheckedType > MessageType::mtNone);
+    Must(uncheckedType < MessageType::mtEnd);
     return static_cast<MessageType>(uncheckedType);
 }
 

--- a/src/ipc/TypedMsgHdr.h
+++ b/src/ipc/TypedMsgHdr.h
@@ -46,7 +46,7 @@ public:
     void checkType(int aType) const; ///< throws if stored type is not aType
     MessageType type() const; ///< converts rawType() to MessageType
     /// received or set message kind; may not be a MessageType value
-    /// \returns 0 if none message kind has been received or set
+    /// \returns 0 if no message kind has been received or set
     int rawType() const { return msg_iov ? data.type_ : 0; }
 
     /* access for Plain Old Data (POD)-based message parts */

--- a/src/ipc/TypedMsgHdr.h
+++ b/src/ipc/TypedMsgHdr.h
@@ -44,7 +44,6 @@ public:
     /* message type manipulation; these must be called before put/get*() */
     void setType(int aType); ///< sets message type; use MessageType enum
     void checkType(int aType) const; ///< throws if stored type is not aType
-    MessageType type() const; ///< converts rawType() to MessageType
     /// received or set message kind; may not be a MessageType value
     /// \returns 0 if no message kind has been received or set
     int rawType() const { return msg_iov ? data.type_ : 0; }

--- a/src/ipc/TypedMsgHdr.h
+++ b/src/ipc/TypedMsgHdr.h
@@ -12,6 +12,7 @@
 #define SQUID_IPC_TYPED_MSG_HDR_H
 
 #include "compat/cmsg.h"
+#include "ipc/Messages.h"
 #if HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
@@ -43,7 +44,10 @@ public:
     /* message type manipulation; these must be called before put/get*() */
     void setType(int aType); ///< sets message type; use MessageType enum
     void checkType(int aType) const; ///< throws if stored type is not aType
-    int type() const; ///< returns stored type or zero if none
+    MessageType type() const; ///< converts rawType() to MessageType
+    /// received or set message kind; may not be a MessageType value
+    /// \returns 0 if none message kind has been received or set
+    int rawType() const { return msg_iov ? data.type_ : 0; }
 
     /* access for Plain Old Data (POD)-based message parts */
     template <class Pod>

--- a/src/ipc/forward.h
+++ b/src/ipc/forward.h
@@ -16,8 +16,7 @@ namespace Ipc
 
 class TypedMsgHdr;
 class StrandCoord;
-class HereIamMessage;
-class StrandSearchResponse;
+class StrandMessage;
 class Forwarder;
 class Inquirer;
 class Request;


### PR DESCRIPTION
No functionality changes other than minor debugging improvements.

* replaced identical (except for the message kind value) HereIamMessage
  and StrandSearchResponse classes with StrandMessage
* reduced code duplication with a new StrandMessage::NotifyCoordinator()
* split TypedMsgHdr::type() into unchecked rawType() and checked type()
* renamed and documented several Ipc::MessageType enum values

The above code improvements will help with adding more IPC messages.

