### PR TITLE
Check for duplicated http_port entries in config files

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -921,6 +921,25 @@ configDoConfigure(void)
     }
 
     for (AnyP::PortCfgPointer s = HttpPortList; s != NULL; s = s->next) {
+        for (AnyP::PortCfgPointer s2 = HttpPortList; s2 != NULL; s2 = s2->next) {
+            if( s == s2)
+                continue;
+            if (s->name && s2->name && strcmp(s->name, s2->name) != 0)
+                continue;
+            if (s->defaultsite && s2->defaultsite && strcmp(s->defaultsite, s2->defaultsite) != 0)
+                continue;
+            if (s->transport.protocol == s2->transport.protocol &&
+                s->transport.major == s2->transport.major &&
+                s->transport.minor == s2->transport.minor) {
+                debugs(3, DBG_CRITICAL, "ERROR: multiple definitions for http_port: " <<
+                        s->name << ' ' << s->transport.protocol << ' ' <<  s->transport.major << '.' <<  s->transport.minor );
+                self_destruct();
+                return;
+            }
+        }
+    }
+
+    for (AnyP::PortCfgPointer s = HttpPortList; s != NULL; s = s->next) {
         if (!s->secure.encryptTransport)
             continue;
         debugs(3, DBG_IMPORTANT, "Initializing " << AnyP::UriScheme(s->transport.protocol) << "_port " << s->s << " TLS contexts");

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -920,19 +920,15 @@ configDoConfigure(void)
         }
     }
 
+    // check for duplicated entries, e.g. we won't have duplicated items like this:
+    // http_port 3128
+    // http_port 3128 ssl-bump ...
     for (AnyP::PortCfgPointer s = HttpPortList; s != NULL; s = s->next) {
-        for (AnyP::PortCfgPointer s2 = HttpPortList; s2 != NULL; s2 = s2->next) {
-            if( s == s2)
-                continue;
+        for (AnyP::PortCfgPointer s2 = s->next; s2 != NULL; s2 = s2->next) {
             if (s->name && s2->name && strcmp(s->name, s2->name) != 0)
                 continue;
-            if (s->defaultsite && s2->defaultsite && strcmp(s->defaultsite, s2->defaultsite) != 0)
-                continue;
-            if (s->transport.protocol == s2->transport.protocol &&
-                s->transport.major == s2->transport.major &&
-                s->transport.minor == s2->transport.minor) {
-                debugs(3, DBG_CRITICAL, "ERROR: multiple definitions for http_port: " <<
-                        s->name << ' ' << s->transport.protocol << ' ' <<  s->transport.major << '.' <<  s->transport.minor );
+            if (s->transport.protocol == s2->transport.protocol) {
+                debugs(3, DBG_CRITICAL, "ERROR: multiple definitions for http_port: " << s->name << ' ' << s->transport.protocol);
                 self_destruct();
                 return;
             }


### PR DESCRIPTION
This fixes a random occurring - but very annoying bug. 

We have a squid cluster with high load in our company (8000+ connects). From time to time we noticed a very annoying bug.

ACL roules were not taken, connections didn't bump to SSL. That happens only with very high load and only randomly on very few of the connects.

After a two week debug session, we found out, that it is caused by multiple PortCfg entries. That happened by our configuration files, where we found, that we had multiple entries for http_ports

```
http_port 3128
...
http_port 3128 ssl-bump ..
```

According to our knowledge and to the official squid docs - http://www.squid-cache.org/Doc/config/http_port/ - it makes no sense to give the user this level of freedom.

The desired level of outcome:

- avoid conflicting configuration (e.g. having ssl-bump and no ssl-bump configured on the same port)
- just have one "type" per  port and protocol 

This was a really annoying issue. Hard to find and we developed tools to reproduce high load in a lab environment. 
