### PR TITLE
Remove m88k-specific support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -334,11 +334,6 @@ if test "x$PRESET_CFLAGS" = "x"; then
     case "$host" in
       *-sun-sunos*)
         # sunos has too many warnings for this to be useful
-        # motorola too
-        ;;
-      *m88k*)
-        # Motorola cc/ld does not like -02 but is ok on -O
-        CFLAGS=`echo $CFLAGS | sed -e 's/-O[0-9]/-O/'`
         ;;
       *)
         CFLAGS="$squid_cv_cc_option_wall $CFLAGS"
@@ -3125,12 +3120,6 @@ assert(myBar != NULL);
     fi
     ;;
 
-    *m88k*)
-      SQUID_CFLAGS="$SQUID_CFLAGS -D_SQUID_MOTOROLA_"
-      SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_SQUID_MOTOROLA_"
-      AC_DEFINE(GETTIMEOFDAY_NO_TZP,1,
-        [If gettimeofday is known to take only one argument])
-    ;;
     [*-*-solaris2.[0-4]])
       AC_DEFINE(GETTIMEOFDAY_NO_TZP,1)
     ;;

--- a/configure.ac
+++ b/configure.ac
@@ -3067,6 +3067,7 @@ esac
 
 dnl System-specific library modifications
 dnl
+AH_TEMPLATE(GETTIMEOFDAY_NO_TZP,[If gettimeofday is known to take only one argument])
 case "$host" in
   i386-*-solaris2.*)
     if test "x$GCC" = "xyes"; then


### PR DESCRIPTION
Modern support for m88k hardware is only available through
OpenBSD and NetBSD which have their own compatibility handling.
We no longer need to detect m88k ourselves.