### PR TITLE
langpack: Fix typo in Russian texts

### DIFF
--- a/errors/TRANSLATORS
+++ b/errors/TRANSLATORS
@@ -20,6 +20,7 @@ and ideas to make Squid available as multi-langual software.
 	Francesco Chemolli
 	George Machitidze <giomac@gmail.com>
 	Henrik Nordström
+	Ilya Gordeev <mirraz1@rambler.ru>
 	Ivan Masár <helix84@centrum.sk>
 	Javier Pacheco <javier@aex.mx>
 	John 'Profic' Ustiuzhanin

--- a/errors/ru.po
+++ b/errors/ru.po
@@ -144,7 +144,7 @@ msgid ""
 "or server may be down or congested. Please retry your request."
 msgstr ""
 "Превышен интервал времени ожидания при получении данных из сети. Сеть или "
-"сервер могут бытьнедоступны или перегружены. Повторите попытку позже."
+"сервер могут быть недоступны или перегружены. Повторите попытку позже."
 
 #: templates/ERR_URN_RESOLVE+html.body.div.h2:16-1
 msgid "A URL for the requested URN could not be retrieved"


### PR DESCRIPTION
Missing whitespace between two words in ERR_READ_TIMEOUT