### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/src/comm/Tcp.cc
+++ b/src/comm/Tcp.cc
@@ -15,6 +15,9 @@
 #if HAVE_NETINET_TCP_H
 #include <netinet/tcp.h>
 #endif
+#if HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
 #include <type_traits>
 
 /// setsockopt(2) wrapper


### PR DESCRIPTION
On OpenBSD 6.9, SOL_SOCKET is defined in sys/socket.h.