### PR TITLE
Improved const-correctness of ALE-driven APIs

### DIFF
--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -276,8 +276,8 @@ class ACLChecklist;
 class StoreEntry;
 
 /* Should be in 'AccessLog.h' as the driver */
-void accessLogLogTo(CustomLog *, const AccessLogEntry::Pointer &, ACLChecklist *checklist = nullptr);
-void accessLogLog(const AccessLogEntry::Pointer &, ACLChecklist *);
+void accessLogLogTo(CustomLog *, const AccessLogEntryPointer &, ACLChecklist *checklist = nullptr);
+void accessLogLog(const AccessLogEntryPointer &, ACLChecklist *);
 void accessLogRotate(void);
 void accessLogClose(void);
 void accessLogInit(void);

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -276,8 +276,8 @@ class ACLChecklist;
 class StoreEntry;
 
 /* Should be in 'AccessLog.h' as the driver */
-void accessLogLogTo(CustomLog* log, AccessLogEntry::Pointer &al, ACLChecklist* checklist = NULL);
-void accessLogLog(AccessLogEntry::Pointer &, ACLChecklist * checklist);
+void accessLogLogTo(CustomLog *, const AccessLogEntry::Pointer &, ACLChecklist *checklist = nullptr);
+void accessLogLog(const AccessLogEntry::Pointer &, ACLChecklist *);
 void accessLogRotate(void);
 void accessLogClose(void);
 void accessLogInit(void);

--- a/src/adaptation/AccessCheck.cc
+++ b/src/adaptation/AccessCheck.cc
@@ -29,7 +29,7 @@ cbdata_type Adaptation::AccessCheck::CBDATA_AccessCheck = CBDATA_UNKNOWN;
 bool
 Adaptation::AccessCheck::Start(Method method, VectPoint vp,
                                HttpRequest *req, HttpReply *rep,
-                               AccessLogEntry::Pointer &al, Adaptation::Initiator *initiator)
+                               const AccessLogEntry::Pointer &al, Adaptation::Initiator *initiator)
 {
 
     if (Config::Enabled) {

--- a/src/adaptation/AccessCheck.cc
+++ b/src/adaptation/AccessCheck.cc
@@ -29,7 +29,7 @@ cbdata_type Adaptation::AccessCheck::CBDATA_AccessCheck = CBDATA_UNKNOWN;
 bool
 Adaptation::AccessCheck::Start(Method method, VectPoint vp,
                                HttpRequest *req, HttpReply *rep,
-                               const AccessLogEntry::Pointer &al, Adaptation::Initiator *initiator)
+                               const AccessLogEntryPointer &al, Adaptation::Initiator *initiator)
 {
 
     if (Config::Enabled) {

--- a/src/adaptation/AccessCheck.h
+++ b/src/adaptation/AccessCheck.h
@@ -36,7 +36,7 @@ public:
 
     // use this to start async ACL checks; returns true if started
     static bool Start(Method method, VectPoint vp, HttpRequest *req,
-                      HttpReply *rep, AccessLogEntry::Pointer &al, Adaptation::Initiator *initiator);
+                      HttpReply *, const AccessLogEntry::Pointer &, Adaptation::Initiator *);
 
 protected:
     // use Start to start adaptation checks

--- a/src/adaptation/AccessCheck.h
+++ b/src/adaptation/AccessCheck.h
@@ -9,13 +9,13 @@
 #ifndef SQUID_ADAPTATION__ACCESS_CHECK_H
 #define SQUID_ADAPTATION__ACCESS_CHECK_H
 
-#include "AccessLogEntry.h"
 #include "acl/Acl.h"
 #include "adaptation/Elements.h"
 #include "adaptation/forward.h"
 #include "adaptation/Initiator.h"
 #include "adaptation/ServiceFilter.h"
 #include "base/AsyncJob.h"
+#include "log/forward.h"
 
 class HttpRequest;
 class HttpReply;
@@ -36,7 +36,7 @@ public:
 
     // use this to start async ACL checks; returns true if started
     static bool Start(Method method, VectPoint vp, HttpRequest *req,
-                      HttpReply *, const AccessLogEntry::Pointer &, Adaptation::Initiator *);
+                      HttpReply *, const AccessLogEntryPointer &, Adaptation::Initiator *);
 
 protected:
     // use Start to start adaptation checks

--- a/src/adaptation/Iterator.cc
+++ b/src/adaptation/Iterator.cc
@@ -21,7 +21,7 @@
 
 Adaptation::Iterator::Iterator(
     Http::Message *aMsg, HttpRequest *aCause,
-    const AccessLogEntry::Pointer &alp,
+    const AccessLogEntryPointer &alp,
     const ServiceGroupPointer &aGroup):
     AsyncJob("Iterator"),
     Adaptation::Initiate("Iterator"),

--- a/src/adaptation/Iterator.cc
+++ b/src/adaptation/Iterator.cc
@@ -21,7 +21,7 @@
 
 Adaptation::Iterator::Iterator(
     Http::Message *aMsg, HttpRequest *aCause,
-    AccessLogEntry::Pointer &alp,
+    const AccessLogEntry::Pointer &alp,
     const ServiceGroupPointer &aGroup):
     AsyncJob("Iterator"),
     Adaptation::Initiate("Iterator"),

--- a/src/adaptation/Iterator.h
+++ b/src/adaptation/Iterator.h
@@ -34,7 +34,7 @@ class Iterator: public Initiate, public Initiator
 
 public:
     Iterator(Http::Message *virginHeader, HttpRequest *virginCause,
-             AccessLogEntry::Pointer &alp,
+             const AccessLogEntry::Pointer &,
              const Adaptation::ServiceGroupPointer &aGroup);
     virtual ~Iterator();
 

--- a/src/adaptation/Iterator.h
+++ b/src/adaptation/Iterator.h
@@ -9,11 +9,11 @@
 #ifndef SQUID_ADAPTATION__ITERATOR_H
 #define SQUID_ADAPTATION__ITERATOR_H
 
-#include "AccessLogEntry.h"
 #include "adaptation/Initiate.h"
 #include "adaptation/Initiator.h"
 #include "adaptation/ServiceGroups.h"
 #include "http/forward.h"
+#include "log/forward.h"
 
 namespace Adaptation
 {
@@ -34,7 +34,7 @@ class Iterator: public Initiate, public Initiator
 
 public:
     Iterator(Http::Message *virginHeader, HttpRequest *virginCause,
-             const AccessLogEntry::Pointer &,
+             const AccessLogEntryPointer &,
              const Adaptation::ServiceGroupPointer &aGroup);
     virtual ~Iterator();
 
@@ -67,7 +67,7 @@ protected:
     ServicePlan thePlan; ///< which services to use and in what order
     Http::Message *theMsg; ///< the message being adapted (virgin for each step)
     HttpRequest *theCause; ///< the cause of the original virgin message
-    AccessLogEntry::Pointer al; ///< info for the future access.log entry
+    AccessLogEntryPointer al; ///< info for the future access.log entry
     CbcPointer<Adaptation::Initiate> theLauncher; ///< current transaction launcher
     int iterations; ///< number of steps initiated
     bool adapted; ///< whether the virgin message has been replaced

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1311,7 +1311,7 @@ void Adaptation::Icap::ModXact::swanSong()
     Adaptation::Icap::Xaction::swanSong();
 }
 
-void prepareLogWithRequestDetails(HttpRequest *, AccessLogEntry::Pointer &);
+void prepareLogWithRequestDetails(HttpRequest *, const AccessLogEntry::Pointer &);
 
 void Adaptation::Icap::ModXact::finalizeLogInfo()
 {

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1311,7 +1311,7 @@ void Adaptation::Icap::ModXact::swanSong()
     Adaptation::Icap::Xaction::swanSong();
 }
 
-void prepareLogWithRequestDetails(HttpRequest *, const AccessLogEntry::Pointer &);
+void prepareLogWithRequestDetails(HttpRequest *, const AccessLogEntryPointer &);
 
 void Adaptation::Icap::ModXact::finalizeLogInfo()
 {

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -186,7 +186,7 @@ static void clientUpdateStatHistCounters(const LogTags &logType, int svc_time);
 static void clientUpdateStatCounters(const LogTags &logType);
 static void clientUpdateHierCounters(HierarchyLogEntry *);
 static bool clientPingHasFinished(ping_data const *aPing);
-void prepareLogWithRequestDetails(HttpRequest *, const AccessLogEntry::Pointer &);
+void prepareLogWithRequestDetails(HttpRequest *, const AccessLogEntryPointer &);
 static void ClientSocketContextPushDeferredIfNeeded(Http::StreamPointer deferredRequest, ConnStateData * conn);
 
 char *skipLeadingSpace(char *aString);
@@ -325,7 +325,7 @@ ClientHttpRequest::updateCounters()
 }
 
 void
-prepareLogWithRequestDetails(HttpRequest *request, const AccessLogEntry::Pointer &aLogEntry)
+prepareLogWithRequestDetails(HttpRequest *request, const AccessLogEntryPointer &aLogEntry)
 {
     assert(request);
     assert(aLogEntry != NULL);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -186,7 +186,7 @@ static void clientUpdateStatHistCounters(const LogTags &logType, int svc_time);
 static void clientUpdateStatCounters(const LogTags &logType);
 static void clientUpdateHierCounters(HierarchyLogEntry *);
 static bool clientPingHasFinished(ping_data const *aPing);
-void prepareLogWithRequestDetails(HttpRequest *, AccessLogEntry::Pointer &);
+void prepareLogWithRequestDetails(HttpRequest *, const AccessLogEntry::Pointer &);
 static void ClientSocketContextPushDeferredIfNeeded(Http::StreamPointer deferredRequest, ConnStateData * conn);
 
 char *skipLeadingSpace(char *aString);
@@ -325,7 +325,7 @@ ClientHttpRequest::updateCounters()
 }
 
 void
-prepareLogWithRequestDetails(HttpRequest * request, AccessLogEntry::Pointer &aLogEntry)
+prepareLogWithRequestDetails(HttpRequest *request, const AccessLogEntry::Pointer &aLogEntry)
 {
     assert(request);
     assert(aLogEntry != NULL);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -151,6 +151,7 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
     uri(NULL),
     log_uri(NULL),
     req_sz(0),
+    al(new AccessLogEntry()),
     calloutContext(NULL),
     maxReplyBodySize_(0),
     entry_(NULL),
@@ -164,7 +165,6 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
     , request_satisfaction_offset(0)
 #endif
 {
-    al = new AccessLogEntry;
     CodeContext::Reset(al);
     al->cache.start_time = current_time;
     if (aConn) {

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -123,7 +123,7 @@ public:
     // NP: still an enum so each stage altering it must take care when replacing it.
     LogTags logType;
 
-    AccessLogEntry::Pointer al; ///< access.log entry
+    const AccessLogEntry::Pointer al; ///< access.log entry
 
     struct Flags {
         Flags() : accel(false), internal(false), done_copying(false) {}

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -9,12 +9,12 @@
 #ifndef SQUID_CLIENTSIDEREQUEST_H
 #define SQUID_CLIENTSIDEREQUEST_H
 
-#include "AccessLogEntry.h"
 #include "acl/forward.h"
 #include "client_side.h"
 #include "clientStream.h"
 #include "http/forward.h"
 #include "HttpHeaderRange.h"
+#include "log/forward.h"
 #include "LogTags.h"
 #include "Store.h"
 
@@ -123,7 +123,7 @@ public:
     // NP: still an enum so each stage altering it must take care when replacing it.
     LogTags logType;
 
-    const AccessLogEntry::Pointer al; ///< access.log entry
+    const AccessLogEntryPointer al; ///< access.log entry
 
     struct Flags {
         Flags() : accel(false), internal(false), done_copying(false) {}

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1413,7 +1413,7 @@ ESIContext::freeResources ()
     /* don't touch incoming, it's a pointer into buffered anyway */
 }
 
-ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, const ConnStateData *, HttpRequest *, const AccessLogEntry::Pointer &);
+ErrorState *clientBuildError(err_type, Http::StatusCode, char const *, const ConnStateData *, HttpRequest *, const AccessLogEntryPointer &);
 
 /* This can ONLY be used before we have sent *any* data to the client */
 void

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -37,6 +37,7 @@
 #include "HttpReply.h"
 #include "HttpRequest.h"
 #include "ip/Address.h"
+#include "log/forward.h"
 #include "MemBuf.h"
 #include "profiler/Profiler.h"
 #include "SquidConfig.h"

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -75,7 +75,7 @@ static void fvdbRegisterWithCacheManager();
 int LogfileStatus = LOG_DISABLE;
 
 void
-accessLogLogTo(CustomLog *log, const AccessLogEntry::Pointer &al, ACLChecklist *checklist)
+accessLogLogTo(CustomLog *log, const AccessLogEntryPointer &al, ACLChecklist *checklist)
 {
 
     if (al->url.isEmpty())
@@ -145,7 +145,7 @@ accessLogLogTo(CustomLog *log, const AccessLogEntry::Pointer &al, ACLChecklist *
 }
 
 void
-accessLogLog(const AccessLogEntry::Pointer &al, ACLChecklist *checklist)
+accessLogLog(const AccessLogEntryPointer &al, ACLChecklist *checklist)
 {
     if (LogfileStatus != LOG_ENABLE)
         return;

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -75,7 +75,7 @@ static void fvdbRegisterWithCacheManager();
 int LogfileStatus = LOG_DISABLE;
 
 void
-accessLogLogTo(CustomLog* log, AccessLogEntry::Pointer &al, ACLChecklist * checklist)
+accessLogLogTo(CustomLog *log, const AccessLogEntry::Pointer &al, ACLChecklist *checklist)
 {
 
     if (al->url.isEmpty())
@@ -145,7 +145,7 @@ accessLogLogTo(CustomLog* log, AccessLogEntry::Pointer &al, ACLChecklist * check
 }
 
 void
-accessLogLog(AccessLogEntry::Pointer &al, ACLChecklist * checklist)
+accessLogLog(const AccessLogEntry::Pointer &al, ACLChecklist *checklist)
 {
     if (LogfileStatus != LOG_ENABLE)
         return;

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 18    Cache Manager Statistics */
 
 #include "squid.h"
+#include "AccessLogEntry.h"
 #include "CacheDigest.h"
 #include "CachePeer.h"
 #include "client_side.h"

--- a/src/tests/stub_liblog.cc
+++ b/src/tests/stub_liblog.cc
@@ -23,8 +23,8 @@ SBuf AccessLogEntry::getLogMethod() const STUB_RETVAL(SBuf())
 AccessLogEntry::SslDetails::SslDetails() {STUB}
 #endif
 */
-void accessLogLogTo(CustomLog *, AccessLogEntry::Pointer &, ACLChecklist *) STUB
-void accessLogLog(AccessLogEntry::Pointer &, ACLChecklist *) STUB
+void accessLogLogTo(CustomLog *, const AccessLogEntry::Pointer &, ACLChecklist *) STUB
+void accessLogLog(const AccessLogEntry::Pointer &, ACLChecklist *) STUB
 void accessLogRotate(void) STUB
 void accessLogClose(void) STUB
 void accessLogInit(void) STUB


### PR DESCRIPTION
Also made ClientHttpRequest::al constant. This work actually started
with changing this data member, to make some ALE-related hack safer.
That change required the API fixes. We have since got rid of the hack,
but all these const-correctness changes are valuable on their own.

No functionality changes.