### PR TITLE
Fix GCC v10.3 build after commit 8b082ed

### DIFF
--- a/src/auth/basic/SMB/basic_smb_auth.cc
+++ b/src/auth/basic/SMB/basic_smb_auth.cc
@@ -53,7 +53,7 @@ struct SMBDOMAIN *lastdom = NULL;
  * to the read command of the bourne shell.
  */
 
-void
+static void
 print_esc(FILE * p, char *s)
 {
     char buf[HELPER_INPUT_BUFFER];


### PR DESCRIPTION
    basic_smb_auth.cc:57:1: warning: no previous declaration for
    `void print_esc(FILE*, char*)` [-Wmissing-declarations]