### PR TITLE
Fix gawk v5 warning

### DIFF
--- a/src/mk-globals-c.awk
+++ b/src/mk-globals-c.awk
@@ -21,7 +21,6 @@ Copyright != 1			{		 print; next }
 
 # arrays defined elsewhere
 /\[\];/				{			next }
-/^extern \"C\"/			{		 print; next }
 
 #
 # Check exactly for lines beginning with "    extern", generated


### PR DESCRIPTION
    gawk: ./mk-globals-c.awk:24:
    warning: regexp escape sequence \" is not a known regexp operator

Some awk variants complain about what they perceive as invalid escape
sequences. Gawk v5+ works but complains about us escaping double quotes.

The corresponding awk statement (added in commit 42c674f) is unnecessary
since commit 582c2af. Removing that statement is better than trying to
guess its portable spelling in the gray zone of awk escape sequences.