### PR TITLE
Support "file" syntax for 'squid_error' and 'has' ACL parameters

### DIFF
--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -29,7 +29,7 @@ ACLHasComponentData::parse()
         self_destruct();
         return;
     }
-    if (ConfigParser::PeekAtToken()) {
+    if (ConfigParser::strtokFile()) {
         debugs(28, DBG_CRITICAL, "FATAL: multiple components not supported for \"has\" acl");
         self_destruct();
         return;

--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -23,7 +23,7 @@ ACLHasComponentData::ACLHasComponentData()
 void
 ACLHasComponentData::parse()
 {
-    const char *tok = ConfigParser::NextToken();
+    const auto tok = ConfigParser::strtokFile();
     if (!tok) {
         debugs(28, DBG_CRITICAL, "FATAL: \"has\" acl argument missing");
         self_destruct();

--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -29,7 +29,9 @@ ACLHasComponentData::parse()
         self_destruct();
         return;
     }
+
     parseComponent(tok);
+
     if (ConfigParser::strtokFile()) {
         debugs(28, DBG_CRITICAL, "FATAL: multiple components not supported for \"has\" acl");
         self_destruct();

--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -29,12 +29,12 @@ ACLHasComponentData::parse()
         self_destruct();
         return;
     }
+    parseComponent(tok);
     if (ConfigParser::strtokFile()) {
         debugs(28, DBG_CRITICAL, "FATAL: multiple components not supported for \"has\" acl");
         self_destruct();
         return;
     }
-    parseComponent(tok);
 }
 
 bool

--- a/src/acl/SquidErrorData.cc
+++ b/src/acl/SquidErrorData.cc
@@ -47,7 +47,7 @@ ACLSquidErrorData::dump() const
 void
 ACLSquidErrorData::parse()
 {
-    while (char *token = ConfigParser::NextToken()) {
+    while (const auto token = ConfigParser::strtokFile()) {
         err_type err = errorTypeByName(token);
 
         if (err < ERR_MAX)


### PR DESCRIPTION
The 'squid_error' and 'has' are the only ACLs that do not support
loading their parameters from a file using the "path/filename" syntax.
We see no justification for this exception, and it stands in the way of
(unrelated) configuration improvements we are working on (that will,
among other things, prevent such accidents from happening again).

This change causes no upgrade problems because it does not change
handling of previously accepted configurations. It only expands the set
of acceptable configurations, better matching documentation and admin
expectations with regard to universal "path/filename" syntax support.