### PR TITLE
The adaptation_rep_header ACL is a regex match against the response

### DIFF
--- a/SPONSORS.list
+++ b/SPONSORS.list
@@ -29,6 +29,11 @@ Treehouse Networks, NZ - http://treenet.co.nz/
 	toward Squid-3+ development and maintenance for their customer
 	gateways and CDN.
 
+Opendium - https://opendium.com
+
+	Opendium has contributed bugfixes, tweaks and new features for
+	their online safety products.
+
 @Squid-5:
 RackSpace - https://www.rackspace.com/
 

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -56,7 +56,8 @@ This section gives an account of those changes in three categories:
 <sect1>New directives<label id="newdirectives">
 <p>
 <descrip>
-	<p>There have been no directives added.
+	<tag>adaptation_rep_header</tag>
+	<p>regex match against the adaptation reply headers.</p>
 </descrip>
 
 <sect1>Changes to existing directives<label id="modifieddirectives">

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -11,6 +11,7 @@
 #if USE_ADAPTATION
 #include "acl/AdaptationService.h"
 #include "acl/AdaptationServiceData.h"
+#include "acl/AdaptationRepHeader.h"
 #endif
 #include "acl/AllOf.h"
 #include "acl/AnnotateClient.h"
@@ -196,6 +197,7 @@ Acl::Init()
 
 #if USE_ADAPTATION
     RegisterMaker("adaptation_service", [](TypeName name)->ACL* { return new ACLStrategised<const char *>(new ACLAdaptationServiceData, new ACLAdaptationServiceStrategy, name); });
+    RegisterMaker("adaptation_rep_header", [](TypeName name)->ACL* { return new ACLStrategised<HttpHeader*>(new ACLHTTPHeaderData, new ACLAdaptationRepHeaderStrategy, name); });
 #endif
 
 #if SQUID_SNMP

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -415,7 +415,10 @@ HttpRequest::adaptHistory(bool createIfNone) const
 Adaptation::History::Pointer
 HttpRequest::adaptLogHistory() const
 {
-    return HttpRequest::adaptHistory(Log::TheConfig.hasAdaptToken);
+    // XXX Adaptation history creation is always turned on so that the
+    // adaptation_rep_header acl works.  Needs to be fixed to only
+    // turn on when a adaptation_rep_header is configured.
+    return HttpRequest::adaptHistory(true);
 }
 
 void

--- a/src/acl/AdaptationRepHeader.cc
+++ b/src/acl/AdaptationRepHeader.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "acl/FilledChecklist.h"
+#include "acl/HttpHeaderData.h"
+#include "acl/AdaptationRepHeader.h"
+#include "HttpReply.h"
+
+int
+ACLAdaptationRepHeaderStrategy::match (ACLData<MatchType> * &data, ACLFilledChecklist *checklist)
+{
+    HttpRequest::Pointer request = checklist->request;
+    if (request == NULL)
+        return 0;
+    Adaptation::History::Pointer ah = request->adaptHistory();
+    if (ah == NULL)
+        return 0;
+    return data->match(&ah->allMeta);
+}

--- a/src/acl/AdaptationRepHeader.h
+++ b/src/acl/AdaptationRepHeader.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_ACLADAPTATIONREPHEADER_H
+#define SQUID_ACLADAPTATIONREPHEADER_H
+
+#include "acl/Strategised.h"
+#include "acl/Strategy.h"
+#include "HttpHeader.h"
+
+/// \ingroup ACLAPI
+class ACLAdaptationRepHeaderStrategy : public ACLStrategy<HttpHeader*>
+{
+
+public:
+    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
+    virtual bool requiresRequest() const { return true; }
+};
+
+#endif /* SQUID_ACLADAPTATIONREPHEADER_H */
+

--- a/src/acl/Makefile.am
+++ b/src/acl/Makefile.am
@@ -183,6 +183,8 @@ endif
 EXTRA_libacls_la_SOURCES += $(SSL_ACLS)
 
 ADAPT_ACLS= \
+	AdaptationRepHeader.h \
+	AdaptationRepHeader.cc \
 	AdaptationService.h \
 	AdaptationService.cc \
 	AdaptationServiceData.h \

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1422,6 +1422,10 @@ endif
 	  # adaptation_meta because it starts matching immediately after
 	  # the service has been selected for adaptation.
 
+	acl aclname adaptation_rep_header header-name [-i] any\.regex\.here
+	  # regex match against the adaptation reply headers.  e.g. ICAP
+	  # reply headers. [fast]
+
 	acl aclname transaction_initiator initiator ...
 	  # Matches transaction's initiator [fast]
 	  #


### PR DESCRIPTION
headers returned by the last adaptation callout (e.g. ICAP).

i.e. the following would make a case insensitive match for the regex
"bar" in the ICAP response header "X-Foo":
  acl icap_says_bar adaptation_rep_header X-Foo -i bar