### PR TITLE
Bug 5129 pt1: remove Lock use from HttpRequestMethod

### DIFF
--- a/src/http/RequestMethod.h
+++ b/src/http/RequestMethod.h
@@ -23,7 +23,7 @@ class SquidConfig;
  * It has a runtime extension facility to allow it to
  * efficiently support new methods
  */
-class HttpRequestMethod : public RefCountable
+class HttpRequestMethod
 {
 public:
     HttpRequestMethod() : theMethod(Http::METHOD_NONE), theImage() {}
@@ -31,12 +31,6 @@ public:
     explicit HttpRequestMethod(const SBuf &);
 
     void HttpRequestMethodXXX(char const *); // deprecated old c-string to SBuf converter.
-
-    HttpRequestMethod & operator = (const HttpRequestMethod& aMethod) {
-        theMethod = aMethod.theMethod;
-        theImage = aMethod.theImage;
-        return *this;
-    }
 
     HttpRequestMethod & operator = (Http::MethodType const aMethod) {
         theMethod = aMethod;

--- a/src/http/forward.h
+++ b/src/http/forward.h
@@ -38,7 +38,6 @@ typedef enum {
 class HttpHdrSc;
 
 class HttpRequestMethod;
-typedef RefCount<HttpRequestMethod> HttpRequestMethodPointer;
 
 class HttpRequest;
 typedef RefCount<HttpRequest> HttpRequestPointer;


### PR DESCRIPTION
Removes the need for a custom assignment operator with a questionable
implementation, addressing compiler and static analysis warnings.
