### PR TITLE
Fix build on Ubuntu 21

### DIFF
--- a/src/tools.cc
+++ b/src/tools.cc
@@ -582,7 +582,10 @@ enter_suid(void)
     }
 #else
 
-    setuid(0);
+    if (setuid(0) < 0) {
+        const auto xerrno = errno;
+        debugs(21, 3, "enter_suid: setuid failed: " << xstrerr(xerrno));
+    }
 #endif
 #if HAVE_PRCTL && defined(PR_SET_DUMPABLE)
     /* Set Linux DUMPABLE flag */

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -584,7 +584,7 @@ enter_suid(void)
 
     if (setuid(0) < 0) {
         const auto xerrno = errno;
-        debugs(21, 3, "enter_suid: setuid failed: " << xstrerr(xerrno));
+        debugs(21, 3, "setuid(0) failed: " << xstrerr(xerrno));
     }
 #endif
 #if HAVE_PRCTL && defined(PR_SET_DUMPABLE)


### PR DESCRIPTION
The `-Wunused-result` warning for setuid(0) call was observed on Ubuntu
21.04 (when cross compiling Squid for Ubuntu 21.10).

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>