### PR TITLE
Add missing CXXFLAGS to several objects

### DIFF
--- a/src/adaptation/ecap/Makefile.am
+++ b/src/adaptation/ecap/Makefile.am
@@ -24,5 +24,7 @@ libecapsquid_la_SOURCES = \
 	XactionRep.h
 
 # add libecap using its pkg-config-produced configuration variables
-libecapsquid_la_CXXFLAGS = $(EXT_LIBECAP_CFLAGS)
+libecapsquid_la_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	$(EXT_LIBECAP_CFLAGS)
 libecapsquid_la_LIBADD = $(EXT_LIBECAP_LIBS)

--- a/src/auth/basic/SMB/Makefile.am
+++ b/src/auth/basic/SMB/Makefile.am
@@ -13,7 +13,9 @@ libexec_PROGRAMS = basic_smb_auth
 endif
 
 basic_smb_auth_SOURCES = basic_smb_auth.cc
-basic_smb_auth_CXXFLAGS = -DHELPERSCRIPT=\"$(libexecdir)/basic_smb_auth.sh\"
+basic_smb_auth_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	-DHELPERSCRIPT=\"$(libexecdir)/basic_smb_auth.sh\"
 basic_smb_auth_LDADD = \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \

--- a/src/auth/basic/SSPI/Makefile.am
+++ b/src/auth/basic/SSPI/Makefile.am
@@ -15,7 +15,9 @@ basic_sspi_auth_SOURCES = \
 	basic_sspi_auth.cc \
 	valid.cc \
 	valid.h
-basic_sspi_auth_CXXFLAGS = -Wl,--enable-auto-import
+basic_sspi_auth_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	-Wl,--enable-auto-import
 basic_sspi_auth_LDADD = \
 	$(top_builddir)/lib/libsspwin32.la \
 	$(top_builddir)/lib/libmiscencoding.la \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -88,7 +88,9 @@ nodist_cachemgr__CGIEXT__SOURCES = \
 	tests/stub_libmem.cc \
 	tests/STUB.h
 
-cachemgr__CGIEXT__CXXFLAGS = -DDEFAULT_CACHEMGR_CONFIG=\"$(DEFAULT_CACHEMGR_CONFIG)\" $(AM_CXXFLAGS)
+cachemgr__CGIEXT__CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	-DDEFAULT_CACHEMGR_CONFIG=\"$(DEFAULT_CACHEMGR_CONFIG)\"
 
 EXTRA_DIST += cachemgr.conf cachemgr.cgi.8 cachemgr.cgi.8.in
 CLEANFILES += cachemgr.cgi.8


### PR DESCRIPTION
Target-specific CXXFLAGS customizations should include AM_CXXFLAGS.
Otherwise, their targets are built without SQUID_CXXFLAGS like -Wextra.
