### PR TITLE
SSL_SESSION::master_key cannot be falsy

### DIFF
--- a/compat/openssl.h
+++ b/compat/openssl.h
@@ -175,7 +175,7 @@ extern "C" {
     inline size_t
     SSL_SESSION_get_master_key(const SSL_SESSION *session, unsigned char *outStart, size_t outSizeMax)
     {
-        if (!session || !session->master_key || session->master_key_length <= 0)
+        if (!session || session->master_key_length <= 0)
             return 0;
 
         const auto sourceSize = static_cast<size_t>(session->master_key_length);


### PR DESCRIPTION
SSL_SESSION::master_key data member is an array. It cannot be falsy.

This fixes clang -Wpointer-bool-conversion.
