### PR TITLE
Simplified Http::Message::parse()

### DIFF
--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -33,11 +33,7 @@ public:
 
     virtual void reset();
 
-    /**
-     \retval true on success
-     \retval false and sets *error to zero when needs more data
-     \retval false and sets *error to a positive Http::StatusCode on error
-     */
+    /* Http::Message API */
     virtual bool sanityCheckStartLine(const char *buf, const size_t hdr_len, Http::StatusCode *error);
 
     /** \par public, readable; never update these or their .hdr equivalents directly */

--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -85,8 +85,8 @@ Http::Message::parse(const char *buf, const size_t sz, bool eof, Http::StatusCod
     // find the end of headers
     const size_t hdr_len = headersEnd(buf, sz);
 
-    if(hdr_len > Config.maxReplyHeaderSize || (hdr_len == 0 && sz > Config.maxReplyHeaderSize))
-        debugs(58, 3, "Too large reply header (" << hdr_len << " > " << Config.maxReplyHeaderSize << ")");
+    if (hdr_len > Config.maxReplyHeaderSize || (hdr_len == 0 && sz > Config.maxReplyHeaderSize)) {
+        debugs(58, 3, "input too large: " << hdr_len << " or " << sz << " > " << Config.maxReplyHeaderSize);
         *error = Http::scHeaderTooLarge;
         return false;
     }

--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -101,7 +101,7 @@ Http::Message::parse(const char *buf, const size_t sz, bool eof, Http::StatusCod
         return false;
     }
 
-    assert(hdr_len > 0); // sanityCheckStartLine() rejects unparsed headers
+    assert(hdr_len > 0); // sanityCheckStartLine() rejects buffers that cannot be parsed
 
     const int res = httpMsgParseStep(buf, sz, eof);
 
@@ -289,4 +289,3 @@ Http::Message::firstLineBuf(MemBuf &mb)
 {
     packFirstLineInto(&mb, true);
 }
-

--- a/src/http/Message.h
+++ b/src/http/Message.h
@@ -123,7 +123,7 @@ protected:
     /**
      * Validate the message start line is syntactically correct.
      * Set HTTP error status according to problems found.
-     * This method must return false if we do do not have valid headers.
+     * This method must return false if it is not passed parsed headers.
      *
      * \retval true   Status line has no serious problems.
      * \retval false  Status line has a serious problem. Correct response is indicated by error.

--- a/src/http/Message.h
+++ b/src/http/Message.h
@@ -123,7 +123,6 @@ protected:
     /**
      * Validate the message start line is syntactically correct.
      * Set HTTP error status according to problems found.
-     * This method must return false if it is not passed parsed headers.
      *
      * \retval true   Status line has no serious problems.
      * \retval false  Status line has a serious problem. Correct response is indicated by error.

--- a/src/http/Message.h
+++ b/src/http/Message.h
@@ -123,6 +123,7 @@ protected:
     /**
      * Validate the message start line is syntactically correct.
      * Set HTTP error status according to problems found.
+     * Zero hdr_len is treated as a serious problem.
      *
      * \retval true   Status line has no serious problems.
      * \retval false  Status line has a serious problem. Correct response is indicated by error.

--- a/src/http/Message.h
+++ b/src/http/Message.h
@@ -123,6 +123,7 @@ protected:
     /**
      * Validate the message start line is syntactically correct.
      * Set HTTP error status according to problems found.
+     * This method must return false if we do do not have valid headers.
      *
      * \retval true   Status line has no serious problems.
      * \retval false  Status line has a serious problem. Correct response is indicated by error.


### PR DESCRIPTION
size_t hdr_len cannot be negative, and sanityCheckStartLine() already
rejects zero values. We now use (and clearly document) the latter fact.

Also replaced a level-1 warning about "Too large" headers with a level-3
debugging message because huge headers is not a Squid problem, and the
problem should already be visible in access.logs records.

