### PR TITLE
%ssl::<negotiated_version, %ssl::>negotiated_version for TLS/1.3

### DIFF
--- a/src/security/NegotiationHistory.cc
+++ b/src/security/NegotiationHistory.cc
@@ -38,6 +38,10 @@ static AnyP::ProtocolVersion
 toProtocolVersion(const int v)
 {
     switch(v) {
+#if defined(TLS1_3_VERSION)
+    case TLS1_3_VERSION:
+        return AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 3);
+#endif
 #if defined(TLS1_2_VERSION)
     case TLS1_2_VERSION:
         return AnyP::ProtocolVersion(AnyP::PROTO_TLS, 1, 2);


### PR DESCRIPTION
Both %codes were logged as dashes when Squid negotiated TLS v1.3.

This is a Measurement Factory project.