### PR TITLE
Preserve configured order of intermediate CA certificate chain

### DIFF
--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -124,7 +124,7 @@ Security::KeyData::loadX509ChainFromFile()
                 // OpenSSL API requires that we order certificates such that the
                 // chain can be appended directly into the on-wire traffic.
                 latestCert = CertPointer(ca);
-                chain.emplace_front(latestCert);
+                chain.emplace_back(latestCert);
             } else {
                 debugs(83, DBG_PARSE_NOTE(2), certFile << ": Ignoring non-issuer CA " << nameStr << ": " << X509_verify_cert_error_string(checkCode) << " (" << checkCode << ")");
             }


### PR DESCRIPTION
    https_port ... tls-cert=signing,itsIssuer,itsIssuerIssuer.pem

The order was reversed in commit cf48712, probably by accident. Wrong
order violates TLS protocol and breaks TLS clients that are incapable of
reordering received intermediate CAs. Squid deployments that use
wrong-order bundles (to compensate for this bug) should reorder their
bundles when deploying this fix (or wait for Squid to order certificates
correctly, regardless of the bundle order -- a work in progress).

This is a Measurement Factory project.