### PR TITLE
Fix "mem_obj->inmem_lo == 0" assertion in StoreEntry::swapOut()

### DIFF
--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -175,7 +175,10 @@ StoreEntry::swapOut()
     Store::Root().memoryOut(*this, weAreOrMayBeSwappingOut);
 
     if (mem_obj->swapout.decision < MemObject::SwapOut::swPossible)
-        return; // nothing else to do
+        return; // decided not to write to disk (at least for now)
+
+    if (!weAreOrMayBeSwappingOut)
+        return; // finished writing to disk after an earlier swStarted decision
 
     // Aborted entries have STORE_OK, but swapoutPossible rejects them. Thus,
     // store_status == STORE_OK below means we got everything we wanted.


### PR DESCRIPTION
Squid may stop writing to disk well before receiving the entire miss
response (e.g., because of swapout errors). When that happens, Squid
continues to call swapOut() to mem-cache the incoming response body.
Avoid the inapplicable disk-writing part of swapOut() in those cases.