### PR TITLE
Bug 5060: Parallel builds are not reliable

### DIFF
--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -95,17 +95,20 @@ time.cc: $(top_srcdir)/src/time.cc
 SquidConfig.cc: $(top_srcdir)/src/SquidConfig.cc
 	cp $(top_srcdir)/src/SquidConfig.cc $@
 
-tests/stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc
+tests/stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc | tests
 	cp $(top_srcdir)/src/tests/stub_HelperChildConfig.cc $@
 
-tests/stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc
+tests/stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc | tests
 	cp $(top_srcdir)/src/tests/stub_fd.cc $@
 
-tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc
+tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc | tests
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 
-tests/stub_SBuf.cc: $(top_srcdir)/src/tests/stub_SBuf.cc
+tests/stub_SBuf.cc: $(top_srcdir)/src/tests/stub_SBuf.cc | tests
 	cp $(top_srcdir)/src/tests/stub_SBuf.cc $@
 
-tests/STUB.h: $(top_srcdir)/src/tests/STUB.h
+tests/STUB.h: $(top_srcdir)/src/tests/STUB.h | tests
 	cp $(top_srcdir)/src/tests/STUB.h $@
+
+tests:
+	mkdir -p $@

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -31,7 +31,7 @@ include $(top_srcdir)/doc/manuals/Substitute.am
 test_tools.cc: $(top_srcdir)/test-suite/test_tools.cc
 	cp $(top_srcdir)/test-suite/test_tools.cc $@
 
-tests/stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc
+tests/stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc | tests
 	cp $(top_srcdir)/src/tests/stub_debug.cc $@
 
 Here.cc: $(top_srcdir)/src/base/Here.cc
@@ -46,14 +46,17 @@ MemBuf.cc: $(top_srcdir)/src/MemBuf.cc
 time.cc: $(top_srcdir)/src/time.cc
 	cp $(top_srcdir)/src/time.cc $@
 
-tests/stub_cbdata.cc: $(top_srcdir)/src/tests/stub_cbdata.cc
+tests/stub_cbdata.cc: $(top_srcdir)/src/tests/stub_cbdata.cc | tests
 	cp $(top_srcdir)/src/tests/stub_cbdata.cc $@
 
-tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc
+tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc | tests
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 
-tests/STUB.h: $(top_srcdir)/src/tests/STUB.h
+tests/STUB.h: $(top_srcdir)/src/tests/STUB.h | tests
 	cp $(top_srcdir)/src/tests/STUB.h $@
+
+tests:
+	mkdir -p $@
 
 # stock tools for unit tests - library independent versions of dlink_list
 # etc.

--- a/tools/squidclient/Makefile.am
+++ b/tools/squidclient/Makefile.am
@@ -30,17 +30,20 @@ include $(top_srcdir)/doc/manuals/Substitute.am
 test_tools.cc: $(top_srcdir)/test-suite/test_tools.cc
 	cp $(top_srcdir)/test-suite/test_tools.cc $@
 
-tests/stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc
+tests/stub_debug.cc: $(top_srcdir)/src/tests/stub_debug.cc | tests
 	cp $(top_srcdir)/src/tests/stub_debug.cc $@
 
 time.cc: $(top_srcdir)/src/time.cc
 	cp $(top_srcdir)/src/time.cc $@
 
-tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc
+tests/stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc | tests
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 
-tests/STUB.h: $(top_srcdir)/src/tests/STUB.h
+tests/STUB.h: $(top_srcdir)/src/tests/STUB.h | tests
 	cp $(top_srcdir)/src/tests/STUB.h $@
+
+tests:
+	mkdir -p $@
 
 # stock tools for unit tests - library independent versions of dlink_list
 # etc.


### PR DESCRIPTION
Create tests directory before using it. Needed since commits 44e802f and
9ba9313.

    cp ../../src/tests/stub_debug.cc tests/stub_debug.cc
    cp ../../src/tests/stub_libmem.cc tests/stub_libmem.cc
    cp: cannot create regular file 'tests/stub_debug.cc':
        No such file or directory
