### PR TITLE
Bug 4922: Improve ftp://... filename extraction

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1073,7 +1073,7 @@ Ftp::Gateway::checkUrlpath()
     auto t = request->url.path().rfind(';');
 
     if (t != SBuf::npos) {
-        auto filenameEnd = t-1;
+        const auto filenameEnd = t;
         if (request->url.path().substr(++t).cmp(str_type_eq, str_type_eq.length()) == 0) {
             t += str_type_eq.length();
             typecode = (char)xtoupper(request->url.path()[t]);

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1069,16 +1069,17 @@ Ftp::Gateway::checkAuth(const HttpHeader * req_hdr)
 void
 Ftp::Gateway::checkUrlpath()
 {
-    static SBuf str_type_eq("type=");
-    auto t = request->url.path().rfind(';');
-
-    if (t != SBuf::npos) {
-        const auto filenameEnd = t;
-        if (request->url.path().substr(++t).cmp(str_type_eq, str_type_eq.length()) == 0) {
-            t += str_type_eq.length();
-            typecode = (char)xtoupper(request->url.path()[t]);
-            request->url.path(request->url.path().substr(0,filenameEnd));
-        }
+    // If typecode was specified, extract it and leave just the filename in
+    // url.path. Tolerate trailing garbage or missing typecode value. Roughly:
+    // [filename] ;type=[typecode char] [trailing garbage]
+    static const SBuf middle(";type=");
+    const auto typeSpecStart = request->url.path().find(middle);
+    if (typeSpecStart != SBuf::npos) {
+        const auto fullPath = request->url.path();
+        const auto typecodePos = typeSpecStart + middle.length();
+        typecode = (typecodePos < fullPath.length()) ?
+            static_cast<char>(xtoupper(fullPath[typecodePos])) : '\0';
+        request->url.path(fullPath.substr(0, typeSpecStart));
     }
 
     int l = request->url.path().length();


### PR DESCRIPTION
Symptoms include: Unexpected ERR_FTP_NOT_FOUND/FTP_REPLY_CODE=550
outcome for GET ftp://... requests with URLs containing `;type=...`.

Broken since commit 51b5dcf.