### PR TITLE
Fix sslcrtd and external_acl helper name lifetimes

### DIFF
--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1115,7 +1115,7 @@ externalAclInit(void)
             p->cache = hash_create((HASHCMP *) strcmp, hashPrime(1024), hash4);
 
         if (!p->theHelper)
-            p->theHelper = new helper(p->name);
+            p->theHelper = new helper("external_acl_type");
 
         p->theHelper->cmdline = p->cmdline;
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -65,6 +65,7 @@ class helper
     CBDATA_CLASS(helper);
 
 public:
+    /// \param name admin-visible helper category (with this process lifetime)
     inline helper(const char *name) :
         cmdline(NULL),
         id_name(name),

--- a/src/ssl/helper.cc
+++ b/src/ssl/helper.cc
@@ -86,7 +86,7 @@ void Ssl::Helper::Init()
     if (!found)
         return;
 
-    ssl_crtd = new helper(Ssl::TheConfig.ssl_crtd);
+    ssl_crtd = new helper("sslcrtd_program");
     ssl_crtd->childs.updateLimits(Ssl::TheConfig.ssl_crtdChildren);
     ssl_crtd->ipc_type = IPC_STREAM;
     // The crtd messages may contain the eol ('\n') character. We are


### PR DESCRIPTION
    helperShutdown: <binary garbage> #Hlpr523 shutting down.
    helperShutdown: See example.net/legal-terms #Hlpr4456 shutting down.

Busy "class helper" objects often outlive configuration that was used to
create them. Ideally, the supplied helper category name should be copied
and maintained by the helper object itself, but that long-term solution
requires a lot more work (TODO) due to out-of-scope bugs.