### PR TITLE
Categorize level-0/1 messages; part 1: "easy" problem messages

### DIFF
--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -486,7 +486,7 @@ ConfigParser::NextKvPair(char * &key, char * &value)
     if (!key)
         return false;
     if (!value) {
-        debugs(3, DBG_CRITICAL, "Error while parsing key=value token. Value missing after: " << key);
+        debugs(3, DBG_CRITICAL, "ERROR: Failure while parsing key=value token. Value missing after: " << key);
         return false;
     }
 

--- a/src/DiskIO/DiskDaemon/DiskdFile.cc
+++ b/src/DiskIO/DiskDaemon/DiskdFile.cc
@@ -355,7 +355,7 @@ DiskdFile::readDone(diomsg * M)
     if (readRequest != NULL) {
         const uint32_t lcount = readRequest->unlock();
         if (lcount == 0)
-            debugs(79, DBG_IMPORTANT, "invariant check failed: readRequest reference count is 0");
+            debugs(79, DBG_IMPORTANT, "ERROR: invariant check failed: readRequest reference count is 0");
     }
 
     if (M->status < 0) {
@@ -384,7 +384,7 @@ DiskdFile::writeDone(diomsg *M)
     if (writeRequest != NULL) {
         const uint32_t lcount = writeRequest->unlock();
         if (lcount == 0)
-            debugs(79, DBG_IMPORTANT, "invariant check failed: writeRequest reference count is 0");
+            debugs(79, DBG_IMPORTANT, "ERROR: invariant check failed: writeRequest reference count is 0");
     }
 
     if (M->status < 0) {

--- a/src/DiskIO/DiskThreads/aiops.cc
+++ b/src/DiskIO/DiskThreads/aiops.cc
@@ -512,7 +512,7 @@ squidaio_queue_request(squidaio_request_t * request)
         if (++filter >= filter_limit) {
             filter_limit += filter;
             filter = 0;
-            debugs(43, DBG_IMPORTANT, "squidaio_queue_request: WARNING - Queue congestion (growing to " << filter_limit << ")");
+            debugs(43, DBG_IMPORTANT, "WARNING: squidaio_queue_request: Queue congestion (growing to " << filter_limit << ")");
         }
     }
 
@@ -535,7 +535,7 @@ squidaio_queue_request(squidaio_request_t * request)
 
         if (squid_curtime >= (last_warn + 15) &&
                 squid_curtime >= (high_start + 5)) {
-            debugs(43, DBG_IMPORTANT, "squidaio_queue_request: WARNING - Disk I/O overloading");
+            debugs(43, DBG_IMPORTANT, "WARNING: squidaio_queue_request: Disk I/O overloading");
 
             if (squid_curtime >= (high_start + 15))
                 debugs(43, DBG_IMPORTANT, "squidaio_queue_request: Queue Length: current=" <<

--- a/src/DiskIO/DiskThreads/aiops_win32.cc
+++ b/src/DiskIO/DiskThreads/aiops_win32.cc
@@ -588,7 +588,7 @@ squidaio_queue_request(squidaio_request_t * request)
         if (++filter >= filter_limit) {
             filter_limit += filter;
             filter = 0;
-            debugs(43, DBG_IMPORTANT, "squidaio_queue_request: WARNING - Queue congestion (growing to " << filter_limit << ")");
+            debugs(43, DBG_IMPORTANT, "WARNING: squidaio_queue_request: Queue congestion (growing to " << filter_limit << ")");
         }
     }
 
@@ -611,7 +611,7 @@ squidaio_queue_request(squidaio_request_t * request)
 
         if (squid_curtime >= (last_warn + 15) &&
                 squid_curtime >= (high_start + 5)) {
-            debugs(43, DBG_IMPORTANT, "squidaio_queue_request: WARNING - Disk I/O overloading");
+            debugs(43, DBG_IMPORTANT, "WARNING: squidaio_queue_request: Disk I/O overloading");
 
             if (squid_curtime >= (high_start + 15))
                 debugs(43, DBG_IMPORTANT, "squidaio_queue_request: Queue Length: current=" <<

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -949,7 +949,7 @@ IpcIoFile::DiskerHandleRequest(const int workerId, IpcIoMsg &ipcIo)
     } catch (const Queue::Full &) {
         // The worker pop queue should not overflow because the worker can
         // push only if pendingRequests() is less than QueueCapacity.
-        debugs(47, DBG_IMPORTANT, "BUG: Worker I/O pop queue for " <<
+        debugs(47, DBG_IMPORTANT, "ERROR: Squid BUG: Worker I/O pop queue for " <<
                DbName << " overflow: " <<
                SipcIo(workerId, ipcIo, KidIdentifier)); // TODO: report queue len
 

--- a/src/DiskIO/Mmapped/MmappedFile.cc
+++ b/src/DiskIO/Mmapped/MmappedFile.cc
@@ -189,7 +189,7 @@ MmappedFile::write(WriteRequest *aRequest)
     const ssize_t written =
         pwrite(fd, aRequest->buf, aRequest->len, aRequest->offset);
     if (written < 0) {
-        debugs(79, DBG_IMPORTANT, HERE << "error: " << xstrerr(errno));
+        debugs(79, DBG_IMPORTANT, "ERROR: " << xstrerr(errno));
         error_ = true;
     } else if (static_cast<size_t>(written) != aRequest->len) {
         debugs(79, DBG_IMPORTANT, HERE << "problem: " << written << " < " << aRequest->len);

--- a/src/EventLoop.cc
+++ b/src/EventLoop.cc
@@ -124,7 +124,7 @@ EventLoop::runOnce()
 
     if (error) {
         ++errcount;
-        debugs(1, DBG_CRITICAL, "Select loop Error. Retry " << errcount);
+        debugs(1, DBG_CRITICAL, "ERROR: Select loop Error. Retry " << errcount);
     } else
         errcount = 0;
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -278,7 +278,7 @@ void
 FwdState::completed()
 {
     if (flags.forward_completed) {
-        debugs(17, DBG_IMPORTANT, HERE << "FwdState::completed called on a completed request! Bad!");
+        debugs(17, DBG_IMPORTANT, "ERROR: FwdState::completed called on a completed request! Bad!");
         return;
     }
 

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -215,7 +215,7 @@ HttpHeader::clean()
         if (e == nullptr)
             continue;
         if (!Http::any_valid_header(e->id)) {
-            debugs(55, DBG_CRITICAL, "BUG: invalid entry (" << e->id << "). Ignored.");
+            debugs(55, DBG_CRITICAL, "ERROR: Squid BUG: invalid entry (" << e->id << "). Ignored.");
         } else {
             if (owner <= hoReply)
                 HttpHeaderStats[owner].fieldTypeDistr.count(e->id);
@@ -1460,7 +1460,7 @@ HttpHeaderEntry::parse(const char *field_start, const char *field_end, const htt
             return nullptr; // reject if we cannot strip
 
         debugs(55, Config.onoff.relaxed_header_parser <= 0 ? 1 : 2,
-               "NOTICE: Whitespace after header name in '" << getStringPrefix(field_start, field_end-field_start) << "'");
+               "WARNING: Whitespace after header name in '" << getStringPrefix(field_start, field_end-field_start) << "'");
 
         while (name_len > 0 && xisspace(field_start[name_len - 1]))
             --name_len;

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -316,7 +316,7 @@ HttpRequest::parseFirstLine(const char *start, const char *end)
         ++end;                 // back to space
 
         if (2 != sscanf(ver + 5, "%d.%d", &http_ver.major, &http_ver.minor)) {
-            debugs(73, DBG_IMPORTANT, "parseRequestLine: Invalid HTTP identifier.");
+            debugs(73, DBG_IMPORTANT, "ERROR: parseRequestLine: Invalid HTTP identifier.");
             return false;
         }
     } else {

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -53,7 +53,7 @@ const char *
 MemObject::storeId() const
 {
     if (!storeId_.size()) {
-        debugs(20, DBG_IMPORTANT, "Bug: Missing MemObject::storeId value");
+        debugs(20, DBG_IMPORTANT, "ERROR: Squid BUG: Missing MemObject::storeId value");
         dump();
         storeId_ = "[unknown_URI]";
     }

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -192,7 +192,7 @@ Notes::validateKey(const SBuf &key) const
             CharacterSet::DIGIT + CharacterSet("specials", "-_");
     const auto specialIndex = key.findFirstNotOf(allowedSpecials);
     if (specialIndex != SBuf::npos) {
-        debugs(28, DBG_CRITICAL, "Warning: used special character '" <<
+        debugs(28, DBG_CRITICAL, "WARNING: used special character '" <<
                key[specialIndex] << "' within annotation name. " <<
                "Future Squid versions will not support this.");
     }
@@ -231,7 +231,7 @@ Notes::parseKvPair() {
         else {
             assert(method == Note::Value::mhReplace);
             if (Note::Pointer oldNote = find(SBuf(k, keyLen)))
-                debugs(28, DBG_CRITICAL, "Warning: annotation configuration with key " << k <<
+                debugs(28, DBG_CRITICAL, "WARNING: annotation configuration with key " << k <<
                        " already exists and will be overwritten");
         }
         SBuf key(k, keyLen);

--- a/src/StoreMeta.cc
+++ b/src/StoreMeta.cc
@@ -25,7 +25,7 @@ StoreMeta::validType(char type)
 {
     /* VOID is reserved, and new types have to be added as classes */
     if (type <= STORE_META_VOID || type >= STORE_META_END + 10) {
-        debugs(20, DBG_CRITICAL, "storeSwapMetaUnpack: bad type (" << type << ")!");
+        debugs(20, DBG_CRITICAL, "ERROR: storeSwapMetaUnpack: bad type (" << type << ")!");
         return false;
     }
 
@@ -42,7 +42,7 @@ StoreMeta::validType(char type)
             type == STORE_META_KEY_SHA ||
             type == STORE_META_HITMETERING ||
             type == STORE_META_VALID) {
-        debugs(20, DBG_CRITICAL, "Obsolete and unused type (" << type << ") in disk metadata");
+        debugs(20, DBG_CRITICAL, "ERROR: Obsolete and unused type (" << type << ") in disk metadata");
         return false;
     }
 
@@ -99,7 +99,7 @@ StoreMeta::Factory (char type, size_t len, void const *value)
         break;
 
     default:
-        debugs(20, DBG_CRITICAL, "Attempt to create unknown concrete StoreMeta");
+        debugs(20, DBG_CRITICAL, "ERROR: Attempt to create unknown concrete StoreMeta");
         return NULL;
     }
 

--- a/src/WinSvc.cc
+++ b/src/WinSvc.cc
@@ -428,7 +428,7 @@ WIN32_IpAddrChangeMonitor(LPVOID lpParam)
     while (1) {
         Result = NotifyAddrChange(NULL, NULL);
         if (Result != NO_ERROR) {
-            debugs(1, DBG_IMPORTANT, "NotifyAddrChange error " << Result);
+            debugs(1, DBG_IMPORTANT, "ERROR: NotifyAddrChange error " << Result);
             return 1;
         }
         debugs(1, DBG_IMPORTANT, "Notification of IP address change received, requesting Squid reconfiguration ...");
@@ -449,7 +449,7 @@ WIN32_IpAddrChangeMonitorInit()
         if (NotifyAddrChange_thread == NULL) {
             status = GetLastError();
             NotifyAddrChange_thread = INVALID_HANDLE_VALUE;
-            debugs(1, DBG_IMPORTANT, "Failed to start IP monitor thread.");
+            debugs(1, DBG_IMPORTANT, "ERROR: Failed to start IP monitor thread.");
         } else
             debugs(1, 2, "Starting IP monitor thread [" << threadID << "] ...");
     }
@@ -593,7 +593,7 @@ WIN32_svcHandler(DWORD Opcode)
 
         if (!SetServiceStatus(svcHandle, &svcStatus)) {
             status = GetLastError();
-            debugs(1, DBG_IMPORTANT, "SetServiceStatus error " << status);
+            debugs(1, DBG_IMPORTANT, "ERROR: SetServiceStatus error " << status);
         }
 
         debugs(1, DBG_IMPORTANT, "Leaving Squid service");
@@ -604,7 +604,7 @@ WIN32_svcHandler(DWORD Opcode)
 
         if (!SetServiceStatus(svcHandle, &svcStatus)) {
             status = GetLastError();
-            debugs(1, DBG_IMPORTANT, "SetServiceStatus error " << status);
+            debugs(1, DBG_IMPORTANT, "ERROR: SetServiceStatus error " << status);
         }
 
         break;
@@ -631,7 +631,7 @@ WIN32_svcHandler(DWORD Opcode)
 
         if (!SetServiceStatus(svcHandle, &svcStatus)) {
             status = GetLastError();
-            debugs(1, DBG_IMPORTANT, "SetServiceStatus error " << status);
+            debugs(1, DBG_IMPORTANT, "ERROR: SetServiceStatus error " << status);
         }
 
         debugs(1, DBG_IMPORTANT, "Leaving Squid service");

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -173,7 +173,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
     /* snarf the ACL name */
 
     if ((t = ConfigParser::NextToken()) == NULL) {
-        debugs(28, DBG_CRITICAL, "aclParseAclLine: missing ACL name.");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseAclLine: missing ACL name.");
         parser.destruct();
         return;
     }
@@ -190,7 +190,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
     const char *theType;
 
     if ((theType = ConfigParser::NextToken()) == NULL) {
-        debugs(28, DBG_CRITICAL, "aclParseAclLine: missing ACL type.");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseAclLine: missing ACL type.");
         parser.destruct();
         return;
     }
@@ -204,7 +204,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
                 debugs(28, DBG_CRITICAL, "WARNING: 'myip' ACL is not reliable for interception proxies. Please use 'myportname' instead.");
             p = p->next;
         }
-        debugs(28, DBG_IMPORTANT, "UPGRADE: ACL 'myip' type is has been renamed to 'localip' and matches the IP the client connected to.");
+        debugs(28, DBG_IMPORTANT, "WARNING: UPGRADE: ACL 'myip' type has been renamed to 'localip' and matches the IP the client connected to.");
         theType = "localip";
     } else if (strcmp(theType, "myport") == 0) {
         AnyP::PortCfgPointer p = HttpPortList;
@@ -216,13 +216,13 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
             p = p->next;
         }
         theType = "localport";
-        debugs(28, DBG_IMPORTANT, "UPGRADE: ACL 'myport' type is has been renamed to 'localport' and matches the port the client connected to.");
+        debugs(28, DBG_IMPORTANT, "WARNING: UPGRADE: ACL 'myport' type has been renamed to 'localport' and matches the port the client connected to.");
     } else if (strcmp(theType, "proto") == 0 && strcmp(aclname, "manager") == 0) {
         // ACL manager is now a built-in and has a different type.
-        debugs(28, DBG_PARSE_NOTE(DBG_IMPORTANT), "UPGRADE: ACL 'manager' is now a built-in ACL. Remove it from your config file.");
+        debugs(28, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: UPGRADE: ACL 'manager' is now a built-in ACL. Remove it from your config file.");
         return; // ignore the line
     } else if (strcmp(theType, "clientside_mark") == 0) {
-        debugs(28, DBG_IMPORTANT, "UPGRADE: ACL 'clientside_mark' type has been renamed to 'client_connection_mark'.");
+        debugs(28, DBG_IMPORTANT, "WARNING: UPGRADE: ACL 'clientside_mark' type has been renamed to 'client_connection_mark'.");
         theType = "client_connection_mark";
     }
 
@@ -262,7 +262,7 @@ ACL::ParseAclLine(ConfigParser &parser, ACL ** head)
         return;
 
     if (A->empty()) {
-        debugs(28, DBG_CRITICAL, "Warning: empty ACL: " << A->cfgline);
+        debugs(28, DBG_CRITICAL, "WARNING: empty ACL: " << A->cfgline);
     }
 
     if (!A->valid()) {

--- a/src/acl/Arp.cc
+++ b/src/acl/Arp.cc
@@ -71,14 +71,14 @@ aclParseArpData(const char *t)
     debugs(28, 5, "aclParseArpData: " << t);
 
     if (sscanf(t, "%[0-9a-fA-F:]", buf) != 1) {
-        debugs(28, DBG_CRITICAL, "aclParseArpData: Bad ethernet address: '" << t << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseArpData: Bad ethernet address: '" << t << "'");
         delete q;
         return NULL;
     }
 
     if (!q->decode(buf)) {
         debugs(28, DBG_CRITICAL, "" << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(28, DBG_CRITICAL, "aclParseArpData: Ignoring invalid ARP acl entry: can't parse '" << buf << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseArpData: Ignoring invalid ARP acl entry: cannot parse '" << buf << "'");
         delete q;
         return NULL;
     }

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -287,7 +287,7 @@ asHandleReply(void *data, StoreIOBuffer result)
         delete asState;
         return;
     } else if (result.flags.error) {
-        debugs(53, DBG_IMPORTANT, "asHandleReply: Called with Error set and size=" << (unsigned int) result.length);
+        debugs(53, DBG_IMPORTANT, "ERROR: asHandleReply: Called with Error set and size=" << (unsigned int) result.length);
         delete asState;
         return;
     } else if (e->mem().baseReply().sline.status() != Http::scOkay) {

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -43,7 +43,7 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
             return 0; // we have warned about the missing request earlier
 
         if (!checklist->request->masterXaction) {
-            debugs(28, DBG_IMPORTANT, "BUG: at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
+            debugs(28, DBG_IMPORTANT, "ERROR: Squid BUG: at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
             return 0;
         }
 

--- a/src/acl/Eui64.cc
+++ b/src/acl/Eui64.cc
@@ -43,14 +43,14 @@ aclParseEuiData(const char *t)
     debugs(28, 5, "aclParseEuiData: " << t);
 
     if (sscanf(t, "%[0-9a-fA-F:]", buf) != 1) {
-        debugs(28, DBG_CRITICAL, "aclParseEuiData: Bad EUI-64 address: '" << t << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseEuiData: Bad EUI-64 address: '" << t << "'");
         delete q;
         return NULL;
     }
 
     if (!q->decode(buf)) {
         debugs(28, DBG_CRITICAL, "" << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(28, DBG_CRITICAL, "aclParseEuiData: Ignoring invalid EUI-64 acl entry: can't parse '" << buf << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseEuiData: Ignoring invalid EUI-64 acl entry: cannot parse '" << buf << "'");
         delete q;
         return NULL;
     }

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -76,7 +76,7 @@ showDebugWarning(const char *msg)
         return;
 
     ++count;
-    debugs(28, Important(58), "ALE missing " << msg);
+    debugs(28, Important(58), "ERROR: ALE missing " << msg);
 }
 
 void

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -110,7 +110,7 @@ aclParseDenyInfoLine(AclDenyInfoList ** head)
 
     if ((t = ConfigParser::NextToken()) == NULL) {
         debugs(28, DBG_CRITICAL, "aclParseDenyInfoLine: " << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(28, DBG_CRITICAL, "aclParseDenyInfoLine: missing 'error page' parameter.");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseDenyInfoLine: missing 'error page' parameter.");
         return;
     }
 
@@ -142,7 +142,7 @@ aclParseAccessLine(const char *directive, ConfigParser &, acl_access **treep)
 
     if (!t) {
         debugs(28, DBG_CRITICAL, "aclParseAccessLine: " << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(28, DBG_CRITICAL, "aclParseAccessLine: missing 'allow' or 'deny'.");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseAccessLine: missing 'allow' or 'deny'.");
         return;
     }
 

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -59,7 +59,7 @@ Acl::InnerNode::lineParse()
         ACL *a = ACL::FindByName(t);
 
         if (a == NULL) {
-            debugs(28, DBG_CRITICAL, "ACL not found: " << t);
+            debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);
             self_destruct();
             return count; // not reached
         }

--- a/src/acl/IntRange.cc
+++ b/src/acl/IntRange.cc
@@ -39,7 +39,7 @@ ACLIntRange::parse()
             RangeType temp(port1, port2+1);
             ranges.push_back(temp);
         } else {
-            debugs(28, DBG_CRITICAL, "ACLIntRange::parse: Invalid port value");
+            debugs(28, DBG_CRITICAL, "ERROR: ACLIntRange::parse: Invalid port value");
             self_destruct();
         }
     }

--- a/src/acl/Ip.cc
+++ b/src/acl/Ip.cc
@@ -377,7 +377,7 @@ acl_ip_data::FactoryParse(const char *t)
             if (strcmp(addr1, "::1") == 0) {
                 debugs(28, DBG_IMPORTANT, "aclIpParseIpData: IPv6 has not been enabled in host DNS resolver.");
             } else {
-                debugs(28, DBG_CRITICAL, "aclIpParseIpData: Bad host/IP: '" << addr1 <<
+                debugs(28, DBG_CRITICAL, "ERROR: aclIpParseIpData: Bad host/IP: '" << addr1 <<
                        "' in '" << t << "', flags=" << hints.ai_flags <<
                        " : (" << errcode << ") " << gai_strerror(errcode) );
                 self_destruct();
@@ -416,7 +416,7 @@ acl_ip_data::FactoryParse(const char *t)
         freeaddrinfo(hp);
 
         if (*Q != NULL) {
-            debugs(28, DBG_CRITICAL, "aclIpParseIpData: Bad host/IP: '" << t << "'");
+            debugs(28, DBG_CRITICAL, "ERROR: aclIpParseIpData: Bad host/IP: '" << t << "'");
             self_destruct();
             return NULL;
         }
@@ -433,7 +433,7 @@ acl_ip_data::FactoryParse(const char *t)
 
     /* Decode addr1 */
     if (!*addr1 || !(q->addr1 = addr1)) {
-        debugs(28, DBG_CRITICAL, "aclIpParseIpData: unknown first address in '" << t << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: aclIpParseIpData: unknown first address in '" << t << "'");
         delete q;
         self_destruct();
         return NULL;
@@ -443,7 +443,7 @@ acl_ip_data::FactoryParse(const char *t)
     if (!*addr2)
         q->addr2.setAnyAddr();
     else if (!(q->addr2=addr2) ) {
-        debugs(28, DBG_CRITICAL, "aclIpParseIpData: unknown second address in '" << t << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: aclIpParseIpData: unknown second address in '" << t << "'");
         delete q;
         self_destruct();
         return NULL;
@@ -451,7 +451,7 @@ acl_ip_data::FactoryParse(const char *t)
 
     /* Decode mask (NULL or empty means a exact host mask) */
     if (!DecodeMask(mask, q->mask, iptype)) {
-        debugs(28, DBG_CRITICAL, "aclParseIpData: unknown netmask '" << mask << "' in '" << t << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: aclParseIpData: unknown netmask '" << mask << "' in '" << t << "'");
         delete q;
         self_destruct();
         return NULL;
@@ -462,7 +462,7 @@ acl_ip_data::FactoryParse(const char *t)
     changed += q->addr2.applyMask(q->mask);
 
     if (changed)
-        debugs(28, DBG_CRITICAL, "aclIpParseIpData: WARNING: Netmask masks away part of the specified IP in '" << t << "'");
+        debugs(28, DBG_CRITICAL, "WARNING: aclIpParseIpData: Netmask masks away part of the specified IP in '" << t << "'");
 
     debugs(28,9, HERE << "Parsed: " << q->addr1 << "-" << q->addr2 << "/" << q->mask << "(/" << q->mask.cidr() <<")");
 

--- a/src/acl/Random.cc
+++ b/src/acl/Random.cc
@@ -53,7 +53,7 @@ ACLRandom::parse()
 
     char *t = ConfigParser::strtokFile();
     if (!t) {
-        debugs(28, DBG_PARSE_NOTE(DBG_IMPORTANT), "ACL random missing pattern");
+        debugs(28, DBG_PARSE_NOTE(DBG_IMPORTANT), "ERROR: ACL random missing pattern");
         return;
     }
 

--- a/src/acl/TimeData.cc
+++ b/src/acl/TimeData.cc
@@ -145,7 +145,7 @@ ACLTimeData::parse()
                 default:
                     debugs(28, DBG_CRITICAL, "" << cfg_filename << " line " << config_lineno <<
                            ": " << config_input_line);
-                    debugs(28, DBG_CRITICAL, "aclParseTimeSpec: Bad Day '" << *t << "'" );
+                    debugs(28, DBG_CRITICAL, "ERROR: aclParseTimeSpec: Bad Day '" << *t << "'" );
                     break;
                 }
             }
@@ -153,7 +153,7 @@ ACLTimeData::parse()
             /* assume its time-of-day spec */
 
             if ((sscanf(t, "%d:%d-%d:%d", &h1, &m1, &h2, &m2) < 4) || (!((h1 >= 0 && h1 < 24) && ((h2 >= 0 && h2 < 24) || (h2 == 24 && m2 == 0)) && (m1 >= 0 && m1 < 60) && (m2 >= 0 && m2 < 60)))) {
-                debugs(28, DBG_CRITICAL, "aclParseTimeSpec: Bad time range '" << t << "'");
+                debugs(28, DBG_CRITICAL, "ERROR: aclParseTimeSpec: Bad time range '" << t << "'");
                 self_destruct();
 
                 if (q != this)

--- a/src/adaptation/ServiceConfig.cc
+++ b/src/adaptation/ServiceConfig.cc
@@ -98,11 +98,11 @@ Adaptation::ServiceConfig::parse()
         if (strcmp(option, "0") == 0) { // backward compatibility
             name = "bypass";
             value = "off";
-            debugs(3, DBG_PARSE_NOTE(DBG_IMPORTANT), "UPGRADE: Please use 'bypass=off' option to disable service bypass");
+            debugs(3, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: UPGRADE: Please use 'bypass=off' option to disable service bypass");
         }  else if (strcmp(option, "1") == 0) { // backward compatibility
             name = "bypass";
             value = "on";
-            debugs(3, DBG_PARSE_NOTE(DBG_IMPORTANT), "UPGRADE: Please use 'bypass=on' option to enable service bypass");
+            debugs(3, DBG_PARSE_NOTE(DBG_IMPORTANT), "WARNING: UPGRADE: Please use 'bypass=on' option to enable service bypass");
         } else {
             char *eq = strstr(option, "=");
             const char *sffx = strstr(option, "://");
@@ -346,7 +346,7 @@ bool
 Adaptation::ServiceConfig::grokExtension(const char *name, const char *value)
 {
     // we do not accept extensions by default
-    debugs(3, DBG_CRITICAL, cfg_filename << ':' << config_lineno << ": " <<
+    debugs(3, DBG_CRITICAL, "ERROR: " << cfg_filename << ':' << config_lineno << ": " <<
            "ERROR: unknown adaptation service option: " <<
            name << '=' << value);
     return false;

--- a/src/adaptation/ecap/ServiceRep.cc
+++ b/src/adaptation/ecap/ServiceRep.cc
@@ -343,7 +343,7 @@ Adaptation::Ecap::CheckUnusedAdapterServices(const Adaptation::Services& cfgs)
             found = (*cfged)->cfg().uri == loaded->second->uri().c_str();
         }
         if (!found)
-            debugs(93, DBG_IMPORTANT, "Warning: loaded eCAP service has no matching " <<
+            debugs(93, DBG_IMPORTANT, "WARNING: loaded eCAP service has no matching " <<
                    "ecap_service config option: " << loaded->second->uri());
     }
 }

--- a/src/adaptation/icap/History.cc
+++ b/src/adaptation/icap/History.cc
@@ -32,7 +32,7 @@ void Adaptation::Icap::History::start(const char *context)
 void Adaptation::Icap::History::stop(const char *context)
 {
     if (!concurrencyLevel) {
-        debugs(93, DBG_IMPORTANT, HERE << "Internal error: poor history accounting " << this);
+        debugs(93, DBG_IMPORTANT, "ERROR: Squid BUG: poor history accounting " << this);
         return;
     }
 

--- a/src/adaptation/icap/ServiceRep.cc
+++ b/src/adaptation/icap/ServiceRep.cc
@@ -615,7 +615,7 @@ void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
         if (eventFind(&ServiceRep_noteTimeToUpdate, this))
             eventDelete(&ServiceRep_noteTimeToUpdate, this);
         else
-            debugs(93, DBG_IMPORTANT, "XXX: ICAP service lost an update event.");
+            debugs(93, DBG_IMPORTANT, "ERROR: Squid BUG: ICAP service lost an update event.");
         updateScheduled = false;
     }
 

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -188,7 +188,7 @@ Adaptation::Icap::Xaction::dnsLookupDone(const ipcache_addrs *ia)
     Adaptation::Icap::ServiceRep &s = service();
 
     if (ia == NULL) {
-        debugs(44, DBG_IMPORTANT, "ICAP: Unknown service host: " << s.cfg().host);
+        debugs(44, DBG_IMPORTANT, "ERROR: ICAP: Unknown service host: " << s.cfg().host);
 
 #if WHEN_IPCACHE_NBGETHOSTBYNAME_USES_ASYNC_CALLS
         dieOnConnectionFailure(); // throws

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -45,7 +45,7 @@ AuthenticateAcl(ACLChecklist *ch)
         /* WWW authorization on accelerated requests */
         headertype = Http::HdrType::AUTHORIZATION;
     } else if (request->flags.intercepted || request->flags.interceptTproxy) {
-        debugs(28, DBG_IMPORTANT, "NOTICE: Authentication not applicable on intercepted requests.");
+        debugs(28, DBG_IMPORTANT, "WARNING: Authentication not applicable on intercepted requests.");
         return ACCESS_DENIED;
     } else {
         /* Proxy authorization on proxy requests */

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -90,12 +90,12 @@ bool
 ACLProxyAuth::valid() const
 {
     if (authenticateSchemeCount() == 0) {
-        debugs(28, DBG_CRITICAL, "Can't use proxy auth because no authentication schemes were compiled.");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot use proxy auth because no authentication schemes were compiled.");
         return false;
     }
 
     if (authenticateActiveSchemeCount() == 0) {
-        debugs(28, DBG_CRITICAL, "Can't use proxy auth because no authentication schemes are fully configured.");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot use proxy auth because no authentication schemes are fully configured.");
         return false;
     }
 

--- a/src/auth/SchemeConfig.cc
+++ b/src/auth/SchemeConfig.cc
@@ -132,7 +132,7 @@ Auth::SchemeConfig::parse(Auth::SchemeConfig * scheme, int, char *param_str)
     } else if (strcmp(param_str, "utf8") == 0) {
         parse_onoff(&utf8);
     } else {
-        debugs(29, DBG_CRITICAL, "Unrecognised " << scheme->type() << " auth scheme parameter '" << param_str << "'");
+        debugs(29, DBG_CRITICAL, "ERROR: Unrecognised " << scheme->type() << " auth scheme parameter '" << param_str << "'");
     }
 }
 

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -155,7 +155,7 @@ Auth::Digest::UserRequest::authenticate(HttpRequest * request, ConnStateData *, 
                 }
 
                 if (last_broken_addr != request->client_addr) {
-                    debugs(29, DBG_IMPORTANT, "Digest POST bug detected from " <<
+                    debugs(29, DBG_IMPORTANT, "ERROR: User agent Digest Authentication POST bug detected from " <<
                            request->client_addr << " using '" <<
                            (useragent ? useragent : "-") <<
                            "'. Please upgrade browser. See Bug #630 for details.");

--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -78,7 +78,7 @@ std::ostream &operator <<(std::ostream &, const TextException &);
     try { \
         code \
     } catch (...) { \
-        debugs(0, DBG_IMPORTANT, "BUG: ignoring exception;" << \
+        debugs(0, DBG_IMPORTANT, "ERROR: Squid BUG: ignoring exception;" << \
                Debug::Extra << "bug location: " << Here() << \
                Debug::Extra << "ignored exception: " << CurrentException); \
     }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -563,7 +563,7 @@ parseOneConfigFile(const char *file_name, unsigned int depth)
                     }
                 } catch (...) {
                     // fatal for now
-                    debugs(3, DBG_CRITICAL, "configuration error: " << CurrentException);
+                    debugs(3, DBG_CRITICAL, "ERROR: configuration failure: " << CurrentException);
                     self_destruct();
                 }
             }
@@ -1862,7 +1862,7 @@ parse_http_header_access(HeaderManglers **pm)
 
     if ((t = ConfigParser::NextToken()) == NULL) {
         debugs(3, DBG_CRITICAL, "" << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(3, DBG_CRITICAL, "parse_http_header_access: missing header name.");
+        debugs(3, DBG_CRITICAL, "ERROR: parse_http_header_access: missing header name.");
         return;
     }
 
@@ -1901,7 +1901,7 @@ parse_http_header_replace(HeaderManglers **pm)
 
     if ((t = ConfigParser::NextToken()) == NULL) {
         debugs(3, DBG_CRITICAL, "" << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(3, DBG_CRITICAL, "parse_http_header_replace: missing header name.");
+        debugs(3, DBG_CRITICAL, "ERROR: parse_http_header_replace: missing header name.");
         return;
     }
 
@@ -1951,7 +1951,7 @@ parse_authparam(Auth::ConfigVector * config)
         Auth::Scheme::Pointer theScheme = Auth::Scheme::Find(type_str);
 
         if (theScheme == NULL) {
-            debugs(3, DBG_CRITICAL, "Parsing Config File: Unknown authentication scheme '" << type_str << "'.");
+            debugs(3, DBG_CRITICAL, "ERROR: Failure while parsing Config File: Unknown authentication scheme '" << type_str << "'.");
             self_destruct();
             return;
         }
@@ -2869,14 +2869,14 @@ parse_refreshpattern(RefreshPattern ** head)
                   ) {
             debugs(22, DBG_PARSE_NOTE(2), "UPGRADE: refresh_pattern option '" << token << "' is obsolete. Remove it.");
         } else
-            debugs(22, DBG_CRITICAL, "refreshAddToList: Unknown option '" << pattern << "': " << token);
+            debugs(22, DBG_CRITICAL, "ERROR: refreshAddToList: Unknown option '" << pattern << "': " << token);
     }
 
     if ((errcode = regcomp(&comp, pattern, flags)) != 0) {
         char errbuf[256];
         regerror(errcode, &comp, errbuf, sizeof errbuf);
         debugs(22, DBG_CRITICAL, "" << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(22, DBG_CRITICAL, "refreshAddToList: Invalid regular expression '" << pattern << "': " << errbuf);
+        debugs(22, DBG_CRITICAL, "ERROR: refreshAddToList: Invalid regular expression '" << pattern << "': " << errbuf);
         xfree(pattern);
         return;
     }
@@ -3727,7 +3727,7 @@ parse_port_option(AnyP::PortCfgPointer &s, char *token)
     } else if (strncmp(token, "key=", 4) == 0) {
         s->secure.parse(token);
     } else if (strncmp(token, "version=", 8) == 0) {
-        debugs(3, DBG_PARSE_NOTE(1), "UPGRADE WARNING: '" << token << "' is deprecated " <<
+        debugs(3, DBG_PARSE_NOTE(1), "WARNING: UPGRADE: '" << token << "' is deprecated " <<
                "in " << cfg_directive << ". Use 'options=' instead.");
         s->secure.parse(token);
     } else if (strncmp(token, "options=", 8) == 0) {
@@ -3737,7 +3737,7 @@ parse_port_option(AnyP::PortCfgPointer &s, char *token)
     } else if (strncmp(token, "clientca=", 9) == 0) {
         s->secure.parse(token);
     } else if (strncmp(token, "cafile=", 7) == 0) {
-        debugs(3, DBG_PARSE_NOTE(1), "UPGRADE WARNING: '" << token << "' is deprecated " <<
+        debugs(3, DBG_PARSE_NOTE(1), "WARNING: UPGRADE: '" << token << "' is deprecated " <<
                "in " << cfg_directive << ". Use 'tls-cafile=' instead.");
         s->secure.parse(token);
     } else if (strncmp(token, "capath=", 7) == 0) {

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -260,7 +260,7 @@ CacheManager::ParseHeaders(const HttpRequest * request, Mgr::ActionParams &param
 
     const auto colonPos = basic_cookie.find(':');
     if (colonPos == SBuf::npos) {
-        debugs(16, DBG_IMPORTANT, "CacheManager::ParseHeaders: unknown basic_cookie format '" << basic_cookie << "'");
+        debugs(16, DBG_IMPORTANT, "ERROR: CacheManager::ParseHeaders: unknown basic_cookie format '" << basic_cookie << "'");
         return;
     }
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -665,10 +665,10 @@ ConnStateData::~ConnStateData()
     debugs(33, 3, HERE << clientConnection);
 
     if (isOpen())
-        debugs(33, DBG_IMPORTANT, "BUG: ConnStateData did not close " << clientConnection);
+        debugs(33, DBG_IMPORTANT, "ERROR: Squid BUG: ConnStateData did not close " << clientConnection);
 
     if (!flags.swanSang)
-        debugs(33, DBG_IMPORTANT, "BUG: ConnStateData was not destroyed properly; " << clientConnection);
+        debugs(33, DBG_IMPORTANT, "ERROR: Squid BUG: ConnStateData was not destroyed properly; " << clientConnection);
 
     if (bodyPipe != NULL)
         stopProducingFor(bodyPipe, false);
@@ -2200,7 +2200,7 @@ ConnStateData::start()
         static bool reported = false;
 
         if (!reported) {
-            debugs(33, DBG_IMPORTANT, "NOTICE: Path MTU discovery disabling is not supported on your platform.");
+            debugs(33, DBG_IMPORTANT, "WARNING: Path MTU discovery disabling is not supported on your platform.");
             reported = true;
         }
 #endif

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1344,7 +1344,7 @@ clientReplyContext::buildReplyHeader()
         else if (http->storeEntry()->timestamp > 0)
             hdr->putTime(Http::HdrType::DATE, http->storeEntry()->timestamp);
         else {
-            debugs(88,DBG_IMPORTANT,"BUG 3279: HTTP reply without Date:");
+            debugs(88, DBG_IMPORTANT, "ERROR: Squid BUG #3279: HTTP reply without Date:");
             /* dump something useful about the problem */
             http->storeEntry()->dump(DBG_IMPORTANT);
         }

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -387,7 +387,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     request->hier.notePeerWrite();
 
     if (io.flag) {
-        debugs(11, DBG_IMPORTANT, "sentRequestBody error: FD " << io.fd << ": " << xstrerr(io.xerrno));
+        debugs(11, DBG_IMPORTANT, "ERROR: sentRequestBody failure: FD " << io.fd << ": " << xstrerr(io.xerrno));
         ErrorState *err;
         err = new ErrorState(ERR_WRITE_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = io.xerrno;

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -382,7 +382,7 @@ Ftp::Client::readControlReply(const CommIoCbParams &io)
 
     if (io.flag != Comm::OK) {
         debugs(50, ignoreErrno(io.xerrno) ? 3 : DBG_IMPORTANT,
-               "FTP control reply read error: " << xstrerr(io.xerrno));
+               "ERROR: FTP control reply read failure: " << xstrerr(io.xerrno));
 
         if (ignoreErrno(io.xerrno)) {
             scheduleReadControlReply(0);
@@ -502,7 +502,7 @@ Ftp::Client::handleEpsvReply(Ip::Address &remoteAddr)
             /* handle broken servers (RFC 2428 says OK code for EPSV MUST be 229 not 200) */
             /* vsftpd for one send '200 EPSV ALL ok.' without even port info.
              * Its okay to re-send EPSV 1/2 but nothing else. */
-            debugs(9, DBG_IMPORTANT, "Broken FTP Server at " << ctrl.conn->remote << ". Wrong accept code for EPSV");
+            debugs(9, DBG_IMPORTANT, "ERROR: Broken FTP Server at " << ctrl.conn->remote << ". Wrong accept code for EPSV");
         } else {
             debugs(9, 2, "EPSV not supported by remote end");
         }
@@ -526,7 +526,7 @@ Ftp::Client::handleEpsvReply(Ip::Address &remoteAddr)
 
         if (buf == NULL || *buf == '\0') {
             /* handle broken server (RFC 2428 says MUST specify supported protocols in 522) */
-            debugs(9, DBG_IMPORTANT, "Broken FTP Server at " << ctrl.conn->remote << ". 522 error missing protocol negotiation hints");
+            debugs(9, DBG_IMPORTANT, "ERROR: Broken FTP Server at " << ctrl.conn->remote << ". 522 error missing protocol negotiation hints");
             return sendPassive();
         } else if (strcmp(buf, "(1)") == 0) {
             state = SENT_EPSV_2; /* simulate having sent and failed EPSV 2 */
@@ -567,7 +567,7 @@ Ftp::Client::handleEpsvReply(Ip::Address &remoteAddr)
     int n = sscanf(buf, "(%c%c%c%hu%c)", &h1, &h2, &h3, &port, &h4);
 
     if (n < 4 || h1 != h2 || h1 != h3 || h1 != h4) {
-        debugs(9, DBG_IMPORTANT, "Invalid EPSV reply from " <<
+        debugs(9, DBG_IMPORTANT, "ERROR: Invalid EPSV reply from " <<
                ctrl.conn->remote << ": " <<
                ctrl.last_reply);
 
@@ -865,7 +865,7 @@ Ftp::Client::writeCommandCallback(const CommIoCbParams &io)
         return;
 
     if (io.flag) {
-        debugs(9, DBG_IMPORTANT, "FTP command write error: " << io.conn << ": " << xstrerr(io.xerrno));
+        debugs(9, DBG_IMPORTANT, "ERROR: FTP command write failure: " << io.conn << ": " << xstrerr(io.xerrno));
         failed(ERR_WRITE_ERROR, io.xerrno);
         /* failed closes ctrl.conn and frees ftpState */
         return;
@@ -977,7 +977,7 @@ Ftp::Client::dataRead(const CommIoCbParams &io)
 
     if (io.flag != Comm::OK) {
         debugs(50, ignoreErrno(io.xerrno) ? 3 : DBG_IMPORTANT,
-               "FTP data read error: " << xstrerr(io.xerrno));
+               "ERROR: FTP data read failure: " << xstrerr(io.xerrno));
 
         if (ignoreErrno(io.xerrno)) {
             maybeReadVirginBody();

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -365,7 +365,7 @@ Ftp::Gateway::~Gateway()
     debugs(9, 3, entry->url());
 
     if (Comm::IsConnOpen(ctrl.conn)) {
-        debugs(9, DBG_IMPORTANT, "Internal bug: FTP Gateway left open " <<
+        debugs(9, DBG_IMPORTANT, "ERROR: Squid BUG: FTP Gateway left open " <<
                "control channel " << ctrl.conn);
     }
 
@@ -458,7 +458,7 @@ Ftp::Gateway::listenForDataChannel(const Comm::ConnectionPointer &conn)
     if (!Comm::IsConnOpen(conn)) {
         conn->fd = comm_open_listener(SOCK_STREAM, IPPROTO_TCP, conn->local, conn->flags, note);
         if (!Comm::IsConnOpen(conn)) {
-            debugs(5, DBG_CRITICAL, HERE << "comm_open_listener failed:" << conn->local << " error: " << errno);
+            debugs(5, DBG_CRITICAL, "ERROR: comm_open_listener failed:" << conn->local << " error: " << errno);
             return;
         }
         debugs(9, 3, HERE << "Unconnected data socket created on " << conn);
@@ -1916,7 +1916,7 @@ Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
         // accept if either our data or ctrl connection is talking to this remote peer.
         if (data.conn->remote != io.conn->remote && ctrl.conn->remote != io.conn->remote) {
             debugs(9, DBG_IMPORTANT,
-                   "FTP data connection from unexpected server (" <<
+                   "ERROR: FTP data connection from unexpected server (" <<
                    io.conn->remote << "), expecting " <<
                    data.conn->remote << " or " << ctrl.conn->remote);
 
@@ -2029,7 +2029,7 @@ void Ftp::Gateway::readStor()
         debugs(9, 3, "ftpReadStor: accepting data channel");
         listenForDataChannel(data.conn);
     } else {
-        debugs(9, DBG_IMPORTANT, HERE << "Unexpected reply code "<< std::setfill('0') << std::setw(3) << code);
+        debugs(9, DBG_IMPORTANT, "ERROR: Unexpected reply code "<< std::setfill('0') << std::setw(3) << code);
         ftpFail(this);
     }
 }
@@ -2533,7 +2533,7 @@ Ftp::Gateway::appendSuccessHeader()
          * not be seeing this condition any more because we'll only
          * send REST if we know the theSize and if it is less than theSize.
          */
-        debugs(0,DBG_CRITICAL,HERE << "Whoops! " <<
+        debugs(0, DBG_CRITICAL, "ERROR: " <<
                " current offset=" << getCurrentOffset() <<
                ", but theSize=" << theSize <<
                ".  assuming full content response");
@@ -2666,7 +2666,7 @@ Ftp::Gateway::haveControlChannel(const char *caller_name) const
 
     /* doneWithServer() only checks BOTH channels are closed. */
     if (!Comm::IsConnOpen(ctrl.conn)) {
-        debugs(9, DBG_IMPORTANT, "WARNING! FTP Server Control channel is closed, but Data channel still active.");
+        debugs(9, DBG_IMPORTANT, "WARNING: FTP Server Control channel is closed, but Data channel still active.");
         debugs(9, 2, caller_name << ": attempted on a closed FTP channel.");
         return false;
     }

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -182,7 +182,7 @@ comm_local_port(int fd)
 
     if (getsockname(fd, addr->ai_addr, &(addr->ai_addrlen)) ) {
         int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "Failed to retrieve TCP/UDP port number for socket: FD " << fd << ": " << xstrerr(xerrno));
+        debugs(50, DBG_IMPORTANT, "ERROR: " << MYNAME << "Failed to retrieve TCP/UDP port number for socket: FD " << fd << ": " << xstrerr(xerrno));
         Ip::Address::FreeAddr(addr);
         return 0;
     }
@@ -211,7 +211,7 @@ commBind(int s, struct addrinfo &inaddr)
         return Comm::OK;
     }
     int xerrno = errno;
-    debugs(50, DBG_CRITICAL, MYNAME << "Cannot bind socket FD " << s << " to " << fd_table[s].local_addr << ": " << xstrerr(xerrno));
+    debugs(50, DBG_CRITICAL, "ERROR: " << MYNAME << "Cannot bind socket FD " << s << " to " << fd_table[s].local_addr << ": " << xstrerr(xerrno));
 
     return Comm::COMM_ERROR;
 }
@@ -467,7 +467,7 @@ comm_apply_flags(int new_socket,
         if ( !(flags & COMM_DOBIND) && addr.isAnyAddr() )
             debugs(5, DBG_IMPORTANT,"WARNING: Squid is attempting to bind() port " << addr << " without being a listener.");
         if ( addr.isNoAddr() )
-            debugs(5,0,"CRITICAL: Squid is attempting to bind() port " << addr << "!!");
+            debugs(5, DBG_CRITICAL, "ERROR: Squid is attempting to bind() port " << addr << "!!");
 
 #if defined(SO_REUSEPORT)
         if (flags & COMM_REUSEPORT) {
@@ -829,7 +829,7 @@ _comm_close(int fd, char const *file, int line)
 
     /* The following fails because ipc.c is doing calls to pipe() to create sockets! */
     if (!isOpen(fd)) {
-        debugs(50, DBG_IMPORTANT, HERE << "BUG 3556: FD " << fd << " is not an open socket.");
+        debugs(50, DBG_IMPORTANT, "ERROR: Squid BUG #3556: FD " << fd << " is not an open socket.");
         // XXX: do we need to run close(fd) or fd_close(fd) here?
         return;
     }
@@ -1109,7 +1109,7 @@ commSetCloseOnExec(int fd)
 
     if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0) {
         int xerrno = errno;
-        debugs(50, DBG_CRITICAL, MYNAME << "FD " << fd << ": set close-on-exec failed: " << xstrerr(xerrno));
+        debugs(50, DBG_CRITICAL, "ERROR: " << MYNAME << "FD " << fd << ": set close-on-exec failed: " << xstrerr(xerrno));
     }
 
     fd_table[fd].flags.close_on_exec = true;

--- a/src/comm/ModDevPoll.cc
+++ b/src/comm/ModDevPoll.cc
@@ -360,10 +360,8 @@ Comm::DoSelect(int msec)
 
         /* handle errors */
         if (do_poll.dp_fds[i].revents & (POLLERR | POLLHUP | POLLNVAL)) {
-            debugs(
-                5,
-                DEBUG_DEVPOLL ? 0 : 8,
-                HERE << "devpoll event error: fd " << fd
+            debugs(5, DEBUG_DEVPOLL ? 0 : 8,
+                "ERROR: devpoll event failure: fd " << fd
             );
             continue;
         }

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -171,7 +171,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
 
         if (epoll_ctl(kdpfd, epoll_ctl_type, fd, &ev) < 0) {
             int xerrno = errno;
-            debugs(5, DEBUG_EPOLL ? 0 : 8, "epoll_ctl(," << epolltype_atoi(epoll_ctl_type) <<
+            debugs(5, DEBUG_EPOLL ? 0 : 8, "ERROR: epoll_ctl(," << epolltype_atoi(epoll_ctl_type) <<
                    ",,): failed on FD " << fd << ": " << xstrerr(xerrno));
         }
     }

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -239,7 +239,7 @@ Comm::TcpAcceptor::okToAccept()
         return true;
 
     if (last_warn + 15 < squid_curtime) {
-        debugs(5, DBG_CRITICAL, "WARNING! Your cache is running out of filedescriptors");
+        debugs(5, DBG_CRITICAL, "WARNING: Your cache is running out of filedescriptors");
         last_warn = squid_curtime;
     }
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -543,7 +543,7 @@ _db_rotate_log(void)
         errno = 0;
         if (rename(from, to) == -1) {
             const auto saved_errno = errno;
-            debugs(0, DBG_IMPORTANT, "log rotation failed: " << xstrerr(saved_errno));
+            debugs(0, DBG_IMPORTANT, "ERROR: log rotation failed: " << xstrerr(saved_errno));
         }
     }
 
@@ -557,14 +557,14 @@ _db_rotate_log(void)
         errno = 0;
         if (remove(to) == -1) {
             const auto saved_errno = errno;
-            debugs(0, DBG_IMPORTANT, "removal of log file " << to << " failed: " << xstrerr(saved_errno));
+            debugs(0, DBG_IMPORTANT, "ERROR: removal of log file " << to << " failed: " << xstrerr(saved_errno));
         }
         TheLog.clear(); // Windows cannot rename() open files
 #endif
         errno = 0;
         if (rename(from, to) == -1) {
             const auto saved_errno = errno;
-            debugs(0, DBG_IMPORTANT, "renaming file " << from << " to "
+            debugs(0, DBG_IMPORTANT, "ERROR: renaming file " << from << " to "
                    << to << "failed: " << xstrerr(saved_errno));
         }
     }
@@ -621,7 +621,7 @@ debugLogKid(void)
 void
 xassert(const char *msg, const char *file, int line)
 {
-    debugs(0, DBG_CRITICAL, "assertion failed: " << file << ":" << line << ": \"" << msg << "\"");
+    debugs(0, DBG_CRITICAL, "FATAL: assertion failed: " << file << ":" << line << ": \"" << msg << "\"");
 
     if (!shutting_down)
         abort();

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -698,7 +698,7 @@ idnsParseWIN32Registry(void)
         break;
 
     default:
-        debugs(78, DBG_IMPORTANT, "Failed to read nameserver from Registry: Unknown System Type.");
+        debugs(78, DBG_IMPORTANT, "ERROR: Failed to read nameserver from Registry: Unknown System Type.");
     }
 
     return result;
@@ -856,7 +856,7 @@ idnsInitVCConnected(const Comm::ConnectionPointer &conn, Comm::Flag status, int,
         char buf[MAX_IPSTRLEN] = "";
         if (vc->ns < nameservers.size())
             nameservers[vc->ns].S.toStr(buf,MAX_IPSTRLEN);
-        debugs(78, DBG_IMPORTANT, HERE << "Failed to connect to nameserver " << buf << " using TCP.");
+        debugs(78, DBG_IMPORTANT, "ERROR: Failed to connect to nameserver " << buf << " using TCP.");
         return;
     }
 
@@ -925,7 +925,7 @@ idnsSendQueryVC(idns_query * q, size_t nsn)
 
     if (!vc) {
         char buf[MAX_IPSTRLEN];
-        debugs(78, DBG_IMPORTANT, "idnsSendQuery: Failed to initiate TCP connection to nameserver " << nameservers[nsn].S.toStr(buf,MAX_IPSTRLEN) << "!");
+        debugs(78, DBG_IMPORTANT, "ERROR: idnsSendQuery: Failed to initiate TCP connection to nameserver " << nameservers[nsn].S.toStr(buf,MAX_IPSTRLEN) << "!");
 
         return;
     }
@@ -1057,7 +1057,7 @@ idnsQueryID()
         ++id;
 
         if (id == first_id) {
-            debugs(78, DBG_IMPORTANT, "idnsQueryID: Warning, too many pending DNS requests");
+            debugs(78, DBG_IMPORTANT, "WARNING: idnsQueryID: too many pending DNS requests");
             break;
         }
     }
@@ -1166,7 +1166,7 @@ idnsGrokReply(const char *buf, size_t sz, int /*from_ns*/)
     int n = rfc1035MessageUnpack(buf, sz, &message);
 
     if (message == NULL) {
-        debugs(78, DBG_IMPORTANT, "idnsGrokReply: Malformed DNS response");
+        debugs(78, DBG_IMPORTANT, "ERROR: idnsGrokReply: Malformed DNS response");
         return;
     }
 
@@ -1603,7 +1603,7 @@ Dns::Init(void)
 #endif
 
     if (!nsFound) {
-        debugs(78, DBG_IMPORTANT, "Warning: Could not find any nameservers. Trying to use localhost");
+        debugs(78, DBG_IMPORTANT, "WARNING: Could not find any nameservers. Trying to use localhost");
 #if _SQUID_WINDOWS_
         debugs(78, DBG_IMPORTANT, "Please check your TCP-IP settings or /etc/resolv.conf file");
 #else

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -371,7 +371,7 @@ TemplateFile::loadDefault()
     /** test error_default_language location */
     if (!loaded() && Config.errorDefaultLanguage) {
         if (!tryLoadTemplate(Config.errorDefaultLanguage)) {
-            debugs(1, (templateCode < TCP_RESET ? DBG_CRITICAL : 3), "Unable to load default error language files. Reset to backups.");
+            debugs(1, (templateCode < TCP_RESET ? DBG_CRITICAL : 3), "ERROR: Unable to load default error language files. Reset to backups.");
         }
     }
 #endif

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1147,7 +1147,7 @@ ESIContext::parserComment (const char *s)
         if (!tempParser->parse("<div>", 5,0) ||
                 !tempParser->parse(s + 3, strlen(s) - 3, 0) ||
                 !tempParser->parse("</div>",6,1)) {
-            debugs(86, DBG_CRITICAL, "ESIContext::parserComment: Parsing fragment '" << s + 3 << "' failed.");
+            debugs(86, DBG_CRITICAL, "ERROR: ESIContext::parserComment: Parsing fragment '" << s + 3 << "' failed.");
             setError();
             char tempstr[1024];
             snprintf(tempstr, 1023, "ESIContext::parserComment: Parse error at line %ld:\n%s\n",
@@ -1339,7 +1339,7 @@ ESIContext::process ()
             break;
 
         case ESI_PROCESS_FAILED:
-            debugs(86, DBG_CRITICAL, "esiProcess: tree Processed FAILED");
+            debugs(86, DBG_CRITICAL, "ERROR: esiProcess: tree Processed FAILED");
             setError();
 
             setErrorMessage("esiProcess: ESI template Processing failed.");
@@ -1668,7 +1668,7 @@ esiTry::addElement(ESIElement::Pointer element)
 
     if (dynamic_cast<esiAttempt*>(element.getRaw())) {
         if (attempt.getRaw()) {
-            debugs(86, DBG_IMPORTANT, "esiTryAdd: Failed for " << this << " - try already has an attempt node (section 3.4)");
+            debugs(86, DBG_IMPORTANT, "ERROR: esiTryAdd: Failed for " << this << " - try already has an attempt node (section 3.4)");
             return false;
         }
 
@@ -1678,7 +1678,7 @@ esiTry::addElement(ESIElement::Pointer element)
 
     if (dynamic_cast<esiExcept*>(element.getRaw())) {
         if (except.getRaw()) {
-            debugs(86, DBG_IMPORTANT, "esiTryAdd: Failed for " << this << " - try already has an except node (section 3.4)");
+            debugs(86, DBG_IMPORTANT, "ERROR: esiTryAdd: Failed for " << this << " - try already has an except node (section 3.4)");
             return false;
         }
 
@@ -1686,7 +1686,7 @@ esiTry::addElement(ESIElement::Pointer element)
         return true;
     }
 
-    debugs(86, DBG_IMPORTANT, "esiTryAdd: Failed to add element " << element.getRaw() << " to try " << this << ", incorrect element type (see section 3.4)");
+    debugs(86, DBG_IMPORTANT, "ERROR: esiTryAdd: Failed to add element " << element.getRaw() << " to try " << this << ", incorrect element type (see section 3.4)");
     return false;
 }
 
@@ -1705,12 +1705,12 @@ esiTry::process (int dovars)
     esiProcessResult_t rv = ESI_PROCESS_PENDING_MAYFAIL;
 
     if (!attempt.getRaw()) {
-        debugs(86, DBG_CRITICAL, "esiTryProcess: Try has no attempt element - ESI template is invalid (section 3.4)");
+        debugs(86, DBG_CRITICAL, "ERROR: esiTryProcess: Try has no attempt element - ESI template is invalid (section 3.4)");
         return ESI_PROCESS_FAILED;
     }
 
     if (!except.getRaw()) {
-        debugs(86, DBG_CRITICAL, "esiTryProcess: Try has no except element - ESI template is invalid (section 3.4)");
+        debugs(86, DBG_CRITICAL, "ERROR: esiTryProcess: Try has no except element - ESI template is invalid (section 3.4)");
         return ESI_PROCESS_FAILED;
     }
 
@@ -1922,7 +1922,7 @@ esiChoose::addElement(ESIElement::Pointer element)
 
     /* Some elements require specific parents */
     if (!(dynamic_cast<esiWhen*>(element.getRaw()) || dynamic_cast<esiOtherwise*>(element.getRaw()))) {
-        debugs(86, DBG_CRITICAL, "esiChooseAdd: invalid child node for esi:choose (section 3.3)");
+        debugs(86, DBG_CRITICAL, "ERROR: esiChooseAdd: invalid child node for esi:choose (section 3.3)");
         return false;
     }
 

--- a/src/esi/Expression.cc
+++ b/src/esi/Expression.cc
@@ -702,7 +702,7 @@ getsymbol(const char *s, char const **endptr)
 
             if (s == end || errno) {
                 /* Couldn't convert to float */
-                debugs(86, DBG_IMPORTANT, "failed to convert '" << s << "' to float ");
+                debugs(86, DBG_IMPORTANT, "ERROR: failed to convert '" << s << "' to float ");
                 *endptr = origs;
             } else {
                 debugs(86,6, "found " << rv.value.floating << " of length " << end - s);
@@ -719,7 +719,7 @@ getsymbol(const char *s, char const **endptr)
 
             if (s == end || errno) {
                 /* Couldn't convert to int */
-                debugs(86, DBG_IMPORTANT, "failed to convert '" << s << "' to int ");
+                debugs(86, DBG_IMPORTANT, "ERROR: failed to convert '" << s << "' to int ");
                 *endptr = origs;
             } else {
                 debugs(86,6, "found " << rv.value.integral << " of length " << end - s);
@@ -752,7 +752,7 @@ getsymbol(const char *s, char const **endptr)
             ++t;
 
         if (!*t) {
-            debugs(86, DBG_IMPORTANT, "missing end \' in '" << s << "'");
+            debugs(86, DBG_IMPORTANT, "ERROR: missing end \' in '" << s << "'");
             *endptr = origs;
         } else {
             *endptr = t + 1;
@@ -805,7 +805,7 @@ getsymbol(const char *s, char const **endptr)
             rv.precedence = 5;
             rv.eval = evalequals;
         } else {
-            debugs(86, DBG_IMPORTANT, "invalid expr '" << s << "'");
+            debugs(86, DBG_IMPORTANT, "ERROR: invalid expr '" << s << "'");
             *endptr = origs;
         }
     } else if ('<' == *s) {
@@ -853,7 +853,7 @@ getsymbol(const char *s, char const **endptr)
         rv.precedence = 1;
         rv.eval = evalexpr;
     } else {
-        debugs(86, DBG_IMPORTANT, "invalid expr '" << s << "'");
+        debugs(86, DBG_IMPORTANT, "ERROR: invalid expr '" << s << "'");
         *endptr = origs;
     }
 
@@ -983,7 +983,7 @@ addmember(stackmember * stack, int *stackdepth, stackmember * candidate)
                 /* cleanup candidate and stack */
                 dumpstack(stack, *stackdepth);
                 cleanmember(candidate);
-                debugs(86, DBG_IMPORTANT, "invalid expression");
+                debugs(86, DBG_IMPORTANT, "ERROR: invalid expression");
                 return 0;
             }
         } else {
@@ -1015,7 +1015,7 @@ ESIExpression::Evaluate(char const *s)
             s = end;
         } else {
             assert (s == end);
-            debugs(86, DBG_IMPORTANT, "failed parsing expression");
+            debugs(86, DBG_IMPORTANT, "ERROR: failed parsing expression");
             return 0;
         }
     }
@@ -1028,7 +1028,7 @@ ESIExpression::Evaluate(char const *s)
         if (stack[stackdepth - 2].
                 eval(stack, &stackdepth, stackdepth - 2, &rv)) {
             /* special case - leading operator failed */
-            debugs(86, DBG_IMPORTANT, "invalid expression");
+            debugs(86, DBG_IMPORTANT, "ERROR: invalid expression");
             return 0;
         }
     }

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -146,7 +146,7 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
         return;
 
     case STREAM_FAILED:
-        debugs(86, DBG_IMPORTANT, "ESI subrequest failed transfer");
+        debugs(86, DBG_IMPORTANT, "ERROR: ESI subrequest failed transfer");
         esiStream->include->includeFail (esiStream);
         esiStream->finished = 1;
         httpRequestFree (http);
@@ -289,7 +289,7 @@ ESIInclude::Start (ESIStreamContext::Pointer stream, char const *url, ESIVarStat
     debugs(86, 5, "ESIIncludeStart: Starting subrequest with url '" << tempUrl << "'");
     const MasterXaction::Pointer mx = new MasterXaction(XactionInitiator::initEsi);
     if (clientBeginRequest(Http::METHOD_GET, tempUrl, esiBufferRecipient, esiBufferDetach, stream.getRaw(), &tempheaders, stream->localbuffer->buf, HTTP_REQBUF_SZ, mx)) {
-        debugs(86, DBG_CRITICAL, "starting new ESI subrequest failed");
+        debugs(86, DBG_CRITICAL, "ERROR: starting new ESI subrequest failed");
     }
 
     tempheaders.clean();
@@ -332,7 +332,7 @@ ESIInclude::ESIInclude(esiTreeParentPtr aParent, int attrcount, char const **att
                 flags.onerrorcontinue = 1;
             } else {
                 /* ignore mistyped attributes */
-                debugs(86, DBG_IMPORTANT, "invalid value for onerror='" << attr[i+1] << "'");
+                debugs(86, DBG_IMPORTANT, "ERROR: invalid value for onerror='" << attr[i+1] << "'");
             }
         } else {
             /* ignore mistyped attributes. TODO:? error on these for user feedback - config parameter needed
@@ -512,7 +512,7 @@ ESIInclude::subRequestDone (ESIStreamContext::Pointer stream, bool success)
          * 'this.finish' while the subrequest is still not completed.
          */
         if (parent.getRaw() == NULL) {
-            debugs (86, 0, "ESIInclude::subRequestDone: Sub request completed "
+            debugs(86, DBG_CRITICAL, "ERROR: Squid Bug #951: ESIInclude::subRequestDone: Sub request completed "
                     "after finish() called and parent unlinked. Unable to "
                     "continue handling the request, and may be memory leaking. "
                     "See http://www.squid-cache.org/bugs/show_bug.cgi?id=951 - we "

--- a/src/eui/Eui48.cc
+++ b/src/eui/Eui48.cc
@@ -99,7 +99,7 @@ Eui::Eui48::decode(const char *asc)
     int a1 = 0, a2 = 0, a3 = 0, a4 = 0, a5 = 0, a6 = 0;
 
     if (sscanf(asc, "%x:%x:%x:%x:%x:%x", &a1, &a2, &a3, &a4, &a5, &a6) != 6) {
-        debugs(28, DBG_CRITICAL, "Decode EUI-48: Invalid ethernet address '" << asc << "'");
+        debugs(28, DBG_CRITICAL, "ERROR: Decode EUI-48: Invalid ethernet address '" << asc << "'");
         clear();
         return false;       /* This is not valid address */
     }
@@ -149,7 +149,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
     int tmpSocket = socket(AF_INET,SOCK_STREAM,0);
     if (tmpSocket < 0) {
         int xerrno = errno;
-        debugs(28, DBG_IMPORTANT, "Attempt to open socket for EUI retrieval failed: " << xstrerr(xerrno));
+        debugs(28, DBG_IMPORTANT, "ERROR: Attempt to open socket for EUI retrieval failed: " << xstrerr(xerrno));
         clear();
         return false;
     }
@@ -206,7 +206,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
 
     if (ioctl(tmpSocket, SIOCGIFCONF, &ifc) < 0) {
         int xerrno = errno;
-        debugs(28, DBG_IMPORTANT, "Attempt to retrieve interface list failed: " << xstrerr(xerrno));
+        debugs(28, DBG_IMPORTANT, "ERROR: Attempt to retrieve interface list failed: " << xstrerr(xerrno));
         clear();
         close(tmpSocket);
         return false;
@@ -254,7 +254,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
             int xerrno = errno;
             //  Query failed.  Do not log failed lookups or "device not supported"
             if (ENXIO != xerrno && ENODEV != xerrno)
-                debugs(28, DBG_IMPORTANT, "ARP query " << ipAddr << " failed: " << ifr->ifr_name << ": " << xstrerr(xerrno));
+                debugs(28, DBG_IMPORTANT, "ERROR: ARP query " << ipAddr << " failed: " << ifr->ifr_name << ": " << xstrerr(xerrno));
 
             continue;
         }
@@ -294,7 +294,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
     int tmpSocket = socket(AF_INET,SOCK_STREAM,0);
     if (tmpSocket < 0) {
         int xerrno = errno;
-        debugs(28, DBG_IMPORTANT, "Attempt to open socket for EUI retrieval failed: " << xstrerr(xerrno));
+        debugs(28, DBG_IMPORTANT, "ERROR: Attempt to open socket for EUI retrieval failed: " << xstrerr(xerrno));
         clear();
         return false;
     }
@@ -378,19 +378,19 @@ Eui::Eui48::lookup(const Ip::Address &c)
 #endif
 
     if (sysctl(mib, 6, NULL, &needed, NULL, 0) < 0) {
-        debugs(28, DBG_CRITICAL, "Can't estimate ARP table size!");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot estimate ARP table size!");
         clear();
         return false;
     }
 
     if ((buf = (char *)xmalloc(needed)) == NULL) {
-        debugs(28, DBG_CRITICAL, "Can't allocate temporary ARP table!");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot allocate temporary ARP table!");
         clear();
         return false;
     }
 
     if (sysctl(mib, 6, buf, &needed, NULL, 0) < 0) {
-        debugs(28, DBG_CRITICAL, "Can't retrieve ARP table!");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot retrieve ARP table!");
         xfree(buf);
         clear();
         return false;
@@ -455,21 +455,21 @@ Eui::Eui48::lookup(const Ip::Address &c)
 
     /* Get size of Windows ARP table */
     if (GetIpNetTable(NetTable, &ipNetTableLen, FALSE) != ERROR_INSUFFICIENT_BUFFER) {
-        debugs(28, DBG_CRITICAL, "Can't estimate ARP table size!");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot estimate ARP table size!");
         clear();
         return false;
     }
 
     /* Allocate space for ARP table and assign pointers */
     if ((NetTable = (PMIB_IPNETTABLE)xmalloc(ipNetTableLen)) == NULL) {
-        debugs(28, DBG_CRITICAL, "Can't allocate temporary ARP table!");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot allocate temporary ARP table!");
         clear();
         return false;
     }
 
     /* Get actual ARP table */
     if ((dwNetTable = GetIpNetTable(NetTable, &ipNetTableLen, FALSE)) != NO_ERROR) {
-        debugs(28, DBG_CRITICAL, "Can't retrieve ARP table!");
+        debugs(28, DBG_CRITICAL, "ERROR: Cannot retrieve ARP table!");
         xfree(NetTable);
         clear();
         return false;

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -544,12 +544,12 @@ ACLExternal::valid () const
 #if USE_AUTH
     if (data->def->require_auth) {
         if (authenticateSchemeCount() == 0) {
-            debugs(28, DBG_CRITICAL, "Can't use proxy auth because no authentication schemes were compiled.");
+            debugs(28, DBG_CRITICAL, "ERROR: Cannot use proxy auth because no authentication schemes were compiled.");
             return false;
         }
 
         if (authenticateActiveSchemeCount() == 0) {
-            debugs(28, DBG_CRITICAL, "Can't use proxy auth because no authentication schemes are fully configured.");
+            debugs(28, DBG_CRITICAL, "ERROR: Cannot use proxy auth because no authentication schemes are fully configured.");
             return false;
         }
     }

--- a/src/format/Config.cc
+++ b/src/format/Config.cc
@@ -51,6 +51,6 @@ Format::FmtConfig::registerTokens(const SBuf &nsName, TokenTableEntry const *tok
     if (tokenArray)
         tokens.emplace_back(TokenNamespace(nsName, tokenArray));
     else
-        debugs(0, DBG_CRITICAL, "BUG: format tokens for '" << nsName << "' missing!");
+        debugs(0, DBG_CRITICAL, "ERROR: Squid BUG: format tokens for '" << nsName << "' missing!");
 }
 

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -961,7 +961,7 @@ Rock::SwapDir::full() const
 void
 Rock::SwapDir::diskFull()
 {
-    debugs(20, DBG_IMPORTANT, "BUG: No space left with rock cache_dir: " <<
+    debugs(20, DBG_IMPORTANT, "ERROR: Squid BUG: No space left with rock cache_dir: " <<
            filePath);
 }
 

--- a/src/fs/ufs/RebuildState.cc
+++ b/src/fs/ufs/RebuildState.cc
@@ -393,7 +393,7 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
 
             if (!td) {
                 int xerrno = errno;
-                debugs(47, DBG_IMPORTANT, MYNAME << "error in opendir (" << fullpath << "): " << xstrerr(xerrno));
+                debugs(47, DBG_IMPORTANT, "ERROR: " << MYNAME << "in opendir (" << fullpath << "): " << xstrerr(xerrno));
             } else {
                 entry = readdir(td);    /* skip . and .. */
                 entry = readdir(td);
@@ -433,7 +433,7 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
 
             if (fd < 0) {
                 int xerrno = errno;
-                debugs(47, DBG_IMPORTANT, MYNAME << "error opening " << fullfilename << ": " << xstrerr(xerrno));
+                debugs(47, DBG_IMPORTANT, "ERROR: " << MYNAME << "opening " << fullfilename << ": " << xstrerr(xerrno));
             } else
                 ++store_open_disk_fd;
 

--- a/src/fs/ufs/UFSStoreState.cc
+++ b/src/fs/ufs/UFSStoreState.cc
@@ -162,7 +162,7 @@ Fs::Ufs::UFSStoreState::write(char const *buf, size_t size, off_t aOffset, FREE 
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) << swap_filen);
 
     if (theFile->error()) {
-        debugs(79, DBG_IMPORTANT,HERE << "avoid write on theFile with error");
+        debugs(79, DBG_IMPORTANT, "ERROR: avoid write on theFile with error");
         debugs(79, DBG_IMPORTANT,HERE << "calling free_func for " << (void*) buf);
         free_func((void*)buf);
         return false;
@@ -204,7 +204,7 @@ Fs::Ufs::UFSStoreState::doWrite()
     auto &q = pending_writes.front();
 
     if (theFile->error()) {
-        debugs(79, DBG_IMPORTANT, MYNAME << " avoid write on theFile with error");
+        debugs(79, DBG_IMPORTANT, "ERROR: " << MYNAME << "avoid write on theFile with error");
         pending_writes.pop();
         return;
     }

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -745,7 +745,7 @@ Fs::Ufs::UFSSwapDir::openLog()
 
     if (swaplog_fd < 0) {
         int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, "ERROR opening swap log " << logPath << ": " << xstrerr(xerrno));
+        debugs(50, DBG_IMPORTANT, "ERROR: opening swap log " << logPath << ": " << xstrerr(xerrno));
         fatal("UFSSwapDir::openLog: Failed to open swap log.");
     }
 

--- a/src/fs/ufs/UFSSwapLogParser.cc
+++ b/src/fs/ufs/UFSSwapLogParser.cc
@@ -99,7 +99,7 @@ Fs::Ufs::UFSSwapLogParser::GetUFSSwapLogParser(FILE *fp)
         if (fseek(fp, header.record_size, SEEK_SET) != 0)
             return NULL;
 
-        debugs(47, DBG_IMPORTANT, "Rejecting swap file v1 to avoid cache " <<
+        debugs(47, DBG_IMPORTANT, "ERROR: Rejecting swap file v1 to avoid cache " <<
                "index corruption. Forcing a full cache index rebuild. " <<
                "See Squid bug #3441.");
         return NULL;
@@ -121,7 +121,7 @@ Fs::Ufs::UFSSwapLogParser::GetUFSSwapLogParser(FILE *fp)
 
     // TODO: v3: write to disk in network-order bytes for the larger fields?
 
-    debugs(47, DBG_IMPORTANT, "Unknown swap file version: " << header.version);
+    debugs(47, DBG_IMPORTANT, "ERROR: Unknown swap file version: " << header.version);
     return NULL;
 }
 

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -203,7 +203,7 @@ diskHandleWrite(int fd, void *)
         errno = 0;
         if (lseek(fd, fdd->write_q->file_offset, SEEK_SET) == -1) {
             int xerrno = errno;
-            debugs(50, DBG_IMPORTANT, "error in seek for FD " << fd << ": " << xstrerr(xerrno));
+            debugs(50, DBG_IMPORTANT, "ERROR: in seek for FD " << fd << ": " << xstrerr(xerrno));
             // XXX: handle error?
         }
     }
@@ -222,7 +222,7 @@ diskHandleWrite(int fd, void *)
         if (!ignoreErrno(errno)) {
             status = errno == ENOSPC ? DISK_NO_SPACE_LEFT : DISK_ERROR;
             int xerrno = errno;
-            debugs(50, DBG_IMPORTANT, "diskHandleWrite: FD " << fd << ": disk write error: " << xstrerr(xerrno));
+            debugs(50, DBG_IMPORTANT, "ERROR: diskHandleWrite: FD " << fd << ": disk write failure: " << xstrerr(xerrno));
 
             /*
              * If there is no write callback, then this file is
@@ -406,7 +406,7 @@ diskHandleRead(int fd, void *data)
         if (lseek(fd, ctrl_dat->offset, SEEK_SET) == -1) {
             xerrno = errno;
             // shouldn't happen, let's detect that
-            debugs(50, DBG_IMPORTANT, "error in seek for FD " << fd << ": " << xstrerr(xerrno));
+            debugs(50, DBG_IMPORTANT, "ERROR: in seek for FD " << fd << ": " << xstrerr(xerrno));
             // XXX handle failures?
         }
         ++ statCounter.syscalls.disk.seeks;
@@ -472,7 +472,7 @@ safeunlink(const char *s, int quiet)
 
     if (unlink(s) < 0 && !quiet) {
         int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, "safeunlink: Couldn't delete " << s << ": " << xstrerr(xerrno));
+        debugs(50, DBG_IMPORTANT, "ERROR: safeunlink: Could not delete " << s << ": " << xstrerr(xerrno));
     }
 }
 
@@ -494,7 +494,7 @@ FileRename(const SBuf &from, const SBuf &to)
         return true;
 
     int xerrno = errno;
-    debugs(21, (errno == ENOENT ? 2 : DBG_IMPORTANT), "Cannot rename " << from << " to " << to << ": " << xstrerr(xerrno));
+    debugs(21, (errno == ENOENT ? 2 : DBG_IMPORTANT), "ERROR: Cannot rename " << from << " to " << to << ": " << xstrerr(xerrno));
 
     return false;
 }

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -789,7 +789,7 @@ gopherReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm
     }
 
     if (flag != Comm::OK) {
-        debugs(50, DBG_IMPORTANT, MYNAME << "error reading: " << xstrerr(xerrno));
+        debugs(50, DBG_IMPORTANT, "ERROR: " << MYNAME << "reading: " << xstrerr(xerrno));
 
         if (ignoreErrno(xerrno)) {
             AsyncCall::Pointer call = commCbCall(5,4, "gopherReadReply",

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1004,7 +1004,7 @@ helperHandleRead(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::
 
     if (!srv->stats.pending && !srv->stats.timedout) {
         /* someone spoke without being spoken to */
-        debugs(84, DBG_IMPORTANT, "helperHandleRead: unexpected read from " <<
+        debugs(84, DBG_IMPORTANT, "ERROR: helperHandleRead: unexpected read from " <<
                hlp->id_name << " #" << srv->index << ", " << (int)len <<
                " bytes '" << srv->rbuf << "'");
 
@@ -1048,7 +1048,7 @@ helperHandleRead(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::
                 if (srv->stats.timedout) {
                     debugs(84, 3, "Timedout reply received for request-ID: " << i << " , ignore");
                 } else {
-                    debugs(84, DBG_IMPORTANT, "helperHandleRead: unexpected reply on channel " <<
+                    debugs(84, DBG_IMPORTANT, "ERROR: helperHandleRead: unexpected reply on channel " <<
                            i << " from " << hlp->id_name << " #" << srv->index <<
                            " '" << srv->rbuf << "'");
                 }
@@ -1123,7 +1123,7 @@ helperStatefulHandleRead(const Comm::ConnectionPointer &conn, char *, size_t len
 
     if (r == NULL) {
         /* someone spoke without being spoken to */
-        debugs(84, DBG_IMPORTANT, "helperStatefulHandleRead: unexpected read from " <<
+        debugs(84, DBG_IMPORTANT, "ERROR: helperStatefulHandleRead: unexpected read from " <<
                hlp->id_name << " #" << srv->index << ", " << (int)len <<
                " bytes '" << srv->rbuf << "'");
 
@@ -1392,7 +1392,7 @@ helperDispatch(helper_server * srv, Helper::Xaction * r)
     const uint64_t reqId = ++srv->nextRequestId;
 
     if (!cbdataReferenceValid(r->request.data)) {
-        debugs(84, DBG_IMPORTANT, "helperDispatch: invalid callback data");
+        debugs(84, DBG_IMPORTANT, "ERROR: helperDispatch: invalid callback data");
         delete r;
         return;
     }
@@ -1438,7 +1438,7 @@ helperStatefulDispatch(helper_stateful_server * srv, Helper::Xaction * r)
     statefulhelper *hlp = srv->parent;
 
     if (!cbdataReferenceValid(r->request.data)) {
-        debugs(84, DBG_IMPORTANT, "helperStatefulDispatch: invalid callback data");
+        debugs(84, DBG_IMPORTANT, "ERROR: helperStatefulDispatch: invalid callback data");
         delete r;
         hlp->cancelReservation(srv->reservationId);
         return;

--- a/src/helper/ChildConfig.cc
+++ b/src/helper/ChildConfig.cc
@@ -94,7 +94,7 @@ Helper::ChildConfig::parseConfig()
         } else if (strncmp(token, "idle=", 5) == 0) {
             n_idle = xatoui(token + 5);
             if (n_idle < 1) {
-                debugs(0, DBG_CRITICAL, "WARNING OVERRIDE: Using idle=0 for helpers causes request failures. Overriding to use idle=1 instead.");
+                debugs(0, DBG_CRITICAL, "WARNING: OVERRIDE: Using idle=0 for helpers causes request failures. Overriding to use idle=1 instead.");
                 n_idle = 1;
             }
         } else if (strncmp(token, "concurrency=", 12) == 0) {
@@ -125,12 +125,12 @@ Helper::ChildConfig::parseConfig()
     /* simple sanity. */
 
     if (n_startup > n_max) {
-        debugs(0, DBG_CRITICAL, "WARNING OVERRIDE: Capping startup=" << n_startup << " to the defined maximum (" << n_max <<")");
+        debugs(0, DBG_CRITICAL, "WARNING: OVERRIDE: Capping startup=" << n_startup << " to the defined maximum (" << n_max <<")");
         n_startup = n_max;
     }
 
     if (n_idle > n_max) {
-        debugs(0, DBG_CRITICAL, "WARNING OVERRIDE: Capping idle=" << n_idle << " to the defined maximum (" << n_max <<")");
+        debugs(0, DBG_CRITICAL, "WARNING: OVERRIDE: Capping idle=" << n_idle << " to the defined maximum (" << n_max <<")");
         n_idle = n_max;
     }
 

--- a/src/http.cc
+++ b/src/http.cc
@@ -1905,7 +1905,7 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
             static int warnedCount = 0;
             if (warnedCount++ < 100) {
                 const SBuf url(entry ? SBuf(entry->url()) : request->effectiveRequestUri());
-                debugs(11, DBG_IMPORTANT, "Warning: likely forwarding loop with " << url);
+                debugs(11, DBG_IMPORTANT, "WARNING: likely forwarding loop with " << url);
             }
         }
 

--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -120,7 +120,7 @@ Http::Message::parse(const char *buf, const size_t sz, bool eof, Http::StatusCod
     debugs(58, 9, "success (" << hdr_len << " bytes) near '" << buf << "'");
 
     if (hdr_sz != (int)hdr_len) {
-        debugs(58, DBG_IMPORTANT, "internal Http::Message::parse vs. headersEnd error: " <<
+        debugs(58, DBG_IMPORTANT, "ERROR: internal Http::Message::parse vs. headersEnd failure: " <<
                hdr_sz << " != " << hdr_len);
         hdr_sz = (int)hdr_len; // because old http.cc code used hdr_len
     }

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -57,7 +57,7 @@ Http::StatusLine::packInto(Packable * p) const
     if (packedStatus == Http::scNone) {
         static unsigned int reports = 0;
         if (++reports <= 100)
-            debugs(57, DBG_IMPORTANT, "BUG: the internalized response lacks status-code");
+            debugs(57, DBG_IMPORTANT, "ERROR: Squid BUG: the internalized response lacks status-code");
         packedStatus = Http::scInternalServerError;
         packedReason = Http::StatusCodeString(packedStatus); // ignore custom reason_ (if any)
     }

--- a/src/http/one/RequestParser.cc
+++ b/src/http/one/RequestParser.cc
@@ -69,7 +69,7 @@ Http::One::RequestParser::parseMethodField(Tokenizer &tok)
 
     SBuf methodFound;
     if (!tok.prefix(methodFound, CharacterSet::TCHAR, maxMethodLength)) {
-        debugs(33, ErrorLevel(), "invalid request-line: missing or malformed method");
+        debugs(33, ErrorLevel(), "ERROR: invalid request-line: missing or malformed method");
         parseStatusCode = Http::scBadRequest;
         return false;
     }
@@ -155,14 +155,14 @@ Http::One::RequestParser::parseUriField(Tokenizer &tok)
     SBuf uriFound;
     if (!tok.prefix(uriFound, RequestTargetCharacters())) {
         parseStatusCode = Http::scBadRequest;
-        debugs(33, ErrorLevel(), "invalid request-line: missing or malformed URI");
+        debugs(33, ErrorLevel(), "ERROR: invalid request-line: missing or malformed URI");
         return false;
     }
 
     if (uriFound.length() > maxUriLength) {
         // RFC 7230 section 3.1.1 mandatory (MUST) 414 response
         parseStatusCode = Http::scUriTooLong;
-        debugs(33, ErrorLevel(), "invalid request-line: " << uriFound.length() <<
+        debugs(33, ErrorLevel(), "ERROR: invalid request-line: " << uriFound.length() <<
                "-byte URI exceeds " << maxUriLength << "-byte limit");
         return false;
     }
@@ -216,7 +216,7 @@ Http::One::RequestParser::parseHttpVersionField(Tokenizer &tok)
         return true;
     }
 
-    debugs(33, ErrorLevel(), "invalid request-line: not HTTP");
+    debugs(33, ErrorLevel(), "ERROR: invalid request-line: not HTTP");
     parseStatusCode = Http::scBadRequest;
     return false;
 }
@@ -230,14 +230,14 @@ bool
 Http::One::RequestParser::skipDelimiter(const size_t count, const char *where)
 {
     if (count <= 0) {
-        debugs(33, ErrorLevel(), "invalid request-line: missing delimiter " << where);
+        debugs(33, ErrorLevel(), "ERROR: invalid request-line: missing delimiter " << where);
         parseStatusCode = Http::scBadRequest;
         return false;
     }
 
     // tolerant parser allows multiple whitespace characters between request-line fields
     if (count > 1 && !Config.onoff.relaxed_header_parser) {
-        debugs(33, ErrorLevel(), "invalid request-line: too many delimiters " << where);
+        debugs(33, ErrorLevel(), "ERROR: invalid request-line: too many delimiters " << where);
         parseStatusCode = Http::scBadRequest;
         return false;
     }
@@ -253,7 +253,7 @@ Http::One::RequestParser::skipTrailingCrs(Tokenizer &tok)
         (void)tok.skipAllTrailing(CharacterSet::CR); // optional; multiple OK
     } else {
         if (!tok.skipOneTrailing(CharacterSet::CR)) {
-            debugs(33, ErrorLevel(), "invalid request-line: missing CR before LF");
+            debugs(33, ErrorLevel(), "ERROR: invalid request-line: missing CR before LF");
             parseStatusCode = Http::scBadRequest;
             return false;
         }
@@ -293,7 +293,7 @@ Http::One::RequestParser::parseRequestFirstLine()
                 return -1; // blame a bad method (or its delimiter)
 
             // assume it is the URI
-            debugs(74, ErrorLevel(), "invalid request-line: URI exceeds " <<
+            debugs(74, ErrorLevel(), "ERROR: invalid request-line: URI exceeds " <<
                    Config.maxRequestHeaderSize << "-byte limit");
             parseStatusCode = Http::scUriTooLong;
             return -1;
@@ -323,7 +323,7 @@ Http::One::RequestParser::parseRequestFirstLine()
         return -1;
 
     if (!tok.atEnd()) {
-        debugs(33, ErrorLevel(), "invalid request-line: garbage after URI");
+        debugs(33, ErrorLevel(), "ERROR: invalid request-line: garbage after URI");
         parseStatusCode = Http::scBadRequest;
         return -1;
     }

--- a/src/icmp/Icmp4.cc
+++ b/src/icmp/Icmp4.cc
@@ -182,7 +182,7 @@ Icmp4::Recv(void)
                  &from->ai_addrlen);
 
     if (n <= 0) {
-        debugs(42, DBG_CRITICAL, HERE << "Error when calling recvfrom() on ICMP socket.");
+        debugs(42, DBG_CRITICAL, "ERROR: when calling recvfrom() on ICMP socket.");
         Ip::Address::FreeAddr(from);
         return;
     }
@@ -244,7 +244,7 @@ Icmp4::Recv(void)
     preply.psize = n - iphdrlen - (sizeof(icmpEchoData) - MAX_PKT4_SZ);
 
     if (preply.psize < 0) {
-        debugs(42, DBG_CRITICAL, HERE << "Malformed ICMP packet.");
+        debugs(42, DBG_CRITICAL, "ERROR: Malformed ICMP packet.");
         Ip::Address::FreeAddr(from);
         return;
     }

--- a/src/icmp/Icmp6.cc
+++ b/src/icmp/Icmp6.cc
@@ -223,7 +223,7 @@ Icmp6::Recv(void)
                  &from->ai_addrlen);
 
     if (n <= 0) {
-        debugs(42, DBG_CRITICAL, HERE << "Error when calling recvfrom() on ICMPv6 socket.");
+        debugs(42, DBG_CRITICAL, "ERROR: when calling recvfrom() on ICMPv6 socket.");
         Ip::Address::FreeAddr(from);
         return;
     }

--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -208,7 +208,7 @@ IcmpPinger::Recv(void)
                        pecho.payload,
                        pecho.psize);
     } else {
-        debugs(42, DBG_IMPORTANT, HERE << " IP has unknown Type. " << pecho.to );
+        debugs(42, DBG_IMPORTANT, "ERROR: IP has unknown Type. " << pecho.to );
     }
 }
 
@@ -219,7 +219,7 @@ IcmpPinger::SendResult(pingerReplyData &preply, int len)
 
     if (send(socket_to_squid, &preply, len, 0) < 0) {
         int xerrno = errno;
-        debugs(42, DBG_CRITICAL, "pinger: FATAL error on send: " << xstrerr(xerrno));
+        debugs(42, DBG_CRITICAL, "FATAL: pinger: send failure: " << xstrerr(xerrno));
         Close();
         exit(EXIT_FAILURE);
     }

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -167,7 +167,7 @@ IcmpSquid::Recv()
         break;
 
     default:
-        debugs(37, DBG_IMPORTANT, HERE << "Bad opcode: " << preply.opcode << " from " << F);
+        debugs(37, DBG_IMPORTANT, "ERROR: Bad opcode: " << preply.opcode << " from " << F);
         break;
     }
 }

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -318,7 +318,7 @@ netdbSendPing(const ipcache_addrs *ia, const Dns::LookupDetails &, void *data)
         x = (net_db_name *) hash_lookup(host_table, hostname);
 
         if (x == NULL) {
-            debugs(38, DBG_IMPORTANT, "netdbSendPing: net_db_name list bug: " << hostname << " not found");
+            debugs(38, DBG_IMPORTANT, "ERROR: Squid BUG: net_db_name list bug: " << hostname << " not found");
             xfree(hostname);
             return;
         }
@@ -807,7 +807,7 @@ netdbExchangeHandleReply(void *data, StoreIOBuffer receivedData)
                 break;
 
             default:
-                debugs(38, DBG_IMPORTANT, "netdbExchangeHandleReply: corrupt data, aborting");
+                debugs(38, DBG_IMPORTANT, "ERROR: netdbExchangeHandleReply: corrupt data, aborting");
                 delete ex;
                 return;
             }
@@ -1301,7 +1301,7 @@ netdbExchangeStart(void *data)
     HttpRequestPointer req(HttpRequest::FromUrlXXX(uri, mx));
 
     if (!req) {
-        debugs(38, DBG_IMPORTANT, MYNAME << ": Bad URI " << uri);
+        debugs(38, DBG_IMPORTANT, "ERROR: " << MYNAME << ": Bad URI " << uri);
         return;
     }
 

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -132,14 +132,14 @@ main(int, char **)
 
     icmp4_worker = icmp4.Open();
     if (icmp4_worker < 0) {
-        debugs(42, DBG_CRITICAL, "pinger: Unable to start ICMP pinger.");
+        debugs(42, DBG_CRITICAL, "ERROR: pinger: Unable to start ICMP pinger.");
     }
     max_fd = max(max_fd, icmp4_worker);
 
 #if USE_IPV6
     icmp6_worker = icmp6.Open();
     if (icmp6_worker <0 ) {
-        debugs(42, DBG_CRITICAL, "pinger: Unable to start ICMPv6 pinger.");
+        debugs(42, DBG_CRITICAL, "ERROR: pinger: Unable to start ICMPv6 pinger.");
     }
     max_fd = max(max_fd, icmp6_worker);
 #endif
@@ -218,7 +218,7 @@ main(int, char **)
 
         if (x < 0) {
             int xerrno = errno;
-            debugs(42, DBG_CRITICAL, HERE << " FATAL Shutdown. select()==" << x << ", ERR: " << xstrerr(xerrno));
+            debugs(42, DBG_CRITICAL, "FATAL: select()==" << x << ", ERR: " << xstrerr(xerrno));
             control.Close();
             exit(EXIT_FAILURE);
         }

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -601,7 +601,7 @@ icpHandleIcpV2(int fd, Ip::Address &from, char *buf, int len)
         break;
 
     default:
-        debugs(12, DBG_CRITICAL, "icpHandleIcpV2: UNKNOWN OPCODE: " << header.opcode << " from " << from);
+        debugs(12, DBG_CRITICAL, "ERROR: icpHandleIcpV2: UNKNOWN OPCODE: " << header.opcode << " from " << from);
 
         break;
     }

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -601,7 +601,7 @@ icpHandleIcpV2(int fd, Ip::Address &from, char *buf, int len)
         break;
 
     default:
-        debugs(12, DBG_CRITICAL, "ERROR: icpHandleIcpV2: UNKNOWN OPCODE: " << header.opcode << " from " << from);
+        debugs(12, DBG_CRITICAL, "ERROR: icpHandleIcpV2: Unknown opcode: " << header.opcode << " from " << from);
 
         break;
     }

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -111,7 +111,7 @@ icpHandleIcpV3(int fd, Ip::Address &from, char *buf, int len)
         break;
 
     default:
-        debugs(12, DBG_CRITICAL, "ERROR: icpHandleIcpV3: UNKNOWN OPCODE: " << header.opcode << " from " << from);
+        debugs(12, DBG_CRITICAL, "ERROR: icpHandleIcpV3: Unknown opcode: " << header.opcode << " from " << from);
         break;
     }
 }

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -111,7 +111,7 @@ icpHandleIcpV3(int fd, Ip::Address &from, char *buf, int len)
         break;
 
     default:
-        debugs(12, DBG_CRITICAL, "icpHandleIcpV3: UNKNOWN OPCODE: " << header.opcode << " from " << from);
+        debugs(12, DBG_CRITICAL, "ERROR: icpHandleIcpV3: UNKNOWN OPCODE: " << header.opcode << " from " << from);
         break;
     }
 }

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -67,7 +67,7 @@ ACLIdent::match(ACLChecklist *cl)
         }
         // else fall through to ACCESS_DUNNO failure below
     } else {
-        debugs(28, DBG_IMPORTANT, HERE << "Can't start ident lookup. No client connection" );
+        debugs(28, DBG_IMPORTANT, "ERROR: Cannot start ident lookup. No client connection" );
         // fall through to ACCESS_DUNNO failure below
     }
 

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -349,7 +349,7 @@ Ip::Address::getReverseString(char buf[MAX_IPSTRLEN], int show_type) const
         return getReverseString6(buf, mSocketAddr_.sin6_addr);
     }
 
-    debugs(14, DBG_CRITICAL, "Unable to convert '" << toStr(buf,MAX_IPSTRLEN) << "' to the rDNS type requested.");
+    debugs(14, DBG_CRITICAL, "ERROR: Unable to convert '" << toStr(buf,MAX_IPSTRLEN) << "' to the rDNS type requested.");
 
     buf[0] = '\0';
 
@@ -927,7 +927,7 @@ Ip::Address::getSockAddr(struct sockaddr_storage &addr, const int family) const
 
     if ( family == AF_INET && !isIPv4()) {
         // TODO INET6: caller using the wrong socket type!
-        debugs(14, DBG_CRITICAL, HERE << "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this);
+        debugs(14, DBG_CRITICAL, "ERROR: Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this);
         assert(false);
     }
 
@@ -950,7 +950,7 @@ Ip::Address::getSockAddr(struct sockaddr_in &buf) const
         buf.sin_port = mSocketAddr_.sin6_port;
         map6to4( mSocketAddr_.sin6_addr, buf.sin_addr);
     } else {
-        debugs(14, DBG_CRITICAL, HERE << "Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this );
+        debugs(14, DBG_CRITICAL, "ERROR: Ip::Address::getSockAddr : Cannot convert non-IPv4 to IPv4. from " << *this );
 
         memset(&buf,0xFFFFFFFF,sizeof(struct sockaddr_in));
         assert(false);
@@ -1027,7 +1027,7 @@ Ip::Address::getInAddr(struct in_addr &buf) const
     // default:
     // non-compatible IPv6 Pure Address
 
-    debugs(14, DBG_IMPORTANT, HERE << "Ip::Address::getInAddr : Cannot convert non-IPv4 to IPv4. IPA=" << *this);
+    debugs(14, DBG_IMPORTANT, "ERROR: Ip::Address::getInAddr : Cannot convert non-IPv4 to IPv4. IPA=" << *this);
     memset(&buf,0xFFFFFFFF,sizeof(struct in_addr));
     assert(false);
     return false;

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -69,11 +69,11 @@ Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &server, fde *clientFde)
             }
         } else {
             int xerrno = errno;
-            debugs(33, DBG_IMPORTANT, "QOS: error in getsockopt(IP_PKTOPTIONS) on " << server << " " << xstrerr(xerrno));
+            debugs(33, DBG_IMPORTANT, "ERROR: QOS: getsockopt(IP_PKTOPTIONS) failure on " << server << " " << xstrerr(xerrno));
         }
     } else {
         int xerrno = errno;
-        debugs(33, DBG_IMPORTANT, "QOS: error in setsockopt(IP_RECVTOS) on " << server << " " << xstrerr(xerrno));
+        debugs(33, DBG_IMPORTANT, "ERROR: QOS: setsockopt(IP_RECVTOS) failure on " << server << " " << xstrerr(xerrno));
     }
 #else
     (void)server;

--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -158,22 +158,22 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
         errno = 0;
         if (setsockopt(fds[0], SOL_SOCKET, SO_SNDBUF, (void *) &buflen, sizeof(buflen)) == -1)  {
             xerrno = errno;
-            debugs(54, DBG_IMPORTANT, "setsockopt failed: " << xstrerr(xerrno));
+            debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
         }
         if (setsockopt(fds[0], SOL_SOCKET, SO_RCVBUF, (void *) &buflen, sizeof(buflen)) == -1) {
             xerrno = errno;
-            debugs(54, DBG_IMPORTANT, "setsockopt failed: " << xstrerr(xerrno));
+            debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
         }
         if (setsockopt(fds[1], SOL_SOCKET, SO_SNDBUF, (void *) &buflen, sizeof(buflen)) == -1) {
             xerrno = errno;
-            debugs(54, DBG_IMPORTANT, "setsockopt failed: " << xstrerr(xerrno));
+            debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
         }
         if (setsockopt(fds[1], SOL_SOCKET, SO_RCVBUF, (void *) &buflen, sizeof(buflen)) == -1) {
             xerrno = errno;
-            debugs(54, DBG_IMPORTANT, "setsockopt failed: " << xstrerr(xerrno));
+            debugs(54, DBG_IMPORTANT, "ERROR: setsockopt failed: " << xstrerr(xerrno));
             errno = 0;
         }
         fd_open(prfd = pwfd = fds[0], FD_PIPE, "IPC UNIX STREAM Parent");
@@ -281,11 +281,11 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
             hello_buf[x] = '\0';
 
         if (x < 0) {
-            debugs(54, DBG_CRITICAL, "ipcCreate: PARENT: hello read test failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: PARENT: hello read test failed");
             debugs(54, DBG_CRITICAL, "--> read: " << xstrerr(xerrno));
             return ipcCloseAllFD(prfd, pwfd, crfd, cwfd);
         } else if (strcmp(hello_buf, hello_string)) {
-            debugs(54, DBG_CRITICAL, "ipcCreate: PARENT: hello read test failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: PARENT: hello read test failed");
             debugs(54, DBG_CRITICAL, "--> read returned " << x);
             debugs(54, DBG_CRITICAL, "--> got '" << rfc1738_escape(hello_buf) << "'");
             return ipcCloseAllFD(prfd, pwfd, crfd, cwfd);
@@ -352,14 +352,14 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
         if (x < 0) {
             xerrno = errno;
             debugs(54, DBG_CRITICAL, "sendto FD " << cwfd << ": " << xstrerr(xerrno));
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: hello write test failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: hello write test failed");
             _exit(1);
         }
     } else {
         if (write(cwfd, hello_string, strlen(hello_string) + 1) < 0) {
             xerrno = errno;
             debugs(54, DBG_CRITICAL, "write FD " << cwfd << ": " << xstrerr(xerrno));
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: hello write test failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: hello write test failed");
             _exit(1);
         }
     }

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -173,7 +173,7 @@ Ipc::Coordinator::handleCacheMgrRequest(const Mgr::Request& request)
             CacheManager::GetInstance()->createRequestedAction(request.params);
         AsyncJob::Start(new Mgr::Inquirer(action, request, strands_));
     } catch (const std::exception &ex) {
-        debugs(54, DBG_IMPORTANT, "BUG: cannot aggregate mgr:" <<
+        debugs(54, DBG_IMPORTANT, "ERROR: Squid BUG: cannot aggregate mgr:" <<
                request.params.actionName << ": " << ex.what());
         // TODO: Avoid half-baked Connections or teach them how to close.
         ::close(request.conn->fd);

--- a/src/ipc/FdNotes.cc
+++ b/src/ipc/FdNotes.cc
@@ -31,7 +31,7 @@ Ipc::FdNote(int fdNoteId)
     if (fdnNone < fdNoteId && fdNoteId < fdnEnd)
         return FdNotes[fdNoteId];
 
-    debugs(54, DBG_IMPORTANT, HERE << "salvaged bug: wrong fd_note ID: " << fdNoteId);
+    debugs(54, DBG_IMPORTANT, "ERROR: Squid BUG: wrong fd_note ID: " << fdNoteId);
     return FdNotes[fdnNone];
 }
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -845,7 +845,7 @@ Ipc::StoreMap::validateHit(const sfileno fileno)
 
     ++statCounter.hitValidation.failures;
 
-    debugs(54, DBG_IMPORTANT, "BUG: purging corrupted cache entry " << fileno <<
+    debugs(54, DBG_IMPORTANT, "ERROR: Squid BUG: purging corrupted cache entry " << fileno <<
            " from " << path <<
            " expected swap_file_sz=" << expectedByteCount <<
            " actual swap_file_sz=" << actualByteCount <<

--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -168,12 +168,12 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     }
 
     if (crfd < 0) {
-        debugs(54, DBG_CRITICAL, "ipcCreate: Failed to create child FD.");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: Failed to create child FD.");
         return ipcCloseAllFD(prfd, pwfd, crfd, cwfd);
     }
 
     if (pwfd < 0) {
-        debugs(54, DBG_CRITICAL, "ipcCreate: Failed to create server FD.");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: Failed to create server FD.");
         return ipcCloseAllFD(prfd, pwfd, crfd, cwfd);
     }
 
@@ -256,12 +256,12 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
     if (x < 0) {
         int xerrno = errno;
-        debugs(54, DBG_CRITICAL, "ipcCreate: PARENT: hello read test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: PARENT: hello read test failed");
         debugs(54, DBG_CRITICAL, "--> read: " << xstrerr(xerrno));
         CloseHandle((HANDLE) thread);
         return ipcCloseAllFD(prfd, pwfd, -1, -1);
     } else if (strcmp(hello_buf, hello_string)) {
-        debugs(54, DBG_CRITICAL, "ipcCreate: PARENT: hello read test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: PARENT: hello read test failed");
         debugs(54, DBG_CRITICAL, "--> read returned " << x);
         debugs(54, DBG_CRITICAL, "--> got '" << rfc1738_escape(hello_buf) << "'");
         CloseHandle((HANDLE) thread);
@@ -272,7 +272,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
     if (x < 0) {
         int xerrno = errno;
-        debugs(54, DBG_CRITICAL, "ipcCreate: PARENT: OK write test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: PARENT: OK write test failed");
         debugs(54, DBG_CRITICAL, "--> read: " << xstrerr(xerrno));
         CloseHandle((HANDLE) thread);
         return ipcCloseAllFD(prfd, pwfd, -1, -1);
@@ -283,12 +283,12 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
 
     if (x < 0) {
         int xerrno = errno;
-        debugs(54, DBG_CRITICAL, "ipcCreate: PARENT: OK read test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: PARENT: OK read test failed");
         debugs(54, DBG_CRITICAL, "--> read: " << xstrerr(xerrno));
         CloseHandle((HANDLE) thread);
         return ipcCloseAllFD(prfd, pwfd, -1, -1);
     } else if (!strcmp(hello_buf, err_string)) {
-        debugs(54, DBG_CRITICAL, "ipcCreate: PARENT: OK read test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: PARENT: OK read test failed");
         debugs(54, DBG_CRITICAL, "--> read returned " << x);
         debugs(54, DBG_CRITICAL, "--> got '" << rfc1738_escape(hello_buf) << "'");
         CloseHandle((HANDLE) thread);
@@ -344,7 +344,7 @@ ipcSend(int cwfd, const char *buf, int len)
     if (x < 0) {
         int xerrno = errno;
         debugs(54, DBG_CRITICAL, "sendto FD " << cwfd << ": " << xstrerr(xerrno));
-        debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: hello write test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: hello write test failed");
     }
 
     return x;
@@ -421,7 +421,7 @@ ipc_thread_1(void *in_params)
     if (x < 0) {
         int xerrno = errno;
         debugs(54, DBG_CRITICAL, "sendto FD " << cwfd << ": " << xstrerr(xerrno));
-        debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: hello write test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: hello write test failed");
         goto cleanup;
     }
 
@@ -431,11 +431,11 @@ ipc_thread_1(void *in_params)
 
     if (x < 0) {
         int xerrno = errno;
-        debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: OK read test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: OK read test failed");
         debugs(54, DBG_CRITICAL, "--> read: " << xstrerr(xerrno));
         goto cleanup;
     } else if (strcmp(buf1, ok_string)) {
-        debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: OK read test failed");
+        debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: OK read test failed");
         debugs(54, DBG_CRITICAL, "--> read returned " << x);
         debugs(54, DBG_CRITICAL, "--> got '" << rfc1738_escape(hello_buf) << "'");
         goto cleanup;
@@ -461,7 +461,7 @@ ipc_thread_1(void *in_params)
         crfd_ipc = cwfd_ipc = comm_open(SOCK_DGRAM, IPPROTO_UDP, local_addr, 0, buf1);
 
         if (crfd_ipc < 0) {
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: Failed to create child FD for " << prog << ".");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: Failed to create child FD for " << prog << ".");
             ipcSend(cwfd, err_string, strlen(err_string));
             goto cleanup;
         }
@@ -470,7 +470,7 @@ ipc_thread_1(void *in_params)
         prfd_ipc = pwfd_ipc = comm_open(SOCK_DGRAM, IPPROTO_UDP, local_addr, 0, buf1);
 
         if (pwfd_ipc < 0) {
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: Failed to create server FD for " << prog << ".");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: Failed to create server FD for " << prog << ".");
             ipcSend(cwfd, err_string, strlen(err_string));
             goto cleanup;
         }
@@ -613,7 +613,7 @@ ipc_thread_1(void *in_params)
         if (x < (ssize_t)sizeof(wpi)) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: write FD " << c2p[1] << ": " << xstrerr(xerrno));
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: " << prog << ": socket exchange failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: " << prog << ": socket exchange failed");
             ipcSend(cwfd, err_string, strlen(err_string));
             goto cleanup;
         }
@@ -623,11 +623,11 @@ ipc_thread_1(void *in_params)
         if (x < 0) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: read FD " << p2c[0] << ": " << xstrerr(xerrno));
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: " << prog << ": socket exchange failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: " << prog << ": socket exchange failed");
             ipcSend(cwfd, err_string, strlen(err_string));
             goto cleanup;
         } else if (strncmp(buf1, ok_string, strlen(ok_string))) {
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: " << prog << ": socket exchange failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: " << prog << ": socket exchange failed");
             debugs(54, DBG_CRITICAL, "--> read returned " << x);
             buf1[x] = '\0';
             debugs(54, DBG_CRITICAL, "--> got '" << rfc1738_escape(buf1) << "'");
@@ -640,7 +640,7 @@ ipc_thread_1(void *in_params)
         if (x < (ssize_t)sizeof(PS_ipc)) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: write FD " << c2p[1] << ": " << xstrerr(xerrno));
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: " << prog << ": socket exchange failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: " << prog << ": socket exchange failed");
             ipcSend(cwfd, err_string, strlen(err_string));
             goto cleanup;
         }
@@ -650,11 +650,11 @@ ipc_thread_1(void *in_params)
         if (x < 0) {
             int xerrno = errno;
             debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: read FD " << p2c[0] << ": " << xstrerr(xerrno));
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: " << prog << ": socket exchange failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: " << prog << ": socket exchange failed");
             ipcSend(cwfd, err_string, strlen(err_string));
             goto cleanup;
         } else if (strncmp(buf1, ok_string, strlen(ok_string))) {
-            debugs(54, DBG_CRITICAL, "ipcCreate: CHILD: " << prog << ": socket exchange failed");
+            debugs(54, DBG_CRITICAL, "ERROR: ipcCreate: CHILD: " << prog << ": socket exchange failed");
             debugs(54, DBG_CRITICAL, "--> read returned " << x);
             buf1[x] = '\0';
             debugs(54, DBG_CRITICAL, "--> got '" << rfc1738_escape(buf1) << "'");

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -455,7 +455,7 @@ ipcacheCallback(ipcache_entry *i, const bool hit, const int wait)
 void
 ipcache_entry::latestError(const char *text, const int debugLevel)
 {
-    debugs(14, debugLevel, "DNS error while resolving " << name() << ": " << text);
+    debugs(14, debugLevel, "ERROR: DNS failure while resolving " << name() << ": " << text);
     safe_free(error_message);
     error_message = xstrdup(text);
 }
@@ -763,12 +763,12 @@ ipcacheStatPrint(ipcache_entry * i, StoreEntry * sentry)
     char buf[MAX_IPSTRLEN];
 
     if (!sentry) {
-        debugs(14, DBG_CRITICAL, HERE << "CRITICAL: sentry is NULL!");
+        debugs(14, DBG_CRITICAL, "ERROR: sentry is NULL!");
         return;
     }
 
     if (!i) {
-        debugs(14, DBG_CRITICAL, HERE << "CRITICAL: ipcache_entry is NULL!");
+        debugs(14, DBG_CRITICAL, "ERROR: ipcache_entry is NULL!");
         storeAppendPrintf(sentry, "CRITICAL ERROR\n");
         return;
     }
@@ -1131,7 +1131,7 @@ ipcacheAddEntryFromHosts(const char *name, const char *ipaddr)
         if (strchr(ipaddr, ':') && strspn(ipaddr, "0123456789abcdefABCDEF:") == strlen(ipaddr)) {
             debugs(14, 3, "ipcacheAddEntryFromHosts: Skipping IPv6 address '" << ipaddr << "'");
         } else {
-            debugs(14, DBG_IMPORTANT, "ipcacheAddEntryFromHosts: Bad IP address '" << ipaddr << "'");
+            debugs(14, DBG_IMPORTANT, "ERROR: ipcacheAddEntryFromHosts: Bad IP address '" << ipaddr << "'");
         }
 
         return 1;
@@ -1146,7 +1146,7 @@ ipcacheAddEntryFromHosts(const char *name, const char *ipaddr)
         if (1 == i->flags.fromhosts) {
             ipcacheUnlockEntry(i);
         } else if (i->locks > 0) {
-            debugs(14, DBG_IMPORTANT, "ipcacheAddEntryFromHosts: can't add static entry for locked name '" << name << "'");
+            debugs(14, DBG_IMPORTANT, "ERROR: ipcacheAddEntryFromHosts: cannot add static entry for locked name '" << name << "'");
             return 1;
         } else {
             ipcacheRelease(i);

--- a/src/log/File.cc
+++ b/src/log/File.cc
@@ -73,7 +73,7 @@ logfileOpen(const char *path, size_t bufsz, int fatal_flag)
         if (fatal_flag)
             fatalf("logfileOpen: %s: couldn't open!\n", path);
         else
-            debugs(50, DBG_IMPORTANT, "logfileOpen: " << path << ": couldn't open!");
+            debugs(50, DBG_IMPORTANT, "ERROR: logfileOpen: " << path << ": could not open!");
         lf->f_close(lf);
         delete lf;
         return NULL;

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -115,7 +115,7 @@ logfileHandleWrite(int, void *data)
             ll->flush_pending = 1;
             return;
         }
-        debugs(50, DBG_IMPORTANT,"logfileHandleWrite: " << lf->path << ": error writing (" << xstrerr(xerrno) << ")");
+        debugs(50, DBG_IMPORTANT, "ERROR: logfileHandleWrite: " << lf->path << ": error writing (" << xstrerr(xerrno) << ")");
         /* XXX should handle this better */
         fatal("I don't handle this error well!");
     }
@@ -338,7 +338,7 @@ logfile_mod_daemon_flush(Logfile * lf)
 {
     l_daemon_t *ll = static_cast<l_daemon_t *>(lf->data);
     if (commUnsetNonBlocking(ll->wfd)) {
-        debugs(50, DBG_IMPORTANT, "Logfile Daemon: Couldn't set the pipe blocking for flush! You're now missing some log entries.");
+        debugs(50, DBG_IMPORTANT, "ERROR: Logfile Daemon: Could not set the pipe blocking for flush! You're now missing some log entries.");
         return;
     }
     while (ll->bufs.head != NULL) {

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -338,7 +338,7 @@ logfile_mod_daemon_flush(Logfile * lf)
 {
     l_daemon_t *ll = static_cast<l_daemon_t *>(lf->data);
     if (commUnsetNonBlocking(ll->wfd)) {
-        debugs(50, DBG_IMPORTANT, "ERROR: Logfile Daemon: Could not set the pipe blocking for flush! You're now missing some log entries.");
+        debugs(50, DBG_IMPORTANT, "ERROR: Logfile Daemon: Could not set the pipe blocking for flush! You are now missing some log entries.");
         return;
     }
     while (ll->bufs.head != NULL) {

--- a/src/log/ModSyslog.cc
+++ b/src/log/ModSyslog.cc
@@ -87,7 +87,7 @@ syslog_ntoa(const char *s)
         if (!strcmp(s, p->name) || !strcasecmp(s, p->name + 4))
             return p->value;
 
-    debugs(1, DBG_IMPORTANT, "Unknown syslog facility/priority '" << s << "'");
+    debugs(1, DBG_IMPORTANT, "ERROR: Unknown syslog facility/priority '" << s << "'");
     return 0;
 }
 

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -153,7 +153,7 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         if (lf->flags.fatal) {
             fatalf("Invalid UDP logging address '%s'\n", lf->path);
         } else {
-            debugs(50, DBG_IMPORTANT, "Invalid UDP logging address '" << lf->path << "'");
+            debugs(50, DBG_IMPORTANT, "ERROR: Invalid UDP logging address '" << lf->path << "'");
             safe_free(strAddr);
             return FALSE;
         }
@@ -173,7 +173,7 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         if (lf->flags.fatal) {
             fatalf("Unable to open UDP socket for logging\n");
         } else {
-            debugs(50, DBG_IMPORTANT, "Unable to open UDP socket for logging");
+            debugs(50, DBG_IMPORTANT, "ERROR: Unable to open UDP socket for logging");
             return FALSE;
         }
     } else if (!comm_connect_addr(ll->fd, addr)) {
@@ -181,7 +181,7 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
         if (lf->flags.fatal) {
             fatalf("Unable to connect to %s for UDP log: %s\n", lf->path, xstrerr(xerrno));
         } else {
-            debugs(50, DBG_IMPORTANT, "Unable to connect to " << lf->path << " for UDP log: " << xstrerr(xerrno));
+            debugs(50, DBG_IMPORTANT, "ERROR: Unable to connect to " << lf->path << " for UDP log: " << xstrerr(xerrno));
             return FALSE;
         }
     }

--- a/src/log/TcpLogger.cc
+++ b/src/log/TcpLogger.cc
@@ -179,9 +179,8 @@ Log::TcpLogger::canFit(const size_t len) const
     }
 
     if (!drops || dieOnError) {
-        debugs(MY_DEBUG_SECTION,
-               dieOnError ? DBG_CRITICAL : DBG_IMPORTANT,
-               "tcp:" << remote << " logger " << bufferCapacity << "-byte " <<
+        debugs(MY_DEBUG_SECTION, dieOnError ? DBG_CRITICAL : DBG_IMPORTANT,
+               "ERROR: tcp:" << remote << " logger " << bufferCapacity << "-byte " <<
                "buffer overflowed; cannot fit " <<
                (bufferedSize+len-bufferCapacity) << " bytes");
     }
@@ -269,7 +268,7 @@ Log::TcpLogger::connectDone(const CommConnectCbParams &params)
     if (params.flag != Comm::OK) {
         const double delay = 0.5; // seconds
         if (connectFailures++ % 100 == 0) {
-            debugs(MY_DEBUG_SECTION, DBG_IMPORTANT, "tcp:" << remote <<
+            debugs(MY_DEBUG_SECTION, DBG_IMPORTANT, "ERROR: tcp:" << remote <<
                    " logger connection attempt #" << connectFailures <<
                    " failed. Will keep trying every " << delay << " seconds.");
         }
@@ -465,7 +464,7 @@ Log::TcpLogger::Open(Logfile * lf, const char *path, size_t bufsz, int fatalFlag
         if (lf->flags.fatal) {
             fatalf("Invalid TCP logging address '%s'\n", lf->path);
         } else {
-            debugs(50, DBG_IMPORTANT, "Invalid TCP logging address '" << lf->path << "'");
+            debugs(50, DBG_IMPORTANT, "ERROR: Invalid TCP logging address '" << lf->path << "'");
             safe_free(strAddr);
             return FALSE;
         }

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -101,7 +101,7 @@ GetStrPool(size_t type)
             strPools[i]->zeroBlocks(false);
 
             if (strPools[i]->objectSize() != PoolAttrs[i].obj_size)
-                debugs(13, DBG_IMPORTANT, "NOTICE: " << PoolAttrs[i].name <<
+                debugs(13, DBG_IMPORTANT, "WARNING: " << PoolAttrs[i].name <<
                        " is " << strPools[i]->objectSize() <<
                        " bytes instead of requested " <<
                        PoolAttrs[i].obj_size << " bytes");

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -277,27 +277,27 @@ mimeInit(char *filename)
         xstrncpy(chopbuf, buf, BUFSIZ);
 
         if ((pattern = strtok(chopbuf, w_space)) == NULL) {
-            debugs(25, DBG_IMPORTANT, "mimeInit: parse error: '" << buf << "'");
+            debugs(25, DBG_IMPORTANT, "ERROR: mimeInit: parse failure: '" << buf << "'");
             continue;
         }
 
         if ((type = strtok(NULL, w_space)) == NULL) {
-            debugs(25, DBG_IMPORTANT, "mimeInit: parse error: '" << buf << "'");
+            debugs(25, DBG_IMPORTANT, "ERROR: mimeInit: parse failure: '" << buf << "'");
             continue;
         }
 
         if ((icon = strtok(NULL, w_space)) == NULL) {
-            debugs(25, DBG_IMPORTANT, "mimeInit: parse error: '" << buf << "'");
+            debugs(25, DBG_IMPORTANT, "ERROR: mimeInit: parse failure: '" << buf << "'");
             continue;
         }
 
         if ((encoding = strtok(NULL, w_space)) == NULL) {
-            debugs(25, DBG_IMPORTANT, "mimeInit: parse error: '" << buf << "'");
+            debugs(25, DBG_IMPORTANT, "ERROR: mimeInit: parse failure: '" << buf << "'");
             continue;
         }
 
         if ((mode = strtok(NULL, w_space)) == NULL) {
-            debugs(25, DBG_IMPORTANT, "mimeInit: parse error: '" << buf << "'");
+            debugs(25, DBG_IMPORTANT, "ERROR: mimeInit: parse failure: '" << buf << "'");
             continue;
         }
 
@@ -310,11 +310,11 @@ mimeInit(char *filename)
             else if (!strcmp(option, "+view"))
                 view_option = 1;
             else
-                debugs(25, DBG_IMPORTANT, "mimeInit: unknown option: '" << buf << "' (" << option << ")");
+                debugs(25, DBG_IMPORTANT, "ERROR: mimeInit: unknown option: '" << buf << "' (" << option << ")");
         }
 
         if (regcomp(&re, pattern, re_flags) != 0) {
-            debugs(25, DBG_IMPORTANT, "mimeInit: regcomp error: '" << buf << "'");
+            debugs(25, DBG_IMPORTANT, "ERROR: mimeInit: regcomp failure: '" << buf << "'");
             continue;
         }
 

--- a/src/multicast.cc
+++ b/src/multicast.cc
@@ -38,7 +38,7 @@ mcastJoinGroups(const ipcache_addrs *ia, const Dns::LookupDetails &, void *)
     struct ip_mreq mr;
 
     if (ia == NULL) {
-        debugs(7, DBG_CRITICAL, "comm_join_mcast_groups: Unknown host");
+        debugs(7, DBG_CRITICAL, "ERROR: comm_join_mcast_groups: Unknown host");
         return;
     }
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -645,7 +645,7 @@ neighborsUdpPing(HttpRequest * request,
 #if USE_HTCP
         if (p->options.htcp && !p->options.htcp_only_clr) {
             if (Config.Port.htcp <= 0) {
-                debugs(15, DBG_CRITICAL, "HTCP is disabled! Cannot send HTCP request to peer.");
+                debugs(15, DBG_CRITICAL, "ERROR: HTCP is disabled! Cannot send HTCP request to peer.");
                 continue;
             }
 
@@ -656,7 +656,7 @@ neighborsUdpPing(HttpRequest * request,
 #endif
         {
             if (Config.Port.icp <= 0 || !Comm::IsConnOpen(icpOutgoingConn)) {
-                debugs(15, DBG_CRITICAL, "ICP is disabled! Cannot send ICP request to peer.");
+                debugs(15, DBG_CRITICAL, "ERROR: ICP is disabled! Cannot send ICP request to peer.");
                 continue;
             } else {
 
@@ -1067,7 +1067,7 @@ neighborsUdpAck(const cache_key * key, icp_common_t * header, const Ip::Address 
     }
 
     if (!mem->ircb_data) {
-        debugs(12, DBG_IMPORTANT, "BUG: missing ICP callback data for " << *entry);
+        debugs(12, DBG_IMPORTANT, "ERROR: Squid BUG: missing ICP callback data for " << *entry);
         neighborCountIgnored(p);
         return;
     }
@@ -1125,7 +1125,7 @@ neighborsUdpAck(const cache_key * key, icp_common_t * header, const Ip::Address 
     } else if (opcode == ICP_MISS_NOFETCH) {
         mem->ping_reply_callback(p, ntype, AnyP::PROTO_ICP, header, mem->ircb_data);
     } else {
-        debugs(15, DBG_CRITICAL, "neighborsUdpAck: Unexpected ICP reply: " << opcode_d);
+        debugs(15, DBG_CRITICAL, "ERROR: neighborsUdpAck: Unexpected ICP reply: " << opcode_d);
     }
 }
 
@@ -1298,7 +1298,7 @@ peerConnectFailedSilent(CachePeer * p)
 void
 peerConnectFailed(CachePeer *p)
 {
-    debugs(15, DBG_IMPORTANT, "TCP connection to " << p->host << "/" << p->http_port << " failed");
+    debugs(15, DBG_IMPORTANT, "ERROR: TCP connection to " << p->host << "/" << p->http_port << " failed");
     peerConnectFailedSilent(p);
 }
 
@@ -1789,7 +1789,7 @@ neighborsHtcpReply(const cache_key * key, HtcpReplyData * htcp, const Ip::Addres
     }
 
     if (!mem->ircb_data) {
-        debugs(12, DBG_IMPORTANT, "BUG: missing HTCP callback data for " << *e);
+        debugs(12, DBG_IMPORTANT, "ERROR: Squid BUG: missing HTCP callback data for " << *e);
         neighborCountIgnored(p);
         return;
     }

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -968,7 +968,7 @@ peerDigestSetCBlock(PeerDigest * pd, const char *buf)
 
     /* there are some things we cannot do yet */
     if (cblock.hash_func_count != CacheDigestHashFuncCount) {
-        debugs(72, DBG_CRITICAL, "" << host << " digest: unsupported #hash functions: " <<
+        debugs(72, DBG_CRITICAL, "ERROR: " << host << " digest: unsupported #hash functions: " <<
                cblock.hash_func_count << " ? " << CacheDigestHashFuncCount << ".");
         return 0;
     }
@@ -1008,7 +1008,7 @@ peerDigestUseful(const PeerDigest * pd)
     const auto bit_util = pd->cd->usedMaskPercent();
 
     if (bit_util > 65.0) {
-        debugs(72, DBG_CRITICAL, "Warning: " << pd->host <<
+        debugs(72, DBG_CRITICAL, "WARNING: " << pd->host <<
                " peer digest has too many bits on (" << bit_util << "%).");
         return 0;
     }

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -244,7 +244,7 @@ PeerSelector::~PeerSelector()
     }
 
     if (acl_checklist) {
-        debugs(44, DBG_IMPORTANT, "BUG: peer selector gone while waiting for a slow ACL");
+        debugs(44, DBG_IMPORTANT, "ERROR: Squid BUG: peer selector gone while waiting for a slow ACL");
         delete acl_checklist;
     }
 

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -99,7 +99,7 @@ redirectHandleReply(void *data, const Helper::Reply &reply)
             size_t replySize = 0;
             if (const char *t = strchr(res, ' ')) {
                 static int warn = 0;
-                debugs(61, (!(warn++%50)? DBG_CRITICAL:2), "UPGRADE WARNING: URL rewriter reponded with garbage '" << t <<
+                debugs(61, (!(warn++%50)? DBG_CRITICAL:2), "WARNING: UPGRADE: URL rewriter reponded with garbage '" << t <<
                        "'. Future Squid will treat this as part of the URL.");
                 replySize = t - res;
             } else
@@ -125,7 +125,7 @@ redirectHandleReply(void *data, const Helper::Reply &reply)
                 if (*result == '!') {
                     static int urlgroupWarning = 0;
                     if (!urlgroupWarning++)
-                        debugs(85, DBG_IMPORTANT, "UPGRADE WARNING: URL rewriter using obsolete Squid-2 urlgroup feature needs updating.");
+                        debugs(85, DBG_IMPORTANT, "WARNING: UPGRADE: URL rewriter using obsolete Squid-2 urlgroup feature needs updating.");
                     if (char *t = strchr(result+1, '!')) {
                         *t = '\0';
                         newReply.notes.add("urlgroup", result+1);

--- a/src/repl/heap/store_repl_heap.cc
+++ b/src/repl/heap/store_repl_heap.cc
@@ -306,7 +306,7 @@ createRemovalPolicy_heap(wordlist * args)
     else if (!strcmp(keytype, "LRU"))
         heap_data->keyfunc = HeapKeyGen_StoreEntry_LRU;
     else {
-        debugs(81, DBG_CRITICAL, "createRemovalPolicy_heap: Unknown key type \"" << keytype << "\". Using LRU");
+        debugs(81, DBG_CRITICAL, "ERROR: createRemovalPolicy_heap: Unknown key type \"" << keytype << "\". Using LRU");
         heap_data->keyfunc = HeapKeyGen_StoreEntry_LRU;
     }
 

--- a/src/security/Io.cc
+++ b/src/security/Io.cc
@@ -184,7 +184,7 @@ Security::Handshake(Comm::Connection &transport, const ErrorCode topError, Fun i
 #else
     (void)topError;
     // TLS I/O code path should never be reachable without a TLS/SSL library.
-    debugs(1, DBG_CRITICAL, ForceAlert << "BUG: " <<
+    debugs(1, DBG_CRITICAL, ForceAlert << "ERROR: Squid BUG: " <<
            "Unexpected TLS I/O in Squid built without a TLS/SSL library");
     assert(false); // we want a stack trace which fatal() does not produce
     return IoResult(nullptr); // not reachable

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -143,7 +143,7 @@ Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
     if (!ctx || !Security::CreateClientSession(ctx, serverConnection(), "server https start")) {
         const auto xerrno = errno;
         if (!ctx) {
-            debugs(83, DBG_IMPORTANT, "Error initializing TLS connection: No security context.");
+            debugs(83, DBG_IMPORTANT, "ERROR: initializing TLS connection: No security context.");
         } // else CreateClientSession() did the appropriate debugs() already
         const auto anErr = new ErrorState(ERR_SOCKET_FAILURE, Http::scInternalServerError, request.getRaw(), al);
         anErr->xerrno = xerrno;
@@ -241,7 +241,7 @@ Security::PeerConnector::negotiate()
                 !(result.errorDetail && result.errorDetail->errorNo() == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY))
             return handleMissingCertificates(result);
 
-        debugs(83, DBG_IMPORTANT, "BUG: Honoring unexpected SSL_connect() error: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
+        debugs(83, DBG_IMPORTANT, "ERROR: Squid BUG: Honoring unexpected SSL_connect() failure: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
         // fall through to regular error handling
     }
 #endif

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -55,7 +55,7 @@ Security::PeerOptions::parse(const char *token)
         KeyData &t = certs.back();
         t.privateKeyFile = SBuf(token + 4);
     } else if (strncmp(token, "version=", 8) == 0) {
-        debugs(0, DBG_PARSE_NOTE(1), "UPGRADE WARNING: SSL version= is deprecated. Use options= and tls-min-version= to limit protocols instead.");
+        debugs(0, DBG_PARSE_NOTE(1), "WARNING: UPGRADE: SSL version= is deprecated. Use options= and tls-min-version= to limit protocols instead.");
         sslVersion = xatoi(token + 8);
     } else if (strncmp(token, "min-version=", 12) == 0) {
         tlsMinVersion = SBuf(token + 12);

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -86,7 +86,7 @@ Security::ServerOptions::parse(const char *token)
 
     } else if (strncmp(token, "dhparams=", 9) == 0) {
         if (!eecdhCurve.isEmpty()) {
-            debugs(83, DBG_PARSE_NOTE(1), "UPGRADE WARNING: EECDH settings in tls-dh= override dhparams=");
+            debugs(83, DBG_PARSE_NOTE(1), "WARNING: UPGRADE: EECDH settings in tls-dh= override dhparams=");
             return;
         }
 

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -115,7 +115,7 @@ CreateSession(const Security::ContextPointer &ctx, const Comm::ConnectionPointer
     if (!session) {
         errCode = ERR_get_error();
         errAction = "failed to allocate handle";
-        debugs(83, DBG_IMPORTANT, "TLS error: " << errAction << ": " << Security::ErrorString(errCode));
+        debugs(83, DBG_IMPORTANT, "ERROR: TLS failure: " << errAction << ": " << Security::ErrorString(errCode));
     }
 #elif USE_GNUTLS
     gnutls_session_t tmp;
@@ -128,7 +128,7 @@ CreateSession(const Security::ContextPointer &ctx, const Comm::ConnectionPointer
     if (errCode != GNUTLS_E_SUCCESS) {
         session.reset();
         errAction = "failed to initialize session";
-        debugs(83, DBG_IMPORTANT, "TLS error: " << errAction << ": " << Security::ErrorString(errCode));
+        debugs(83, DBG_IMPORTANT, "ERROR: TLS failure: " << errAction << ": " << Security::ErrorString(errCode));
     }
 #endif /* USE_GNUTLS */
 

--- a/src/send-announce.cc
+++ b/src/send-announce.cc
@@ -53,7 +53,7 @@ send_announce(const ipcache_addrs *ia, const Dns::LookupDetails &, void *)
     int fd;
 
     if (ia == NULL) {
-        debugs(27, DBG_IMPORTANT, "send_announce: Unknown host '" << host << "'");
+        debugs(27, DBG_IMPORTANT, "ERROR: send_announce: Unknown host '" << host << "'");
         return;
     }
 

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -368,7 +368,7 @@ Ftp::Server::listenForDataConnection()
     const char *const note = uri.c_str();
     comm_open_listener(SOCK_STREAM, IPPROTO_TCP, conn, note);
     if (!Comm::IsConnOpen(conn)) {
-        debugs(5, DBG_CRITICAL, "comm_open_listener failed for FTP data: " <<
+        debugs(5, DBG_CRITICAL, "ERROR: comm_open_listener failed for FTP data: " <<
                conn->local << " error: " << errno);
         writeCustomReply(451, "Internal error");
         return 0;

--- a/src/snmp/Var.cc
+++ b/src/snmp/Var.cc
@@ -67,7 +67,7 @@ Snmp::Var::operator += (const Var& var)
         setTimeTicks(asTimeTicks() + var.asTimeTicks());
         break;
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "ERROR: Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }
@@ -95,7 +95,7 @@ Snmp::Var::operator /= (int num)
         setTimeTicks(asTimeTicks() / num);
         break;
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "ERROR: Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }
@@ -117,7 +117,7 @@ Snmp::Var::operator < (const Var& var) const
     case SMI_TIMETICKS:
         return asTimeTicks() < var.asTimeTicks();
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "ERROR: Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }
@@ -139,7 +139,7 @@ Snmp::Var::operator > (const Var& var) const
     case SMI_TIMETICKS:
         return asTimeTicks() > var.asTimeTicks();
     default:
-        debugs(49, DBG_CRITICAL, HERE << "Unsupported type: " << type);
+        debugs(49, DBG_CRITICAL, "ERROR: Unsupported type: " << type);
         throw TexcHere("Unsupported type");
         break;
     }

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -212,15 +212,13 @@ Ssl::ErrorDetailFile::parse()
             Http::ContentLengthInterpreter interpreter;
             // no applyStatusCodeRules() -- error templates lack HTTP status code
             if (!parser.parse(s, e - s, interpreter)) {
-                debugs(83, DBG_IMPORTANT, HERE <<
-                       "WARNING! parse error on:" << s);
+                debugs(83, DBG_IMPORTANT, "WARNING: parse error on:" << s);
                 return false;
             }
 
             const String errorName = parser.getByName("name");
             if (!errorName.size()) {
-                debugs(83, DBG_IMPORTANT, HERE <<
-                       "WARNING! invalid or no error detail name on:" << s);
+                debugs(83, DBG_IMPORTANT, "WARNING: invalid or no error detail name on:" << s);
                 return false;
             }
 
@@ -228,8 +226,7 @@ Ssl::ErrorDetailFile::parse()
             if (ssl_error != SSL_ERROR_NONE) {
 
                 if (theDetails->getErrorDetail(ssl_error)) {
-                    debugs(83, DBG_IMPORTANT, HERE <<
-                           "WARNING! duplicate entry: " << errorName);
+                    debugs(83, DBG_IMPORTANT, "WARNING: duplicate entry: " << errorName);
                     return false;
                 }
 
@@ -243,14 +240,12 @@ Ssl::ErrorDetailFile::parse()
                 // TODO: Validate "descr" and "detail" field values.
 
                 if (!detailsParseOk || !descrParseOk) {
-                    debugs(83, DBG_IMPORTANT, HERE <<
-                           "WARNING! missing important field for detail error: " <<  errorName);
+                    debugs(83, DBG_IMPORTANT, "WARNING: missing important field for detail error: " <<  errorName);
                     return false;
                 }
 
             } else if (!Ssl::ErrorIsOptional(errorName.termedBuf())) {
-                debugs(83, DBG_IMPORTANT, HERE <<
-                       "WARNING! invalid error detail name: " << errorName);
+                debugs(83, DBG_IMPORTANT, "WARNING: invalid error detail name: " << errorName);
                 return false;
             }
 

--- a/src/ssl/helper.cc
+++ b/src/ssl/helper.cc
@@ -273,7 +273,7 @@ sslCrtvdHandleReplyWrapper(void *data, const ::Helper::Reply &reply)
     assert(crtdvdData->ssl.get());
     Ssl::CertValidationResponse::Pointer validationResponse = new Ssl::CertValidationResponse(crtdvdData->ssl);
     if (reply.result == ::Helper::BrokenHelper) {
-        debugs(83, DBG_IMPORTANT, "\"ssl_crtvd\" helper error response: " << reply.other().content());
+        debugs(83, DBG_IMPORTANT, "ERROR: \"ssl_crtvd\" helper error response: " << reply.other().content());
         validationResponse->resultCode = ::Helper::BrokenHelper;
     } else if (!reply.other().hasContent()) {
         debugs(83, DBG_IMPORTANT, "\"ssl_crtvd\" helper returned NULL response");
@@ -281,7 +281,7 @@ sslCrtvdHandleReplyWrapper(void *data, const ::Helper::Reply &reply)
     } else if (replyMsg.parse(reply.other().content(), reply.other().contentSize()) != Ssl::CrtdMessage::OK ||
                !replyMsg.parseResponse(*validationResponse) ) {
         debugs(83, DBG_IMPORTANT, "WARNING: Reply from ssl_crtvd for " << " is incorrect");
-        debugs(83, DBG_IMPORTANT, "Certificate cannot be validated. ssl_crtvd response: " << replyMsg.getBody());
+        debugs(83, DBG_IMPORTANT, "ERROR: Certificate cannot be validated. ssl_crtvd response: " << replyMsg.getBody());
         validationResponse->resultCode = ::Helper::BrokenHelper;
     } else
         validationResponse->resultCode = reply.result;

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -107,7 +107,7 @@ ssl_temp_rsa_cb(SSL *, int, int keylen)
     if (!e) {
         e = BN_new();
         if (!e || !BN_set_word(e, RSA_F4)) {
-            debugs(83, DBG_IMPORTANT, "ssl_temp_rsa_cb: Failed to set exponent for key " << keylen);
+            debugs(83, DBG_IMPORTANT, "ERROR: ssl_temp_rsa_cb: Failed to set exponent for key " << keylen);
             BN_free(e);
             e = nullptr;
             return nullptr;
@@ -147,12 +147,12 @@ ssl_temp_rsa_cb(SSL *, int, int keylen)
         break;
 
     default:
-        debugs(83, DBG_IMPORTANT, "ssl_temp_rsa_cb: Unexpected key length " << keylen);
+        debugs(83, DBG_IMPORTANT, "ERROR: ssl_temp_rsa_cb: Unexpected key length " << keylen);
         return NULL;
     }
 
     if (rsa == NULL) {
-        debugs(83, DBG_IMPORTANT, "ssl_temp_rsa_cb: Failed to generate key " << keylen);
+        debugs(83, DBG_IMPORTANT, "ERROR: ssl_temp_rsa_cb: Failed to generate key " << keylen);
         return NULL;
     }
 
@@ -346,7 +346,7 @@ ssl_verify_cb(int ok, X509_STORE_CTX * ctx)
         if (const char *err_descr = Ssl::GetErrorDescr(error_no))
             debugs(83, 5, err_descr << ": " << buffer);
         else
-            debugs(83, DBG_IMPORTANT, "SSL unknown certificate error " << error_no << " in " << buffer);
+            debugs(83, DBG_IMPORTANT, "ERROR: SSL unknown certificate error " << error_no << " in " << buffer);
 
         // Check if the certificate error can be bypassed.
         // Infinity validation loop errors can not bypassed.
@@ -412,7 +412,7 @@ Ssl::ConfigurePeerVerification(Security::ContextPointer &ctx, const Security::Pa
     // assume each flag is exclusive; flags creator must check this assumption
     if (flags & SSL_FLAG_DONT_VERIFY_PEER) {
         debugs(83, DBG_IMPORTANT, "SECURITY WARNING: Peer certificates are not verified for validity!");
-        debugs(83, DBG_IMPORTANT, "UPGRADE NOTICE: The DONT_VERIFY_PEER flag is deprecated. Remove the clientca= option to disable client certificates.");
+        debugs(83, DBG_IMPORTANT, "WARNING: UPGRADE: The DONT_VERIFY_PEER flag is deprecated. Remove the clientca= option to disable client certificates.");
         mode = SSL_VERIFY_NONE;
     }
     else if (flags & SSL_FLAG_DELAYED_AUTH) {
@@ -1113,7 +1113,7 @@ Ssl::loadCerts(const char *certsFile, Ssl::CertsIndexedList &list)
 {
     const BIO_Pointer in(BIO_new_file(certsFile, "r"));
     if (!in) {
-        debugs(83, DBG_IMPORTANT, "Failed to open '" << certsFile << "' to load certificates");
+        debugs(83, DBG_IMPORTANT, "ERROR: Failed to open '" << certsFile << "' to load certificates");
         return false;
     }
 
@@ -1174,7 +1174,7 @@ findIssuerInCaDb(X509 *cert, const Security::ContextPointer &connContext)
 
     X509_STORE_CTX *storeCtx = X509_STORE_CTX_new();
     if (!storeCtx) {
-        debugs(83, DBG_IMPORTANT, "Failed to allocate STORE_CTX object");
+        debugs(83, DBG_IMPORTANT, "ERROR: Failed to allocate STORE_CTX object");
         return nullptr;
     }
 
@@ -1192,7 +1192,7 @@ findIssuerInCaDb(X509 *cert, const Security::ContextPointer &connContext)
         }
     } else {
         const auto ssl_error = ERR_get_error();
-        debugs(83, DBG_IMPORTANT, "Failed to initialize STORE_CTX object: " << Security::ErrorString(ssl_error));
+        debugs(83, DBG_IMPORTANT, "ERROR: Failed to initialize STORE_CTX object: " << Security::ErrorString(ssl_error));
     }
 
     X509_STORE_CTX_free(storeCtx);

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -909,7 +909,7 @@ GetAvgStat(Mgr::IntervalActionData& stats, int minutes, int hours)
 
         l = &CountHourHist[hours];
     } else {
-        debugs(18, DBG_IMPORTANT, "statAvgDump: Invalid args, minutes=" << minutes << ", hours=" << hours);
+        debugs(18, DBG_IMPORTANT, "ERROR: statAvgDump: Invalid args, minutes=" << minutes << ", hours=" << hours);
         return;
     }
 

--- a/src/stmem.cc
+++ b/src/stmem.cc
@@ -67,7 +67,7 @@ bool
 mem_hdr::unlink(mem_node *aNode)
 {
     if (aNode->write_pending) {
-        debugs(0, DBG_CRITICAL, "cannot unlink mem_node " << aNode << " while write_pending");
+        debugs(0, DBG_CRITICAL, "ERROR: cannot unlink mem_node " << aNode << " while write_pending");
         return false;
     }
 
@@ -244,7 +244,7 @@ mem_hdr::copy(StoreIOBuffer const &target) const
     mem_node *p = getBlockContainingLocation(target.offset);
 
     if (!p) {
-        debugs(19, DBG_IMPORTANT, "memCopy: could not find start of " << target.range() <<
+        debugs(19, DBG_IMPORTANT, "ERROR: memCopy: could not find start of " << target.range() <<
                " in memory.");
         debugDump();
         fatal_dump("Squid has attempted to read data from memory that is not present. This is an indication of of (pre-3.0) code that hasn't been updated to deal with sparse objects in memory. Squid should coredump.allowing to review the cause. Immediately preceding this message is a dump of the available data in the format [start,end). The [ means from the value, the ) means up to the value. I.e. [1,5) means that there are 4 bytes of data, at offsets 1,2,3,4.\n");

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -384,7 +384,7 @@ Store::Controller::allowSharing(StoreEntry &entry, const cache_key *key)
         if (!found) {
             // !found should imply hittingRequiresCollapsing() regardless of writer presence
             if (!entry.hittingRequiresCollapsing()) {
-                debugs(20, DBG_IMPORTANT, "BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
+                debugs(20, DBG_IMPORTANT, "ERROR: Squid BUG: missing ENTRY_REQUIRES_COLLAPSING for " << entry);
                 throw TextException("transients entry missing ENTRY_REQUIRES_COLLAPSING", Here());
             }
 

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -721,7 +721,7 @@ storeDirWriteCleanLogs(int reopen)
         auto &sd = SwapDirByIndex(dirn);
 
         if (sd.writeCleanStart() < 0) {
-            debugs(20, DBG_IMPORTANT, "log.clean.start() failed for dir #" << sd.index);
+            debugs(20, DBG_IMPORTANT, "ERROR: log.clean.start() failed for dir #" << sd.index);
             continue;
         }
     }

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -505,7 +505,7 @@ store_client::readBody(const char *, ssize_t len)
     if (copyInto.offset == 0 && len > 0 && rep && rep->sline.status() == Http::scNone) {
         /* Our structure ! */
         if (!entry->mem_obj->adjustableBaseReply().parseCharBuf(copyInto.data, headersEnd(copyInto.data, len))) {
-            debugs(90, DBG_CRITICAL, "Could not parse headers from on disk object");
+            debugs(90, DBG_CRITICAL, "ERROR: Could not parse headers from on disk object");
         } else {
             parsed_header = 1;
         }

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -153,7 +153,7 @@ storeRebuildComplete(StoreRebuildData *dc)
 
     const auto dt = tvSubDsec(counts.startTime, current_time);
 
-    debugs(20, Important(46), "ERROR: Finished rebuilding storage from disk." <<
+    debugs(20, Important(46), "Finished rebuilding storage from disk." <<
            Debug::Extra << std::setw(7) << counts.scancount << " Entries scanned" <<
            Debug::Extra << std::setw(7) << counts.invalid << " Invalid entries" <<
            Debug::Extra << std::setw(7) << counts.badflags << " With invalid flags" <<

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -153,7 +153,7 @@ storeRebuildComplete(StoreRebuildData *dc)
 
     const auto dt = tvSubDsec(counts.startTime, current_time);
 
-    debugs(20, Important(46), "Finished rebuilding storage from disk." <<
+    debugs(20, Important(46), "ERROR: Finished rebuilding storage from disk." <<
            Debug::Extra << std::setw(7) << counts.scancount << " Entries scanned" <<
            Debug::Extra << std::setw(7) << counts.invalid << " Invalid entries" <<
            Debug::Extra << std::setw(7) << counts.badflags << " With invalid flags" <<

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -34,12 +34,12 @@ storeSwapInStart(store_client * sc)
     debugs(20, 3, *e << " " <<  e->getMD5Text());
 
     if (!e->hasDisk()) {
-        debugs(20, DBG_IMPORTANT, "BUG: Attempt to swap in a not-stored entry " << *e << ". Salvaged.");
+        debugs(20, DBG_IMPORTANT, "ERROR: Squid BUG: Attempt to swap in a not-stored entry " << *e << ". Salvaged.");
         return;
     }
 
     if (e->swapoutFailed()) {
-        debugs(20, DBG_IMPORTANT, "BUG: Attempt to swap in a failed-to-store entry " << *e << ". Salvaged.");
+        debugs(20, DBG_IMPORTANT, "ERROR: Squid BUG: Attempt to swap in a failed-to-store entry " << *e << ". Salvaged.");
         return;
     }
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -514,7 +514,7 @@ leave_suid(void)
 
         if (setgid(Config2.effectiveGroupID) < 0) {
             int xerrno = errno;
-            debugs(50, DBG_CRITICAL, "ALERT: setgid: " << xstrerr(xerrno));
+            debugs(50, DBG_CRITICAL, "ERROR: setgid: " << xstrerr(xerrno));
         }
     }
 
@@ -531,11 +531,11 @@ leave_suid(void)
 
         if (setgid(Config2.effectiveGroupID) < 0) {
             int xerrno = errno;
-            debugs(50, DBG_CRITICAL, "ALERT: setgid: " << xstrerr(xerrno));
+            debugs(50, DBG_CRITICAL, "ERROR: setgid: " << xstrerr(xerrno));
         }
 
         if (initgroups(Config.effectiveUser, Config2.effectiveGroupID) < 0) {
-            debugs(50, DBG_CRITICAL, "ALERT: initgroups: unable to set groups for User " <<
+            debugs(50, DBG_CRITICAL, "ERROR: initgroups: unable to set groups for User " <<
                    Config.effectiveUser << " and Group " <<
                    (unsigned) Config2.effectiveGroupID << "");
         }
@@ -817,7 +817,7 @@ setSystemLimits(void)
     }
 #endif /* RLIMIT_DATA */
     if (Config.max_filedescriptors > Squid_MaxFD) {
-        debugs(50, DBG_IMPORTANT, "NOTICE: Could not increase the number of filedescriptors");
+        debugs(50, DBG_IMPORTANT, "WARNING: Could not increase the number of filedescriptors");
     }
 
 #if HAVE_SETRLIMIT && defined(RLIMIT_VMEM) && !_SQUID_CYGWIN_

--- a/src/unlinkd.cc
+++ b/src/unlinkd.cc
@@ -109,7 +109,7 @@ unlinkdUnlink(const char *path)
 
     if (bytes_written < 0) {
         int xerrno = errno;
-        debugs(2, DBG_IMPORTANT, "unlinkdUnlink: write FD " << unlinkd_wfd << " failed: " << xstrerr(xerrno));
+        debugs(2, DBG_IMPORTANT, "ERROR: unlinkdUnlink: write FD " << unlinkd_wfd << " failed: " << xstrerr(xerrno));
         safeunlink(path, 0);
         return;
     } else if (bytes_written != l) {
@@ -149,7 +149,7 @@ unlinkdClose(void)
     if (hIpc) {
         if (WaitForSingleObject(hIpc, 5000) != WAIT_OBJECT_0) {
             getCurrentTime();
-            debugs(2, DBG_IMPORTANT, "unlinkdClose: WARNING: (unlinkd," << pid << "d) didn't exit in 5 seconds");
+            debugs(2, DBG_IMPORTANT, "WARNING: unlinkdClose: (unlinkd," << pid << "d) didn't exit in 5 seconds");
         }
 
         CloseHandle(hIpc);

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -624,7 +624,7 @@ wccp2_check_security(struct wccp2_service_list_t *srv, char *security, char *pac
     }
 
     if (srv->wccp2_security_type != WCCP2_MD5_SECURITY) {
-        debugs(80, DBG_IMPORTANT, "wccp2_check_security: invalid security option");
+        debugs(80, DBG_IMPORTANT, "ERROR: wccp2_check_security: invalid security option");
         return 0;
     }
 
@@ -1293,7 +1293,7 @@ wccp2HandleUdp(int sock, void *)
             break;
 
         default:
-            debugs(80, DBG_IMPORTANT, "Unknown record type in WCCPv2 Packet (" << ntohs(itemHeader->type) << ").");
+            debugs(80, DBG_IMPORTANT, "ERROR: Unknown record type in WCCPv2 Packet (" << ntohs(itemHeader->type) << ").");
         }
 
         offset += itemSize;
@@ -1319,17 +1319,17 @@ wccp2HandleUdp(int sock, void *)
     }
 
     if (service_list_ptr == NULL) {
-        debugs(80, DBG_IMPORTANT, "WCCPv2 Unknown service received from router (" << service_info->service_id << ")");
+        debugs(80, DBG_IMPORTANT, "ERROR: WCCPv2 Unknown service received from router (" << service_info->service_id << ")");
         return;
     }
 
     if (ntohl(security_info->security_option) != ntohl(service_list_ptr->security_info->security_option)) {
-        debugs(80, DBG_IMPORTANT, "Invalid security option in WCCPv2 Packet (" << ntohl(security_info->security_option) << " vs " << ntohl(service_list_ptr->security_info->security_option) << ").");
+        debugs(80, DBG_IMPORTANT, "ERROR: Invalid security option in WCCPv2 Packet (" << ntohl(security_info->security_option) << " vs " << ntohl(service_list_ptr->security_info->security_option) << ").");
         return;
     }
 
     if (!wccp2_check_security(service_list_ptr, (char *) security_info, (char *) &wccp2_i_see_you, len)) {
-        debugs(80, DBG_IMPORTANT, "Received WCCPv2 Packet failed authentication");
+        debugs(80, DBG_IMPORTANT, "ERROR: Received WCCPv2 Packet failed authentication");
         return;
     }
 
@@ -1353,7 +1353,7 @@ wccp2HandleUdp(int sock, void *)
     /* TODO: check return/forwarding methods */
     if (router_capability_header == NULL) {
         if ((Config.Wccp2.return_method != WCCP2_PACKET_RETURN_METHOD_GRE) || (Config.Wccp2.forwarding_method != WCCP2_FORWARDING_METHOD_GRE)) {
-            debugs(80, DBG_IMPORTANT, "wccp2HandleUdp: fatal error - A WCCP router does not support the forwarding method specified, only GRE supported");
+            debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router does not support the forwarding method specified, only GRE supported");
             wccp2ConnectionClose();
             return;
         }
@@ -1379,7 +1379,7 @@ wccp2HandleUdp(int sock, void *)
             case WCCP2_CAPABILITY_FORWARDING_METHOD:
 
                 if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.forwarding_method)) {
-                    debugs(80, DBG_IMPORTANT, "wccp2HandleUdp: fatal error - A WCCP router has specified a different forwarding method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.forwarding_method);
+                    debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different forwarding method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.forwarding_method);
                     wccp2ConnectionClose();
                     return;
                 }
@@ -1389,7 +1389,7 @@ wccp2HandleUdp(int sock, void *)
             case WCCP2_CAPABILITY_ASSIGNMENT_METHOD:
 
                 if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.assignment_method)) {
-                    debugs(80, DBG_IMPORTANT, "wccp2HandleUdp: fatal error - A WCCP router has specified a different assignment method " << ntohl(router_capability_element->capability_value) << ", expected "<< Config.Wccp2.assignment_method);
+                    debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different assignment method " << ntohl(router_capability_element->capability_value) << ", expected "<< Config.Wccp2.assignment_method);
                     wccp2ConnectionClose();
                     return;
                 }
@@ -1399,7 +1399,7 @@ wccp2HandleUdp(int sock, void *)
             case WCCP2_CAPABILITY_RETURN_METHOD:
 
                 if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.return_method)) {
-                    debugs(80, DBG_IMPORTANT, "wccp2HandleUdp: fatal error - A WCCP router has specified a different return method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.return_method);
+                    debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different return method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.return_method);
                     wccp2ConnectionClose();
                     return;
                 }
@@ -1411,7 +1411,7 @@ wccp2HandleUdp(int sock, void *)
                 break; // ignore silently for now
 
             default:
-                debugs(80, DBG_IMPORTANT, "Unknown capability type in WCCPv2 Packet (" << ntohs(router_capability_element->capability_type) << ").");
+                debugs(80, DBG_IMPORTANT, "ERROR: Unknown capability type in WCCPv2 Packet (" << ntohs(router_capability_element->capability_type) << ").");
             }
 
             router_capability_data_current += elementSize;
@@ -2056,7 +2056,7 @@ parse_wccp2_method(int *method)
 
     /* Snarf the method */
     if ((t = ConfigParser::NextToken()) == NULL) {
-        debugs(80, DBG_CRITICAL, "wccp2_*_method: missing setting.");
+        debugs(80, DBG_CRITICAL, "ERROR: wccp2_*_method: missing setting.");
         self_destruct();
         return;
     }
@@ -2067,7 +2067,7 @@ parse_wccp2_method(int *method)
     } else if (strcmp(t, "l2") == 0 || strcmp(t, "2") == 0) {
         *method = WCCP2_METHOD_L2;
     } else {
-        debugs(80, DBG_CRITICAL, "wccp2_*_method: unknown setting, got " << t );
+        debugs(80, DBG_CRITICAL, "ERROR: wccp2_*_method: unknown setting, got " << t );
         self_destruct();
     }
 }
@@ -2104,7 +2104,7 @@ parse_wccp2_amethod(int *method)
 
     /* Snarf the method */
     if ((t = ConfigParser::NextToken()) == NULL) {
-        debugs(80, DBG_CRITICAL, "wccp2_assignment_method: missing setting.");
+        debugs(80, DBG_CRITICAL, "ERROR: wccp2_assignment_method: missing setting.");
         self_destruct();
         return;
     }
@@ -2115,7 +2115,7 @@ parse_wccp2_amethod(int *method)
     } else if (strcmp(t, "mask") == 0 || strcmp(t, "2") == 0) {
         *method = WCCP2_ASSIGNMENT_METHOD_MASK;
     } else {
-        debugs(80, DBG_CRITICAL, "wccp2_assignment_method: unknown setting, got " << t );
+        debugs(80, DBG_CRITICAL, "ERROR: wccp2_assignment_method: unknown setting, got " << t );
         self_destruct();
     }
 }
@@ -2161,7 +2161,7 @@ parse_wccp2_service(void *)
 
     /* Snarf the type */
     if ((t = ConfigParser::NextToken()) == NULL) {
-        debugs(80, DBG_CRITICAL, "wccp2ParseServiceInfo: missing service info type (standard|dynamic)");
+        debugs(80, DBG_CRITICAL, "ERROR: wccp2ParseServiceInfo: missing service info type (standard|dynamic)");
         self_destruct();
         return;
     }
@@ -2171,7 +2171,7 @@ parse_wccp2_service(void *)
     } else if (strcmp(t, "dynamic") == 0) {
         service = WCCP2_SERVICE_DYNAMIC;
     } else {
-        debugs(80, DBG_CRITICAL, "wccp2ParseServiceInfo: bad service info type (expected standard|dynamic, got " << t << ")");
+        debugs(80, DBG_CRITICAL, "ERROR: wccp2ParseServiceInfo: bad service info type (expected standard|dynamic, got " << t << ")");
         self_destruct();
         return;
     }


### PR DESCRIPTION
Today, it is impractical to reliably identify important cache.log
messages in automated sysadmin notification systems. No regular
expression is guaranteed to match all important messages and none of the
unimportant ones. While message importance is naturally subjective (with
cache_log_message and notification system regexes available to customize
handling of specific messages), even reliable detection of _potentially_
important messages (to bootstrap admin customization efforts) is
impractical today. Any notification configuration is likely to miss an
important message (in today's or future code) and/or spam admins with
unimportant messages.

Fully addressing this problem requires many changes. This change lays a
foundation for that work by standardizing three well-known message
prefixes (`FATAL:`, `ERROR:`, and `WARNING:`) for debugs() messages
reporting various problems. Eventually, all problem-reporting messages
(and only those) will use one of the standard prefixes. This change
converts 300+ debugs(), bringing the total to 900+ messages using a
a standard prefix. There are more than 5'000 debugs() in Squid.

The scope of this change are problem-reporting debugs() statements that
can be detected and converted by a simple script. We also applied a few
easy-to-automate polishing touches to modified debugs(), like replacing
debug level 0 with DBG_CRITICAL, expanding some contractions (e.g.,
"can't"), and fixing grammar (e.g., "is has").