### PR TITLE
Cleanup macros in src/defines.h

### DIFF
--- a/src/acl/TimeData.cc
+++ b/src/acl/TimeData.cc
@@ -16,6 +16,16 @@
 #include "Debug.h"
 #include "wordlist.h"
 
+#define ACL_SUNDAY  0x01
+#define ACL_MONDAY  0x02
+#define ACL_TUESDAY 0x04
+#define ACL_WEDNESDAY   0x08
+#define ACL_THURSDAY    0x10
+#define ACL_FRIDAY  0x20
+#define ACL_SATURDAY    0x40
+#define ACL_ALLWEEK 0x7F
+#define ACL_WEEKDAYS    0x3E
+
 ACLTimeData::ACLTimeData () : weekbits (0), start (0), stop (0), next (NULL) {}
 
 ACLTimeData::ACLTimeData(ACLTimeData const &old) : weekbits(old.weekbits), start (old.start), stop (old.stop), next (NULL)

--- a/src/defines.h
+++ b/src/defines.h
@@ -20,16 +20,6 @@
 #define BUFSIZ  4096            /* make unreasonable guess */
 #endif
 
-#define ACL_SUNDAY  0x01
-#define ACL_MONDAY  0x02
-#define ACL_TUESDAY 0x04
-#define ACL_WEDNESDAY   0x08
-#define ACL_THURSDAY    0x10
-#define ACL_FRIDAY  0x20
-#define ACL_SATURDAY    0x40
-#define ACL_ALLWEEK 0x7F
-#define ACL_WEEKDAYS    0x3E
-
 /* Select types. */
 #define COMM_SELECT_READ   (0x1)
 #define COMM_SELECT_WRITE  (0x2)

--- a/src/defines.h
+++ b/src/defines.h
@@ -126,10 +126,6 @@
 #define AUTH_MSG_SZ 4096
 #define CLIENT_REQ_BUF_SZ 4096
 
-#if !defined(ERROR_BUF_SZ) && defined(MAX_URL)
-#define ERROR_BUF_SZ (MAX_URL << 2)
-#endif
-
 #if SQUID_SNMP
 #define VIEWINCLUDED    1
 #define VIEWEXCLUDED    2

--- a/src/defines.h
+++ b/src/defines.h
@@ -20,8 +20,6 @@
 #define BUFSIZ  4096            /* make unreasonable guess */
 #endif
 
-#define BROWSERNAMELEN 128
-
 #define ACL_SUNDAY  0x01
 #define ACL_MONDAY  0x02
 #define ACL_TUESDAY 0x04

--- a/src/defines.h
+++ b/src/defines.h
@@ -29,33 +29,15 @@
 #define DISK_EOF                 (-2)
 #define DISK_NO_SPACE_LEFT       (-6)
 
-#define DNS_INBUF_SZ 4096
-
 #define FD_DESC_SZ      64
 
 #define FQDN_LOOKUP_IF_MISS 0x01
 #define FQDN_MAX_NAMES 5
 
-#define BUF_TYPE_8K     1
-#define BUF_TYPE_MALLOC 2
-
-#define ANONYMIZER_NONE     0
-#define ANONYMIZER_STANDARD 1
-#define ANONYMIZER_PARANOID 2
-
 #define USER_IDENT_SZ 64
-#define IDENT_NONE 0
-#define IDENT_PENDING 1
-#define IDENT_DONE 2
 
 #define IP_LOOKUP_IF_MISS   0x01
 
-#define MAX_MIME 4096
-
-/* Mark a neighbor cache as dead if it doesn't answer this many pings */
-#define HIER_MAX_DEFICIT  20
-
-#define ICP_FLAG_HIT_OBJ     0x80000000ul
 #define ICP_FLAG_SRC_RTT     0x40000000ul
 
 /* Version */
@@ -74,19 +56,13 @@
 #define REDIRECT_PENDING 1
 #define REDIRECT_DONE 2
 
-#define AUTHENTICATE_AV_FACTOR 1000
 /* AUTHENTICATION */
-
-#define NTLM_CHALLENGE_SZ 300
-
-#define current_stacksize(stack) ((stack)->top - (stack)->base)
 
 /* logfile status */
 #define LOG_ENABLE  1
 #define LOG_DISABLE 0
 
 #define SM_PAGE_SIZE 4096
-#define MAX_CLIENT_BUF_SZ 4096
 
 #define EBIT_SET(flag, bit)     ((void)((flag) |= ((1L<<(bit)))))
 #define EBIT_CLR(flag, bit)     ((void)((flag) &= ~((1L<<(bit)))))
@@ -99,8 +75,6 @@
 #define CBIT_CLR(mask, bit)     ((void)(CBIT_BIN(mask, bit) &= ~CBIT_BIT(bit)))
 #define CBIT_TEST(mask, bit)    (CBIT_BIN(mask, bit) & CBIT_BIT(bit))
 
-#define MAX_FILES_PER_DIR (1<<20)
-
 #define MAX_URL  8192
 #define MAX_LOGIN_SZ  128
 
@@ -111,17 +85,9 @@
 #define PEER_DEAD 0
 #define PEER_ALIVE 1
 
-#define AUTH_MSG_SZ 4096
 #define CLIENT_REQ_BUF_SZ 4096
 
-#if SQUID_SNMP
-#define VIEWINCLUDED    1
-#define VIEWEXCLUDED    2
-#endif
-
 #define STORE_META_OK     0x03
-#define STORE_META_DIRTY  0x04
-#define STORE_META_BAD    0x05
 
 #define IPC_NONE 0
 #define IPC_TCP_SOCKET 1
@@ -145,11 +111,6 @@
 
 #define STORE_META_KEY STORE_META_KEY_MD5
 
-#define STORE_META_TLD_START sizeof(int)+sizeof(char)
-#define STORE_META_TLD_SIZE STORE_META_TLD_START
-#define SwapMetaType(x) (char)x[0]
-#define SwapMetaSize(x) &x[sizeof(char)]
-#define SwapMetaData(x) &x[STORE_META_TLD_START]
 #define STORE_HDR_METASIZE (4*sizeof(time_t)+2*sizeof(uint16_t)+sizeof(uint64_t))
 #define STORE_HDR_METASIZE_OLD (4*sizeof(time_t)+2*sizeof(uint16_t)+sizeof(size_t))
 
@@ -162,9 +123,6 @@
  * keep 3 days' (72 hours) worth of hourly readings
  */
 #define N_COUNT_HOUR_HIST (86400 * 3) / (60 * COUNT_INTERVAL)
-
-/* handy to determine the #elements in a static array */
-#define countof(arr) (sizeof(arr)/sizeof(*arr))
 
 /*
  * This many TCP connections must FAIL before we mark the

--- a/src/defines.h
+++ b/src/defines.h
@@ -48,8 +48,6 @@
 #define FQDN_LOOKUP_IF_MISS 0x01
 #define FQDN_MAX_NAMES 5
 
-#define HTTP_REPLY_FIELD_SZ 128
-
 #define BUF_TYPE_8K     1
 #define BUF_TYPE_MALLOC 2
 
@@ -126,7 +124,6 @@
 #define PEER_ALIVE 1
 
 #define AUTH_MSG_SZ 4096
-#define HTTP_REPLY_BUF_SZ 4096
 #define CLIENT_REQ_BUF_SZ 4096
 
 #if !defined(ERROR_BUF_SZ) && defined(MAX_URL)
@@ -212,8 +209,6 @@
 #else
 #define FILE_MODE(x) ((x)&(O_RDONLY|O_WRONLY|O_RDWR))
 #endif
-
-#define HTTP_REQBUF_SZ  4096
 
 /* CygWin & Windows NT Port */
 #if _SQUID_WINDOWS_

--- a/src/esi/Segment.h
+++ b/src/esi/Segment.h
@@ -15,7 +15,7 @@
 
 #include "base/RefCount.h"
 #include "cbdata.h"
-#include "defines.h"
+#include "http/forward.h"
 #include "SquidString.h"
 
 class ESISegment : public RefCountable

--- a/src/globals.h
+++ b/src/globals.h
@@ -18,7 +18,6 @@
 
 extern char *ConfigFile;    /* NULL */
 extern char *IcpOpcodeStr[];
-extern char tmp_error_buf[ERROR_BUF_SZ];
 extern char ThisCache[RFC2181_MAXHOSTNAMELEN << 1];
 extern char ThisCache2[RFC2181_MAXHOSTNAMELEN << 1];
 extern char config_input_line[BUFSIZ];

--- a/src/http/forward.h
+++ b/src/http/forward.h
@@ -11,6 +11,8 @@
 
 #include "http/one/forward.h"
 
+#define HTTP_REQBUF_SZ  4096
+
 namespace Http
 {
 

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -13,6 +13,7 @@
 
 #include "base/AsyncJob.h"
 #include "comm/forward.h"
+#include "http/forward.h"
 #include "mgr/Action.h"
 #include "StoreIOBuffer.h"
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -78,6 +78,8 @@ SQUIDCEXTERN int setresuid(uid_t, uid_t, uid_t);
 
 #endif /* _SQUID_LINUX */
 
+static char tmp_error_buf[32768]; /* 32KB */
+
 void
 releaseServerSockets(void)
 {
@@ -794,7 +796,7 @@ setSystemLimits(void)
         rl.rlim_cur = Squid_MaxFD;
         if (setrlimit(RLIMIT_NOFILE, &rl) < 0) {
             int xerrno = errno;
-            snprintf(tmp_error_buf, ERROR_BUF_SZ, "setrlimit: RLIMIT_NOFILE: %s", xstrerr(xerrno));
+            snprintf(tmp_error_buf, sizeof(tmp_error_buf), "setrlimit: RLIMIT_NOFILE: %s", xstrerr(xerrno));
             fatal_dump(tmp_error_buf);
         }
     }
@@ -809,7 +811,7 @@ setSystemLimits(void)
 
         if (setrlimit(RLIMIT_DATA, &rl) < 0) {
             int xerrno = errno;
-            snprintf(tmp_error_buf, ERROR_BUF_SZ, "setrlimit: RLIMIT_DATA: %s", xstrerr(xerrno));
+            snprintf(tmp_error_buf, sizeof(tmp_error_buf), "setrlimit: RLIMIT_DATA: %s", xstrerr(xerrno));
             fatal_dump(tmp_error_buf);
         }
     }
@@ -827,7 +829,7 @@ setSystemLimits(void)
 
         if (setrlimit(RLIMIT_VMEM, &rl) < 0) {
             int xerrno = errno;
-            snprintf(tmp_error_buf, ERROR_BUF_SZ, "setrlimit: RLIMIT_VMEM: %s", xstrerr(xerrno));
+            snprintf(tmp_error_buf, sizeof(tmp_error_buf), "setrlimit: RLIMIT_VMEM: %s", xstrerr(xerrno));
             fatal_dump(tmp_error_buf);
         }
     }


### PR DESCRIPTION
Reduce compile unit dependencies on src/defines.h by moving some
src/defines.h macros to their most-relevant header.

Also remove all src/defines.h macros known to be unused.
