### PR TITLE
Allow sending "squid -k ..." signals to PID 1

### DIFF
--- a/src/Instance.cc
+++ b/src/Instance.cc
@@ -81,7 +81,7 @@ GetOtherPid(File &pidFile)
 
     debugs(50, 7, "found PID " << rawPid << " in " << TheFile);
 
-    if (rawPid <= 1)
+    if (rawPid < 1)
         throw TexcHere(ToSBuf("Bad ", TheFile, " contains unreasonably small PID value: ", rawPid));
     const auto finalPid = static_cast<pid_t>(rawPid);
     if (static_cast<int64_t>(finalPid) != rawPid)


### PR DESCRIPTION
Inside a container, Squid usually runs with PID=1. Since "squid -k"
feature was added in 1996 (commit 7690e8e), Squid refused to signal a
PID=1 instance. We do not know why, and it could have been an accident.
We cannot find a good reason to keep prohibiting such signalling.