### PR TITLE
Fix GCC 10.2.0 build on Ubuntu Hirsute s390x

### DIFF
--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -947,7 +947,7 @@ snmpCreateOidFromStr(const char *str, oid **name, int *nl)
     }
 
     // if we aborted before the lst octet was found, return false.
-    safe_free(name);
+    safe_free(*name);
     return false;
 }
 


### PR DESCRIPTION
GCC reports
 error: free-nonheap-object: snmp_core.cc(950): snmpCreateOidFromStr