### PR TITLE
Reduce dependencies of testConfigParser

### DIFF
--- a/src/HttpUpgradeProtocolAccess.cc
+++ b/src/HttpUpgradeProtocolAccess.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "acl/Acl.h"
 #include "acl/Gadgets.h"
+#include "cache_cf.h"
 #include "ConfigParser.h"
 #include "globals.h"
 #include "HttpUpgradeProtocolAccess.h"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2828,38 +2828,19 @@ tests_testStatHist_LDFLAGS = $(LIBADD_DL)
 
 check_PROGRAMS += tests/testConfigParser
 tests_testConfigParser_SOURCES = \
-	ClientInfo.h \
-	ConfigParser.cc \
 	tests/testConfigParser.cc \
-	tests/testConfigParser.h \
-	tests/stub_HelperChildConfig.cc \
-	tests/stub_MemBuf.cc \
-	tests/stub_SBufDetailedStats.cc \
+	tests/testConfigParser.h
+nodist_tests_testConfigParser_SOURCES = \
+	ConfigParser.cc \
 	String.cc \
 	tests/stub_acl.cc \
 	tests/stub_cache_cf.cc \
-	cache_cf.h \
-	tests/stub_cbdata.cc \
 	tests/stub_debug.cc \
-	tests/stub_event.cc \
 	tests/stub_fatal.cc \
-	fatal.h \
 	tests/stub_libmem.cc \
-	tests/stub_time.cc \
-	tests/stub_tools.cc \
-	tools.h \
-	wordlist.cc \
-	wordlist.h
-nodist_tests_testConfigParser_SOURCES = \
-	$(TESTSOURCES)
+	tests/stub_SBuf.cc
 tests_testConfigParser_LDADD = \
-	libsquid.la \
-	ip/libip.la \
-	sbuf/libsbuf.la \
 	base/libbase.la \
-	$(top_builddir)/lib/libmiscutil.la \
-	$(REGEXLIB) \
-	$(SSLLIB) \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \
 	$(XTRA_LIBS)

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -10,8 +10,9 @@
 #include "acl/AllOf.h"
 #include "acl/BoolOps.h"
 #include "acl/Checklist.h"
-#include "globals.h"
+#include "cache_cf.h"
 #include "MemBuf.h"
+#include "sbuf/SBuf.h"
 
 char const *
 Acl::AllOf::typeString() const

--- a/src/acl/Arp.cc
+++ b/src/acl/Arp.cc
@@ -14,6 +14,7 @@
 
 #include "acl/Arp.h"
 #include "acl/FilledChecklist.h"
+#include "cache_cf.h"
 #include "Debug.h"
 #include "eui/Eui48.h"
 #include "globals.h"

--- a/src/acl/Eui64.cc
+++ b/src/acl/Eui64.cc
@@ -14,6 +14,7 @@
 
 #include "acl/Eui64.h"
 #include "acl/FilledChecklist.h"
+#include "cache_cf.h"
 #include "Debug.h"
 #include "eui/Eui64.h"
 #include "globals.h"

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -23,6 +23,7 @@
 #include "acl/Gadgets.h"
 #include "acl/Strategised.h"
 #include "acl/Tree.h"
+#include "cache_cf.h"
 #include "ConfigParser.h"
 #include "errorpage.h"
 #include "globals.h"

--- a/src/acl/HttpHeaderData.cc
+++ b/src/acl/HttpHeaderData.cc
@@ -14,6 +14,7 @@
 #include "acl/HttpHeaderData.h"
 #include "acl/RegexData.h"
 #include "base/RegexPattern.h"
+#include "cache_cf.h"
 #include "ConfigParser.h"
 #include "Debug.h"
 #include "HttpHeaderTools.h"

--- a/src/acl/RegexData.cc
+++ b/src/acl/RegexData.cc
@@ -19,6 +19,7 @@
 #include "acl/Checklist.h"
 #include "acl/RegexData.h"
 #include "base/RegexPattern.h"
+#include "cache_cf.h"
 #include "ConfigParser.h"
 #include "Debug.h"
 #include "sbuf/Algorithms.h"

--- a/src/adaptation/Config.cc
+++ b/src/adaptation/Config.cc
@@ -14,6 +14,7 @@
 #include "adaptation/History.h"
 #include "adaptation/Service.h"
 #include "adaptation/ServiceGroups.h"
+#include "cache_cf.h"
 #include "ConfigParser.h"
 #include "DebugMessages.h"
 #include "globals.h"

--- a/src/adaptation/ServiceConfig.cc
+++ b/src/adaptation/ServiceConfig.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "adaptation/ServiceConfig.h"
+#include "cache_cf.h"
 #include "ConfigParser.h"
 #include "Debug.h"
 #include "globals.h"

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -266,6 +266,11 @@ static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **prot
  */
 static ConfigParser LegacyParser = ConfigParser();
 
+const char *cfg_directive = nullptr;
+const char *cfg_filename = nullptr;
+int config_lineno = 0;
+char config_input_line[BUFSIZ] = {};
+
 void
 self_destruct(void)
 {

--- a/src/cache_cf.h
+++ b/src/cache_cf.h
@@ -27,5 +27,11 @@ void parse_time_t(time_t * var);
 /// Parse bytes number from a string
 void parseBytesOptionValue(size_t * bptr, const char *units, char const * value);
 
+/// During parsing, the name of the current squid.conf directive being parsed.
+extern const char *cfg_directive;
+extern const char *cfg_filename;
+extern int config_lineno;
+extern char config_input_line[BUFSIZ];
+
 #endif /* SQUID_CACHE_CF_H_ */
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -20,10 +20,6 @@ extern char *ConfigFile;    /* NULL */
 extern char *IcpOpcodeStr[];
 extern char ThisCache[RFC2181_MAXHOSTNAMELEN << 1];
 extern char ThisCache2[RFC2181_MAXHOSTNAMELEN << 1];
-extern char config_input_line[BUFSIZ];
-/// During parsing, the name of the current squid.conf directive being parsed.
-extern const char *cfg_directive; /* NULL */
-extern const char *cfg_filename;    /* NULL */
 extern const char *dash_str;    /* "-" */
 extern const char *null_string; /* "" */
 extern const char *version_string;  /* VERSION */
@@ -41,7 +37,6 @@ extern int Opening_FD;      /* 0 */
 extern int NDnsServersAlloc;    /* 0 */
 extern int RESERVED_FD;
 extern int Squid_MaxFD;     /* SQUID_MAXFD */
-extern int config_lineno;   /* 0 */
 extern int opt_reuseaddr;   /* 1 */
 extern int neighbors_do_private_keys;   /* 1 */
 extern int opt_catch_signals;   /* 1 */

--- a/src/tests/stub_cache_cf.cc
+++ b/src/tests/stub_cache_cf.cc
@@ -18,6 +18,10 @@
 #include "tests/STUB.h"
 
 #include "cache_cf.h"
+const char *cfg_directive = nullptr;
+const char *cfg_filename = nullptr;
+int config_lineno = 0;
+char config_input_line[BUFSIZ] = {};
 void self_destruct(void) STUB
 void parse_int(int *) STUB
 void parse_onoff(int *) STUB

--- a/src/tests/testConfigParser.cc
+++ b/src/tests/testConfigParser.cc
@@ -14,6 +14,8 @@
 
 CPPUNIT_TEST_SUITE_REGISTRATION( testConfigParser);
 
+int shutting_down = 0;
+
 void testConfigParser::setUp()
 {
 }

--- a/src/tests/testConfigParser.cc
+++ b/src/tests/testConfigParser.cc
@@ -9,7 +9,7 @@
 #include "squid.h"
 #include "ConfigParser.h"
 #include "SquidString.h"
-#include "testConfigParser.h"
+#include "tests/testConfigParser.h"
 #include "unitTestMain.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( testConfigParser);


### PR DESCRIPTION
Move several globals used by the legacy parse logic into cache_cf.cc
and remove unnecessary objects linked to testConfigParser.