### PR TITLE
Support helper ttl= annotations for Basic authentication

### DIFF
--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -47,6 +47,21 @@ Auth::User::credentials(CredentialState newCreds)
     credentials_state = newCreds;
 }
 
+void
+Auth::User::noteHelperTtl(const char *ttlNote)
+{
+    const int64_t ttl = (ttlNote ? strtoll(ttlNote, nullptr, 10) : -1);
+    updateExpiration(ttl);
+}
+
+void
+Auth::User::updateExpiration(int64_t ttl)
+{
+    /// Default behaviour: set expiry to current time + TTL.
+    /// Where TTL is 0 or a positive value.
+    expiretime = current_time.tv_sec + (ttl >= 0 ? ttl : 0);
+}
+
 /**
  * Combine two user structs. ONLY to be called from within a scheme
  * module. The scheme module is responsible for ensuring that the

--- a/src/auth/User.h
+++ b/src/auth/User.h
@@ -71,6 +71,16 @@ public:
      */
     virtual int32_t ttl() const = 0;
 
+    /// simple accessor to detect expired credentials
+    bool expired() const { return ttl() < 0; }
+
+    /// update credentials lifetime using ttl= from helper
+    virtual void noteHelperTtl(const char *);
+
+    /// Scheme-specific update of credentials lifetime
+    /// using TTL value in seconds
+    virtual void updateExpiration(int64_t);
+
     /* Manage list of IPs using this username */
     void clearIp();
     void removeIp(Ip::Address);

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -274,8 +274,7 @@ Auth::Basic::Config::decode(char const *proxy_auth, const HttpRequest *request, 
         debugs(29, 9, HERE << "Creating new user '" << lb->username() << "'");
         /* set the auth_user type */
         lb->auth_type = Auth::AUTH_BASIC;
-        /* current time for timeouts */
-        lb->expiretime = current_time.tv_sec;
+        lb->updateExpiration(0); // default expiry: current time
 
         /* this basic_user struct is the 'lucky one' to get added to the username cache */
         /* the requests after this link to the basic_user */

--- a/src/auth/basic/User.cc
+++ b/src/auth/basic/User.cc
@@ -38,7 +38,7 @@ void
 Auth::Basic::User::updateExpiration(int64_t ttl)
 {
     if (ttl < 0)
-        ttl = min(Auth::TheConfig.credentialsTtl, static_cast<Auth::Basic::Config*>(config)->credentialsTTL);
+        ttl = static_cast<Auth::Basic::Config*>(config)->credentialsTTL;
 
     Auth::User::updateExpiration(ttl);
 }

--- a/src/auth/basic/User.cc
+++ b/src/auth/basic/User.cc
@@ -31,16 +31,22 @@ Auth::Basic::User::ttl() const
     if (credentials() != Auth::Ok && credentials() != Auth::Pending)
         return -1; // TTL is obsolete NOW.
 
-    int32_t basic_ttl = expiretime - squid_curtime + static_cast<Auth::Basic::Config*>(config)->credentialsTTL;
-    int32_t global_ttl = static_cast<int32_t>(expiretime - squid_curtime + Auth::TheConfig.credentialsTtl);
+    return expiretime - current_time.tv_sec;
+}
 
-    return min(basic_ttl, global_ttl);
+void
+Auth::Basic::User::updateExpiration(int64_t ttl)
+{
+    if (ttl < 0)
+        ttl = min(Auth::TheConfig.credentialsTtl, static_cast<Auth::Basic::Config*>(config)->credentialsTTL);
+
+    Auth::User::updateExpiration(ttl);
 }
 
 bool
 Auth::Basic::User::authenticated() const
 {
-    if ((credentials() == Auth::Ok) && (expiretime + static_cast<Auth::Basic::Config*>(config)->credentialsTTL > squid_curtime))
+    if (credentials() == Auth::Ok && !expired())
         return true;
 
     debugs(29, 4, "User not authenticated or credentials need rechecking.");

--- a/src/auth/basic/User.h
+++ b/src/auth/basic/User.h
@@ -36,9 +36,10 @@ public:
 
     /** Update the cached password for a username. */
     void updateCached(User *from);
-    virtual int32_t ttl() const override;
 
     /* Auth::User API */
+    virtual int32_t ttl() const override;
+    virtual void updateExpiration(int64_t) override;
     static CbcPointer<Auth::CredentialsCache> Cache();
     virtual void addToNameCache() override;
 

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -13,6 +13,7 @@
  * See acl.c for access control and client_side.c for auditing */
 
 #include "squid.h"
+#include "auth/Config.h"
 #include "auth/CredentialsCache.h"
 #include "auth/digest/Config.h"
 #include "auth/digest/Scheme.h"
@@ -1050,9 +1051,8 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
          */
         authDigestUserLinkNonce(digest_user, nonce);
 
-        /* auth_user is now linked, we reset these values
-         * after external auth occurs anyway */
-        auth_user->expiretime = current_time.tv_sec;
+        /* auth_user is now linked */
+        auth_user->updateExpiration(Auth::TheConfig.credentialsTtl);
     } else {
         debugs(29, 9, "Found user '" << username << "' in the user cache as '" << auth_user << "'");
         digest_user = static_cast<Auth::Digest::User *>(auth_user.getRaw());

--- a/src/auth/digest/User.cc
+++ b/src/auth/digest/User.cc
@@ -39,7 +39,7 @@ Auth::Digest::User::~User()
 int32_t
 Auth::Digest::User::ttl() const
 {
-    int32_t global_ttl = static_cast<int32_t>(expiretime - squid_curtime + Auth::TheConfig.credentialsTtl);
+    int32_t global_ttl = static_cast<int32_t>(expiretime - squid_curtime);
 
     /* find the longest lasting nonce. */
     int32_t latest_nonce = -1;

--- a/src/auth/negotiate/UserRequest.cc
+++ b/src/auth/negotiate/UserRequest.cc
@@ -348,9 +348,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
             local_auth_user = cached_user;
             auth_user_request->user(local_auth_user);
         }
-        /* set these to now because this is either a new login from an
-         * existing user or a new user */
-        local_auth_user->expiretime = current_time.tv_sec;
+        local_auth_user->updateExpiration(0); // either new user or fresh re-login
         auth_user_request->user()->credentials(Auth::Ok);
         debugs(29, 4, HERE << "Successfully validated user via Negotiate. Username '" << auth_user_request->user()->username() << "'");
     }

--- a/src/auth/ntlm/UserRequest.cc
+++ b/src/auth/ntlm/UserRequest.cc
@@ -342,9 +342,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
             local_auth_user = cached_user;
             auth_user_request->user(local_auth_user);
         }
-        /* set these to now because this is either a new login from an
-         * existing user or a new user */
-        local_auth_user->expiretime = current_time.tv_sec;
+        local_auth_user->updateExpiration(0); // either new user or fresh re-login
         auth_user_request->user()->credentials(Auth::Ok);
         debugs(29, 4, HERE << "Successfully validated user via NTLM. Username '" << auth_user_request->user()->username() << "'");
     }

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -724,6 +724,9 @@ IF HAVE_AUTH_MODULE_BASIC
 		often the helper program is called for that user. Set this
 		low to force revalidation with short lived passwords.
 
+		When a ttl= annotation is received from the helper it will
+		be used instead.
+
 		NOTE: setting this high does not impact your susceptibility
 		to replay attacks unless you are using an one-time password
 		system (such as SecureID). If you are using such a system,
@@ -814,10 +817,13 @@ TYPE: time_t
 DEFAULT: 1 hour
 LOC: Auth::TheConfig.credentialsTtl
 DOC_START
-	The time a user & their credentials stay in the logged in
-	user cache since their last request. When the garbage
-	interval passes, all user credentials that have passed their
-	TTL are removed from memory.
+	The time to remember old Basic or Digest credentials after they expire.
+	When the next garbage interval passes, all user credentials which have
+	been expired for longer than this TTL are removed from memory.
+
+	Use helper ttl= annotation, 'auth_param basic credentialsttl', or
+	'auth_param digest nonce_max_duration' to control the expiry period
+	of user credentials before this TTL period begins counting down.
 DOC_END
 
 NAME: authenticate_ip_ttl

--- a/src/tests/stub_libauth.cc
+++ b/src/tests/stub_libauth.cc
@@ -45,6 +45,8 @@ Auth::CredentialState Auth::User::credentials() const STUB_RETVAL(credentials_st
 void Auth::User::credentials(CredentialState) STUB
 void Auth::User::absorb(Auth::User::Pointer) STUB
 Auth::User::~User() STUB_NOP
+void Auth::User::noteHelperTtl(const char *) STUB
+void Auth::User::updateExpiration(int64_t) STUB
 void Auth::User::clearIp() STUB
 void Auth::User::removeIp(Ip::Address) STUB
 void Auth::User::addIp(Ip::Address) STUB


### PR DESCRIPTION
... and clean up the TTL / expiry information for all authentication
schemes behind an API of Auth::User.

Also, fixes a small bug where Basic auth credentials could be expired
by authenticate_ttl earlier than their squid.conf credentialsttl is set to.
These two configuration settings are supposed to cover different time
periods in credentials lifetime within Squid memory.

Documentation updated to clarify the various credential TTL config
setting meaning and behaviour impact.