### PR TITLE
Bug 4832: '!schemeAccess' assertion on exit

### DIFF
--- a/src/auth/Config.cc
+++ b/src/auth/Config.cc
@@ -18,3 +18,4 @@ Auth::Config::~Config()
 {
     delete schemeAccess;
 }
+

--- a/src/auth/Config.cc
+++ b/src/auth/Config.cc
@@ -14,3 +14,7 @@
 
 Auth::Config Auth::TheConfig;
 
+Auth::Config::~Config()
+{
+    delete schemeAccess;
+}

--- a/src/auth/Config.cc
+++ b/src/auth/Config.cc
@@ -14,8 +14,3 @@
 
 Auth::Config Auth::TheConfig;
 
-Auth::Config::~Config()
-{
-    delete schemeAccess;
-}
-

--- a/src/auth/Config.h
+++ b/src/auth/Config.h
@@ -11,7 +11,7 @@
 
 #if USE_AUTH
 
-#include "acl/Tree.h"
+#include "acl/forward.h"
 #include "auth/SchemeConfig.h"
 #include "auth/SchemesConfig.h"
 
@@ -26,7 +26,7 @@ class Config
 public:
     Config() = default;
     explicit Config(Config &&) = default;
-    ~Config() { delete schemeAccess; }
+    ~Config();
 
     /// set of auth_params directives
     Auth::ConfigVector schemes;

--- a/src/auth/Config.h
+++ b/src/auth/Config.h
@@ -23,7 +23,7 @@ class Config
 public:
     Config() = default;
     Config(Config &&) = delete; // no support for copying of any kind
-    ~Config();
+    ~Config() = default;
 
     /// set of auth_params directives
     Auth::ConfigVector schemes;

--- a/src/auth/Config.h
+++ b/src/auth/Config.h
@@ -20,12 +20,9 @@ namespace Auth
 
 class Config
 {
-    explicit Config(const Config &) = delete;
-    explicit Config(const Config *) = delete;
-
 public:
     Config() = default;
-    explicit Config(Config &&) = default;
+    Config(Config &&) = delete; // no support for copying of any kind
     ~Config();
 
     /// set of auth_params directives

--- a/src/auth/Config.h
+++ b/src/auth/Config.h
@@ -11,7 +11,7 @@
 
 #if USE_AUTH
 
-#include "acl/forward.h"
+#include "acl/Tree.h"
 #include "auth/SchemeConfig.h"
 #include "auth/SchemesConfig.h"
 
@@ -26,7 +26,7 @@ class Config
 public:
     Config() = default;
     explicit Config(Config &&) = default;
-    ~Config() { assert(!schemeAccess); }
+    ~Config() { delete schemeAccess; }
 
     /// set of auth_params directives
     Auth::ConfigVector schemes;

--- a/test-suite/squidconf/bug4832
+++ b/test-suite/squidconf/bug4832
@@ -1,0 +1,2 @@
+auth_param basic /dev/null
+auth_schemes basic all


### PR DESCRIPTION
* Add test to detect the bug and prevent regressions

* delete the access list if not cleared by the time
  Auth::Config instance is destructed. This is what the
  free_AuthSchemes() code does when the function call
  nesting and debugs are pruned away.