### PR TITLE
Fix build on RISC-V

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -451,6 +451,8 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
 #include <cstdint>
       int
       main(int, char **) {
+          std::atomic<unsigned char> foo(0);
+          foo.exchange(1);
           return std::atomic<uint64_t>{}.is_lock_free() ? 0 : 1;
       }
   ]])],[

--- a/configure.ac
+++ b/configure.ac
@@ -450,10 +450,11 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
 #include <atomic>
 #include <cstdint>
       int
-      main(int, char **) {
-          std::atomic<int> foo(0);
-          foo.exchange(1);
-          return std::atomic<uint64_t>{}.is_lock_free() ? 0 : 1;
+      main(int argc, char **) {
+          return (
+              std::atomic<int>(argc).exchange(0) &&
+              std::atomic<uint64_t>{}.is_lock_free()
+              ) ? 0 : 1;
       }
   ]])],[
     AC_MSG_RESULT(yes)

--- a/configure.ac
+++ b/configure.ac
@@ -452,7 +452,7 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
       int
       main(int argc, char **) {
           return (
-              std::atomic<int>(argc).exchange(0) &&
+              std::atomic<uint8_t>(uint8_t(argc)).exchange(0) &&
               std::atomic<uint64_t>{}.is_lock_free()
               ) ? 0 : 1;
       }

--- a/configure.ac
+++ b/configure.ac
@@ -451,7 +451,7 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
 #include <cstdint>
       int
       main(int, char **) {
-          std::atomic<unsigned char> foo(0);
+          std::atomic<int> foo(0);
           foo.exchange(1);
           return std::atomic<uint64_t>{}.is_lock_free() ? 0 : 1;
       }


### PR DESCRIPTION
Compiling on RISC-V (without an explicit -latomic) fails with

    /usr/riscv64-linux-gnu/include/c++/10/ostream:611:
    undefined reference to __atomic_compare_exchange_1

Use std::atomic<uint8_t>::exchange() to detect whether -latomic
implements 1-byte compare-and-exchange API used by Squid.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>