### PR TITLE
PROXY protocol support for https_port

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -188,9 +188,7 @@ void FwdState::start(Pointer aSelf)
     // Bug 3243: CVE 2009-0801
     // Bypass of browser same-origin access control in intercepted communication
     // To resolve this we must force DIRECT and only to the original client destination.
-    const bool isIntercepted = request && !request->flags.redirected && (request->flags.intercepted || request->flags.interceptTproxy);
-    const bool useOriginalDst = Config.onoff.client_dst_passthru || (request && !request->flags.hostVerified);
-    if (isIntercepted && useOriginalDst) {
+    if (request && request->mustGoToOriginalDestination()) {
         selectPeerForIntercepted();
         return;
     }

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -542,7 +542,8 @@ HttpRequest::maybeCacheable()
     // Because it failed verification, or someone bypassed the security tests
     // we cannot cache the response for sharing between clients.
     // TODO: update cache to store for particular clients only (going to same Host: and destination IP)
-    if (!flags.hostVerified && (flags.intercepted || flags.interceptTproxy))
+    // XXX: add missing checks, see HttpRequest::mustGoToOriginalDestination()
+    if (!flags.hostVerified && masterXaction->hasListeningInterceptedPort())
         return false;
 
     switch (url.getScheme()) {
@@ -737,10 +738,7 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
 #endif /* FOLLOW_X_FORWARDED_FOR */
         my_addr = clientConnection->local;
 
-        flags.intercepted = ((clientConnection->flags & COMM_INTERCEPTION) != 0);
-        flags.interceptTproxy = ((clientConnection->flags & COMM_TRANSPARENT) != 0 ) ;
-        const bool proxyProtocolPort = port ? port->flags.proxySurrogate : false;
-        if (flags.interceptTproxy && !proxyProtocolPort) {
+        if (port && port->flags.tproxyInterceptLocally()) {
             if (Config.accessList.spoof_client_ip) {
                 ACLFilledChecklist *checklist = new ACLFilledChecklist(Config.accessList.spoof_client_ip, this, clientConnection->rfc931);
                 checklist->al = al;
@@ -752,6 +750,16 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
         } else
             flags.spoofClientIp = false;
     }
+}
+
+bool
+HttpRequest::mustGoToOriginalDestination() const
+{
+    // TODO: exclude flags.internal requests
+    // TODO: REQMOD/redirection occur after host header verification
+    const auto isIntercepted = !flags.redirected && masterXaction->hasListeningInterceptedPort();
+    const auto useOriginalDst = Config.onoff.client_dst_passthru || !flags.hostVerified;
+    return isIntercepted && useOriginalDst;
 }
 
 char *
@@ -798,9 +806,12 @@ FindListeningPortAddress(const HttpRequest *callerRequest, const AccessLogEntry 
     if (!ip && ale)
         ip = FindListeningPortAddressInPort(ale->cache.port);
 
-    // XXX: also handle PROXY protocol here when we have a flag to identify such request
-    if (ip || request->flags.interceptTproxy || request->flags.intercepted)
+    if (ip || request->masterXaction->hasListeningInterceptedPort())
         return ip;
+
+    // if (request->masterXaction->squidPort->flags.proxySurrogateHttp()) {
+    //     XXX: handle PROXY protocol here when we have a flag to identify such request
+    // }
 
     /* handle non-intercepted cases that were not handled above */
     ip = FindListeningPortAddressInConn(request->masterXaction->tcpClient);

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -104,6 +104,8 @@ public:
 
     /// associates the request with a from-client connection manager
     void manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntryPointer &al);
+    /// should use the original server IP and port provided by the client
+    bool mustGoToOriginalDestination() const;
 
 protected:
     void clean();

--- a/src/MasterXaction.h
+++ b/src/MasterXaction.h
@@ -43,7 +43,7 @@ public:
 
     /// Does not have association with a listening port.
     /// \param anInitiator any value other from XactionInitiator::initClient.
-   explicit MasterXaction(const XactionInitiator anInitiator) :
+    explicit MasterXaction(const XactionInitiator anInitiator) :
         initiator(anInitiator)
     {
         assert(!initiator.in(XactionInitiator::initClient));

--- a/src/MasterXaction.h
+++ b/src/MasterXaction.h
@@ -41,7 +41,24 @@ class MasterXaction : public RefCountable
 public:
     typedef RefCount<MasterXaction> Pointer;
 
-    explicit MasterXaction(const XactionInitiator anInitiator) : initiator(anInitiator) {};
+    /// Does not have association with a listening port.
+    /// \param anInitiator any value other from XactionInitiator::initClient.
+   explicit MasterXaction(const XactionInitiator anInitiator) :
+        initiator(anInitiator)
+    {
+        assert(!initiator.in(XactionInitiator::initClient));
+    };
+
+    /// Requires a listening port.
+    /// Compatible only with XactionInitiator::initClient.
+    explicit MasterXaction(const AnyP::PortCfgPointer &port) :
+        squidPort(port),
+        initiator(XactionInitiator::initClient)
+    {};
+
+    /// a convenience method returning TrafficMode::interceptedSomewhere() for the port accepted this transaction
+    /// \see TrafficMode::interceptedSomewhere() for details
+    bool hasListeningInterceptedPort() const { return squidPort && squidPort->flags.interceptedSomewhere(); }
 
     /// transaction ID.
     InstanceId<MasterXaction, uint64_t> id;

--- a/src/RequestFlags.h
+++ b/src/RequestFlags.h
@@ -58,12 +58,8 @@ public:
     bool accelerated = false;
     /** if set, ignore Cache-Control headers */
     bool ignoreCc = false;
-    /** set for intercepted requests */
-    bool intercepted = false;
     /** set if the Host: header passed verification */
     bool hostVerified = false;
-    /// Set for requests handled by a "tproxy" port.
-    bool interceptTproxy = false;
     /// The client IP address should be spoofed when connecting to the web server.
     /// This applies to TPROXY traffic that has not had spoofing disabled through
     /// the spoof_client_ip squid.conf ACL.

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -203,7 +203,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
         AnyP::PortCfgPointer p = HttpPortList;
         while (p != NULL) {
             // Bug 3239: not reliable when there is interception traffic coming
-            if (p->flags.natIntercept)
+            if (p->flags.interceptedSomewhere())
                 debugs(28, DBG_CRITICAL, "WARNING: 'myip' ACL is not reliable for interception proxies. Please use 'myportname' instead.");
             p = p->next;
         }
@@ -214,7 +214,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
         while (p != NULL) {
             // Bug 3239: not reliable when there is interception traffic coming
             // Bug 3239: myport - not reliable (yet) when there is interception traffic coming
-            if (p->flags.natIntercept)
+            if (p->flags.interceptedSomewhere())
                 debugs(28, DBG_CRITICAL, "WARNING: 'myport' ACL is not reliable for interception proxies. Please use 'myportname' instead.");
             p = p->next;
         }

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -45,7 +45,8 @@ ACLDestinationIP::match(ACLChecklist *cl)
     // Bypass of browser same-origin access control in intercepted communication
     // To resolve this we will force DIRECT and only to the original client destination.
     // In which case, we also need this ACL to accurately match the destination
-    if (Config.onoff.client_dst_passthru && (checklist->request->flags.intercepted || checklist->request->flags.interceptTproxy)) {
+    // TODO: use HttpRequest::mustGoToOriginalDestination() after XXX: add missing checks
+    if (Config.onoff.client_dst_passthru && checklist->request->masterXaction->hasListeningInterceptedPort()) {
         const auto conn = checklist->conn();
         return (conn && conn->clientConnection) ?
                ACLIP::match(conn->clientConnection->local) : -1;

--- a/src/anyp/TrafficMode.h
+++ b/src/anyp/TrafficMode.h
@@ -12,13 +12,8 @@
 namespace AnyP
 {
 
-/**
- * Set of 'mode' flags defining types of traffic which can be received.
- *
- * Use to determine the processing steps which need to be applied
- * to this traffic under any special circumstances which may apply.
- */
-class TrafficMode
+/// POD representation of TrafficMode flags
+class TrafficModeFlags
 {
 public:
     /** marks HTTP accelerator (reverse/surrogate proxy) traffic
@@ -29,7 +24,7 @@ public:
      */
     bool accelSurrogate = false;
 
-    /** marks ports receiving PROXY protocol traffic
+    /** marks http ports receiving PROXY protocol traffic
      *
      * Indicating the following are required:
      *  - PROXY protocol magic header
@@ -37,7 +32,20 @@ public:
      *  - indirect client IP trust verification is mandatory
      *  - TLS is not supported
      */
-    bool proxySurrogate = false;
+    bool proxySurrogateHttp = false;
+
+    /** marks https ports receiving PROXY protocol traffic
+     *
+     * Indicating the following are required:
+     *  - PROXY protocol magic header
+     *  - URL translation from relative to absolute form
+     *  - src/dst IP retrieved from magic PROXY header
+     *  - indirect client IP trust verification is mandatory
+     *  - Same-Origin verification is mandatory
+     *  - TLS is supported
+     *  - Squid authentication prohibited
+     */
+    bool proxySurrogateHttps = false;
 
     /** marks NAT intercepted traffic
      *
@@ -46,7 +54,7 @@ public:
      *  - URL translation from relative to absolute form
      *  - Same-Origin verification is mandatory
      *  - destination pinning is recommended
-     *  - authentication prohibited
+     *  - Squid authentication prohibited
      */
     bool natIntercept = false;
 
@@ -58,26 +66,98 @@ public:
      *  - URL translation from relative to absolute form
      *  - Same-Origin verification is mandatory
      *  - destination pinning is recommended
-     *  - authentication prohibited
+     *  - Squid authentication prohibited
      */
     bool tproxyIntercept = false;
+};
+
+/**
+ * Set of 'mode' flags defining types of trafic which can be received.
+ *
+ * Use to determine the processing steps which need to be applied
+ * to this traffic under any special circumstances which may apply.
+ */
+class TrafficMode
+{
+public:
+    /// This port handles traffic that has been intercepted prior to being delivered
+    /// to the TCP client of the accepted connection and/or to us. This port mode
+    /// alone does not imply that the client of the accepted TCP connection was not
+    /// connecting directly to this port (since commit 151ba0d).
+    bool interceptedSomewhere() const { return flags_.natIntercept || flags_.tproxyIntercept || flags_.proxySurrogateHttps; }
+
+    /// The client of the accepted TCP connection was connecting to this port.
+    /// The accepted traffic may have been intercepted earlier!
+    bool tcpToUs() const { return proxySurrogate() || !interceptedSomewhere(); }
+
+    /// The client of the accepted TCP connection was not connecting to this port.
+    /// The accepted traffic may have been intercepted earlier as well!
+    bool interceptedLocally() const { return interceptedSomewhere() && !tcpToUs(); }
+
+    // Unused yet.
+    /// This port handles traffic that has been intercepted prior to being delivered
+    /// to the TCP client of the accepted connection (which then connected to us).
+    bool interceptedRemotely() const { return interceptedSomewhere() && tcpToUs(); }
+
+    /// The client of the accepted TCP connection was connecting directly to this proxy port.
+    bool forwarded() const { return !interceptedSomewhere() && !flags_.accelSurrogate; }
+
+    /// whether the PROXY protocol header is required
+    bool proxySurrogate() const { return flags_.proxySurrogateHttp || flags_.proxySurrogateHttps; }
+
+    /// interceptedLocally() with configured NAT interception
+    bool natInterceptLocally() const { return flags_.natIntercept && interceptedLocally(); }
+
+    /// interceptedLocally() with configured TPROXY interception
+    bool tproxyInterceptLocally() const { return flags_.tproxyIntercept && interceptedLocally(); }
+
+    /// whether the reverse proxy is configured
+    bool accelSurrogate() const { return flags_.accelSurrogate; }
+
+    TrafficModeFlags &rawConfig() { return flags_; }
+
+    std::ostream &print(std::ostream &) const;
 
     /** marks intercept and decryption of CONNECT (tunnel) SSL traffic
      *
      * Indicating the following are required:
      *  - decryption of CONNECT request
      *  - URL translation from relative to absolute form
-     *  - authentication prohibited on unwrapped requests (only on the CONNECT tunnel)
+     *  - Squid authentication prohibited on unwrapped requests (only on the CONNECT tunnel)
      *  - encrypted outbound server connections
      *  - peer relay prohibited. TODO: re-encrypt and re-wrap with CONNECT
      */
     bool tunnelSslBumping = false;
 
-    /** true if the traffic is in any way intercepted
-     *
-     */
-    bool isIntercepted() { return natIntercept||tproxyIntercept ;}
+private:
+    TrafficModeFlags flags_;
 };
+
+inline std::ostream &
+TrafficMode::print(std::ostream &os) const
+{
+    if (flags_.natIntercept)
+        os << " NAT intercepted";
+    else if (flags_.tproxyIntercept)
+        os << " TPROXY intercepted";
+    else if (flags_.accelSurrogate)
+        os << " reverse-proxy";
+    else
+        os << " forward-proxy";
+
+    if (tunnelSslBumping)
+        os << " SSL bumped";
+    if (proxySurrogate())
+        os << " (with PROXY protocol header)";
+
+    return os;
+}
+
+inline std::ostream &
+operator <<(std::ostream &os, const TrafficMode &flags)
+{
+    return flags.print(os);
+}
 
 } // namespace AnyP
 

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -44,7 +44,7 @@ AuthenticateAcl(ACLChecklist *ch)
     } else if (request->flags.accelerated) {
         /* WWW authorization on accelerated requests */
         headertype = Http::HdrType::AUTHORIZATION;
-    } else if (request->flags.intercepted || request->flags.interceptTproxy) {
+    } else if (request->masterXaction->hasListeningInterceptedPort()) {
         debugs(28, DBG_IMPORTANT, "NOTICE: Authentication not applicable on intercepted requests.");
         return ACCESS_DENIED;
     } else {

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3596,37 +3596,38 @@ parse_port_option(AnyP::PortCfgPointer &s, char *token)
 {
     /* modes first */
 
+    auto &rawFlags = s->flags.rawConfig();
     if (strcmp(token, "accel") == 0) {
-        if (s->flags.isIntercepted()) {
+        if (s->flags.interceptedSomewhere()) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": Accelerator mode requires its own port. It cannot be shared with other modes.");
             self_destruct();
             return;
         }
-        s->flags.accelSurrogate = true;
+        rawFlags.accelSurrogate = true;
         s->vhost = true;
     } else if (strcmp(token, "transparent") == 0 || strcmp(token, "intercept") == 0) {
-        if (s->flags.accelSurrogate || s->flags.tproxyIntercept) {
+        if (rawFlags.accelSurrogate || rawFlags.tproxyIntercept) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": Intercept mode requires its own interception port. It cannot be shared with other modes.");
             self_destruct();
             return;
         }
-        s->flags.natIntercept = true;
+        rawFlags.natIntercept = true;
         Ip::Interceptor.StartInterception();
         /* Log information regarding the port modes under interception. */
         debugs(3, DBG_IMPORTANT, "Starting Authentication on port " << s->s);
         debugs(3, DBG_IMPORTANT, "Disabling Authentication on port " << s->s << " (interception enabled)");
     } else if (strcmp(token, "tproxy") == 0) {
-        if (s->flags.natIntercept || s->flags.accelSurrogate) {
+        if (rawFlags.natIntercept || rawFlags.accelSurrogate) {
             debugs(3,DBG_CRITICAL, "FATAL: " << cfg_directive << ": TPROXY option requires its own interception port. It cannot be shared with other modes.");
             self_destruct();
             return;
         }
-        s->flags.tproxyIntercept = true;
+        rawFlags.tproxyIntercept = true;
         Ip::Interceptor.StartTransparency();
         /* Log information regarding the port modes under transparency. */
         debugs(3, DBG_IMPORTANT, "Disabling Authentication on port " << s->s << " (TPROXY enabled)");
 
-        if (s->flags.proxySurrogate) {
+        if (s->flags.proxySurrogate()) {
             debugs(3, DBG_IMPORTANT, "Disabling TPROXY Spoofing on port " << s->s << " (require-proxy-header enabled)");
         }
 
@@ -3637,15 +3638,18 @@ parse_port_option(AnyP::PortCfgPointer &s, char *token)
         }
 
     } else if (strcmp(token, "require-proxy-header") == 0) {
-        s->flags.proxySurrogate = true;
-        if (s->flags.tproxyIntercept) {
+        if (s->transport.protocol == AnyP::PROTO_HTTPS)
+            rawFlags.proxySurrogateHttps = true;
+        else
+            rawFlags.proxySurrogateHttp = true;
+        if (rawFlags.tproxyIntercept) {
             // receiving is still permitted, so we do not unset the TPROXY flag
             // spoofing access control override takes care of the spoof disable later
             debugs(3, DBG_IMPORTANT, "Disabling TPROXY Spoofing on port " << s->s << " (require-proxy-header enabled)");
         }
 
     } else if (strncmp(token, "defaultsite=", 12) == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": defaultsite option requires Acceleration mode flag.");
             self_destruct();
             return;
@@ -3653,52 +3657,52 @@ parse_port_option(AnyP::PortCfgPointer &s, char *token)
         safe_free(s->defaultsite);
         s->defaultsite = xstrdup(token + 12);
     } else if (strcmp(token, "vhost") == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_CRITICAL, "WARNING: " << cfg_directive << ": vhost option is deprecated. Use 'accel' mode flag instead.");
         }
-        s->flags.accelSurrogate = true;
+        rawFlags.accelSurrogate = true;
         s->vhost = true;
     } else if (strcmp(token, "no-vhost") == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_IMPORTANT, "ERROR: " << cfg_directive << ": no-vhost option requires Acceleration mode flag.");
         }
         s->vhost = false;
     } else if (strcmp(token, "vport") == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": vport option requires Acceleration mode flag.");
             self_destruct();
             return;
         }
         s->vport = -1;
     } else if (strncmp(token, "vport=", 6) == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": vport option requires Acceleration mode flag.");
             self_destruct();
             return;
         }
         s->vport = xatos(token + 6);
     } else if (strncmp(token, "protocol=", 9) == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": protocol option requires Acceleration mode flag.");
             self_destruct();
             return;
         }
         s->transport = parsePortProtocol(ToUpper(SBuf(token + 9)));
     } else if (strcmp(token, "allow-direct") == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": allow-direct option requires Acceleration mode flag.");
             self_destruct();
             return;
         }
         s->allow_direct = true;
     } else if (strcmp(token, "act-as-origin") == 0) {
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_IMPORTANT, "ERROR: " << cfg_directive << ": act-as-origin option requires Acceleration mode flag.");
         } else
             s->actAsOrigin = true;
     } else if (strcmp(token, "ignore-cc") == 0) {
 #if !USE_HTTP_VIOLATIONS
-        if (!s->flags.accelSurrogate) {
+        if (!rawFlags.accelSurrogate) {
             debugs(3, DBG_CRITICAL, "FATAL: " << cfg_directive << ": ignore-cc option requires Acceleration mode flag.");
             self_destruct();
             return;
@@ -3857,24 +3861,25 @@ parsePortCfg(AnyP::PortCfgPointer *head, const char *optionName)
 
     s->secure.syncCaFiles();
 
+    const auto &rawFlags = s->flags.rawConfig();
     if (s->transport.protocol == AnyP::PROTO_HTTPS) {
         s->secure.encryptTransport = true;
 #if USE_OPENSSL
-        /* ssl-bump on https_port configuration requires either tproxy or intercept, and vice versa */
-        const bool hijacked = s->flags.isIntercepted();
-        if (s->flags.tunnelSslBumping && !hijacked) {
-            debugs(3, DBG_CRITICAL, "FATAL: ssl-bump on https_port requires tproxy/intercept which is missing.");
+        // https_port: ssl-bump requires one of: tproxy, intercept or require-proxy-header.
+        if (s->flags.tunnelSslBumping && !s->flags.interceptedSomewhere()) {
+            debugs(3, DBG_CRITICAL, "FATAL: ssl-bump on https_port requires tproxy/intercept/require-proxy-header which is missing.");
             self_destruct();
             return;
         }
-        if (hijacked && !s->flags.tunnelSslBumping) {
-            debugs(3, DBG_CRITICAL, "FATAL: tproxy/intercept on https_port requires ssl-bump which is missing.");
+        // https_port: tproxy, intercept and require-proxy-header require ssl-bump
+        if (s->flags.interceptedSomewhere() && !s->flags.tunnelSslBumping) {
+            debugs(3, DBG_CRITICAL, "FATAL: tproxy/intercept/require-proxy-header on https_port requires ssl-bump which is missing.");
             self_destruct();
             return;
         }
 #endif
-        if (s->flags.proxySurrogate) {
-            debugs(3,DBG_CRITICAL, "FATAL: https_port: require-proxy-header option is not supported on HTTPS ports.");
+        if (rawFlags.proxySurrogateHttps && (rawFlags.natIntercept || rawFlags.tproxyIntercept || rawFlags.accelSurrogate)) {
+            debugs(3, DBG_CRITICAL, "FATAL: require-proxy-header option is incompatible with tproxy/intercept/accel for https_port.");
             self_destruct();
             return;
         }
@@ -3885,9 +3890,14 @@ parsePortCfg(AnyP::PortCfgPointer *head, const char *optionName)
             self_destruct();
             return;
         }
-        if (s->flags.proxySurrogate) {
+        if (rawFlags.proxySurrogateHttp) {
             // Passive FTP data channel does not work without deep protocol inspection in the frontend.
             debugs(3,DBG_CRITICAL, "FATAL: require-proxy-header option is not supported on ftp_port.");
+            self_destruct();
+            return;
+        }
+        if (rawFlags.accelSurrogate) {
+            debugs(3,DBG_CRITICAL, "FATAL: Accelerator mode is not supported on ftp_port.");
             self_destruct();
             return;
         }
@@ -3925,17 +3935,18 @@ dump_generic_port(StoreEntry * e, const char *n, const AnyP::PortCfgPointer &s)
                       n,
                       s->s.toUrl(buf,MAX_IPSTRLEN));
 
+    const auto &rawFlags = s->flags.rawConfig();
     // MODES and specific sub-options.
-    if (s->flags.natIntercept)
+    if (rawFlags.natIntercept)
         storeAppendPrintf(e, " intercept");
 
-    else if (s->flags.tproxyIntercept)
+    else if (rawFlags.tproxyIntercept)
         storeAppendPrintf(e, " tproxy");
 
-    else if (s->flags.proxySurrogate)
+    else if (s->flags.proxySurrogate())
         storeAppendPrintf(e, " require-proxy-header");
 
-    else if (s->flags.accelSurrogate) {
+    else if (rawFlags.accelSurrogate) {
         storeAppendPrintf(e, " accel");
 
         if (s->vhost)
@@ -3967,7 +3978,7 @@ dump_generic_port(StoreEntry * e, const char *n, const AnyP::PortCfgPointer &s)
         storeAppendPrintf(e, " name=%s", s->name);
 
 #if USE_HTTP_VIOLATIONS
-    if (!s->flags.accelSurrogate && s->ignore_cc)
+    if (!rawFlags.accelSurrogate && s->ignore_cc)
         storeAppendPrintf(e, " ignore-cc");
 #endif
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2501,6 +2501,12 @@ DOC_START
 	The tls-cert= option is mandatory on HTTPS ports.
 
 	See http_port for a list of modes and options.
+
+	Enabling support for PROXY protocol connections on https_port (see
+	require-proxy-header) places the port in interception mode. Squid
+	assumes that the interception happens at or near a network agent like
+	HAProxy, and that agent then forwards the intercepted TLS connection
+	to Squid using a basic TCP connection with the PROXY protocol prefix.
 DOC_END
 
 NAME: ftp_port

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2605,8 +2605,7 @@ ConnStateData::httpsSslBumpStep1AccessCheck()
     // TODO: Use these request/ALE when waiting for new bumped transactions.
 
     ACLFilledChecklist *acl_checklist = new ACLFilledChecklist(Config.accessList.ssl_bump, request, NULL);
-    acl_checklist->src_addr = clientConnection->remote;
-    acl_checklist->my_addr = port->s;
+    fillChecklist(*acl_checklist);
     // Build a local AccessLogEntry to allow requiresAle() acls work
     acl_checklist->al = connectAle;
     acl_checklist->al->cache.start_time = current_time;

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -154,6 +154,8 @@ public:
         AsyncCall::Pointer closeHandler; ///< The close handler for pinned server side connection
     } pinning;
 
+    /// a convenience method returning TrafficMode::interceptedSomewhere() for the port accepted this connection
+    /// \see TrafficMode::interceptedSomewhere() for details
     bool transparent() const;
 
     /// true if we stopped receiving the request
@@ -256,6 +258,10 @@ public:
     void postHttpsAccept();
 
 #if USE_OPENSSL
+    /// initiates acl checks for step1 SSL bump
+    void httpsSslBumpStep1AccessCheck();
+    /// callback for httpsSslBumpStep1AccessCheck()
+    void httpsSslBumpStep1AccessCheckDone(const Acl::Answer answer);
     /// Initializes and starts a peek-and-splice negotiation with the SSL client
     void startPeekAndSplice();
 

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -47,8 +47,7 @@ namespace Comm
 #define COMM_NOCLOEXEC          0x02
 #define COMM_REUSEADDR          0x04  // shared FD may be both accept()ing and read()ing
 #define COMM_DOBIND             0x08  // requires a bind()
-#define COMM_TRANSPARENT        0x10  // arrived via TPROXY
-#define COMM_INTERCEPTION       0x20  // arrived via NAT
+#define COMM_TRANSPARENT        0x10  ///< whether TPROXY spoofing should be applied
 #define COMM_REUSEPORT          0x40 //< needs SO_REUSEPORT
 /// not registered with Comm and not owned by any connection-closing code
 #define COMM_ORPHANED           0x40
@@ -152,7 +151,9 @@ private:
     Connection & operator =(const Connection &c);
 
 public:
-    /** Address/Port for the Squid end of a TCP link. */
+    /// Address/Port for the Squid end of a TCP link or
+    /// the remote server Address/Port in a case of interception (for client connections)
+    /// \see TrafficMode::interceptedSomewhere()
     Ip::Address local;
 
     /** Address for the Remote end of a TCP link. */

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -333,7 +333,7 @@ Comm::TcpAcceptor::notify(const Comm::Flag flag, const Comm::ConnectionPointer &
     if (theCallSub != NULL) {
         AsyncCall::Pointer call = theCallSub->callback();
         CommAcceptCbParams &params = GetCommParams<CommAcceptCbParams>(call);
-        params.xaction = new MasterXaction(XactionInitiator::initClient);
+        params.xaction = new MasterXaction(listenPort_);
         params.xaction->squidPort = listenPort_;
         params.fd = conn->fd;
         params.conn = params.xaction->tcpClient = newConnDetails;
@@ -404,12 +404,20 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
     details->local = *gai;
     Ip::Address::FreeAddr(gai);
 
-    // Perform NAT or TPROXY operations to retrieve the real client/dest IP addresses
-    if (conn->flags&(COMM_TRANSPARENT|COMM_INTERCEPTION) && !Ip::Interceptor.Lookup(details, conn)) {
-        debugs(50, DBG_IMPORTANT, "ERROR: NAT/TPROXY lookup failed to locate original IPs on " << details);
-        // Failed.
-        PROF_stop(comm_accept);
-        return Comm::COMM_ERROR;
+    // Handle interceptedLocally() traffic here. The PROXY protocol supplies original
+    // client and destination IP addresses later, after parsing the PROXY protocol prefix.
+    if (listenPort_->flags.tproxyInterceptLocally()) {
+        if (!Ip::Interceptor.LookupTproxy(details)) {
+             debugs(50, DBG_IMPORTANT, "ERROR: TPROXY lookup failed to locate original IPs on " << details);
+             PROF_stop(comm_accept);
+             return Comm::COMM_ERROR;
+         }
+    } else if (listenPort_->flags.natInterceptLocally()) {
+        if (!Ip::Interceptor.LookupNat(details)) {
+            debugs(50, DBG_IMPORTANT, "ERROR: NAT lookup failed to locate original IPs on " << details);
+            PROF_stop(comm_accept);
+            return Comm::COMM_ERROR;
+        }
     }
 
 #if USE_SQUID_EUI

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -129,7 +129,7 @@ Ip::Intercept::StopInterception(const char *str)
 }
 
 bool
-Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn, int silent)
+Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn)
 {
 #if LINUX_NETFILTER
     struct sockaddr_storage lookup;
@@ -143,11 +143,9 @@ Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn, int
                     newConn->local.isIPv6() ? IP6T_SO_ORIGINAL_DST : SO_ORIGINAL_DST,
                     &lookup,
                     &len) != 0) {
-        if (!silent) {
-            int xerrno = errno;
-            debugs(89, DBG_IMPORTANT, "ERROR: NF getsockopt(ORIGINAL_DST) failed on " << newConn << ": " << xstrerr(xerrno));
-            lastReported_ = squid_curtime;
-        }
+        int xerrno = errno;
+        debugs(89, errorReportingLevel(), "ERROR: NF getsockopt(ORIGINAL_DST) failed on " << newConn << ": " << xstrerr(xerrno));
+        lastReported_ = squid_curtime;
         debugs(89, 9, "address: " << newConn);
         return false;
     } else {
@@ -160,8 +158,12 @@ Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn, int
 }
 
 bool
-Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn, int)
+Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn)
 {
+    /* --enable-linux-netfilter    */
+    /* --enable-ipfw-transparent   */
+    /* --enable-ipf-transparent    */
+    /* --enable-pf-transparent     */
 #if (LINUX_NETFILTER && defined(IP_TRANSPARENT)) || \
     (PF_TRANSPARENT && defined(SO_BINDANY)) || \
     (IPFW_TRANSPARENT && defined(IP_BINDANY))
@@ -171,13 +173,13 @@ Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn, int)
      */
     debugs(89, 5, HERE << "address TPROXY: " << newConn);
     return true;
-#else
-    return false;
 #endif
+    debugs(89, DBG_IMPORTANT, "WARNING: transparent proxying not supported");
+    return false;
 }
 
 bool
-Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn, int)
+Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn)
 {
 #if IPFW_TRANSPARENT
     /* The getsockname() call performed already provided the TCP packet details.
@@ -192,7 +194,7 @@ Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn, int)
 }
 
 bool
-Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silent)
+Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
 {
 #if IPF_TRANSPARENT  /* --enable-ipf-transparent */
 
@@ -243,12 +245,10 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
     }
 
     if (natfd < 0) {
-        if (!silent) {
-            int xerrno = errno;
-            debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT open failed: " << xstrerr(xerrno));
-            lastReported_ = squid_curtime;
-            return false;
-        }
+        const auto xerrno = errno;
+        debugs(89, errorReportingLevel(), "IPF (IPFilter) NAT open failed: " << xstrerr(xerrno));
+        lastReported_ = squid_curtime;
+        return false;
     }
 
 #if defined(IPFILTER_VERSION) && (IPFILTER_VERSION >= 4000027)
@@ -280,10 +280,8 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
     if (x < 0) {
         int xerrno = errno;
         if (xerrno != ESRCH) {
-            if (!silent) {
-                debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT lookup failed: ioctl(SIOCGNATL) (v=" << IPFILTER_VERSION << "): " << xstrerr(xerrno));
-                lastReported_ = squid_curtime;
-            }
+            debugs(89, errorReportingLevel(), "IPF (IPFilter) NAT lookup failed: ioctl(SIOCGNATL) (v=" << IPFILTER_VERSION << "): " << xstrerr(xerrno));
+            lastReported_ = squid_curtime;
 
             close(natfd);
             natfd = -1;
@@ -310,7 +308,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
 }
 
 bool
-Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent)
+Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
 {
 #if PF_TRANSPARENT  /* --enable-pf-transparent */
 
@@ -333,11 +331,9 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
         pffd = open("/dev/pf", O_RDONLY);
 
     if (pffd < 0) {
-        if (!silent) {
-            int xerrno = errno;
-            debugs(89, DBG_IMPORTANT, MYNAME << "PF open failed: " << xstrerr(xerrno));
-            lastReported_ = squid_curtime;
-        }
+        const auto xerrno = errno;
+        debugs(89, errorReportingLevel(), MYNAME << "PF open failed: " << xstrerr(xerrno));
+        lastReported_ = squid_curtime;
         return false;
     }
 
@@ -362,10 +358,8 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
     if (ioctl(pffd, DIOCNATLOOK, &nl)) {
         int xerrno = errno;
         if (xerrno != ENOENT) {
-            if (!silent) {
-                debugs(89, DBG_IMPORTANT, HERE << "PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
-                lastReported_ = squid_curtime;
-            }
+            debugs(89, errorReportingLevel(), HERE << "PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
+            lastReported_ = squid_curtime;
             close(pffd);
             pffd = -1;
         }
@@ -386,7 +380,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
 }
 
 bool
-Ip::Intercept::Lookup(const Comm::ConnectionPointer &newConn, const Comm::ConnectionPointer &listenConn)
+Ip::Intercept::LookupNat(const Comm::ConnectionPointer &newConn)
 {
     /* --enable-linux-netfilter    */
     /* --enable-ipfw-transparent   */
@@ -394,31 +388,20 @@ Ip::Intercept::Lookup(const Comm::ConnectionPointer &newConn, const Comm::Connec
     /* --enable-pf-transparent     */
 #if IPF_TRANSPARENT || LINUX_NETFILTER || IPFW_TRANSPARENT || PF_TRANSPARENT
 
-#if 0
-    // Crop interception errors down to one per minute.
-    int silent = (squid_curtime - lastReported_ > 60 ? 0 : 1);
-#else
-    // Show all interception errors.
-    int silent = 0;
-#endif
-
     debugs(89, 5, HERE << "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
 
-    newConn->flags |= (listenConn->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION));
-
-    /* NP: try TPROXY first, its much quieter than NAT when non-matching */
-    if (transparentActive_ && listenConn->flags&COMM_TRANSPARENT) {
-        if (TproxyTransparent(newConn, silent)) return true;
-    }
-
-    if (interceptActive_ && listenConn->flags&COMM_INTERCEPTION) {
+    if (interceptActive_) {
         /* NAT methods that use sock-opts to return client address */
-        if (NetfilterInterception(newConn, silent)) return true;
-        if (IpfwInterception(newConn, silent)) return true;
+        if (NetfilterInterception(newConn))
+            return true;
+        if (IpfwInterception(newConn))
+            return true;
 
         /* NAT methods that use ioctl to return client address AND destination address */
-        if (PfInterception(newConn, silent)) return true;
-        if (IpfInterception(newConn, silent)) return true;
+        if (PfInterception(newConn))
+            return true;
+        if (IpfInterception(newConn))
+            return true;
     }
 
 #else /* none of the transparent options configured */
@@ -426,6 +409,24 @@ Ip::Intercept::Lookup(const Comm::ConnectionPointer &newConn, const Comm::Connec
 #endif
 
     return false;
+}
+
+bool
+Ip::Intercept::LookupTproxy(const Comm::ConnectionPointer &newConn)
+{
+    debugs(89, 5, "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
+    return transparentActive_ && TproxyTransparent(newConn);
+}
+
+/// XXX: TcpAcceptor::oldAccept() reports "same" errors while ignoring this code.
+/// \returns debugs() level for reporting the current error
+int
+Ip::Intercept::errorReportingLevel()
+{
+    // TODO: Consider limiting level-1 errors to, say, one per minute:
+    // const auto important = squid_curtime - lastReported_ > 60;
+    lastReported_ = squid_curtime;
+    return DBG_IMPORTANT;
 }
 
 bool

--- a/src/ip/Intercept.h
+++ b/src/ip/Intercept.h
@@ -33,8 +33,10 @@ public:
     Intercept() : transparentActive_(0), interceptActive_(0), lastReported_(0) {};
     ~Intercept() {};
 
-    /** Perform NAT lookups */
-    bool Lookup(const Comm::ConnectionPointer &newConn, const Comm::ConnectionPointer &listenConn);
+    /// perform NAT lookups
+    bool LookupNat(const Comm::ConnectionPointer &newConn);
+    /// perform Tproxy lookups
+    bool LookupTproxy(const Comm::ConnectionPointer &newConn);
 
     /**
      * Test system networking calls for TPROXY support.
@@ -95,47 +97,44 @@ private:
      * perform Lookups on fully-transparent interception targets (TPROXY).
      * Supports Netfilter, PF and IPFW.
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool TproxyTransparent(const Comm::ConnectionPointer &newConn, int silent);
+    bool TproxyTransparent(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on Netfilter interception targets (REDIRECT, DNAT).
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool NetfilterInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool NetfilterInterception(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on IPFW interception.
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool IpfwInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool IpfwInterception(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on IPF interception.
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool IpfInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool IpfInterception(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on PF interception target (REDIRECT).
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool PfInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool PfInterception(const Comm::ConnectionPointer &newConn);
+
+    int errorReportingLevel();
 
     int transparentActive_;
     int interceptActive_;

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -421,11 +421,8 @@ PeerSelector::resolveSelected()
     // To resolve this we must use only the original client destination when going DIRECT
     // on intercepted traffic which failed Host verification
     const HttpRequest *req = request;
-    const bool isIntercepted = !req->flags.redirected &&
-                               (req->flags.intercepted || req->flags.interceptTproxy);
-    const bool useOriginalDst = Config.onoff.client_dst_passthru || !req->flags.hostVerified;
     const bool choseDirect = fs && fs->code == HIER_DIRECT;
-    if (isIntercepted && useOriginalDst && choseDirect) {
+    if (req->mustGoToOriginalDestination() && choseDirect) {
         // check the client is still around before using any of its details
         if (req->clientConnectionManager.valid()) {
             // construct a "result" adding the ORIGINAL_DST to the set instead of DIRECT

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -724,7 +724,7 @@ Ftp::Server::parseOneRequest()
     const SBuf *path = (params.length() && CommandHasPathParameter(cmd)) ?
                        &params : NULL;
     calcUri(path);
-    MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
+    MasterXaction::Pointer mx = new MasterXaction(port);
     mx->tcpClient = clientConnection;
     auto * const request = HttpRequest::FromUrl(uri, mx, method);
     if (!request) {
@@ -1444,7 +1444,25 @@ Ftp::Server::createDataConnection(Ip::Address cltAddr)
     Comm::ConnectionPointer conn = new Comm::Connection();
     conn->flags |= COMM_DOBIND;
 
-    if (clientConnection->flags & COMM_INTERCEPTION) {
+    if (port->flags.tproxyInterceptLocally() || port->flags.forwarded()) {
+       // In the case of explicit-proxy the local IP of the control connection
+       // is the Squid IP the client is knowingly talking to.
+       //
+       // In the case of TPROXY the IP address of the control connection is
+       // server IP the client is connecting to, it can be spoofed by Squid.
+       //
+       // In both cases some clients may refuse to accept data connections if
+       // these control connectin local-IP's are not used.
+       conn->setAddrs(clientConnection->local, cltAddr);
+
+       // Using non-local addresses in TPROXY mode requires appropriate socket option.
+       if (port->flags.tproxyInterceptLocally())
+           conn->flags |= COMM_TRANSPARENT;
+    } else {
+        assert(!port->flags.accelSurrogate());
+        // replace with interceptedSomewhere() when ftp_port supports PROXY protocol
+        Must(port->flags.natInterceptLocally());
+
         // In the case of NAT interception conn->local value is not set
         // because the TCP stack will automatically pick correct source
         // address for the data connection. We must only ensure that IP
@@ -1455,20 +1473,6 @@ Ftp::Server::createDataConnection(Ip::Address cltAddr)
             conn->local.setIPv4();
 
         conn->remote = cltAddr;
-    } else {
-        // In the case of explicit-proxy the local IP of the control connection
-        // is the Squid IP the client is knowingly talking to.
-        //
-        // In the case of TPROXY the IP address of the control connection is
-        // server IP the client is connecting to, it can be spoofed by Squid.
-        //
-        // In both cases some clients may refuse to accept data connections if
-        // these control connectin local-IP's are not used.
-        conn->setAddrs(clientConnection->local, cltAddr);
-
-        // Using non-local addresses in TPROXY mode requires appropriate socket option.
-        if (clientConnection->flags & COMM_TRANSPARENT)
-            conn->flags |= COMM_TRANSPARENT;
     }
 
     // RFC 959 requires active FTP connections to originate from port 20

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -22,7 +22,7 @@ class Server: public ConnStateData
     CBDATA_CLASS(Server);
 
 public:
-    Server(const MasterXaction::Pointer &xact, const bool beHttpsServer);
+    Server(const MasterXaction::Pointer &xact);
     virtual ~Server() {}
 
     void readSomeHttpData();
@@ -60,9 +60,6 @@ private:
 
     Http1::RequestParserPointer parser_;
     HttpRequestMethod method_; ///< parsed HTTP method
-
-    /// temporary hack to avoid creating a true HttpsServer class
-    const bool isHttpsServer;
 };
 
 } // namespace One

--- a/src/servers/forward.h
+++ b/src/servers/forward.h
@@ -28,14 +28,6 @@ ConnStateData *NewServer(MasterXactionPointer &xact);
 
 } // namespace Http
 
-namespace Https
-{
-
-/// create a new HTTPS connection handler; never returns NULL
-ConnStateData *NewServer(MasterXactionPointer &xact);
-
-} // namespace Https
-
 namespace Ftp
 {
 

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -162,7 +162,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
             // While we are peeking at the certificate, we may not know the server
             // name that the client will request (after interception or CONNECT)
             // unless it was the CONNECT request with a user-typed address.
-            const bool isConnectRequest = !csd->port->flags.isIntercepted();
+            const auto isConnectRequest = csd->port->flags.forwarded();
             if (!request->flags.sslPeek || isConnectRequest)
                 hostName = new SBuf(request->url.host());
         }
@@ -235,7 +235,7 @@ Ssl::PeekingPeerConnector::noteNegotiationDone(ErrorState *error)
             // For intercepted connections, set the host name to the server
             // certificate CN. Otherwise, we just hope that CONNECT is using
             // a user-entered address (a host name or a user-entered IP).
-            const bool isConnectRequest = !request->clientConnectionManager->port->flags.isIntercepted();
+            const auto isConnectRequest = request->clientConnectionManager->port->flags.forwarded();
             if (request->flags.sslPeek && !isConnectRequest) {
                 if (X509 *srvX509 = serverBump->serverCert.get()) {
                     if (const char *name = Ssl::CommonHostName(srvX509)) {

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -46,7 +46,7 @@ testHttpRequest::testCreateFromUrl()
     /* vanilla url, implicit method */
     unsigned short expected_port;
     SBuf url("http://foo:90/bar");
-    const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
+    const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initHtcp);
     HttpRequest *aRequest = HttpRequest::FromUrl(url, mx);
     expected_port = 90;
     CPPUNIT_ASSERT(aRequest != nullptr);
@@ -109,7 +109,7 @@ testHttpRequest::testIPv6HostColonBug()
 
     /* valid IPv6 address without port */
     SBuf url("http://[2000:800::45]/foo");
-    const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
+    const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initHtcp);
     aRequest = HttpRequest::FromUrl(url, mx, Http::METHOD_GET);
     expected_port = 80;
     CPPUNIT_ASSERT_EQUAL(expected_port, aRequest->url.port());
@@ -143,7 +143,7 @@ void
 testHttpRequest::testSanityCheckStartLine()
 {
     MemBuf input;
-    const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initClient);
+    const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initHtcp);
     PrivateHttpRequest engine(mx);
     Http::StatusCode error = Http::scNone;
     size_t hdr_len;

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -1005,7 +1005,7 @@ getMyPort(void)
     AnyP::PortCfgPointer p;
     if ((p = HttpPortList) != NULL) {
         // skip any special interception ports
-        while (p != NULL && p->flags.isIntercepted())
+        while (p && p->flags.interceptedSomewhere())
             p = p->next;
         if (p != NULL)
             return p->s.port();
@@ -1013,7 +1013,7 @@ getMyPort(void)
 
     if ((p = FtpPortList) != NULL) {
         // skip any special interception ports
-        while (p != NULL && p->flags.isIntercepted())
+        while (p && p->flags.interceptedSomewhere())
             p = p->next;
         if (p != NULL)
             return p->s.port();

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -107,8 +107,10 @@ public:
         if (http.valid() && http->getConn() && http->getConn()->serverBump() && http->getConn()->serverBump()->at(XactionStep::tlsBump2, XactionStep::tlsBump3))
             return false;
 #endif
-        return !(request != NULL &&
-                 (request->flags.interceptTproxy || request->flags.intercepted));
+        // TODO: add a boolean ClientHttpRequest::faked field to mark
+        // faked CONNECT requests instead of trying to guess whether a request was
+        // faked based on its port configuration.
+        return !(request && request->masterXaction->hasListeningInterceptedPort());
     }
 
     /// starts connecting to the next hop, either for the first time or while


### PR DESCRIPTION
To enable PROXY protocol support on an https_port with SslBump:

https_port ... ssl-bump ... require-proxy-header

SslBump is currently required for receiving PROXY protocol on an
https_port. The following https_port configurations lead to a fatal
configuration error:

* require-proxy-header without the ssl-bump mode
* require-proxy-header with one of the following https_port modes:
intercept, tproxy, and accel.

The implementation is based on a new proxySurrogateHttps flag
(the already existing proxySurrogateHttp serves for http_port).
To avoid complex conditions with TrafficMode flags combinations
throughout the code (often duplicated) we had to supply TrafficMode
with several methods covering all required modes and making the
flags themselves private. The old flags should be accessed/initialized
only from the configuration code.