### PR TITLE
Reconfiguration orphans stateless helper connection

### DIFF
--- a/src/helper.cc
+++ b/src/helper.cc
@@ -967,8 +967,7 @@ helperReturnBuffer(helper_server * srv, helper * hlp, char * msg, size_t msgSize
     if (!srv->flags.shutdown) {
         helperKickQueue(hlp);
     } else if (!srv->flags.closing && !srv->stats.pending) {
-        srv->flags.closing=true;
-        srv->writePipe->close();
+        srv->closeWritePipeSafely(srv->parent->id_name);
     }
 }
 


### PR DESCRIPTION
The helper.cc code (ab)uses two different Connection objects with the
same FD. Properly fixing that problem requires significant work, but the
official code almost gets away with it, in part, because helper.cc, with
one exception, uses heavily customized code to "safely" close its
connections (instead of just calling conn->close() as many Squid jobs
still do). This fix replaces that single exceptional case with a
closeWritePipeSafely() call which prevents orphaning readPipe and
triggering BUG 3329 warnings. It also restores the symmetry between the
corresponding (previously buggy) stateless and (OK) statefull code.

A code merge mistake in commit b038892 created this bug AFAICT.