### PR TITLE
Bug 5128: Translation: Fix % i typo in es/ERR_FORWARDING_DENIED

### DIFF
--- a/errors/es.po
+++ b/errors/es.po
@@ -1090,7 +1090,7 @@ msgid ""
 "misconfigured."
 msgstr ""
 "Este caché no transmitirá su solicitud, ya que intenta imponer una relación "
-"de conexión. Quizás el cliente en% i es un caché que se ha desconfigurado."
+"de conexión. Quizás el cliente en %i es un caché que se ha desconfigurado."
 
 #: templates/ERR_GATEWAY_FAILURE+html.body.div.p:29-1
 #, fuzzy


### PR DESCRIPTION
    | ERROR: .../es/ERR_FORWARDING_DENIED: Unsupported error page %code
    near % i es un...

Typo added in bbeb83f.