### PR TITLE
Bug 5029: assertion failed: MemBuf.cc: new_cap > (size_t) capacity

### DIFF
--- a/src/MemBuf.cc
+++ b/src/MemBuf.cc
@@ -76,22 +76,8 @@
 #include "MemBuf.h"
 #include "profiler/Profiler.h"
 
-/* local constants */
-
-/* default values for buffer sizes, used by memBufDefInit */
-#define MEM_BUF_INIT_SIZE   (2*1024)
-#define MEM_BUF_MAX_SIZE    (2*1000*1024*1024)
-
 CBDATA_CLASS_INIT(MemBuf);
 
-/** init with defaults */
-void
-MemBuf::init()
-{
-    init(MEM_BUF_INIT_SIZE, MEM_BUF_MAX_SIZE);
-}
-
-/** init with specific sizes */
 void
 MemBuf::init(mb_size_t szInit, mb_size_t szMax)
 {

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -109,7 +109,7 @@ redirectHandleReply(void *data, const Helper::Reply &reply)
             // parse it into status=, url= and rewrite-url= keys
             if (replySize) {
                 MemBuf replyBuffer;
-                replyBuffer.init(replySize, replySize);
+                replyBuffer.init(replySize+1); // allow termination
                 replyBuffer.append(reply.other().content(), reply.other().contentSize());
                 char * result = replyBuffer.content();
 

--- a/src/tests/stub_MemBuf.cc
+++ b/src/tests/stub_MemBuf.cc
@@ -19,7 +19,6 @@ void MemBuf::appended(mb_size_t) STUB
 void MemBuf::truncate(mb_size_t) STUB
 void MemBuf::terminate() STUB
 void MemBuf::init(mb_size_t, mb_size_t) STUB
-void MemBuf::init() STUB
 void MemBuf::clean() STUB
 void MemBuf::reset() STUB
 int MemBuf::isNull() const STUB_RETVAL(1)


### PR DESCRIPTION
Since v4 the code converting URL-rewrite helper replies from
legacy Squid-2 syntax. Allocated a temporary MemBuf sized to be
exactly the response I/O size. This did not allow for
MemBuf::append use of grow() to ensure there is always free
space in the MemBuf and later code possibly using terminate()
to make the buffer a c-string.

Use new C++11 MemBuf initialization to remove the max capacity
limitation on this temporary buffer and add +1 to the initial
size so the first allocation does not need to grow() in order
to terminate().