### PR TITLE
Fix GCC v10 --with-openssl build after commit 030a9b3

### DIFF
--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -374,25 +374,23 @@ Ssl::ServerBio::write(const char *buf, int size, BIO *table)
         //Hello message is the first message we write to server
         assert(helloMsg.isEmpty());
 
-        if (auto ssl = fd_table[fd_].ssl.get()) {
-            if (bumpMode_ == Ssl::bumpPeek) {
-                // we should not be here if we failed to parse the client-sent ClientHello
-                Must(!clientSentHello.isEmpty());
-                allowSplice = true;
-                // Replace OpenSSL-generated ClientHello with client-sent one.
-                helloMsg.append(clientSentHello);
-                debugs(83, 7,  "FD " << fd_ << ": Using client-sent ClientHello for peek mode");
-            } else { /*Ssl::bumpStare*/
-                allowBump = true;
-            }
+        if (bumpMode_ == Ssl::bumpPeek) {
+            // we should not be here if we failed to parse the client-sent ClientHello
+            Must(!clientSentHello.isEmpty());
+            allowSplice = true;
+            // Replace OpenSSL-generated ClientHello with client-sent one.
+            helloMsg.append(clientSentHello);
+            debugs(83, 7,  "FD " << fd_ << ": Using client-sent ClientHello for peek mode");
+        } else { /*Ssl::bumpStare*/
+            allowBump = true;
         }
+
         // if we did not use the client-sent ClientHello, then use the OpenSSL-generated one
         if (helloMsg.isEmpty())
             helloMsg.append(buf, size);
 
         helloBuild = true;
         helloMsgSize = helloMsg.length();
-        //allowBump = true;
 
         if (allowSplice) {
             // Do not write yet.....


### PR DESCRIPTION
    bio.cc:377:18: warning: unused variable 'ssl' [-Wunused-variable]

I removed the whole "we have a valid TLS connection" condition because
the code in question no longer uses the TLS connection object, and the
condition itself may change _after_ this code runs. The condition is
important to higher-level code (that calls the code that uses
allowSplice/allowBump state set in the affected low-level BIO method),
but there are many such conditions on that code path; there is no good
reason to single out this specific condition in this low-level code.