### PR TITLE
Fix FD accept() error handling

### DIFF
--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -24,7 +24,7 @@ Comm::AcceptLimiter::Instance()
 void
 Comm::AcceptLimiter::defer(const Comm::TcpAcceptor::Pointer &afd)
 {
-    debugs(5, 5, afd->conn << "; already queued: " << deferred_.size());
+    debugs(5, 5, afd->listenConn << "; already queued: " << deferred_.size());
     deferred_.push_back(afd);
 }
 
@@ -34,11 +34,11 @@ Comm::AcceptLimiter::removeDead(const Comm::TcpAcceptor::Pointer &afd)
     for (auto it = deferred_.begin(); it != deferred_.end(); ++it) {
         if (*it == afd) {
             *it = nullptr; // fast. kick() will skip empty entries later.
-            debugs(5,4, "Abandoned client TCP SYN by closing socket: " << afd->conn);
+            debugs(5,4, "Abandoned client TCP SYN by closing socket: " << afd->listenConn);
             return;
         }
     }
-    debugs(5,4, "Not found " << afd->conn << " in queue, size: " << deferred_.size());
+    debugs(5,4, "Not found " << afd->listenConn << " in queue, size: " << deferred_.size());
 }
 
 void

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -88,7 +88,7 @@ private:
 
     /// conn being listened on for new connections
     /// Reserved for read-only use.
-    ConnectionPointer conn;
+    ConnectionPointer listenConn;
 
     /// configuration details of the listening port (if provided)
     AnyP::PortCfgPointer listenPort_;


### PR DESCRIPTION
FD begin their lifecycle belonging to TcpAcceptor which
is responsible for closing per Comm::Connection API.

That means FD which have issues within the TcpAcceptor
logic should be close()'d with a specific ERROR or
WARNING message displayed about the reason for closure.

Do not enter connections for orphanage until their
ownership is passed into the async queue for a Subscriber.