### PR TITLE
Do not process empty filenames using CWD command. (#820)

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1462,6 +1462,9 @@ ftpSendCwd(Ftp::Gateway * ftpState)
 
     path = ftpState->filepath;
 
+    if(!path)
+        return;
+
     if (!strcmp(path, "..") || !strcmp(path, "/")) {
         ftpState->flags.no_dotdot = 1;
     } else {


### PR DESCRIPTION
Various different functions call ftpSendCwd, but there is no check in this function to ensure filepath is not NULL, for example, via hackShortcut(), which even explicitly deals with the case of filepath being NULL (but does not change it).