### PR TITLE
Remove HTTP reply header completion hack

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -686,8 +686,8 @@ HttpStateData::processReplyHeader()
             debugs(11, 3, "Non-HTTP-compliant header:\n---------\n" << inBuf << "\n----------");
             flags.headers_parsed = true;
             HttpReply *newrep = new HttpReply;
-            // hp->needsMoreData() means hp->parseStatusCode is unusable, but it
-            // also means that the reply header got truncated by a premature EOF
+            // hp->needsMoreData() means hp->parseStatusCode is unusable, but, here,
+            // it also means that the reply header got truncated by a premature EOF
             assert(!hp->needsMoreData() || eof);
             const auto scode = hp->needsMoreData() ? Http::scInvalidHeader : hp->parseStatusCode;
             newrep->sline.set(Http::ProtocolVersion(), scode);


### PR DESCRIPTION
Treat responses with truncated HTTP headers (i.e. no CRLF after all the
field-lines) as malformed, replacing them with an HTTP 502
ERR_INVALID_RESP error (same as any other HTTP response with malformed
headers would get).

Since Bug 2879 (commit da6c841 and earlier v2-only changes), Squid was
"fixing" such truncated headers by adding an extra CRLF sequence and
re-parsing them. Depending on the truncation circumstances, that old
workaround could result in rather bad outcomes for Squid and its
clients. Hopefully, we no longer need to work around such bugs. If we
do, we should do it in a safer manner and with admin permission.