### PR TITLE
Maintenance: Fix two misspellings

### DIFF
--- a/src/HttpHdrSc.cc
+++ b/src/HttpHdrSc.cc
@@ -300,7 +300,7 @@ HttpHdrSc::getMergedTarget(const char *ourtarget)
 
     /* W3C Edge Architecture Specification 1.0 section 3
      *
-     * "If more than one is targetted at a surrogate, the most specific applies.
+     * "If more than one is targeted at a surrogate, the most specific applies.
      *  For example,
      *    Surrogate-Control: max-age=60, no-store;abc
      *  The surrogate that identified itself as 'abc' would apply no-store;

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -418,7 +418,7 @@ Ssl::ConfigurePeerVerification(Security::ContextPointer &ctx, const Security::Pa
         mode = SSL_VERIFY_NONE;
     }
     else if (flags & SSL_FLAG_CONDITIONAL_AUTH) {
-        debugs(83, DBG_PARSE_NOTE(3), "will request the client certificate but ignore its absense");
+        debugs(83, DBG_PARSE_NOTE(3), "will request the client certificate but ignore its absence");
         mode = SSL_VERIFY_PEER;
     }
     else {


### PR DESCRIPTION
These typos were caught by scripts/spell-check.sh but then merged anyway
due to a `git diff` status code misinterpretation bug in the CI scripts.