### PR TITLE
Refactor Valid_Global_Groups

### DIFF
--- a/src/acl/external/LM_group/ext_lm_group_acl.cc
+++ b/src/acl/external/LM_group/ext_lm_group_acl.cc
@@ -336,7 +336,7 @@ Valid_Global_Groups(char *UserName, const char **Groups)
     DWORD i;
     DWORD dwTotalCount = 0;
 
-    strncpy(NTDomain, UserName, sizeof(NTDomain));
+    xstrncpy(NTDomain, UserName, sizeof(NTDomain));
 
     for (j = 0; j < strlen(NTV_VALID_DOMAIN_SEPARATOR); ++j) {
         if ((domain_qualify = strchr(NTDomain, NTV_VALID_DOMAIN_SEPARATOR[j])) != NULL)


### PR DESCRIPTION
Prevent Valid_Global_Groups from further possible dangers. UserName
is copied in NTDomain without ensuring that it's null-terminated.
Write now that's true, because the next stack memory chunk is zeroed
(wszUserDomain), but this could change in future.

Replace libc strncpy with squid defined xstrcpy which add '\0' even
when first n bytes are non zero.