### PR TITLE
Remove unused code silencing intercept errors

### DIFF
--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -129,7 +129,7 @@ Ip::Intercept::StopInterception(const char *str)
 }
 
 bool
-Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn, int silent)
+Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn)
 {
 #if LINUX_NETFILTER
     struct sockaddr_storage lookup;
@@ -143,12 +143,8 @@ Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn, int
                     newConn->local.isIPv6() ? IP6T_SO_ORIGINAL_DST : SO_ORIGINAL_DST,
                     &lookup,
                     &len) != 0) {
-        if (!silent) {
-            int xerrno = errno;
-            debugs(89, DBG_IMPORTANT, "ERROR: NF getsockopt(ORIGINAL_DST) failed on " << newConn << ": " << xstrerr(xerrno));
-            lastReported_ = squid_curtime;
-        }
-        debugs(89, 9, "address: " << newConn);
+        int xerrno = errno;
+        debugs(89, DBG_IMPORTANT, "ERROR: NF getsockopt(ORIGINAL_DST) failed on " << newConn << ": " << xstrerr(xerrno));
         return false;
     } else {
         newConn->local = lookup;
@@ -160,7 +156,7 @@ Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn, int
 }
 
 bool
-Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn, int)
+Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn)
 {
 #if (LINUX_NETFILTER && defined(IP_TRANSPARENT)) || \
     (PF_TRANSPARENT && defined(SO_BINDANY)) || \
@@ -177,7 +173,7 @@ Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn, int)
 }
 
 bool
-Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn, int)
+Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn)
 {
 #if IPFW_TRANSPARENT
     /* The getsockname() call performed already provided the TCP packet details.
@@ -192,7 +188,7 @@ Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn, int)
 }
 
 bool
-Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silent)
+Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
 {
 #if IPF_TRANSPARENT  /* --enable-ipf-transparent */
 
@@ -243,12 +239,9 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
     }
 
     if (natfd < 0) {
-        if (!silent) {
-            int xerrno = errno;
-            debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT open failed: " << xstrerr(xerrno));
-            lastReported_ = squid_curtime;
-            return false;
-        }
+        int xerrno = errno;
+        debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT open failed: " << xstrerr(xerrno));
+        return false;
     }
 
 #if defined(IPFILTER_VERSION) && (IPFILTER_VERSION >= 4000027)
@@ -280,11 +273,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
     if (x < 0) {
         int xerrno = errno;
         if (xerrno != ESRCH) {
-            if (!silent) {
-                debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT lookup failed: ioctl(SIOCGNATL) (v=" << IPFILTER_VERSION << "): " << xstrerr(xerrno));
-                lastReported_ = squid_curtime;
-            }
-
+            debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT lookup failed: ioctl(SIOCGNATL) (v=" << IPFILTER_VERSION << "): " << xstrerr(xerrno));
             close(natfd);
             natfd = -1;
         }
@@ -310,7 +299,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn, int silen
 }
 
 bool
-Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent)
+Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
 {
 #if PF_TRANSPARENT  /* --enable-pf-transparent */
 
@@ -333,11 +322,8 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
         pffd = open("/dev/pf", O_RDONLY);
 
     if (pffd < 0) {
-        if (!silent) {
-            int xerrno = errno;
-            debugs(89, DBG_IMPORTANT, MYNAME << "PF open failed: " << xstrerr(xerrno));
-            lastReported_ = squid_curtime;
-        }
+        int xerrno = errno;
+        debugs(89, DBG_IMPORTANT, "PF open failed: " << xstrerr(xerrno));
         return false;
     }
 
@@ -362,10 +348,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn, int silent
     if (ioctl(pffd, DIOCNATLOOK, &nl)) {
         int xerrno = errno;
         if (xerrno != ENOENT) {
-            if (!silent) {
-                debugs(89, DBG_IMPORTANT, HERE << "PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
-                lastReported_ = squid_curtime;
-            }
+            debugs(89, DBG_IMPORTANT, "PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
             close(pffd);
             pffd = -1;
         }
@@ -394,31 +377,23 @@ Ip::Intercept::Lookup(const Comm::ConnectionPointer &newConn, const Comm::Connec
     /* --enable-pf-transparent     */
 #if IPF_TRANSPARENT || LINUX_NETFILTER || IPFW_TRANSPARENT || PF_TRANSPARENT
 
-#if 0
-    // Crop interception errors down to one per minute.
-    int silent = (squid_curtime - lastReported_ > 60 ? 0 : 1);
-#else
-    // Show all interception errors.
-    int silent = 0;
-#endif
-
     debugs(89, 5, HERE << "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
 
     newConn->flags |= (listenConn->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION));
 
     /* NP: try TPROXY first, its much quieter than NAT when non-matching */
     if (transparentActive_ && listenConn->flags&COMM_TRANSPARENT) {
-        if (TproxyTransparent(newConn, silent)) return true;
+        if (TproxyTransparent(newConn)) return true;
     }
 
     if (interceptActive_ && listenConn->flags&COMM_INTERCEPTION) {
         /* NAT methods that use sock-opts to return client address */
-        if (NetfilterInterception(newConn, silent)) return true;
-        if (IpfwInterception(newConn, silent)) return true;
+        if (NetfilterInterception(newConn)) return true;
+        if (IpfwInterception(newConn)) return true;
 
         /* NAT methods that use ioctl to return client address AND destination address */
-        if (PfInterception(newConn, silent)) return true;
-        if (IpfInterception(newConn, silent)) return true;
+        if (PfInterception(newConn)) return true;
+        if (IpfInterception(newConn)) return true;
     }
 
 #else /* none of the transparent options configured */

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -143,7 +143,7 @@ Ip::Intercept::NetfilterInterception(const Comm::ConnectionPointer &newConn)
                     newConn->local.isIPv6() ? IP6T_SO_ORIGINAL_DST : SO_ORIGINAL_DST,
                     &lookup,
                     &len) != 0) {
-        int xerrno = errno;
+        const auto xerrno = errno;
         debugs(89, DBG_IMPORTANT, "ERROR: NF getsockopt(ORIGINAL_DST) failed on " << newConn << ": " << xstrerr(xerrno));
         return false;
     } else {
@@ -239,8 +239,8 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
     }
 
     if (natfd < 0) {
-        int xerrno = errno;
-        debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT open failed: " << xstrerr(xerrno));
+        const auto xerrno = errno;
+        debugs(89, DBG_IMPORTANT, "ERROR: IPF (IPFilter) NAT open failed: " << xstrerr(xerrno));
         return false;
     }
 
@@ -271,9 +271,9 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
 
 #endif
     if (x < 0) {
-        int xerrno = errno;
+        const auto xerrno = errno;
         if (xerrno != ESRCH) {
-            debugs(89, DBG_IMPORTANT, "IPF (IPFilter) NAT lookup failed: ioctl(SIOCGNATL) (v=" << IPFILTER_VERSION << "): " << xstrerr(xerrno));
+            debugs(89, DBG_IMPORTANT, "ERROR: IPF (IPFilter) NAT lookup failed: ioctl(SIOCGNATL) (v=" << IPFILTER_VERSION << "): " << xstrerr(xerrno));
             close(natfd);
             natfd = -1;
         }
@@ -322,8 +322,8 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
         pffd = open("/dev/pf", O_RDONLY);
 
     if (pffd < 0) {
-        int xerrno = errno;
-        debugs(89, DBG_IMPORTANT, "PF open failed: " << xstrerr(xerrno));
+        const auto xerrno = errno;
+        debugs(89, DBG_IMPORTANT, "ERROR: PF open failed: " << xstrerr(xerrno));
         return false;
     }
 
@@ -346,9 +346,9 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
     nl.direction = PF_OUT;
 
     if (ioctl(pffd, DIOCNATLOOK, &nl)) {
-        int xerrno = errno;
+        const auto xerrno = errno;
         if (xerrno != ENOENT) {
-            debugs(89, DBG_IMPORTANT, "PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
+            debugs(89, DBG_IMPORTANT, "ERROR: PF lookup failed: ioctl(DIOCNATLOOK): " << xstrerr(xerrno));
             close(pffd);
             pffd = -1;
         }

--- a/src/ip/Intercept.h
+++ b/src/ip/Intercept.h
@@ -11,9 +11,6 @@
 #ifndef SQUID_IP_IPINTERCEPT_H
 #define SQUID_IP_IPINTERCEPT_H
 
-/* for time_t */
-#include "SquidTime.h"
-
 namespace Ip
 {
 
@@ -30,7 +27,7 @@ class Address;
 class Intercept
 {
 public:
-    Intercept() : transparentActive_(0), interceptActive_(0), lastReported_(0) {};
+    Intercept() : transparentActive_(0), interceptActive_(0) {}
     ~Intercept() {};
 
     /** Perform NAT lookups */
@@ -95,51 +92,45 @@ private:
      * perform Lookups on fully-transparent interception targets (TPROXY).
      * Supports Netfilter, PF and IPFW.
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool TproxyTransparent(const Comm::ConnectionPointer &newConn, int silent);
+    bool TproxyTransparent(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on Netfilter interception targets (REDIRECT, DNAT).
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool NetfilterInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool NetfilterInterception(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on IPFW interception.
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool IpfwInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool IpfwInterception(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on IPF interception.
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool IpfInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool IpfInterception(const Comm::ConnectionPointer &newConn);
 
     /**
      * perform Lookups on PF interception target (REDIRECT).
      *
-     * \param silent   0 if errors are to be displayed. 1 if errors are to be hidden.
      * \param newConn  Details known, to be updated where relevant.
      * \return         Whether successfully located the new address.
      */
-    bool PfInterception(const Comm::ConnectionPointer &newConn, int silent);
+    bool PfInterception(const Comm::ConnectionPointer &newConn);
 
     int transparentActive_;
     int interceptActive_;
-    time_t lastReported_; /**< Time of last error report. Throttles NAT error display to 1 per minute */
 };
 
 #if LINUX_NETFILTER && !defined(IP_TRANSPARENT)


### PR DESCRIPTION
The removed code has not been actively used almost since it was added.

It is now widely accepted that NAT and TPROXY can only be done on the
machine running Squid. The corresponding address lookup errors are an
indication of either a system misconfiguration or an adverse external
event such as flushing of conntrack tables. Since these errors should be
fatal to the affected transactions and the admin usually has the power
to address them, Squid should report them at level 1.