### PR TITLE
support type w in gopher.

### DIFF
--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -600,7 +600,7 @@ gopherToHTML(GopherStateData * gopherState, char *inbuf, int len)
                         snprintf(tmpbuf, TEMP_BUF_SIZE, "\t%s\n", html_quote(name));
                     } else if (gtype == GOPHER_WWW) {	/* Gopher pointer to W3 */
                         snprintf(tmpbuf, TEMP_BUF_SIZE, "<IMG border=\"0\" SRC=\"%s\"> <A HREF=\"%s\">%s</A>\n",
-                                     selector, html_quote(name));                        
+                                     icon_url, selector, html_quote(name));                        
                     } else {
                         if (strncmp(selector, "GET /", 5) == 0) {
                             /* WWW link */

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -598,6 +598,9 @@ gopherToHTML(GopherStateData * gopherState, char *inbuf, int len)
 
                     } else if (gtype == GOPHER_INFO) {
                         snprintf(tmpbuf, TEMP_BUF_SIZE, "\t%s\n", html_quote(name));
+                    } else if (gtype == GOPHER_WWW) {	/* Gopher pointer to W3 */
+                        snprintf(tmpbuf, TEMP_BUF_SIZE, "<IMG border=\"0\" SRC=\"%s\"> <A HREF=\"%s\">%s</A>\n",
+                                     selector, html_quote(name));                        
                     } else {
                         if (strncmp(selector, "GET /", 5) == 0) {
                             /* WWW link */


### PR DESCRIPTION
src/gopher.cc mentions the w gopher type code, but doesn't actually handle it at all...
This enables basic support.

A url that can be used for testing: gopher://gopher.zcrayfish.soy/1/irc/test
contains a link to CNN and a link to gopher://gopher.zcrayfish.soy