### PR TITLE
Remove unused/broken ACL copying support

### DIFF
--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -42,11 +42,8 @@ public:
     static void ExternalAclLookup(ACLChecklist * ch, ACLExternal *);
 
     ACLExternal(char const *);
-    ACLExternal(ACLExternal const &);
     ~ACLExternal();
-    ACLExternal&operator=(ACLExternal const &);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -48,6 +48,7 @@ public:
     static ACL *FindByName(const char *name);
 
     ACL();
+    ACL(ACL &&) = delete; // no copying of any kind
     virtual ~ACL();
 
     /// sets user-specified ACL name and squid.conf context

--- a/src/acl/AdaptationServiceData.cc
+++ b/src/acl/AdaptationServiceData.cc
@@ -38,9 +38,3 @@ ACLAdaptationServiceData::parse()
     }
 }
 
-ACLData<char const *> *
-ACLAdaptationServiceData::clone() const
-{
-    return new ACLAdaptationServiceData(*this);
-}
-

--- a/src/acl/AdaptationServiceData.h
+++ b/src/acl/AdaptationServiceData.h
@@ -18,11 +18,7 @@ class ACLAdaptationServiceData : public ACLStringData
 {
 public:
     ACLAdaptationServiceData() : ACLStringData() {}
-    ACLAdaptationServiceData(ACLAdaptationServiceData const &old) : ACLStringData(old) {};
-    // Not implemented
-    ACLAdaptationServiceData &operator= (ACLAdaptationServiceData const &);
     virtual void parse();
-    virtual ACLData<char const *> *clone() const;
 };
 
 #endif /* SQUID_ADAPTATIONSERVICEDATA_H */

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -20,12 +20,6 @@ Acl::AllOf::typeString() const
     return "all-of";
 }
 
-ACL *
-Acl::AllOf::clone() const
-{
-    return new AllOf;
-}
-
 SBufList
 Acl::AllOf::dump() const
 {

--- a/src/acl/AllOf.h
+++ b/src/acl/AllOf.h
@@ -24,7 +24,6 @@ class AllOf: public Acl::InnerNode
 public:
     /* ACL API */
     virtual char const *typeString() const;
-    virtual ACL *clone() const;
     virtual void parse();
     virtual SBufList dump() const;
 

--- a/src/acl/AnnotationData.cc
+++ b/src/acl/AnnotationData.cc
@@ -45,9 +45,3 @@ ACLAnnotationData::annotate(NotePairs::Pointer pairs, const CharacterSet *delimi
     notes->updateNotePairs(pairs, delimiters, al);
 }
 
-ACLData<NotePairs::Entry *> *
-ACLAnnotationData::clone() const
-{
-    return new ACLAnnotationData;
-}
-

--- a/src/acl/AnnotationData.h
+++ b/src/acl/AnnotationData.h
@@ -26,7 +26,6 @@ public:
     virtual SBufList dump() const;
     virtual void parse();
     virtual bool empty() const { return notes->empty(); }
-    virtual ACLData<NotePairs::Entry *> *clone() const;
 
     /// Stores annotations into pairs.
     void annotate(NotePairs::Pointer pairs, const CharacterSet *delimiters, const AccessLogEntry::Pointer &al);

--- a/src/acl/AnyOf.cc
+++ b/src/acl/AnyOf.cc
@@ -15,12 +15,6 @@ Acl::AnyOf::typeString() const
     return "any-of";
 }
 
-ACL *
-Acl::AnyOf::clone() const
-{
-    return new AnyOf;
-}
-
 // called once per "acl name any-of name1 name2 ...." line
 // but since multiple lines are ORed, the line boundary does not matter,
 // so we flatten the tree into one line/level here to minimize overheads

--- a/src/acl/AnyOf.h
+++ b/src/acl/AnyOf.h
@@ -22,7 +22,6 @@ class AnyOf: public Acl::OrNode
 public:
     /* ACL API */
     virtual char const *typeString() const;
-    virtual ACL *clone() const;
     virtual void parse();
 };
 

--- a/src/acl/Arp.cc
+++ b/src/acl/Arp.cc
@@ -22,18 +22,8 @@
 
 #include <algorithm>
 
-ACL *
-ACLARP::clone() const
-{
-    return new ACLARP(*this);
-}
-
 ACLARP::ACLARP (char const *theClass) : class_ (theClass)
 {}
-
-ACLARP::ACLARP (ACLARP const & old) : class_ (old.class_), aclArpData(old.aclArpData)
-{
-}
 
 char const *
 ACLARP::typeString() const

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -25,11 +25,8 @@ class ACLARP : public ACL
 
 public:
     ACLARP(char const *);
-    ACLARP(ACLARP const &);
     ~ACLARP() {}
-    ACLARP&operator=(ACLARP const &);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -570,15 +570,6 @@ ACLASN::parse()
     }
 }
 
-ACLData<Ip::Address> *
-ACLASN::clone() const
-{
-    if (data)
-        fatal ("cloning of ACLASN not implemented");
-
-    return new ACLASN(*this);
-}
-
 /* explicit template instantiation required for some systems */
 
 template class ACLStrategised<Ip::Address>;

--- a/src/acl/Asn.h
+++ b/src/acl/Asn.h
@@ -34,7 +34,6 @@ public:
     virtual SBufList dump() const;
     virtual void parse();
     bool empty() const;
-    virtual ACLData<Ip::Address> *clone() const;
     virtual void prepareForUse();
 
 private:

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -50,11 +50,6 @@ StepValue(const char *name)
 ACLAtStepData::ACLAtStepData()
 {}
 
-ACLAtStepData::ACLAtStepData(ACLAtStepData const &old)
-{
-    values.assign(old.values.begin(), old.values.end());
-}
-
 ACLAtStepData::~ACLAtStepData()
 {
 }
@@ -90,11 +85,5 @@ bool
 ACLAtStepData::empty() const
 {
     return values.empty();
-}
-
-ACLAtStepData *
-ACLAtStepData::clone() const
-{
-    return new ACLAtStepData(*this);
 }
 

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -20,14 +20,11 @@ class ACLAtStepData : public ACLData<XactionStep>
 
 public:
     ACLAtStepData();
-    ACLAtStepData(ACLAtStepData const &);
-    ACLAtStepData &operator= (ACLAtStepData const &);
     virtual ~ACLAtStepData();
     bool match(XactionStep);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
-    virtual ACLAtStepData *clone() const;
 
     std::list<XactionStep> values;
 };

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -52,16 +52,6 @@ Acl::NotNode::typeString() const
     return "!";
 }
 
-ACL *
-Acl::NotNode::clone() const
-{
-    // Not implemented: we are not a named ACL type in squid.conf so nobody
-    // should try to create a NotNode instance by ACL type name (which is
-    // what clone() API is for -- it does not really clone anything).
-    assert(false);
-    return NULL;
-}
-
 SBufList
 Acl::NotNode::dump() const
 {
@@ -76,12 +66,6 @@ char const *
 Acl::AndNode::typeString() const
 {
     return "and";
-}
-
-ACL *
-Acl::AndNode::clone() const
-{
-    return new AndNode;
 }
 
 int
@@ -110,12 +94,6 @@ char const *
 Acl::OrNode::typeString() const
 {
     return "any-of";
-}
-
-ACL *
-Acl::OrNode::clone() const
-{
-    return new OrNode;
 }
 
 bool

--- a/src/acl/BoolOps.h
+++ b/src/acl/BoolOps.h
@@ -29,7 +29,6 @@ public:
 private:
     /* ACL API */
     virtual char const *typeString() const;
-    virtual ACL *clone() const;
     virtual void parse();
     virtual SBufList dump() const;
 
@@ -47,7 +46,6 @@ class AndNode: public InnerNode
 public:
     /* ACL API */
     virtual char const *typeString() const;
-    virtual ACL *clone() const;
     virtual void parse();
 
 private:
@@ -68,7 +66,6 @@ public:
 
     /* ACL API */
     virtual char const *typeString() const;
-    virtual ACL *clone() const;
     virtual void parse();
 
 protected:

--- a/src/acl/CertificateData.cc
+++ b/src/acl/CertificateData.cc
@@ -30,15 +30,6 @@ ACLCertificateData::ACLCertificateData(Ssl::GETX509ATTRIBUTE *sslStrategy, const
     }
 }
 
-ACLCertificateData::ACLCertificateData(ACLCertificateData const &old) : attribute (NULL), values (old.values), sslAttributeCall (old.sslAttributeCall)
-{
-    validAttributesStr = old.validAttributesStr;
-    validAttributes.assign (old.validAttributes.begin(), old.validAttributes.end());
-    attributeIsOptional = old.attributeIsOptional;
-    if (old.attribute)
-        attribute = xstrdup(old.attribute);
-}
-
 template<class T>
 inline void
 xRefFree(T &thing)
@@ -157,12 +148,5 @@ bool
 ACLCertificateData::empty() const
 {
     return values.empty();
-}
-
-ACLData<X509 *> *
-ACLCertificateData::clone() const
-{
-    /* Splay trees don't clone yet. */
-    return new ACLCertificateData(*this);
 }
 

--- a/src/acl/CertificateData.h
+++ b/src/acl/CertificateData.h
@@ -23,14 +23,11 @@ class ACLCertificateData : public ACLData<X509 *>
 
 public:
     ACLCertificateData(Ssl::GETX509ATTRIBUTE *, const char *attributes, bool optionalAttr = false);
-    ACLCertificateData(ACLCertificateData const &);
-    ACLCertificateData &operator= (ACLCertificateData const &);
     virtual ~ACLCertificateData();
     bool match(X509 *);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
-    virtual ACLData<X509 *> *clone() const;
 
     /// A '|'-delimited list of valid ACL attributes.
     /// A "*" item means that any attribute is acceptable.

--- a/src/acl/ConnectionsEncrypted.cc
+++ b/src/acl/ConnectionsEncrypted.cc
@@ -16,16 +16,7 @@
 #include "HttpRequest.h"
 #include "SquidConfig.h"
 
-ACL *
-Acl::ConnectionsEncrypted::clone() const
-{
-    return new Acl::ConnectionsEncrypted(*this);
-}
-
 Acl::ConnectionsEncrypted::ConnectionsEncrypted (char const *theClass) : class_ (theClass)
-{}
-
-Acl::ConnectionsEncrypted::ConnectionsEncrypted (Acl::ConnectionsEncrypted const & old) :class_ (old.class_)
 {}
 
 Acl::ConnectionsEncrypted::~ConnectionsEncrypted()

--- a/src/acl/ConnectionsEncrypted.h
+++ b/src/acl/ConnectionsEncrypted.h
@@ -21,11 +21,8 @@ class ConnectionsEncrypted : public ACL
 
 public:
     ConnectionsEncrypted(char const *);
-    ConnectionsEncrypted(ConnectionsEncrypted const &);
     virtual ~ConnectionsEncrypted();
-    ConnectionsEncrypted &operator =(ConnectionsEncrypted const &);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/Data.h
+++ b/src/acl/Data.h
@@ -27,7 +27,6 @@ public:
     virtual bool match(M) =0;
     virtual SBufList dump() const =0;
     virtual void parse() =0;
-    virtual ACLData *clone() const =0;
     virtual void prepareForUse() {}
 
     virtual bool empty() const =0;

--- a/src/acl/Data.h
+++ b/src/acl/Data.h
@@ -18,7 +18,8 @@ class ACLData
 {
 
 public:
-
+    ACLData() = default;
+    ACLData(ACLData<M> &&) = delete; // no copying of any kind
     virtual ~ACLData() {}
 
     /// \returns the flags supported by these ACL parameters (e.g., "-i")

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -108,9 +108,3 @@ DestinationIPLookup::LookupDone(const ipcache_addrs *, const Dns::LookupDetails 
     checklist->resumeNonBlockingCheck(DestinationIPLookup::Instance());
 }
 
-ACL *
-ACLDestinationIP::clone() const
-{
-    return new ACLDestinationIP(*this);
-}
-

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -34,8 +34,6 @@ public:
     virtual const Acl::Options &options();
     virtual int match(ACLChecklist *checklist);
 
-    virtual ACL *clone()const;
-
 private:
     Acl::BooleanOptionValue lookupBanned; ///< are DNS lookups allowed?
 };

--- a/src/acl/DomainData.cc
+++ b/src/acl/DomainData.cc
@@ -150,11 +150,3 @@ ACLDomainData::empty() const
     return domains->empty();
 }
 
-ACLData<char const *> *
-ACLDomainData::clone() const
-{
-    /* Splay trees don't clone yet. */
-    assert (!domains);
-    return new ACLDomainData;
-}
-

--- a/src/acl/DomainData.h
+++ b/src/acl/DomainData.h
@@ -24,7 +24,6 @@ public:
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
-    virtual ACLData<char const *> *clone() const;
 
     Splay<char *> *domains;
 };

--- a/src/acl/Eui64.cc
+++ b/src/acl/Eui64.cc
@@ -20,18 +20,8 @@
 #include "globals.h"
 #include "ip/Address.h"
 
-ACL *
-ACLEui64::clone() const
-{
-    return new ACLEui64(*this);
-}
-
 ACLEui64::ACLEui64 (char const *theClass) : class_ (theClass)
 {}
-
-ACLEui64::ACLEui64 (ACLEui64 const & old) : eui64Data(old.eui64Data), class_ (old.class_)
-{
-}
 
 char const *
 ACLEui64::typeString() const

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -24,11 +24,8 @@ class ACLEui64 : public ACL
 
 public:
     ACLEui64(char const *);
-    ACLEui64(ACLEui64 const &);
     ~ACLEui64() {}
-    ACLEui64&operator=(ACLEui64 const &);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/ExtUser.cc
+++ b/src/acl/ExtUser.cc
@@ -26,17 +26,6 @@ ACLExtUser::~ACLExtUser()
 
 ACLExtUser::ACLExtUser(ACLData<char const *> *newData, char const *newType) : data (newData), type_ (newType) {}
 
-ACLExtUser::ACLExtUser (ACLExtUser const &old) : data (old.data->clone()), type_ (old.type_)
-{}
-
-ACLExtUser &
-ACLExtUser::operator= (ACLExtUser const &rhs)
-{
-    data = rhs.data->clone();
-    type_ = rhs.type_;
-    return *this;
-}
-
 char const *
 ACLExtUser::typeString() const
 {
@@ -76,12 +65,6 @@ bool
 ACLExtUser::empty () const
 {
     return data->empty();
-}
-
-ACL *
-ACLExtUser::clone() const
-{
-    return new ACLExtUser(*this);
 }
 
 #endif /* USE_AUTH */

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -21,8 +21,6 @@ class ACLExtUser : public ACL
 
 public:
     ACLExtUser(ACLData<char const *> *newData, char const *);
-    ACLExtUser (ACLExtUser const &old);
-    ACLExtUser & operator= (ACLExtUser const &rhs);
     ~ACLExtUser();
 
     /* ACL API */
@@ -32,7 +30,6 @@ public:
     virtual int match(ACLChecklist *checklist);
     virtual SBufList dump() const;
     virtual bool empty () const;
-    virtual ACL *clone()const;
 
 private:
     ACLData<char const *> *data;

--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -76,9 +76,3 @@ ACLHasComponentData::parseComponent(const char *token)
     }
 }
 
-ACLData<ACLChecklist *> *
-ACLHasComponentData::clone() const
-{
-    return new ACLHasComponentData(*this);
-}
-

--- a/src/acl/HasComponentData.h
+++ b/src/acl/HasComponentData.h
@@ -25,7 +25,6 @@ public:
     virtual SBufList dump() const override;
     virtual void parse() override;
     virtual bool empty() const override { return false; }
-    virtual ACLData<ACLChecklist *> *clone() const override;
 
 private:
     enum ComponentKind { coRequest = 0, coResponse, coAle, coEnd };

--- a/src/acl/HierCodeData.cc
+++ b/src/acl/HierCodeData.cc
@@ -19,11 +19,6 @@ ACLHierCodeData::ACLHierCodeData()
     memset(values, 0, sizeof(values));
 }
 
-ACLHierCodeData::ACLHierCodeData(ACLHierCodeData const &old)
-{
-    memcpy(values, old.values, sizeof(values) );
-}
-
 ACLHierCodeData::~ACLHierCodeData()
 { }
 
@@ -72,11 +67,5 @@ ACLHierCodeData::empty() const
         if (values[iter]) return false; // not empty.
     }
     return true;
-}
-
-ACLData<hier_code> *
-ACLHierCodeData::clone() const
-{
-    return new ACLHierCodeData(*this);
 }
 

--- a/src/acl/HierCodeData.h
+++ b/src/acl/HierCodeData.h
@@ -19,14 +19,11 @@ class ACLHierCodeData : public ACLData<hier_code>
 
 public:
     ACLHierCodeData();
-    ACLHierCodeData(ACLHierCodeData const &);
-    ACLHierCodeData &operator= (ACLHierCodeData const &);
     virtual ~ACLHierCodeData();
     bool match(hier_code);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
-    virtual ACLData<hier_code> *clone() const;
 
     /// mask of codes this ACL might match.
     bool values[HIER_MAX];

--- a/src/acl/HttpHeaderData.cc
+++ b/src/acl/HttpHeaderData.cc
@@ -94,14 +94,3 @@ ACLHTTPHeaderData::empty() const
     return (hdrId == Http::HdrType::BAD_HDR && hdrName.isEmpty()) || regex_rule->empty();
 }
 
-ACLData<HttpHeader*> *
-ACLHTTPHeaderData::clone() const
-{
-    /* Header's don't clone yet. */
-    ACLHTTPHeaderData * result = new ACLHTTPHeaderData;
-    result->regex_rule = regex_rule->clone();
-    result->hdrId = hdrId;
-    result->hdrName = hdrName;
-    return result;
-}
-

--- a/src/acl/HttpHeaderData.h
+++ b/src/acl/HttpHeaderData.h
@@ -25,7 +25,6 @@ public:
     virtual SBufList dump() const;
     virtual void parse();
     virtual bool empty() const;
-    virtual ACLData<HttpHeader*> *clone() const;
 
 private:
     Http::HdrType hdrId;            /**< set if header is known */

--- a/src/acl/HttpStatus.cc
+++ b/src/acl/HttpStatus.cc
@@ -56,20 +56,8 @@ int acl_httpstatus_data::compare(acl_httpstatus_data* const& a, acl_httpstatus_d
     return ret;
 }
 
-ACL *
-ACLHTTPStatus::clone() const
-{
-    return new ACLHTTPStatus(*this);
-}
-
 ACLHTTPStatus::ACLHTTPStatus (char const *theClass) : data(NULL), class_ (theClass)
 {}
-
-ACLHTTPStatus::ACLHTTPStatus (ACLHTTPStatus const & old) : data(NULL), class_ (old.class_)
-{
-    /* we don't have copy constructors for the data yet */
-    assert(!old.data);
-}
 
 ACLHTTPStatus::~ACLHTTPStatus()
 {

--- a/src/acl/HttpStatus.h
+++ b/src/acl/HttpStatus.h
@@ -30,11 +30,8 @@ class ACLHTTPStatus : public ACL
 
 public:
     ACLHTTPStatus(char const *);
-    ACLHTTPStatus(ACLHTTPStatus const &);
     ~ACLHTTPStatus();
-    ACLHTTPStatus&operator=(ACLHTTPStatus const &);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/IntRange.cc
+++ b/src/acl/IntRange.cc
@@ -64,15 +64,6 @@ ACLIntRange::match(int i)
     return false;
 }
 
-ACLData<int> *
-ACLIntRange::clone() const
-{
-    if (!ranges.empty())
-        fatal("ACLIntRange::clone: attempt to clone used ACL");
-
-    return new ACLIntRange(*this);
-}
-
 ACLIntRange::~ACLIntRange()
 {}
 

--- a/src/acl/IntRange.h
+++ b/src/acl/IntRange.h
@@ -25,7 +25,6 @@ public:
     virtual SBufList dump() const;
     virtual void parse();
     virtual bool empty() const;
-    virtual ACLData<int> *clone() const;
 
 private:
     typedef Range<int> RangeType;

--- a/src/acl/LocalIp.cc
+++ b/src/acl/LocalIp.cc
@@ -24,9 +24,3 @@ ACLLocalIP::match(ACLChecklist *checklist)
     return ACLIP::match (Filled(checklist)->my_addr);
 }
 
-ACL *
-ACLLocalIP::clone() const
-{
-    return new ACLLocalIP(*this);
-}
-

--- a/src/acl/LocalIp.h
+++ b/src/acl/LocalIp.h
@@ -19,7 +19,6 @@ class ACLLocalIP : public ACLIP
 public:
     virtual char const *typeString() const;
     virtual int match(ACLChecklist *checklist);
-    virtual ACL *clone()const;
 };
 
 #endif /* SQUID_ACLLOCALIP_H */

--- a/src/acl/MaxConnection.cc
+++ b/src/acl/MaxConnection.cc
@@ -15,16 +15,7 @@
 #include "Debug.h"
 #include "SquidConfig.h"
 
-ACL *
-ACLMaxConnection::clone() const
-{
-    return new ACLMaxConnection(*this);
-}
-
 ACLMaxConnection::ACLMaxConnection (char const *theClass) : class_ (theClass), limit(-1)
-{}
-
-ACLMaxConnection::ACLMaxConnection (ACLMaxConnection const & old) :class_ (old.class_), limit (old.limit)
 {}
 
 ACLMaxConnection::~ACLMaxConnection()

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -18,11 +18,8 @@ class ACLMaxConnection : public ACL
 
 public:
     ACLMaxConnection(char const *);
-    ACLMaxConnection(ACLMaxConnection const &);
     ~ACLMaxConnection();
-    ACLMaxConnection&operator=(ACLMaxConnection const &);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/MethodData.cc
+++ b/src/acl/MethodData.cc
@@ -16,11 +16,6 @@
 
 int ACLMethodData::ThePurgeCount = 0;
 
-ACLMethodData::ACLMethodData(ACLMethodData const &old)
-{
-    assert(old.values.empty());
-}
-
 ACLMethodData::~ACLMethodData()
 {
     values.clear();
@@ -61,12 +56,5 @@ ACLMethodData::parse()
         if (values.back() == Http::METHOD_PURGE)
             ++ThePurgeCount; // configuration code wants to know
     }
-}
-
-ACLData<HttpRequestMethod> *
-ACLMethodData::clone() const
-{
-    assert(values.empty());
-    return new ACLMethodData(*this);
 }
 

--- a/src/acl/MethodData.h
+++ b/src/acl/MethodData.h
@@ -21,14 +21,11 @@ class ACLMethodData : public ACLData<HttpRequestMethod>
 
 public:
     ACLMethodData() {}
-    ACLMethodData(ACLMethodData const &);
-    ACLMethodData &operator= (ACLMethodData const &);
     virtual ~ACLMethodData();
     bool match(HttpRequestMethod);
     virtual SBufList dump() const;
     void parse();
     bool empty() const {return values.empty();}
-    virtual ACLData<HttpRequestMethod> *clone() const;
 
     std::list<HttpRequestMethod> values;
 

--- a/src/acl/NoteData.cc
+++ b/src/acl/NoteData.cc
@@ -59,13 +59,3 @@ ACLNoteData::empty() const
     return name.isEmpty();
 }
 
-ACLData<NotePairs::Entry *> *
-ACLNoteData::clone() const
-{
-    ACLNoteData * result = new ACLNoteData;
-    result->values = dynamic_cast<ACLStringData*>(values->clone());
-    assert(result->values);
-    result->name = name;
-    return result;
-}
-

--- a/src/acl/NoteData.h
+++ b/src/acl/NoteData.h
@@ -27,7 +27,6 @@ public:
     virtual SBufList dump() const;
     virtual void parse();
     virtual bool empty() const;
-    virtual ACLData<NotePairs::Entry *> *clone() const;
 
 private:
     SBuf name;                   ///< Note name to check. It is always set

--- a/src/acl/ProtocolData.cc
+++ b/src/acl/ProtocolData.cc
@@ -15,11 +15,6 @@
 #include "Debug.h"
 #include "wordlist.h"
 
-ACLProtocolData::ACLProtocolData(ACLProtocolData const &old)
-{
-    assert(old.values.empty());
-}
-
 ACLProtocolData::~ACLProtocolData()
 {
     values.clear();
@@ -66,13 +61,5 @@ ACLProtocolData::parse()
             // XXX: store the text pattern of this protocol name for live comparisons
         }
     }
-}
-
-ACLData<AnyP::ProtocolType> *
-ACLProtocolData::clone() const
-{
-    /* Splay trees don't clone yet. */
-    assert(values.empty());
-    return new ACLProtocolData(*this);
 }
 

--- a/src/acl/ProtocolData.h
+++ b/src/acl/ProtocolData.h
@@ -21,14 +21,11 @@ class ACLProtocolData : public ACLData<AnyP::ProtocolType>
 
 public:
     ACLProtocolData() {}
-    ACLProtocolData(ACLProtocolData const &);
-    ACLProtocolData &operator= (ACLProtocolData const &);
     virtual ~ACLProtocolData();
     bool match(AnyP::ProtocolType);
     virtual SBufList dump() const;
     void parse();
     bool empty() const {return values.empty();}
-    virtual ACLData<AnyP::ProtocolType> *clone() const;
 
     std::list<AnyP::ProtocolType> values;
 };

--- a/src/acl/Random.cc
+++ b/src/acl/Random.cc
@@ -17,20 +17,9 @@
 
 #include <random>
 
-ACL *
-ACLRandom::clone() const
-{
-    return new ACLRandom(*this);
-}
-
 ACLRandom::ACLRandom(char const *theClass) : data(0.0), class_(theClass)
 {
     memset(pattern, 0, sizeof(pattern));
-}
-
-ACLRandom::ACLRandom(ACLRandom const & old) : data(old.data), class_(old.class_)
-{
-    memcpy(pattern, old.pattern, sizeof(pattern));
 }
 
 ACLRandom::~ACLRandom()

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -17,11 +17,8 @@ class ACLRandom : public ACL
 
 public:
     ACLRandom(char const *);
-    ACLRandom(ACLRandom const &);
     ~ACLRandom();
-    ACLRandom&operator=(ACLRandom const &);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/RegexData.cc
+++ b/src/acl/RegexData.cc
@@ -268,11 +268,3 @@ ACLRegexData::empty() const
     return data.empty();
 }
 
-ACLData<char const *> *
-ACLRegexData::clone() const
-{
-    /* Regex's don't clone yet. */
-    assert(data.empty());
-    return new ACLRegexData;
-}
-

--- a/src/acl/RegexData.h
+++ b/src/acl/RegexData.h
@@ -26,7 +26,6 @@ public:
     virtual void parse();
     virtual const Acl::ParameterFlags &supportedFlags() const;
     virtual bool empty() const;
-    virtual ACLData<char const *> *clone() const;
 
 private:
     std::list<RegexPattern> data;

--- a/src/acl/ServerName.cc
+++ b/src/acl/ServerName.cc
@@ -50,14 +50,6 @@ ACLServerNameData::match(const char *host)
 
 }
 
-ACLData<char const *> *
-ACLServerNameData::clone() const
-{
-    /* Splay trees don't clone yet. */
-    assert (!domains);
-    return new ACLServerNameData;
-}
-
 /// A helper function to be used with Ssl::matchX509CommonNames().
 /// \retval 0 when the name (cn or an alternate name) matches acl data
 /// \retval 1 when the name does not match

--- a/src/acl/ServerName.h
+++ b/src/acl/ServerName.h
@@ -18,7 +18,6 @@ class ACLServerNameData : public ACLDomainData {
 public:
     ACLServerNameData() : ACLDomainData() {}
     virtual bool match(const char *);
-    virtual ACLData<char const *> *clone() const;
 };
 
 class ACLServerNameStrategy : public ACLStrategy<char const *>

--- a/src/acl/SourceIp.cc
+++ b/src/acl/SourceIp.cc
@@ -24,9 +24,3 @@ ACLSourceIP::match(ACLChecklist *checklist)
     return ACLIP::match(Filled(checklist)->src_addr);
 }
 
-ACL *
-ACLSourceIP::clone() const
-{
-    return new ACLSourceIP(*this);
-}
-

--- a/src/acl/SourceIp.h
+++ b/src/acl/SourceIp.h
@@ -18,7 +18,6 @@ class ACLSourceIP : public ACLIP
 public:
     virtual char const *typeString() const;
     virtual int match(ACLChecklist *checklist);
-    virtual ACL *clone()const;
 };
 
 #endif /* SQUID_ACLSOURCEIP_H */

--- a/src/acl/SquidErrorData.cc
+++ b/src/acl/SquidErrorData.cc
@@ -66,12 +66,3 @@ ACLSquidErrorData::empty() const
     return errors.empty();
 }
 
-ACLData<err_type> *
-ACLSquidErrorData::clone() const
-{
-    if (!errors.empty())
-        fatal("ACLSquidError::clone: attempt to clone used ACL");
-
-    return new ACLSquidErrorData (*this);
-}
-

--- a/src/acl/SquidErrorData.h
+++ b/src/acl/SquidErrorData.h
@@ -25,7 +25,6 @@ public:
     virtual SBufList dump() const;
     virtual void parse();
     virtual bool empty() const;
-    virtual ACLData<err_type> *clone() const;
 
 private:
     CbDataListContainer <err_type> errors;

--- a/src/acl/SslErrorData.cc
+++ b/src/acl/SslErrorData.cc
@@ -12,10 +12,6 @@
 #include "security/CertError.h"
 #include "ssl/ErrorDetail.h"
 
-ACLSslErrorData::ACLSslErrorData(ACLSslErrorData const &o) :
-    values(o.values)
-{}
-
 bool
 ACLSslErrorData::match(const Security::CertErrors *toFind)
 {
@@ -42,11 +38,5 @@ ACLSslErrorData::parse()
     while (char *t = ConfigParser::strtokFile()) {
         Ssl::ParseErrorString(t, values);
     }
-}
-
-ACLSslErrorData *
-ACLSslErrorData::clone() const
-{
-    return new ACLSslErrorData(*this);
 }
 

--- a/src/acl/SslErrorData.h
+++ b/src/acl/SslErrorData.h
@@ -19,14 +19,11 @@ class ACLSslErrorData : public ACLData<const Security::CertErrors *>
 
 public:
     ACLSslErrorData() = default;
-    ACLSslErrorData(ACLSslErrorData const &);
-    ACLSslErrorData &operator= (ACLSslErrorData const &);
     virtual ~ACLSslErrorData() {}
     bool match(const Security::CertErrors *);
     virtual SBufList dump() const;
     void parse();
     bool empty() const { return values.empty(); }
-    virtual  ACLSslErrorData *clone() const;
 
     Security::Errors values;
 };

--- a/src/acl/Strategised.h
+++ b/src/acl/Strategised.h
@@ -34,7 +34,6 @@ public:
 
     ~ACLStrategised();
     ACLStrategised(ACLData<MatchType> *, ACLStrategy<MatchType> *, char const *);
-    ACLStrategised(ACLStrategised const &&) = delete;
 
     virtual char const *typeString() const;
     virtual void parseFlags();

--- a/src/acl/StringData.cc
+++ b/src/acl/StringData.cc
@@ -14,10 +14,6 @@
 #include "ConfigParser.h"
 #include "Debug.h"
 
-ACLStringData::ACLStringData(ACLStringData const &old) : stringValues(old.stringValues)
-{
-}
-
 void
 ACLStringData::insert(const char *value)
 {
@@ -64,12 +60,5 @@ bool
 ACLStringData::empty() const
 {
     return stringValues.empty();
-}
-
-ACLData<char const *> *
-ACLStringData::clone() const
-{
-    /* Splay trees don't clone yet. */
-    return new ACLStringData(*this);
 }
 

--- a/src/acl/StringData.h
+++ b/src/acl/StringData.h
@@ -21,8 +21,6 @@ class ACLStringData : public ACLData<char const *>
 
 public:
     ACLStringData() {}
-    ACLStringData(ACLStringData const &);
-    ACLStringData &operator= (ACLStringData const &);
     virtual ~ACLStringData() {}
     /// \deprecated use match(SBuf&) instead.
     bool match(char const *);
@@ -30,7 +28,7 @@ public:
     virtual SBufList dump() const;
     virtual void parse();
     bool empty() const;
-    virtual ACLData<char const *> *clone() const;
+
     /// Insert a string data value
     void insert(const char *);
 

--- a/src/acl/TimeData.cc
+++ b/src/acl/TimeData.cc
@@ -28,26 +28,6 @@
 
 ACLTimeData::ACLTimeData () : weekbits (0), start (0), stop (0), next (NULL) {}
 
-ACLTimeData::ACLTimeData(ACLTimeData const &old) : weekbits(old.weekbits), start (old.start), stop (old.stop), next (NULL)
-{
-    if (old.next)
-        next = (ACLTimeData *)old.next->clone();
-}
-
-ACLTimeData&
-ACLTimeData::operator=(ACLTimeData const &old)
-{
-    weekbits = old.weekbits;
-    start = old.start;
-    stop = old.stop;
-    next = NULL;
-
-    if (old.next)
-        next = (ACLTimeData *)old.next->clone();
-
-    return *this;
-}
-
 ACLTimeData::~ACLTimeData()
 {
     if (next)
@@ -234,11 +214,5 @@ bool
 ACLTimeData::empty() const
 {
     return false;
-}
-
-ACLData<time_t> *
-ACLTimeData::clone() const
-{
-    return new ACLTimeData(*this);
 }
 

--- a/src/acl/TimeData.h
+++ b/src/acl/TimeData.h
@@ -18,14 +18,11 @@ class ACLTimeData : public ACLData<time_t>
 
 public:
     ACLTimeData();
-    ACLTimeData(ACLTimeData const &);
-    ACLTimeData&operator=(ACLTimeData const &);
     virtual ~ACLTimeData();
     bool match(time_t);
     virtual SBufList dump() const;
     void parse();
     bool empty() const;
-    virtual ACLData<time_t> *clone() const;
 
 private:
     int weekbits;

--- a/src/acl/TransactionInitiator.cc
+++ b/src/acl/TransactionInitiator.cc
@@ -17,12 +17,6 @@
 #include "MasterXaction.h"
 #include "SquidConfig.h"
 
-ACL *
-Acl::TransactionInitiator::clone() const
-{
-    return new Acl::TransactionInitiator(*this);
-}
-
 Acl::TransactionInitiator::TransactionInitiator (const char *aClass) : class_ (aClass), initiators_(0)
 {}
 

--- a/src/acl/TransactionInitiator.h
+++ b/src/acl/TransactionInitiator.h
@@ -24,7 +24,6 @@ class TransactionInitiator : public ACL
 public:
     TransactionInitiator(char const *);
 
-    virtual ACL *clone()const;
     virtual char const *typeString() const;
     virtual void parse();
     virtual int match(ACLChecklist *checklist);

--- a/src/acl/UserData.cc
+++ b/src/acl/UserData.cc
@@ -145,9 +145,3 @@ ACLUserData::empty() const
     return userDataNames.empty();
 }
 
-ACLData<char const *> *
-ACLUserData::clone() const
-{
-    return new ACLUserData;
-}
-

--- a/src/acl/UserData.h
+++ b/src/acl/UserData.h
@@ -27,7 +27,6 @@ public:
     void parse();
     virtual const Acl::ParameterFlags &supportedFlags() const;
     bool empty() const;
-    virtual ACLData<char const *> *clone() const;
 
 private:
 

--- a/src/auth/AclMaxUserIp.cc
+++ b/src/auth/AclMaxUserIp.cc
@@ -23,12 +23,6 @@ ACLMaxUserIP::ACLMaxUserIP(char const *theClass) :
     maximum(0)
 {}
 
-ACL *
-ACLMaxUserIP::clone() const
-{
-    return new ACLMaxUserIP(*this);
-}
-
 char const *
 ACLMaxUserIP::typeString() const
 {

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -21,7 +21,6 @@ class ACLMaxUserIP : public ACL
 public:
     explicit ACLMaxUserIP(char const *theClass);
 
-    virtual ACL *clone() const;
     virtual char const *typeString() const;
     virtual const Acl::Options &options();
     virtual void parse();

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -31,19 +31,6 @@ ACLProxyAuth::ACLProxyAuth(ACLData<char const *> *newData, char const *theType) 
     type_(theType)
 {}
 
-ACLProxyAuth::ACLProxyAuth(ACLProxyAuth const &old) :
-    data(old.data->clone()),
-    type_(old.type_)
-{}
-
-ACLProxyAuth &
-ACLProxyAuth::operator=(ACLProxyAuth const &rhs)
-{
-    data = rhs.data->clone();
-    type_ = rhs.type_;
-    return *this;
-}
-
 char const *
 ACLProxyAuth::typeString() const
 {
@@ -153,12 +140,6 @@ ProxyAuthLookup::LookupDone(void *data)
     }
 
     checklist->resumeNonBlockingCheck(ProxyAuthLookup::Instance());
-}
-
-ACL *
-ACLProxyAuth::clone() const
-{
-    return new ACLProxyAuth(*this);
 }
 
 int

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -34,8 +34,6 @@ class ACLProxyAuth : public ACL
 public:
     ~ACLProxyAuth();
     ACLProxyAuth(ACLData<char const *> *, char const *);
-    ACLProxyAuth(ACLProxyAuth const &);
-    ACLProxyAuth &operator =(ACLProxyAuth const &);
 
     /* ACL API */
     virtual char const *typeString() const;
@@ -47,7 +45,6 @@ public:
     virtual bool valid() const;
     virtual bool empty() const;
     virtual bool requiresRequest() const {return true;}
-    virtual ACL *clone() const;
     virtual int matchForCache(ACLChecklist *checklist);
 
 private:

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1169,20 +1169,8 @@ ExternalACLLookup::LookupDone(void *data, const ExternalACLEntryPointer &result)
     checklist->resumeNonBlockingCheck(ExternalACLLookup::Instance());
 }
 
-ACL *
-ACLExternal::clone() const
-{
-    return new ACLExternal(*this);
-}
-
 ACLExternal::ACLExternal(char const *theClass) : data(NULL), class_(xstrdup(theClass))
 {}
-
-ACLExternal::ACLExternal(ACLExternal const & old) : data(NULL), class_(old.class_ ? xstrdup(old.class_) : NULL)
-{
-    /* we don't have copy constructors for the data yet */
-    assert(!old.data);
-}
 
 char const *
 ACLExternal::typeString() const

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -29,17 +29,6 @@ ACLIdent::~ACLIdent()
 
 ACLIdent::ACLIdent(ACLData<char const *> *newData, char const *newType) : data (newData), type_ (newType) {}
 
-ACLIdent::ACLIdent (ACLIdent const &old) : data (old.data->clone()), type_ (old.type_)
-{}
-
-ACLIdent &
-ACLIdent::operator= (ACLIdent const &rhs)
-{
-    data = rhs.data->clone();
-    type_ = rhs.type_;
-    return *this;
-}
-
 char const *
 ACLIdent::typeString() const
 {
@@ -96,12 +85,6 @@ bool
 ACLIdent::empty () const
 {
     return data->empty();
-}
-
-ACL *
-ACLIdent::clone() const
-{
-    return new ACLIdent(*this);
 }
 
 IdentLookup IdentLookup::instance_;

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -36,8 +36,6 @@ class ACLIdent : public ACL
 
 public:
     ACLIdent(ACLData<char const *> *newData, char const *);
-    ACLIdent (ACLIdent const &old);
-    ACLIdent & operator= (ACLIdent const &rhs);
     ~ACLIdent();
 
     /* ACL API */
@@ -48,7 +46,6 @@ public:
     virtual int match(ACLChecklist *checklist);
     virtual SBufList dump() const;
     virtual bool empty () const;
-    virtual ACL *clone()const;
 
 private:
     ACLData<char const *> *data;

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -18,7 +18,6 @@
 Acl::Answer AuthenticateAcl(ACLChecklist *) STUB_RETVAL(ACCESS_DENIED)
 
 #include "auth/AclMaxUserIp.h"
-ACL * ACLMaxUserIP::clone() const STUB_RETVAL(NULL)
 ACLMaxUserIP::ACLMaxUserIP (char const *) STUB
 char const * ACLMaxUserIP::typeString() const STUB_RETVAL(NULL)
 bool ACLMaxUserIP::empty () const STUB_RETVAL(false)
@@ -32,8 +31,6 @@ const Acl::Options &ACLMaxUserIP::options() STUB_RETVAL(Acl::NoOptions())
 #include "auth/AclProxyAuth.h"
 ACLProxyAuth::~ACLProxyAuth() STUB
 ACLProxyAuth::ACLProxyAuth(ACLData<char const *> *, char const *) STUB
-ACLProxyAuth::ACLProxyAuth (ACLProxyAuth const &) STUB
-ACLProxyAuth & ACLProxyAuth::operator= (ACLProxyAuth const & a) STUB_RETVAL(const_cast<ACLProxyAuth &>(a))
 char const * ACLProxyAuth::typeString() const STUB_RETVAL(NULL)
 void ACLProxyAuth::parse() STUB
 int ACLProxyAuth::match(ACLChecklist *) STUB_RETVAL(0)
@@ -43,7 +40,6 @@ bool ACLProxyAuth::valid () const STUB_RETVAL(false)
 ProxyAuthLookup * ProxyAuthLookup::Instance() STUB_RETVAL(NULL)
 void ProxyAuthLookup::checkForAsync(ACLChecklist *) const STUB
 void ProxyAuthLookup::LookupDone(void *) STUB
-ACL * ACLProxyAuth::clone() const STUB_RETVAL(NULL)
 int ACLProxyAuth::matchForCache(ACLChecklist *) STUB_RETVAL(0)
 int ACLProxyAuth::matchProxyAuth(ACLChecklist *) STUB_RETVAL(0)
 void ACLProxyAuth::parseFlags() STUB


### PR DESCRIPTION
This code is unused. The clone() methods were the only use of
copy construction and operator. Most ACL related classes lack
implementation of the copy and/or assert so even if used this
code would be quite dangerous.

Explicitly forbid copy/move at the hierarchy base classes
ACL and ACLData. Removing all child specific copy
implementations and prohibitions (now unnecessary).