### PR TITLE
Extend MasterXaction lifetime across ::Server existence

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -722,7 +722,7 @@ HttpRequest::manager(const CbcPointer<ConnStateData> &aMgr, const AccessLogEntry
     if (!clientConnectionManager.valid())
         return;
 
-    AnyP::PortCfgPointer port = clientConnectionManager->port;
+    auto &port = clientConnectionManager->xaction->squidPort;
     if (port) {
         myportname = port->name;
         flags.ignoreCc = port->ignore_cc;

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -88,7 +88,7 @@ ACLFilledChecklist::verifyAle() const
 
     if (!al->cache.port && conn()) {
         showDebugWarning("listening port");
-        al->cache.port = conn()->port;
+        al->cache.port = conn()->xaction->squidPort;
     }
 
     if (request) {

--- a/src/acl/MyPortName.cc
+++ b/src/acl/MyPortName.cc
@@ -18,8 +18,8 @@
 int
 ACLMyPortNameStrategy::match(ACLData<MatchType> * &data, ACLFilledChecklist *checklist)
 {
-    if (checklist->conn() != NULL && checklist->conn()->port != NULL)
-        return data->match(checklist->conn()->port->name);
+    if (checklist->conn() && checklist->conn()->xaction->squidPort)
+        return data->match(checklist->conn()->xaction->squidPort->name);
     if (checklist->request != NULL)
         return data->match(checklist->request->myportname.termedBuf());
     return 0;

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1293,7 +1293,7 @@ clientReplyContext::buildReplyHeader()
         if (EBIT_TEST(http->storeEntry()->flags, ENTRY_SPECIAL)) {
             hdr->delById(Http::HdrType::DATE);
             hdr->putTime(Http::HdrType::DATE, squid_curtime);
-        } else if (http->getConn() && http->getConn()->port->actAsOrigin) {
+        } else if (http->getConn() && http->getConn()->xaction->squidPort->actAsOrigin) {
             // Swap the Date: header to current time if we are simulating an origin
             HttpHeaderEntry *h = hdr->findEntry(Http::HdrType::DATE);
             if (h)
@@ -1457,8 +1457,8 @@ clientReplyContext::buildReplyHeader()
         debugs(88, 3, "pinned reply forces close");
         request->flags.proxyKeepalive = false;
     } else if (http->getConn()) {
-        ConnStateData * conn = http->getConn();
-        if (!Comm::IsConnOpen(conn->port->listenConn)) {
+        const auto &p = http->getConn()->xaction->squidPort;
+        if (!Comm::IsConnOpen(p->listenConn)) {
             // The listening port closed because of a reconfigure
             debugs(88, 3, "listening port closed");
             request->flags.proxyKeepalive = false;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -168,7 +168,7 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
     al->cache.start_time = current_time;
     if (aConn) {
         al->tcpClient = clientConnection = aConn->clientConnection;
-        al->cache.port = aConn->port;
+        al->cache.port = aConn->xaction->squidPort;
         al->cache.caddr = aConn->log_addr;
         al->proxyProtocolHeader = aConn->proxyProtocolHeader();
         al->updateError(aConn->bareError);
@@ -972,7 +972,7 @@ clientCheckPinning(ClientHttpRequest * http)
     if (!http_conn)
         return;
 
-    request->flags.connectionAuthDisabled = http_conn->port->connection_auth_disabled;
+    request->flags.connectionAuthDisabled = http_conn->xaction->squidPort->connection_auth_disabled;
     if (!request->flags.connectionAuthDisabled) {
         if (Comm::IsConnOpen(http_conn->pinning.serverConnection)) {
             if (http_conn->pinning.auth) {
@@ -1428,7 +1428,7 @@ ClientRequestContext::sslBumpAccessCheck()
     // We also do not bump redirected CONNECT requests.
     if (http->request->method != Http::METHOD_CONNECT || http->redirect.status ||
             !Config.accessList.ssl_bump ||
-            !http->getConn()->port->flags.tunnelSslBumping) {
+            !http->getConn()->xaction->squidPort->flags.tunnelSslBumping) {
         http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
         debugs(85, 5, HERE << "cannot SslBump this request");
         return false;

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -640,7 +640,7 @@ Ftp::Relay::readDataReply()
 bool
 Ftp::Relay::startDirTracking()
 {
-    if (!fwd->request->clientConnectionManager->port->ftp_track_dirs)
+    if (!fwd->request->clientConnectionManager->xaction->squidPort->ftp_track_dirs)
         return false;
 
     debugs(9, 5, "start directory tracking");

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -340,7 +340,7 @@ Ftp::Server::calcUri(const SBuf *file)
     // TODO: fill a class AnyP::Uri instead of string
     uri = "ftp://";
     uri.append(host);
-    if (port->ftp_track_dirs && master->workingDir.length()) {
+    if (xaction->squidPort->ftp_track_dirs && master->workingDir.length()) {
         if (master->workingDir[0] != '/')
             uri.append("/", 1);
         uri.append(master->workingDir);
@@ -349,7 +349,7 @@ Ftp::Server::calcUri(const SBuf *file)
     if (uri[uri.length() - 1] != '/')
         uri.append("/", 1);
 
-    if (port->ftp_track_dirs && file) {
+    if (xaction->squidPort->ftp_track_dirs && file) {
         static const CharacterSet Slash("/", "/");
         Parser::Tokenizer tok(*file);
         tok.skipAll(Slash);
@@ -366,7 +366,7 @@ Ftp::Server::listenForDataConnection()
 
     Comm::ConnectionPointer conn = new Comm::Connection;
     conn->flags = COMM_NONBLOCKING;
-    conn->local = transparent() ? port->s : clientConnection->local;
+    conn->local = transparent() ? xaction->squidPort->s : clientConnection->local;
     conn->local.port(0);
     const char *const note = uri.c_str();
     comm_open_listener(SOCK_STREAM, IPPROTO_TCP, conn, note);

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -27,7 +27,6 @@ Server::Server(const MasterXaction::Pointer &xact) :
     xaction(xact),
     clientConnection(xact->tcpClient),
     transferProtocol(xact->squidPort->transport),
-    port(xact->squidPort),
     receivedFirstByte_(false)
 {
     clientConnection->leaveOrphanage();

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -7,7 +7,6 @@
  */
 
 #include "squid.h"
-#include "anyp/PortCfg.h"
 #include "client_side.h"
 #include "comm.h"
 #include "comm/Read.h"
@@ -25,6 +24,7 @@
 
 Server::Server(const MasterXaction::Pointer &xact) :
     AsyncJob("::Server"), // kids overwrite
+    xaction(xact),
     clientConnection(xact->tcpClient),
     transferProtocol(xact->squidPort->transport),
     port(xact->squidPort),

--- a/src/servers/Server.h
+++ b/src/servers/Server.h
@@ -94,6 +94,9 @@ public:
     /// grows the available read buffer space (if possible)
     void maybeMakeSpaceAvailable();
 
+    /// transaction details about the client connection
+    MasterXactionPointer xaction;
+
     // Client TCP connection details from comm layer.
     Comm::ConnectionPointer clientConnection;
 

--- a/src/servers/Server.h
+++ b/src/servers/Server.h
@@ -107,9 +107,6 @@ public:
      */
     AnyP::ProtocolVersion transferProtocol;
 
-    /// Squid listening port details where this connection arrived.
-    AnyP::PortCfgPointer port;
-
     /// read I/O buffer for the client connection
     SBuf inBuf;
 

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -162,7 +162,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
             // While we are peeking at the certificate, we may not know the server
             // name that the client will request (after interception or CONNECT)
             // unless it was the CONNECT request with a user-typed address.
-            const bool isConnectRequest = !csd->port->flags.isIntercepted();
+            const bool isConnectRequest = !csd->xaction->squidPort->flags.isIntercepted();
             if (!request->flags.sslPeek || isConnectRequest)
                 hostName = new SBuf(request->url.host());
         }
@@ -235,7 +235,7 @@ Ssl::PeekingPeerConnector::noteNegotiationDone(ErrorState *error)
             // For intercepted connections, set the host name to the server
             // certificate CN. Otherwise, we just hope that CONNECT is using
             // a user-entered address (a host name or a user-entered IP).
-            const bool isConnectRequest = !request->clientConnectionManager->port->flags.isIntercepted();
+            const bool isConnectRequest = !request->clientConnectionManager->xaction->squidPort->flags.isIntercepted();
             if (request->flags.sslPeek && !isConnectRequest) {
                 if (X509 *srvX509 = serverBump->serverCert.get()) {
                     if (const char *name = Ssl::CommonHostName(srvX509)) {


### PR DESCRIPTION
Give ::Server child classes access to MasterXaction object
for storage of per-protocol transaction details at any time.