### PR TITLE
Detail certificate validation errors during TLS handshake

### DIFF
--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -438,11 +438,8 @@ Security::ErrorNameFromCode(const ErrorCode err, const bool prefixRawCode)
 
 /* Security::ErrorDetail */
 
-uint64_t Security::ErrorDetail::Generations = 0;
-
 /// helper constructor implementing the logic shared by the two public ones
 Security::ErrorDetail::ErrorDetail(const ErrorCode err, const int aSysErrorNo):
-    generation(++Generations),
     error_no(err),
     // We could restrict errno(3) collection to cases where the TLS library
     // explicitly talks about the errno being set, but correctly detecting those

--- a/src/security/ErrorDetail.h
+++ b/src/security/ErrorDetail.h
@@ -55,12 +55,6 @@ public:
     ErrorDetail(ErrorCode anErrorCode, LibErrorCode aLibErrorNo, int aSysErrorNo);
 #endif
 
-    /// \returns whether we (rather than `them`) should detail ErrorState
-    bool takesPriorityOver(const ErrorDetail &them) const {
-        // to reduce pointless updates, return false if us is them
-        return this->generation < them.generation;
-    }
-
     /* ErrorDetail API */
     virtual SBuf brief() const;
     virtual SBuf verbose(const HttpRequestPointer &) const;
@@ -96,9 +90,6 @@ private:
     const char *err_descr() const;
     const char *err_lib_error() const;
     size_t convert(const char *code, const char **value) const;
-
-    static uint64_t Generations; ///< the total number of ErrorDetails ever made
-    uint64_t generation; ///< the number of ErrorDetails made before us plus one
 
     CertPointer peer_cert; ///< A pointer to the peer certificate
     CertPointer broken_cert; ///< A pointer to the broken certificate (peer or intermediate)

--- a/src/security/Io.cc
+++ b/src/security/Io.cc
@@ -83,11 +83,11 @@ Security::Handshake(Comm::Connection &transport, const ErrorCode topError, Fun i
         ; // fall through to handle the problem
     }
 
+    // now we know that we are dealing with a real problem; detail it
     ErrorDetail::Pointer errorDetail;
-    if (const auto verifyErrorDetailRaw = SSL_get_ex_data(connection, ssl_ex_index_ssl_error_detail)) {
-        errorDetail = *static_cast<ErrorDetail::Pointer*>(verifyErrorDetailRaw);
+    if (const auto oldDetail = SSL_get_ex_data(connection, ssl_ex_index_ssl_error_detail)) {
+        errorDetail = *static_cast<ErrorDetail::Pointer*>(oldDetail);
     } else {
-        // now we know that we are dealing with a real problem; detail it
         errorDetail = new ErrorDetail(topError, ioError, xerrno);
         if (const auto serverCert = SSL_get_peer_certificate(connection))
             errorDetail->setPeerCertificate(CertPointer(serverCert));

--- a/src/security/Io.cc
+++ b/src/security/Io.cc
@@ -83,10 +83,16 @@ Security::Handshake(Comm::Connection &transport, const ErrorCode topError, Fun i
         ; // fall through to handle the problem
     }
 
+    if (const auto verifyErrorDetailRaw = SSL_get_ex_data(connection, ssl_ex_index_ssl_error_detail)) {
+        const auto verifyErrorDetail = *static_cast<ErrorDetail::Pointer*>(verifyErrorDetailRaw);
+        return IoResult(verifyErrorDetail);
+    }
+
     // now we know that we are dealing with a real problem; detail it
     const ErrorDetail::Pointer errorDetail =
         new ErrorDetail(topError, ioError, xerrno);
-
+    if (const auto serverCert = SSL_get_peer_certificate(connection))
+        errorDetail->setPeerCertificate(CertPointer(serverCert));
     IoResult ioResult(errorDetail);
 
     // collect debugging-related details

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -418,8 +418,10 @@ void
 Security::PeerConnector::noteNegotiationError(const Security::ErrorDetailPointer &detail)
 {
     const auto anErr = ErrorState::NewForwarding(ERR_SECURE_CONNECT_FAIL, request, al);
-    anErr->xerrno = detail->sysError();
-    anErr->detailError(detail);
+    if (detail) {
+        anErr->xerrno = detail->sysError();
+        anErr->detailError(detail);
+    }
     noteNegotiationDone(anErr);
     bail(anErr);
 }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -417,7 +417,6 @@ Security::PeerConnector::noteWantWrite()
 void
 Security::PeerConnector::noteNegotiationError(const Security::ErrorDetailPointer &detail)
 {
-    auto primaryDetail = detail;
     const auto anErr = ErrorState::NewForwarding(ERR_SECURE_CONNECT_FAIL, request, al);
     anErr->xerrno = detail->sysError();
     anErr->detailError(detail);

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -415,28 +415,12 @@ Security::PeerConnector::noteWantWrite()
 }
 
 void
-Security::PeerConnector::noteNegotiationError(const Security::ErrorDetailPointer &callerDetail)
+Security::PeerConnector::noteNegotiationError(const Security::ErrorDetailPointer &detail)
 {
-    auto primaryDetail = callerDetail;
-#if USE_OPENSSL
-    const auto tlsConnection = fd_table[serverConnection()->fd].ssl.get();
-
-    // find the highest priority detail
-    if (const auto storedDetailRaw = SSL_get_ex_data(tlsConnection, ssl_ex_index_ssl_error_detail)) {
-        const auto &storedDetail = *static_cast<ErrorDetail::Pointer*>(storedDetailRaw);
-        if (storedDetail->takesPriorityOver(*primaryDetail))
-            primaryDetail = storedDetail;
-    }
-
-    if (!primaryDetail->peerCert()) {
-        if (const auto serverCert = SSL_get_peer_certificate(tlsConnection))
-            primaryDetail->setPeerCertificate(CertPointer(serverCert));
-    }
-#endif
-
+    auto primaryDetail = detail;
     const auto anErr = ErrorState::NewForwarding(ERR_SECURE_CONNECT_FAIL, request, al);
-    anErr->xerrno = primaryDetail->sysError();
-    anErr->detailError(primaryDetail);
+    anErr->xerrno = detail->sysError();
+    anErr->detailError(detail);
     noteNegotiationDone(anErr);
     bail(anErr);
 }

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -338,8 +338,8 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const Security::ErrorDetailPoint
     // thus hiding them.
     // Abort if no certificate found probably because of malformed or
     // unsupported server Hello message (TODO: make configurable).
-    if (!SSL_get_ex_data(session.get(), ssl_ex_index_ssl_error_detail) &&
-            (srvBio->bumpMode() == Ssl::bumpPeek  || srvBio->bumpMode() == Ssl::bumpStare) && srvBio->holdWrite()) {
+    if (!errorDetail->brokenCert() &&
+        (srvBio->bumpMode() == Ssl::bumpPeek  || srvBio->bumpMode() == Ssl::bumpStare) && srvBio->holdWrite()) {
         Security::CertPointer serverCert(SSL_get_peer_certificate(session.get()));
         if (serverCert) {
             debugs(81, 3, "hold TLS write on FD " << fd << " despite " << errorDetail);

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -339,7 +339,7 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const Security::ErrorDetailPoint
     // Abort if no certificate found probably because of malformed or
     // unsupported server Hello message (TODO: make configurable).
     if (!errorDetail->brokenCert() &&
-        (srvBio->bumpMode() == Ssl::bumpPeek  || srvBio->bumpMode() == Ssl::bumpStare) && srvBio->holdWrite()) {
+            (srvBio->bumpMode() == Ssl::bumpPeek  || srvBio->bumpMode() == Ssl::bumpStare) && srvBio->holdWrite()) {
         Security::CertPointer serverCert(SSL_get_peer_certificate(session.get()));
         if (serverCert) {
             debugs(81, 3, "hold TLS write on FD " << fd << " despite " << errorDetail);

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -338,7 +338,10 @@ Ssl::PeekingPeerConnector::noteNegotiationError(const Security::ErrorDetailPoint
     // thus hiding them.
     // Abort if no certificate found probably because of malformed or
     // unsupported server Hello message (TODO: make configurable).
-    if (!errorDetail->brokenCert() &&
+    // TODO: Add/use a positive "successfully validated server cert" signal
+    // instead of relying on the "![presumably_]validation_error && serverCert"
+    // signal combo.
+    if (!SSL_get_ex_data(session.get(), ssl_ex_index_ssl_error_detail) &&
             (srvBio->bumpMode() == Ssl::bumpPeek  || srvBio->bumpMode() == Ssl::bumpStare) && srvBio->holdWrite()) {
         Security::CertPointer serverCert(SSL_get_peer_certificate(session.get()));
         if (serverCert) {


### PR DESCRIPTION
Fix certificate validation error handling in Security::Connect/Accept().
The existing validation details were not propagated/copied to IoResult,
requiring the caller to extract them via ssl_ex_index_ssl_error_detail.
The clunky approach even required a special "ErrorDetail generations"
API to figure out which error detail is "primary": the one received in
IoResult or the just extracted one. That API is removed now.

This change is used by the upcoming improvements that fetch missing TLS
v1.3 server certificates, but it also has an immediate positive effect
on the existing reporting of the client certificate validation errors.
Currently, only a general TLS error is reported for those cases because
Security::Accept() code forgot to check ssl_ex_index_ssl_error_detail.

This is a Measurement Factory project.