### PR TITLE
Bug 5154: reject literal IPv6 addresses when Ipv6 support is disabled

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -222,6 +222,7 @@ Thank you!
     Jean-Gabriel Dick <jean-gabriel.dick@curie.fr>
     Jean-Philippe Menil <jean-philippe.menil@univ-nantes.fr>
     Jeff Licquia <jlicquia@scinet.springfieldclinic.com>
+    Jeffrey Kintscher <websurfer@surf2c.net>
     Jens-S. V?ckler <voeckler@rvs.uni-hannover.de>
     Jeremy Allison
     Jerry Murdock <jmurdock@itraktech.com>

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -915,7 +915,10 @@ Ip::Address::fromHost(const char *host)
 
     char *tmp = xstrdup(start); // XXX: Slow. TODO: Bail on huge strings and use an on-stack buffer.
     tmp[strlen(tmp)-1] = '\0'; // XXX: Wasteful: xstrdup() just did strlen().
-    const bool result = lookupHostIP(tmp, true);
+    /* force result to false if IPv6 is disabled and the bracketed value is an IPv6 address */
+    /* NB: RFC 6874 specifies that square brackets are for all IP addresses that are IPv6 */
+    /*      or newer, not just IPv6. */
+    const bool result = lookupHostIP(tmp, true) && (Ip::EnableIpv6 || !isIPv6());
     xfree(tmp);
     return result;
 }


### PR DESCRIPTION
Squid v5 added `Ip::Address::fromHost()`, which attempts to parse the host field of a URL to see if it is a literal IP address.  When the function parses a literal IPv6 address, it returns true, which eventually leads to a failed assert in `IP::Address::getAddrInfo()` when IPv6 is disabled.  The fix is to have `fromHost()` return false when the URL contains a literal IPv6 address and IPv6 support is disabled, causing squid to return 500 to the user like other existing code paths that encounter IPv6 addresses.