### PR TITLE
Fix SslBump reconfiguration leaking public key memory

### DIFF
--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -376,8 +376,10 @@ mimicExtensions(Security::CertPointer & cert, Security::CertPointer const &mimic
         DecipherOnly
     };
 
-    EVP_PKEY *certKey = X509_get_pubkey(mimicCert.get());
-    const bool rsaPkey = (EVP_PKEY_get0_RSA(certKey) != nullptr);
+    // XXX: Add PublicKeyPointer. In OpenSSL, public and private keys are
+    // internally represented by EVP_PKEY pair, but GnuTLS uses distinct types.
+    const Security::PrivateKeyPointer certKey(X509_get_pubkey(mimicCert.get()));
+    const auto rsaPkey = EVP_PKEY_get0_RSA(certKey.get()) != nullptr;
 
     int added = 0;
     int nid;


### PR DESCRIPTION
X509_get_pubkey() increments key reference count.

Probably leaking since commit 2a268a0.