### PR TITLE
Implement RAII wrapper for ctx_* functions

### DIFF
--- a/src/DebugContext.h
+++ b/src/DebugContext.h
@@ -21,3 +21,4 @@ class DebugContext {
         ctx_exit(context_);
     }
 };
+

--- a/src/DebugContext.h
+++ b/src/DebugContext.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "Debug.h"
+
+/*
+ * RAII wrapper for ctx_enter / ctx_exit
+ */
+class DebugContext {
+    Ctx context_;
+    public:
+    DebugContext(const char *descr) {
+        context_ = ctx_enter(descr);
+    };
+    ~DebugContext() {
+        ctx_exit(context_);
+    }
+};

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -251,6 +251,7 @@ squid_SOURCES = \
 	CpuAffinitySet.cc \
 	CpuAffinitySet.h \
 	Debug.h \
+	DebugContext.h \
 	Downloader.cc \
 	Downloader.h \
 	ETag.cc \
@@ -758,7 +759,7 @@ squid.conf.default squid.conf.documented: cf_parser.cci
 cf_parser.cci: cf.data cf_gen$(EXEEXT)
 	./cf_gen$(EXEEXT) cf.data $(srcdir)/cf.data.depend
 
-# The cf_gen_defines.cci is auto-generated and does not exist when the 
+# The cf_gen_defines.cci is auto-generated and does not exist when the
 # dependencies computed. We need to add its include files (autoconf.h) here
 cf_gen_defines.cci: $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre $(top_builddir)/include/autoconf.h
 	$(AWK) -f $(srcdir)/cf_gen_defines <$(srcdir)/cf.data.pre >$@ || ($(RM) -f $@ && exit 1)
@@ -836,7 +837,7 @@ CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 test_tools.cc: $(top_srcdir)/test-suite/test_tools.cc
 	cp $(top_srcdir)/test-suite/test_tools.cc .
 
-# stock tools for unit tests - library independent versions of dlink_list 
+# stock tools for unit tests - library independent versions of dlink_list
 # etc.
 # globals.cc is needed by test_tools.cc.
 # Neither of these should be disted from here.
@@ -2082,6 +2083,7 @@ tests_test_http_range_LDFLAGS = $(LIBADD_DL)
 check_PROGRAMS += tests/testHttp1Parser
 tests_testHttp1Parser_SOURCES = \
 	Debug.h \
+	DebugContext.h \
 	tests/stub_HelperChildConfig.cc \
 	tests/testHttp1Parser.cc \
 	tests/testHttp1Parser.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -759,7 +759,7 @@ squid.conf.default squid.conf.documented: cf_parser.cci
 cf_parser.cci: cf.data cf_gen$(EXEEXT)
 	./cf_gen$(EXEEXT) cf.data $(srcdir)/cf.data.depend
 
-# The cf_gen_defines.cci is auto-generated and does not exist when the
+# The cf_gen_defines.cci is auto-generated and does not exist when the 
 # dependencies computed. We need to add its include files (autoconf.h) here
 cf_gen_defines.cci: $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre $(top_builddir)/include/autoconf.h
 	$(AWK) -f $(srcdir)/cf_gen_defines <$(srcdir)/cf.data.pre >$@ || ($(RM) -f $@ && exit 1)
@@ -837,7 +837,7 @@ CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 test_tools.cc: $(top_srcdir)/test-suite/test_tools.cc
 	cp $(top_srcdir)/test-suite/test_tools.cc .
 
-# stock tools for unit tests - library independent versions of dlink_list
+# stock tools for unit tests - library independent versions of dlink_list 
 # etc.
 # globals.cc is needed by test_tools.cc.
 # Neither of these should be disted from here.
@@ -3130,4 +3130,3 @@ testHeaders: $(srcdir)/*.h $(srcdir)/DiskIO/*.h $(srcdir)/DiskIO/*/*.h
 
 CLEANFILES += testHeaders
 .PHONY: testHeaders
-

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -107,7 +107,7 @@ MemObject::MemObject()
 MemObject::~MemObject()
 {
     debugs(20, 3, "MemObject destructed, this=" << this);
-    const auto ctx = DebugContext(hasUris() ? urlXXX() : "[unknown_ctx]");
+    const DebugContext ctx(hasUris() ? urlXXX() : "[unknown_ctx]");
 
 #if URL_CHECKSUM_DEBUG
     checkUrlChecksum();

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "comm/Connection.h"
+#include "DebugContext.h"
 #include "Generic.h"
 #include "globals.h"
 #include "HttpReply.h"
@@ -106,7 +107,7 @@ MemObject::MemObject()
 MemObject::~MemObject()
 {
     debugs(20, 3, "MemObject destructed, this=" << this);
-    const Ctx ctx = ctx_enter(hasUris() ? urlXXX() : "[unknown_ctx]");
+    const auto ctx = DebugContext(hasUris() ? urlXXX() : "[unknown_ctx]");
 
 #if URL_CHECKSUM_DEBUG
     checkUrlChecksum();
@@ -128,8 +129,6 @@ MemObject::~MemObject()
     assert(clients.head == NULL);
 
 #endif
-
-    ctx_exit(ctx);              /* must exit before we free mem->url */
 }
 
 HttpReply &

--- a/src/http.cc
+++ b/src/http.cc
@@ -964,7 +964,7 @@ HttpStateData::haveParsedReplyHeaders()
 {
     Client::haveParsedReplyHeaders();
 
-    auto ctx = DebugContext(entry->mem_obj->urlXXX());
+    const DebugContext ctx(entry->mem_obj->urlXXX());
     HttpReply *rep = finalReply();
     const Http::StatusCode statusCode = rep->sline.status();
 


### PR DESCRIPTION
Current uses of ctx_enter and ctx_exit are scope-based.
We can enrich them by implementing a RAII wrapper class
and fully rely on scope for entering and leaving contexts safely