### PR TITLE
Fix ACL-related reconfiguration memory leak

### DIFF
--- a/src/acl/Strategised.h
+++ b/src/acl/Strategised.h
@@ -64,6 +64,7 @@ template <class MatchType>
 ACLStrategised<MatchType>::~ACLStrategised()
 {
     delete data;
+    delete matcher;
 }
 
 template <class MatchType>


### PR DESCRIPTION
Leaking since commit 4eac340 that migrated from statically-allocated
ACLStrategy<...>::Instance_ objects to dynamically allocated ones.

Most ACLStrategy objects have no data members, probably leaking just one
virtual table pointer (per named ACL), but strategies that support ACL
(data) --options, like ACLDestinationDomainStrategy and
ACLServerNameStrategy, leak memory used for options storage.