### PR TITLE
Fix an OpenBSD compile issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -369,6 +369,13 @@ if test "x$ac_cv_require_wno_deprecated_register" = "xyes"; then
   SQUID_CXXFLAGS="$SQUID_CXXFLAGS -Wno-deprecated-register"
 fi
 
+dnl openbsd is super strict when dealing with system headers
+SQUID_CC_CHECK_ARGUMENT([ac_cv_support_wno_error_system_headers],
+                         [-Werror -Wno-system-headers])
+if test "x$ac_cv_support_wno_error_system_headers" != "xno"; then
+  SQUID_CXXFLAGS="$SQUID_CXXFLAGS -Wno-system-headers"
+fi
+
 # squid_cv_cc_arg_pipe is set by SQUID_CC_GUESS_OPTIONS
 SQUID_CXXFLAGS="$SQUID_CXXFLAGS $squid_cv_cc_arg_pipe"
 SQUID_CFLAGS="$SQUID_CFLAGS $squid_cv_cc_arg_pipe"


### PR DESCRIPTION
System headers are super strict on OpenBSD,
as are default compile options.
Our custom operators delete and new, defined
in SquidNew.cc, have a mismatching exception
signature against egcc and stdlibc++.

Add a compile-time option not to abort on issues
with system headers