### PR TITLE
Bug 5132: Close the tunnel if to-server conn closes after client

### DIFF
--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -318,6 +318,8 @@ void
 TunnelStateData::serverClosed()
 {
     server.noteClosure();
+
+    retryOrBail(__FUNCTION__);
 }
 
 /// TunnelStateData::clientClosed() wrapper
@@ -417,9 +419,6 @@ TunnelStateData::checkRetry()
 void
 TunnelStateData::retryOrBail(const char *context)
 {
-    // Since no TCP payload has been passed to client or server, we may
-    // TCP-connect to other destinations (including alternate IPs).
-
     assert(!server.conn);
 
     const auto *bailDescription = checkRetry();


### PR DESCRIPTION
Since commit 25d2603, blind CONNECT tunnel "jobs" (and equivalent) were
not destroyed upon a "lonely" to-server connection closure, leading to
memory leaks. And when a from-client connection was still present at the
time of the to-server connection closure, we did not try to reforward,
violating the spirit of commit 25d2603 changes. Calling retryOrBail() is
sufficient to handle both cases.
