### PR TITLE
Replace defective Must2(c, "not c") API

### DIFF
--- a/scripts/calc-must-ids.pl
+++ b/scripts/calc-must-ids.pl
@@ -66,7 +66,7 @@ sub ComputeMustIds
         $line =~ s@/[*].*?[*]/@@; # strip simple single-line /* comments */
 
         my($id);
-        if ($line =~ /\bMust2?\s*\(/ || # Must(...) and Must2(...)
+        if ($line =~ /\bMust\s*\(/ || # Must(...)
             $line =~ /\bTexcHere\s*\(/ || # TexcHere(...)
             $line =~ /\bHere\s*\(\s*\)/) { # Here()
             $line =~ s/^\s*//;

--- a/src/base/TextException.cc
+++ b/src/base/TextException.cc
@@ -8,7 +8,9 @@
 
 #include "squid.h"
 #include "base/TextException.h"
+#include "base/Optional.h"
 #include "sbuf/SBuf.h"
+#include "SquidMath.h"
 
 #include <iostream>
 #include <sstream>
@@ -57,6 +59,49 @@ TextException::what() const throw()
 
     return result.what();
 }
+
+SBuf
+MakeFailedCheckMessage(const SBuf &message)
+{
+    static const SBuf prefix("check failed: ");
+    static const SBuf lastResortMessage("check failed: [no details]");
+    static SBuf buf; // optimization to prevent some allocations
+
+    // try hard to handle recursive failures
+    static bool making = false;
+    if (making)
+        return lastResortMessage;
+
+    making = true;
+    try {
+        if (const auto combinedLength = Sum(prefix.length(), message.length())) {
+            buf.clear();
+            buf.reserveSpace(combinedLength.value());
+            buf.append(prefix);
+            buf.append(message);
+            making = false;
+            return buf;
+        }
+        // Handle huge messages by returning lastResortMessage without risking
+        // more troubles by reporting this huge message.
+        // [[fallthrough]]
+    }
+    catch (...) {
+        // Handle this message-forming exception by returning lastResortMessage
+        // without risking more exceptions while reporting this low-level one.
+        // [[fallthrough]]
+    }
+    making = false;
+    return lastResortMessage;
+}
+
+SBuf
+MakeFailedCheckMessage(const char *message)
+{
+    return MakeFailedCheckMessage(SBuf(message));
+}
+
+
 
 std::ostream &
 operator <<(std::ostream &os, const TextException &ex)

--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -58,7 +58,7 @@ std::ostream &operator <<(std::ostream &, const TextException &);
 #define TexcHere(msg) TextException((msg), Here())
 
 /// Like assert() but throws an exception instead of aborting the process
-/// and allows the caller to specify a custom exception message.
+/// and allows the caller to customize the exception message and location.
 /// \param description string literal describing the condition; what MUST happen
 #define Must3(condition, description, location) \
     do { \

--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -57,19 +57,26 @@ std::ostream &operator <<(std::ostream &, const TextException &);
 /// legacy convenience macro; it is not difficult to type Here() now
 #define TexcHere(msg) TextException((msg), Here())
 
+/// formats a message similar to that of a failed assert(success) check
+SBuf MakeFailedCheckMessage(const SBuf &successDescription);
+/// convenience wrapper for MakeFailedCheckMessage(SBuf)
+SBuf MakeFailedCheckMessage(const char *successDescription);
+
 /// Like assert() but throws an exception instead of aborting the process
 /// and allows the caller to specify a custom exception message.
-#define Must2(condition, message) \
-    do { \
-        if (!(condition)) { \
-            const TextException Must_ex_((message), Here()); \
-            debugs(0, 3, Must_ex_.what()); \
-            throw Must_ex_; \
-        } \
-    } while (/*CONSTCOND*/ false)
+/// \param successDescription description of the condition -- what MUST happen
+template <typename Description>
+inline void
+Must3(const bool condition, const Description successDescription, const SourceLocation &location)
+{
+    // XXX: Cannot pass SBuf to TextException() without #including SBuf.h:
+    // compile error: invalid use of incomplete type ‘class SBuf’
+    if (!condition)
+        throw TextException("MakeFailedCheckMessage(successDescription)", location);
+}
 
 /// Like assert() but throws an exception instead of aborting the process.
-#define Must(condition) Must2((condition), "check failed: " #condition)
+#define Must(condition) Must3(!!(condition), (#condition), Here())
 
 /// Reports and swallows all exceptions to prevent compiler warnings and runtime
 /// errors related to throwing class destructors. Should be used for most dtors.

--- a/src/sbuf/SBuf.cc
+++ b/src/sbuf/SBuf.cc
@@ -148,7 +148,7 @@ SBuf::rawAppendFinish(const char *start, size_type actualSize)
     debugs(24, 8, id << " finish appending " << actualSize << " bytes");
 
     size_type newSize = length() + actualSize;
-    Must2(newSize <= min(maxSize,store_->capacity-off_), "raw append overflow");
+    Must3(newSize <= min(maxSize, store_->capacity-off_), "raw append fits", Here());
     len_ = newSize;
     store_->size = off_ + newSize;
 }
@@ -258,7 +258,7 @@ SBuf::vappendf(const char *fmt, va_list vargs)
     va_copy(ap, vargs);
     sz = vsnprintf(space, spaceSize(), fmt, ap);
     va_end(ap);
-    Must2(sz >= 0, "vsnprintf() output error");
+    Must3(sz >= 0, "vsnprintf() succeeds", Here());
 
     /* check for possible overflow */
     /* snprintf on Linux returns -1 on output errors, or the size
@@ -270,7 +270,7 @@ SBuf::vappendf(const char *fmt, va_list vargs)
         requiredSpaceEstimate = sz*2; // TODO: tune heuristics
         space = rawSpace(requiredSpaceEstimate);
         sz = vsnprintf(space, spaceSize(), fmt, vargs);
-        Must2(sz >= 0, "vsnprintf() output error despite increased buffer space");
+        Must3(sz >= 0, "vsnprintf() succeeds (with increased buffer space)", Here());
     }
 
     // data was appended, update internal state


### PR DESCRIPTION
... with Must3(c, "c", Here())

* We should not make a Must*() API different from the standard C++
  static_assert() API. It is just too confusing, especially since the
  two calls are very closely related.

* We should not tell Must*() writers to specify one condition (i.e. what
  must happen) but then describe the opposite condition (i.e. what went
  wrong). When the text describes the opposite condition, it is easy for
  a human writing or thinking about the text to type the wrong
  condition: Must2(got < need, "incomplete message") looks correct!

We should not keep the same macro name when changing the meaning of the
second parameter. Fortunately, adding a third argument to the macro fits
nicely into how modern Squid code should pass the source code location.

Must3() does not support SBuf descriptions. I tried to support them, but
doing so without duplicating non-trivial code is too difficult, and
since the current code does not actually use them, wasteful.

If future (complex) code needs SBuf conditions, then it should probably
use an explicit throw statement instead, especially since Must*() is,
like assert(), supposed to quickly check source code sanity rather than
validate unsafe input. A compile-time condition description and the
source code location is usually enough for sanity checks, while proper
reporting of invalid input usually also requires parsing context info.