### PR TITLE
ext_lm_group_acl: Improved username handling

### DIFF
--- a/src/acl/external/LM_group/ext_lm_group_acl.cc
+++ b/src/acl/external/LM_group/ext_lm_group_acl.cc
@@ -336,7 +336,7 @@ Valid_Global_Groups(char *UserName, const char **Groups)
     DWORD i;
     DWORD dwTotalCount = 0;
 
-    strncpy(NTDomain, UserName, sizeof(NTDomain));
+    xstrncpy(NTDomain, UserName, sizeof(NTDomain));
 
     for (j = 0; j < strlen(NTV_VALID_DOMAIN_SEPARATOR); ++j) {
         if ((domain_qualify = strchr(NTDomain, NTV_VALID_DOMAIN_SEPARATOR[j])) != NULL)


### PR DESCRIPTION
Ensure that NTDomain is terminated even if UserName is long.
It happened to be terminated in the current code, but only by accident.