### PR TITLE
Remove OSF/1 support

### DIFF
--- a/compat/osdetect.h
+++ b/compat/osdetect.h
@@ -34,9 +34,6 @@
 #elif defined(__hpux)       /* HP-UX - SysV-like? */
 #define _SQUID_HPUX_ 1
 
-#elif defined(__osf__)      /* OSF/1 */
-#define _SQUID_OSF_ 1
-
 #elif defined(_AIX)     /* AIX */
 #define _SQUID_AIX_ 1
 

--- a/compat/shm.cc
+++ b/compat/shm.cc
@@ -22,7 +22,7 @@
 bool
 shm_portable_segment_name_is_path()
 {
-#if _SQUID_HPUX_ || _SQUID_OSF_ || defined(__vms) || (_SQUID_FREEBSD_ && (__FreeBSD__ < 7)) || _SQUID_DRAGONFLY_
+#if _SQUID_HPUX_ ||  defined(__vms) || (_SQUID_FREEBSD_ && (__FreeBSD__ < 7)) || _SQUID_DRAGONFLY_
     return true;
 #elif _SQUID_FREEBSD_
     int jailed = 0;

--- a/configure.ac
+++ b/configure.ac
@@ -3627,9 +3627,6 @@ AC_MSG_NOTICE([BUILD C++ FLAGS: $CXXFLAGS])
 AC_MSG_NOTICE([BUILD EXTRA C++ FLAGS: $SQUID_CXXFLAGS])
 AC_MSG_NOTICE([BUILD Tools C++ FLAGS: $BUILDCXXFLAGS])
 
-dnl Clean up after OSF/1 core dump bug
-rm -f core 
-
 AC_CONFIG_FILES([
 	Makefile
 	compat/Makefile

--- a/scripts/icpserver.pl
+++ b/scripts/icpserver.pl
@@ -49,7 +49,6 @@ if ($SERVER ne "0.0.0.0") { # i.e. multicast
     $IP_ADD_MEMBERSHIP=5;
     $whoami =~ /SunOS [^\s]+ 5/ && ($IP_MULTICAST_TTL=19);
     $whoami =~ /IRIX [^\s]+ 5/ && ($IP_MULTICAST_TTL=23);
-    $whoami =~ /OSF1/ && ($IP_MULTICAST_TTL=12);
     # any more funnies ?
 
     setsockopt(S, 0, $IP_ADD_MEMBERSHIP, $SERVERIP."\0\0\0\0")

--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -74,10 +74,6 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     int x;
     int xerrno;
 
-#if USE_POLL && _SQUID_OSF_
-    assert(type != IPC_FIFO);
-#endif
-
     if (rfd)
         *rfd = -1;
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -246,7 +246,7 @@ rusage_maxrss(struct rusage *r)
 {
 #if _SQUID_SGI_ && _ABIAPI
     return r->ru_pad[0];
-#elif _SQUID_SGI_|| _SQUID_OSF_ || _SQUID_AIX_ || defined(BSD4_4)
+#elif _SQUID_SGI_|| _SQUID_AIX_ || defined(BSD4_4)
 
     return r->ru_maxrss;
 #elif defined(HAVE_GETPAGESIZE) && HAVE_GETPAGESIZE != 0

--- a/src/unlinkd.cc
+++ b/src/unlinkd.cc
@@ -202,10 +202,7 @@ unlinkdInit(void)
     localhost.setLocalhost();
 
     pid = ipcCreate(
-#if USE_POLL && _SQUID_OSF_
-              /* pipes and poll() don't get along on DUNIX -DW */
-              IPC_STREAM,
-#elif _SQUID_WINDOWS_
+#if _SQUID_WINDOWS_
               /* select() will fail on a pipe */
               IPC_TCP_SOCKET,
 #else


### PR DESCRIPTION
The last version of OSF/1 was released in 2012 under the name
Tru64 Unix for MIPS architecture CPUs. Its long-term support
by HP will be over by the time Squid-6 is released.