### PR TITLE
Bug 5104: Memory leak in RFC 2169 response parsing

### DIFF
--- a/src/urn.cc
+++ b/src/urn.cc
@@ -425,6 +425,7 @@ urnParseReply(const char *inbuf, const HttpRequestMethod& m)
     }
 
     debugs(52, 3, "urnParseReply: Found " << i << " URLs");
+    xfree(buf);
     return list;
 }
 


### PR DESCRIPTION
A temporary parsing buffer was not being released when
parsing completed.