### PR TITLE
Refactor event scheduling for AsyncCall support

### DIFF
--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -16,6 +16,7 @@
 #include "DiskIO/IpcIo/IpcIoFile.h"
 #include "DiskIO/ReadRequest.h"
 #include "DiskIO/WriteRequest.h"
+#include "event.h"
 #include "fd.h"
 #include "fs_io.h"
 #include "globals.h"

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -11,6 +11,7 @@
 #include "base/CodeContext.h"
 #include "CachePeer.h"
 #include "errorpage.h"
+#include "event.h"
 #include "FwdState.h"
 #include "HappyConnOpener.h"
 #include "HttpRequest.h"

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -11,7 +11,6 @@
 
 #include "base/CodeContext.h"
 #include "base/InstanceId.h"
-#include "event.h"
 #include "RefCount.h"
 
 /**

--- a/src/comm.h
+++ b/src/comm.h
@@ -9,6 +9,7 @@
 #ifndef __COMM_H__
 #define __COMM_H__
 
+#include "AsyncEngine.h"
 #include "comm/IoCallback.h"
 #include "CommCalls.h"
 #include "StoreIOBuffer.h"

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -14,6 +14,7 @@
 #include "comm/Connection.h"
 #include "comm/ConnOpener.h"
 #include "comm/Loops.h"
+#include "event.h"
 #include "fd.h"
 #include "fde.h"
 #include "globals.h"

--- a/src/comm/ConnOpener.h
+++ b/src/comm/ConnOpener.h
@@ -49,7 +49,6 @@ private:
     void timeout(const CommTimeoutCbParams &);
     void sendAnswer(Comm::Flag errFlag, int xerrno, const char *why);
     static void InProgressConnectRetry(int fd, void *data);
-    static void DelayedConnectRetry(void *data);
     void doConnect();
     void connected();
     void lookupLocalAddress();
@@ -80,9 +79,8 @@ private:
     struct Calls {
         AsyncCall::Pointer earlyAbort_;
         AsyncCall::Pointer timeout_;
-        /// Whether we are idling before retrying to connect; not yet a call
-        /// [that we can cancel], but it will probably become one eventually.
-        bool sleep_;
+        /// Whether we are idling before retrying to connect
+        AsyncCall::Pointer sleep_;
     } calls_;
 };
 

--- a/src/event.cc
+++ b/src/event.cc
@@ -94,8 +94,7 @@ ev_entry::ev_entry(char const * aName, EVH * aFunction, void * aArgument, double
     arg(haveArg ? cbdataReference(aArgument) : aArgument),
     when(evWhen),
     weight(aWeight),
-    cbdata(haveArg),
-    next(NULL)
+    cbdata(haveArg)
 {
 }
 

--- a/src/event.cc
+++ b/src/event.cc
@@ -157,8 +157,6 @@ eventFind(EVH * func, void *arg)
     return EventScheduler::GetInstance()->find(func, arg);
 }
 
-EventScheduler EventScheduler::_instance;
-
 EventScheduler::EventScheduler(): tasks(NULL)
 {}
 
@@ -306,7 +304,8 @@ EventScheduler::find(EVH * func, void * arg)
 EventScheduler *
 EventScheduler::GetInstance()
 {
-    return &_instance;
+    static EventScheduler instance;
+    return &instance;
 }
 
 void

--- a/src/event.h
+++ b/src/event.h
@@ -31,15 +31,17 @@ class ev_entry
 public:
     ev_entry(char const * name, EVH * func, void *arg, double when, int weight, bool cbdata=true);
     ~ev_entry();
-    const char *name;
+
+public:
+    const char *name = nullptr;
     EVH *func;
-    void *arg;
-    double when;
+    void *arg = nullptr;
+    double when = 0.1;
 
-    int weight;
-    bool cbdata;
+    int weight = 0;
+    bool cbdata = false;
 
-    ev_entry *next;
+    ev_entry *next = nullptr;
 };
 
 // manages time-based events

--- a/src/event.h
+++ b/src/event.h
@@ -10,6 +10,7 @@
 #define SQUID_EVENT_H
 
 #include "AsyncEngine.h"
+#include "base/AsyncCall.h"
 #include "base/Packable.h"
 #include "mem/forward.h"
 
@@ -29,17 +30,15 @@ class ev_entry
     MEMPROXY_CLASS(ev_entry);
 
 public:
-    ev_entry(char const * name, EVH * func, void *arg, double when, int weight, bool cbdata=true);
-    ~ev_entry();
+    ev_entry(char const * name, double when, int weight, AsyncCall::Pointer &);
+    ~ev_entry() = default;
 
 public:
     const char *name = nullptr;
-    EVH *func;
-    void *arg = nullptr;
     double when = 0.1;
 
     int weight = 0;
-    bool cbdata = false;
+    AsyncCall::Pointer call;
 
     ev_entry *next = nullptr;
 };

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "base/AsyncJobCalls.h"
 #include "DebugMessages.h"
+#include "event.h"
 #include "fs/rock/RockDbCell.h"
 #include "fs/rock/RockRebuild.h"
 #include "fs/rock/RockSwapDir.h"

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_FS_UFS_UFSSWAPDIR_H
 #define SQUID_FS_UFS_UFSSWAPDIR_H
 
+#include "event.h"
 #include "SquidString.h"
 #include "Store.h"
 #include "store/Disk.h"

--- a/src/ipc/Forwarder.cc
+++ b/src/ipc/Forwarder.cc
@@ -12,6 +12,7 @@
 #include "base/AsyncJobCalls.h"
 #include "base/TextException.h"
 #include "errorpage.h"
+#include "event.h"
 #include "HttpReply.h"
 #include "HttpRequest.h"
 #include "ipc/Forwarder.h"

--- a/src/ipc/Inquirer.cc
+++ b/src/ipc/Inquirer.cc
@@ -12,6 +12,7 @@
 #include "base/TextException.h"
 #include "comm.h"
 #include "comm/Write.h"
+#include "event.h"
 #include "ipc/Inquirer.h"
 #include "ipc/Port.h"
 #include "ipc/TypedMsgHdr.h"

--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -14,6 +14,7 @@
 #include "comm/Connection.h"
 #include "comm/Write.h"
 #include "CommCalls.h"
+#include "event.h"
 #include "ipc/UdsOp.h"
 
 Ipc::UdsOp::UdsOp(const String& pathAddr):

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "cbdata.h"
 #include "comm/Loops.h"
+#include "event.h"
 #include "fatal.h"
 #include "fde.h"
 #include "globals.h"

--- a/src/log/TcpLogger.cc
+++ b/src/log/TcpLogger.cc
@@ -12,6 +12,7 @@
 #include "comm/ConnOpener.h"
 #include "comm/Loops.h"
 #include "comm/Write.h"
+#include "event.h"
 #include "fatal.h"
 #include "fde.h"
 #include "globals.h" // for shutting_down

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -70,8 +70,8 @@ testEvent::testDump()
     const char *expected = "Last event to run: last event\n"
                            "\n"
                            "Operation                \tNext Execution \tWeight\tCallback Valid?\n"
-                           "test event               \t0.000 sec\t    0\t N/A\n"
-                           "test event2              \t0.000 sec\t    0\t N/A\n";
+                           "test event               \t0.000 sec\t    0\t yes\n"
+                           "test event2              \t0.000 sec\t    0\t yes\n";
     MemBuf expect;
     expect.init();
     expect.append(expected, strlen(expected));

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -69,9 +69,9 @@ testEvent::testDump()
     CalledEvent event2;
     const char *expected = "Last event to run: last event\n"
                            "\n"
-                           "Operation                \tNext Execution \tWeight\tCallback Valid?\n"
-                           "test event               \t0.000 sec\t    0\t yes\n"
-                           "test event2              \t0.000 sec\t    0\t yes\n";
+                           "Operation                \tNext Execution \tWeight\n"
+                           "test event               \t0.000 sec\t    0\n"
+                           "test event2              \t0.000 sec\t    0\n";
     MemBuf expect;
     expect.init();
     expect.append(expected, strlen(expected));

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -23,6 +23,7 @@
 #include "comm/Read.h"
 #include "comm/Write.h"
 #include "errorpage.h"
+#include "event.h"
 #include "fd.h"
 #include "fde.h"
 #include "FwdState.h"


### PR DESCRIPTION
Integrate AsyncCall better with Squid events mechanism by
storing events as an AsyncCall which will be dialed when the
event timeout occurs rather than as callback and generating a
Call when event is due.

Add an API for scheduling AsyncCall with custom Dialers.
Allowing Jobs to maintain a Pointer to their scheduled event
and cancel it at any time up to the real dialing. Also allows
Jobs to avoid static event callbacks that generate a Call
just to jump back inside async protections.

Begins conversion of eventAdd() callers to the new API with
a wishlist/TODO for ConnOpener sleeping.