### PR TITLE
Fix ClpMap build error on arm32

### DIFF
--- a/src/SquidMath.h
+++ b/src/SquidMath.h
@@ -80,8 +80,8 @@ Sum(const T a, const U b) {
 template <typename T, typename... Args>
 Optional<T>
 Sum(const T first, Args... args) {
-    if (const auto others = Sum(args...)) {
-        return Sum(first, others.value());
+    if (const auto others = Sum<T>(args...)) {
+        return Sum<T>(first, others.value());
     } else {
         return Optional<T>();
     }

--- a/src/base/ClpMap.h
+++ b/src/base/ClpMap.h
@@ -194,12 +194,13 @@ ClpMap<Key, Value, MemoryUsedBy>::MemoryCountedFor(const Key &k, const Value &v)
 
     // approximate calculation (e.g., containers store wrappers not value_types)
     return Sum<uint64_t>(
-               keySz,
                // storage
                sizeof(typename Entries::value_type),
                MemoryUsedBy(v),
                // index
-               sizeof(typename Index::value_type));
+               sizeof(typename Index::value_type),
+               // key
+               keySz);
 }
 
 template <class Key, class Value, uint64_t MemoryUsedBy(const Value &)>

--- a/src/base/ClpMap.h
+++ b/src/base/ClpMap.h
@@ -194,13 +194,12 @@ ClpMap<Key, Value, MemoryUsedBy>::MemoryCountedFor(const Key &k, const Value &v)
 
     // approximate calculation (e.g., containers store wrappers not value_types)
     return Sum<uint64_t>(
+               keySz,
                // storage
                sizeof(typename Entries::value_type),
                MemoryUsedBy(v),
                // index
-               sizeof(typename Index::value_type),
-               // key
-               keySz);
+               sizeof(typename Index::value_type));
 }
 
 template <class Key, class Value, uint64_t MemoryUsedBy(const Value &)>


### PR DESCRIPTION
    static_assert ... "Sum() return type can fit its (unsigned) result"
    in ClpMap member instantiation inside sslCrtvdHandleReplyWrapper()

Honor Sum<T>() caller's explicit request to use a specific accumulation
type T instead of guessing the right type for inner sum iterations
(based on the second, third, etc. arguments) and hitting static
assertions when those guesses were wrong because some of those arguments
used types smaller than T.

This fix also allows Sum() callers to avoid explicit T when the first
argument is already the largest one. Callers should not be forced to be
explicit at all, but computing the largest type is a complex known TODO
outside this fix scope.
