### PR TITLE
Bug 4696: Fix leaky String move assignment operator

### DIFF
--- a/src/SquidString.h
+++ b/src/SquidString.h
@@ -42,6 +42,7 @@ public:
     String &operator =(String const &);
     String &operator =(String && S) {
         if (this != &S) {
+            clean();
             size_ = S.size_;
             len_ = S.len_;
             buf_ = S.buf_;


### PR DESCRIPTION
The original attempt at fixing String move assignment operator (i.e.
commit 20a04c1) leaked the assigned-to String object memory.

These leaks are measurable even in --disable-optimizations builds.