### PR TITLE
Update configure.ac scripts

### DIFF
--- a/acinclude/ax_cxx_0x_types.m4
+++ b/acinclude/ax_cxx_0x_types.m4
@@ -12,7 +12,8 @@ AC_DEFUN([AX_CXX_TYPE_UNIFORM_DISTRIBUTIONS],[
   AC_CHECK_HEADERS(tr1/random)
   AC_CACHE_CHECK([whether std::uniform_int_distribution<T> is supported],
                  [squid_cv_std_uniform_int_distribution_works],[
-    AC_TRY_COMPILE([#include <random>],[std::uniform_int_distribution<int> c;],
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <random>]],
+      [[std::uniform_int_distribution<int> c;]])],
       [squid_cv_std_uniform_int_distribution_works=yes],
       [squid_cv_std_uniform_int_distribution_works=no])
     ])
@@ -24,7 +25,8 @@ AC_DEFUN([AX_CXX_TYPE_UNIFORM_DISTRIBUTIONS],[
                  [squid_cv_std_uniform_real_distribution_works],[
     AC_REQUIRE([AC_PROG_CXX])
     AC_LANG_PUSH([C++])
-    AC_TRY_COMPILE([#include <random>],[std::uniform_real_distribution<double> c;],
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <random>]],
+      [[std::uniform_real_distribution<double> c;]])],
       [squid_cv_std_uniform_real_distribution_works=yes],
       [squid_cv_std_uniform_real_distribution_works=no])
     ])
@@ -66,8 +68,8 @@ AC_DEFUN([SQUID_CXX_STD_IS_TRIVIALLY_COPYABLE],[
     [squid_cv_have_std_is_trivially_copyable],[
       AC_REQUIRE([AC_PROG_CXX])
       AC_LANG_PUSH([C++])
-      AC_TRY_COMPILE([#include <type_traits>],
-        [return std::is_trivially_copyable<int>::value ? 1 : 0;],
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <type_traits>]],
+        [[return std::is_trivially_copyable<int>::value ? 1 : 0;]])],
         [squid_cv_have_std_is_trivially_copyable=yes],
         [squid_cv_have_std_is_trivially_copyable=no])
       AC_LANG_POP

--- a/acinclude/compiler-flags.m4
+++ b/acinclude/compiler-flags.m4
@@ -165,44 +165,44 @@ AC_DEFUN([SQUID_CC_ADD_CXXFLAG_WARNING_IF_SUPPORTED],[
 # squid_cv_cc_option_optimize (-O3)
 #
 AC_DEFUN([SQUID_CC_GUESS_OPTIONS], [
- AC_REQUIRE([SQUID_CC_GUESS_VARIANT])
- AC_MSG_CHECKING([for compiler variant])
- case "$squid_cv_compiler" in
-  gcc)
-   squid_cv_cc_option_werror="-Werror"
-   squid_cv_cxx_option_werror="-Werror"
-   squid_cv_cc_option_wall="-Wall"
-   squid_cv_cc_option_optimize="-O3"
-   squid_cv_cc_arg_pipe="-pipe"
-   ;;
-  sunstudio)
-   squid_cv_cc_option_werror="-errwarn=%all -errtags"
-   squid_cv_cxx_option_werror="-errwarn=%all,no%badargtype2w,no%wbadinit,no%wbadasg -errtags"
-   squid_cv_cc_option_wall="+w"
-   squid_cv_cc_option_optimize="-fast"
-   squid_cv_cc_arg_pipe=""
-   ;;
-  clang)
-   squid_cv_cxx_option_werror="-Werror"
-   squid_cv_cc_option_werror="$squid_cv_cxx_option_werror"
-   squid_cv_cc_option_wall="-Wall"
-   squid_cv_cc_option_optimize="-O2"
-   squid_cv_cc_arg_pipe=""
-   ;;
-  icc)
-   squid_cv_cxx_option_werror="-Werror"
-   squid_cv_cc_option_werror="$squid_cv_cxx_option_werror"
-   squid_cv_cc_option_wall="-Wall"
-   squid_cv_cc_option_optimize="-O2"
-   squid_cv_cc_arg_pipe=""
-   ;;
-  *)
-   squid_cv_cxx_option_werror=""
-   squid_cv_cc_option_werror=""
-   squid_cv_cc_option_wall=""
-   squid_cv_cc_option_optimize="-O"
-   squid_cv_cc_arg_pipe=""
-   ;;
- esac
- AC_MSG_RESULT([$squid_cv_compiler])
+  AC_REQUIRE([SQUID_CC_GUESS_VARIANT])
+  AC_MSG_CHECKING([for compiler variant])
+  AS_CASE([$squid_cv_compiler],
+    [gcc],[
+      squid_cv_cc_option_werror="-Werror"
+      squid_cv_cxx_option_werror="-Werror"
+      squid_cv_cc_option_wall="-Wall"
+      squid_cv_cc_option_optimize="-O3"
+      squid_cv_cc_arg_pipe="-pipe"
+    ],
+    [sunstudio],[
+      squid_cv_cc_option_werror="-errwarn=%all -errtags"
+      squid_cv_cxx_option_werror="-errwarn=%all,no%badargtype2w,no%wbadinit,no%wbadasg -errtags"
+      squid_cv_cc_option_wall="+w"
+      squid_cv_cc_option_optimize="-fast"
+      squid_cv_cc_arg_pipe=""
+    ],
+    [clang],[
+      squid_cv_cxx_option_werror="-Werror"
+      squid_cv_cc_option_werror="$squid_cv_cxx_option_werror"
+      squid_cv_cc_option_wall="-Wall"
+      squid_cv_cc_option_optimize="-O2"
+      squid_cv_cc_arg_pipe=""
+    ],
+    [icc],[
+      squid_cv_cxx_option_werror="-Werror"
+      squid_cv_cc_option_werror="$squid_cv_cxx_option_werror"
+      squid_cv_cc_option_wall="-Wall"
+      squid_cv_cc_option_optimize="-O2"
+      squid_cv_cc_arg_pipe=""
+    ],
+    [
+      squid_cv_cxx_option_werror=""
+      squid_cv_cc_option_werror=""
+      squid_cv_cc_option_wall=""
+      squid_cv_cc_option_optimize="-O"
+      squid_cv_cc_arg_pipe=""
+    ]
+  )
+  AC_MSG_RESULT([$squid_cv_compiler])
 ])

--- a/acinclude/compiler-flags.m4
+++ b/acinclude/compiler-flags.m4
@@ -17,8 +17,7 @@ AC_DEFUN([SQUID_CC_CHECK_ARGUMENT],[
     SQUID_STATE_SAVE([ARGCHECK])
     CFLAGS="$CFLAGS $2"
     CXXFLAGS="$CXXFLAGS $2"
-    AC_TRY_LINK([],[],
-      [$1=yes],[$1=no])
+    AC_LINK_IFELSE([],[$1=yes],[$1=no])
     SQUID_STATE_ROLLBACK([ARGCHECK])
   ])
 ])

--- a/acinclude/compiler-flags.m4
+++ b/acinclude/compiler-flags.m4
@@ -38,11 +38,11 @@ AC_DEFUN([SQUID_CC_REQUIRE_ARGUMENT],[
     AC_REQUIRE([AC_PROG_CC])
     SQUID_STATE_SAVE([ARGREQ])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM($3,$4)],[$1=no],[],[$1=no])
-    if test "x$$1" != "xno" ; then
+    AS_IF([test "x$$1" != "xno"],[
       CFLAGS="$CFLAGS $2"
       CXXFLAGS="$CXXFLAGS $2"
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM($3,$4)],[$1=yes],[$1=no],[$1=no])
-    fi
+    ])
     SQUID_STATE_ROLLBACK([ARGREQ])
   }])
 ])
@@ -62,54 +62,52 @@ AC_DEFUN([SQUID_CC_GUESS_VARIANT], [
   dnl preprocessor definition so that it depends on platform-specific
   dnl predefined macros
   dnl SunPro CC
-  if test -z "$squid_cv_compiler" ; then
+  AS_IF([test -z "$squid_cv_compiler"],[
    AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([[
 #if !defined(__SUNPRO_C) && !defined(__SUNPRO_CC)
 #error "not sunpro c"
 #endif
     ]])],[squid_cv_compiler="sunstudio"],[])
-  fi
+  ])
   dnl Intel CC
-  if test -z "$squid_cv_compiler" ; then
+  AS_IF([test -z "$squid_cv_compiler"],[
    AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([[
 #if !defined(__ICC)
 #error "not Intel(R) C++ Compiler"
 #endif
     ]])],[squid_cv_compiler="icc"],[])
-  fi
+  ])
   dnl clang
-  if test -z "$squid_cv_compiler" ; then
+  AS_IF([test -z "$squid_cv_compiler"],[
    AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([[
 #if !defined(__clang__)
 #error "not clang"
 #endif
     ]])],[squid_cv_compiler="clang"],[])
-  fi
+  ])
   dnl microsoft visual c++
-  if test -z "$squid_cv_compiler" ; then
+  AS_IF([test -z "$squid_cv_compiler"],[
    AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([[
 #if !defined(_MSC_VER)
 #error "not Microsoft VC++"
 #endif
     ]])],[squid_cv_compiler="msvc"],[])
-  fi
+  ])
   dnl gcc. MUST BE LAST as many other compilers also define it for compatibility
-  if test -z "$squid_cv_compiler" ; then
+  AS_IF([test -z "$squid_cv_compiler"],[
    AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([[
 #if !defined(__GNUC__)
 #error "not gcc"
 #endif
     ]])],[squid_cv_compiler="gcc"],[])
-  fi
+  ])
   dnl end of block to be repeated
-  if test -z "$squid_cv_compiler" ; then
-   squid_cv_compiler="none"
-  fi
+  AS_IF([test -z "$squid_cv_compiler"],[squid_cv_compiler="none"])
   ]) dnl AC_CACHE_CHECK
  ]) dnl AC_DEFUN
 

--- a/acinclude/krb5.m4
+++ b/acinclude/krb5.m4
@@ -192,9 +192,9 @@ main(void)
         return 0;
 }
   ]])],  [ squid_cv_working_gssapi=yes ], [ squid_cv_working_gssapi=no ], [:])])
-if test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "\-L"` -gt 0; then
-  AC_MSG_NOTICE([Check Runtime library path !])
-fi
+  AS_IF([test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "\-L"` -gt 0],[
+    AC_MSG_NOTICE([Check Runtime library path !])
+  ])
 ])
 
 dnl check for a working spnego, and set squid_cv_have_spnego
@@ -284,9 +284,9 @@ main(void)
         return 0;
 }
   ]])], [ squid_cv_working_krb5=yes ], [ squid_cv_working_krb5=no ],[:])])
-if test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "\-L"` -gt 0; then
-  AC_MSG_NOTICE([Check Runtime library path !])
-fi
+  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "\-L"` -gt 0],[
+    AC_MSG_NOTICE([Check Runtime library path !])
+  ])
 ])
 
 
@@ -294,21 +294,19 @@ dnl checks for existence of krb5 functions
 AC_DEFUN([SQUID_CHECK_KRB5_FUNCS],[
 
   ac_com_error_message=no
-  if test "x$ac_cv_header_com_err_h" = "xyes" ; then
-    AC_EGREP_HEADER(error_message,com_err.h,ac_com_error_message=yes)
-  elif test "x$ac_cv_header_et_com_err_h" = "xyes" ; then
+  AS_IF([test "x$ac_cv_header_com_err_h" = "xyes"],[
+    AC_EGREP_HEADER(error_message,com_err.h,ac_com_error_message=yes)],
+  [test "x$ac_cv_header_et_com_err_h" = "xyes"],[
     AC_EGREP_HEADER(error_message,et/com_err.h,ac_com_error_message=yes)
-  fi
+  ])
 
-  if test `echo $KRB5LIBS | grep -c com_err` -ne 0 -a "x$ac_com_error_message" = "xyes" ; then
+  AS_IF([test `echo $KRB5LIBS | grep -c com_err` -ne 0 -a "x$ac_com_error_message" = "xyes"],[
     AC_CHECK_LIB(com_err,error_message,
-      AC_DEFINE(HAVE_ERROR_MESSAGE,1,
-        [Define to 1 if you have error_message]),)
-  elif test  "x$ac_com_error_message" = "xyes" ; then
+      AC_DEFINE(HAVE_ERROR_MESSAGE,1,[Define to 1 if you have error_message]),)
+  ],[test  "x$ac_com_error_message" = "xyes"],[
     AC_CHECK_LIB(krb5,error_message,
-      AC_DEFINE(HAVE_ERROR_MESSAGE,1,
-        [Define to 1 if you have error_message]),)
-  fi
+      AC_DEFINE(HAVE_ERROR_MESSAGE,1,[Define to 1 if you have error_message]),)
+  ])
 
   AC_CHECK_LIB(krb5,krb5_get_err_text,
     AC_DEFINE(HAVE_KRB5_GET_ERR_TEXT,1,

--- a/acinclude/lib-checks.m4
+++ b/acinclude/lib-checks.m4
@@ -126,9 +126,7 @@ AC_DEFUN([SQUID_CHECK_OPENSSL_GETCERTIFICATE_WORKS],[
   AH_TEMPLATE(SQUID_USE_SSLGETCERTIFICATE_HACK, "Define to 1 to use squid workaround for SSL_get_certificate")
   SQUID_STATE_SAVE(check_SSL_get_certificate)
   LIBS="$SSLLIB $LIBS"
-  if test "x$SSLLIBDIR" != "x"; then
-     LIBS="$LIBS -Wl,-rpath -Wl,$SSLLIBDIR"
-  fi
+  AS_IF([test "x$SSLLIBDIR" != "x"],[LIBS="$LIBS -Wl,-rpath -Wl,$SSLLIBDIR"])
 
   AC_MSG_CHECKING(whether the SSL_get_certificate is buggy)
   AC_RUN_IFELSE([
@@ -320,75 +318,57 @@ AC_DEFUN([SQUID_CHECK_OPENSSL_TXTDB],[
   LIBS="$LIBS $SSLLIB"
   squid_cv_check_openssl_pstring="no"
   AC_MSG_CHECKING(whether the TXT_DB use OPENSSL_PSTRING data member)
-  AC_COMPILE_IFELSE([
-  AC_LANG_PROGRAM(
-    [
-     #include <openssl/txt_db.h>
-    ],
-    [
-    TXT_DB *db = NULL;
-    int i = sk_OPENSSL_PSTRING_num(db->data);
-    return 0;
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+      #include <openssl/txt_db.h>
+    ],[
+      TXT_DB *db = NULL;
+      int i = sk_OPENSSL_PSTRING_num(db->data);
+      return 0;
     ])
-  ],
-  [
-   AC_DEFINE(SQUID_SSLTXTDB_PSTRINGDATA, 1)
-   AC_MSG_RESULT([yes])
-   squid_cv_check_openssl_pstring="yes"
-  ],
-  [
-   AC_MSG_RESULT([no])
-  ],
-  [])
+  ],[
+    AC_DEFINE(SQUID_SSLTXTDB_PSTRINGDATA, 1)
+    AC_MSG_RESULT([yes])
+    squid_cv_check_openssl_pstring="yes"
+  ],[
+    AC_MSG_RESULT([no])
+  ],[])
 
-  if test x"$squid_cv_check_openssl_pstring" = "xyes"; then
-     AC_MSG_CHECKING(whether the squid workaround for buggy versions of sk_OPENSSL_PSTRING_value should used)
-     AC_COMPILE_IFELSE([
-     AC_LANG_PROGRAM(
-       [
+  AS_IF([test "x$squid_cv_check_openssl_pstring" = "xyes"],[
+    AC_MSG_CHECKING(whether the squid workaround for buggy versions of sk_OPENSSL_PSTRING_value should used)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
         #include <openssl/txt_db.h>
-       ],
-       [
+      ],[
        TXT_DB *db = NULL;
        const char ** current_row = ((const char **)sk_OPENSSL_PSTRING_value(db->data, 0));
        return (current_row != NULL);
-       ])
-     ],
-     [
+      ])
+    ],[
       AC_MSG_RESULT([no])
-     ],
-     [
+    ],[
       AC_DEFINE(SQUID_STACKOF_PSTRINGDATA_HACK, 1)
       AC_MSG_RESULT([yes])
-     ],
-     [])
-  fi
+    ],[])
+  ])
 
   AC_MSG_CHECKING(whether the workaround for OpenSSL IMPLEMENT_LHASH_  macros should used)
-  AC_COMPILE_IFELSE([
-  AC_LANG_PROGRAM(
-    [
-     #include <openssl/txt_db.h>
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+      #include <openssl/txt_db.h>
 
-     static unsigned long index_serial_hash(const char **a){}
-     static int index_serial_cmp(const char **a, const char **b){}
-     static IMPLEMENT_LHASH_HASH_FN(index_serial_hash,const char **)
-     static IMPLEMENT_LHASH_COMP_FN(index_serial_cmp,const char **)
-    ],
-    [
-    TXT_DB *db = NULL;
-    TXT_DB_create_index(db, 1, NULL, LHASH_HASH_FN(index_serial_hash), LHASH_COMP_FN(index_serial_cmp));
+      static unsigned long index_serial_hash(const char **a){}
+      static int index_serial_cmp(const char **a, const char **b){}
+      static IMPLEMENT_LHASH_HASH_FN(index_serial_hash,const char **)
+      static IMPLEMENT_LHASH_COMP_FN(index_serial_cmp,const char **)
+    ],[
+      TXT_DB *db = NULL;
+      TXT_DB_create_index(db, 1, NULL, LHASH_HASH_FN(index_serial_hash), LHASH_COMP_FN(index_serial_cmp));
     ])
-  ],
-  [
-   AC_MSG_RESULT([no])
-  ],
-  [
-   AC_MSG_RESULT([yes])
-   AC_DEFINE(SQUID_USE_SSLLHASH_HACK, 1)
-  ],
-[])
+  ],[
+    AC_MSG_RESULT([no])
+  ],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(SQUID_USE_SSLLHASH_HACK, 1)
+  ],[])
 
-SQUID_STATE_ROLLBACK(check_TXTDB)
+  SQUID_STATE_ROLLBACK(check_TXTDB)
 ])
 

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -9,12 +9,12 @@ dnl check that strnstr() works fine. On Macos X it can cause a buffer overrun
 dnl sets squid_cv_func_strnstr to "yes" or "no", and defines HAVE_STRNSTR
 AC_DEFUN([SQUID_CHECK_FUNC_STRNSTR],[
 
-# Yay!  This one is  a MacOSX brokenness.  Its not good enough
-# to know that strnstr() exists, because MacOSX 10.4 have a bad
-# copy that crashes with a buffer over-run!
-AH_TEMPLATE(HAVE_STRNSTR,[MacOS brokenness: strnstr() can overrun on that system])
-AC_CACHE_CHECK([if strnstr is well implemented], squid_cv_func_strnstr,
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+  # Yay!  This one is  a MacOSX brokenness.  Its not good enough
+  # to know that strnstr() exists, because MacOSX 10.4 have a bad
+  # copy that crashes with a buffer over-run!
+  AH_TEMPLATE(HAVE_STRNSTR,[MacOS brokenness: strnstr() can overrun on that system])
+  AC_CACHE_CHECK([if strnstr is well implemented], squid_cv_func_strnstr,
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -28,12 +28,9 @@ int main(int argc, char **argv)
     strnstr(str, "fubar", size);
     return 0;
 }
-  ]])],[squid_cv_func_strnstr="yes"],[squid_cv_func_strnstr="no"],[:])
-)
-if test "$squid_cv_func_strnstr" = "yes" ; then
-  AC_DEFINE(HAVE_STRNSTR,1)
-fi
-
+    ]])],[squid_cv_func_strnstr="yes"],[squid_cv_func_strnstr="no"],[:])
+  )
+  AS_IF([test "x$squid_cv_func_strnstr" = "xyes"],[AC_DEFINE(HAVE_STRNSTR,1)])
 ]) dnl SQUID_CHECK_FUNC_STRNSTR
 
 dnl check that epoll actually works
@@ -235,8 +232,8 @@ int main(int argc, char **argv) {
   dnl Microsoft MSVCRT.DLL supports 2048 maximum FDs
   AS_CASE(["$host_os"],[mingw|mingw32],[squid_filedescriptors_limit="2048"])
   AC_MSG_RESULT($squid_filedescriptors_limit)
-  AS_IF([ test "x$squid_filedescriptors_num" = "x" ],[
-    AS_IF([ test "x$squid_filedescriptors_limit" != "x" ],[
+  AS_IF([test "x$squid_filedescriptors_num" = "x"],[
+    AS_IF([test "x$squid_filedescriptors_limit" != "x"],[
       squid_filedescriptors_num=$squid_filedescriptors_limit
     ],[
       AC_MSG_NOTICE([Unable to detect filedescriptor limits. Assuming 256 is okay.])
@@ -462,12 +459,12 @@ int main(int argc, char **argv)
 	return 0;
 }
 ]])],[SQUID_TCP_SO_SNDBUF=`cat conftestval`],[SQUID_TCP_SO_SNDBUF=16384],[SQUID_TCP_SO_SNDBUF=16384])
-AC_MSG_RESULT($SQUID_TCP_SO_SNDBUF)
-if test $SQUID_TCP_SO_SNDBUF -gt 32768; then
+  AC_MSG_RESULT($SQUID_TCP_SO_SNDBUF)
+  AS_IF([test $SQUID_TCP_SO_SNDBUF -gt 32768],[
     AC_MSG_NOTICE([Limiting send buffer size to 32K])
     SQUID_TCP_SO_SNDBUF=32768
-fi
-AC_DEFINE_UNQUOTED(SQUID_TCP_SO_SNDBUF, $SQUID_TCP_SO_SNDBUF,[TCP send buffer size])
+  ])
+  AC_DEFINE_UNQUOTED(SQUID_TCP_SO_SNDBUF, $SQUID_TCP_SO_SNDBUF,[TCP send buffer size])
 ])
 
 
@@ -516,12 +513,12 @@ int main(int argc, char **argv)
 	return 0;
 }
 ]])],[SQUID_TCP_SO_RCVBUF=`cat conftestval`],[SQUID_TCP_SO_RCVBUF=16384],[SQUID_TCP_SO_RCVBUF=16384])
-AC_MSG_RESULT($SQUID_TCP_SO_RCVBUF)
-if test $SQUID_TCP_SO_RCVBUF -gt 65535; then
+  AC_MSG_RESULT($SQUID_TCP_SO_RCVBUF)
+  AS_IF([test $SQUID_TCP_SO_RCVBUF -gt 65535],[
     AC_MSG_NOTICE([Limiting receive buffer size to 64K])
     SQUID_TCP_SO_RCVBUF=65535
-fi
-AC_DEFINE_UNQUOTED(SQUID_TCP_SO_RCVBUF, $SQUID_TCP_SO_RCVBUF,[TCP receive buffer size])
+  ])
+  AC_DEFINE_UNQUOTED(SQUID_TCP_SO_RCVBUF, $SQUID_TCP_SO_RCVBUF, [TCP receive buffer size])
 ])
 
 
@@ -633,12 +630,12 @@ AC_DEFUN([SQUID_CHECK_RESOLVER_FIELDS],[
     [[_res_ext.nsaddr_list[[0]].s_addr;]])],[
       ac_cv_have_res_ext_nsaddr_list="yes" ],[
       ac_cv_have_res_ext_nsaddr_list="no"]))
-  if test "$ac_cv_have_res_ext_nsaddr_list" = "yes" ; then
+  AS_IF([test "x$ac_cv_have_res_ext_nsaddr_list" = "xyes"],[
     AC_DEFINE(_SQUID_RES_NSADDR6_LARRAY,_res_ext.nsaddr_list,[If _res_ext structure has nsaddr_list member])
     AC_DEFINE(_SQUID_RES_NSADDR6_COUNT,ns6count,[Nameserver Counter for IPv6 _res_ext])
-  fi
+  ])
 
-if test "$_SQUID_RES_NSADDR6_LIST" = ""; then
+AS_IF([test "x$_SQUID_RES_NSADDR6_LIST" = "x"],[
   AC_CACHE_CHECK(for _res._u._ext.nsaddrs, ac_cv_have_res_ext_nsaddrs,
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #if HAVE_SYS_TYPES_H
@@ -659,11 +656,11 @@ if test "$_SQUID_RES_NSADDR6_LIST" = ""; then
     ]], i
     [[_res._u._ext.nsaddrs[[0]]->sin6_addr;]])],
     [ac_cv_have_res_ext_nsaddrs="yes"],[ac_cv_have_res_ext_nsaddrs="no"]))
-  if test "$ac_cv_have_res_ext_nsaddrs" = "yes" ; then
+  AS_IF([test "x$ac_cv_have_res_ext_nsaddrs" = "xyes"],[
     AC_DEFINE(_SQUID_RES_NSADDR6_LPTR,_res._u._ext.nsaddrs,[If _res structure has _ext.nsaddrs member])
     AC_DEFINE(_SQUID_RES_NSADDR6_COUNT,_res._u._ext.nscount6,[Nameserver Counter for IPv6 _res])
-  fi
-fi
+  ])
+])
 
 AC_CACHE_CHECK(for _res.nsaddr_list, ac_cv_have_res_nsaddr_list,
   AC_COMPILE_IFELSE([
@@ -685,12 +682,12 @@ AC_CACHE_CHECK(for _res.nsaddr_list, ac_cv_have_res_nsaddr_list,
 #endif
   ]], [[_res.nsaddr_list[[0]];]])],
   [ac_cv_have_res_nsaddr_list="yes"],[ac_cv_have_res_nsaddr_list="no"]))
-  if test $ac_cv_have_res_nsaddr_list = "yes" ; then
+  AS_IF([test "x$ac_cv_have_res_nsaddr_list" = "xyes"],[
     AC_DEFINE(_SQUID_RES_NSADDR_LIST,_res.nsaddr_list,[If _res structure has nsaddr_list member])
     AC_DEFINE(_SQUID_RES_NSADDR_COUNT,_res.nscount,[Nameserver counter for IPv4 _res])
-  fi
+  ])
 
-  if test "$_SQUID_RES_NSADDR_LIST" = ""; then
+  AS_IF([test "x$_SQUID_RES_NSADDR_LIST" = "x"],[
     AC_CACHE_CHECK(for _res.ns_list, ac_cv_have_res_ns_list,
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #if HAVE_SYS_TYPES_H
@@ -708,14 +705,13 @@ AC_CACHE_CHECK(for _res.nsaddr_list, ac_cv_have_res_nsaddr_list,
 #if HAVE_RESOLV_H
 #include <resolv.h>
 #endif
-  ]],
-  [[_res.ns_list[[0]].addr;]])],
+  ]],[[_res.ns_list[[0]].addr;]])],
   [ac_cv_have_res_ns_list="yes"],[ac_cv_have_res_ns_list="no"]))
-  if test $ac_cv_have_res_ns_list = "yes" ; then
-    AC_DEFINE(_SQUID_RES_NSADDR_LIST,_res.ns_list,[If _res structure has ns_list member])
-    AC_DEFINE(_SQUID_RES_NSADDR_COUNT,_res.nscount,[Nameserver counter for IPv4 _res])
-  fi
-fi
+    AS_IF([test "x$ac_cv_have_res_ns_list" = "xyes"],[
+      AC_DEFINE(_SQUID_RES_NSADDR_LIST,_res.ns_list,[If _res structure has ns_list member])
+      AC_DEFINE(_SQUID_RES_NSADDR_COUNT,_res.nscount,[Nameserver counter for IPv4 _res])
+    ])
+  ])
 ])
 
 
@@ -757,8 +753,7 @@ dnl check that setresuid is properly implemented.
 dnl sets squid_cv_resuid_works to "yes" or "no"
 AC_DEFUN([SQUID_CHECK_SETRESUID_WORKS],[
   AC_CACHE_CHECK(if setresuid is actually implemented, squid_cv_resuid_works,
-    AC_RUN_IFELSE([
-      AC_LANG_SOURCE([[
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
@@ -775,9 +770,7 @@ AC_DEFUN([SQUID_CHECK_SETRESUID_WORKS],[
     }
     return 0;
   }
-  ]])],[
-    squid_cv_resuid_works="yes" ],[
-    squid_cv_resuid_works="no" ],[:])
+    ]])],[squid_cv_resuid_works="yes"],[squid_cv_resuid_works="no"],[:])
   )
 ])
 
@@ -810,7 +803,7 @@ int main (int argc, char ** argv) {
 
 dnl check whether Solaris has broken IPFilter headers (Solaris 10 at least does)
 AC_DEFUN([SQUID_CHECK_BROKEN_SOLARIS_IPFILTER],[
-  if test "x$squid_cv_broken_ipfilter_minor_t" = "x"; then
+  AS_IF([test "x$squid_cv_broken_ipfilter_minor_t" = "x"],[
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #     include <sys/types.h>
 #     include <sys/time.h>
@@ -842,7 +835,7 @@ AC_DEFUN([SQUID_CHECK_BROKEN_SOLARIS_IPFILTER],[
         AC_MSG_ERROR(unable to make IPFilter work with netinet/ headers)
       ])
     ])
-  fi
+  ])
 
   AC_DEFINE_UNQUOTED(USE_SOLARIS_IPFILTER_MINOR_T_HACK,$squid_cv_broken_ipfilter_minor_t,
     [Workaround IPFilter minor_t breakage])

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -736,24 +736,20 @@ void squid_getprotobynumber(void) {
 }
   ])
   AC_MSG_CHECKING([for winsock library])
-  case "$ac_cv_search_squid_getprotobynumber" in
-    "no")
-      AC_MSG_RESULT([winsock library not found])
-      ;;
-    "none required")
-      AC_MSG_RESULT([winsock library already in LIBS])
-      ;;
-    "-lws2_32")
+  AS_CASE(["$ac_cv_search_squid_getprotobynumber"],
+    ["no"],[AC_MSG_RESULT([winsock library not found])],
+    ["none required"],[AC_MSG_RESULT([winsock library already in LIBS])],
+    ["-lws2_32"],[
       AC_MSG_RESULT([winsock2])
       XTRA_LIBS="-lws2_32 $XTRA_LIBS"
-      ac_cv_func_select='yes'
-      ;;
-    "-lwsock32")
+      ac_cv_func_select="yes"
+    ],
+    ["-lwsock32"],[
       AC_MSG_RESULT([winsock])
       XTRA_LIBS="-lwsock32 $XTRA_LIBS"
-      ac_cv_func_select='yes'
-      ;;
-  esac
+      ac_cv_func_select="yes"
+    ]
+  )
   SQUID_STATE_ROLLBACK(winsock)
 ])
 

--- a/acinclude/pam.m4
+++ b/acinclude/pam.m4
@@ -38,11 +38,10 @@ static struct pam_conv conv = { &password_conversation, 0 };
   ])
     ])
   ])
-  case $squid_cv_pam_conv_signature in
-    linux) AC_DEFINE([PAM_CONV_FUNC_CONST_PARM],[const]) ;;
-    solaris) AC_DEFINE([PAM_CONV_FUNC_CONST_PARM],[]) ;;
-    *) AC_DEFINE([PAM_CONV_FUNC_CONST_PARM],[]) ;;
-  esac
+  AS_IF([test "$squid_cv_pam_conv_signature" = "linux"],
+    AC_DEFINE([PAM_CONV_FUNC_CONST_PARM],[const]),
+    AC_DEFINE([PAM_CONV_FUNC_CONST_PARM],[])
+  )
 ]) dnl CHECK_STRUCT_PAM_CONV
 
 

--- a/acinclude/pam.m4
+++ b/acinclude/pam.m4
@@ -25,7 +25,7 @@ password_conversation(int, const struct pam_message **, struct pam_response **, 
 static struct pam_conv conv = { &password_conversation, 0 };
 ]])], [
    squid_cv_pam_conv_signature=linux
-], [
+],[
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <security/pam_appl.h>
 static int
@@ -33,7 +33,7 @@ password_conversation(int, struct pam_message **, struct pam_response **, void *
 static struct pam_conv conv = { &password_conversation, 0 };
 ]])], [
   squid_cv_pam_conv_signature=solaris
- ], [
+ ],[
   squid_cv_pam_conv_signature=unknown
   ])
     ])

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -116,7 +116,7 @@ dnl and $foo_module_candidates_gazonk to "yes"
 AC_DEFUN([SQUID_CHECK_EXISTING_MODULES],[
   for squid_module_check_exist_tmp in $$2
   do
-    AS_IF([test -d $1/$squid_module_check_exist_tmp],[
+    AS_IF([test -d "$1/$squid_module_check_exist_tmp"],[
       eval "$2_$squid_module_check_exist_tmp='yes'"
       #echo "defining $2_$squid_module_check_exist_tmp"
     ],[

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -97,7 +97,7 @@ do
     squid_cleanup_tmp_outlist="${squid_cleanup_tmp_outlist} $squid_cleanup_tmp"
   ])
 done
-$1=$squid_cleanup_tmp_outlist
+$1=`echo "$squid_cleanup_tmp_outlist" | sed -e 's/^ *//'`
 unset squid_cleanup_tmp_outlist
 unset squid_cleanup_tmp_dupe
 unset squid_cleanup_tmp2

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -75,9 +75,7 @@ AC_DEFUN([SQUID_LOOK_FOR_MODULES],[
 $2=""
 for dir in $1/*; do
   module="`basename $dir`"
-  if test -d "$dir" && test "$module" != CVS; then
-      $2="$$2 $module"
-  fi
+  AS_IF([test -d "$dir" -a "$module" != "CVS"], $2="$$2 $module")
 done
 ])
 
@@ -90,14 +88,14 @@ do
   squid_cleanup_tmp_dupe=0
   for squid_cleanup_tmp2 in $squid_cleanup_tmp_outlist
   do
-    if test "$squid_cleanup_tmp" = "$squid_cleanup_tmp2"; then
+    AS_IF([test "$squid_cleanup_tmp" = "$squid_cleanup_tmp2"],[
       squid_cleanup_tmp_dupe=1
       break
-    fi
+    ])
   done
-  if test $squid_cleanup_tmp_dupe -eq 0; then
+  AS_IF([test $squid_cleanup_tmp_dupe -eq 0],[
     squid_cleanup_tmp_outlist="${squid_cleanup_tmp_outlist} $squid_cleanup_tmp"
-  fi
+  ])
 done
 $1=$squid_cleanup_tmp_outlist
 unset squid_cleanup_tmp_outlist
@@ -118,13 +116,12 @@ dnl and $foo_module_candidates_gazonk to "yes"
 AC_DEFUN([SQUID_CHECK_EXISTING_MODULES],[
   for squid_module_check_exist_tmp in $$2
   do
-    if test -d $1/$squid_module_check_exist_tmp
-    then
+    AS_IF([test -d $1/$squid_module_check_exist_tmp],[
       eval "$2_$squid_module_check_exist_tmp='yes'"
       #echo "defining $2_$squid_module_check_exist_tmp"
-    else
+    ],[
       AC_MSG_ERROR([$squid_module_check_exist_tmp not found in $1])
-    fi
+    ])
   done
 ])
 
@@ -160,9 +157,7 @@ unset squid_tmp_define
 dnl aborts with an error specified as the second argument if the first argument doesn't
 dnl contain either "yes" or "no"
 AC_DEFUN([SQUID_YESNO],[
-if test "$1" != "yes" -a "$1" != "no" ; then
-  AC_MSG_ERROR([$2])
-fi
+  AS_IF([test "$1" != "yes" -a "$1" != "no"],[AC_MSG_ERROR([$2])])
 ])
 
 dnl check the build parameters for a library to auto-enable
@@ -205,22 +200,22 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
     AS_CASE(["$enableval"],
       [no],[:],
       [yes],[
-        if test -d "${srcdir}/.bzr"; then
+        AS_IF([test -d "${srcdir}/.bzr"],[
           AC_PATH_PROG(BZR,bzr,$FALSE)
           squid_bzr_branch_nick=`cd ${srcdir} && ${BZR} nick 2>/dev/null`
-          if test $? -eq 0 -a "x$squid_bzr_branch_nick" != "x"; then
+          AS_IF([test $? -eq 0 -a "x$squid_bzr_branch_nick" != "x"],[
             squid_bzr_branch_revno=`cd ${srcdir} && ${BZR} revno 2>/dev/null | sed 's/\"//g'`
-          fi
-          if test $? -eq 0 -a "x$squid_bzr_branch_revno" != "x"; then
+          ])
+          AS_IF([test $? -eq 0 -a "x$squid_bzr_branch_revno" != "x"],[
             sh -c "cd ${srcdir} && ${BZR} diff 2>&1 >/dev/null"
-            if test $? -eq 1; then
+            AS_IF([test $? -eq 1],[
               squid_bzr_branch_revno="$squid_bzr_branch_revno+changes"
-            fi
-          fi
-          if test "x$squid_bzr_branch_revno" != "x"; then
+            ])
+          ])
+          AS_IF([test "x$squid_bzr_branch_revno" != "x"],[
             squid_build_info="Built branch: ${squid_bzr_branch_nick}-r${squid_bzr_branch_revno}"
-          fi
-        fi
+          ])
+        ])
       ],
       [squid_build_info=$enableval]
     )
@@ -237,12 +232,12 @@ AC_CACHE_CHECK([for library containing $1], [ac_Search],
 [ac_func_search_save_LIBS=$LIBS
 AC_LANG_CONFTEST([AC_LANG_PROGRAM([$6], [$1()])])
 for ac_lib in '' $2; do
-  if test -z "$ac_lib"; then
+  AS_IF([test -z "$ac_lib"],[
     ac_res="none required"
-  else
+  ],[
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib $5 $ac_func_search_save_LIBS"
-  fi
+  ])
   AC_LINK_IFELSE([], [AS_VAR_SET([ac_Search], [$ac_res])])
   AS_VAR_SET_IF([ac_Search], [break])
 done
@@ -250,10 +245,9 @@ AS_VAR_SET_IF([ac_Search], , [AS_VAR_SET([ac_Search], [no])])
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS])
 ac_res=AS_VAR_GET([ac_Search])
-AS_IF([test "$ac_res" != no],
-  [test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-  $3],
-      [$4])
+AS_IF([test "$ac_res" != no],[
+  AS_IF([test "$ac_res" != "none required"],[LIBS="$ac_res $LIBS"])
+  $3],[$4])
 AS_VAR_POPDEF([ac_Search])dnl
 ])
 
@@ -267,19 +261,19 @@ AC_DEFUN([SQUID_CHECK_SASL],[
     ])
   ])
   AS_IF([test "$squid_host_os" = "Darwin"],[
-    if test "$ac_cv_lib_sasl2_sasl_errstring" = "yes" ; then
+    AS_IF([test "$ac_cv_lib_sasl2_sasl_errstring" = "yes"],[
       AC_DEFINE(HAVE_SASL_DARWIN,1,[Define to 1 if Mac Darwin without sasl.h])
       echo "checking for MAC Darwin without sasl.h ... yes"
       squid_cv_check_sasl="yes"
-    else
+    ],[
       echo "checking for MAC Darwin without sasl.h ... no"
       squid_cv_check_sasl="no"
-    fi
+    ])
   ])
-  if test "x$squid_cv_check_sasl" = "xno"; then
+  AS_IF([test "x$squid_cv_check_sasl" = "xno"],[
     AC_MSG_WARN([Neither SASL nor SASL2 found])
-  else
+  ],[
     squid_cv_check_sasl="yes"
-  fi
+  ])
   AC_SUBST(LIBSASL)
 ])

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -169,7 +169,7 @@ AC_DEFUN([SQUID_HELPER_FEATURE_CHECK],[
   ])
   SQUID_CLEANUP_MODULES_LIST([enable_$1])
   AC_MSG_NOTICE([checking $3 helpers: $enable_$1])
-  AS_IF([test "x$enable_$1" != "xno" -a test "x$enable_$1" != "x"],[
+  AS_IF([test "x$enable_$1" != "xno" -a "x$enable_$1" != "x"],[
     SQUID_CHECK_EXISTING_MODULES([$$ac_top_srcdir/src/$3],[enable_$1])
     for helper in $enable_$1 ; do
       $4

--- a/acinclude/tdb.m4
+++ b/acinclude/tdb.m4
@@ -9,19 +9,17 @@ dnl check for --with-tdb option
 AC_DEFUN([SQUID_CHECK_LIBTDB],[
 AC_ARG_WITH(tdb,
   AS_HELP_STRING([--without-tdb],
-                 [Do not use Samba TrivialDB. Default: auto-detect]), [
-case "$with_tdb" in
-  yes|no|auto)
-    : # Nothing special to do here
-    ;;
-  *)
-    AS_IF([test ! -d "$withval"],
-      AC_MSG_ERROR([--with-tdb path ($with_tdb) does not point to a directory])
-    )
-    LIBTDB_PATH="-L$withval/lib"
-    CPPFLAGS="-I$withval/include $CPPFLAGS"
-  ;;
-esac
+                 [Do not use Samba TrivialDB. Default: auto-detect]),[
+  AS_CASE(["$with_tdb"],
+    [yes|no|auto],[:],
+    [
+      AS_IF([test ! -d "$withval"],
+        AC_MSG_ERROR([--with-tdb path ($with_tdb) does not point to a directory])
+      )
+      LIBTDB_PATH="-L$withval/lib"
+      CPPFLAGS="-I$withval/include $CPPFLAGS"
+    ]
+  )
 ])
 AH_TEMPLATE(USE_TRIVIALDB,[Samba TrivialDB support is available])
 AS_IF([test "x$with_tdb" != "xno"],[

--- a/compat/assert.h
+++ b/compat/assert.h
@@ -13,10 +13,8 @@
 #define assert(EX) ((void)0)
 #elif defined(NODEBUG)
 #define assert(EX) ((void)0)
-#elif STDC_HEADERS
-#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 #else
-#define assert(EX)  ((EX)?((void)0):xassert("EX", __FILE__, __LINE__))
+#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 #endif
 
 #ifdef __cplusplus

--- a/compat/compat_shared.h
+++ b/compat/compat_shared.h
@@ -40,36 +40,18 @@ extern void (*failure_notify) (const char *);
 #include <sys/resource.h>       /* needs sys/time.h above it */
 #endif
 
-/*
- * DIRENT functionality can apparently come from many places.
- * With various complaints by different compilers
- */
-#if HAVE_DIRENT_H
-#include <dirent.h>
-#define NAMLEN(dirent) strlen((dirent)->d_name)
-#else /* if not HAVE_DIRENT_H */
-#define dirent direct
-#define NAMLEN(dirent) (dirent)->d_namlen
-#if HAVE_SYS_NDIR_H
-#include <sys/ndir.h>
-#endif /* HAVE_SYS_NDIR_H */
-#if HAVE_SYS_DIR_H
-#include <sys/dir.h>
-#endif /* HAVE_SYS_DIR_H */
-#if HAVE_NDIR_H
-#include <ndir.h>
-#endif /* HAVE_NDIR_H */
-#endif /* HAVE_DIRENT_H */
-
 /* The structure dirent also varies between 64-bit and 32-bit environments.
  * Define our own dirent_t type for consistent simple internal use.
  * NP: GCC seems not to care about the type naming differences.
  */
+#if HAVE_DIRENT_H
+#include <dirent.h>
 #if defined(__USE_FILE_OFFSET64) && !defined(__GNUC__)
 #define dirent_t struct dirent64
 #else
 #define dirent_t struct dirent
 #endif
+#endif /* HAVE_DIRENT_H */
 
 /*
  * Filedescriptor limits in the different select loops

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ AS_IF([test "x${enable_arch_native}" != "xno"],[
 # NP: BUILDCXXFLAGS defined at the end of configure after CXXFLAGS fully known.
 AC_ARG_VAR([BUILDCXX],[path to compiler for building compile-time tools. e.g. cf_gen])
 AS_IF([test "x$HOSTCXX" != "x" -a "x$BUILDCXX" = "x"],[
-  AC_MSG_WARN([Cross-compiling with HOSTCXX is deprecated. Uses BUILDCXX instead.])
+  AC_MSG_WARN([Cross-compiling with HOSTCXX is deprecated. Use BUILDCXX instead.])
   BUILDCXX="$HOSTCXX"
 ])
 AS_IF([test "x$BUILDCXX" = "x"],[
@@ -149,14 +149,13 @@ AC_MSG_NOTICE([strict error checking enabled: ${enable_strict_error_checking:=ye
 # LT_INIT requires libtool v2, might as well state it loud
 LT_PREREQ([2.2])
 LT_INIT([dlopen])
-if ! test "${ac_top_build_prefix}" = "";
-then
-	# LTDL v3-v7 macros assume the autoconf 2.62 variable top_build_prefix is defined
-	# But from autoconf 2.64 its called ac_top_build_prefix and not automatically added to the Makefile
-	# This fixes Linux LTDLv3-v7, and BSD LTDL v2.2
-	top_build_prefix=${ac_top_build_prefix}
-	AC_SUBST(top_build_prefix)
-fi
+AS_IF([test "x$ac_top_build_prefix" != "x"],[
+  # LTDL v3-v7 macros assume the autoconf 2.62 variable top_build_prefix is defined
+  # But from autoconf 2.64 its called ac_top_build_prefix and not automatically added to the Makefile
+  # This fixes Linux LTDLv3-v7, and BSD LTDL v2.2
+  top_build_prefix=${ac_top_build_prefix}
+  AC_SUBST(top_build_prefix)
+])
 LTDL_INIT
 
 dnl LibTool environment is now prepared for setup. Check that it is usable and initialize.
@@ -184,7 +183,7 @@ AC_SUBST(CGIEXT)
 AM_CONDITIONAL(ENABLE_WIN32SPECIFIC,[test "x$squid_host_os" = "xmingw"])
 AM_CONDITIONAL(ENABLE_WIN32_IPC,[test "x$squid_host_os" = "xmingw"])
 
-AS_CASE([$squid_host_os],
+AS_CASE(["$squid_host_os"],
   [mingw],[
     AC_PATH_PROG(WIN32_PSAPI, psapi.dll, none)
     CFLAGS="$CFLAGS -mthreads"
@@ -3260,7 +3259,7 @@ SQUID_DEFINE_BOOL(USE_QOS_TOS,${enable_zph_qos:=yes},
           [Enable Zero Penalty Hit QOS. When set, Squid will alter the
            TOS field of HIT responses to help policing network traffic])
 AC_MSG_NOTICE([ZPH QOS enabled: $enable_zph_qos])
-AS_IF(test x"$enable_zph_qos" = "xyes"],[
+AS_IF(test "x$enable_zph_qos" = "xyes"],[
   AC_MSG_NOTICE([QOS netfilter mark preservation enabled: $with_netfilter_conntrack])
   SQUID_DEFINE_BOOL(USE_LIBNETFILTERCONNTRACK,${with_netfilter_conntrack:=no},
     [Enable support for QOS netfilter mark preservation])

--- a/configure.ac
+++ b/configure.ac
@@ -33,9 +33,7 @@ PRESET_CXXFLAGS="$CXXFLAGS"
 PRESET_LDFLAGS="$LDFLAGS"
 
 dnl Set default LDFLAGS
-if test "x$LDFLAGS" = "x" ; then
-  LDFLAGS="-g"
-fi
+AS_IF([test "x$LDFLAGS" = "x"],[LDFLAGS="-g"])
 
 # Check for GNU cc
 AC_PROG_CC
@@ -57,48 +55,48 @@ AC_ARG_ENABLE(arch-native,
     [Unrecognized argument to --disable-arch-native: $enableval])
 ])
 AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=auto}])
-if test "x${enable_arch_native}" != "xno"; then
+AS_IF([test "x${enable_arch_native}" != "xno"],[
   SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
-fi
+])
 
 # might be cross-compiling.
 # NP: BUILDCXXFLAGS defined at the end of configure after CXXFLAGS fully known.
 AC_ARG_VAR([BUILDCXX],[path to compiler for building compile-time tools. e.g. cf_gen])
-if test "x$HOSTCXX" != "x" -a "x$BUILDCXX" = "x"; then
+AS_IF([test "x$HOSTCXX" != "x" -a "x$BUILDCXX" = "x"],[
   AC_MSG_WARN([Cross-compiling with HOSTCXX is deprecated. Uses BUILDCXX instead.])
   BUILDCXX="$HOSTCXX"
-fi
-if test "x$BUILDCXX" = "x"; then
+])
+AS_IF([test "x$BUILDCXX" = "x"],[
   BUILDCXX="$CXX"
-  if test "x$squid_cv_check_marchnative" = "xyes"; then
+  AS_IF([test "x$squid_cv_check_marchnative" = "xyes"],[
     CXXFLAGS="$CXXFLAGS -march=native"
-  fi
-fi
+  ])
+])
 AC_SUBST(BUILDCXX)
 
 AC_MSG_CHECKING([simplified host os])
 simple_host_os=`echo $host_os|sed 's/[0-9].*//g;s/-.*//g'`
 squid_host_os_version=`echo $host_os|tr -d "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"`
-if test -n "$squid_host_os_version"; then
-	squid_host_os="`echo $simple_host_os| sed s/$squid_host_os_version//g`"
-else
-	squid_host_os="$simple_host_os"
-fi
+AS_IF([test -n "$squid_host_os_version"],[
+  squid_host_os="`echo $simple_host_os| sed s/$squid_host_os_version//g`"
+],[
+  squid_host_os="$simple_host_os"
+])
 AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
 
 # this needs to be before any test is run, to have more standard
 # functions available on some Unix sysems (e.g. Solaris)
-if test "x$squid_host_os" = "solaris" -a "x$GCC" != "x" ; then
-	AC_USE_SYSTEM_EXTENSIONS
-fi
+AS_IF([test "x$squid_host_os" = "solaris" -a "x$GCC" != "x"],[
+  AC_USE_SYSTEM_EXTENSIONS
+])
 
 # If the user did not specify a C++ version.
 user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "\-std="`
-if test "x$user_cxx" = "x"; then
+AS_IF([test "x$user_cxx" = "x"],[
   # Check for C++11 compiler support
   AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
-fi
+])
 
 # test for programs
 AC_PROG_RANLIB
@@ -122,16 +120,13 @@ RM="$RM -f"
 PKG_PROG_PKG_CONFIG
 
 AC_PATH_PROG(PERL, perl, none)
-if test "x$ac_cv_path_PERL" = "xnone"; then
+AS_IF([test "x$ac_cv_path_PERL" = "xnone"],[
   AC_MSG_FAILURE([Perl is required to compile Squid. Please install Perl and then re-run configure ])
-fi
+])
 AC_PATH_PROG(POD2MAN, pod2man, $FALSE)
 AM_CONDITIONAL(ENABLE_POD2MAN_DOC, test "x${ac_cv_path_POD2MAN}" != "x$FALSE")
 
-dnl set $(AR) if not provided by the build environment
-if test "x$AR" = "x"; then
-  AC_PATH_PROG(AR, ar, $FALSE)
-fi
+AC_PATH_PROG(AR, ar, $FALSE)
 AR_R="$AR r"
 AC_SUBST(AR_R)
 
@@ -139,11 +134,7 @@ AC_PATH_PROG(LINUXDOC, linuxdoc, $FALSE)
 AM_CONDITIONAL(ENABLE_RELEASE_DOCS, test "x${ac_cv_path_LINUXDOC}" != "x$FALSE")
 
 # pre-define DEFAULT_PREFIX, some modules need it.
-if test "${prefix}" = "NONE" ; then
-  squid_prefix=$ac_default_prefix
-else
-  squid_prefix=$prefix
-fi
+AS_IF([test "${prefix}" = "NONE"],[squid_prefix=$ac_default_prefix],[squid_prefix=$prefix])
 AC_DEFINE_UNQUOTED(DEFAULT_PREFIX,[$squid_prefix],[The install prefix])
 
 AC_ARG_ENABLE(strict-error-checking,
@@ -187,13 +178,7 @@ dnl find out the exe extension for this platform.
 dnl If it is not empty, use it for CGI as well.
 AC_EXEEXT
 AC_OBJEXT
-
-if test "x$EXEEXT" = "x" ; then
-  CGIEXT=".cgi"
-else
-  # automake automatically adds .exe when installing binaries
-  CGIEXT=""
-fi
+AS_IF([test "x$EXEEXT" = "x"],[CGIEXT=".cgi"],[CGIEXT=""])
 AC_SUBST(CGIEXT)
 
 AM_CONDITIONAL(ENABLE_WIN32SPECIFIC,[test "x$squid_host_os" = "xmingw"])
@@ -204,13 +189,13 @@ AS_CASE([$squid_host_os],
     AC_PATH_PROG(WIN32_PSAPI, psapi.dll, none)
     CFLAGS="$CFLAGS -mthreads"
     CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
-    if test "x$ac_cv_path_WIN32_PSAPI" = "xnone"; then
+    AS_IF([test "x$ac_cv_path_WIN32_PSAPI" = "xnone"],[
       AC_MSG_NOTICE([PSAPI.DLL is recommended to run Squid on Windows NT Platform])
       AC_MSG_NOTICE([Please see PSAPI.DLL section on doc/win32-relnotes.html.])
-    else
+    ],[
       AC_DEFINE(HAVE_WIN32_PSAPI,1,[Define if you have PSAPI.DLL on Windows systems])
       LIBS="$LIBS -lpsapi"
-    fi
+    ])
     MINGW_LIBS="-lmingwex"
     AC_SUBST(MINGW_LIBS)
   ],
@@ -270,8 +255,8 @@ AC_ARG_WITH(swapdir,
 AC_SUBST(DEFAULT_SWAP_DIR)
 
 dnl Set Default CFLAGS
-if test "x$PRESET_CFLAGS" = "x"; then
-  if test "$squid_cv_compiler" = "gcc"; then
+AS_IF([test "x$PRESET_CFLAGS" = "x"],[
+  AS_IF([test "$squid_cv_compiler" = "gcc"],[
     # TODO check if these exceptions are still necessary
     AS_CASE(["$host"],
       [*-sun-sunos*],[
@@ -279,7 +264,7 @@ if test "x$PRESET_CFLAGS" = "x"; then
       ],
       [CFLAGS="$squid_cv_cc_option_wall $CFLAGS"]
     )
-  else
+  ],[
     AS_CASE(["$host"],
       [*mips-sgi-irix6.*],[
         # suggested by Rafael Seidl <rafaels@cthulhu.engr.sgi.com>
@@ -292,8 +277,8 @@ if test "x$PRESET_CFLAGS" = "x"; then
                   -Wl,-woff,85,-woff,84,-woff,134 \
                   -nostdinc -I/usr/include -D_BSD_SIGNALS $CXXFLAGS"
     ])
-  fi
-fi
+  ])
+])
 
 AC_MSG_CHECKING([compiler name-version])
 squid_cv_cc_name=`$CC --version | head -1 | cut -f1 -d" "`
@@ -340,14 +325,14 @@ SQUID_CC_ADD_CXXFLAG_WARNING_IF_SUPPORTED([-Woverloaded-virtual])
 dnl CentOS (and RHEL) still define ntohs() using deprecated C++ features
 SQUID_CC_REQUIRE_ARGUMENT([ac_cv_require_wno_deprecated_register],[-Werror -Wno-deprecated-register],[[#include <arpa/inet.h>]],[[int fox=ntohs(1);]])
 
-if test "x$enable_strict_error_checking" != "xno"; then
+AS_IF([test "x$enable_strict_error_checking" != "xno"],[
   SQUID_CFLAGS="$SQUID_CFLAGS $squid_cv_cc_option_werror"
   SQUID_CXXFLAGS="$SQUID_CXXFLAGS $squid_cv_cxx_option_werror"
-fi
+])
 
-if test "x$ac_cv_require_wno_deprecated_register" = "xyes"; then
+AS_IF([test "x$ac_cv_require_wno_deprecated_register" = "xyes"],[
   SQUID_CXXFLAGS="$SQUID_CXXFLAGS -Wno-deprecated-register"
-fi
+])
 
 # squid_cv_cc_arg_pipe is set by SQUID_CC_GUESS_OPTIONS
 SQUID_CXXFLAGS="$SQUID_CXXFLAGS $squid_cv_cc_arg_pipe"
@@ -363,11 +348,11 @@ AC_ARG_ENABLE(optimizations,
                   good for debugging. During development, use
                   --disable-optimizations to reduce compilation times
                   and allow easier debugging.]), [
-if test "x$enableval" = "xno" ; then
-  AC_MSG_NOTICE([Disabling compiler optimizations (-O flag)])
-  CFLAGS="`echo $CFLAGS | sed -e 's/-O[[0-9g]]*//'`"
-  CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-O[[0-9g]]*//'`"
-fi
+  AS_IF([test "x$enableval" = "xno"],[
+    AC_MSG_NOTICE([Disabling compiler optimizations (-O flag)])
+    CFLAGS="`echo $CFLAGS | sed -e 's/-O[[0-9g]]*//'`"
+    CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-O[[0-9g]]*//'`"
+  ])
 ])
 
 AC_ARG_ENABLE(debug-cbdata,
@@ -405,19 +390,19 @@ AC_ARG_WITH(aufs-threads,
     AC_MSG_ERROR(--with-aufs-threads expects a numeric argument)
   )
 ])
-if test "x$squid_opt_aufs_threads" != "x"; then
-    AC_MSG_NOTICE([With $squid_opt_aufs_threads aufs threads])
-    AC_DEFINE_UNQUOTED(AUFS_IO_THREADS,$squid_opt_aufs_threads,
-                 [Defines how many threads aufs uses for I/O])
-fi
+AS_IF([test "x$squid_opt_aufs_threads" != "x"],[
+  AC_MSG_NOTICE([With $squid_opt_aufs_threads aufs threads])
+  AC_DEFINE_UNQUOTED(AUFS_IO_THREADS,$squid_opt_aufs_threads,
+    [Defines how many threads aufs uses for I/O])
+])
 
 ## TODO check if this is necessary, LT_INIT does these checks
 SQUID_AUTO_LIB(dl,[dynamic linking],[LIBDL])
-if test "x$with_dl" != "xno"; then
+AS_IF([test "x$with_dl" != "xno"],[
   CXXFLAGS="$LIBDL_CFLAGS $CXXFLAGS"
   LDFLAGS="$LIBDL_PATH $LDFLAGS"
   AC_CHECK_LIB(dl, dlopen)
-fi
+])
 
 AC_DEFUN([LIBATOMIC_CHECKER],[
   AC_MSG_CHECKING(whether linking $1 -latomic works)
@@ -453,9 +438,9 @@ SQUID_STATE_ROLLBACK(LIBATOMIC)
 AC_SUBST(ATOMICLIB)
 
 AC_SEARCH_LIBS([shm_open], [rt])
-if test "x$ac_cv_search_shm_open" != "xno" ; then
+AS_IF([test "x$ac_cv_search_shm_open" != "xno"],[
   AC_DEFINE(HAVE_SHM,1,[Support shared memory features])
-fi
+])
 
 AC_MSG_CHECKING([for DiskIO modules to be enabled])
 squid_disk_module_candidates=""
@@ -478,14 +463,14 @@ AC_ARG_ENABLE(disk-io,
 ])
 
 # if requested to autodetect, find out what we have
-if test "x$squid_opt_enable_diskio" = "xauto"; then
-    squid_opt_enable_diskio="yes"
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
-    if test "x$ac_cv_search_shm_open" = "xno" ; then
-        # disable IpcIo
-        squid_disk_module_candidates=`echo $squid_disk_module_candidates|sed 's/IpcIo//'`
-    fi
-fi
+AS_IF([test "x$squid_opt_enable_diskio" = "xauto"],[
+  squid_opt_enable_diskio="yes"
+  SQUID_LOOK_FOR_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
+  AS_IF([test "x$ac_cv_search_shm_open" = "xno"],[
+    # disable IpcIo
+    squid_disk_module_candidates=`echo $squid_disk_module_candidates|sed 's/IpcIo//'`
+  ])
+])
 
 AC_MSG_RESULT([${squid_disk_module_candidates:-none}])
 SQUID_CHECK_EXISTING_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
@@ -513,28 +498,24 @@ AH_TEMPLATE(HAVE_DISKIO_MODULE_IPCIO, [Whether IpcIo Disk I/O module is built])
 AH_TEMPLATE(HAVE_DISKIO_MODULE_MMAPPED, [Whether Mmapped Disk I/O module is built])
 for module in $squid_disk_module_candidates none; do
   # maybe not needed
-  if test "x$module" = "xnone"; then
-    continue
-  fi
-  if ! test -d "$srcdir/src/DiskIO/$module"; then
-    AC_MSG_ERROR(disk-io $module does not exist)
-  fi
+  AS_IF([test "x$module" = "xnone"],[continue])
+  AS_IF([!test -d "$srcdir/src/DiskIO/$module"],[AC_MSG_ERROR([disk-io $module does not exist])])
   AS_CASE(["$module"],
     [AIO],[
       dnl Check for POSIX AIO availability
       squid_opt_use_aio="yes"
       AIOLIB=
-      if test "x$with_aio" != "xno"; then
+      AS_IF([test "x$with_aio" != "xno"],[
         have_aio_header=no
         AC_CHECK_HEADERS(aio.h,[have_aio_header=yes])
         dnl On some systems POSIX AIO functions are in librt
         dnl On some systems POSIX AIO functions are in libaio
         AC_CHECK_LIB(rt,aio_read,[AIOLIB="-lrt"],AC_CHECK_LIB(aio,aio_read,[AIOLIB="-laio"],[]))
         dnl Enable AIO if the library and headers are found
-        if test "x$AIOLIB" != "x" && test "x$have_aio_header" = "xyes"; then
+        AS_IF([test "x$AIOLIB" != "x" -a "x$have_aio_header" = "xyes"],[
           AC_MSG_NOTICE([Native POSIX AIO support detected.])
           squid_opt_use_aio="yes"
-        else
+        ],[
           dnl Windows does things differently. We provide wrappers.
           dnl TODO: Windows really needs its own DiskIO module or its Overlaped IO
           AS_IF([test "$squid_host_os" = "mingw"],[
@@ -544,25 +525,25 @@ for module in $squid_disk_module_candidates none; do
             squid_opt_use_aio="no"
             AC_MSG_NOTICE([Native POSIX AIO support not detected. AIO automatically disabled.])
           ])
-        fi
-      else
+        ])
+      ],[
         AC_MSG_NOTICE([POSIX AIO support manually disabled.])
         squid_opt_use_aio="no"
-      fi
+      ])
       dnl Use the POSIX AIO pieces if we actually need them.
-      if test "x$squid_opt_use_aio" = "xyes" ; then
+      AS_IF([test "x$squid_opt_use_aio" = "xyes"],[
         DISK_MODULES="$DISK_MODULES AIO"
         AC_DEFINE([HAVE_DISKIO_MODULE_AIO],1,[POSIX AIO Disk I/O module is built])
         AS_IF([test "$squid_host_os" = "mingw"],[
-            ENABLE_WIN32_AIO=1
-            AC_MSG_NOTICE([Replacing AIO DiskIO module with: Windows overlapped I/O support])
-          ],
+          ENABLE_WIN32_AIO=1
+          AC_MSG_NOTICE([Replacing AIO DiskIO module with: Windows overlapped I/O support])
+        ],[
           AC_MSG_NOTICE([Enabling AIO DiskIO module])
-        )
-      else
+        ])
+      ],[
         AC_MSG_NOTICE([AIO DiskIO Module disabled. Missing POSIX AIO support.])
         squid_disk_module_candidates_AIO=no
-      fi
+      ])
     ],
 
     [Blocking],[
@@ -573,61 +554,60 @@ for module in $squid_disk_module_candidates none; do
 
     [DiskDaemon],[
       AS_IF([test "$squid_host_os" = "mingw"],[
-          AC_MSG_NOTICE([DiskDaemon not supported on MinGW])
-          squid_disk_module_candidates_DiskDaemon=no
-        ],[
-          AC_MSG_NOTICE([Enabling DiskDaemon DiskIO module])
-          DISK_MODULES="$DISK_MODULES DiskDaemon"
-          AC_DEFINE([HAVE_DISKIO_MODULE_DISKDAEMON],1,[DiskDaemon Disk I/O module is built])
-        ])
+        AC_MSG_NOTICE([DiskDaemon not supported on MinGW])
+        squid_disk_module_candidates_DiskDaemon=no
+      ],[
+        AC_MSG_NOTICE([Enabling DiskDaemon DiskIO module])
+        DISK_MODULES="$DISK_MODULES DiskDaemon"
+        AC_DEFINE([HAVE_DISKIO_MODULE_DISKDAEMON],1,[DiskDaemon Disk I/O module is built])
+      ])
     ],
 
     [DiskThreads],[
       squid_opt_use_diskthreads="yes"
       LIBPTHREADS=
       SQUID_STATE_SAVE([diskthreads_state],[SQUID_CFLAGS SQUID_CXXFLAGS])
-      if test "x$with_pthreads" != "xno"; then
-      dnl TODO: this needs to be extended to handle more systems and better
-      dnl REF: http://www.openldap.org/lists/openldap-bugs/200006/msg00070.html
-      dnl REF: http://autoconf-archive.cryp.to/acx_pthread.html
+      AS_IF([test "x$with_pthreads" != "xno"],[
+        dnl TODO: this needs to be extended to handle more systems and better
+        dnl REF: http://www.openldap.org/lists/openldap-bugs/200006/msg00070.html
+        dnl REF: http://autoconf-archive.cryp.to/acx_pthread.html
         AS_CASE(["$squid_host_os"],
           [mingw],[
             ENABLE_WIN32_AIOPS=1
-            AC_MSG_NOTICE([Windows threads support automatically enabled])],
+            AC_MSG_NOTICE([Windows threads support automatically enabled])
+          ],
 
           [freebsd],[
-            if test `echo "$squid_host_os_version" | tr -d .` -lt 70 ; then
-                AC_MSG_NOTICE(pthread library requires FreeBSD 7 or later)
-                squid_opt_use_diskthreads="no"
-            else
+            AS_IF([test `echo "$squid_host_os_version" | tr -d .` -lt 70],[
+              AC_MSG_NOTICE(pthread library requires FreeBSD 7 or later)
+              squid_opt_use_diskthreads="no"
+            ],[
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT"
-              if test "x$GCC" = "xyes" -a "x$PRESET_LDFLAGS" = "x" ; then
-                LDFLAGS="$LDFLAGS -pthread"
-              fi
-            fi
-            ],
+              AS_IF([test "x$GCC" = "xyes" -a "x$PRESET_LDFLAGS" = "x"],[LDFLAGS="$LDFLAGS -pthread"])
+            ])
+          ],
 
           [openbsd],[
-            if test `echo "$squid_host_os_version" | tr -d .` -lt 52 ; then
-                AC_MSG_NOTICE(pthread library requires OpenBSD 5.2 or later)
-                squid_opt_use_diskthreads="no"
-            else
+            AS_IF([test `echo "$squid_host_os_version" | tr -d .` -lt 52],[
+              AC_MSG_NOTICE(pthread library requires OpenBSD 5.2 or later)
+              squid_opt_use_diskthreads="no"
+            ],[
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT"
               LDFLAGS="$LDFLAGS -lpthread"
-            fi
-            ],
+            ])
+          ],
 
           [solaris],[
-            if test "x$GCC" = "xyes" ; then
+            AS_IF([test "x$GCC" = "xyes"],[
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT -pthreads"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT -pthreads"
               AC_CHECK_LIB(pthread, pthread_create ,[LIBPTHREADS="-lpthread"], [
                 AC_MSG_NOTICE(pthread library required but cannot be found.)
                 squid_opt_use_diskthreads="no"
                ])
-            else
+            ],[
               dnl test for -lpthread first. libc version is a stub apparently on Solaris.
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT -lpthread"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT -lpthread"
@@ -637,8 +617,8 @@ for module in $squid_disk_module_candidates none; do
                 AC_MSG_NOTICE(pthread library required but cannot be found.)
                 squid_opt_use_diskthreads="no"
               ])
-            fi
-            ],
+            ])
+          ],
 
           [
             SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT"
@@ -647,44 +627,45 @@ for module in $squid_disk_module_candidates none; do
               AC_MSG_NOTICE(pthread library required but cannot be found.)
               squid_opt_use_diskthreads="no"
             ])
-          ])
-        else
-          AC_MSG_NOTICE([Native pthreads support manually disabled.])
-          squid_opt_use_diskthreads="no"
-        fi
-        if test "x$squid_opt_use_diskthreads" = "xyes" ; then
-          AC_MSG_NOTICE([Enabling DiskThreads DiskIO module])
-          DISK_MODULES="$DISK_MODULES DiskThreads"
-          AC_DEFINE([HAVE_DISKIO_MODULE_DISKTHREADS],1,[DiskThreads Disk I/O module is built])
-        else
-          AC_MSG_NOTICE([Native pthreads support disabled. DiskThreads module automaticaly disabled.])
-          SQUID_STATE_ROLLBACK([diskthreads_state])
-          squid_disk_module_candidates_DiskThreads=no
-        fi
+          ]
+        )
+      ],[
+        AC_MSG_NOTICE([Native pthreads support manually disabled.])
+        squid_opt_use_diskthreads="no"
+      ])
+      AS_IF([test "x$squid_opt_use_diskthreads" = "xyes"],[
+        AC_MSG_NOTICE([Enabling DiskThreads DiskIO module])
+        DISK_MODULES="$DISK_MODULES DiskThreads"
+        AC_DEFINE([HAVE_DISKIO_MODULE_DISKTHREADS],1,[DiskThreads Disk I/O module is built])
+      ],[
+        AC_MSG_NOTICE([Native pthreads support disabled. DiskThreads module automaticaly disabled.])
+        SQUID_STATE_ROLLBACK([diskthreads_state])
+        squid_disk_module_candidates_DiskThreads=no
+      ])
     ],
 
     [IpcIo],[
-      if test "x$ac_cv_search_shm_open" = "xno" ; then
+      AS_IF([test "x$ac_cv_search_shm_open" = "xno"],[
         AC_MSG_NOTICE([DiskIO IpcIo module requires shared memory support])
         squid_disk_module_candidates_IpcIo=no
-      else
+      ],[
         AC_MSG_NOTICE([Enabling IpcIo DiskIO module])
         DISK_MODULES="$DISK_MODULES IpcIo"
         AC_DEFINE([HAVE_DISKIO_MODULE_IPCIO],1,[IpcIo Disk I/O module is built])
-      fi
+      ])
     ],
 
     [Mmapped],[
       dnl TODO: use availability of sys/mman.h and/or mmap to define
       dnl  OR support windows mmap functions
-      if test "x$squid_host_os" = "xmingw" ; then
+      AS_IF([test "x$squid_host_os" = "xmingw"],[
         AC_MSG_NOTICE([Mmapped DiskIO is not available on Mingw])
         squid_disk_module_candidates_Mmapped=no
-      else
+      ],[
         AC_MSG_NOTICE([Enabling Mmapped DiskIO module])
         DISK_MODULES="$DISK_MODULES Mmapped"
         AC_DEFINE([HAVE_DISKIO_MODULE_MMAPPED],1,[Mmapped Disk I/O module is built])
-      fi
+      ])
     ],
 
     [
@@ -728,12 +709,12 @@ AC_ARG_ENABLE([storeio],
       squid_storeio_module_candidates="$squid_storeio_module_candidates ufs"
   ])
 ])
-if test "x$squid_opt_enable_storeio" = "xauto"; then
+AS_IF([test "x$squid_opt_enable_storeio" = "xauto"],[
   squid_opt_enable_storeio=yes
   AC_MSG_CHECKING([for available StoreIO modules])
   SQUID_LOOK_FOR_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
   AC_MSG_RESULT([$squid_storeio_module_candidates])
-fi
+])
 
 SQUID_CLEANUP_MODULES_LIST([squid_storeio_module_candidates])
 SQUID_CHECK_EXISTING_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
@@ -742,28 +723,28 @@ AC_MSG_NOTICE([Store modules built: $squid_storeio_module_candidates])
 for fs in $squid_storeio_module_candidates none; do
   AS_CASE(["$fs"],
     [diskd],[
-      if test "x$squid_disk_module_candidates_Blocking" != "xyes" -a \
-        "$squid_disk_module_candidates_DiskDaemon" != "yes" ; then
+      AS_IF([test "x$squid_disk_module_candidates_Blocking" != "xyes" -a \
+        "x$squid_disk_module_candidates_DiskDaemon" != "xyes"],[
         AC_MSG_ERROR([Storage diskd module requires DiskIO module: Blocking or DiskDaemon])
-      fi
+      ])
     ],
     [aufs],[
-      if test "x$squid_disk_module_candidates_Blocking" != "xyes" -a \
-        "$squid_disk_module_candidates_DiskThreads" != "yes" ; then
+      AS_IF([test "x$squid_disk_module_candidates_Blocking" != "xyes" -a \
+        "x$squid_disk_module_candidates_DiskThreads" != "xyes"],[
         AC_MSG_ERROR([Storage module aufs requires DiskIO module: Blocking or DiskThreads])
-      fi
+      ])
     ],
     [rock],[
-      if test "x$squid_disk_module_candidates_IpcIo" != "xyes" -a \
-        "x$squid_disk_module_candidates_Blocking" != "xyes"; then
+      AS_IF([test "x$squid_disk_module_candidates_IpcIo" != "xyes" -a \
+        "x$squid_disk_module_candidates_Blocking" != "xyes"],[
          AC_MSG_ERROR([Storage module Rock requires DiskIO module: Blocking or IpcIo])
-      fi
+      ])
       squid_do_build_rock=true
     ],
     [ufs],[
-      if test "x$squid_disk_module_candidates_Blocking" != "xyes"; then
+      AS_IF([test "x$squid_disk_module_candidates_Blocking" != "xyes"],[
         AC_MSG_ERROR([Storage module ufs requires DiskIO module: Blocking])
-      fi
+      ])
       squid_do_build_ufs=true
     ])
 done
@@ -813,34 +794,34 @@ AC_ARG_ENABLE(removal-policies,
     [ REPL_POLICIES="`echo $enableval| sed -e 's/,/ /g;s/  */ /g'`" ]
   )
 ])
-if test "x$REPL_POLICIES" != "x" ; then
-    SQUID_CHECK_EXISTING_MODULES([$srcdir/src/repl],[REPL_POLICIES])
-    AC_MSG_NOTICE([Removal policies to build: $REPL_POLICIES])
-    REPL_OBJS="repl/lib`echo $REPL_POLICIES|sed -e 's% %.a repl/lib%g'`.a"
-    REPL_LIBS="`echo $REPL_OBJS|sed -e 's%repl/%%g'`"
-fi
+AS_IF([test "x$REPL_POLICIES" != "x"],[
+  SQUID_CHECK_EXISTING_MODULES([$srcdir/src/repl],[REPL_POLICIES])
+  AC_MSG_NOTICE([Removal policies to build: $REPL_POLICIES])
+  REPL_OBJS="repl/lib`echo $REPL_POLICIES|sed -e 's% %.a repl/lib%g'`.a"
+  REPL_LIBS="`echo $REPL_OBJS|sed -e 's%repl/%%g'`"
+])
 AC_SUBST(REPL_POLICIES)
 AC_SUBST(REPL_OBJS)
 AC_SUBST(REPL_LIBS)
 
 AM_CONDITIONAL(ENABLE_PINGER, false)
 AC_ARG_ENABLE(icmp,
-  AS_HELP_STRING([--enable-icmp],[Enable ICMP pinging and Network Measurement]),
-[ if test "x$enableval" = "xyes" ; then
+  AS_HELP_STRING([--enable-icmp],[Enable ICMP pinging and Network Measurement]),[
+  AS_IF([test "x$enableval" = "xyes"],[
     AC_MSG_NOTICE([ICMP enabled])
     AC_DEFINE(USE_ICMP,1,[Define to use Squid ICMP and Network Measurement features (highly recommended!)])
     AM_CONDITIONAL(ENABLE_PINGER, true)
-  fi
+  ])
 ])
 
 AM_CONDITIONAL(ENABLE_DELAY_POOLS, false)
 AC_ARG_ENABLE(delay-pools,
-  AS_HELP_STRING([--enable-delay-pools],[Enable delay pools to limit bandwidth usage]),
-[ if test "x$enableval" = "xyes" ; then
+  AS_HELP_STRING([--enable-delay-pools],[Enable delay pools to limit bandwidth usage]),[
+  AS_IF([test "x$enableval" = "xyes"],[
     AC_MSG_NOTICE([Delay pools enabled])
     AC_DEFINE([USE_DELAY_POOLS],1,[Traffic management via "delay pools".])
     AM_CONDITIONAL(ENABLE_DELAY_POOLS, true)
-  fi
+  ])
 ])
 
 dnl disable generic/common adaptation support by default
@@ -861,24 +842,24 @@ XMLLIB=
 
 # ESI support libraries: expat
 SQUID_AUTO_LIB(expat,[ESI expat],[LIBEXPAT])
-if test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno" ; then
+AS_IF([test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno"],[
   AC_CHECK_LIB([expat], [main], [EXPATLIB="-lexpat"; HAVE_LIBEXPAT=1])
   AC_CHECK_HEADERS([expat.h])
   AC_DEFINE_UNQUOTED(HAVE_LIBEXPAT, $HAVE_LIBEXPAT, [Define to 1 if you have the expat library])
-  AS_IF(test "x$HAVE_LIBEXPAT" = "x1",[
+  AS_IF([test "x$HAVE_LIBEXPAT" = "x1"],[
     squid_opt_use_esi=yes
   ],[
-    AS_IF(test "x$with_expat" = "xyes",[
+    AS_IF([test "x$with_expat" = "xyes"],[
       AC_MSG_ERROR([Required library expat not found.])
     ],[
       AC_MSG_NOTICE([Library expat not found.])
     ])
   ])
-fi
+])
 
 # TODO: remove this 'lib' prefix to match coding standard
 SQUID_AUTO_LIB(libxml2,[ESI libxml2],[LIBXML2])
-if test "x$squid_opt_use_esi" != "xno" -a "x$with_libxml2" != "xno" ; then
+AS_IF([test "x$squid_opt_use_esi" != "xno" -a "x$with_libxml2" != "xno"],[
   SQUID_STATE_SAVE([squid_libxml2_save])
   PKG_CHECK_MODULES([LIBXML2],[libxml-2.0],[],[
     AC_CHECK_LIB([xml2], [main], [LIBXML2_LIBS="$LIBXML2_LIBS -lxml2"])
@@ -906,19 +887,19 @@ if test "x$squid_opt_use_esi" != "xno" -a "x$with_libxml2" != "xno" ; then
   AC_CHECK_HEADERS(libxml/parser.h libxml/HTMLparser.h libxml/HTMLtree.h)
   SQUID_STATE_ROLLBACK([squid_libxml2_save])
 
-  if test "x$LIBXML2_LIBS" != "x"; then
+  AS_IF([test "x$LIBXML2_LIBS" != "x"],[
     HAVE_LIBXML2=1
     squid_opt_use_esi=yes
     SQUID_CXXFLAGS="$SQUID_CXXFLAGS $LIBXML2_CFLAGS"
     CPPFLAGS="$CPPFLAGS $LIBXML2_CFLAGS"
     XMLLIB="$LIBXML2_LIBS"
     AC_DEFINE_UNQUOTED(HAVE_LIBXML2, $HAVE_LIBXML2, [Define to 1 if you have the libxml2 library])
-  elif test "x$with_libxml2" = "xyes"; then
+  ],[test "x$with_libxml2" = "xyes"],[
     AC_MSG_ERROR([Required library libxml2 not found])
-  else
+  ],[
     AC_MSG_NOTICE([Library libxml2 not found.])
-  fi
-fi
+  ])
+])
 
 AS_IF([test "x$squid_opt_use_esi" = "xyes"],[
   AS_IF(test "x$HAVE_LIBXML2" = "x0" -a "x$HAVE_LIBEXPAT" = "x0",[
@@ -952,34 +933,32 @@ squid_opt_use_ecap=1
 AC_MSG_CHECKING(whether to support eCAP)
 AC_ARG_ENABLE(ecap,
   AS_HELP_STRING([--enable-ecap],[support loadable content adaptation modules]),[
-  AS_CASE(["${enableval}"],
+  AS_CASE([$enableval],
     [yes|no],[squid_opt_use_ecap=$enableval],
-    [AC_MSG_ERROR([bad value ${enableval} for --enable-ecap])]
+    [AC_MSG_ERROR([bad value $enableval for --enable-ecap])]
   )
   AC_MSG_RESULT([$squid_opt_use_ecap, explicitly])
 ],[
-  squid_opt_use_ecap=no;
+  squid_opt_use_ecap=no
   AC_MSG_RESULT([$squid_opt_use_ecap, implicitly])
 ])
 
 dnl Perform configuration consistency checks for eCAP
-if test "x$squid_opt_use_ecap" != "xno";
-then
+AS_IF([test "x$squid_opt_use_ecap" != "xno"],[
   dnl eCAP support requires loadable modules, which are enabled by default
-  if test "x$enable_shared" != "xyes"
-  then
+  AS_IF([test "x$enable_shared" != "xyes"],[
     AC_MSG_ERROR([eCAP support requires loadable modules. Please do not use --disable-shared with --enable-ecap.])
-  fi
+  ])
 
-  if test -n "$PKG_CONFIG"; then
+  AS_IF([test -n "$PKG_CONFIG"],[
     dnl eCAP support requires libecap.
     dnl This Squid supports libecap v1.0.x.
     dnl Use EXT_ prefix to distinguish external libecap (that we check for
     dnl here) from our own convenience ecap library in Makefiles.
     PKG_CHECK_MODULES([EXT_LIBECAP],[libecap >= 1.0 libecap < 1.1])
-  else
+  ],[
     AC_MSG_NOTICE([eCAP support requires pkg-config to verify the correct library version. Trouble may follow.])
-  fi
+  ])
 
   SQUID_STATE_SAVE(squid_ecap_state)
   AC_MSG_CHECKING([whether -lecap will link])
@@ -992,32 +971,30 @@ then
     squid_opt_use_adaptation=yes
   ],[
     AC_MSG_RESULT(no)
-    AS_IF(
-      test "x$squid_opt_use_ecap" = "xyes", AC_MSG_ERROR([eCAP library will not link.
+    AS_IF([test "x$squid_opt_use_ecap" = "xyes"],[
+      AC_MSG_ERROR([eCAP library will not link.
                   You may need to rebuild libecap using the same version of GCC as Squid.
-                  There have been breaking ABI changes in the libstdc++ STL with GCC 5.]),
-
-    [AC_MSG_NOTICE([eCAP library will not link.
+                  There have been breaking ABI changes in the libstdc++ STL with GCC 5.])
+    ],[
+      AC_MSG_NOTICE([eCAP library will not link.
                   You may need to rebuild libecap using the same version of GCC as Squid.
                   There have been breaking ABI changes in the libstdc++ STL with GCC 5.])
       squid_opt_use_ecap="no"
     ])
   ])
   SQUID_STATE_ROLLBACK(squid_ecap_state)
-fi
+])
 SQUID_DEFINE_BOOL(USE_ECAP,${squid_opt_use_ecap:=no},[Whether to use eCAP support])
 AM_CONDITIONAL(ENABLE_ECAP, test "x$squid_opt_use_ecap" = "xyes")
 
 dnl enable adaptation if requested by specific adaptation mechanisms
 ADAPTATION_LIBS=""
-if test "x$squid_opt_use_adaptation" = "xyes"; then
-    ADAPTATION_LIBS="adaptation/libadaptation.la"
-fi
+AS_IF([test "x$squid_opt_use_adaptation" = "xyes"],[ADAPTATION_LIBS="adaptation/libadaptation.la"])
 SQUID_DEFINE_BOOL(USE_ADAPTATION,${squid_opt_use_adaptation:=no}, [common adaptation support])
 AM_CONDITIONAL(ENABLE_ADAPTATION, test "x$squid_opt_use_adaptation" = "xyes")
 AC_SUBST(ADAPTATION_LIBS)
 
-test "x$squid_host_os" = "xmingw" && enable_wccp=no
+AS_IF([test "x$squid_host_os" = "xmingw"],[enable_wccp=no])
 AC_ARG_ENABLE(wccp,
   AS_HELP_STRING([--disable-wccp],[Disable Web Cache Coordination Protocol]), [
 SQUID_YESNO([$enableval],[unrecognized argument to --disable-wccp: $enableval])
@@ -1025,7 +1002,7 @@ SQUID_YESNO([$enableval],[unrecognized argument to --disable-wccp: $enableval])
 SQUID_DEFINE_BOOL(USE_WCCP, ${enable_wccp:=yes}, [Define to enable WCCP])
 AC_MSG_NOTICE([Web Cache Coordination Protocol enabled: $enable_wccp])
 
-test "x$squid_host_os" = "xmingw" && enable_wccpv2=no
+AS_IF([test "x$squid_host_os" = "xmingw"],[enable_wccpv2=no])
 AC_ARG_ENABLE(wccpv2,
   AS_HELP_STRING([--disable-wccpv2],
                  [Disable Web Cache Coordination V2 Protocol]), [
@@ -1055,9 +1032,7 @@ AC_ARG_ENABLE(snmp,
 SQUID_DEFINE_BOOL(SQUID_SNMP,${enable_snmp:=yes},
    [Define to enable SNMP monitoring of Squid])
 AM_CONDITIONAL(ENABLE_SNMP, [test "x$enable_snmp" = "xyes"])
-if test "x$enable_snmp" = "xyes"; then
-    SNMPLIB='../lib/snmplib/libsnmplib.la'
-fi
+AS_IF([test "x$enable_snmp" = "xyes"],[SNMPLIB="../lib/snmplib/libsnmplib.la"])
 AC_MSG_NOTICE([SNMP support enabled: $enable_snmp])
 AC_SUBST(SNMPLIB)
 
@@ -1083,7 +1058,7 @@ AC_ARG_ENABLE(eui,
                  [Disable use of ARP / MAC/ EUI (ether address)]), [
 SQUID_YESNO([$enableval],[--disable-eui expects no arguments])
 ])
-if test "x${enable_eui:=yes}" = "xyes" ; then
+AS_IF([test "x${enable_eui:=yes}" = "xyes"],[
   SQUID_STATE_SAVE(LIBEUI)
   # GLIBC 2.30 deprecates sysctl.h. Test with the same flags that (may) break includes later.
   CFLAGS=$SQUID_CFLAGS
@@ -1122,7 +1097,7 @@ include <windows.h>
 #endif
   ]])
   SQUID_STATE_ROLLBACK(LIBEUI)
-fi
+])
 AC_SUBST(EUILIB)
 AC_MSG_NOTICE([EUI (MAC address) controls enabled: $enable_eui])
 SQUID_DEFINE_BOOL(USE_SQUID_EUI,$enable_eui,
@@ -1142,13 +1117,13 @@ AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 
 # Cryptograhic libraries
 SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
-if test "x$with_nettle" != "xno" ; then
+AS_IF(test "x$with_nettle" != "xno"],[
   CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
   AC_CHECK_LIB(nettle, nettle_md5_init,[
     NETTLELIB="$LIBNETTLE_PATH -lnettle"
     AC_CHECK_HEADERS(nettle/md5.h)
   ],[with_nettle=no])
-  if test "x$with_nettle" != "xno" ; then
+  AS_IF([test "x$with_nettle" != "xno"],[
     # Base64 uses the nettle 3.4 API
     # which matters on 64-bit systems
     AC_CHECK_HEADERS(nettle/base64.h)
@@ -1171,8 +1146,8 @@ if test "x$with_nettle" != "xno" ; then
     ]])],[AC_MSG_RESULT(yes)
       AC_DEFINE(HAVE_NETTLE34_BASE64,1,[set to 1 if Nettle 3.4 API will link])
     ],[AC_MSG_RESULT(no)])
-  fi
-fi
+  ])
+])
 AC_MSG_NOTICE([Using Nettle cryptographic library: ${with_nettle:=yes}])
 AC_SUBST(NETTLELIB)
 
@@ -1189,7 +1164,7 @@ SSLLIB=""
 
 SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[LIBGNUTLS])
 AH_TEMPLATE(USE_GNUTLS,[GnuTLS support is available])
-if test "x$with_gnutls" != "xno"; then
+AS_IF([test "x$with_gnutls" != "xno"],[
   SQUID_STATE_SAVE(squid_gnutls_state)
 
   # User may have provided a custom location for GnuTLS. Otherwise...
@@ -1209,24 +1184,24 @@ if test "x$with_gnutls" != "xno"; then
 
   SQUID_STATE_ROLLBACK(squid_gnutls_state) #de-pollute LIBS
 
-  if test "x$with_gnutls" = "xyes" -a "x$LIBGNUTLS_LIBS" = "x"; then
+  AS_IF([test "x$with_gnutls" = "xyes" -a "x$LIBGNUTLS_LIBS" = "x"],[
     AC_MSG_ERROR([Required GnuTLS library not found])
-  fi
-  if test "x$LIBGNUTLS_LIBS" != "x" ; then
+  ])
+  AS_IF([test "x$LIBGNUTLS_LIBS" != "x"],[
     CXXFLAGS="$LIBGNUTLS_CFLAGS $CXXFLAGS"
     SSLLIB="$LIBGNUTLS_PATH $LIBGNUTLS_LIBS $SSLLIB"
     AC_DEFINE(USE_GNUTLS,1,[GnuTLS support is available])
-  else
+  ],[
     with_gnutls=no
-  fi
-fi
+  ])
+])
 AC_MSG_NOTICE([GnuTLS library support: ${with_gnutls:=auto} ${LIBGNUTLS_PATH} ${LIBGNUTLS_LIBS}])
 
 dnl User may specify OpenSSL is needed from a non-standard location
 SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[LIBOPENSSL])
 AH_TEMPLATE(USE_OPENSSL,[OpenSSL support is available])
 ## OpenSSL is default disable due to licensing issues on some OS
-if test "x$with_openssl" = "xyes"; then
+AS_IF([test "x$with_openssl" = "xyes"],[
   CPPFLAGS="$LIBOPENSSL_CFLAGS $CPPFLAGS"
   AC_CHECK_HEADERS( \
     openssl/asn1.h \
@@ -1258,10 +1233,10 @@ if test "x$with_openssl" = "xyes"; then
     ## Detect libraries the hard way.
 
     # Windows MinGW has some special libraries ...
-    if test "x$squid_host_os" = "xmingw" ; then
+    AS_IF([test "x$squid_host_os" = "xmingw"],[
       LIBOPENSSL_LIBS='-lssleay32 -leay32 -lgdi32 $LIBOPENSSL_LIBS'
       AC_MSG_NOTICE([Windows OpenSSL library support: yes -lssleay32 -leay32 -lgdi32])
-    fi
+    ])
 
     AC_CHECK_LIB(crypto,[CRYPTO_new_ex_data],[LIBOPENSSL_LIBS="-lcrypto $LIBOPENSSL_LIBS"],[
       AC_MSG_ERROR([library 'crypto' is required for OpenSSL])
@@ -1272,14 +1247,14 @@ if test "x$with_openssl" = "xyes"; then
   ])
 
   # This is a workaround for RedHat 9 brain damage..
-  if test -d /usr/kerberos/include -a -f /usr/include/openssl/kssl.h; then
+  AS_IF([test -d /usr/kerberos/include -a -f /usr/include/openssl/kssl.h],[
     AC_MSG_NOTICE([OpenSSL depends on Kerberos])
     LIBOPENSSL_LIBS="-L/usr/kerberos/lib $LIBOPENSSL_LIBS"
     CPPFLAGS="$CPPFLAGS -I/usr/kerberos/include"
-  fi
+  ])
   SQUID_STATE_ROLLBACK(squid_openssl_state) #de-pollute LIBS
 
-  if test "x$LIBOPENSSL_LIBS" != "x"; then
+  AS_IF([test "x$LIBOPENSSL_LIBS" != "x"],[
     CXXFLAGS="$LIBOPENSSL_CFLAGS $CXXFLAGS"
     SSLLIB="$LIBOPENSSL_PATH $LIBOPENSSL_LIBS $SSLLIB"
     AC_DEFINE(USE_OPENSSL,1,[OpenSSL support is available])
@@ -1298,19 +1273,15 @@ if test "x$with_openssl" = "xyes"; then
     SQUID_STATE_ROLLBACK(check_SSL_CTX_get0_certificate)
 
     # check for other specific broken implementations
-    if test "x$missing_SSL_CTX_get0_certificate" = "xyes"; then
-      SQUID_CHECK_OPENSSL_GETCERTIFICATE_WORKS
-    fi
+    AS_IF([test "x$missing_SSL_CTX_get0_certificate" = "xyes"],SQUID_CHECK_OPENSSL_GETCERTIFICATE_WORKS)
     SQUID_CHECK_OPENSSL_CONST_SSL_METHOD
     SQUID_CHECK_OPENSSL_CONST_CRYPTO_EX_DATA
     SQUID_CHECK_OPENSSL_CONST_SSL_SESSION_CB_ARG
     SQUID_CHECK_OPENSSL_CONST_X509_GET0_SIGNATURE_ARGS
     SQUID_CHECK_OPENSSL_TXTDB
-  fi
-  if test "x$SSLLIB" = "x"; then
-    AC_MSG_ERROR([Required OpenSSL library not found])
-  fi
-fi
+  ])
+  AS_IF([test "x$SSLLIB" = "x"],[AC_MSG_ERROR([Required OpenSSL library not found])])
+])
 AC_MSG_NOTICE([OpenSSL library support: ${with_openssl:=no} ${LIBOPENSSL_PATH} ${LIBOPENSSL_LIBS}])
 AM_CONDITIONAL(ENABLE_SSL,[ test "x$with_openssl" = "xyes" ])
 AC_SUBST(SSLLIB)
@@ -1322,7 +1293,7 @@ AH_TEMPLATE(USE_MIT_KRB5,[MIT Kerberos support is available])
 AH_TEMPLATE(USE_SOLARIS_KRB5,[Solaris Kerberos support is available])
 
 ## find out if pkg-config or krb5-config will work
-if test "x$with_mit_krb5" != "xno"; then
+AS_IF([test "x$with_mit_krb5" != "xno"],[
   CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
   krb5confpath="$with_mit_krb5/bin"
   # find installed libs via pkg-config or krb5-config
@@ -1330,60 +1301,52 @@ if test "x$with_mit_krb5" != "xno"; then
   PKG_CHECK_EXISTS(mit-krb5-gssapi mit-krb5, [squid_pc_krb5_name="mit-krb5-gssapi mit-krb5"],[
     PKG_CHECK_EXISTS(gssapi-krb5 krb5, [squid_pc_krb5_name="gssapi-krb5 krb5"])
   ])
-  if test "x$squid_pc_krb5_name" = "x" -a "$cross_compiling" = "no"; then
+  AS_IF([test "x$squid_pc_krb5_name" = "x" -a "$cross_compiling" = "no"],[
     # Look for krb5-config (unless cross-compiling)
     AC_PATH_PROG(krb5_config,krb5-config,no,$krb5confpath)
-    if test "x$ac_cv_path_krb5_config" != "xno" ; then
+    AS_IF([test "x$ac_cv_path_krb5_config" != "xno"],[
       krb5confpath="`dirname $ac_cv_path_krb5_config`"
       ac_heimdal="`$ac_cv_path_krb5_config --version 2>/dev/null | grep -c -i heimdal`"
       ac_solaris="`$ac_cv_path_krb5_config --version 2>/dev/null | grep -c -i solaris`"
       ac_apple="`$ac_cv_path_krb5_config --vendor 2>/dev/null | grep -c -i apple`"
-      if test $ac_solaris -gt 0 ; then
-	with_solaris_krb5=yes
-      elif test $ac_apple -gt 0 ; then
-	with_apple_krb5=yes
-      elif test $ac_heimdal -gt 0; then
-	with_mit_krb5=no
-        if test "x$with_mit_krb5" = "xyes"; then
-          AC_MSG_ERROR([Could not find pkg-config or krb5-config for MIT Kerberos])
-        fi
-      fi
-    else
-      if test "x$with_mit_krb5" = "xyes"; then
+      AS_IF([test $ac_solaris -gt 0],[with_solaris_krb5=yes],
+        [test $ac_apple -gt 0],[with_apple_krb5=yes],
+        [test $ac_heimdal -gt 0],[with_mit_krb5=no]
+      )
+    ],[
+      AS_IF([test "x$with_mit_krb5" = "xyes"],[
         AC_MSG_ERROR([Could not find krb5-config in path])
-      else
+      ],[
         with_mit_krb5=no
-      fi
-    fi
-  fi
-fi
+      ])
+    ])
+  ])
+])
 
 # detect MIT Kerberos dependencies (except on Solaris)
-if test "x$with_mit_krb5" != "xno" -a "x$with_solaris_krb5" != "xyes"; then
+AS_IF([test "x$with_mit_krb5" != "xno" -a "x$with_solaris_krb5" != "xyes"],[
   SQUID_STATE_SAVE([squid_krb5_save])
   LIBS="$LIBS $LIB_KRB5_PATH"
 
   # auto-detect using pkg-config
   PKG_CHECK_MODULES([LIB_KRB5], $squid_pc_krb5_name,,[
     # look for krb5-config (unless cross-compiling)
-    if test "$cross_compiling" = "no"; then
-      if test "x$krb5confpath" = "x" ; then
+    AS_IF([test "$cross_compiling" = "no"],[
+      AS_IF([test "x$krb5confpath" = "x"],[
         AC_PATH_PROG(krb5_config,krb5-config,no)
-        if test "x$ac_cv_path_krb5_config" != "xno" ; then
-          ac_krb5_config="$ac_cv_path_krb5_config"
-        fi
-      else
+        AS_IF([test "x$ac_cv_path_krb5_config" != "xno"],[ac_krb5_config="$ac_cv_path_krb5_config"])
+      ],[
         ac_krb5_config="$krb5confpath/krb5-config"
-      fi
-    fi
-    if test "x$ac_krb5_config" != "x" && test -x "$ac_krb5_config"; then
+      ])
+    ])
+    AS_IF([test "x$ac_krb5_config" != "x" -a -x "$ac_krb5_config"],[
       # Get libs, etc
       AC_MSG_NOTICE([Use krb5-config to get CXXFLAGS and LIBS])
       LIB_KRB5_CFLAGS="`$ac_krb5_config --cflags krb5 2>/dev/null`"
       LIB_KRB5_LIBS="`$ac_krb5_config --libs krb5 2>/dev/null`"
       LIB_KRB5_CFLAGS="`$ac_krb5_config --cflags gssapi 2>/dev/null` $LIB_KRB5_CFLAGS"
       LIB_KRB5_LIBS="`$ac_krb5_config --libs gssapi 2>/dev/null` $LIB_KRB5_LIBS"
-    else
+    ],[
       ## For some OS pkg-config is broken or unavailable.
       ## Detect libraries the hard way.
 
@@ -1410,20 +1373,18 @@ if test "x$with_mit_krb5" != "xno" -a "x$with_solaris_krb5" != "xyes"; then
         missing_required=yes
       ])
       SQUID_STATE_ROLLBACK([squid_mit_save])
-      if test "x$missing_required" = "xyes"; then
-        LIB_KRB5_LIBS=""
-      fi
-    fi
+      AS_IF([test "x$missing_required" = "xyes"],[LIB_KRB5_LIBS=""])
+    ])
   ])
 
-  if test "x$LIB_KRB5_LIBS" != "x"; then
-    if test "x$with_apple_krb5" = "xyes" ; then
+  AS_IF([test "x$LIB_KRB5_LIBS" != "x"],[
+    AS_IF([test "x$with_apple_krb5" = "xyes"],[
       AC_DEFINE(USE_APPLE_KRB5,1,[Apple Kerberos support is available])
       KRB5_FLAVOUR="Apple"
-    else
+    ],[
       AC_DEFINE(USE_MIT_KRB5,1,[MIT Kerberos support is available])
       KRB5_FLAVOUR="MIT"
-    fi
+    ])
     KRB5LIBS="$LIB_KRB5_PATH $LIB_KRB5_LIBS $KRB5LIBS"
     KRB5INCS="$LIB_KRB5_CFLAGS"
 
@@ -1438,45 +1399,43 @@ if test "x$with_mit_krb5" != "xno" -a "x$with_solaris_krb5" != "xyes"; then
     AC_CHECK_HEADERS(profile.h)
 
     SQUID_CHECK_KRB5_FUNCS
-  fi
-  if test "x$with_mit_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
+  ])
+  AS_IF([test "x$with_mit_krb5" = "xyes" -a "x$KRB5LIBS" = "x"],[
     AC_MSG_ERROR([Required Kerberos library not found])
-  elif test "x$KRB5LIBS" = "x"; then
+  ],[test "x$KRB5LIBS" = "x"],[
     with_mit_krb5=no
     with_apple_krb5=no
-  fi
+  ])
   SQUID_STATE_ROLLBACK([squid_krb5_save])
-fi
+])
 
 # detect Solaris Kerberos dependencies
-if test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
+AS_IF([test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"],[
   SQUID_STATE_SAVE([squid_krb5_save])
   LIBS="$LIBS $LIB_KRB5_PATH"
 
   # no pkg-config for solaris native Kerberos
   # look for krb5-config (unless cross-compiling)
-  if test "$cross_compiling" = "no"; then
-    if test "x$krb5confpath" = "x" ; then
+  AS_IF([test "$cross_compiling" = "no"],[
+    AS_IF([test "x$krb5confpath" = "x"],[
       AC_PATH_PROG(krb5_config,krb5-config,no)
-      if test "x$ac_cv_path_krb5_config" != "xno" ; then
-        ac_krb5_config="$ac_cv_path_krb5_config"
-      fi
-    else
+      AS_IF([test "x$ac_cv_path_krb5_config" != "xno"],[ac_krb5_config="$ac_cv_path_krb5_config"])
+    ],[
       ac_krb5_config="$krb5confpath/krb5-config"
-    fi
-  fi
-  if test "x$ac_krb5_config" != "x" && test -x "$ac_krb5_config"; then
+    ])
+  ])
+  AS_IF([test "x$ac_krb5_config" != "x" -a -x "$ac_krb5_config"],[
     # Get libs, etc
     AC_MSG_NOTICE([Use krb5-config to get CXXFLAGS and LIBS])
     LIB_KRB5_CFLAGS="`$ac_krb5_config --cflags krb5 2>/dev/null`"
     LIB_KRB5_LIBS="`$ac_krb5_config --libs krb5 2>/dev/null`"
     # Solaris 10 Update 11 patches the krb5-config tool to produce stderr messages on stdout.
     SOLARIS_BROKEN_KRB5CONFIG_GSSAPI="`$ac_krb5_config --libs gssapi 2>/dev/null | grep "krb5-config"`"
-    if test "x$SOLARIS_BROKEN_KRB5CONFIG_GSSAPI" = "x"; then
+    AS_IF([test "x$SOLARIS_BROKEN_KRB5CONFIG_GSSAPI" = "x"],[
       LIB_KRB5_CFLAGS="`$ac_krb5_config --cflags gssapi 2>/dev/null` $LIB_KRB5_CFLAGS"
       LIB_KRB5_LIBS="`$ac_krb5_config --libs gssapi 2>/dev/null` $LIB_KRB5_LIBS"
-    fi
-  else
+    ])
+  ],[
     ## For some OS pkg-config is broken or unavailable.
     ## Detect libraries the hard way.
 
@@ -1495,12 +1454,10 @@ if test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
         missing_required=yes
     ])
     SQUID_STATE_ROLLBACK([squid_solaris_save])
-    if test "x$missing_required" = "xyes"; then
-      LIB_KRB5_LIBS=""
-    fi
-  fi
+    AS_IF([test "x$missing_required" = "xyes"],[LIB_KRB5_LIBS=""])
+  ])
 
-  if test "x$LIB_KRB5_LIBS" != "x"; then
+  AS_IF([test "x$LIB_KRB5_LIBS" != "x"],[
     KRB5LIBS="$LIB_KRB5_PATH $LIB_KRB5_LIBS $KRB5LIBS"
     KRB5INCS="$LIB_KRB5_CFLAGS"
     AC_DEFINE(USE_SOLARIS_KRB5,1,[Solaris Kerberos support is available])
@@ -1515,80 +1472,78 @@ if test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
     AC_CHECK_HEADERS(krb5.h com_err.h)
 
     SQUID_CHECK_KRB5_SOLARIS_BROKEN_KRB5_H
-    if test "x$squid_cv_broken_krb5_h" = "xyes"; then
+    AS_IF([test "x$squid_cv_broken_krb5_h" = "xyes"],[
       AC_DEFINE(HAVE_BROKEN_SOLARIS_KRB5_H, 1, [Define to 1 if Solaris krb5.h is broken for C++])
       AC_MSG_WARN([You have a broken Solaris <krb5.h> system include.])
       AC_MSG_WARN([Please see http://bugs.opensolaris.org/bugdatabase/view_bug.do?bug_id=6837512])
       AC_MSG_WARN([If you need Kerberos support you will have to patch])
       AC_MSG_WARN([your system. See contrib/solaris/solaris-krb5-include.patch])
-    fi
+    ])
     SQUID_CHECK_KRB5_FUNCS
-  fi
-  if test "x$with_mit_krb5" = "xyes" -a "x$KRB5LIBS" = "x"; then
+  ])
+  AS_IF([test "x$with_mit_krb5" = "xyes" -a "x$KRB5LIBS" = "x"],[
     # Error only if Solaris flavour was detected while looking for required MIT Kerberos
     AC_MSG_ERROR([Required Kerberos library not found])
-  elif test "x$KRB5LIBS" = "x"; then
+  ],[test "x$KRB5LIBS" = "x"],[
     with_solaris_krb5=no
     with_mit_krb5=no
-  fi
+  ])
   SQUID_STATE_ROLLBACK([squid_krb5_save])
-fi
+])
 
 dnl User may specify Heimdal Kerberos is needed from a non-standard location
 SQUID_AUTO_LIB(heimdal-krb5,[Heimdal Kerberos],[LIB_KRB5])
 AH_TEMPLATE(USE_HEIMDAL_KRB5,[Heimdal Kerberos support is available])
-if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
+AS_IF([test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"],[
   CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
   krb5confpath="$with_heimdal_krb5/bin"
   # find installed libs via pkg-config or krb5-config
   PKG_CHECK_EXISTS(heimdal-krb5, [squid_pc_krb5_name="heimdal-krb5"])
-  if test "x$squid_pc_krb5_name" = "x"; then
+  AS_IF([test "x$squid_pc_krb5_name" = "x"],[
     PKG_CHECK_EXISTS(heimdal-gssapi, [squid_pc_krb5_name="heimdal-gssapi"])
-  fi
-  if test "x$squid_pc_krb5_name" = "x" -a "$cross_compiling" = "no"; then
+  ])
+  AS_IF([test "x$squid_pc_krb5_name" = "x" -a "$cross_compiling" = "no"],[
     # Look for krb5-config (unless cross-compiling)
     AC_PATH_PROG(krb5_config,krb5-config,no,$krb5confpath)
-    if test "x$ac_cv_path_krb5_config" != "xno" ; then
+    AS_IF([test "x$ac_cv_path_krb5_config" != "xno"],[
       krb5confpath="`dirname $ac_cv_path_krb5_config`"
       ac_heimdal="`$ac_cv_path_krb5_config --version 2>/dev/null | grep -c -i heimdal`"
-      if test "x$with_heimdal_krb5" = "xyes" -a $ac_heimdal = 0; then
+      AS_IF([test "x$with_heimdal_krb5" = "xyes" -a $ac_heimdal = 0],[
         AC_MSG_ERROR([Could not find pkg-config or krb5-config for Heimdal Kerberos])
-      fi
-    else
-      if test "x$with_heimdal_krb5" = "xyes"; then
+      ])
+    ],[
+      AS_IF([test "x$with_heimdal_krb5" = "xyes"],[
         AC_MSG_ERROR([Could not find krb5-config in path])
-      else
+      ],[
         AC_MSG_WARN([Could not find krb5-config in path])
         with_heimdal_krb5=no
-      fi
-    fi
-  fi
-fi
-if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
+      ])
+    ])
+  ])
+])
+AS_IF([test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"],[
   SQUID_STATE_SAVE([squid_krb5_save])
   LIBS="$LIBS $LIB_KRB5_PATH"
 
   # auto-detect using pkg-config
   PKG_CHECK_MODULES([LIB_KRB5], $squid_pc_krb5_name,,[
     # look for krb5-config (unless cross-compiling)
-    if test "$cross_compiling" = "no"; then
-      if test "x$krb5confpath" = "x" ; then
+    AS_IF([test "$cross_compiling" = "no"],[
+      AS_IF([test "x$krb5confpath" = "x"],[
         AC_PATH_PROG(krb5_config,krb5-config,no)
-        if test "x$ac_cv_path_krb5_config" != "xno" ; then
-          ac_krb5_config="$ac_cv_path_krb5_config"
-        fi
-      else
+        AS_IF([test "x$ac_cv_path_krb5_config" != "xno"],[ac_krb5_config="$ac_cv_path_krb5_config"])
+      ],[
         ac_krb5_config="$krb5confpath/krb5-config"
-      fi
-    fi
-    if test "x$ac_krb5_config" != "x" -a -x "$ac_krb5_config"; then
+      ])
+    ])
+    AS_IF([test "x$ac_krb5_config" != "x" -a -x "$ac_krb5_config"],[
       # Get libs, etc
       AC_MSG_NOTICE([Use krb5-config to get CXXFLAGS and LIBS])
       LIB_KRB5_CFLAGS="`$ac_krb5_config --cflags krb5 2>/dev/null`"
       LIB_KRB5_LIBS="`$ac_krb5_config --libs krb5 2>/dev/null`"
       LIB_KRB5_CFLAGS="`$ac_krb5_config --cflags gssapi 2>/dev/null` $LIB_KRB5_CFLAGS"
       LIB_KRB5_LIBS="`$ac_krb5_config --libs gssapi 2>/dev/null` $LIB_KRB5_LIBS"
-    else
+    ],[
       ## For some OS pkg-config is broken or unavailable.
       ## Detect libraries the hard way.
       SQUID_STATE_SAVE([squid_heimdal_save])
@@ -1650,12 +1605,10 @@ if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
         missing_required=yes
       ])
       SQUID_STATE_ROLLBACK([squid_heimdal_save])
-      if test "x$missing_required" = "xyes"; then
-        LIB_KRB5_LIBS=""
-      fi
-    fi
+      AS_IF([test "x$missing_required" = "xyes"],[LIB_KRB5_LIBS=""])
+    ])
   ])
-  if test "x$LIB_KRB5_LIBS" != "x"; then
+  AS_IF([test "x$LIB_KRB5_LIBS" != "x"],[
     KRB5LIBS="$LIB_KRB5_PATH $LIB_KRB5_LIBS $KRB5LIBS"
     KRB5INCS="$LIB_KRB5_CFLAGS"
     AC_DEFINE(USE_HEIMDAL_KRB5,1,[Heimdal Kerberos support is available])
@@ -1670,25 +1623,25 @@ if test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"; then
     AC_CHECK_HEADERS(krb5.h com_err.h et/com_err.h)
 
     SQUID_CHECK_KRB5_HEIMDAL_BROKEN_KRB5_H
-    if test "x$squid_cv_broken_heimdal_krb5_h" = "xyes"; then
+    AS_IF([test "x$squid_cv_broken_heimdal_krb5_h" = "xyes"],[
       AC_DEFINE(HAVE_BROKEN_HEIMDAL_KRB5_H, 1, [Define to 1 if Heimdal krb5.h is broken for C++])
-    fi
+    ])
     SQUID_CHECK_KRB5_FUNCS
-  fi
-  if test "x$KRB5LIBS" = "x"; then
-    if test "x$with_heimdal_krb5" = "xyes"; then
+  ])
+  AS_IF([test "x$KRB5LIBS" = "x"],[
+    AS_IF([test "x$with_heimdal_krb5" = "xyes"],[
       AC_MSG_ERROR([Required Heimdal Kerberos library not found])
-    else
+    ],[
       AC_MSG_WARN([Heimdal Kerberos library not found])
-    fi
-  fi
+    ])
+  ])
   SQUID_STATE_ROLLBACK([squid_krb5_save])
-fi
+])
 
 dnl User may specify GNU gss is needed from a non-standard location
 SQUID_AUTO_LIB(gnugss,[GNU gss],[LIB_KRB5])
 AH_TEMPLATE(USE_GNUGSS,[GNU gss support is available])
-if test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"; then
+AS_IF([test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"],[
   CXXFLAGS="$LIB_KRB5_CFLAGS $CXXFLAGS"
   krb5confpath=
   SQUID_STATE_SAVE([squid_krb5_save])
@@ -1705,7 +1658,7 @@ if test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"; then
     ])
   ])
 
-  if test "x$LIB_KRB5_LIBS" != "x"; then
+  AS_IF([test "x$LIB_KRB5_LIBS" != "x"],[
     KRB5LIBS="$LIB_KRB5_PATH $LIB_KRB5_LIBS $KRB5LIBS"
     KRB5INCS="$LIB_KRB5_CFLAGS"
     AC_DEFINE(USE_GNUGSS,1,[GNU Kerberos support is available])
@@ -1726,20 +1679,18 @@ if test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"; then
 
     SQUID_CHECK_WORKING_KRB5
     SQUID_DEFINE_BOOL(HAVE_KRB5,$squid_cv_working_krb5,[KRB5 support])
-  fi
-  if test "x$KRB5LIBS" = "x"; then
-    if test "x$with_gnugss" = "xyes"; then
+  ])
+  AS_IF([test "x$KRB5LIBS" = "x"],[
+    AS_IF([test "x$with_gnugss" = "xyes"],[
       AC_MSG_ERROR([Required GNU GSS Kerberos library not found])
-    else
+    ],[
       AC_MSG_WARN([GNU GSS Kerberos library not found])
-    fi
-  fi
+    ])
+  ])
   SQUID_STATE_ROLLBACK([squid_krb5_save])
-fi
+])
 
-if test "x$KRB5LIBS" != "x"; then
-  with_krb5=yes
-fi
+AS_IF([test "x$KRB5LIBS" != "x"],[with_krb5=yes])
 AC_MSG_NOTICE([$KRB5_FLAVOUR Kerberos library support: ${with_krb5:=no} ${LIB_KRB5_PATH} ${LIB_KRB5_LIBS}])
 AC_SUBST(KRB5INCS)
 AC_SUBST(KRB5LIBS)
@@ -1747,228 +1698,213 @@ AC_SUBST(KRB5LIBS)
 dnl On MinGW OpenLDAP is not available, so LDAP helpers can be linked
 dnl only with Windows LDAP libraries using -lwldap32
 AS_IF([test "$squid_host_os" = "mingw"],[
-    LDAPLIB="-lwldap32"
-    LBERLIB=""
-  ],[
-    AC_CHECK_LIB(ldap, ldap_init, [LDAPLIB="-lldap"])
-    dnl LDAP helpers need to know if -llber is needed or not
-    AC_CHECK_LIB(lber, ber_init, [LBERLIB="-llber"])
-    dnl if no ldap lib found check for mozilla version
-    if test "x$ac_cv_lib_ldap_ldap_init" != x""yes; then
-      oLIBS=$LIBS
-      LIBS="$LIBPTHREADS"
-      AC_CHECK_LIB(ldap60, ldap_init, [LDAPLIB="-lldap60"])
-      LIBS="$LDAPLIB $LIBPTHREADS"
-      AC_CHECK_LIB(prldap60, prldap_init, [LDAPLIB="-lprldap60 $LDAPLIB"])
-      LIBS="$LDAPLIB $LIBPTHREADS"
-      AC_CHECK_LIB(ssldap60, ldapssl_init, [LDAPLIB="-lssldap60 $LDAPLIB"])
-      LIBS=$oLIBS
-    fi
-
-    AC_CHECK_HEADERS(ldap.h lber.h)
-    AC_CHECK_HEADERS(mozldap/ldap.h)
-
-    dnl Check for LDAP_OPT_DEBUG_LEVEL
-    AC_MSG_CHECKING([for LDAP_OPT_DEBUG_LEVEL])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <ldap.h>
-    ]],[[
-      int i=LDAP_OPT_DEBUG_LEVEL
-    ]])],[
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ])
-
-    dnl Check for working ldap
+  LDAPLIB="-lwldap32"
+  LBERLIB=""
+],[
+  AC_CHECK_LIB(ldap, ldap_init, [LDAPLIB="-lldap"])
+  AC_CHECK_LIB(lber, ber_init, [LBERLIB="-llber"])
+  dnl if no ldap lib found check for mozilla version
+  AS_IF([test "x$ac_cv_lib_ldap_ldap_init" != "xyes"],[
     oLIBS=$LIBS
-    LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
-    AC_MSG_CHECKING([for working ldap])
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#     define  LDAP_DEPRECATED 1
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     elif HAVE_MOZLDAP_LDAP_H
-#     include <mozldap/ldap.h>
-#     endif
-      int
-      main(void)
-      {
-          char host[]="";
-          int port;
-
-          ldap_init((const char *)&host, port);
-
-          return 0;
-      }
-    ]])],[
-      AC_DEFINE(HAVE_LDAP, 1, [LDAP support])
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ],[
-       AC_MSG_RESULT(cross-compiler cant tell)
-    ])
+    LIBS="$LIBPTHREADS"
+    AC_CHECK_LIB(ldap60, ldap_init, [LDAPLIB="-lldap60"])
+    LIBS="$LDAPLIB $LIBPTHREADS"
+    AC_CHECK_LIB(prldap60, prldap_init, [LDAPLIB="-lprldap60 $LDAPLIB"])
+    LIBS="$LDAPLIB $LIBPTHREADS"
+    AC_CHECK_LIB(ssldap60, ldapssl_init, [LDAPLIB="-lssldap60 $LDAPLIB"])
     LIBS=$oLIBS
+  ])
 
-    dnl Check for ldap vendor
-    AC_MSG_CHECKING([for OpenLDAP])
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     endif
-#     include <string.h>
-      int
-      main(void)
-      {
-          return strcmp(LDAP_VENDOR_NAME,"OpenLDAP");
-      }
-    ]])],[
-      AC_DEFINE(HAVE_OPENLDAP, 1, [OpenLDAP support])
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ],[
-      AC_MSG_RESULT(cross-compiler cant tell)
-    ])
+  AC_CHECK_HEADERS(ldap.h lber.h)
+  AC_CHECK_HEADERS(mozldap/ldap.h)
 
-    AC_MSG_CHECKING([for Sun LDAP SDK])
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     endif
-#     include <string.h>
-      int
-      main(void)
-      {
-          return strcmp(LDAP_VENDOR_NAME,"Sun Microsystems Inc.");
-      }
-    ]])],[
-      AC_DEFINE(HAVE_SUN_LDAP_SDK, 1, [Sun LDAP SDK support])
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ],[
-      AC_MSG_RESULT(cross-compiler cant tell)
-    ])
-
-    AC_MSG_CHECKING([for Mozilla LDAP SDK])
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     elif HAVE_MOZLDAP_LDAP_H
-#     include <mozldap/ldap.h>
-#     endif
-#     include <string.h>
-      int
-      main(void)
-      {
-          return strcmp(LDAP_VENDOR_NAME,"mozilla.org");
-      }
-    ]])],[
-      AC_DEFINE(HAVE_MOZILLA_LDAP_SDK, 1, [Mozilla LDAP SDK support])
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ],[
-      AC_MSG_RESULT(cross-compiler cant tell)
-    ])
-
-    dnl Check for LDAP_REBINDPROC_CALLBACK
-    AC_MSG_CHECKING([for LDAP_REBINDPROC_CALLBACK])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     elif HAVE_MOZLDAP_LDAP_H
-#     include <mozldap/ldap.h>
-#     endif
-    ]],[[
-      LDAP_REBINDPROC_CALLBACK ldap_rebind;
-    ]])],[
-      AC_DEFINE(HAVE_LDAP_REBINDPROC_CALLBACK,1,[Define to 1 if you have LDAP_REBINDPROC_CALLBACK])
-      AC_MSG_RESULT(yes)
-    ],[
-       AC_MSG_RESULT(no)
-    ])
-
-    dnl Check for LDAP_REBIND_PROC
-    AC_MSG_CHECKING([for LDAP_REBIND_PROC])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     elif HAVE_MOZLDAP_LDAP_H
-#     include <mozldap/ldap.h>
-#     endif
-    ]],[[
-      LDAP_REBIND_PROC ldap_rebind;
-    ]])],[
-      AC_DEFINE(HAVE_LDAP_REBIND_PROC,1,[Define to 1 if you have LDAP_REBIND_PROC])
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ])
-
-    dnl Check for LDAP_REBIND_FUNCTION
-    AC_MSG_CHECKING([for LDAP_REBIND_FUNCTION])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#     define LDAP_REFERRALS
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     elif HAVE_MOZLDAP_LDAP_H
-#     include <mozldap/ldap.h>
-#     endif
-    ]],[[
-      LDAP_REBIND_FUNCTION ldap_rebind;
-    ]])],[
-      AC_DEFINE(HAVE_LDAP_REBIND_FUNCTION,1,[Define to 1 if you have LDAP_REBIND_FUNCTION])
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ])
-
-    dnl Check for LDAP_SCOPE_DEFAULT
-    AC_MSG_CHECKING([for LDAP_SCOPE_DEFAULT])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#     if HAVE_LDAP_H
-#     include <ldap.h>
-#     elif HAVE_MOZLDAP_LDAP_H
-#     include <mozldap/ldap.h>
-#     endif
-    ]],[[
-      int i=LDAP_SCOPE_DEFAULT;
-    ]])],[
-      AC_DEFINE(HAVE_LDAP_SCOPE_DEFAULT,1,[Define to 1 if you have LDAP_SCOPE_DEFAULT])
-      AC_MSG_RESULT(yes)
-    ],[
-      AC_MSG_RESULT(no)
-    ])
-
-    dnl Check for ldap_url_desc.lud_scheme
-    AC_CHECK_MEMBER(struct ldap_url_desc.lud_scheme,[
-      AC_DEFINE(HAVE_LDAP_URL_LUD_SCHEME,1,[Define to 1 if you have LDAPURLDesc.lud_scheme])
-    ],,[
+  AC_MSG_CHECKING([for LDAP_OPT_DEBUG_LEVEL])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <ldap.h>
-    ])
+  ]],[[
+    int i=LDAP_OPT_DEBUG_LEVEL
+  ]])],[
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ])
 
-    dnl Check for ldapssl_client_init
-    AC_CHECK_LIB(ldap,ldapssl_client_init,[
-      AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
-    ],)
+  AC_MSG_CHECKING([for working ldap])
+  oLIBS=$LIBS
+  LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#   define  LDAP_DEPRECATED 1
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   elif HAVE_MOZLDAP_LDAP_H
+#   include <mozldap/ldap.h>
+#   endif
+    int
+    main(void)
+    {
+        char host[]="";
+        int port;
+        ldap_init((const char *)&host, port);
+        return 0;
+    }
+  ]])],[
+    AC_DEFINE(HAVE_LDAP, 1, [LDAP support])
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ],[
+     AC_MSG_RESULT(cross-compiler cant tell)
+  ])
+  LIBS=$oLIBS
 
-    dnl Check for ldap_url_desc2str
-    AC_CHECK_LIB(ldap,ldap_url_desc2str,[
-      AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
-    ],)
+  AC_MSG_CHECKING([for OpenLDAP])
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   endif
+#   include <string.h>
+    int
+    main(void)
+    {
+        return strcmp(LDAP_VENDOR_NAME,"OpenLDAP");
+    }
+  ]])],[
+    AC_DEFINE(HAVE_OPENLDAP, 1, [OpenLDAP support])
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ],[
+    AC_MSG_RESULT(cross-compiler cant tell)
+  ])
 
-    dnl Check for ldap_url_parse
-    AC_CHECK_LIB(ldap,ldap_url_parse,[
-      AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
-    ],)
+  AC_MSG_CHECKING([for Sun LDAP SDK])
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   endif
+#   include <string.h>
+    int
+    main(void)
+    {
+        return strcmp(LDAP_VENDOR_NAME,"Sun Microsystems Inc.");
+    }
+  ]])],[
+    AC_DEFINE(HAVE_SUN_LDAP_SDK, 1, [Sun LDAP SDK support])
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ],[
+    AC_MSG_RESULT(cross-compiler cant tell)
+  ])
 
-    dnl Check for ldap_start_tls_s
-    AC_CHECK_LIB(ldap,ldap_start_tls_s,[
-      AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
-    ],)
+  AC_MSG_CHECKING([for Mozilla LDAP SDK])
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   elif HAVE_MOZLDAP_LDAP_H
+#   include <mozldap/ldap.h>
+#   endif
+#   include <string.h>
+    int
+    main(void)
+    {
+        return strcmp(LDAP_VENDOR_NAME,"mozilla.org");
+    }
+  ]])],[
+    AC_DEFINE(HAVE_MOZILLA_LDAP_SDK, 1, [Mozilla LDAP SDK support])
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ],[
+    AC_MSG_RESULT(cross-compiler cant tell)
+  ])
+
+  AC_MSG_CHECKING([for LDAP_REBINDPROC_CALLBACK])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   elif HAVE_MOZLDAP_LDAP_H
+#   include <mozldap/ldap.h>
+#   endif
+  ]],[[
+    LDAP_REBINDPROC_CALLBACK ldap_rebind;
+  ]])],[
+    AC_DEFINE(HAVE_LDAP_REBINDPROC_CALLBACK,1,[Define to 1 if you have LDAP_REBINDPROC_CALLBACK])
+    AC_MSG_RESULT(yes)
+  ],[
+     AC_MSG_RESULT(no)
+  ])
+
+  AC_MSG_CHECKING([for LDAP_REBIND_PROC])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   elif HAVE_MOZLDAP_LDAP_H
+#   include <mozldap/ldap.h>
+#   endif
+  ]],[[
+    LDAP_REBIND_PROC ldap_rebind;
+  ]])],[
+    AC_DEFINE(HAVE_LDAP_REBIND_PROC,1,[Define to 1 if you have LDAP_REBIND_PROC])
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ])
+
+  AC_MSG_CHECKING([for LDAP_REBIND_FUNCTION])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#   define LDAP_REFERRALS
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   elif HAVE_MOZLDAP_LDAP_H
+#   include <mozldap/ldap.h>
+#   endif
+  ]],[[
+    LDAP_REBIND_FUNCTION ldap_rebind;
+  ]])],[
+    AC_DEFINE(HAVE_LDAP_REBIND_FUNCTION,1,[Define to 1 if you have LDAP_REBIND_FUNCTION])
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ])
+
+  AC_MSG_CHECKING([for LDAP_SCOPE_DEFAULT])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#   if HAVE_LDAP_H
+#   include <ldap.h>
+#   elif HAVE_MOZLDAP_LDAP_H
+#   include <mozldap/ldap.h>
+#   endif
+  ]],[[
+    int i=LDAP_SCOPE_DEFAULT;
+  ]])],[
+    AC_DEFINE(HAVE_LDAP_SCOPE_DEFAULT,1,[Define to 1 if you have LDAP_SCOPE_DEFAULT])
+    AC_MSG_RESULT(yes)
+  ],[
+    AC_MSG_RESULT(no)
+  ])
+
+  AC_CHECK_MEMBER([struct ldap_url_desc.lud_scheme],[
+    AC_DEFINE(HAVE_LDAP_URL_LUD_SCHEME,1,[Define to 1 if you have LDAPURLDesc.lud_scheme])
+  ],,[
+#include <ldap.h>
+  ])
+
+  AC_CHECK_LIB(ldap,ldapssl_client_init,[
+    AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
+  ],)
+
+  AC_CHECK_LIB(ldap,ldap_url_desc2str,[
+    AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
+  ],)
+
+  AC_CHECK_LIB(ldap,ldap_url_parse,[
+    AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
+  ],)
+
+  AC_CHECK_LIB(ldap,ldap_start_tls_s,[
+    AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
+  ],)
 ])
 
 AC_SUBST(LDAPLIB)
@@ -1976,7 +1912,7 @@ AC_SUBST(LBERLIB)
 
 SQUID_AUTO_LIB(systemd,[systemd API for start-up notification],[SYSTEMD])
 AH_TEMPLATE(USE_SYSTEMD,[systemd support is available])
-if test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"; then
+AS_IF([test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"],[
   SQUID_STATE_SAVE(squid_systemd_state)
 
   # User may have provided a custom location for systemd. Otherwise...
@@ -1992,17 +1928,17 @@ if test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"; then
 
   SQUID_STATE_ROLLBACK(squid_systemd_state) #de-pollute LIBS
 
-  if test "x$with_systemd" = "xyes" -a "x$SYSTEMD_LIBS" = "x"; then
+  AS_IF([test "x$with_systemd" = "xyes" -a "x$SYSTEMD_LIBS" = "x"],[
     AC_MSG_ERROR([Required systemd library not found])
-  fi
-  if test "x$SYSTEMD_LIBS" != "x" ; then
+  ])
+  AS_IF([test "x$SYSTEMD_LIBS" != "x"],[
     CXXFLAGS="$SYSTEMD_CFLAGS $CXXFLAGS"
     LDFLAGS="$SYSTEMD_PATH $SYSTEMD_LIBS $LDFLAGS"
     AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
-  else
+  ],[
     with_systemd=no
-  fi
-fi
+  ])
+])
 AC_MSG_NOTICE([systemd library support: ${with_systemd:=auto} ${SYSTEMD_PATH} ${SYSTEMD_LIBS}])
 
 AC_ARG_ENABLE(forw-via-db,
@@ -2032,24 +1968,19 @@ dnl order of these options handling is relevant in case the user
 dnl supplies more than one --enable option. Options handled later
 dnl override those handled earlier for io loop method manual override
 AC_ARG_ENABLE(select,
-  AS_HELP_STRING([--disable-select],[Disable select(2) support.]),
-[
-SQUID_YESNO($enableval,[--disable-select takes no extra argument])
-if test "x$enableval" = "xyes"; then
-  if test "x$squid_host_os" = "xmingw"; then
-    squid_opt_io_loop_engine="select_win32"
-  else
+  AS_HELP_STRING([--disable-select],[Disable select(2) support.]),[
+  SQUID_YESNO($enableval,[--disable-select takes no extra argument])
+  AS_IF([test "x$enableval" = "xyes"],[
     squid_opt_io_loop_engine="select"
-  fi
-fi
+    AS_IF([test "x$squid_host_os" = "xmingw"],[squid_opt_io_loop_engine="select_win32"])
+  ])
 ])
 AC_MSG_NOTICE([enabling select syscall for net I/O: ${enable_select:=auto}])
 
 AC_ARG_ENABLE(poll,
-  AS_HELP_STRING([--disable-poll],[Disable poll(2) support.]),
-[
-SQUID_YESNO($enableval,[--disable-poll takes no extra argument])
-test "x$enableval" = "xyes" && squid_opt_io_loop_engine="poll"
+  AS_HELP_STRING([--disable-poll],[Disable poll(2) support.]),[
+  SQUID_YESNO($enableval,[--disable-poll takes no extra argument])
+  AS_IF(["x$enableval" = "xyes"],[squid_opt_io_loop_engine="poll"])
 ])
 AC_MSG_NOTICE([enabling poll syscall for net I/O: ${enable_poll:=auto}])
 
@@ -2058,23 +1989,23 @@ AC_ARG_ENABLE(kqueue,
                  [Disable kqueue(2) support.]), [
 SQUID_YESNO($enableval,[--enable-kqueue takes no extra argument])
 ])
-if test "x${enable_kqueue:=auto}" != "xno" ; then
+AS_IF([test "x${enable_kqueue:=auto}" != "xno"],[
   AC_CHECK_HEADERS([sys/event.h],[],[
-    if test "x${enable_kqueue}" = "xyes" ; then
+    AS_IF([test "x${enable_kqueue}" = "xyes"],[
       AC_MSG_ERROR([kqueue support requires sys/event.h header file.])
-    fi
+    ])
   ])
   AC_CHECK_FUNCS(kqueue,[],[
-    if test "x${enable_kqueue}" = "xyes" ; then
+    AS_IF([test "x${enable_kqueue}" = "xyes"],[
       AC_MSG_ERROR([kqueue support missing in libc library.])
-    fi
+    ])
   ])
-  if test "x$ac_cv_func_kqueue" = "xyes" -a "x$ac_cv_header_sys_event_h" = "xyes" ; then
+  AS_IF([test "x$ac_cv_func_kqueue" = "xyes" -a "x$ac_cv_header_sys_event_h" = "xyes"],[
     squid_opt_io_loop_engine="kqueue"
-  else
+  ],[
     enable_kqueue="no"
-  fi
-fi
+  ])
+])
 AC_MSG_NOTICE([enabling kqueue for net I/O: ${enable_kqueue:=auto}])
 
 dnl Enable epoll()
@@ -2082,26 +2013,20 @@ AC_ARG_ENABLE(epoll,
   AS_HELP_STRING([--disable-epoll],[Disable Linux epoll(2) support.]),
 [
 SQUID_YESNO($enableval,[--disable-epoll takes no extra argument])
-test "x$enableval" = "xyes" && squid_opt_io_loop_engine="epoll"
+AS_IF([test "x$enableval" = "xyes"],[squid_opt_io_loop_engine="epoll"])
 ])
 AC_MSG_NOTICE([enabling epoll syscall for net I/O: ${enable_epoll:=auto}])
 
 # auto-detect and verify epoll header and library present and working
 # logic mapping and loop method selection are performed later
-if test "x$enable_epoll" != "xno" ; then
-
+AS_IF([test "x$enable_epoll" != "xno"],[
   # check if libs are needed to support epoll
-  # note: this code block seems quite generic. Could it be extracted
-  #   into a squid specific configure function?
   SQUID_STATE_SAVE(squid_epoll_state)
   AC_SEARCH_LIBS(epoll_ctl,[epoll])
-  if test "x$ac_cv_search_epoll_ctl" = "xno" ; then
-    enable_epoll=no #disable. Needed code not found
-  elif test "x$ac_cv_search_epoll_ctl" = "xnone required" ; then
-    EPOLL_LIBS=""
-  else
-    EPOLL_LIBS=$ac_cv_search_epoll_ctl
-  fi
+  AS_IF([test "x$ac_cv_search_epoll_ctl" = "xno"],[enable_epoll=no],
+    [test "x$ac_cv_search_epoll_ctl" = "xnone required"],[EPOLL_LIBS=""],
+    [EPOLL_LIBS=$ac_cv_search_epoll_ctl]
+  )
   AC_SUBST(EPOLL_LIBS)
   SQUID_STATE_ROLLBACK(squid_epoll_state) #de-pollute LIBS
 
@@ -2109,48 +2034,42 @@ if test "x$enable_epoll" != "xno" ; then
   AC_CHECK_HEADERS([sys/epoll.h])
 
   dnl Verify that epoll really works
-  if test "x$ac_cv_search_epoll_ctl" != 'xno' ; then
-    SQUID_CHECK_EPOLL
-  fi
+  AS_IF([test "x$ac_cv_search_epoll_ctl" != "xno"], SQUID_CHECK_EPOLL)
 
-  if test "x$enable_epoll" = "xyes" -a "x$squid_cv_epoll_works" = "xno" ; then
+  AS_IF([test "x$enable_epoll" = "xyes" -a "x$squid_cv_epoll_works" = "xno"],[
     AC_MSG_ERROR([Epoll does not work. Force-enabling it is not going to help.])
-  fi
-fi
+  ])
+])
 
 dnl Enable /dev/poll
 AC_ARG_ENABLE(devpoll,
-  AS_HELP_STRING([--disable-devpoll],[Disable Solaris /dev/poll support.]),
-[
-SQUID_YESNO($enableval,[--disable-devpoll takes no extra argument])
-test "x$enableval" = "xyes" && squid_opt_io_loop_engine="devpoll"
+  AS_HELP_STRING([--disable-devpoll],[Disable Solaris /dev/poll support.]),[
+  SQUID_YESNO($enableval,[--disable-devpoll takes no extra argument])
+  AS_IF([test "x$enableval" = "xyes"],[squid_opt_io_loop_engine="devpoll"])
 ])
 AC_MSG_NOTICE([enabling /dev/poll for net I/O: ${enable_devpoll:=auto}])
 
 ## auto-detect and verify devpoll header and library present and working
-if test "x$enable_devpoll" != "xno"; then
-
+AS_IF([test "x$enable_devpoll" != "xno"],[
   # /dev/poll requires ioctl() and write()
   AC_CHECK_FUNCS(ioctl)
   AC_CHECK_FUNCS(write)
 
   # /dev/poll requires sys/devpoll.h
   AC_CHECK_HEADERS([sys/devpoll.h],,[
-        if test "x$enable_devpoll" = "xyes"; then
-            AC_MSG_ERROR([--enable-devpoll specified but /dev/poll headers not found])
-        fi
-        enable_devpoll=no])
+    AS_IF([test "x$enable_devpoll" = "xyes"],[
+      AC_MSG_ERROR([--enable-devpoll specified but /dev/poll headers not found])
+    ])
+    enable_devpoll=no
+  ])
 
   # Verify that /dev/poll really works
-  if test "x$enable_devpoll" != 'xno' ; then
-    SQUID_CHECK_DEVPOLL
-  fi
+  AS_IF([test "x$enable_devpoll" != "xno"], SQUID_CHECK_DEVPOLL)
 
-  if test "x$enable_devpoll" = "xyes" -a "x$squid_cv_devpoll_works" = "xno" ; then
+  AS_IF([test "x$enable_devpoll" = "xyes" -a "x$squid_cv_devpoll_works" = "xno"],[
     AC_MSG_ERROR([/dev/poll does not work. Force-enabling it is not going to help.])
-  fi
-fi
-
+  ])
+])
 
 AC_ARG_ENABLE(http-violations,
   AS_HELP_STRING([--disable-http-violations],
@@ -2220,36 +2139,34 @@ AC_MSG_NOTICE([Linux Netfilter support requested: ${enable_linux_netfilter:=auto
 dnl Look for libnetfilter_conntrack options (needed for QOS netfilter marking)
 SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[LIBNETFILTER_CONNTRACK])
 AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_conntrack:=auto}])
-if test "x$with_netfilter_conntrack" != "xno"; then
-    LDFLAGS="$LIBNETFILTER_CONNTRACK_PATH $LDFLAGS"
-    CPPFLAGS="$LIBNETFILTER_CONNTRACK_CFLAGS $CPPFLAGS"
-    AC_SEARCH_LIBS([nfct_query], [netfilter_conntrack],,[
-        if test x"$with_netfilter_conntrack" = "xyes"; then
-            AC_MSG_ERROR([--with-netfilter-conntrack specified but libnetfilter-conntrack library not found])
-        fi
-        with_netfilter_conntrack=no])
-    AC_CHECK_HEADERS([libnetfilter_conntrack/libnetfilter_conntrack.h \
-        libnetfilter_conntrack/libnetfilter_conntrack_tcp.h],,[
-        if test x"$with_netfilter_conntrack" = "xyes"; then
-            AC_MSG_ERROR([--with-netfilter-conntrack specified but libnetfilter-conntrack headers not found])
-        fi
-        with_netfilter_conntrack=no])
-  # If nothing is broken; enable the libraries usage.
-  if test "x$with_netfilter_conntrack" != "xno"; then
-    with_netfilter_conntrack=yes
-  fi
-fi
-
+AS_IF([test "x$with_netfilter_conntrack" != "xno"],[
+  LDFLAGS="$LIBNETFILTER_CONNTRACK_PATH $LDFLAGS"
+  CPPFLAGS="$LIBNETFILTER_CONNTRACK_CFLAGS $CPPFLAGS"
+  AC_SEARCH_LIBS([nfct_query], [netfilter_conntrack],,[
+    AS_IF([test "x$with_netfilter_conntrack" = "xyes"],[
+      AC_MSG_ERROR([--with-netfilter-conntrack specified but libnetfilter-conntrack library not found])
+    ])
+    with_netfilter_conntrack=no
+  ])
+  AC_CHECK_HEADERS([ \
+    libnetfilter_conntrack/libnetfilter_conntrack.h \
+    libnetfilter_conntrack/libnetfilter_conntrack_tcp.h
+  ],,[
+    AS_IF([test "x$with_netfilter_conntrack" = "xyes"],[
+      AC_MSG_ERROR([--with-netfilter-conntrack specified but libnetfilter-conntrack headers not found])
+    ])
+    with_netfilter_conntrack=no
+  ])
+  AS_IF([test "x$with_netfilter_conntrack" != "xno"],[with_netfilter_conntrack=yes])
+])
 
 dnl Enable Large file support
 buildmodel=""
-squid_opt_enable_large_files=no
 
 AC_ARG_WITH(large-files,
   AS_HELP_STRING([--with-large-files],[Enable support for large files (logs etc).]), [
-  if test "x$withval" = "xyes"; then
-    squid_opt_enable_large_files=yes
-  fi
+  SQUID_YESNO($withval,[--with-large-files does not take a parameter])
+  squid_opt_enable_large_files=$withval
 ])
 
 dnl UNIX Build environment
@@ -2275,43 +2192,41 @@ AC_ARG_WITH(build-environment,
 #hack. Let's early-detect sizeof(long)
 AC_CHECK_SIZEOF(long)
 
-if test "x$squid_opt_enable_large_files" = "xyes" -a "x$buildmodel" = "x"; then
+AS_IF([test "x$squid_opt_enable_large_files" = "xyes" -a "x$buildmodel" = "x"],[
   for model in POSIX_V6_LPBIG_OFFBIG XBS5_LPBIG_OFFBIG POSIX_V6_LP64_OFF64 XBS5_LP64_OFF64 POSIX_V6_ILP32_OFFBIG XBS5_ILP32_OFFBIG; do
-    if test "`getconf _$model 2>/dev/null || true`" = 1 || test "`getconf $model 2>/dev/null || true`" ; then
+    AS_IF([test "`getconf _$model 2>/dev/null || true`" = 1 -o "`getconf $model 2>/dev/null || true`"],[
       buildmodel=$model
       break
-    fi
+    ])
   done
-  if test "x$buildmodel" = "x"; then
+  AS_IF([test "x$buildmodel" = "x"],[
     AC_MSG_WARN([No suitable build environment found for large files. Trying to use _FILE_OFFSET_BITS=64])
-  fi
-fi
-if test "x$buildmodel" = "xdefault" -o "x$buildmodel" = "x"; then
+  ])
+])
+AS_IF([test "x$buildmodel" = "xdefault" -o "x$buildmodel" = "x"],[
   # define _FILE_OFFSET_BITS if requested and needed
-  if test "x$squid_opt_enable_large_files" = "xyes" -a $ac_cv_sizeof_long -le 4 ; then
+  AS_IF([test "x$squid_opt_enable_large_files" = "xyes" -a $ac_cv_sizeof_long -le 4],[
     AC_MSG_NOTICE([Enabling -D_FILE_OFFSET_BITS=64])
     CFLAGS="-D_FILE_OFFSET_BITS=64 $CFLAGS"
     CXXFLAGS="-D_FILE_OFFSET_BITS=64 $CXXFLAGS"
-  fi
-else
+  ])
+],[
   AC_MSG_NOTICE([Using $buildmodel build environment])
-  if test "`getconf _$buildmodel 2>/dev/null || true`" = 1 || test "`getconf $buildmodel 2>/dev/null || true`" ; then
-    : # All fine
-  else
-    AC_MSG_ERROR(Build environment $buildmodel not known to getconf.)
-  fi
+  AS_IF([ ! test "`getconf _$buildmodel 2>/dev/null || true`" = 1 -o "`getconf $buildmodel 2>/dev/null || true`"],[
+    AC_MSG_ERROR([Build environment $buildmodel not known to getconf.])
+  ])
   CFLAGS="`getconf ${buildmodel}_CFLAGS` $CFLAGS"
   CXXFLAGS="`getconf ${buildmodel}_CFLAGS` $CXXFLAGS"
   LIBS="`getconf ${buildmodel}_LIBS` $LIBS"
   LDFLAGS="`getconf ${buildmodel}_LDFLAGS` $LDFLAGS"
-  if test "x$squid_host_os" = "xsolaris" ; then
 
+  AS_IF([test "x$squid_host_os" = "xsolaris"],[
 # On Solaris getconf returns for CFLAGS -xarch=generic64, -Xa and -Usun options, and
 # for LDFLAGS -xarch=generic64, but:
 #   "-Xa" is supported only by Sun cc, so we need to remove it when using gcc
 #   For gcc "-xarch=generic64" must be replaced with "-m64"
 #   The 'sun' define is needed by ipfilter includes, so we must remove "-Usun"
-    if test "x$GCC" = "xyes"; then
+    AS_IF([test "x$GCC" = "xyes"],[
       AC_MSG_NOTICE([Removing -Xa for gcc/g++ on $host])
       CFLAGS="`echo $CFLAGS | sed -e 's/-Xa//'`"
       CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-Xa//'`"
@@ -2319,12 +2234,12 @@ else
       CFLAGS="`echo $CFLAGS | sed -e 's/-xarch=generic64/-m64/'`"
       CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-xarch=generic64/-m64/'`"
       LDFLAGS="`echo $LDFLAGS | sed -e 's/-xarch=generic64//'`"
-    fi
+    ])
     AC_MSG_NOTICE([Removing -Usun on $host])
     CFLAGS="`echo $CFLAGS | sed -e 's/-Usun//'`"
     CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-Usun//'`"
-  fi
-fi
+  ])
+])
 
 AC_ARG_ENABLE(follow-x-forwarded-for,
   AS_HELP_STRING([--disable-follow-x-forwarded-for],
@@ -2352,14 +2267,15 @@ AC_ARG_ENABLE(default-hostsfile,
   AS_HELP_STRING([--enable-default-hostsfile=path],
                  [Select default location for hosts file.
                   See hosts_file directive in squid.conf for details]), [
-if test "x$enableval" != "xnone" -a "x$enableval" != "xno" ; then
-  if test \! -f "$enableval"; then
-    AC_MSG_WARN([Unable to find file $enableval. I hope you know what you are doing.])
-  fi
-  squid_opt_default_hosts=$enableval
-else
-  squid_opt_default_hosts="none"
-fi
+  # TODO: handle the "yes" case cleanly
+  AS_CASE(["$enableval"],
+    [no|none],[squid_opt_default_hosts="none"],
+    [
+      squid_opt_default_hosts=$enableval
+      AS_IF([ ! test -f "$enableval"],[
+        AC_MSG_WARN([Unable to find file $enableval. I hope you know what you are doing.])
+      ])
+    ])
 ])
 AC_MSG_NOTICE([Default hosts file set to: ${squid_opt_default_hosts:=/etc/hosts}])
 DEFAULT_HOSTS=$squid_opt_default_hosts
@@ -2513,13 +2429,12 @@ AC_ARG_WITH(valgrind-debug,
   AS_HELP_STRING([--with-valgrind-debug],
                  [Include debug instrumentation for use with valgrind]),
 [
-  SQUID_YESNO([$withval],
-            [unrecognized argument to --with-valgrind-debug: $withval])
-  if test "x$withval" != "xno" ; then
+  SQUID_YESNO([$withval],[unrecognized argument to --with-valgrind-debug: $withval])
+  AS_IF([test "x$withval" != "xno"],[
     AC_CHECK_HEADERS(valgrind/memcheck.h,[],[
       AC_MSG_ERROR([Valgrind support requested, needed headers not found.])
     ])
-  fi
+  ])
 ])
 SQUID_DEFINE_BOOL(WITH_VALGRIND,${with_valgrind_debug:=no},
                   [Valgrind memory debugger support])
@@ -2838,7 +2753,7 @@ AC_FUNC_ALLOCA
 
 # TODO: remove this 'lib' prefix to match coding standard
 SQUID_AUTO_LIB(libcap,[Linux capabilities],[LIBCAP])
-if test "x$with_libcap" != "xno"; then
+AS_IF([test "x$with_libcap" != "xno"],[
   CXXFLAGS="$LIBCAP_CFLAGS $CXXFLAGS"
   LDFLAGS="$LIBCAP_PATH $LDFLAGS"
   # cap_clear_flag is the most recent libcap function we require
@@ -2847,21 +2762,19 @@ if test "x$with_libcap" != "xno"; then
   SQUID_CHECK_FUNCTIONAL_LIBCAP2
 
   # if it can't be supported..
-  if test "x$ac_cv_header_sys_capability_h" = "xno" -o \
-     "x$ac_cv_lib_cap_cap_clear_flag" = "xno"; then
+  AS_IF([test "x$ac_cv_header_sys_capability_h" = "xno" -o \
+     "x$ac_cv_lib_cap_cap_clear_flag" = "xno"],[
     # and it was forced on: error
-    if test "x$with_libcap" = "xyes" ; then
+    AS_IF([test "x$with_libcap" = "xyes"],[
       AC_MSG_ERROR([libcap forced enabled but not available or not usable, requires libcap-2.09 or later])
-    else
-      # with_libcap is "auto"; it can't be supported. Disable.
+    ],[
+      # or it can't be supported: disable
       with_libcap=no
-    fi
-  else
-    # header and lib are ok, we support
+    ])
+  ],[
     with_libcap=yes
-  fi
-
-fi
+  ])
+])
 
 SQUID_DEFINE_BOOL(USE_LIBCAP,$with_libcap,
    [use libcap to set capabilities required for TPROXY])
@@ -2879,7 +2792,7 @@ AC_SEARCH_LIBS([bind],[socket])
 AC_SEARCH_LIBS([opcom_stack_trace],[opcom_stack])
 AC_SEARCH_LIBS([yp_match], [nsl nss_nis nss_nisplus])
 dnl Check for Winsock only on MinGW, on Cygwin we must use emulated BSD socket API
-if test "x$squid_host_os" = "xmingw" ; then
+AS_IF([test "x$squid_host_os" = "xmingw"],[
   SQUID_CHECK_WINSOCK_LIB
   AC_CHECK_HEADERS( \
     windows.h \
@@ -2894,25 +2807,25 @@ if test "x$squid_host_os" = "xmingw" ; then
 #if HAVE_WS2TCPIP_H
 #include <ws2tcpip.h>
 #endif
+  ])
 ])
-fi
 
 # check that we have unix sockets
 SQUID_CHECK_UNIX_SOCKET
 SQUID_DEFINE_BOOL(HAVE_UNIXSOCKET,$squid_cv_unixsocket,[System supports unix sockets])
 
 AC_CHECK_LIB(gnumalloc, malloc)
-if test "x$ac_cv_lib_gnumalloc_malloc" = "xyes"; then
+AS_IF([test "x$ac_cv_lib_gnumalloc_malloc" = "xyes"],[
   AC_MSG_NOTICE([Disabling extended malloc functions when using bundled gnumalloc])
   ac_cv_func_mallocblksize=no
   ac_cv_func_mallopt=no
-else
+],[
   AS_CASE(["$squid_host_os"],
     [solaris],[AC_MSG_NOTICE([skipping libmalloc check for $host])],
     [freebsd],[AC_MSG_NOTICE([skipping libmalloc check for $host])],
     [AC_CHECK_LIB(malloc, main)]
   )
-fi
+])
 
 AS_IF([test "$squid_host_os" = "mingw"],[
   AC_MSG_NOTICE([Use MSVCRT for math functions.])
@@ -2959,9 +2872,7 @@ SQUID_YESNO([$enableval],[unrecognized argument to --disable-ipv6: $enableval])
 AC_MSG_RESULT(${enable_ipv6:=yes})
 SQUID_DEFINE_BOOL(USE_IPV6,$enable_ipv6,[Enable support for IPv6 ])
 
-if test "x$enable_ipv6" = "xyes" ; then
-  SQUID_CHECK_SIN6_LEN_IN_SAI
-fi
+AS_IF([test "x$enable_ipv6" = "xyes"],[SQUID_CHECK_SIN6_LEN_IN_SAI])
 SQUID_CHECK_SS_LEN_IN_SOCKADDR_STORAGE
 SQUID_CHECK_SIN_LEN_IN_SOCKADDR_IN
 
@@ -2976,10 +2887,10 @@ AS_CASE(["$host"],
   ],
 
   [i386-*-solaris2.*],[
-    if test "x$GCC" = "xyes"; then
+    AS_IF([test "x$GCC" = "xyes"],[
       AC_MSG_NOTICE([Removing -O for gcc on $host])
       CFLAGS="`echo $CFLAGS | sed -e 's/-O[[0-9g]]*//'`"
-    fi
+    ])
   ],
 
   [*-sgi-irix*],[
@@ -3007,17 +2918,17 @@ Foo * myFoo=new Bar();
 Bar * myBar=dynamic_cast<Bar *>(myFoo);
 assert(myBar != NULL);
       ]])
-    if test "$ac_cv_require_rtti" = "yes"; then
+    AS_IF([test "$ac_cv_require_rtti" = "yes"],[
       SQUID_CFLAGS="-rtti $SQUID_CFLAGS"
       SQUID_CXXFLAGS="-rtti $SQUID_CXXFLAGS"
-    fi
+    ])
 
     AC_LANG_PUSH([C])
     SQUID_CC_REQUIRE_ARGUMENT([ac_cv_require_qcpluscmt],[-qcpluscmt],[[]],[[//c++ cmt]])
     AC_LANG_POP([C])
-    if test "$ac_cv_require_qcpluscmt" = "yes"; then
+    AS_IF([test "$ac_cv_require_qcpluscmt" = "yes"],[
       SQUID_CFLAGS="-qcpluscmt $SQUID_CFLAGS"
-    fi
+    ])
   ],
 
   [*-*-solaris2.[[0-4]]],[AC_DEFINE(GETTIMEOFDAY_NO_TZP,1)],
@@ -3028,7 +2939,7 @@ assert(myBar != NULL);
 dnl This has to be before AC_CHECK_FUNCS
 # Disable poll() on certain platforms. Override by setting ac_cv_func_poll
 # when running configure.
-if test "x$ac_cv_func_poll" = "x" ; then
+AS_IF([test "x$ac_cv_func_poll" = "x"],[
   AS_CASE(["$host"],
     [*-hp-hpux*.*],[
       # Duane Wessels
@@ -3041,10 +2952,10 @@ if test "x$ac_cv_func_poll" = "x" ; then
       # poll is problematic on Linux.  We disable it
       # by default until Linux gets it right.
       rev=`uname -r | awk -F. '{printf "%03d%03d",$1,$2}'`
-      if test $rev -lt 002002; then
+      AS_IF([test $rev -lt 002002],[
           AC_MSG_NOTICE([disabling poll for $host < 2.2...])
           ac_cv_func_poll='no'
-      fi
+      ])
     ],
 
     [powerpc-ibm-aix4.1.*],[
@@ -3053,7 +2964,7 @@ if test "x$ac_cv_func_poll" = "x" ; then
       ac_cv_func_poll='no'
     ]
   )
-fi
+])
 
 dnl Check for library functions
 AC_CHECK_FUNCS(\
@@ -3149,25 +3060,26 @@ AC_CHECK_DECLS([getaddrinfo,getnameinfo,inet_ntop,inet_pton,InetNtopA,InetPtonA]
 # are actually going to (ab)use.
 # Mostly ripped from squid-commloops, thanks to adrian and benno
 
-if test "x$squid_opt_io_loop_engine" != "x"; then
-	AC_MSG_NOTICE([choosing user-specified net I/O API $squid_opt_io_loop_engine])
-elif test "x$enable_epoll" != "xno" -a "x$squid_cv_epoll_works" = "xyes" ; then
-  squid_opt_io_loop_engine="epoll"
-elif test "x$enable_kqueue" != "xno" ; then
-  squid_opt_io_loop_engine="kqueue"
-elif test "x$enable_devpoll" != "xno" ; then
-  squid_opt_io_loop_engine="devpoll"
-elif test "x$enable_poll" != "xno" -a "x$ac_cv_func_poll" = "xyes" ; then
-  squid_opt_io_loop_engine="poll"
-elif test "x$enable_select" != "xno" -a "x$ac_cv_func_select" = "xyes"; then
-  squid_opt_io_loop_engine="select"
-elif test "x$enable_select" != "xno" -a "x$squid_host_os" = "xmingw"; then
-  squid_opt_io_loop_engine="select_win32"
-else
-  AC_MSG_WARN([Eep!  Cannot find epoll, kqueue, /dev/poll, poll or select!])
-  AC_MSG_WARN([Will try select and hope for the best.])
-  squid_opt_io_loop_engine="select"
-fi
+AS_IF([test "x$squid_opt_io_loop_engine" != "x"],
+  AC_MSG_NOTICE([choosing user-specified net I/O API $squid_opt_io_loop_engine]),
+  [test "x$enable_epoll" != "xno" -a "x$squid_cv_epoll_works" = "xyes"],
+  squid_opt_io_loop_engine="epoll",
+  [test "x$enable_kqueue" != "xno"],
+  squid_opt_io_loop_engine="kqueue",
+  [test "x$enable_devpoll" != "xno"],
+  squid_opt_io_loop_engine="devpoll",
+  [test "x$enable_poll" != "xno" -a "x$ac_cv_func_poll" = "xyes"],
+  squid_opt_io_loop_engine="poll",
+  [test "x$enable_select" != "xno" -a "x$ac_cv_func_select" = "xyes"],
+  squid_opt_io_loop_engine="select",
+  [test "x$enable_select" != "xno" -a "x$squid_host_os" = "xmingw"],
+  squid_opt_io_loop_engine="select_win32",
+  [
+    AC_MSG_WARN([Eep!  Cannot find epoll, kqueue, /dev/poll, poll or select!])
+    AC_MSG_WARN([Will try select and hope for the best.])
+    squid_opt_io_loop_engine="select"
+  ]
+)
 
 AC_MSG_NOTICE([Using ${squid_opt_io_loop_engine} for the IO loop.])
 
@@ -3187,14 +3099,14 @@ AS_CASE([$squid_opt_io_loop_engine],
   [select],[AC_DEFINE(USE_SELECT,1,[Use select() for the IO loop])],
 )
 
-if test "x$ac_cv_func_sched_getaffinity" = "xyes" -a "x$ac_cv_func_sched_setaffinity" = "xyes" ; then
+AS_IF([test "x$ac_cv_func_sched_getaffinity" = "xyes" -a "x$ac_cv_func_sched_setaffinity" = "xyes"],[
   AC_DEFINE(HAVE_CPU_AFFINITY,1,[Support setting CPU affinity for workers])
-fi
+])
 
 SQUID_CHECK_SETRESUID_WORKS
-if test "x$squid_cv_resuid_works" = "xyes" ; then
+AS_IF([test "x$squid_cv_resuid_works" = "xyes"],[
   AC_DEFINE(HAVE_SETRESUID,1,[Yay! Another Linux brokenness. Knowing that setresuid() exists is not enough, because RedHat 5.0 declares setresuid() but does not implement it.])
-fi
+])
 
 AC_CHECK_HEADERS(mswsock.h)
 AC_MSG_CHECKING([for constant CMSG_SPACE])
@@ -3266,90 +3178,82 @@ SQUID_CHECK_FUNC_STRNSTR
 
 dnl IP-Filter support requires ipf header files. These aren't
 dnl installed by default, so we need to check for them
-if test "x$enable_ipf_transparent" != "xno" ; then
-    SQUID_CHECK_BROKEN_SOLARIS_IPFILTER
-    AC_MSG_CHECKING(for availability of IP-Filter header files)
-    # hold on to your hats...
-    if test "x$ac_cv_header_ip_compat_h" = "xyes" -o \
-        "x$ac_cv_header_ip_fil_compat_h" = "xyes" -o \
-        "x$ac_cv_header_netinet_ip_compat_h" = "xyes" -o \
-        "x$ac_cv_header_netinet_ip_fil_compat_h" = "xyes" ; then
-        have_ipfilter_compat_header="yes"
-    fi
-    if test "x$have_ipfilter_compat_header" = "xyes" -a \
-       "x$ac_cv_header_ip_fil_h" = "xyes" -a \
-       "x$ac_cv_header_ip_nat_h" = "xyes" ; then
-        enable_ipf_transparent="yes"
-    elif test "x$have_ipfilter_compat_header" = "xyes" -a \
-         "x$ac_cv_header_netinet_ip_fil_h" = "xyes" -a \
-         "x$ac_cv_header_netinet_ip_nat_h" = "xyes" ; then
-        enable_ipf_transparent="yes"
-    else
-        enable_ipf_transparent="no"
-    fi
-    AC_MSG_RESULT($IPF_TRANSPARENT)
+AS_IF([test "x$enable_ipf_transparent" != "xno"],[
+  SQUID_CHECK_BROKEN_SOLARIS_IPFILTER
+  AC_MSG_CHECKING(for availability of IP-Filter header files)
+  # hold on to your hats...
+  AS_IF([test "x$ac_cv_header_ip_compat_h" = "xyes" -o \
+    "x$ac_cv_header_ip_fil_compat_h" = "xyes" -o \
+    "x$ac_cv_header_netinet_ip_compat_h" = "xyes" -o \
+    "x$ac_cv_header_netinet_ip_fil_compat_h" = "xyes"
+  ],[have_ipfilter_compat_header="yes"])
+
+  AS_IF([test "x$have_ipfilter_compat_header" = "xyes" -a \
+    "x$ac_cv_header_ip_fil_h" = "xyes" -a \
+    "x$ac_cv_header_ip_nat_h" = "xyes"
+  ],[enable_ipf_transparent="yes"],
+  [test "x$have_ipfilter_compat_header" = "xyes" -a \
+    "x$ac_cv_header_netinet_ip_fil_h" = "xyes" -a \
+    "x$ac_cv_header_netinet_ip_nat_h" = "xyes"
+  ],[enable_ipf_transparent="yes"],[enable_ipf_transparent="no"])
+  AC_MSG_RESULT($IPF_TRANSPARENT)
 
 ## On Solaris Ipfilter includes expect that SOLARIS2 is defined with the
 ## Solaris minor version (8, 9, 10, ...)
-  if test "x$enable_ipf_transparent" = "xyes" -a "x$squid_host_os" = "xsolaris" ; then
+  AS_IF([test "x$enable_ipf_transparent" = "xyes" -a "x$squid_host_os" = "xsolaris"],[
     solrev=`uname -r | sh -c 'IFS=. read j n x; echo $n'`
     CFLAGS="-DSOLARIS2=$solrev $CFLAGS"
     CXXFLAGS="-DSOLARIS2=$solrev $CXXFLAGS"
-  fi
-
-fi
+  ])
+])
 AC_MSG_NOTICE([IPF-based transparent proxying enabled: $enable_ipf_transparent])
 SQUID_DEFINE_BOOL(IPF_TRANSPARENT,$enable_ipf_transparent,
     [Enable support for IPF-style transparent proxying])
 
 dnl PF /dev/pf support requires a header file.
-if test "x$with_nat_devpf" != "xno" ; then
-  if test "x$ac_cv_header_net_pfvar_h" = "xyes" -o \
-    "x$ac_cv_header_net_pf_pfvar_h" = "xyes"; then
-    if test "x$with_nat_devpf" = "xauto" ; then
-      with_nat_devpf="no"
-    fi
-  else
-    if test "x$with_nat_devpf" = "xyes" ; then
+AS_IF([test "x$with_nat_devpf" != "xno"],[
+  AS_IF([test "x$ac_cv_header_net_pfvar_h" = "xyes" -o \
+    "x$ac_cv_header_net_pf_pfvar_h" = "xyes"],[
+    AS_IF([test "x$with_nat_devpf" = "xauto"],[with_nat_devpf="no"])
+  ],[
+    AS_IF([test "x$with_nat_devpf" = "xyes"],[
       AC_MSG_ERROR([PF /dev/pf based NAT requested but needed header not found])
-    fi
+    ])
     with_nat_devpf="no"
-  fi
-fi
+  ])
+])
 SQUID_DEFINE_BOOL(PF_TRANSPARENT,${enable_pf_transparent:=no},
   [Enable support for PF-style transparent proxying])
 SQUID_DEFINE_BOOL(USE_NAT_DEVPF,${with_nat_devpf:=no},
   [Enable support for /dev/pf NAT lookups])
 
-if test "x$enable_linux_netfilter" != "xno" ; then
-  if test "x$ac_cv_header_linux_netfilter_ipv4_h" = "xyes"; then
-    if test "x$enable_linux_netfilter" = "xauto" ; then
-      enable_linux_netfilter=yes
-    fi
-  else
-    if test "x$enable_linux_netfilter" = "xauto" ; then
+AS_IF([test "x$enable_linux_netfilter" != "xno"],[
+  AS_IF([test "x$ac_cv_header_linux_netfilter_ipv4_h" = "xyes"],[
+    AS_IF([test "x$enable_linux_netfilter" = "xauto"],[enable_linux_netfilter=yes])
+  ],[
+    AS_IF([test "x$enable_linux_netfilter" = "xauto"],[
       enable_linux_netfilter=no
-    else
+    ],[
       AC_MSG_ERROR([Linux Netfilter support requested but needed headers not found])
-    fi
-  fi
-fi
+    ])
+  ])
+])
 SQUID_DEFINE_BOOL(LINUX_NETFILTER,$enable_linux_netfilter,
   [Enable support for Transparent Proxy on Linux via Netfilter])
 
 dnl Netfilter TPROXY depends on libcap but the NAT parts can still work.
 AC_MSG_NOTICE([Support for Netfilter-based interception proxy requested: $enable_linux_netfilter])
-if test "x$enable_linux_netfilter" = "xyes" -a "x$with_libcap" != "xyes" ; then
-    AC_MSG_WARN([Missing needed capabilities (libcap 2.09+) for TPROXY])
-    AC_MSG_WARN([Linux Transparent Proxy (version 4+) support WILL NOT be enabled])
-    AC_MSG_WARN([Reduced support to NAT Interception Proxy])
-    # AC_DEFINEd later
-fi
-if test "x$with_netfilter_conntrack" = "xyes" -a "x$with_libcap" != "xyes" ; then
-    AC_MSG_WARN([Missing needed capabilities (libcap 2.09+) for netfilter mark support])
-    AC_MSG_WARN([Linux netfilter marking support WILL NOT be enabled])
-    with_netfilter_conntrack=no
-fi
+AS_IF([test "x$enable_linux_netfilter" = "xyes" -a "x$with_libcap" != "xyes"],[
+  AC_MSG_WARN([Missing needed capabilities (libcap 2.09+) for TPROXY])
+  AC_MSG_WARN([Linux Transparent Proxy (version 4+) support WILL NOT be enabled])
+  AC_MSG_WARN([Reduced support to NAT Interception Proxy])
+  # AC_DEFINEd later
+])
+AS_IF([test "x$with_netfilter_conntrack" = "xyes" -a "x$with_libcap" != "xyes"],[
+  AC_MSG_WARN([Missing needed capabilities (libcap 2.09+) for netfilter mark support])
+  AC_MSG_WARN([Linux netfilter marking support WILL NOT be enabled])
+  with_netfilter_conntrack=no
+])
 AC_MSG_NOTICE([Linux Netfilter Conntrack support enabled: ${with_netfilter_conntrack}])
 
 
@@ -3362,12 +3266,11 @@ SQUID_DEFINE_BOOL(USE_QOS_TOS,${enable_zph_qos:=yes},
           [Enable Zero Penalty Hit QOS. When set, Squid will alter the
            TOS field of HIT responses to help policing network traffic])
 AC_MSG_NOTICE([ZPH QOS enabled: $enable_zph_qos])
-if test x"$enable_zph_qos" = "xyes" ; then
-        AC_MSG_NOTICE([QOS netfilter mark preservation enabled: $with_netfilter_conntrack])
-        SQUID_DEFINE_BOOL(USE_LIBNETFILTERCONNTRACK,${with_netfilter_conntrack:=no},
-                      [Enable support for QOS netfilter mark preservation])
-fi
-
+AS_IF(test x"$enable_zph_qos" = "xyes"],[
+  AC_MSG_NOTICE([QOS netfilter mark preservation enabled: $with_netfilter_conntrack])
+  SQUID_DEFINE_BOOL(USE_LIBNETFILTERCONNTRACK,${with_netfilter_conntrack:=no},
+    [Enable support for QOS netfilter mark preservation])
+])
 
 AC_CHECK_LIB(regex, regexec, [REGEXLIB="-lregex"],[REGEXLIB=''])
 AC_ARG_ENABLE(gnuregex,
@@ -3380,31 +3283,25 @@ AC_ARG_ENABLE(gnuregex,
 SQUID_YESNO([$enableval],[unrecognized argument to --enable-gnuregex: $enableval])
 ])
 # force-enable on old solaris
-if test "x${enable_gnuregex:=auto}" = "xauto" ; then
+AS_IF([test "x${enable_gnuregex:=auto}" = "xauto"],[
   AS_CASE(["$host"],
     [*-sun-solaris2.[[0-4]]],[enable_gnuregex="yes"]
   )
-fi
+])
 
 # try detecting if it is needed
-if test "x$enable_gnuregex" = "xauto" ; then
+AS_IF([test "x$enable_gnuregex" = "xauto"],[
   SQUID_CHECK_REGEX_WORKS
-  if test "x$squid_cv_regex_works" = "xyes" ; then
-    enable_gnuregex=no
-  else
-    enable_gnuregex=yes
-  fi
-fi
+  AS_IF([test "x$squid_cv_regex_works" = "xyes"],[enable_gnuregex=no],[enable_gnuregex=yes])
+])
 AC_MSG_CHECKING(if GNUregex needs to be compiled)
 AC_MSG_RESULT($enable_gnuregex)
-if test "x$enable_gnuregex" = "xyes"; then
+AS_IF([test "x$enable_gnuregex" = "xyes"],[
   # for some reason (force-enable, test..) gnuregex was found as needed. Override any system lib
   REGEXLIB=""
-fi
+])
 #if no reason was found to enable gnuregex, disable it
-if test "x$enable_gnuregex" = "xauto" ; then
-  enable_gnuregex=no
-fi
+AS_IF([test "x$enable_gnuregex" = "xauto"],[enable_gnuregex=no])
 SQUID_DEFINE_BOOL(USE_GNUREGEX,$enable_gnuregex,[Define if we should use GNU regex])
 AC_SUBST(REGEXLIB)
 
@@ -3421,14 +3318,12 @@ SQUID_CHECK_LIBRESOLV_DNS_TTL_HACK
 SQUID_CHECK_RESOLVER_FIELDS
 
 AC_CHECK_HEADERS(sys/statvfs.h)
-if test "x$ac_cv_header_sys_statvfs_h" = "xyes" ; then
-  SQUID_CHECK_WORKING_STATVFS
-fi
-if test "x$ac_cv_func_statvfs" != "xyes" ; then
+AS_IF([test "x$ac_cv_header_sys_statvfs_h" = "xyes"],[SQUID_CHECK_WORKING_STATVFS])
+AS_IF([test "x$ac_cv_func_statvfs" != "xyes"],[
   AC_CHECK_HEADERS(sys/param.h sys/mount.h sys/vfs.h sys/statfs.h)
   AC_CHECK_FUNCS(statfs)
   SQUID_CHECK_F_FRSIZE_IN_STATFS
-fi
+])
 
 dnl Squid will not usually attempt to translate templates when building
 AC_ARG_ENABLE(translation,
@@ -3437,13 +3332,13 @@ AC_ARG_ENABLE(translation,
   SQUID_YESNO([$enableval],
      [unrecognized argument to --enable-translation: $enableval])
 ])
-if test "x${enable_translation:=no}" = "xyes" ; then
+AS_IF([test "x${enable_translation:=no}" = "xyes"],[
   AX_WITH_PROG([PO2HTML],[po2html])
   AX_WITH_PROG([PO2TEXT],[po2txt])
-else
+],[
   PO2HTML="off"
   PO2TEXT="off"
-fi
+])
 AC_SUBST(PO2HTML)
 AC_SUBST(PO2TEXT)
 AM_CONDITIONAL(ENABLE_TRANSLATION, test "x${enable_translation:=no}" = "xyes")
@@ -3464,37 +3359,33 @@ SQUID_DEFINE_BOOL(USE_ERR_LOCALES,$enable_auto_locale,
 
 dnl Need the debugging version of malloc if available
 XTRA_OBJS=''
-if test "x$ac_cv_lib_malloc_main" = "xyes" ; then
-	if test -r /usr/lib/debug/malloc.o ; then
-		XTRA_OBJS="$XTRA_OBJS /usr/lib/debug/malloc.o"
-	fi
-	if test -r /usr/lib/debug/mallocmap.o ; then
-		XTRA_OBJS="$XTRA_OBJS /usr/lib/debug/mallocmap.o"
-	fi
-fi
+AS_IF([test "x$ac_cv_lib_malloc_main" = "xyes"],[
+  AS_IF([test -r /usr/lib/debug/malloc.o],[XTRA_OBJS="$XTRA_OBJS /usr/lib/debug/malloc.o"])
+  AS_IF([test -r /usr/lib/debug/mallocmap.o],[XTRA_OBJS="$XTRA_OBJS /usr/lib/debug/mallocmap.o"]);
+])
 AC_SUBST(XTRA_OBJS)
 
-if test "x$XTRA_LIBS" = "x"; then
-	XTRA_LIBS="$LIBS"
-	dnl minor cleanup
-	XTRA_LIBS=`echo $XTRA_LIBS | sed -e "s/  */ /g"`
-	LIBS=''
-fi
+AS_IF([test "x$XTRA_LIBS" = "x"],[
+  XTRA_LIBS="$LIBS"
+  dnl minor cleanup
+  XTRA_LIBS=`echo $XTRA_LIBS | sed -e "s/  */ /g"`
+  LIBS=''
+])
 AC_SUBST(XTRA_LIBS)
 
 AC_SUBST(SQUID_CFLAGS)
 AC_SUBST(SQUID_CXXFLAGS)
 
 AC_ARG_VAR([BUILDCXXFLAGS],[C++ compiler flags for building compile-time tools. e.g. cf_gen])
-if test "x$BUILDCXXFLAGS" = "x"; then
+AS_IF([test "x$BUILDCXXFLAGS" = "x"],[
   # if we are NOT cross-compiling, use the default build flags for cf_gen and friends
   # otherwise rely on the user-provided value
-  if test "x$squid_cv_check_marchnative" = "xyes"; then
+  AS_IF([test "x$squid_cv_check_marchnative" = "xyes"],[
     # always valid for the Build compiler.
     BUILDCXXFLAGS="-march=native"
-  fi
+  ])
   BUILDCXXFLAGS="$BUILDCXXFLAGS $CXXFLAGS"
-fi
+])
 AC_SUBST(BUILDCXXFLAGS)
 
 AC_MSG_NOTICE([BUILD LIBRARIES: $LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -199,30 +199,29 @@ AC_SUBST(CGIEXT)
 AM_CONDITIONAL(ENABLE_WIN32SPECIFIC,[test "x$squid_host_os" = "xmingw"])
 AM_CONDITIONAL(ENABLE_WIN32_IPC,[test "x$squid_host_os" = "xmingw"])
 
-case "$squid_host_os" in
-mingw)
-  AC_PATH_PROG(WIN32_PSAPI, psapi.dll, none)
-  CFLAGS="$CFLAGS -mthreads"
-  CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
-  if test "x$ac_cv_path_WIN32_PSAPI" = "xnone"; then
-    AC_MSG_NOTICE([PSAPI.DLL is recommended to run Squid on Windows NT Platform])
-    AC_MSG_NOTICE([Please see PSAPI.DLL section on doc/win32-relnotes.html.])
-  else
-    AC_DEFINE(HAVE_WIN32_PSAPI,1,[Define if you have PSAPI.DLL on Windows systems])
-    LIBS="$LIBS -lpsapi"
-  fi
-  MINGW_LIBS="-lmingwex"
-  AC_SUBST(MINGW_LIBS)
-  ;;
-freebsd)
+AS_CASE([$squid_host_os],
+  [mingw],[
+    AC_PATH_PROG(WIN32_PSAPI, psapi.dll, none)
+    CFLAGS="$CFLAGS -mthreads"
+    CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
+    if test "x$ac_cv_path_WIN32_PSAPI" = "xnone"; then
+      AC_MSG_NOTICE([PSAPI.DLL is recommended to run Squid on Windows NT Platform])
+      AC_MSG_NOTICE([Please see PSAPI.DLL section on doc/win32-relnotes.html.])
+    else
+      AC_DEFINE(HAVE_WIN32_PSAPI,1,[Define if you have PSAPI.DLL on Windows systems])
+      LIBS="$LIBS -lpsapi"
+    fi
+    MINGW_LIBS="-lmingwex"
+    AC_SUBST(MINGW_LIBS)
+  ],
+
+  [freebsd],[
     # FreeBSD places local libraries and packages in /usr/local
     CFLAGS="$CFLAGS -I/usr/local/include"
     CXXFLAGS="$CXXFLAGS -I/usr/local/include"
     LDFLAGS="$LDFLAGS -L/usr/local/lib -Wl,-R/usr/local/lib"
-    ;;
-*)
-    ;;
-esac
+  ]
+)
 
 dnl Substitutions
 AC_DEFINE_UNQUOTED(CONFIG_HOST_TYPE, "$host",[Host type from configure])
@@ -240,63 +239,49 @@ AC_SUBST(CACHE_EFFECTIVE_USER)
 DEFAULT_LOG_DIR="$localstatedir/logs"
 AC_ARG_WITH(logdir,
   AS_HELP_STRING([--with-logdir=PATH],
-    [Default location for squid logs. default: PREFIX/var/logs]), [
-case $withval in
-  yes|no)
-    AC_MSG_ERROR( --with-logdir requires a directory PATH. --with-logdir=PATH )
-    ;;
-  *)
-    DEFAULT_LOG_DIR="$withval"
-    ;;
-esac
- ]
-)
+    [Default location for squid logs. default: PREFIX/var/logs]),[
+  AS_CASE([$withval],
+    [yes|no],[AC_MSG_ERROR([--with-logdir requires a directory PATH. --with-logdir=PATH])],
+    [DEFAULT_LOG_DIR="$withval"]
+  )
+])
 AC_SUBST(DEFAULT_LOG_DIR)
 
 DEFAULT_PID_FILE="$localstatedir/run/@SERVICE_NAME@.pid"
 AC_ARG_WITH(pidfile,
   AS_HELP_STRING([--with-pidfile=PATH],
-    [Default location for squid pid file. Default: PREFIX/var/run/squid.pid]), [
-case $withval in
- yes|no)
-   AC_MSG_ERROR( --with-pidfile requires a file PATH. --with-pidfile=PATH )
-   ;;
- *)
-   DEFAULT_PID_FILE="$withval"
-   ;;
- esac
+    [Default location for squid pid file. Default: PREFIX/var/run/squid.pid]),[
+  AS_CASE([$withval],
+    [yes|no],[AC_MSG_ERROR([--with-pidfile requires a file PATH. --with-pidfile=PATH])],
+    [DEFAULT_PID_FILE="$withval"]
+  )
 ])
 AC_SUBST(DEFAULT_PID_FILE)
 
 DEFAULT_SWAP_DIR="$localstatedir/cache/squid"
 AC_ARG_WITH(swapdir,
   AS_HELP_STRING([--with-swapdir=PATH],
-    [Default location for squid cache directories. Default: PREFIX/var/cache/squid]), [
-case $withval in
- yes|no)
-   AC_MSG_ERROR( --with-swapdir requires a directory PATH. --with-swapdir=PATH )
-   ;;
- *)
-   DEFAULT_SWAP_DIR="$withval"
-   ;;
- esac
+    [Default location for squid cache directories. Default: PREFIX/var/cache/squid]),[
+  AS_CASE([$withval],
+    [yes|no],[AC_MSG_ERROR([--with-swapdir requires a directory PATH. --with-swapdir=PATH])],
+    [DEFAULT_SWAP_DIR="$withval"]
+  )
 ])
 AC_SUBST(DEFAULT_SWAP_DIR)
 
 dnl Set Default CFLAGS
 if test "x$PRESET_CFLAGS" = "x"; then
   if test "$squid_cv_compiler" = "gcc"; then
-    case "$host" in
-      *-sun-sunos*)
-        # sunos has too many warnings for this to be useful
-        ;;
-      *)
-        CFLAGS="$squid_cv_cc_option_wall $CFLAGS"
-        ;;
-    esac
+    # TODO check if these exceptions are still necessary
+    AS_CASE(["$host"],
+      [*-sun-sunos*],[
+        # sunos has too many warnings for -Wall to be useful
+      ],
+      [CFLAGS="$squid_cv_cc_option_wall $CFLAGS"]
+    )
   else
-    case "$host" in
-      *mips-sgi-irix6.*)
+    AS_CASE(["$host"],
+      [*mips-sgi-irix6.*],[
         # suggested by Rafael Seidl <rafaels@cthulhu.engr.sgi.com>
         CFLAGS="$squid_cv_cc_option_optimize -OPT:Olimit=0:space=OFF \
                 -woff 1009,1014,1110,1116,1183,1185,1188,1204,1230,1233,1355 \
@@ -306,10 +291,7 @@ if test "x$PRESET_CFLAGS" = "x"; then
                   -woff 1009,1014,1110,1116,1183,1185,1188,1204,1230,1233,1355 \
                   -Wl,-woff,85,-woff,84,-woff,134 \
                   -nostdinc -I/usr/include -D_BSD_SIGNALS $CXXFLAGS"
-          ;;
-        *)
-          ;;
-    esac
+    ])
   fi
 fi
 
@@ -417,15 +399,11 @@ AC_MSG_NOTICE([xmalloc stats display: $enable_xmalloc_statistics])
 squid_opt_aufs_threads=""
 AC_ARG_WITH(aufs-threads,
   AS_HELP_STRING([--with-aufs-threads=N_THREADS],
-   [Tune the number of worker threads for the aufs object store.]), [
-case $withval in
-  [[0-9]]*)
-    squid_opt_aufs_threads=$withval
-    ;;
-  *)
+    [Tune the number of worker threads for the aufs object store.]), [
+  AS_CASE([$withval],
+    [[[0-9]]*],[squid_opt_aufs_threads=$withval],
     AC_MSG_ERROR(--with-aufs-threads expects a numeric argument)
-    ;;
-  esac
+  )
 ])
 if test "x$squid_opt_aufs_threads" != "x"; then
     AC_MSG_NOTICE([With $squid_opt_aufs_threads aufs threads])
@@ -489,20 +467,14 @@ AC_ARG_ENABLE(disk-io,
      See src/DiskIO for a list of available modules, or
      Programmers Guide section on DiskIO
      for details on how to build your custom disk module]), [
-case $enableval in
-  yes)
-    ${TRUE}
-    #do nothing, "auto" is ok
-    ;;
-  no)
-    squid_opt_enable_diskio="no"
-    ;;
-  *)
-    squid_opt_enable_diskio="yes"
-    squid_disk_module_candidates=" `echo $enableval| sed -e 's/,/ /g;s/  */ /g'` "
-    SQUID_CLEANUP_MODULES_LIST([squid_disk_module_candidates])
-    ;;
-  esac
+  AS_CASE([$enableval],
+    [yes],[],
+    [no],[squid_opt_enable_diskio="no"],
+    [
+      squid_opt_enable_diskio="yes"
+      squid_disk_module_candidates=" `echo $enableval| sed -e 's/,/ /g;s/  */ /g'` "
+      SQUID_CLEANUP_MODULES_LIST([squid_disk_module_candidates])
+  ])
 ])
 
 # if requested to autodetect, find out what we have
@@ -547,9 +519,8 @@ for module in $squid_disk_module_candidates none; do
   if ! test -d "$srcdir/src/DiskIO/$module"; then
     AC_MSG_ERROR(disk-io $module does not exist)
   fi
-  case "$module" in
-
-    AIO)
+  AS_CASE(["$module"],
+    [AIO],[
       dnl Check for POSIX AIO availability
       squid_opt_use_aio="yes"
       AIOLIB=
@@ -566,16 +537,13 @@ for module in $squid_disk_module_candidates none; do
         else
           dnl Windows does things differently. We provide wrappers.
           dnl TODO: Windows really needs its own DiskIO module or its Overlaped IO
-          case "$squid_host_os" in
-            mingw)
-              squid_opt_use_aio="yes"
-              AC_MSG_NOTICE([Windows being built. Maybe-enable POSIX AIO.])
-              ;;
-            *)
-              AC_MSG_NOTICE([Native POSIX AIO support not detected. AIO automatically disabled.])
-              squid_opt_use_aio="no"
-              ;;
-          esac
+          AS_IF([test "$squid_host_os" = "mingw"],[
+            squid_opt_use_aio="yes"
+            AC_MSG_NOTICE([Windows being built. Maybe-enable POSIX AIO.])
+          ],[
+            squid_opt_use_aio="no"
+            AC_MSG_NOTICE([Native POSIX AIO support not detected. AIO automatically disabled.])
+          ])
         fi
       else
         AC_MSG_NOTICE([POSIX AIO support manually disabled.])
@@ -585,42 +553,36 @@ for module in $squid_disk_module_candidates none; do
       if test "x$squid_opt_use_aio" = "xyes" ; then
         DISK_MODULES="$DISK_MODULES AIO"
         AC_DEFINE([HAVE_DISKIO_MODULE_AIO],1,[POSIX AIO Disk I/O module is built])
-        case "$squid_host_os" in
-          mingw)
+        AS_IF([test "$squid_host_os" = "mingw"],[
             ENABLE_WIN32_AIO=1
             AC_MSG_NOTICE([Replacing AIO DiskIO module with: Windows overlapped I/O support])
-            ;;
-          *)
-            AC_MSG_NOTICE([Enabling AIO DiskIO module])
-            ;;
-        esac
+          ],
+          AC_MSG_NOTICE([Enabling AIO DiskIO module])
+        )
       else
         AC_MSG_NOTICE([AIO DiskIO Module disabled. Missing POSIX AIO support.])
         squid_disk_module_candidates_AIO=no
       fi
-      ;;
+    ],
 
-    Blocking)
+    [Blocking],[
       AC_MSG_NOTICE([Enabling Blocking DiskIO module])
       DISK_MODULES="$DISK_MODULES Blocking"
       AC_DEFINE([HAVE_DISKIO_MODULE_BLOCKING],1,[Blocking Disk I/O module is built])
-      ;;
+    ],
 
-    DiskDaemon)
-      case "$squid_host_os" in
-        mingw)
-          AC_MSG_NOTICE(["DiskDaemon not supported on MinGW"])
+    [DiskDaemon],[
+      AS_IF([test "$squid_host_os" = "mingw"],[
+          AC_MSG_NOTICE([DiskDaemon not supported on MinGW])
           squid_disk_module_candidates_DiskDaemon=no
-          ;;
-        *)
+        ],[
           AC_MSG_NOTICE([Enabling DiskDaemon DiskIO module])
           DISK_MODULES="$DISK_MODULES DiskDaemon"
           AC_DEFINE([HAVE_DISKIO_MODULE_DISKDAEMON],1,[DiskDaemon Disk I/O module is built])
-          ;;
-        esac
-      ;;
+        ])
+    ],
 
-    DiskThreads)
+    [DiskThreads],[
       squid_opt_use_diskthreads="yes"
       LIBPTHREADS=
       SQUID_STATE_SAVE([diskthreads_state],[SQUID_CFLAGS SQUID_CXXFLAGS])
@@ -628,12 +590,12 @@ for module in $squid_disk_module_candidates none; do
       dnl TODO: this needs to be extended to handle more systems and better
       dnl REF: http://www.openldap.org/lists/openldap-bugs/200006/msg00070.html
       dnl REF: http://autoconf-archive.cryp.to/acx_pthread.html
-        case "$squid_host_os" in
-          mingw)
+        AS_CASE(["$squid_host_os"],
+          [mingw],[
             ENABLE_WIN32_AIOPS=1
-            AC_MSG_NOTICE([Windows threads support automatically enabled])
-            ;;
-          freebsd)
+            AC_MSG_NOTICE([Windows threads support automatically enabled])],
+
+          [freebsd],[
             if test `echo "$squid_host_os_version" | tr -d .` -lt 70 ; then
                 AC_MSG_NOTICE(pthread library requires FreeBSD 7 or later)
                 squid_opt_use_diskthreads="no"
@@ -644,8 +606,9 @@ for module in $squid_disk_module_candidates none; do
                 LDFLAGS="$LDFLAGS -pthread"
               fi
             fi
-            ;;
-          openbsd)
+            ],
+
+          [openbsd],[
             if test `echo "$squid_host_os_version" | tr -d .` -lt 52 ; then
                 AC_MSG_NOTICE(pthread library requires OpenBSD 5.2 or later)
                 squid_opt_use_diskthreads="no"
@@ -654,8 +617,9 @@ for module in $squid_disk_module_candidates none; do
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT"
               LDFLAGS="$LDFLAGS -lpthread"
             fi
-            ;;
-          solaris)
+            ],
+
+          [solaris],[
             if test "x$GCC" = "xyes" ; then
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT -pthreads"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT -pthreads"
@@ -674,16 +638,16 @@ for module in $squid_disk_module_candidates none; do
                 squid_opt_use_diskthreads="no"
               ])
             fi
-            ;;
-          *)
+            ],
+
+          [
             SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT"
             SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT"
             AC_CHECK_LIB(pthread, pthread_create ,[LIBPTHREADS="-lpthread"], [
               AC_MSG_NOTICE(pthread library required but cannot be found.)
               squid_opt_use_diskthreads="no"
             ])
-            ;;
-          esac
+          ])
         else
           AC_MSG_NOTICE([Native pthreads support manually disabled.])
           squid_opt_use_diskthreads="no"
@@ -697,9 +661,9 @@ for module in $squid_disk_module_candidates none; do
           SQUID_STATE_ROLLBACK([diskthreads_state])
           squid_disk_module_candidates_DiskThreads=no
         fi
-      ;;
+    ],
 
-    IpcIo)
+    [IpcIo],[
       if test "x$ac_cv_search_shm_open" = "xno" ; then
         AC_MSG_NOTICE([DiskIO IpcIo module requires shared memory support])
         squid_disk_module_candidates_IpcIo=no
@@ -708,9 +672,9 @@ for module in $squid_disk_module_candidates none; do
         DISK_MODULES="$DISK_MODULES IpcIo"
         AC_DEFINE([HAVE_DISKIO_MODULE_IPCIO],1,[IpcIo Disk I/O module is built])
       fi
-      ;;
+    ],
 
-    Mmapped)
+    [Mmapped],[
       dnl TODO: use availability of sys/mman.h and/or mmap to define
       dnl  OR support windows mmap functions
       if test "x$squid_host_os" = "xmingw" ; then
@@ -721,14 +685,13 @@ for module in $squid_disk_module_candidates none; do
         DISK_MODULES="$DISK_MODULES Mmapped"
         AC_DEFINE([HAVE_DISKIO_MODULE_MMAPPED],1,[Mmapped Disk I/O module is built])
       fi
-      ;;
+    ],
 
-    *)
+    [
       AC_MSG_NOTICE([Enabling $module DiskIO module])
       DISK_LIBS="$DISK_LIBS lib${module}.la"
       DISK_MODULES="$DISK_MODULES ${module}"
-      ;;
-    esac
+    ])
 done
 AC_MSG_NOTICE([IO Modules built: $DISK_MODULES])
 AC_SUBST(DISK_MODULES)
@@ -754,21 +717,16 @@ AC_ARG_ENABLE([storeio],
                   See src/fs for a list of available modules, or
                   Programmers Guide section <not yet written>
                   for details on how to build your custom store module]), [
-case $enableval in
-  yes)
-    squid_opt_enable_storeio=auto
-    ;;
-  no)
-    squid_opt_enable_storeio=no
-    ;;
-  *)
-    squid_opt_enable_storeio=yes
-    squid_storeio_module_candidates="`echo $enableval| sed -e 's/,/ /g;s/  */ /g'`"
-    # ufs is really always needed as it has low-level routines
-    # if it is a dupe it will be cleaned-up later
-    squid_storeio_module_candidates="$squid_storeio_module_candidates ufs"
-    ;;
-  esac
+  AS_CASE([$enableval],
+    [yes],[squid_opt_enable_storeio=auto],
+    [no],[squid_opt_enable_storeio=no],
+    [
+      squid_opt_enable_storeio=yes
+      squid_storeio_module_candidates="`echo $enableval| sed -e 's/,/ /g;s/  */ /g'`"
+      # ufs is really always needed as it has low-level routines
+      # if it is a dupe it will be cleaned-up later
+      squid_storeio_module_candidates="$squid_storeio_module_candidates ufs"
+  ])
 ])
 if test "x$squid_opt_enable_storeio" = "xauto"; then
   squid_opt_enable_storeio=yes
@@ -782,33 +740,32 @@ SQUID_CHECK_EXISTING_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
 AC_MSG_NOTICE([Store modules built: $squid_storeio_module_candidates])
 
 for fs in $squid_storeio_module_candidates none; do
-  case "$fs" in
-    diskd)
+  AS_CASE(["$fs"],
+    [diskd],[
       if test "x$squid_disk_module_candidates_Blocking" != "xyes" -a \
         "$squid_disk_module_candidates_DiskDaemon" != "yes" ; then
         AC_MSG_ERROR([Storage diskd module requires DiskIO module: Blocking or DiskDaemon])
       fi
-      ;;
-    aufs)
+    ],
+    [aufs],[
       if test "x$squid_disk_module_candidates_Blocking" != "xyes" -a \
         "$squid_disk_module_candidates_DiskThreads" != "yes" ; then
         AC_MSG_ERROR([Storage module aufs requires DiskIO module: Blocking or DiskThreads])
       fi
-      ;;
-    rock)
+    ],
+    [rock],[
       if test "x$squid_disk_module_candidates_IpcIo" != "xyes" -a \
         "x$squid_disk_module_candidates_Blocking" != "xyes"; then
          AC_MSG_ERROR([Storage module Rock requires DiskIO module: Blocking or IpcIo])
       fi
       squid_do_build_rock=true
-      ;;
-    ufs)
+    ],
+    [ufs],[
       if test "x$squid_disk_module_candidates_Blocking" != "xyes"; then
         AC_MSG_ERROR([Storage module ufs requires DiskIO module: Blocking])
       fi
       squid_do_build_ufs=true
-      ;;
-    esac
+    ])
 done
 
 AM_CONDITIONAL(ENABLE_FS_UFS, test "x$squid_do_build_ufs" = "xtrue")
@@ -850,16 +807,11 @@ AC_ARG_ENABLE(removal-policies,
                   See src/repl for a list of available modules, or
                   Programmers Guide section 9.9 for details on how
                   to build your custom policy]), [
-case $enableval in
-  yes)
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/repl],[REPL_POLICIES])
-    ;;
-  no)
-    ;;
-  *)
-    REPL_POLICIES="`echo $enableval| sed -e 's/,/ /g;s/  */ /g'`"
-    ;;
-  esac
+  AS_CASE([$enableval],
+    [yes],[SQUID_LOOK_FOR_MODULES([$srcdir/src/repl],[REPL_POLICIES])],
+    [no],[:],
+    [ REPL_POLICIES="`echo $enableval| sed -e 's/,/ /g;s/  */ /g'`" ]
+  )
 ])
 if test "x$REPL_POLICIES" != "x" ; then
     SQUID_CHECK_EXISTING_MODULES([$srcdir/src/repl],[REPL_POLICIES])
@@ -999,17 +951,16 @@ AM_CONDITIONAL(ENABLE_ICAP_CLIENT, test "x$enable_icap_client" != "xno")
 squid_opt_use_ecap=1
 AC_MSG_CHECKING(whether to support eCAP)
 AC_ARG_ENABLE(ecap,
-  AS_HELP_STRING([--enable-ecap],[support loadable content adaptation modules]), [
-    case "${enableval}" in
-       yes|no) squid_opt_use_ecap=$enableval ;;
-       *) AC_MSG_ERROR(bad value ${enableval} for --enable-ecap) ;;
-    esac
-AC_MSG_RESULT([$squid_opt_use_ecap, explicitly])
-    ], [
-        squid_opt_use_ecap=no;
-        AC_MSG_RESULT([$squid_opt_use_ecap, implicitly])
-    ]
-)
+  AS_HELP_STRING([--enable-ecap],[support loadable content adaptation modules]),[
+  AS_CASE(["${enableval}"],
+    [yes|no],[squid_opt_use_ecap=$enableval],
+    [AC_MSG_ERROR([bad value ${enableval} for --enable-ecap])]
+  )
+  AC_MSG_RESULT([$squid_opt_use_ecap, explicitly])
+],[
+  squid_opt_use_ecap=no;
+  AC_MSG_RESULT([$squid_opt_use_ecap, implicitly])
+])
 
 dnl Perform configuration consistency checks for eCAP
 if test "x$squid_opt_use_ecap" != "xno";
@@ -1114,20 +1065,17 @@ AC_ARG_ENABLE(cachemgr-hostname,
   AS_HELP_STRING([--enable-cachemgr-hostname=hostname],
                  [Make cachemgr.cgi default to this host.
                   If unspecified, uses the name of the build-host]), [
-  case $enableval in
-  yes)
-    AC_DEFINE(CACHEMGR_HOSTNAME,[getfullhostname()],
-    [If you are upset that the cachemgr.cgi form comes up with the hostname field blank, then define this to getfullhostname()])
-    AC_MSG_NOTICE([Cachemgr default hostname == host where cachemgr runs])
-    ;;
-  no)
-    : # Nothing to do..
-   ;;
-  *)
-    AC_DEFINE_UNQUOTED(CACHEMGR_HOSTNAME,"${enableval}")
-    AC_MSG_NOTICE([Cachemgr default hostname set to ${enableval}])
-    ;;
-  esac
+  AS_CASE([$enableval],
+    [yes],[
+      AC_DEFINE(CACHEMGR_HOSTNAME,[getfullhostname()],
+        [If you are upset that the cachemgr.cgi form comes up with the hostname field blank, then define this to getfullhostname()])
+      AC_MSG_NOTICE([Cachemgr default hostname == host where cachemgr runs])
+    ],
+    [no],[:],
+    [
+      AC_DEFINE_UNQUOTED(CACHEMGR_HOSTNAME,"${enableval}")
+      AC_MSG_NOTICE([Cachemgr default hostname set to ${enableval}])
+  ])
 ])
 
 AC_ARG_ENABLE(eui,
@@ -1140,17 +1088,11 @@ if test "x${enable_eui:=yes}" = "xyes" ; then
   # GLIBC 2.30 deprecates sysctl.h. Test with the same flags that (may) break includes later.
   CFLAGS=$SQUID_CFLAGS
   CXXFLAGS=$SQUID_CXXFLAGS
-  case "$squid_host_os" in
-    linux|solaris|freebsd|openbsd|netbsd|cygwin)
-      ${TRUE}
-      ;;
-    mingw)
-      EUILIB="-liphlpapi"
-      ;;
-    *)
-      AC_MSG_WARN([EUI support probably will not work on host $host.])
-      ;;
-  esac
+  AS_CASE(["$squid_host_os"],
+    [linux|solaris|freebsd|openbsd|netbsd|cygwin],[:],
+    [mingw],[EUILIB="-liphlpapi"],
+    [AC_MSG_WARN([EUI support probably will not work on host $host.])]
+  )
   # iphlpapi.h check delayed after winsock2.h
   AC_CHECK_HEADERS( \
     windows.h \
@@ -1804,229 +1746,230 @@ AC_SUBST(KRB5LIBS)
 
 dnl On MinGW OpenLDAP is not available, so LDAP helpers can be linked
 dnl only with Windows LDAP libraries using -lwldap32
-case "$squid_host_os" in
-	mingw)
-		LDAPLIB="-lwldap32"
-		LBERLIB=""
-		;;
-	*)
-		AC_CHECK_LIB(ldap, ldap_init, [LDAPLIB="-lldap"])
-		dnl LDAP helpers need to know if -llber is needed or not
-		AC_CHECK_LIB(lber, ber_init, [LBERLIB="-llber"])
-		dnl if no ldap lib found check for mozilla version
-		if test "x$ac_cv_lib_ldap_ldap_init" != x""yes; then
-		        oLIBS=$LIBS
-		        LIBS="$LIBPTHREADS"
-			AC_CHECK_LIB(ldap60, ldap_init, [LDAPLIB="-lldap60"])
-		        LIBS="$LDAPLIB $LIBPTHREADS"
-			AC_CHECK_LIB(prldap60, prldap_init, [LDAPLIB="-lprldap60 $LDAPLIB"])
-		        LIBS="$LDAPLIB $LIBPTHREADS"
-			AC_CHECK_LIB(ssldap60, ldapssl_init, [LDAPLIB="-lssldap60 $LDAPLIB"])
-		        LIBS=$oLIBS
-		fi
+AS_IF([test "$squid_host_os" = "mingw"],[
+    LDAPLIB="-lwldap32"
+    LBERLIB=""
+  ],[
+    AC_CHECK_LIB(ldap, ldap_init, [LDAPLIB="-lldap"])
+    dnl LDAP helpers need to know if -llber is needed or not
+    AC_CHECK_LIB(lber, ber_init, [LBERLIB="-llber"])
+    dnl if no ldap lib found check for mozilla version
+    if test "x$ac_cv_lib_ldap_ldap_init" != x""yes; then
+      oLIBS=$LIBS
+      LIBS="$LIBPTHREADS"
+      AC_CHECK_LIB(ldap60, ldap_init, [LDAPLIB="-lldap60"])
+      LIBS="$LDAPLIB $LIBPTHREADS"
+      AC_CHECK_LIB(prldap60, prldap_init, [LDAPLIB="-lprldap60 $LDAPLIB"])
+      LIBS="$LDAPLIB $LIBPTHREADS"
+      AC_CHECK_LIB(ssldap60, ldapssl_init, [LDAPLIB="-lssldap60 $LDAPLIB"])
+      LIBS=$oLIBS
+    fi
 
-		AC_CHECK_HEADERS(ldap.h lber.h)
-		AC_CHECK_HEADERS(mozldap/ldap.h)
+    AC_CHECK_HEADERS(ldap.h lber.h)
+    AC_CHECK_HEADERS(mozldap/ldap.h)
 
-		dnl
-		dnl Check for LDAP_OPT_DEBUG_LEVEL
-		dnl
-		AC_MSG_CHECKING([for LDAP_OPT_DEBUG_LEVEL])
-		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#                   include <ldap.h>
-		]],[[
-                    int i=LDAP_OPT_DEBUG_LEVEL
-		]])],
-		[ AC_MSG_RESULT(yes) ],
-		[ AC_MSG_RESULT(no) ])
+    dnl Check for LDAP_OPT_DEBUG_LEVEL
+    AC_MSG_CHECKING([for LDAP_OPT_DEBUG_LEVEL])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <ldap.h>
+    ]],[[
+      int i=LDAP_OPT_DEBUG_LEVEL
+    ]])],[
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ])
 
-		dnl
-		dnl Check for working ldap
-		dnl
-		oLIBS=$LIBS
-		LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
-		AC_MSG_CHECKING([for working ldap])
-		AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#                   define  LDAP_DEPRECATED 1
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   elif HAVE_MOZLDAP_LDAP_H
-#                   include <mozldap/ldap.h>
-#                   endif
-                    int
-                    main(void)
-                    {
-                        char host[]="";
-                        int port;
+    dnl Check for working ldap
+    oLIBS=$LIBS
+    LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
+    AC_MSG_CHECKING([for working ldap])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#     define  LDAP_DEPRECATED 1
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     elif HAVE_MOZLDAP_LDAP_H
+#     include <mozldap/ldap.h>
+#     endif
+      int
+      main(void)
+      {
+          char host[]="";
+          int port;
 
-                        ldap_init((const char *)&host, port);
+          ldap_init((const char *)&host, port);
 
-                        return 0;
-                    }
-		]])],
-		[ AC_DEFINE(HAVE_LDAP, 1, [LDAP support])
-		  AC_MSG_RESULT(yes) ],
-		[ AC_MSG_RESULT(no) ],
-		[ AC_MSG_RESULT(cross-compiler cant tell) ])
-		LIBS=$oLIBS
+          return 0;
+      }
+    ]])],[
+      AC_DEFINE(HAVE_LDAP, 1, [LDAP support])
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ],[
+       AC_MSG_RESULT(cross-compiler cant tell)
+    ])
+    LIBS=$oLIBS
 
-		dnl
-		dnl Check for ldap vendor
-		dnl
-		AC_MSG_CHECKING([for OpenLDAP])
-		AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   endif
-#                   include <string.h>
-                    int
-                    main(void)
-                    {
-                        return strcmp(LDAP_VENDOR_NAME,"OpenLDAP");
-                    }
-		]])],
-		[ AC_DEFINE(HAVE_OPENLDAP, 1, [OpenLDAP support])
-		  AC_MSG_RESULT(yes) ],
-		[ AC_MSG_RESULT(no) ],
-		[ AC_MSG_RESULT(cross-compiler cant tell) ])
+    dnl Check for ldap vendor
+    AC_MSG_CHECKING([for OpenLDAP])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     endif
+#     include <string.h>
+      int
+      main(void)
+      {
+          return strcmp(LDAP_VENDOR_NAME,"OpenLDAP");
+      }
+    ]])],[
+      AC_DEFINE(HAVE_OPENLDAP, 1, [OpenLDAP support])
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ],[
+      AC_MSG_RESULT(cross-compiler cant tell)
+    ])
 
-		AC_MSG_CHECKING([for Sun LDAP SDK])
-		AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   endif
-#                   include <string.h>
-                    int
-                    main(void)
-                    {
-                        return strcmp(LDAP_VENDOR_NAME,"Sun Microsystems Inc.");
-                    }
-		]])],
-		[ AC_DEFINE(HAVE_SUN_LDAP_SDK, 1, [Sun LDAP SDK support])
-		  AC_MSG_RESULT(yes) ],
-		[ AC_MSG_RESULT(no) ],
-		[ AC_MSG_RESULT(cross-compiler cant tell) ])
+    AC_MSG_CHECKING([for Sun LDAP SDK])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     endif
+#     include <string.h>
+      int
+      main(void)
+      {
+          return strcmp(LDAP_VENDOR_NAME,"Sun Microsystems Inc.");
+      }
+    ]])],[
+      AC_DEFINE(HAVE_SUN_LDAP_SDK, 1, [Sun LDAP SDK support])
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ],[
+      AC_MSG_RESULT(cross-compiler cant tell)
+    ])
 
-		AC_MSG_CHECKING([for Mozilla LDAP SDK])
-		AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   elif HAVE_MOZLDAP_LDAP_H
-#                   include <mozldap/ldap.h>
-#                   endif
-#                   include <string.h>
-                    int
-                    main(void)
-                    {
-                        return strcmp(LDAP_VENDOR_NAME,"mozilla.org");
-                    }
-		]])],
-		[ AC_DEFINE(HAVE_MOZILLA_LDAP_SDK, 1, [Mozilla LDAP SDK support])
-		  AC_MSG_RESULT(yes) ],
-		[ AC_MSG_RESULT(no)],
-		[ AC_MSG_RESULT(cross-compiler cant tell) ])
+    AC_MSG_CHECKING([for Mozilla LDAP SDK])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     elif HAVE_MOZLDAP_LDAP_H
+#     include <mozldap/ldap.h>
+#     endif
+#     include <string.h>
+      int
+      main(void)
+      {
+          return strcmp(LDAP_VENDOR_NAME,"mozilla.org");
+      }
+    ]])],[
+      AC_DEFINE(HAVE_MOZILLA_LDAP_SDK, 1, [Mozilla LDAP SDK support])
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ],[
+      AC_MSG_RESULT(cross-compiler cant tell)
+    ])
 
-		dnl
-		dnl Check for LDAP_REBINDPROC_CALLBACK
-		dnl
-                AC_MSG_CHECKING([for LDAP_REBINDPROC_CALLBACK])
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   elif HAVE_MOZLDAP_LDAP_H
-#                   include <mozldap/ldap.h>
-#                   endif
-                ]],[[
-                    LDAP_REBINDPROC_CALLBACK ldap_rebind;
-                ]])],
-                [ AC_DEFINE(HAVE_LDAP_REBINDPROC_CALLBACK,1,[Define to 1 if you have LDAP_REBINDPROC_CALLBACK])
-                  AC_MSG_RESULT(yes) ],
-                [ AC_MSG_RESULT(no) ])
+    dnl Check for LDAP_REBINDPROC_CALLBACK
+    AC_MSG_CHECKING([for LDAP_REBINDPROC_CALLBACK])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     elif HAVE_MOZLDAP_LDAP_H
+#     include <mozldap/ldap.h>
+#     endif
+    ]],[[
+      LDAP_REBINDPROC_CALLBACK ldap_rebind;
+    ]])],[
+      AC_DEFINE(HAVE_LDAP_REBINDPROC_CALLBACK,1,[Define to 1 if you have LDAP_REBINDPROC_CALLBACK])
+      AC_MSG_RESULT(yes)
+    ],[
+       AC_MSG_RESULT(no)
+    ])
 
-		dnl
-		dnl Check for LDAP_REBIND_PROC
-		dnl
-                AC_MSG_CHECKING([for LDAP_REBIND_PROC])
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   elif HAVE_MOZLDAP_LDAP_H
-#                   include <mozldap/ldap.h>
-#                   endif
-                ]],[[
-                    LDAP_REBIND_PROC ldap_rebind;
-                ]])],
-                [ AC_DEFINE(HAVE_LDAP_REBIND_PROC,1,[Define to 1 if you have LDAP_REBIND_PROC])
-                  AC_MSG_RESULT(yes) ],
-                [ AC_MSG_RESULT(no) ])
+    dnl Check for LDAP_REBIND_PROC
+    AC_MSG_CHECKING([for LDAP_REBIND_PROC])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     elif HAVE_MOZLDAP_LDAP_H
+#     include <mozldap/ldap.h>
+#     endif
+    ]],[[
+      LDAP_REBIND_PROC ldap_rebind;
+    ]])],[
+      AC_DEFINE(HAVE_LDAP_REBIND_PROC,1,[Define to 1 if you have LDAP_REBIND_PROC])
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ])
 
-		dnl
-		dnl Check for LDAP_REBIND_FUNCTION
-		dnl
-                AC_MSG_CHECKING([for LDAP_REBIND_FUNCTION])
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#                   define LDAP_REFERRALS
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   elif HAVE_MOZLDAP_LDAP_H
-#                   include <mozldap/ldap.h>
-#                   endif
-                ]],[[
-                    LDAP_REBIND_FUNCTION ldap_rebind;
-                ]])],
-                [ AC_DEFINE(HAVE_LDAP_REBIND_FUNCTION,1,[Define to 1 if you have LDAP_REBIND_FUNCTION])
-                  AC_MSG_RESULT(yes) ],
-                [ AC_MSG_RESULT(no) ])
+    dnl Check for LDAP_REBIND_FUNCTION
+    AC_MSG_CHECKING([for LDAP_REBIND_FUNCTION])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#     define LDAP_REFERRALS
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     elif HAVE_MOZLDAP_LDAP_H
+#     include <mozldap/ldap.h>
+#     endif
+    ]],[[
+      LDAP_REBIND_FUNCTION ldap_rebind;
+    ]])],[
+      AC_DEFINE(HAVE_LDAP_REBIND_FUNCTION,1,[Define to 1 if you have LDAP_REBIND_FUNCTION])
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ])
 
-		dnl
-		dnl Check for LDAP_SCOPE_DEFAULT
-		dnl
-                AC_MSG_CHECKING([for LDAP_SCOPE_DEFAULT])
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#                   if HAVE_LDAP_H
-#                   include <ldap.h>
-#                   elif HAVE_MOZLDAP_LDAP_H
-#                   include <mozldap/ldap.h>
-#                   endif
-                ]],[[
-                    int i=LDAP_SCOPE_DEFAULT;
-                ]])],
-                [ AC_DEFINE(HAVE_LDAP_SCOPE_DEFAULT,1,[Define to 1 if you have LDAP_SCOPE_DEFAULT])
-                  AC_MSG_RESULT(yes) ],
-                [ AC_MSG_RESULT(no) ])
+    dnl Check for LDAP_SCOPE_DEFAULT
+    AC_MSG_CHECKING([for LDAP_SCOPE_DEFAULT])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#     if HAVE_LDAP_H
+#     include <ldap.h>
+#     elif HAVE_MOZLDAP_LDAP_H
+#     include <mozldap/ldap.h>
+#     endif
+    ]],[[
+      int i=LDAP_SCOPE_DEFAULT;
+    ]])],[
+      AC_DEFINE(HAVE_LDAP_SCOPE_DEFAULT,1,[Define to 1 if you have LDAP_SCOPE_DEFAULT])
+      AC_MSG_RESULT(yes)
+    ],[
+      AC_MSG_RESULT(no)
+    ])
 
-		dnl
-		dnl Check for ldap_url_desc.lud_scheme
-		dnl
-		AC_CHECK_MEMBER(struct ldap_url_desc.lud_scheme,
-		  AC_DEFINE(HAVE_LDAP_URL_LUD_SCHEME,1,
-		    [Define to 1 if you have LDAPURLDesc.lud_scheme]),,[#include <ldap.h>])
+    dnl Check for ldap_url_desc.lud_scheme
+    AC_CHECK_MEMBER(struct ldap_url_desc.lud_scheme,[
+      AC_DEFINE(HAVE_LDAP_URL_LUD_SCHEME,1,[Define to 1 if you have LDAPURLDesc.lud_scheme])
+    ],,[
+#include <ldap.h>
+    ])
 
-		dnl
-		dnl Check for ldapssl_client_init
-		dnl
-		AC_CHECK_LIB(ldap,ldapssl_client_init,
-		  AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init]),)
+    dnl Check for ldapssl_client_init
+    AC_CHECK_LIB(ldap,ldapssl_client_init,[
+      AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
+    ],)
 
-		dnl
-		dnl Check for ldap_url_desc2str
-		dnl
-		AC_CHECK_LIB(ldap,ldap_url_desc2str,
-		  AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str]),)
+    dnl Check for ldap_url_desc2str
+    AC_CHECK_LIB(ldap,ldap_url_desc2str,[
+      AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
+    ],)
 
-		dnl
-		dnl Check for ldap_url_parse
-		dnl
-		AC_CHECK_LIB(ldap,ldap_url_parse,
-		  AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse]),)
+    dnl Check for ldap_url_parse
+    AC_CHECK_LIB(ldap,ldap_url_parse,[
+      AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
+    ],)
 
-		dnl
-		dnl Check for ldap_start_tls_s
-		dnl
-		AC_CHECK_LIB(ldap,ldap_start_tls_s,
-		  AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s]),)
-		;;
-esac
+    dnl Check for ldap_start_tls_s
+    AC_CHECK_LIB(ldap,ldap_start_tls_s,[
+      AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
+    ],)
+])
 
 AC_SUBST(LDAPLIB)
 AC_SUBST(LBERLIB)
@@ -2323,14 +2266,10 @@ AC_ARG_WITH(build-environment,
       XBS5_LP64_OFF64 (legacy, 64 bits),
       XBS5_LPBIG_OFFBIG (legacy, large pointers and files)
       or default (The default for your OS)]), [
-case "$withval" in
-  yes|no)
-    AC_MSG_FAILURE([--with-build-environment expects a build environment string as used by getconf])
-    ;;
-  *)
-    buildmodel="$withval"
-    ;;
-esac
+  AS_CASE(["$withval"],
+    [yes|no],[AC_MSG_FAILURE([--with-build-environment expects a build environment string as used by getconf])],
+    [buildmodel="$withval"]
+  )
 ])
 
 #hack. Let's early-detect sizeof(long)
@@ -2785,22 +2724,20 @@ AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[
 ])
 
 dnl Override rusage() detect on MinGW because is emulated in source code
-case "$squid_host_os" in
-  mingw)
-    AC_DEFINE(HAVE_STRUCT_RUSAGE)
-    ac_cv_func_getrusage='yes'
-    AC_MSG_NOTICE([Using own rusage on Windows.])
-    ;;
-  *)
-    AC_CHECK_TYPE(struct rusage,AC_DEFINE(HAVE_STRUCT_RUSAGE,1,[The system provides struct rusage]),,[
+AS_IF([test "$squid_host_os" = "mingw"],[
+  AC_DEFINE(HAVE_STRUCT_RUSAGE)
+  ac_cv_func_getrusage="yes"
+  AC_MSG_NOTICE([Using own rusage on Windows.])
+],[
+  AC_CHECK_TYPE(struct rusage,AC_DEFINE(HAVE_STRUCT_RUSAGE,1,[The system provides struct rusage]),,[
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 #if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
-#endif])
-    ;;
-esac
+#endif
+  ])
+])
 
 AC_CHECK_MEMBERS([struct iphdr.ip_hl],,,[
 #if HAVE_SYS_TYPES_H
@@ -2970,61 +2907,44 @@ if test "x$ac_cv_lib_gnumalloc_malloc" = "xyes"; then
   ac_cv_func_mallocblksize=no
   ac_cv_func_mallopt=no
 else
-  case "$squid_host_os" in
-    solaris)
-      AC_MSG_NOTICE([skipping libmalloc check for $host])
-      ;;
-    freebsd)
-      AC_MSG_NOTICE([skipping libmalloc check for $host])
-      ;;
-    *)
-      # XXX: used later
-      AC_CHECK_LIB(malloc, main)
-      ;;
-  esac
+  AS_CASE(["$squid_host_os"],
+    [solaris],[AC_MSG_NOTICE([skipping libmalloc check for $host])],
+    [freebsd],[AC_MSG_NOTICE([skipping libmalloc check for $host])],
+    [AC_CHECK_LIB(malloc, main)]
+  )
 fi
 
-case "$squid_host_os" in
-  mingw)
-    AC_MSG_NOTICE([Use MSVCRT for math functions.])
-    ;;
-  *)
-    dnl log() are only used in old C code for now.
-    AC_LANG_PUSH([C])
-    AC_SEARCH_LIBS([log],[m])
-    AC_LANG_POP([C])
-    ;;
-esac
+AS_IF([test "$squid_host_os" = "mingw"],[
+  AC_MSG_NOTICE([Use MSVCRT for math functions.])
+],[
+  dnl log() are only used in old C code for now.
+  AC_LANG_PUSH([C])
+  AC_SEARCH_LIBS([log],[m])
+  AC_LANG_POP([C])
+])
 
 dnl --with-maxfd present for compatibility with Squid-2.
 dnl undocumented in ./configure --help  to encourage using the Squid-3 directive
-AC_ARG_WITH(maxfd,,
-[
-  case ${withval} in
-    [[0-9]]*)
+AC_ARG_WITH(maxfd,,[
+  AS_CASE([$withval],
+    [[[0-9]]*],[
       squid_filedescriptors_num=$withval
       AC_MSG_NOTICE([forcing default of $squid_filedescriptors_num filedescriptors (user-forced)])
-      ;;
-    *)
-      AC_MSG_ERROR(--with-maxfd expects a numeric argument)
-      ;;
-    esac
+    ],
+    [AC_MSG_ERROR(--with-maxfd expects a numeric argument)]
+  )
 ])
 
 AC_ARG_WITH(filedescriptors,
   AS_HELP_STRING([--with-filedescriptors=NUMBER],
-                 [Force squid to support NUMBER filedescriptors]),
-[
-  case ${withval} in
-    [[0-9]]*)
+    [Force squid to support NUMBER filedescriptors]),
+  AS_CASE([$withval],
+    [[[0-9]]*],[
       squid_filedescriptors_num=$withval
-      AC_MSG_NOTICE([forcing default of $squid_filedescriptors_num filedescriptors (user-forced)])
-      ;;
-    *)
-      AC_MSG_ERROR(--with-filedescriptors expects a numeric argument)
-      ;;
-    esac
-])
+      AC_MSG_NOTICE([forcing default of $squid_filedescriptors_num filedescriptors (user-forced)])],
+    [AC_MSG_ERROR([--with-filedescriptors expects a numeric argument])]
+  )
+)
 
 SQUID_CHECK_DEFAULT_FD_SETSIZE
 SQUID_CHECK_MAXFD
@@ -3046,24 +2966,31 @@ SQUID_CHECK_SS_LEN_IN_SOCKADDR_STORAGE
 SQUID_CHECK_SIN_LEN_IN_SOCKADDR_IN
 
 dnl System-specific library modifications
-dnl
-AH_TEMPLATE(GETTIMEOFDAY_NO_TZP,[If gettimeofday is known to take only one argument])
-case "$host" in
-  i386-*-solaris2.*)
+AH_TEMPLATE(GETTIMEOFDAY_NO_TZP,[Whether gettimeofday takes only one argument])
+AS_CASE(["$host"],
+  [*-pc-sco3.2*],[
+    # -lintl is needed on SCO version 3.2v4.2 for strftime()
+    # Robert Side <rside@aiinc.bc.ca>
+    # Mon, 18 Jan 1999 17:48:00 GMT
+    AC_CHECK_LIB(intl, strftime)
+  ],
+
+  [i386-*-solaris2.*],[
     if test "x$GCC" = "xyes"; then
       AC_MSG_NOTICE([Removing -O for gcc on $host])
       CFLAGS="`echo $CFLAGS | sed -e 's/-O[[0-9g]]*//'`"
     fi
-  ;;
+  ],
 
-  *-sgi-irix*)
+  [*-sgi-irix*],[
     AC_MSG_NOTICE([Removing -lsocket for IRIX...])
     LIBS=`echo $LIBS | sed -e s/-lsocket//`
     AC_MSG_NOTICE([Removing -lnsl for IRIX...])
     LIBS=`echo $LIBS | sed -e s/-lnsl//`
     ac_cv_lib_nsl_main=no
-  ;;
-  *-ibm-aix*)
+  ],
+
+  [*-ibm-aix*],[
     SQUID_CC_REQUIRE_ARGUMENT([ac_cv_require_rtti],[-rtti],[[
 #include <assert.h>
 #ifndef NULL
@@ -3091,27 +3018,25 @@ assert(myBar != NULL);
     if test "$ac_cv_require_qcpluscmt" = "yes"; then
       SQUID_CFLAGS="-qcpluscmt $SQUID_CFLAGS"
     fi
-    ;;
+  ],
 
-    [*-*-solaris2.[0-4]])
-      AC_DEFINE(GETTIMEOFDAY_NO_TZP,1)
-    ;;
-    [*-sony-newsos[56]*])
-      AC_DEFINE(GETTIMEOFDAY_NO_TZP,1)
-    ;;
-  esac
+  [*-*-solaris2.[[0-4]]],[AC_DEFINE(GETTIMEOFDAY_NO_TZP,1)],
+
+  [*-sony-newsos[[56]]*],[AC_DEFINE(GETTIMEOFDAY_NO_TZP,1)]
+)
 
 dnl This has to be before AC_CHECK_FUNCS
 # Disable poll() on certain platforms. Override by setting ac_cv_func_poll
 # when running configure.
 if test "x$ac_cv_func_poll" = "x" ; then
-  case "$host" in
-    [*-hp-hpux*.*])
+  AS_CASE(["$host"],
+    [*-hp-hpux*.*],[
       # Duane Wessels
       AC_MSG_NOTICE([disabling poll for $host...])
       ac_cv_func_poll='no'
-      ;;
-    [*-linux-*])
+    ],
+
+    [*-linux-*],[
       # Henrik Nordstrom (hno@squid-cache.org) 19980817
       # poll is problematic on Linux.  We disable it
       # by default until Linux gets it right.
@@ -3120,13 +3045,14 @@ if test "x$ac_cv_func_poll" = "x" ; then
           AC_MSG_NOTICE([disabling poll for $host < 2.2...])
           ac_cv_func_poll='no'
       fi
-      ;;
-    [powerpc-ibm-aix4.1.*])
+    ],
+
+    [powerpc-ibm-aix4.1.*],[
       # Mike Laster (mlaster@metavillage.com) 19981021
       AC_MSG_NOTICE([disabling poll for $host...])
       ac_cv_func_poll='no'
-      ;;
-  esac
+    ]
+  )
 fi
 
 dnl Check for library functions
@@ -3252,14 +3178,14 @@ AM_CONDITIONAL(ENABLE_SELECT_WIN32, test "x$squid_opt_io_loop_engine" = "xselect
 AM_CONDITIONAL(ENABLE_KQUEUE, test "x$squid_opt_io_loop_engine" = "xkqueue")
 AM_CONDITIONAL(ENABLE_DEVPOLL, test "x$squid_opt_io_loop_engine" = "xdevpoll")
 
-case $squid_opt_io_loop_engine in
-  epoll) AC_DEFINE(USE_EPOLL,1,[Use epoll() for the IO loop]) ;;
-  devpoll) AC_DEFINE(USE_DEVPOLL,1,[Use /dev/poll for the IO loop]) ;;
-  poll) AC_DEFINE(USE_POLL,1,[Use poll() for the IO loop]) ;;
-  kqueue) AC_DEFINE(USE_KQUEUE,1,[Use kqueue() for the IO loop]) ;;
-  select_win32) AC_DEFINE(USE_SELECT_WIN32,1,[Use Winsock select() for the IO loop]) ;;
-  select) AC_DEFINE(USE_SELECT,1,[Use select() for the IO loop]) ;;
-esac
+AS_CASE([$squid_opt_io_loop_engine],
+  [epoll],[AC_DEFINE(USE_EPOLL,1,[Use epoll() for the IO loop])],
+  [devpoll],[AC_DEFINE(USE_DEVPOLL,1,[Use /dev/poll for the IO loop])],
+  [poll],[AC_DEFINE(USE_POLL,1,[Use poll() for the IO loop])],
+  [kqueue],[AC_DEFINE(USE_KQUEUE,1,[Use kqueue() for the IO loop])],
+  [select_win32],[AC_DEFINE(USE_SELECT_WIN32,1,[Use Winsock select() for the IO loop])],
+  [select],[AC_DEFINE(USE_SELECT,1,[Use select() for the IO loop])],
+)
 
 if test "x$ac_cv_func_sched_getaffinity" = "xyes" -a "x$ac_cv_func_sched_setaffinity" = "xyes" ; then
   AC_DEFINE(HAVE_CPU_AFFINITY,1,[Support setting CPU affinity for workers])
@@ -3455,11 +3381,9 @@ SQUID_YESNO([$enableval],[unrecognized argument to --enable-gnuregex: $enableval
 ])
 # force-enable on old solaris
 if test "x${enable_gnuregex:=auto}" = "xauto" ; then
-    case "$host" in
-    *-sun-solaris2.[[0-4]])
-	  enable_gnuregex="yes"
-	  ;;
-    esac
+  AS_CASE(["$host"],
+    [*-sun-solaris2.[[0-4]]],[enable_gnuregex="yes"]
+  )
 fi
 
 # try detecting if it is needed

--- a/configure.ac
+++ b/configure.ac
@@ -910,7 +910,8 @@ AM_CONDITIONAL(ENABLE_ICAP_CLIENT, test "x$enable_icap_client" != "xno")
 
 AC_ARG_ENABLE(ecap,
   AS_HELP_STRING([--enable-ecap],[support loadable content adaptation modules]),[
-  SQUID_YESNO([$enableval],[bad value $enableval for --enable-ecap])
+  SQUID_YESNO([$enableval],[bad value $enableval for --enable-ecap])],[
+  enable_ecap="no"
 ])
 dnl Perform configuration consistency checks for eCAP
 AS_IF([test "x$enable_ecap" != "xno"],[

--- a/configure.ac
+++ b/configure.ac
@@ -457,7 +457,7 @@ AC_ARG_ENABLE(disk-io,
       squid_disk_module_candidates="$enableval"
   ])
 )
-AS_IF([test "x${enable_disk_io:-yes}" = "xyes"],[
+AS_IF([test "x${enable_disk_io:=yes}" = "xyes"],[
   SQUID_LOOK_FOR_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
   AS_IF([test "x$ac_cv_search_shm_open" = "xno"],[
     squid_disk_module_candidates=`echo "$squid_disk_module_candidates" | sed 's/IpcIo//g'`
@@ -696,7 +696,7 @@ AC_ARG_ENABLE([storeio],
       squid_storeio_module_candidates="$enableval ufs"
   ])
 ])
-AS_IF([test "x${enable_disk_io:-yes}" = "xyes"],[
+AS_IF([test "x${enable_storeio:=yes}" = "xyes"],[
   SQUID_LOOK_FOR_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
 ])
 SQUID_CLEANUP_MODULES_LIST([squid_storeio_module_candidates])

--- a/configure.ac
+++ b/configure.ac
@@ -441,41 +441,31 @@ AS_IF([test "x$ac_cv_search_shm_open" != "xno"],[
   AC_DEFINE(HAVE_SHM,1,[Support shared memory features])
 ])
 
-AC_MSG_CHECKING([for DiskIO modules to be enabled])
 squid_disk_module_candidates=""
-squid_opt_enable_diskio="auto"  #values: no, yes, "auto"(=yes+detect modules)
 AC_ARG_ENABLE(disk-io,
   AS_HELP_STRING([--enable-disk-io="list of modules"],
     [Build support for the list of disk I/O modules.
      Set without a value or omitted, all available modules will be built.
      See src/DiskIO for a list of available modules, or
      Programmers Guide section on DiskIO
-     for details on how to build your custom disk module]), [
-  AS_CASE([$enableval],
-    [yes],[],
-    [no],[squid_opt_enable_diskio="no"],
+     for details on how to build your custom disk module]),
+  AS_CASE(["$enableval"],
+    [yes],[
+      SQUID_LOOK_FOR_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
+      AS_IF([test "x$ac_cv_search_shm_open" = "xno"],[
+        squid_disk_module_candidates=`echo "$squid_disk_module_candidates" | sed 's/IpcIo//g'`
+      ])
+    ],
+    [no|none],[enable_disk_io="no"],
     [
-      squid_opt_enable_diskio="yes"
-      SQUID_CLEANUP_MODULES_LIST([squid_disk_module_candidates])
+      enable_disk_io="yes"
+      squid_disk_module_candidates="$enableval"
   ])
-])
-
-# if requested to autodetect, find out what we have
-AS_IF([test "x$squid_opt_enable_diskio" = "xauto"],[
-  squid_opt_enable_diskio="yes"
-  SQUID_LOOK_FOR_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
-  AS_IF([test "x$ac_cv_search_shm_open" = "xno"],[
-    # disable IpcIo
-    squid_disk_module_candidates=`echo $squid_disk_module_candidates|sed 's/IpcIo//'`
-  ])
-])
-
-AC_MSG_RESULT([${squid_disk_module_candidates:-none}])
+)
+SQUID_CLEANUP_MODULES_LIST([squid_disk_module_candidates])
 SQUID_CHECK_EXISTING_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
-SQUID_DEFINE_BOOL(USE_DISKIO,$squid_opt_enable_diskio,
-    [DiskIO modules are expected to be available.])
-
-
+AC_MSG_NOTICE([DiskIO modules built: ${squid_disk_module_candidates:-none}])
+SQUID_DEFINE_BOOL(USE_DISKIO,$enable_disk_io,[DiskIO modules are expected to be available.])
 
 dnl Some autoconf.h defines we might enable later...
 AC_ARG_WITH(pthreads,AS_HELP_STRING([--without-pthreads],[Disable POSIX Threads]))
@@ -688,7 +678,6 @@ AM_CONDITIONAL(ENABLE_DISKIO_MMAPPED, test "x$squid_disk_module_candidates_Mmapp
 
 dnl Check what Storage formats are wanted.
 dnl This version will error out with a message saying why if a required DiskIO is missing.
-squid_opt_enable_storeio=auto
 AC_ARG_ENABLE([storeio],
   AS_HELP_STRING([--enable-storeio="list of modules"],
                  [Build support for the list of store I/O modules.
@@ -696,30 +685,24 @@ AC_ARG_ENABLE([storeio],
                   See src/fs for a list of available modules, or
                   Programmers Guide section <not yet written>
                   for details on how to build your custom store module]), [
-  AS_CASE([$enableval],
-    [yes],[squid_opt_enable_storeio=auto],
-    [no],[squid_opt_enable_storeio=no],
+  AS_CASE(["$enableval"],
+    [yes],[
+      SQUID_LOOK_FOR_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
+    ],
+    [no|none],[enable_storeio=no],
     [
-      squid_opt_enable_storeio=yes
-      squid_storeio_module_candidates="`echo $enableval| sed -e 's/,/ /g;s/  */ /g'`"
+      enable_storeio=yes
       # ufs is really always needed as it has low-level routines
       # if it is a dupe it will be cleaned-up later
-      squid_storeio_module_candidates="$squid_storeio_module_candidates ufs"
+      squid_storeio_module_candidates="$enableval ufs"
   ])
 ])
-AS_IF([test "x$squid_opt_enable_storeio" = "xauto"],[
-  squid_opt_enable_storeio=yes
-  AC_MSG_CHECKING([for available StoreIO modules])
-  SQUID_LOOK_FOR_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
-  AC_MSG_RESULT([$squid_storeio_module_candidates])
-])
-
 SQUID_CLEANUP_MODULES_LIST([squid_storeio_module_candidates])
 SQUID_CHECK_EXISTING_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
-AC_MSG_NOTICE([Store modules built: $squid_storeio_module_candidates])
+AC_MSG_NOTICE([Store modules built: ${squid_storeio_module_candidates:-none}])
 
-for fs in $squid_storeio_module_candidates none; do
-  AS_CASE(["$fs"],
+for fs in ${squid_storeio_module_candidates:-none}; do
+  AS_CASE([$fs],
     [diskd],[
       AS_IF([test "x$squid_disk_module_candidates_Blocking" != "xyes" -a \
         "x$squid_disk_module_candidates_DiskDaemon" != "xyes"],[
@@ -786,18 +769,17 @@ AC_ARG_ENABLE(removal-policies,
                   See src/repl for a list of available modules, or
                   Programmers Guide section 9.9 for details on how
                   to build your custom policy]), [
-  AS_CASE([$enableval],
-    [yes],[SQUID_LOOK_FOR_MODULES([$srcdir/src/repl],[REPL_POLICIES])],
-    [no],[:],
-    [ REPL_POLICIES="`echo $enableval| sed -e 's/,/ /g;s/  */ /g'`" ]
+  AS_CASE(["$enableval"],
+    [yes],[ SQUID_LOOK_FOR_MODULES([$srcdir/src/repl],[REPL_POLICIES]) ],
+    [no],[],
+    [ REPL_POLICIES="$enableval" ]
   )
 ])
-AS_IF([test "x$REPL_POLICIES" != "x"],[
-  SQUID_CHECK_EXISTING_MODULES([$srcdir/src/repl],[REPL_POLICIES])
-  AC_MSG_NOTICE([Removal policies to build: $REPL_POLICIES])
-  REPL_OBJS="repl/lib`echo $REPL_POLICIES|sed -e 's% %.a repl/lib%g'`.a"
-  REPL_LIBS="`echo $REPL_OBJS|sed -e 's%repl/%%g'`"
-])
+SQUID_CLEANUP_MODULES_LIST([REPL_POLICIES])
+SQUID_CHECK_EXISTING_MODULES([$srcdir/src/repl],[REPL_POLICIES])
+AC_MSG_NOTICE([Removal policies to build: $REPL_POLICIES])
+REPL_OBJS="repl/lib`echo \"$REPL_POLICIES\" | sed -e 's% %.a repl/lib%g'`.a"
+REPL_LIBS=`echo "$REPL_OBJS" | sed -e 's%repl/%%g'`
 AC_SUBST(REPL_POLICIES)
 AC_SUBST(REPL_OBJS)
 AC_SUBST(REPL_LIBS)
@@ -918,7 +900,6 @@ AC_SUBST(EXPATLIB)
 AM_CONDITIONAL(ENABLE_LIBXML2, test "x$HAVE_LIBXML2" = "x1")
 AC_SUBST(XMLLIB)
 
-# icap argument handling
 AC_ARG_ENABLE(icap-client,
   AS_HELP_STRING([--disable-icap-client],[Disable the ICAP client.]),[
   SQUID_YESNO([$enableval],[Unrecognized argument to --disable-icap-client: $enableval])
@@ -927,23 +908,12 @@ SQUID_DEFINE_BOOL(ICAP_CLIENT,${enable_icap_client:=yes}, [Enable ICAP client fe
 AS_IF(test "x$enable_icap_client" != "xno", squid_opt_use_adaptation="yes")
 AM_CONDITIONAL(ENABLE_ICAP_CLIENT, test "x$enable_icap_client" != "xno")
 
-squid_opt_use_ecap=1
-AC_MSG_CHECKING(whether to support eCAP)
 AC_ARG_ENABLE(ecap,
   AS_HELP_STRING([--enable-ecap],[support loadable content adaptation modules]),[
-  AS_CASE([$enableval],
-    [yes|no],[squid_opt_use_ecap=$enableval],
-    [AC_MSG_ERROR([bad value $enableval for --enable-ecap])]
-  )
-  AC_MSG_RESULT([$squid_opt_use_ecap, explicitly])
-],[
-  squid_opt_use_ecap=no
-  AC_MSG_RESULT([$squid_opt_use_ecap, implicitly])
+  SQUID_YESNO([$enableval],[bad value $enableval for --enable-ecap])
 ])
-
 dnl Perform configuration consistency checks for eCAP
-AS_IF([test "x$squid_opt_use_ecap" != "xno"],[
-  dnl eCAP support requires loadable modules, which are enabled by default
+AS_IF([test "x$enable_ecap" != "xno"],[
   AS_IF([test "x$enable_shared" != "xyes"],[
     AC_MSG_ERROR([eCAP support requires loadable modules. Please do not use --disable-shared with --enable-ecap.])
   ])
@@ -969,7 +939,7 @@ AS_IF([test "x$squid_opt_use_ecap" != "xno"],[
     squid_opt_use_adaptation=yes
   ],[
     AC_MSG_RESULT(no)
-    AS_IF([test "x$squid_opt_use_ecap" = "xyes"],[
+    AS_IF([test "x$enable_ecap" = "xyes"],[
       AC_MSG_ERROR([eCAP library will not link.
                   You may need to rebuild libecap using the same version of GCC as Squid.
                   There have been breaking ABI changes in the libstdc++ STL with GCC 5.])
@@ -977,13 +947,13 @@ AS_IF([test "x$squid_opt_use_ecap" != "xno"],[
       AC_MSG_NOTICE([eCAP library will not link.
                   You may need to rebuild libecap using the same version of GCC as Squid.
                   There have been breaking ABI changes in the libstdc++ STL with GCC 5.])
-      squid_opt_use_ecap="no"
+      enable_ecap="no"
     ])
   ])
   SQUID_STATE_ROLLBACK(squid_ecap_state)
 ])
-SQUID_DEFINE_BOOL(USE_ECAP,${squid_opt_use_ecap:=no},[Whether to use eCAP support])
-AM_CONDITIONAL(ENABLE_ECAP, test "x$squid_opt_use_ecap" = "xyes")
+SQUID_DEFINE_BOOL(USE_ECAP,${enable_ecap:=no},[Whether to use eCAP support])
+AM_CONDITIONAL(ENABLE_ECAP, test "x$enable_ecap" = "xyes")
 
 dnl enable adaptation if requested by specific adaptation mechanisms
 ADAPTATION_LIBS=""

--- a/configure.ac
+++ b/configure.ac
@@ -2624,13 +2624,8 @@ SQUID_BSDNET_INCLUDES)
 AC_C_CONST
 AC_C_BIGENDIAN
 
-AC_STRUCT_TM
 AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[
-#if TM_IN_SYS_TIME
-#if HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-#elif HAVE_TIME_H
+#if HAVE_TIME_H
 #include <time.h>
 #endif
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -457,7 +457,6 @@ AC_ARG_ENABLE(disk-io,
     [no],[squid_opt_enable_diskio="no"],
     [
       squid_opt_enable_diskio="yes"
-      squid_disk_module_candidates=" `echo $enableval| sed -e 's/,/ /g;s/  */ /g'` "
       SQUID_CLEANUP_MODULES_LIST([squid_disk_module_candidates])
   ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -3173,20 +3173,23 @@ AS_IF([test "x$enable_ipf_transparent" != "xno"],[
   SQUID_CHECK_BROKEN_SOLARIS_IPFILTER
   AC_MSG_CHECKING(for availability of IP-Filter header files)
   # hold on to your hats...
-  AS_IF([test "x$ac_cv_header_ip_compat_h" = "xyes" -o \
+  AS_IF(
+  [test "x$ac_cv_header_ip_compat_h" = "xyes" -o \
     "x$ac_cv_header_ip_fil_compat_h" = "xyes" -o \
     "x$ac_cv_header_netinet_ip_compat_h" = "xyes" -o \
-    "x$ac_cv_header_netinet_ip_fil_compat_h" = "xyes"
-  ],[have_ipfilter_compat_header="yes"])
+    "x$ac_cv_header_netinet_ip_fil_compat_h" = "xyes"],
+  [have_ipfilter_compat_header="yes"])
 
-  AS_IF([test "x$have_ipfilter_compat_header" = "xyes" -a \
+  AS_IF(
+  [test "x$have_ipfilter_compat_header" = "xyes" -a \
     "x$ac_cv_header_ip_fil_h" = "xyes" -a \
-    "x$ac_cv_header_ip_nat_h" = "xyes"
-  ],[enable_ipf_transparent="yes"],
+    "x$ac_cv_header_ip_nat_h" = "xyes"],[enable_ipf_transparent="yes"],
+
   [test "x$have_ipfilter_compat_header" = "xyes" -a \
     "x$ac_cv_header_netinet_ip_fil_h" = "xyes" -a \
-    "x$ac_cv_header_netinet_ip_nat_h" = "xyes"
-  ],[enable_ipf_transparent="yes"],[enable_ipf_transparent="no"])
+    "x$ac_cv_header_netinet_ip_nat_h" = "xyes"],[enable_ipf_transparent="yes"],
+  [enable_ipf_transparent="no"])
+
   AC_MSG_RESULT($IPF_TRANSPARENT)
 
 ## On Solaris Ipfilter includes expect that SOLARIS2 is defined with the

--- a/configure.ac
+++ b/configure.ac
@@ -441,7 +441,7 @@ AS_IF([test "x$ac_cv_search_shm_open" != "xno"],[
   AC_DEFINE(HAVE_SHM,1,[Support shared memory features])
 ])
 
-squid_disk_module_candidates=""
+squid_disk_module_candidates=
 AC_ARG_ENABLE(disk-io,
   AS_HELP_STRING([--enable-disk-io="list of modules"],
     [Build support for the list of disk I/O modules.
@@ -450,18 +450,19 @@ AC_ARG_ENABLE(disk-io,
      Programmers Guide section on DiskIO
      for details on how to build your custom disk module]),
   AS_CASE(["$enableval"],
-    [yes],[
-      SQUID_LOOK_FOR_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
-      AS_IF([test "x$ac_cv_search_shm_open" = "xno"],[
-        squid_disk_module_candidates=`echo "$squid_disk_module_candidates" | sed 's/IpcIo//g'`
-      ])
-    ],
+    [yes],[],
     [no|none],[enable_disk_io="no"],
     [
       enable_disk_io="yes"
       squid_disk_module_candidates="$enableval"
   ])
 )
+AS_IF([test "x${enable_disk_io:-yes}" = "xyes"],[
+  SQUID_LOOK_FOR_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
+  AS_IF([test "x$ac_cv_search_shm_open" = "xno"],[
+    squid_disk_module_candidates=`echo "$squid_disk_module_candidates" | sed 's/IpcIo//g'`
+  ])
+])
 SQUID_CLEANUP_MODULES_LIST([squid_disk_module_candidates])
 SQUID_CHECK_EXISTING_MODULES([$srcdir/src/DiskIO],[squid_disk_module_candidates])
 AC_MSG_NOTICE([DiskIO modules built: ${squid_disk_module_candidates:-none}])
@@ -487,7 +488,7 @@ AH_TEMPLATE(HAVE_DISKIO_MODULE_MMAPPED, [Whether Mmapped Disk I/O module is buil
 for module in $squid_disk_module_candidates none; do
   # maybe not needed
   AS_IF([test "x$module" = "xnone"],[continue])
-  AS_IF([!test -d "$srcdir/src/DiskIO/$module"],[AC_MSG_ERROR([disk-io $module does not exist])])
+  AS_IF([! test -d "$srcdir/src/DiskIO/$module"],[AC_MSG_ERROR([disk-io $module does not exist])])
   AS_CASE(["$module"],
     [AIO],[
       dnl Check for POSIX AIO availability
@@ -686,16 +687,17 @@ AC_ARG_ENABLE([storeio],
                   Programmers Guide section <not yet written>
                   for details on how to build your custom store module]), [
   AS_CASE(["$enableval"],
-    [yes],[
-      SQUID_LOOK_FOR_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
-    ],
-    [no|none],[enable_storeio=no],
+    [yes],[],
+    [no|none],[enable_storeio="no"],
     [
-      enable_storeio=yes
+      enable_storeio="yes"
       # ufs is really always needed as it has low-level routines
       # if it is a dupe it will be cleaned-up later
       squid_storeio_module_candidates="$enableval ufs"
   ])
+])
+AS_IF([test "x${enable_disk_io:-yes}" = "xyes"],[
+  SQUID_LOOK_FOR_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
 ])
 SQUID_CLEANUP_MODULES_LIST([squid_storeio_module_candidates])
 SQUID_CHECK_EXISTING_MODULES([$srcdir/src/fs],[squid_storeio_module_candidates])
@@ -727,7 +729,8 @@ for fs in ${squid_storeio_module_candidates:-none}; do
         AC_MSG_ERROR([Storage module ufs requires DiskIO module: Blocking])
       ])
       squid_do_build_ufs=true
-    ])
+    ]
+  )
 done
 
 AM_CONDITIONAL(ENABLE_FS_UFS, test "x$squid_do_build_ufs" = "xtrue")

--- a/configure.ac
+++ b/configure.ac
@@ -2509,7 +2509,6 @@ AS_IF([test "x$with_cppunit" != "xno"],[
 
 dnl Check for headers
 AC_HEADER_DIRENT
-AC_HEADER_STDC
 
 AC_CHECK_HEADERS( \
   arpa/inet.h \
@@ -2718,10 +2717,9 @@ AC_CHECK_TYPE(fd_mask,  AC_DEFINE(HAVE_FD_MASK,1,[fd_mask is defined by the syst
 AC_CHECK_TYPE(socklen_t,AC_DEFINE(HAVE_SOCKLEN_T,1,[socklen_t is defined by the system headers]),,[
 #include <sys/types.h>
 #include <sys/socket.h>
-#if STDC_HEADERS
 #include <stdlib.h>
 #include <stddef.h>
-#endif])
+])
 
 AC_CHECK_TYPE(mtyp_t,AC_DEFINE(HAVE_MTYP_T,1,
    [mtyp_t is defined by the system headers]),,[#include <sys/types.h>

--- a/configure.ac
+++ b/configure.ac
@@ -2508,8 +2508,6 @@ AS_IF([test "x$with_cppunit" != "xno"],[
 ])
 
 dnl Check for headers
-AC_HEADER_DIRENT
-
 AC_CHECK_HEADERS( \
   arpa/inet.h \
   arpa/nameser.h \
@@ -2518,6 +2516,7 @@ AC_CHECK_HEADERS( \
   crypt.h \
   ctype.h \
   direct.h \
+  dirent.h \
   errno.h \
   execinfo.h \
   fcntl.h \

--- a/src/acl/external/helpers.m4
+++ b/src/acl/external/helpers.m4
@@ -5,86 +5,22 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_external_acl_helpers list containing double entries.
-
-#define list of modules to build
-auto_ext_acl_modules=no
-if test "x${enable_external_acl_helpers:=yes}" = "xyes" ;then
-  SQUID_LOOK_FOR_MODULES([$srcdir/src/acl/external],[enable_external_acl_helpers])
-  auto_ext_acl_modules=yes
-fi
-if test "x$enable_external_acl_helpers" = "xnone" ; then
-  enable_external_acl_helpers=""
-fi
 EXTERNAL_ACL_HELPERS=""
-enable_external_acl_helpers="`echo $enable_external_acl_helpers| sed -e 's/,/ /g;s/  */ /g'`"
-if test "x$enable_external_acl_helpers" != "xno" ; then
-  for helper in $enable_external_acl_helpers ; do
-    dir="$srcdir/src/acl/external/$helper"
-
-      # modules converted to autoconf macros already
-      # NP: we only need this list because m4_include() does not accept variables
-      if test "x$helper" = "xAD_group" ; then
-        m4_include([src/acl/external/AD_group/required.m4])
-
-      elif test "x$helper" = "xLDAP_group" ; then
-        m4_include([src/acl/external/LDAP_group/required.m4])
-
-      elif test "x$helper" = "xLM_group" ; then
-        m4_include([src/acl/external/LM_group/required.m4])
-
-      elif test "x$helper" = "xdelayer" ; then
-        m4_include([src/acl/external/delayer/required.m4])
-
-      elif test "x$helper" = "xSQL_session" ; then
-        m4_include([src/acl/external/SQL_session/required.m4])
-
-      elif test "x$helper" = "xeDirectory_userip" ; then
-        m4_include([src/acl/external/eDirectory_userip/required.m4])
-
-      elif test "x$helper" = "xfile_userip" ; then
-        m4_include([src/acl/external/file_userip/required.m4])
-
-      elif test "x$helper" = "xkerberos_ldap_group" ; then
-        m4_include([src/acl/external/kerberos_ldap_group/required.m4])
-
-      elif test "x$helper" = "xkerberos_sid_group" ; then
-        m4_include([src/acl/external/kerberos_sid_group/required.m4])
-
-      elif test "x$helper" = "xsession" ; then
-        m4_include([src/acl/external/session/required.m4])
-
-      elif test "x$helper" = "xtime_quota" ; then
-        m4_include([src/acl/external/time_quota/required.m4])
-
-      elif test "x$helper" = "xunix_group" ; then
-        m4_include([src/acl/external/unix_group/required.m4])
-
-      elif test "x$helper" = "xwbinfo_group" ; then
-        m4_include([src/acl/external/wbinfo_group/required.m4])
-
-      # modules not yet converted to autoconf macros (or third party drop-in's)
-      elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-        BUILD_HELPER="$helper"
-      fi
-
-      if test -d "$srcdir/src/acl/external/$helper"; then
-        if test "$BUILD_HELPER" != "$helper"; then
-          if test "x$auto_ext_acl_modules" = "xyes"; then
-            AC_MSG_NOTICE([external acl helper $helper ... found but cannot be built])
-          else
-            AC_MSG_ERROR([external acl helper $helper ... found but cannot be built])
-          fi
-        else
-          EXTERNAL_ACL_HELPERS="$EXTERNAL_ACL_HELPERS $BUILD_HELPER"
-        fi
-      else
-        AC_MSG_ERROR([external acl helper $helper ... not found])
-      fi
-  done
-fi
-AC_MSG_NOTICE([External acl helpers to be built: $EXTERNAL_ACL_HELPERS])
+SQUID_HELPER_FEATURE_CHECK([external_acl_helpers],[yes],[acl/external],[
+  # NP: we only need this list because m4_include() does not accept variables
+  SQUID_CHECK_HELPER([AD_group],[acl/external])
+  SQUID_CHECK_HELPER([LDAP_group],[acl/external])
+  SQUID_CHECK_HELPER([LM_group],[acl/external])
+  SQUID_CHECK_HELPER([delayer],[acl/external])
+  SQUID_CHECK_HELPER([SQL_session],[acl/external])
+  SQUID_CHECK_HELPER([eDirectory_userip],[acl/external])
+  SQUID_CHECK_HELPER([file_userip],[acl/external])
+  SQUID_CHECK_HELPER([kerberos_ldap_group],[acl/external])
+  SQUID_CHECK_HELPER([kerberos_sid_group],[acl/external])
+  SQUID_CHECK_HELPER([session],[acl/external])
+  SQUID_CHECK_HELPER([time_quota],[acl/external])
+  SQUID_CHECK_HELPER([unix_group],[acl/external])
+  SQUID_CHECK_HELPER([wbinfo_group],[acl/external])
+])
+EXTERNAL_ACL_HELPERS=$squid_cv_BUILD_HELPERS
 AC_SUBST(EXTERNAL_ACL_HELPERS)

--- a/src/auth/basic/DB/required.m4
+++ b/src/auth/basic/DB/required.m4
@@ -5,10 +5,8 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-if test "x$PERL" != "x"; then
-  BUILD_HELPER="DB"
-fi
-if test "x$POD2MAN" = "x"; then
+AS_IF([test "x$PERL" != "x"],[BUILD_HELPER="DB"])
+AS_IF([test "x$POD2MAN" = "x"],[
   AC_MSG_WARN([pod2man not found. basic_db_auth man(8) page will not be built])
-fi
+])
 

--- a/src/auth/basic/NIS/required.m4
+++ b/src/auth/basic/NIS/required.m4
@@ -6,8 +6,18 @@
 ##
 
 BUILD_HELPER="NIS"
-AC_CHECK_HEADERS([sys/types.h rpc/rpc.h rpcsvc/ypclnt.h rpcsvc/yp_prot.h crypt.h],[],[BUILD_HELPER=""],AC_INCLUDES_DEFAULT([
+AC_CHECK_HEADERS([ \
+  sys/types.h \
+  rpc/rpc.h \
+  rpcsvc/ypclnt.h \
+  rpcsvc/yp_prot.h \
+  crypt.h \
+],[],[
+  BUILD_HELPER=""
+],[
+  AC_INCLUDES_DEFAULT([
 #if HAVE_RPC_RPC_H
 #include <rpc/rpc.h>
 #endif
-]))
+  ])
+])

--- a/src/auth/basic/POP3/required.m4
+++ b/src/auth/basic/POP3/required.m4
@@ -5,10 +5,8 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-if test "x$PERL" != "x"; then
-  BUILD_HELPER="POP3"
-fi
-if test "x$POD2MAN" = "x"; then
+AS_IF([test "x$PERL" != "x"],[BUILD_HELPER="POP3"])
+AS_IF([test "x$POD2MAN" = "x"],[
   AC_MSG_WARN([pod2man not found. basic_pop3_auth man(8) page will not be built])
-fi
+])
 

--- a/src/auth/basic/SASL/required.m4
+++ b/src/auth/basic/SASL/required.m4
@@ -6,8 +6,4 @@
 ##
 
 SQUID_CHECK_SASL
-
-# on success, add to the built modules list
-if test "x$squid_cv_check_sasl" = "xyes"; then
-  BUILD_HELPER="SASL"
-fi
+AS_IF([test "x$squid_cv_check_sasl" = "xyes"],[BUILD_HELPER="SASL"])

--- a/src/auth/basic/SMB/required.m4
+++ b/src/auth/basic/SMB/required.m4
@@ -9,8 +9,8 @@
 # We can install anyway, but warn if smbclient not found already
 #
 AC_PATH_PROG(SMBCLIENT, smbclient)
-if test "x$SMBCLIENT" = "x"; then
+AS_IF([test "x$SMBCLIENT" = "x"],[
   AC_MSG_WARN([Samba smbclient not found in default location. basic_smb_auth may not work on this machine])
-fi
+])
 # allow script install anyway.
 BUILD_HELPER="SMB"

--- a/src/auth/basic/SMB_LM/required.m4
+++ b/src/auth/basic/SMB_LM/required.m4
@@ -7,8 +7,8 @@
 
 # DONT build this helper on Windows
 # DONT build this helper by default
-if test "x$auto_auth_basic_modules" != "xyes";then
+AS_IF([test "x$auto_helpers" != "xyes"],[
   BUILD_HELPER="SMB_LM"
   AC_CHECK_HEADERS([w32api/windows.h windows.h],[BUILD_HELPER=""])
   AS_IF([test "x$BUILD_HELPER" = "xSMB_LM"],[require_smblib="yes"])
-fi
+])

--- a/src/auth/basic/getpwnam/required.m4
+++ b/src/auth/basic/getpwnam/required.m4
@@ -13,9 +13,8 @@ AC_CHECK_HEADERS([pwd.h],[
   SQUID_STATE_ROLLBACK(getpwnam_helper)
 
   # unconditionally requires crypt(3), for now
-  if test "x$ac_cv_func_crypt" != "x"; then
+  AS_IF([test "x$ac_cv_func_crypt" != "x"],[
     AC_CHECK_HEADERS(unistd.h crypt.h shadow.h)
-
     BUILD_HELPER="getpwnam"
-  fi
+  ])
 ])

--- a/src/auth/basic/helpers.m4
+++ b/src/auth/basic/helpers.m4
@@ -5,101 +5,28 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
+AS_IF([test "x$enable_auth" != "xno"],[
+  BASIC_AUTH_HELPERS=""
+  SQUID_HELPER_FEATURE_CHECK([auth_basic],[$enable_auth],[auth/basic],[
+    # NP: we only need this list because m4_include() does not accept variables
+    SQUID_CHECK_HELPER([DB],[auth/basic])
+    SQUID_CHECK_HELPER([LDAP],[auth/basic])
+    SQUID_CHECK_HELPER([NCSA],[auth/basic])
+    SQUID_CHECK_HELPER([NIS],[auth/basic])
+    SQUID_CHECK_HELPER([PAM],[auth/basic])
+    SQUID_CHECK_HELPER([POP3],[auth/basic])
+    SQUID_CHECK_HELPER([RADIUS],[auth/basic])
+    SQUID_CHECK_HELPER([SASL],[auth/basic])
+    SQUID_CHECK_HELPER([SMB],[auth/basic])
+    SQUID_CHECK_HELPER([SMB_LM],[auth/basic])
+    SQUID_CHECK_HELPER([SSPI],[auth/basic])
+    SQUID_CHECK_HELPER([fake],[auth/basic])
+    SQUID_CHECK_HELPER([getpwnam],[auth/basic])
+  ])
 
-# TODO: de-duplicate $enable_auth_basic list containing double entries.
-
-#not specified. Inherit global
-if test "x$enable_auth_basic" = "x"; then
-    enable_auth_basic=$enable_auth
-fi
-#conflicts with global
-if test "x$enable_auth_basic" != "xno" -a "x$enable_auth" = "xno" ; then
-    AC_MSG_ERROR([Basic auth requested but auth disabled])
-fi
-#define list of modules to build
-auto_auth_basic_modules=no
-if test "x$enable_auth_basic" = "xyes" ; then
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/auth/basic],[enable_auth_basic])
-  auto_auth_basic_modules=yes
-fi
-#handle the "none" special case
-if test "x$enable_auth_basic" = "xnone" ; then
-    enable_auth_basic=""
-fi
-
-BASIC_AUTH_HELPERS=""
-#enable_auth_basic contains either "no" or the list of modules to be built
-enable_auth_basic="`echo $enable_auth_basic| sed -e 's/,/ /g;s/  */ /g'`"
-if test "x$enable_auth_basic" != "xno" ; then
-    AUTH_MODULES="$AUTH_MODULES basic"
-    AC_DEFINE([HAVE_AUTH_MODULE_BASIC],1,[Basic auth module is built])
-    for helper in $enable_auth_basic; do
-      dir="$srcdir/src/auth/basic/$helper"
-
-      # modules converted to autoconf macros already
-      # NP: we only need this list because m4_include() does not accept variables
-      if test "x$helper" = "xDB" ; then
-        m4_include([src/auth/basic/DB/required.m4])
-
-      elif test "x$helper" = "xLDAP" ; then
-        m4_include([src/auth/basic/LDAP/required.m4])
-
-      elif test "x$helper" = "xNCSA" ; then
-        m4_include([src/auth/basic/NCSA/required.m4])
-
-      elif test "x$helper" = "xNIS" ; then
-        m4_include([src/auth/basic/NIS/required.m4])
-
-      elif test "x$helper" = "xPAM" ; then
-        m4_include([src/auth/basic/PAM/required.m4])
-
-      elif test "x$helper" = "xPOP3" ; then
-        m4_include([src/auth/basic/POP3/required.m4])
-
-      elif test "x$helper" = "xRADIUS" ; then
-        m4_include([src/auth/basic/RADIUS/required.m4])
-
-      elif test "x$helper" = "xSASL" ; then
-        m4_include([src/auth/basic/SASL/required.m4])
-
-      elif test "x$helper" = "xSMB" ; then
-        m4_include([src/auth/basic/SMB/required.m4])
-
-      elif test "x$helper" = "xSMB_LM" ; then
-        m4_include([src/auth/basic/SMB_LM/required.m4])
-
-      elif test "x$helper" = "xSSPI" ; then
-        m4_include([src/auth/basic/SSPI/required.m4])
-
-      elif test "x$helper" = "xfake" ; then
-        m4_include([src/auth/basic/fake/required.m4])
-
-      elif test "x$helper" = "xgetpwnam" ; then
-        m4_include([src/auth/basic/getpwnam/required.m4])
-
-      # modules not yet converted to autoconf macros (or third party drop-in's)
-      elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-        BUILD_HELPER="$helper"
-      fi
-
-      if test -d "$srcdir/src/auth/basic/$helper"; then
-        if test "$BUILD_HELPER" != "$helper"; then
-          if test "x$auto_auth_basic_modules" = "xyes"; then
-            AC_MSG_NOTICE([Basic auth helper $helper ... found but cannot be built])
-          else
-            AC_MSG_ERROR([Basic auth helper $helper ... found but cannot be built])
-          fi
-        else
-          BASIC_AUTH_HELPERS="$BASIC_AUTH_HELPERS $BUILD_HELPER"
-        fi
-      else
-        AC_MSG_ERROR([Basic auth helper $helper ... not found])
-      fi
-    done
-fi
-
-AC_MSG_NOTICE([Basic auth helpers to be built: $BASIC_AUTH_HELPERS])
+  BASIC_AUTH_HELPERS=$squid_cv_BUILD_HELPERS
+  AUTH_MODULES="$AUTH_MODULES basic"
+  AC_DEFINE([HAVE_AUTH_MODULE_BASIC],1,[Basic auth module is built])
+])
 AM_CONDITIONAL(ENABLE_AUTH_BASIC, test "x$enable_auth_basic" != "xno")
 AC_SUBST(BASIC_AUTH_HELPERS)

--- a/src/auth/digest/helpers.m4
+++ b/src/auth/digest/helpers.m4
@@ -5,69 +5,17 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_auth_digest list containing double entries.
-
-#not specified. Inherit global
-if test "x$enable_auth_digest" = "x"; then
-    enable_auth_digest=$enable_auth
-fi
-#conflicts with global
-if test "x$enable_auth_digest" != "xno" -a "x$enable_auth" = "xno" ; then
-    AC_MSG_ERROR([Digest auth requested but auth disabled])
-fi
-#define list of modules to build
-auto_auth_digest_modules=no
-if test "x$enable_auth_digest" = "xyes" ; then
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/auth/digest],[enable_auth_digest])
-  auto_auth_digest_modules=yes
-fi
-#handle the "none" special case
-if test "x$enable_auth_digest" = "xnone" ; then
-    enable_auth_digest=""
-fi
-
-DIGEST_AUTH_HELPERS=""
-enable_auth_digest="`echo $enable_auth_digest| sed -e 's/,/ /g;s/  */ /g'`"
-if test "x$enable_auth_digest" != "xno" ; then
-    AUTH_MODULES="$AUTH_MODULES digest"
-    AC_DEFINE([HAVE_AUTH_MODULE_DIGEST],1,[Digest auth module is built])
-    for helper in $enable_auth_digest; do
-      dir="$srcdir/src/auth/digest/$helper"
-
-      # modules converted to autoconf macros already
-      # NP: we only need this list because m4_include() does not accept variables
-      if test "x$helper" = "xeDirectory" ; then
-        m4_include([src/auth/digest/eDirectory/required.m4])
-
-      elif test "x$helper" = "xfile" ; then
-        m4_include([src/auth/digest/file/required.m4])
-
-      elif test "x$helper" = "xLDAP" ; then
-        m4_include([src/auth/digest/LDAP/required.m4])
-
-      # modules not yet converted to autoconf macros (or third party drop-in's)
-      elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-        BUILD_HELPER="$helper"
-      fi
-
-      if test -d "$srcdir/src/auth/digest/$helper"; then
-        if test "$BUILD_HELPER" != "$helper"; then
-          if test "x$auto_auth_digest_modules" = "xyes"; then
-            AC_MSG_NOTICE([Digest auth helper $helper ... found but cannot be built])
-          else
-            AC_MSG_ERROR([Digest auth helper $helper ... found but cannot be built])
-          fi
-        else
-          DIGEST_AUTH_HELPERS="$DIGEST_AUTH_HELPERS $BUILD_HELPER"
-        fi
-      else
-        AC_MSG_ERROR([Digest auth helper $helper ... not found])
-      fi
-    done
-fi
-AC_MSG_NOTICE([Digest auth helpers to be built: $DIGEST_AUTH_HELPERS])
+AS_IF([test "x$enable_auth" != "xno"],[
+  DIGEST_AUTH_HELPERS=""
+  SQUID_HELPER_FEATURE_CHECK([auth_digest],[$enable_auth],[auth/digest],[
+    # NP: we only need this list because m4_include() does not accept variables
+    SQUID_CHECK_HELPER([eDirectory],[auth/digest])
+    SQUID_CHECK_HELPER([file],[auth/digest])
+    SQUID_CHECK_HELPER([LDAP],[auth/digest])
+  ])
+  DIGEST_AUTH_HELPERS=$squid_cv_BUILD_HELPERS
+  AUTH_MODULES="$AUTH_MODULES digest"
+  AC_DEFINE([HAVE_AUTH_MODULE_DIGEST],1,[Digest auth module is built])
+])
 AM_CONDITIONAL(ENABLE_AUTH_DIGEST, test "x$enable_auth_digest" != "xno")
 AC_SUBST(DIGEST_AUTH_HELPERS)

--- a/src/auth/negotiate/helpers.m4
+++ b/src/auth/negotiate/helpers.m4
@@ -5,70 +5,17 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_auth_negotiate list containing double entries.
-
-#not specified. Inherit global
-if test "x$enable_auth_negotiate" = "x"; then
-    enable_auth_negotiate=$enable_auth
-fi
-#conflicts with global
-if test "x$enable_auth_negotiate" != "xno" -a "x$enable_auth" = "xno" ; then
-  AC_MSG_ERROR([Negotiate auth requested but auth disabled])
-fi
-#define list of modules to build
-auto_auth_negotiate_modules=no
-if test "x$enable_auth_negotiate" = "xyes" ; then
-  SQUID_LOOK_FOR_MODULES([$srcdir/src/auth/negotiate],[enable_auth_negotiate])
-  auto_auth_negotiate_modules=yes
-fi
-#handle the "none" special case
-if test "x$enable_auth_negotiate" = "xnone" ; then
-    enable_auth_negotiate=""
-fi
-
-NEGOTIATE_AUTH_HELPERS=""
-enable_auth_negotiate="`echo $enable_auth_negotiate| sed -e 's/,/ /g;s/  */ /g'`"
-if test "x$enable_auth_negotiate" != "xno" ; then
-    AUTH_MODULES="$AUTH_MODULES negotiate"
-    AC_DEFINE([HAVE_AUTH_MODULE_NEGOTIATE],1,[Negotiate auth module is built])
-    for helper in $enable_auth_negotiate; do
-      dir="$srcdir/src/auth/negotiate/$helper"
-
-      # modules converted to autoconf macros already
-      # NP: we only need this list because m4_include() does not accept variables
-      if test "x$helper" = "xSSPI" ; then
-        m4_include([src/auth/negotiate/SSPI/required.m4])
-
-      elif test "x$helper" = "xkerberos" ; then
-        m4_include([src/auth/negotiate/kerberos/required.m4])
-
-      elif test "x$helper" = "xwrapper" ; then
-        m4_include([src/auth/negotiate/wrapper/required.m4])
-
-      # modules not yet converted to autoconf macros (or third party drop-in's)
-      elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-        BUILD_HELPER="$helper"
-      fi
-
-      if test -d "$srcdir/src/auth/negotiate/$helper"; then
-        if test "$BUILD_HELPER" != "$helper"; then
-          if test "x$auto_auth_negotiate_modules" = "xyes"; then
-            AC_MSG_NOTICE([Negotiate auth helper $helper ... found but cannot be built])
-          else
-            AC_MSG_ERROR([Negotiate auth helper $helper ... found but cannot be built])
-          fi
-        else
-          NEGOTIATE_AUTH_HELPERS="$NEGOTIATE_AUTH_HELPERS $BUILD_HELPER"
-        fi
-      else
-        AC_MSG_ERROR([Negotiate auth helper $helper ... not found])
-      fi
-    done
-fi
-
-AC_MSG_NOTICE([Negotiate auth helpers to be built: $NEGOTIATE_AUTH_HELPERS])
+AS_IF([test "x$enable_auth" != "xno"],[
+  NEGOTIATE_AUTH_HELPERS=""
+  SQUID_HELPER_FEATURE_CHECK([auth_negotiate],[$enable_auth],[auth/negotiate],[
+    # NP: we only need this list because m4_include() does not accept variables
+    SQUID_CHECK_HELPER([SSPI],[auth/negotiate])
+    SQUID_CHECK_HELPER([kerberos],[auth/negotiate])
+    SQUID_CHECK_HELPER([wrapper],[auth/negotiate])
+  ])
+  NEGOTIATE_AUTH_HELPERS=$squid_cv_BUILD_HELPERS
+  AUTH_MODULES="$AUTH_MODULES negotiate"
+  AC_DEFINE([HAVE_AUTH_MODULE_NEGOTIATE],1,[Negotiate auth module is built])
+])
 AM_CONDITIONAL(ENABLE_AUTH_NEGOTIATE, test "x$enable_auth_negotiate" != "xno")
 AC_SUBST(NEGOTIATE_AUTH_HELPERS)

--- a/src/auth/negotiate/kerberos/required.m4
+++ b/src/auth/negotiate/kerberos/required.m4
@@ -5,6 +5,4 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-if test "x$with_krb5" = "xyes"; then
-  BUILD_HELPER="kerberos"
-fi
+AS_IF([test "x$with_krb5" = "xyes"],[BUILD_HELPER="kerberos"])

--- a/src/auth/ntlm/SMB_LM/required.m4
+++ b/src/auth/ntlm/SMB_LM/required.m4
@@ -10,8 +10,8 @@
 # DONT build this helper by default
 #
 # XXX: do we really need the mingw check?
-if test "$squid_host_os" != "mingw" -a "x$auto_auth_ntlm_modules" != "xyes"; then
+AS_IF([test "$squid_host_os" != "mingw" -a "x$auto_helpers" != "xyes"],[
   BUILD_HELPER="SMB_LM"
   AC_CHECK_HEADERS([w32api/windows.h windows.h],[BUILD_HELPER=""])
   AS_IF([test "x$BUILD_HELPER" = "xSMB_LM"],[require_smblib="yes"])
-fi
+])

--- a/src/auth/ntlm/helpers.m4
+++ b/src/auth/ntlm/helpers.m4
@@ -4,77 +4,23 @@
 ## contributions from numerous individuals and organizations.
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
-
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_auth_ntlm list containing double entries.
-
-#not specified. Inherit global
-if test "x$enable_auth_ntlm" = "x"; then
-    enable_auth_ntlm=$enable_auth
-fi
-#conflicts with global
-if test "x$enable_auth_ntlm" != "xno" -a "x$enable_auth" = "xno" ; then
-    AC_MSG_ERROR([NTLM auth requested but auth disabled])
-fi
-#define list of modules to build
-auto_auth_ntlm_modules=no
-if test "x$enable_auth_ntlm" = "xyes" ; then
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/auth/ntlm],[enable_auth_ntlm])
-  auto_auth_ntlm_modules=yes
-fi
-#handle the "none" special case
-if test "x$enable_auth_ntlm" = "xnone" ; then
-    enable_auth_ntlm=""
-fi
-
-NTLM_AUTH_HELPERS=""
-#enable_auth_ntlm contains either "no" or the list of modules to be built
-enable_auth_ntlm="`echo $enable_auth_ntlm| sed -e 's/,/ /g;s/  */ /g'`"
-if test "x$enable_auth_ntlm" != "xno" ; then
-    AUTH_MODULES="$AUTH_MODULES ntlm"
-    AC_DEFINE([HAVE_AUTH_MODULE_NTLM],1,[NTLM auth module is built])
-    for helper in $enable_auth_ntlm; do
-      dir="$srcdir/src/auth/ntlm/$helper"
-
-      # modules converted to autoconf macros already
-      # NP: we only need this list because m4_include() does not accept variables
-      if test "x$helper" = "xfake" ; then
-        m4_include([src/auth/ntlm/fake/required.m4])
-
-      elif test "x$helper" = "xSMB_LM" ; then
-        m4_include([src/auth/ntlm/SMB_LM/required.m4])
-
-      elif test "x$helper" = "xSSPI" ; then
-        m4_include([src/auth/ntlm/SSPI/required.m4])
-
-      # modules not yet converted to autoconf macros (or third party drop-in's)
-      elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-        BUILD_HELPER="$helper"
-      fi
-
-      if test -d "$srcdir/src/auth/ntlm/$helper"; then
-        if test "$BUILD_HELPER" != "$helper"; then
-          if test "x$auto_auth_ntlm_modules" = "xyes"; then
-            AC_MSG_NOTICE([NTLM auth helper $helper ... found but cannot be built])
-          else
-            AC_MSG_ERROR([NTLM auth helper $helper ... found but cannot be built])
-          fi
-        else
-          NTLM_AUTH_HELPERS="$NTLM_AUTH_HELPERS $BUILD_HELPER"
-        fi
-      else
-        AC_MSG_ERROR([NTLM auth helper $helper ... not found])
-      fi
-    done
-fi
-AC_MSG_NOTICE([NTLM auth helpers to be built: $NTLM_AUTH_HELPERS])
+AS_IF([test "x$enable_auth" != "xno"],[
+  NTLM_AUTH_HELPERS=""
+  SQUID_HELPER_FEATURE_CHECK([auth_ntlm],[$enable_auth],[auth/ntlm],[
+    # NP: we only need this list because m4_include() does not accept variables
+    SQUID_CHECK_HELPER([fake],[auth/ntlm])
+    SQUID_CHECK_HELPER([SMB_LM],[auth/ntlm])
+    SQUID_CHECK_HELPER([SSPI],[auth/ntlm])
+  ])
+  NTLM_AUTH_HELPERS=$squid_cv_BUILD_HELPERS
+  AUTH_MODULES="$AUTH_MODULES ntlm"
+  AC_DEFINE([HAVE_AUTH_MODULE_NTLM],1,[NTLM auth module is built])
+])
 AM_CONDITIONAL(ENABLE_AUTH_NTLM, test "x$enable_auth_ntlm" != "xno")
 AC_SUBST(NTLM_AUTH_HELPERS)
 
 ## NTLM requires some special Little-Endian conversion hacks
-if test "x$enable_auth_ntlm" != "xno"; then
+AS_IF([test "x$enable_auth_ntlm" != "xno"],[
   AC_CHECK_HEADERS(machine/byte_swap.h sys/bswap.h endian.h sys/endian.h)
   AC_CHECK_FUNCS(
     bswap_16 bswap16 \
@@ -84,4 +30,4 @@ if test "x$enable_auth_ntlm" != "xno"; then
     le16toh __le16toh \
     le32toh __le32toh \
   )
-fi
+])

--- a/src/debug/Stream.h
+++ b/src/debug/Stream.h
@@ -22,9 +22,13 @@
 #if defined(assert)
 #undef assert
 #endif
-// re-do custom assert definitions
-#undef SQUID_ASSERT_H
-#include "compat/assert.h"
+#if PURIFY
+#define assert(EX) ((void)0)
+#elif defined(NODEBUG)
+#define assert(EX) ((void)0)
+#else
+#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
+#endif
 
 /* defined debug section limits */
 #define MAX_DEBUG_SECTIONS 100

--- a/src/debug/Stream.h
+++ b/src/debug/Stream.h
@@ -22,16 +22,9 @@
 #if defined(assert)
 #undef assert
 #endif
-
-#if PURIFY
-#define assert(EX) ((void)0)
-#elif defined(NODEBUG)
-#define assert(EX) ((void)0)
-#elif STDC_HEADERS
-#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
-#else
-#define assert(EX)  ((EX)?((void)0):xassert("EX", __FILE__, __LINE__))
-#endif
+// re-do custom assert definitions
+#undef SQUID_ASSERT_H
+#include "compat/assert.h"
 
 /* defined debug section limits */
 #define MAX_DEBUG_SECTIONS 100

--- a/src/http/url_rewriters/helpers.m4
+++ b/src/http/url_rewriters/helpers.m4
@@ -5,52 +5,11 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_url_rewrite_helpers list containing double entries.
-
-#define list of modules to build
-auto_urlrewrite_modules=no
-if test "x${enable_url_rewrite_helpers:=yes}" = "xyes" ; then
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/http/url_rewriters],[enable_url_rewrite_helpers])
-  auto_urlrewrite_modules=yes
-fi
-
-enable_url_rewrite_helpers="`echo $enable_url_rewrite_helpers| sed -e 's/,/ /g;s/  */ /g'`"
-AC_MSG_NOTICE([URL rewrite helper candidates: $enable_url_rewrite_helpers])
 URL_REWRITE_HELPERS=""
-if test "x$enable_url_rewrite_helpers" != "xno" ; then
-  for helper in $enable_url_rewrite_helpers; do
-    dir="$srcdir/src/http/url_rewriters/$helper"
-
-    # modules converted to autoconf macros already
-    # NP: we only need this list because m4_include() does not accept variables
-    if test "x$helper" = "xfake" ; then
-      m4_include([src/http/url_rewriters/fake/required.m4])
-
-    elif test "x$helper" = "xLFS" ; then
-      m4_include([src/http/url_rewriters/LFS/required.m4])
-
-    # modules not yet converted to autoconf macros (or third party drop-in's)
-    elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-      BUILD_HELPER="$helper"
-    fi
-
-    if test -d "$srcdir/src/http/url_rewriters/$helper"; then
-      if test "$BUILD_HELPER" != "$helper"; then
-        if test "x$auto_urlrewrite_modules" = "xyes"; then
-          AC_MSG_NOTICE([URL rewrite helper $helper ... found but cannot be built])
-        else
-          AC_MSG_ERROR([URL rewrite helper $helper ... found but cannot be built])
-        fi
-      else
-        URL_REWRITE_HELPERS="$URL_REWRITE_HELPERS $BUILD_HELPER"
-      fi
-    else
-      AC_MSG_ERROR([URL rewrite helper $helper ... not found])
-    fi
-  done
-fi
-AC_MSG_NOTICE([URL rewrite helpers to be built: $URL_REWRITE_HELPERS])
+SQUID_HELPER_FEATURE_CHECK([url_rewrite_helpers],[yes],[http/url_rewriters],[
+  # NP: we only need this list because m4_include() does not accept variables
+  SQUID_CHECK_HELPER([fake],[http/url_rewriters])
+  SQUID_CHECK_HELPER([LFS],[http/url_rewriters])
+])
+URL_REWRITE_HELPERS=$squid_cv_BUILD_HELPERS
 AC_SUBST(URL_REWRITE_HELPERS)

--- a/src/log/DB/required.m4
+++ b/src/log/DB/required.m4
@@ -5,10 +5,8 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-if test "x$PERL" != "x"; then
-  BUILD_HELPER="DB"
-fi
-if test "x$POD2MAN" = "x"; then
+AS_IF([test "x$PERL" != "x"],[BUILD_HELPER="DB"])
+AS_IF([test "x$POD2MAN" = "x"],[
   AC_MSG_WARN([pod2man not found. log_db_daemon man(8) page will not be built])
-fi
+])
 

--- a/src/log/helpers.m4
+++ b/src/log/helpers.m4
@@ -5,55 +5,11 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_log_daemon_helpers list containing double entries.
-
-#define list of modules to build
-auto_logdaemon_modules=no
-if test "x${enable_log_daemon_helpers:=yes}" = "xyes" ;then
-  enable_log_daemon_helpers=""
-  SQUID_LOOK_FOR_MODULES([$srcdir/src/log],[enable_log_daemon_helpers])
-  auto_logdaemon_modules=yes
-fi
-if test "x$enable_log_daemon_helpers" = "xnone" ; then
-  enable_log_daemon_helpers=""
-fi
-
 LOG_DAEMON_HELPERS=""
-enable_log_daemon_helpers="`echo $enable_log_daemon_helpers| sed -e 's/,/ /g;s/  */ /g'`"
-if test "x$enable_log_daemon_helpers" != "xno"; then
-  for helper in $enable_log_daemon_helpers ; do
-    dir="$srcdir/src/log/$helper"
-
-    # modules converted to autoconf macros already
-    # NP: we only need this list because m4_include() does not accept variables
-    if test "x$helper" = "xDB" ; then
-      m4_include([src/log/DB/required.m4])
-
-    elif test "x$helper" = "xfile" ; then
-      m4_include([src/log/file/required.m4])
-
-    # modules not yet converted to autoconf macros (or third party drop-in's)
-    elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-      BUILD_HELPER="$helper"
-    fi
-
-    if test -d "$srcdir/src/log/$helper"; then
-      if test "$BUILD_HELPER" != "$helper"; then
-        if test "x$auto_logdaemon_modules" = "xyes"; then
-          AC_MSG_NOTICE([Log daemon helper $helper ... found but cannot be built])
-        else
-          AC_MSG_ERROR([Log daemon helper $helper ... found but cannot be built])
-        fi
-      else
-       LOG_DAEMON_HELPERS="$LOG_DAEMON_HELPERS $BUILD_HELPER"
-      fi
-    else
-      AC_MSG_ERROR([Log daemon helper $helper ... not found])
-    fi
-  done
-fi
-AC_MSG_NOTICE([Log daemon helpers to be built: $LOG_DAEMON_HELPERS])
+SQUID_HELPER_FEATURE_CHECK([log_daemon_helpers],[yes],[log],[
+  # NP: we only need this list because m4_include() does not accept variables
+  SQUID_CHECK_HELPER([DB],[log])
+  SQUID_CHECK_HELPER([file],[log])
+])
+LOG_DAEMON_HELPERS=$squid_cv_BUILD_HELPERS
 AC_SUBST(LOG_DAEMON_HELPERS)

--- a/src/security/cert_generators/file/required.m4
+++ b/src/security/cert_generators/file/required.m4
@@ -5,6 +5,4 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-if test "x$with_openssl" = "xyes" ; then
-  BUILD_HELPER="file"
-fi
+AS_IF([test "x$with_openssl" = "xyes"],[BUILD_HELPER="file"])

--- a/src/security/cert_generators/helpers.m4
+++ b/src/security/cert_generators/helpers.m4
@@ -5,51 +5,12 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_security_cert_generators list containing double entries.
-
-#define list of modules to build
-auto_security_modules=no
-if test "x${enable_security_cert_generators:=yes}" = "xyes" ; then
-  SQUID_LOOK_FOR_MODULES([$srcdir/src/security/cert_generators],[enable_security_cert_generators])
-  auto_security_certgen_modules=yes
-fi
-
-enable_security_cert_generators="`echo $enable_security_cert_generators| sed -e 's/,/ /g;s/  */ /g'`"
-AC_MSG_NOTICE([Security certificate generator helper candidates: $enable_security_cert_generators])
 SECURITY_CERTGEN_HELPERS=""
-if test "x$enable_security_cert_generators" != "xno" ; then
-  for helper in $enable_security_cert_generators; do
-    dir="$srcdir/src/security/cert_generators/$helper"
-
-    # modules converted to autoconf macros already
-    # NP: we only need this list because m4_include() does not accept variables
-    if test "x$helper" = "xfile" ; then
-      m4_include([src/security/cert_generators/file/required.m4])
-
-    # modules not yet converted to autoconf macros (or third party drop-in's)
-    elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-      BUILD_HELPER="$helper"
-    fi
-
-    if test -d "$srcdir/src/security/cert_generators/$helper"; then
-      if test "$BUILD_HELPER" != "$helper"; then
-        if test "x$auto_security_certgen_modules" = "xyes"; then
-          AC_MSG_NOTICE([Security certificate generator helper $helper ... found but cannot be built])
-        else
-          AC_MSG_ERROR([Security certificate generator helper $helper ... found but cannot be built])
-        fi
-      else
-        SECURITY_CERTGEN_HELPERS="$SECURITY_CERTGEN_HELPERS $BUILD_HELPER"
-      fi
-    else
-      AC_MSG_ERROR([Security certificate generator helper $helper ... not found])
-    fi
-  done
-fi
-AC_MSG_NOTICE([Security certificate generator helpers to be built: $SECURITY_CERTGEN_HELPERS])
+SQUID_HELPER_FEATURE_CHECK([security_cert_generators],[yes],[security/cert_generators],[
+  # NP: we only need this list because m4_include() does not accept variables
+  SQUID_CHECK_HELPER([file],[security/cert_generators])
+])
+SECURITY_CERTGEN_HELPERS=$squid_cv_BUILD_HELPERS
 AC_SUBST(SECURITY_CERTGEN_HELPERS)
 
 # XXX: Enabling the interface in Squid still requires separate option
@@ -58,10 +19,9 @@ AC_ARG_ENABLE(ssl-crtd,
                  [Prevent Squid from directly generating TLS/SSL private key
                   and certificate. Instead enables the certificate generator
                   processes.]), [
-  SQUID_YESNO([$enableval],
-  [unrecogized argument to --enable-ssl-crtd: $enableval])
+  SQUID_YESNO([$enableval],[unrecogized argument to --enable-ssl-crtd: $enableval])
 ])
-if test "x$enable_ssl_crtd" = "xyes" -a "x$with_openssl" = "xno" ; then
-  AC_MSG_ERROR([You need ssl gatewaying support to enable ssl-crtd feature. Try to use --with-openssl.])
-fi
+AS_IF([test "x$enable_ssl_crtd" = "xyes" -a "x$with_openssl" = "xno"],[
+  AC_MSG_ERROR([You need TLS gatewaying support to enable ssl-crtd feature. Try to use --with-openssl.])
+])
 SQUID_DEFINE_BOOL(USE_SSL_CRTD, ${enable_ssl_crtd:=no},[Use ssl-crtd daemon])

--- a/src/security/cert_generators/helpers.m4
+++ b/src/security/cert_generators/helpers.m4
@@ -54,7 +54,7 @@ AC_SUBST(SECURITY_CERTGEN_HELPERS)
 
 # XXX: Enabling the interface in Squid still requires separate option
 AC_ARG_ENABLE(ssl-crtd,
-  AC_HELP_STRING([--enable-ssl-crtd],
+  AS_HELP_STRING([--enable-ssl-crtd],
                  [Prevent Squid from directly generating TLS/SSL private key
                   and certificate. Instead enables the certificate generator
                   processes.]), [

--- a/src/security/cert_validators/fake/required.m4
+++ b/src/security/cert_validators/fake/required.m4
@@ -5,10 +5,8 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-if test "x$PERL" != "x"; then
-  BUILD_HELPER="fake"
-fi
-if test "x$POD2MAN" = "x"; then
+AS_IF([test "x$PERL" != "x"],[BUILD_HELPER="fake"])
+AS_IF([test "x$POD2MAN" = "x"],[
   AC_MSG_WARN([pod2man not found. security_fake_certverify man(8) page will not be built])
-fi
+])
 

--- a/src/security/cert_validators/helpers.m4
+++ b/src/security/cert_validators/helpers.m4
@@ -5,49 +5,10 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_security_cert_validators list containing double entries.
-
-#define list of modules to build
-auto_security_certv_modules=no
-if test "x${enable_security_cert_validators:=yes}" = "xyes" ; then
-  SQUID_LOOK_FOR_MODULES([$srcdir/src/security/cert_validators],[enable_security_cert_validators])
-  auto_security_certv_modules=yes
-fi
-
-enable_security_cert_validators="`echo $enable_security_cert_validators| sed -e 's/,/ /g;s/  */ /g'`"
-AC_MSG_NOTICE([Security certificate validator helper candidates: $enable_security_cert_validators])
 SECURITY_CERTV_HELPERS=""
-if test "x$enable_security_cert_validators" != "xno" ; then
-  for helper in $enable_security_cert_validators; do
-    dir="$srcdir/src/security/cert_validators/$helper"
-
-    # modules converted to autoconf macros already
-    # NP: we only need this list because m4_include() does not accept variables
-    if test "x$helper" = "xfake" ; then
-      m4_include([src/security/cert_validators/fake/required.m4])
-
-    # modules not yet converted to autoconf macros (or third party drop-in's)
-    elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-      BUILD_HELPER="$helper"
-    fi
-
-    if test -d "$srcdir/src/security/cert_validators/$helper"; then
-      if test "$BUILD_HELPER" != "$helper"; then
-        if test "x$auto_security_certv_modules" = "xyes"; then
-          AC_MSG_NOTICE([Security certificate validator helper $helper ... found but cannot be built])
-        else
-          AC_MSG_ERROR([Security certificate validator helper $helper ... found but cannot be built])
-        fi
-      else
-        SECURITY_CERTV_HELPERS="$SECURITY_CERTV_HELPERS $BUILD_HELPER"
-      fi
-    else
-      AC_MSG_ERROR([Security certificate validator helper $helper ... not found])
-    fi
-  done
-fi
-AC_MSG_NOTICE([Security certificate validator helpers to be built: $SECURITY_CERTV_HELPERS])
+SQUID_HELPER_FEATURE_CHECK([security_cert_validators],[yes],[security/cert_validators],[
+  # NP: we only need this list because m4_include() does not accept variables
+  SQUID_CHECK_HELPER([fake],[security/cert_validators])
+])
+SECURITY_CERTV_HELPERS=$squid_cv_BUILD_HELPERS
 AC_SUBST(SECURITY_CERTV_HELPERS)

--- a/src/store/id_rewriters/helpers.m4
+++ b/src/store/id_rewriters/helpers.m4
@@ -5,49 +5,10 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-# This file is supposed to run all the tests required to identify which
-# configured modules are able to be built in this environment
-
-# TODO: de-duplicate $enable_storeid_rewrite_helpers list containing double entries.
-
-#define list of modules to build
-auto_storeid_modules=no
-if test "x${enable_storeid_rewrite_helpers:=yes}" = "xyes" ; then
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/store/id_rewriters],[enable_storeid_rewrite_helpers])
-  auto_storeid_modules=yes
-fi
-
-enable_storeid_rewrite_helpers="`echo $enable_storeid_rewrite_helpers| sed -e 's/,/ /g;s/  */ /g'`"
-AC_MSG_NOTICE([Store-ID rewrite helper candidates: $enable_storeid_rewrite_helpers])
 STOREID_REWRITE_HELPERS=""
-if test "x$enable_storeid_rewrite_helpers" != "xno" ; then
-  for helper in $enable_storeid_rewrite_helpers; do
-    dir="$srcdir/src/store/id_rewriters/$helper"
-
-    # modules converted to autoconf macros already
-    # NP: we only need this list because m4_include() does not accept variables
-    if test "x$helper" = "xfile" ; then
-      m4_include([src/store/id_rewriters/file/required.m4])
-
-    # modules not yet converted to autoconf macros (or third party drop-in's)
-    elif test -f "$dir/config.test" && sh "$dir/config.test" "$squid_host_os"; then
-      BUILD_HELPER="$helper"
-    fi
-
-    if test -d "$srcdir/src/store/id_rewriters/$helper"; then
-      if test "$BUILD_HELPER" != "$helper"; then
-        if test "x$auto_storeid_modules" = "xyes"; then
-          AC_MSG_NOTICE([Store-ID rewrite helper $helper ... found but cannot be built])
-        else
-          AC_MSG_ERROR([Store-ID rewrite helper $helper ... found but cannot be built])
-        fi
-      else
-        STOREID_REWRITE_HELPERS="$STOREID_REWRITE_HELPERS $BUILD_HELPER"
-      fi
-    else
-      AC_MSG_ERROR([Store-ID rewrite helper $helper ... not found])
-    fi
-  done
-fi
-AC_MSG_NOTICE([Store-ID rewrite helpers to be built: $STOREID_REWRITE_HELPERS])
+SQUID_HELPER_FEATURE_CHECK([storeid_rewrite_helpers],[yes],[store/id_rewriters],[
+  # NP: we only need this list because m4_include() does not accept variables
+  SQUID_CHECK_HELPER([file],[store/id_rewriters])
+])
+STOREID_REWRITE_HELPERS=$squid_cv_BUILD_HELPERS
 AC_SUBST(STOREID_REWRITE_HELPERS)


### PR DESCRIPTION
Various cleanup changes to reduce the size of autoconf scripts and
remove deprecated macros causing build warnings with autoconf v2.71.