### PR TITLE
Maintenance: De-duplicate PackableStreamBuf and SBufStreamBuf

### DIFF
--- a/src/sbuf/Stream.h
+++ b/src/sbuf/Stream.h
@@ -10,72 +10,7 @@
 #define SQUID_SBUFSTREAM_H
 
 #include "sbuf/SBuf.h"
-
-#include <ostream>
-
-/** streambuf class for a SBuf-backed stream interface.
- *
- * Auxiliary class to be able to leverage an ostream generating SBuf's
- * analogous to std::ostrstream.
- */
-class SBufStreamBuf : public std::streambuf
-{
-public:
-    /// initialize streambuf; use supplied SBuf as backing store
-    explicit SBufStreamBuf(SBuf aBuf) : theBuf(aBuf) {}
-
-    /// get a copy of the stream's contents
-    SBuf getBuf() {
-        return theBuf;
-    }
-
-    /// clear the stream's store
-    void clearBuf() {
-        theBuf.clear();
-    }
-
-protected:
-    virtual int_type overflow(int_type aChar = traits_type::eof()) {
-        std::streamsize pending(pptr() - pbase());
-
-        if (pending && sync())
-            return traits_type::eof();
-
-        if (aChar != traits_type::eof()) {
-            char chars[1] = {static_cast<char>(aChar)};
-
-            if (aChar != traits_type::eof())
-                theBuf.append(chars, 1);
-        }
-
-        pbump(-pending);  // Reset pptr().
-        return aChar;
-    }
-
-    /// push the streambuf to the backing SBuf
-    virtual int sync() {
-        std::streamsize pending(pptr() - pbase());
-
-        if (pending)
-            theBuf.append(pbase(), pending);
-
-        return 0;
-    }
-
-    /** write multiple characters to the store entry
-     * \note this is an optimisation consistent with std::streambuf API
-     */
-    virtual std::streamsize xsputn(const char * chars, std::streamsize number) {
-        if (number)
-            theBuf.append(chars, number);
-
-        return number;
-    }
-
-private:
-    SBuf theBuf;
-    SBufStreamBuf(); // no default constructor
-};
+#include "base/PackableStream.h"
 
 /** Stream interface to write to a SBuf.
  *
@@ -90,32 +25,36 @@ public:
      * The supplied SBuf copied: in order to retrieve the written-to contents
      * they must be later fetched using the buf() class method.
      */
-    SBufStream(SBuf aBuf): std::ostream(0), theBuffer(aBuf) {
-        rdbuf(&theBuffer); // set the buffer to now-initialized theBuffer
-        clear(); //clear badbit set by calling init(0)
+    SBufStream(const SBuf &aBuf):
+        std::ostream(nullptr), // initialize the parent; no stream buffer yet
+        sink_(aBuf),
+        streamBuffer_(sink_) // initialize the stream buffer
+    {
+        rdbuf(&streamBuffer_); // supply the now-initialized stream buffer
+        clear(); // clear the badbit that a nullptr stream buffer has triggered
     }
 
     /// Create an empty SBufStream
-    SBufStream(): std::ostream(0), theBuffer(SBuf()) {
-        rdbuf(&theBuffer); // set the buffer to now-initialized theBuffer
-        clear(); //clear badbit set by calling init(0)
-    }
+    SBufStream(): SBufStream(SBuf()) {}
 
-    /// Retrieve a copy of the current stream status
+    /// bytes written so far
     SBuf buf() {
         flush();
-        return theBuffer.getBuf();
+        return sink_;
     }
 
     /// Clear the stream's backing store
     SBufStream& clearBuf() {
         flush();
-        theBuffer.clearBuf();
+        sink_.clear();
         return *this;
     }
 
 private:
-    SBufStreamBuf theBuffer;
+    /// buffer for (flushed) bytes written to the stream
+    SBuf sink_;
+    /// writes raw (post-formatting) bytes to the sink_
+    AppendingStreamBuf<SBuf> streamBuffer_;
 };
 
 /// slowly stream-prints all arguments into a freshly allocated SBuf


### PR DESCRIPTION
SBufStreamBuf was almost identical to PackableStreamBuf. Both classes
are pass-through write-only streambufs that lack their own put area. Now
their common code lives in AppendingStreamBuf.

No functionality changes intended.

The removed std::streambuf method descriptions were imprecise and some
were misleading. STL documentation describes this standard/parent API.

While also similar, PackableStream and SBufStream have important
differences in API and implementation. For example, unlike
PackableStream, SBufStream owns the sink buffer and does not modify the
buffer it was created with, providing a safe content extraction method
instead. The two classes cannot be merged without changing their users,
and it may be impossible to justify SBufStream users exposure to the
dangers of forgetting to sync() the streambuf before accessing the sink.