### PR TITLE
Bug 4528: ICAP transactions quit on async DNS lookups

### DIFF
--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -86,6 +86,7 @@ Adaptation::Icap::Xaction::Xaction(const char *aTypeName, Adaptation::Icap::Serv
     isRetriable(true),
     isRepeatable(true),
     ignoreLastWrite(false),
+    waitingForDns(false),
     stopReason(NULL),
     connector(NULL),
     reader(NULL),
@@ -187,12 +188,17 @@ Adaptation::Icap::Xaction::openConnection()
     debugs(93,3, typeName << " opens connection to " << s.cfg().host.termedBuf() << ":" << s.cfg().port);
 
     // Locate the Service IP(s) to open
+    assert(!waitingForDns);
+    waitingForDns = true; // before the possibly-synchronous ipcache_nbgethostbyname()
     ipcache_nbgethostbyname(s.cfg().host.termedBuf(), icapLookupDnsResults, this);
 }
 
 void
 Adaptation::Icap::Xaction::dnsLookupDone(const ipcache_addrs *ia)
 {
+    assert(waitingForDns);
+    waitingForDns = false;
+
     Adaptation::Icap::ServiceRep &s = service();
 
     if (ia == NULL) {
@@ -418,7 +424,8 @@ void Adaptation::Icap::Xaction::callEnd()
 
 bool Adaptation::Icap::Xaction::doneAll() const
 {
-    return !connector && !securer && !reader && !writer && Adaptation::Initiate::doneAll();
+    return !waitingForDns && !connector && !securer && !reader && !writer &&
+           Adaptation::Initiate::doneAll();
 }
 
 void Adaptation::Icap::Xaction::updateTimeout()
@@ -690,6 +697,9 @@ void Adaptation::Icap::Xaction::fillPendingStatus(MemBuf &buf) const
 
         buf.append(";", 1);
     }
+
+    if (waitingForDns)
+        buf.append("D", 1);
 }
 
 void Adaptation::Icap::Xaction::fillDoneStatus(MemBuf &buf) const

--- a/src/adaptation/icap/Xaction.h
+++ b/src/adaptation/icap/Xaction.h
@@ -137,6 +137,7 @@ protected:
     bool isRetriable;  ///< can retry on persistent connection failures
     bool isRepeatable; ///< can repeat if no or unsatisfactory response
     bool ignoreLastWrite;
+    bool waitingForDns; ///< expecting a ipcache_nbgethostbyname() callback
 
     const char *stopReason;
 


### PR DESCRIPTION
When an ICAP OPTIONS transaction needed to look up an IP address of the
ICAP service, and that address was not cached by Squid, the transaction
ended prematurely because Adaptation::Icap::Xaction::doneAll() was
unaware of ipcache_nbgethostbyname()'s async nature.

Adaptation::Icap::ModXact uses the same buggy Xaction code, but hides
the bug because ModXact::startWriting() sets state.writing before
calling openConnection() which schedules the DNS lookup. That "I am
still writing" state makes ModXact::doneAll() false.

However, some REQMOD and RESPMOD transactions are still affected by this
bug because they require an OPTIONS transaction if the service options
have never been fetched before or have expired. For example, the first
few transactions for a given service -- all those started before the DNS
lookup completes and Squid caches its result -- will fail.

Broken since inception (commit fb505fa).