### PR TITLE
Deduplicate transaction LogTags

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -313,12 +313,12 @@ clientUpdateHierCounters(HierarchyLogEntry * someEntry)
 void
 ClientHttpRequest::updateCounters()
 {
-    clientUpdateStatCounters(logType);
+    clientUpdateStatCounters(loggingTags());
 
     if (request->error)
         ++ statCounter.client_http.errors;
 
-    clientUpdateStatHistCounters(logType,
+    clientUpdateStatHistCounters(loggingTags(),
                                  tvSubMsec(al->cache.start_time, current_time));
 
     clientUpdateHierCounters(&request->hier);
@@ -379,7 +379,7 @@ prepareLogWithRequestDetails(HttpRequest * request, AccessLogEntry::Pointer &aLo
 void
 ClientHttpRequest::logRequest()
 {
-    if (!out.size && logType.oldType == LOG_TAG_NONE)
+    if (!out.size && loggingTags().oldType == LOG_TAG_NONE)
         debugs(33, 5, "logging half-baked transaction: " << log_uri);
 
     al->icp.opcode = ICP_INVALID;
@@ -412,8 +412,6 @@ ClientHttpRequest::logRequest()
     al->http.clientReplySz.payloadData = out.size - out.headers_sz; // pretend its all un-encoded data for now.
 
     al->cache.highOffset = out.offset;
-
-    al->cache.code = logType;
 
     tvSub(al->cache.trTime, al->cache.start_time, current_time);
 
@@ -474,7 +472,7 @@ ClientHttpRequest::logRequest()
             updateCounters();
 
         if (getConn() != NULL && getConn()->clientConnection != NULL)
-            clientdbUpdate(getConn()->clientConnection->remote, logType, AnyP::PROTO_HTTP, out.size);
+            clientdbUpdate(getConn()->clientConnection->remote, loggingTags(), AnyP::PROTO_HTTP, out.size);
     }
 }
 
@@ -1026,7 +1024,7 @@ ConnStateData::afterClientWrite(size_t size)
     auto ctx = pipeline.front();
     if (size) {
         statCounter.client_http.kbytes_out += size;
-        if (ctx->http->logType.isTcpHit())
+        if (ctx->http->loggingTags().isTcpHit())
             statCounter.client_http.hit_kbytes_out += size;
     }
     ctx->writeComplete(size);

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -281,7 +281,7 @@ clientReplyContext::processExpired()
         return;
     }
 
-    http->logType.update(LOG_TCP_REFRESH);
+    http->updateLoggingTags(LOG_TCP_REFRESH);
     http->request->flags.refresh = true;
 #if STORE_CLIENT_LIST_DEBUG
     /* Prevent a race with the store client memory free routines
@@ -434,7 +434,7 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
         debugs(88, 3, "CF slave hit private non-shareable " << *http->storeEntry() << ". MISS");
         // restore context to meet processMiss() expectations
         restoreState();
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         processMiss();
         return;
     }
@@ -445,7 +445,7 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
     // request to origin was aborted
     if (EBIT_TEST(http->storeEntry()->flags, ENTRY_ABORTED)) {
         debugs(88, 3, "request to origin aborted '" << http->storeEntry()->url() << "', sending old entry to client");
-        http->logType.update(LOG_TCP_REFRESH_FAIL_OLD);
+        http->updateLoggingTags(LOG_TCP_REFRESH_FAIL_OLD);
         sendClientOldEntry();
         return;
     }
@@ -459,7 +459,7 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
 
     // origin replied 304
     if (status == Http::scNotModified) {
-        http->logType.update(LOG_TCP_REFRESH_UNMODIFIED);
+        http->updateLoggingTags(LOG_TCP_REFRESH_UNMODIFIED);
         http->request->flags.staleIfHit = false; // old_entry is no longer stale
 
         // TODO: The update may not be instantaneous. Should we wait for its
@@ -485,13 +485,13 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
         // RFC 7234 section 4: a cache MUST use the most recent response
         // (as determined by the Date header field)
         if (new_rep.olderThan(&old_entry->mem().freshestReply())) {
-            http->logType.err.ignored = true;
+            http->al->cache.code.err.ignored = true;
             debugs(88, 3, "origin replied " << status << " but with an older date header, sending old entry (" << oldStatus << ") to client");
             sendClientOldEntry();
             return;
         }
 
-        http->logType.update(LOG_TCP_REFRESH_MODIFIED);
+        http->updateLoggingTags(LOG_TCP_REFRESH_MODIFIED);
         debugs(88, 3, "origin replied " << status << ", forwarding to client");
         sendClientUpstreamResponse();
         return;
@@ -499,14 +499,14 @@ clientReplyContext::handleIMSReply(StoreIOBuffer result)
 
     // origin replied with an error
     if (http->request->flags.failOnValidationError) {
-        http->logType.update(LOG_TCP_REFRESH_FAIL_ERR);
+        http->updateLoggingTags(LOG_TCP_REFRESH_FAIL_ERR);
         debugs(88, 3, "origin replied with error " << status << ", forwarding to client due to fail_on_validation_err");
         sendClientUpstreamResponse();
         return;
     }
 
     // ignore and let client have old entry
-    http->logType.update(LOG_TCP_REFRESH_FAIL_OLD);
+    http->updateLoggingTags(LOG_TCP_REFRESH_FAIL_OLD);
     debugs(88, 3, "origin replied with error " << status << ", sending old entry (" << oldStatus << ") to client");
     sendClientOldEntry();
 }
@@ -552,7 +552,7 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
     } else if (result.flags.error) {
         /* swap in failure */
         debugs(88, 3, "clientCacheHit: swapin failure for " << http->uri);
-        http->logType.update(LOG_TCP_SWAPFAIL_MISS);
+        http->updateLoggingTags(LOG_TCP_SWAPFAIL_MISS);
         removeClientStoreReference(&sc, http);
         processMiss();
         return;
@@ -563,7 +563,7 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
     // happen to regular hits because we are called asynchronously.
     if (!e->mayStartHitting()) {
         debugs(88, 3, "unshareable " << *e << ". MISS");
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         processMiss();
         return;
     }
@@ -574,7 +574,7 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
          * object
          */
         /* treat as a miss */
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         processMiss();
         return;
     }
@@ -586,11 +586,11 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
     /*
      * Got the headers, now grok them
      */
-    assert(http->logType.oldType == LOG_TCP_HIT);
+    assert(http->loggingTags().oldType == LOG_TCP_HIT);
 
     if (http->request->storeId().cmp(e->mem_obj->storeId()) != 0) {
         debugs(33, DBG_IMPORTANT, "clientProcessHit: URL mismatch, '" << e->mem_obj->storeId() << "' != '" << http->request->storeId() << "'");
-        http->logType.update(LOG_TCP_MISS); // we lack a more precise LOG_*_MISS code
+        http->updateLoggingTags(LOG_TCP_MISS); // we lack a more precise LOG_*_MISS code
         processMiss();
         return;
     }
@@ -622,7 +622,7 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
     case VARY_CANCEL:
         /* varyEvaluateMatch found a object loop. Process as miss */
         debugs(88, DBG_IMPORTANT, "clientProcessHit: Vary object loop!");
-        http->logType.update(LOG_TCP_MISS); // we lack a more precise LOG_*_MISS code
+        http->updateLoggingTags(LOG_TCP_MISS); // we lack a more precise LOG_*_MISS code
         processMiss();
         return;
     }
@@ -637,12 +637,12 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
 
     if (e->checkNegativeHit() && !r->flags.noCacheHack()) {
         debugs(88, 5, "negative-HIT");
-        http->logType.update(LOG_TCP_NEGATIVE_HIT);
+        http->updateLoggingTags(LOG_TCP_NEGATIVE_HIT);
         sendMoreData(result);
         return;
     } else if (blockedHit()) {
         debugs(88, 5, "send_hit forces a MISS");
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         processMiss();
         return;
     } else if (!http->flags.internal && refreshCheckHTTP(e, r)) {
@@ -666,7 +666,7 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
              * modification time.
              * XXX: BUG 1890 objects without Date do not get one added.
              */
-            http->logType.update(LOG_TCP_MISS);
+            http->updateLoggingTags(LOG_TCP_MISS);
             processMiss();
         } else if (r->flags.noCache) {
             debugs(88, 3, "validate HIT object? NO. Client sent CC:no-cache. Do CLIENT_REFRESH_MISS");
@@ -674,7 +674,7 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
              * This did not match a refresh pattern that overrides no-cache
              * we should honour the client no-cache header.
              */
-            http->logType.update(LOG_TCP_CLIENT_REFRESH_MISS);
+            http->updateLoggingTags(LOG_TCP_CLIENT_REFRESH_MISS);
             processMiss();
         } else if (r->url.getScheme() == AnyP::PROTO_HTTP || r->url.getScheme() == AnyP::PROTO_HTTPS) {
             debugs(88, 3, "validate HIT object? YES.");
@@ -689,7 +689,7 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
              * We don't know how to re-validate other protocols. Handle
              * them as if the object has expired.
              */
-            http->logType.update(LOG_TCP_MISS);
+            http->updateLoggingTags(LOG_TCP_MISS);
             processMiss();
         }
         return;
@@ -706,13 +706,13 @@ clientReplyContext::cacheHit(StoreIOBuffer result)
 
 #if USE_DELAY_POOLS
     if (e->store_status != STORE_OK)
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
     else
 #endif
         if (e->mem_status == IN_MEMORY)
-            http->logType.update(LOG_TCP_MEM_HIT);
+            http->updateLoggingTags(LOG_TCP_MEM_HIT);
         else if (Config.onoff.offline)
-            http->logType.update(LOG_TCP_OFFLINE_HIT);
+            http->updateLoggingTags(LOG_TCP_OFFLINE_HIT);
 
     sendMoreData(result);
 }
@@ -735,7 +735,7 @@ clientReplyContext::processMiss()
     if (http->storeEntry()) {
         if (EBIT_TEST(http->storeEntry()->flags, ENTRY_SPECIAL)) {
             debugs(88, DBG_CRITICAL, "clientProcessMiss: miss on a special object (" << url << ").");
-            debugs(88, DBG_CRITICAL, "\tlog_type = " << http->logType.c_str());
+            debugs(88, DBG_CRITICAL, "\tlog_type = " << http->loggingTags().c_str());
             http->storeEntry()->dump(1);
         }
 
@@ -774,7 +774,7 @@ clientReplyContext::processMiss()
 
         if (http->redirect.status) {
             const HttpReplyPointer rep(new HttpReply);
-            http->logType.update(LOG_TCP_REDIRECT);
+            http->updateLoggingTags(LOG_TCP_REDIRECT);
             http->storeEntry()->releaseRequest();
             rep->redirect(http->redirect.status, http->redirect.location);
             http->storeEntry()->replaceHttpReply(rep);
@@ -816,7 +816,7 @@ clientReplyContext::processConditional()
     const auto replyStatusCode = e->mem().baseReply().sline.status();
     if (replyStatusCode != Http::scOkay) {
         debugs(88, 4, "miss because " << replyStatusCode << " != 200");
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         processMiss();
         return true;
     }
@@ -917,7 +917,7 @@ clientReplyContext::loggingTags() const
     // XXX: clientReplyContext code assumes that http cbdata is always valid.
     // TODO: Either add cbdataReferenceValid(http) checks in all the relevant
     // places, like this one, or remove cbdata protection of the http member.
-    return &http->logType;
+    return &http->al->cache.code;
 }
 
 void
@@ -927,7 +927,7 @@ clientReplyContext::purgeRequest()
            Config2.onoff.enable_purge);
 
     if (!Config2.onoff.enable_purge) {
-        http->logType.update(LOG_TCP_DENIED);
+        http->updateLoggingTags(LOG_TCP_DENIED);
         ErrorState *err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, NULL,
                                            http->getConn(), http->request, http->al);
         startError(err);
@@ -948,7 +948,7 @@ clientReplyContext::purgeDoPurge()
     if (const auto entry = storeGetPublicByRequestMethod(http->request, Http::METHOD_GET)) {
         // special entries are only METHOD_GET entries without variance
         if (EBIT_TEST(entry->flags, ENTRY_SPECIAL)) {
-            http->logType.update(LOG_TCP_DENIED);
+            http->updateLoggingTags(LOG_TCP_DENIED);
             const auto err = clientBuildError(ERR_ACCESS_DENIED, Http::scForbidden, nullptr,
                                               http->getConn(), http->request, http->al);
             startError(err);
@@ -1252,7 +1252,7 @@ void
 clientReplyContext::buildReplyHeader()
 {
     HttpHeader *hdr = &reply->header;
-    const bool is_hit = http->logType.isTcpHit();
+    const bool is_hit = http->loggingTags().isTcpHit();
     HttpRequest *request = http->request;
 
     if (is_hit || collapsedRevalidation == crSlave)
@@ -1351,14 +1351,14 @@ clientReplyContext::buildReplyHeader()
     }
 
     // add Warnings required by RFC 2616 if serving a stale hit
-    if (http->request->flags.staleIfHit && http->logType.isTcpHit()) {
+    if (http->request->flags.staleIfHit && http->loggingTags().isTcpHit()) {
         hdr->putWarning(110, "Response is stale");
         if (http->request->flags.needValidation)
             hdr->putWarning(111, "Revalidation failed");
     }
 
     /* Filter unproxyable authentication types */
-    if (http->logType.oldType != LOG_TCP_DENIED &&
+    if (http->loggingTags().oldType != LOG_TCP_DENIED &&
             hdr->has(Http::HdrType::WWW_AUTHENTICATE)) {
         HttpHeaderPos pos = HttpHeaderInitPos;
         HttpHeaderEntry *e;
@@ -1402,7 +1402,7 @@ clientReplyContext::buildReplyHeader()
 
 #if USE_AUTH
     /* Handle authentication headers */
-    if (http->logType.oldType == LOG_TCP_DENIED &&
+    if (http->loggingTags().oldType == LOG_TCP_DENIED &&
             ( reply->sline.status() == Http::scProxyAuthenticationRequired ||
               reply->sline.status() == Http::scUnauthorized)
        ) {
@@ -1418,7 +1418,7 @@ clientReplyContext::buildReplyHeader()
 #endif
 
     SBuf cacheStatus(uniqueHostname());
-    if (const auto hitOrFwd = http->logType.cacheStatusSource())
+    if (const auto hitOrFwd = http->loggingTags().cacheStatusSource())
         cacheStatus.append(hitOrFwd);
     if (firstStoreLookup_) {
         cacheStatus.append(";detail=");
@@ -1577,7 +1577,7 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry, const char *detail
     if (!e) {
         /** \li If no StoreEntry object is current assume this object isn't in the cache set MISS*/
         debugs(85, 3, "StoreEntry is NULL -  MISS");
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         doGetMoreData();
         return;
     }
@@ -1585,7 +1585,7 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry, const char *detail
     if (Config.onoff.offline) {
         /** \li If we are running in offline mode set to HIT */
         debugs(85, 3, "offline HIT " << *e);
-        http->logType.update(LOG_TCP_HIT);
+        http->updateLoggingTags(LOG_TCP_HIT);
         doGetMoreData();
         return;
     }
@@ -1594,7 +1594,7 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry, const char *detail
         /** \li If redirection status is True force this to be a MISS */
         debugs(85, 3, "REDIRECT status forced StoreEntry to NULL (no body on 3XX responses) " << *e);
         forgetHit();
-        http->logType.update(LOG_TCP_REDIRECT);
+        http->updateLoggingTags(LOG_TCP_REDIRECT);
         doGetMoreData();
         return;
     }
@@ -1602,7 +1602,7 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry, const char *detail
     if (!e->validToSend()) {
         debugs(85, 3, "!storeEntryValidToSend MISS " << *e);
         forgetHit();
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         doGetMoreData();
         return;
     }
@@ -1610,7 +1610,7 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry, const char *detail
     if (EBIT_TEST(e->flags, ENTRY_SPECIAL)) {
         /* \li Special entries are always hits, no matter what the client says */
         debugs(85, 3, "ENTRY_SPECIAL HIT " << *e);
-        http->logType.update(LOG_TCP_HIT);
+        http->updateLoggingTags(LOG_TCP_HIT);
         doGetMoreData();
         return;
     }
@@ -1618,7 +1618,7 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry, const char *detail
     if (r->flags.noCache) {
         debugs(85, 3, "no-cache REFRESH MISS " << *e);
         forgetHit();
-        http->logType.update(LOG_TCP_CLIENT_REFRESH_MISS);
+        http->updateLoggingTags(LOG_TCP_CLIENT_REFRESH_MISS);
         doGetMoreData();
         return;
     }
@@ -1626,13 +1626,13 @@ clientReplyContext::identifyFoundObject(StoreEntry *newEntry, const char *detail
     if (e->hittingRequiresCollapsing() && !startCollapsingOn(*e, false)) {
         debugs(85, 3, "prohibited CF MISS " << *e);
         forgetHit();
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
         doGetMoreData();
         return;
     }
 
     debugs(85, 3, "default HIT " << *e);
-    http->logType.update(LOG_TCP_HIT);
+    http->updateLoggingTags(LOG_TCP_HIT);
     doGetMoreData();
 }
 
@@ -1700,7 +1700,7 @@ clientGetMoreData(clientStreamNode * aNode, ClientHttpRequest * http)
         }
 
         /* continue forwarding, not finished yet. */
-        http->logType.update(LOG_TCP_MISS);
+        http->updateLoggingTags(LOG_TCP_MISS);
 
         context->doGetMoreData();
     } else
@@ -1724,7 +1724,7 @@ clientReplyContext::doGetMoreData()
         sc->setDelayId(DelayId::DelayClient(http));
 #endif
 
-        assert(http->logType.oldType == LOG_TCP_HIT);
+        assert(http->loggingTags().oldType == LOG_TCP_HIT);
         reqofs = 0;
         /* guarantee nothing has been sent yet! */
         assert(http->out.size == 0);
@@ -1745,7 +1745,7 @@ clientReplyContext::doGetMoreData()
         localTempBuffer.data = getNextNode()->readBuffer.data;
         storeClientCopy(sc, http->storeEntry(), localTempBuffer, CacheHit, this);
     } else {
-        /* MISS CASE, http->logType is already set! */
+        /* MISS CASE, http->loggingTags() are already set! */
         processMiss();
     }
 }
@@ -1834,7 +1834,7 @@ clientReplyContext::next() const
 void
 clientReplyContext::sendBodyTooLargeError()
 {
-    http->logType.update(LOG_TCP_DENIED_REPLY);
+    http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
     ErrorState *err = clientBuildError(ERR_TOO_BIG, Http::scForbidden, NULL,
                                        http->getConn(), http->request, http->al);
     removeClientStoreReference(&(sc), http);
@@ -1847,7 +1847,7 @@ clientReplyContext::sendBodyTooLargeError()
 void
 clientReplyContext::sendPreconditionFailedError()
 {
-    http->logType.update(LOG_TCP_HIT);
+    http->updateLoggingTags(LOG_TCP_HIT);
     ErrorState *const err =
         clientBuildError(ERR_PRECONDITION_FAILED, Http::scPreconditionFailed,
                          nullptr, http->getConn(), http->request, http->al);
@@ -1866,9 +1866,9 @@ clientReplyContext::sendNotModified()
     // log as TCP_INM_HIT if code 304 generated for
     // If-None-Match request
     if (!http->request->flags.ims)
-        http->logType.update(LOG_TCP_INM_HIT);
+        http->updateLoggingTags(LOG_TCP_INM_HIT);
     else
-        http->logType.update(LOG_TCP_IMS_HIT);
+        http->updateLoggingTags(LOG_TCP_IMS_HIT);
     removeClientStoreReference(&sc, http);
     createStoreEntry(http->request->method, RequestFlags());
     e = http->storeEntry();
@@ -1905,8 +1905,8 @@ clientReplyContext::processReplyAccess ()
     assert(reply);
 
     /** Don't block our own responses or HTTP status messages */
-    if (http->logType.oldType == LOG_TCP_DENIED ||
-            http->logType.oldType == LOG_TCP_DENIED_REPLY ||
+    if (http->loggingTags().oldType == LOG_TCP_DENIED ||
+            http->loggingTags().oldType == LOG_TCP_DENIED_REPLY ||
             alwaysAllowResponse(reply->sline.status())) {
         headers_sz = reply->hdr_sz;
         processReplyAccessResult(ACCESS_ALLOWED);
@@ -1954,7 +1954,7 @@ clientReplyContext::processReplyAccessResult(const Acl::Answer &accessAllowed)
         err_type page_id;
         page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, 1);
 
-        http->logType.update(LOG_TCP_DENIED_REPLY);
+        http->updateLoggingTags(LOG_TCP_DENIED_REPLY);
 
         if (page_id == ERR_NONE)
             page_id = ERR_ACCESS_DENIED;
@@ -2056,7 +2056,7 @@ clientReplyContext::sendMoreData (StoreIOBuffer result)
             return;
         }
 
-        if (reqofs==0 && !http->logType.isTcpHit()) {
+        if (reqofs==0 && !http->loggingTags().isTcpHit()) {
             if (Ip::Qos::TheConfig.isHitTosActive()) {
                 Ip::Qos::doTosLocalMiss(conn->clientConnection, http->request->hier.code);
             }

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -773,7 +773,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
          */
         page_id = aclGetDenyInfoPage(&Config.denyInfoList, AclMatchedName, answer != ACCESS_AUTH_REQUIRED);
 
-        http->logType.update(LOG_TCP_DENIED);
+        http->updateLoggingTags(LOG_TCP_DENIED);
 
         if (auth_challenge) {
 #if USE_AUTH
@@ -1529,8 +1529,8 @@ ClientHttpRequest::httpStart()
 {
     PROF_start(httpStart);
     // XXX: Re-initializes rather than updates. Should not be needed at all.
-    logType.update(LOG_TAG_NONE);
-    debugs(85, 4, logType.c_str() << " for '" << uri << "'");
+    updateLoggingTags(LOG_TAG_NONE);
+    debugs(85, 4, loggingTags().c_str() << " for '" << uri << "'");
 
     /* no one should have touched this */
     assert(out.offset == 0);
@@ -1892,7 +1892,7 @@ ClientHttpRequest::doCallouts()
 #if ICAP_CLIENT
     Adaptation::Icap::History::Pointer ih = request->icapHistory();
     if (ih != NULL)
-        ih->logType = logType;
+        ih->logType = loggingTags();
 #endif
 }
 

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_CLIENTSIDEREQUEST_H
 #define SQUID_CLIENTSIDEREQUEST_H
 
-#include "acl/forward.h"
+#include "AccessLogEntry.h"
 #include "client_side.h"
 #include "clientStream.h"
 #include "http/forward.h"
@@ -125,7 +125,7 @@ public:
     HttpHdrRangeIter range_iter;    /* data for iterating thru range specs */
     size_t req_sz;      /* raw request size on input, not current request size */
 
-    const AccessLogEntryPointer al; ///< access.log entry
+    const AccessLogEntry::Pointer al; ///< access.log entry
 
     struct Flags {
         Flags() : accel(false), internal(false), done_copying(false) {}

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -76,6 +76,12 @@ public:
     /// the request. To set the virgin request, use initRequest().
     void resetRequest(HttpRequest *);
 
+    /// update the code in the transaction processing tags
+    void updateLoggingTags(const LogTags_ot code) { al->cache.code.update(code); }
+
+    /// the processing tags associated with this request transaction.
+    const LogTags &loggingTags() const { return al->cache.code; }
+
     /** Details of the client socket which produced us.
      * Treat as read-only for the lifetime of this HTTP request.
      */
@@ -118,10 +124,6 @@ public:
 
     HttpHdrRangeIter range_iter;    /* data for iterating thru range specs */
     size_t req_sz;      /* raw request size on input, not current request size */
-
-    /// the processing tags associated with this request transaction.
-    // NP: still an enum so each stage altering it must take care when replacing it.
-    LogTags logType;
 
     AccessLogEntry::Pointer al; ///< access.log entry
 

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -446,7 +446,7 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
     /* hits only - upstream CachePeer determines correct behaviour on misses,
      * and client_side_reply determines hits candidates
      */
-    else if (http->logType.isTcpHit() &&
+    else if (http->loggingTags().isTcpHit() &&
              http->request->header.has(Http::HdrType::IF_RANGE) &&
              !clientIfRangeMatch(http, rep))
         range_err = "If-Range match failed";
@@ -455,7 +455,7 @@ Http::Stream::buildRangeHeader(HttpReply *rep)
         range_err = "canonization failed";
     else if (http->request->range->isComplex())
         range_err = "too complex range header";
-    else if (!http->logType.isTcpHit() && http->request->range->offsetLimitExceeded(roffLimit))
+    else if (!http->loggingTags().isTcpHit() && http->request->range->offsetLimitExceeded(roffLimit))
         range_err = "range outside range_offset_limit";
 
     /* get rid of our range specs on error */
@@ -528,7 +528,7 @@ Http::Stream::noteIoError(const Error &error, const LogTagsErrors &lte)
 {
     if (http) {
         http->updateError(error);
-        http->logType.err.update(lte);
+        http->al->cache.code.err.update(lte);
     }
 }
 

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1826,7 +1826,7 @@ statClientRequests(StoreEntry * s)
         }
 
         storeAppendPrintf(s, "uri %s\n", http->uri);
-        storeAppendPrintf(s, "logType %s\n", http->logType.c_str());
+        storeAppendPrintf(s, "logType %s\n", http->loggingTags().c_str());
         storeAppendPrintf(s, "out.offset %ld, out.size %lu\n",
                           (long int) http->out.offset, (unsigned long int) http->out.size);
         storeAppendPrintf(s, "req_sz %ld\n", (long int) http->req_sz);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -177,7 +177,6 @@ public:
 
     Connection client, server;
     int *status_ptr;        ///< pointer for logging HTTP status
-    LogTags *logTag_ptr;    ///< pointer for logging Squid processing code
 
     SBuf preReadClientData;
     SBuf preReadServerData;
@@ -374,7 +373,6 @@ TunnelStateData::TunnelStateData(ClientHttpRequest *clientRequest) :
     server.size_ptr = &clientRequest->out.size;
     client.size_ptr = &clientRequest->al->http.clientRequestSz.payloadData;
     status_ptr = &clientRequest->al->http.code;
-    logTag_ptr = &clientRequest->logType;
     al = clientRequest->al;
     http = clientRequest;
 
@@ -491,8 +489,7 @@ void
 TunnelStateData::syncHierNote(const Comm::ConnectionPointer &conn, const char *origin)
 {
     request->hier.resetPeerNotes(conn, origin);
-    if (al)
-        al->hier.resetPeerNotes(conn, origin);
+    al->hier.resetPeerNotes(conn, origin);
 }
 
 int
@@ -916,8 +913,7 @@ tunnelStartShoveling(TunnelStateData *tunnelState)
     commSetConnTimeout(tunnelState->server.conn, Config.Timeout.read, timeoutCall);
 
     *tunnelState->status_ptr = Http::scOkay;
-    if (tunnelState->logTag_ptr)
-        tunnelState->logTag_ptr->update(LOG_TCP_TUNNEL);
+    tunnelState->al->cache.code.update(LOG_TCP_TUNNEL);
     if (cbdataReferenceValid(tunnelState)) {
 
         // Shovel any payload already pushed into reply buffer by the server response
@@ -970,8 +966,7 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
     peerWait.finish();
     server.len = 0;
 
-    if (logTag_ptr)
-        logTag_ptr->update(LOG_TCP_TUNNEL);
+    al->cache.code.update(LOG_TCP_TUNNEL);
 
     if (answer.peerResponseStatus != Http::scNone)
         *status_ptr = answer.peerResponseStatus;


### PR DESCRIPTION
...using ALE cache.code instead of its partial
ClientSideRequest::logType duplicate.

The need to de-duplicate these two LogTag members became apparent when
we tried to update/detail LogTags in forwarding code (e.g., to report
peer timeouts) and noticed that ALE cache.code value could be
overwritten by (stale) ClientSideRequest::logType information. Those
updates needed other significant changes, so we factored this small
stand-alone improvement out.

Fortunately, ClientSideRequest::logType lifetime does not exceed ALE's,
making ClientHttpRequest::logTags removal straightforward.

Also removed a paranoid TunnelStateData::al check after verifying that
the ALE pointer is never nil.