### PR TITLE
Source Format Enforcement

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/QUICKSTART
+++ b/QUICKSTART
@@ -99,7 +99,7 @@ typically have to modify something in a /etc/rc_something).
 ==============================================================================
 
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 SQUID Web Proxy Cache                        http://www.squid-cache.org/
 ------------------------------------------------------------------------
 
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 
 Squid software is distributed under GPLv2+ license and includes 
 contributions from numerous individuals and organizations.

--- a/acinclude/ax_cxx_0x_types.m4
+++ b/acinclude/ax_cxx_0x_types.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/ax_cxx_compile_stdcxx_11.m4
+++ b/acinclude/ax_cxx_compile_stdcxx_11.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/ax_with_prog.m4
+++ b/acinclude/ax_with_prog.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/compiler-flags.m4
+++ b/acinclude/compiler-flags.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/init.m4
+++ b/acinclude/init.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/krb5.m4
+++ b/acinclude/krb5.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/lib-checks.m4
+++ b/acinclude/lib-checks.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/pam.m4
+++ b/acinclude/pam.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/pkg.m4
+++ b/acinclude/pkg.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/acinclude/tdb.m4
+++ b/acinclude/tdb.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/compat/GnuRegex.c
+++ b/compat/GnuRegex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/GnuRegex.h
+++ b/compat/GnuRegex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/compat/assert.cc
+++ b/compat/assert.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/assert.h
+++ b/compat/assert.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/cmsg.h
+++ b/compat/cmsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/compat.cc
+++ b/compat/compat.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/compat.dox
+++ b/compat/compat.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/compat_shared.h
+++ b/compat/compat_shared.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/cppunit.h
+++ b/compat/cppunit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/cpu.h
+++ b/compat/cpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/debug.cc
+++ b/compat/debug.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/debug.h
+++ b/compat/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/eui64_aton.c
+++ b/compat/eui64_aton.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/eui64_aton.h
+++ b/compat/eui64_aton.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/fdsetsize.h
+++ b/compat/fdsetsize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/getaddrinfo.cc
+++ b/compat/getaddrinfo.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/getaddrinfo.h
+++ b/compat/getaddrinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/getnameinfo.cc
+++ b/compat/getnameinfo.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/getnameinfo.h
+++ b/compat/getnameinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/inet_ntop.cc
+++ b/compat/inet_ntop.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/inet_ntop.h
+++ b/compat/inet_ntop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/inet_pton.cc
+++ b/compat/inet_pton.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/inet_pton.h
+++ b/compat/inet_pton.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/initgroups.c
+++ b/compat/initgroups.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/initgroups.h
+++ b/compat/initgroups.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/memrchr.cc
+++ b/compat/memrchr.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/memrchr.h
+++ b/compat/memrchr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/mswindows.cc
+++ b/compat/mswindows.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/openssl.h
+++ b/compat/openssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/aix.h
+++ b/compat/os/aix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/android.h
+++ b/compat/os/android.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/dragonfly.h
+++ b/compat/os/dragonfly.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/freebsd.h
+++ b/compat/os/freebsd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/hpux.h
+++ b/compat/os/hpux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/linux.h
+++ b/compat/os/linux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/macosx.h
+++ b/compat/os/macosx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/netbsd.h
+++ b/compat/os/netbsd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/openbsd.h
+++ b/compat/os/openbsd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/opensolaris_10_netdb.h
+++ b/compat/os/opensolaris_10_netdb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/os2.h
+++ b/compat/os/os2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/qnx.h
+++ b/compat/os/qnx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/sgi.h
+++ b/compat/os/sgi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/solaris.h
+++ b/compat/os/solaris.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/os/sunos.h
+++ b/compat/os/sunos.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/osdetect.h
+++ b/compat/osdetect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/psignal.c
+++ b/compat/psignal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/psignal.h
+++ b/compat/psignal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/shm.cc
+++ b/compat/shm.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/shm.h
+++ b/compat/shm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/statvfs.cc
+++ b/compat/statvfs.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/statvfs.h
+++ b/compat/statvfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/stdio.h
+++ b/compat/stdio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/stdvarargs.h
+++ b/compat/stdvarargs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/strerror.c
+++ b/compat/strerror.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/strnrchr.c
+++ b/compat/strnrchr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/strnrchr.h
+++ b/compat/strnrchr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/strnstr.cc
+++ b/compat/strnstr.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/strtoll.c
+++ b/compat/strtoll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/strtoll.h
+++ b/compat/strtoll.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/tempnam.c
+++ b/compat/tempnam.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/tempnam.h
+++ b/compat/tempnam.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/testPreCompiler.cc
+++ b/compat/testPreCompiler.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/testPreCompiler.h
+++ b/compat/testPreCompiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/types.h
+++ b/compat/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/valgrind.h
+++ b/compat/valgrind.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xalloc.cc
+++ b/compat/xalloc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xalloc.h
+++ b/compat/xalloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xis.h
+++ b/compat/xis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xstrerror.cc
+++ b/compat/xstrerror.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xstrerror.h
+++ b/compat/xstrerror.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xstring.cc
+++ b/compat/xstring.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xstring.h
+++ b/compat/xstring.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xstrto.cc
+++ b/compat/xstrto.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/compat/xstrto.h
+++ b/compat/xstrto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/contrib/solaris/solaris-krb5-include.patch
+++ b/contrib/solaris/solaris-krb5-include.patch
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/contrib/url-normalizer.pl
+++ b/contrib/url-normalizer.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl -Tw
 #
-# * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+# * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 # *
 # * Squid software is distributed under GPLv2+ license and includes
 # * contributions from numerous individuals and organizations.

--- a/contrib/user-agents.pl
+++ b/contrib/user-agents.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+# * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 # *
 # * Squid software is distributed under GPLv2+ license and includes
 # * contributions from numerous individuals and organizations.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/01_Main.dox
+++ b/doc/Programming-Guide/01_Main.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/02_CodingConventions.dox
+++ b/doc/Programming-Guide/02_CodingConventions.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/03_MajorComponents.dox
+++ b/doc/Programming-Guide/03_MajorComponents.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/05_TypicalRequestFlow.dox
+++ b/doc/Programming-Guide/05_TypicalRequestFlow.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/AccessControls.dox
+++ b/doc/Programming-Guide/AccessControls.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/DelayPools.dox
+++ b/doc/Programming-Guide/DelayPools.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/Groups.dox
+++ b/doc/Programming-Guide/Groups.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/Makefile
+++ b/doc/Programming-Guide/Makefile
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/StorageManager.dox
+++ b/doc/Programming-Guide/StorageManager.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/doxygen.footer.dyn
+++ b/doc/Programming-Guide/doxygen.footer.dyn
@@ -1,6 +1,6 @@
 </div>
 <!--
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/doxygen.footer.html
+++ b/doc/Programming-Guide/doxygen.footer.html
@@ -1,7 +1,7 @@
 <hr size="1"><address style="text-align: right;"><small>
 Generated on $datetime for $projectname by&nbsp;<a href="http://www.doxygen.org/index.html"><img src="doxygen.png" alt="doxygen" align="middle" border="0"></a> $doxygenversion</small></address>
 <small>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <br>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/doxygen.header.dyn
+++ b/doc/Programming-Guide/doxygen.header.dyn
@@ -1,5 +1,5 @@
 <!--
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/doc/Programming-Guide/doxygen.header.html
+++ b/doc/Programming-Guide/doxygen.header.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html><head>
 <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-<meta name="dcterms.rights" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta name="dcterms.rights" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <title>Squid3 Programmers Guide - $title</title>
 <link href="$relpath$doxygen.css" rel="stylesheet" type="text/css">
 <link href="$relpath$tabs.css" rel="stylesheet" type="text/css">

--- a/doc/debug-messages.dox
+++ b/doc/debug-messages.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -56,7 +56,7 @@ ID Message gist
 46 Finished rebuilding storage from disk. ... Entries scanned ... Invalid entries ... With invalid flags ... Objects loaded ... Objects expired ... Objects canceled ... Duplicate URLs purged ... Swapfile clashes avoided ...Took ... seconds ( ... objects/sec).
 56 Beginning Validation Procedure
 57 Indexing cache entries: ...
-58 ALE missing ...
+58 ERROR: ALE missing ...
 59 Shutdown: Digest authentication.
 60 Shutdown: Negotiate authentication.
 61 Shutdown: NTLM authentication.

--- a/doc/debug-sections.txt
+++ b/doc/debug-sections.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -7,7 +7,6 @@
  */
 
 
-section 00    Announcement Server
 section 00    Client Database
 section 00    Debug Routines
 section 00    Hash Tables
@@ -24,6 +23,7 @@ section 05    Disk I/O pipe manager
 section 05    Listener Socket Handler
 section 05    Socket Connection Opener
 section 05    Socket Functions
+section 05    TCP Socket Functions
 section 06    Disk I/O Routines
 section 07    Multicast
 section 08    Swap File Bitmap
@@ -113,6 +113,7 @@ section 61    Redirector
 section 64    HTTP Range Header
 section 65    HTTP Cache Control Header
 section 66    HTTP Header Tools
+section 67    String
 section 68    HTTP Content-Range Header
 section 70    Cache Digest
 section 71    Store Digest Manager
@@ -130,7 +131,6 @@ section 79    Squid-side Disk I/O functions.
 section 79    Storage Manager UFS Interface
 section 80    WCCP Support
 section 81    aio_xxx() POSIX emulation on Windows
-section 81    CPU Profiling Routines
 section 81    Store HEAP Removal Policies
 section 82    External ACL
 section 83    SSL accelerator support

--- a/doc/manuals/Makefile.am
+++ b/doc/manuals/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/doc/manuals/Substitute.am
+++ b/doc/manuals/Substitute.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/doc/manuals/language.am
+++ b/doc/manuals/language.am
@@ -1,5 +1,5 @@
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/doc/release-notes/Makefile.am
+++ b/doc/release-notes/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-3.0.sgml
+++ b/doc/release-notes/release-3.0.sgml
@@ -1082,7 +1082,7 @@ See the accf_http(9) man page.
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-3.1.sgml
+++ b/doc/release-notes/release-3.1.sgml
@@ -1779,7 +1779,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-3.2.sgml
+++ b/doc/release-notes/release-3.2.sgml
@@ -1124,7 +1124,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-3.3.sgml
+++ b/doc/release-notes/release-3.3.sgml
@@ -363,7 +363,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-3.4.sgml
+++ b/doc/release-notes/release-3.4.sgml
@@ -501,7 +501,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-3.5.sgml
+++ b/doc/release-notes/release-3.5.sgml
@@ -683,7 +683,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-4.sgml
+++ b/doc/release-notes/release-4.sgml
@@ -641,7 +641,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-5.sgml
+++ b/doc/release-notes/release-5.sgml
@@ -404,7 +404,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -180,7 +180,7 @@ This section gives an account of those changes in three categories:
 
 <sect>Copyright
 <p>
-Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 <p>
 Squid software is distributed under GPLv2+ license and includes
 contributions from numerous individuals and organizations.

--- a/errors/COPYRIGHT
+++ b/errors/COPYRIGHT
@@ -1,6 +1,6 @@
 ==============================================================================
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/errors/TRANSLATORS
+++ b/errors/TRANSLATORS
@@ -1,4 +1,4 @@
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/errors/alias-link.sh
+++ b/errors/alias-link.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/errors/alias-upgrade
+++ b/errors/alias-upgrade
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/errors/aliases
+++ b/errors/aliases
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/errors/errorpage.css
+++ b/errors/errorpage.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/errors/language.am
+++ b/errors/language.am
@@ -1,5 +1,5 @@
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/errors/template.am
+++ b/errors/template.am
@@ -1,5 +1,5 @@
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/errors/templates/ERR_ACCESS_DENIED
+++ b/errors/templates/ERR_ACCESS_DENIED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!--

--- a/errors/templates/ERR_ACL_TIME_QUOTA_EXCEEDED
+++ b/errors/templates/ERR_ACL_TIME_QUOTA_EXCEEDED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_AGENT_CONFIGURE
+++ b/errors/templates/ERR_AGENT_CONFIGURE
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>Web Browser Configuration</title>
 <style type="text/css"><!--

--- a/errors/templates/ERR_AGENT_WPAD
+++ b/errors/templates/ERR_AGENT_WPAD
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>Web Browser Configuration</title>
 <style type="text/css"><!--

--- a/errors/templates/ERR_CACHE_ACCESS_DENIED
+++ b/errors/templates/ERR_CACHE_ACCESS_DENIED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: Cache Access Denied</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_CACHE_MGR_ACCESS_DENIED
+++ b/errors/templates/ERR_CACHE_MGR_ACCESS_DENIED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: Cache Manager Access Denied</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_CANNOT_FORWARD
+++ b/errors/templates/ERR_CANNOT_FORWARD
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_CONFLICT_HOST
+++ b/errors/templates/ERR_CONFLICT_HOST
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_CONNECT_FAIL
+++ b/errors/templates/ERR_CONNECT_FAIL
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_DIR_LISTING
+++ b/errors/templates/ERR_DIR_LISTING
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>Directory: %U</title>
 <style type="text/css"><!--

--- a/errors/templates/ERR_DNS_FAIL
+++ b/errors/templates/ERR_DNS_FAIL
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_ESI
+++ b/errors/templates/ERR_ESI
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FORWARDING_DENIED
+++ b/errors/templates/ERR_FORWARDING_DENIED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_DISABLED
+++ b/errors/templates/ERR_FTP_DISABLED
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_FAILURE
+++ b/errors/templates/ERR_FTP_FAILURE
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_FORBIDDEN
+++ b/errors/templates/ERR_FTP_FORBIDDEN
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_NOT_FOUND
+++ b/errors/templates/ERR_FTP_NOT_FOUND
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_PUT_CREATED
+++ b/errors/templates/ERR_FTP_PUT_CREATED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>FTP PUT Successful.</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_PUT_ERROR
+++ b/errors/templates/ERR_FTP_PUT_ERROR
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: FTP upload failed</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_PUT_MODIFIED
+++ b/errors/templates/ERR_FTP_PUT_MODIFIED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>FTP PUT Successful.</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_FTP_UNAVAILABLE
+++ b/errors/templates/ERR_FTP_UNAVAILABLE
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_GATEWAY_FAILURE
+++ b/errors/templates/ERR_GATEWAY_FAILURE
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_ICAP_FAILURE
+++ b/errors/templates/ERR_ICAP_FAILURE
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_INVALID_REQ
+++ b/errors/templates/ERR_INVALID_REQ
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_INVALID_RESP
+++ b/errors/templates/ERR_INVALID_RESP
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_INVALID_URL
+++ b/errors/templates/ERR_INVALID_URL
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_LIFETIME_EXP
+++ b/errors/templates/ERR_LIFETIME_EXP
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_NO_RELAY
+++ b/errors/templates/ERR_NO_RELAY
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_ONLY_IF_CACHED_MISS
+++ b/errors/templates/ERR_ONLY_IF_CACHED_MISS
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_PRECONDITION_FAILED
+++ b/errors/templates/ERR_PRECONDITION_FAILED
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_PROTOCOL_UNKNOWN
+++ b/errors/templates/ERR_PROTOCOL_UNKNOWN
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_READ_ERROR
+++ b/errors/templates/ERR_READ_ERROR
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_READ_TIMEOUT
+++ b/errors/templates/ERR_READ_TIMEOUT
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_SECURE_CONNECT_FAIL
+++ b/errors/templates/ERR_SECURE_CONNECT_FAIL
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_SHUTTING_DOWN
+++ b/errors/templates/ERR_SHUTTING_DOWN
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_SOCKET_FAILURE
+++ b/errors/templates/ERR_SOCKET_FAILURE
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_TOO_BIG
+++ b/errors/templates/ERR_TOO_BIG
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_UNSUP_HTTPVERSION
+++ b/errors/templates/ERR_UNSUP_HTTPVERSION
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_UNSUP_REQ
+++ b/errors/templates/ERR_UNSUP_REQ
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_URN_RESOLVE
+++ b/errors/templates/ERR_URN_RESOLVE
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URN could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_WRITE_ERROR
+++ b/errors/templates/ERR_WRITE_ERROR
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/ERR_ZERO_SIZE_OBJECT
+++ b/errors/templates/ERR_ZERO_SIZE_OBJECT
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/errors/templates/generic
+++ b/errors/templates/generic
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html><head>
-<meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+<meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>ERROR: The requested URL could not be retrieved</title>
 <style type="text/css"><!-- 

--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/icons/icon.am
+++ b/icons/icon.am
@@ -1,5 +1,5 @@
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/include/asn1.h
+++ b/include/asn1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/base64.h
+++ b/include/base64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/cache_snmp.h
+++ b/include/cache_snmp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/getfullhostname.h
+++ b/include/getfullhostname.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/hash.h
+++ b/include/hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/heap.h
+++ b/include/heap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/html_quote.h
+++ b/include/html_quote.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/md5.h
+++ b/include/md5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/parse.h
+++ b/include/parse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/radix.h
+++ b/include/radix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/rfc1123.h
+++ b/include/rfc1123.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/rfc1738.h
+++ b/include/rfc1738.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/rfc2181.h
+++ b/include/rfc2181.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/rfc2617.h
+++ b/include/rfc2617.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp-internal.h
+++ b/include/snmp-internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp-mib.h
+++ b/include/snmp-mib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp.h
+++ b/include/snmp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_api.h
+++ b/include/snmp_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_api_error.h
+++ b/include/snmp_api_error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_api_util.h
+++ b/include/snmp_api_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_client.h
+++ b/include/snmp_client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_coexist.h
+++ b/include/snmp_coexist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_debug.h
+++ b/include/snmp_debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_error.h
+++ b/include/snmp_error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_impl.h
+++ b/include/snmp_impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_msg.h
+++ b/include/snmp_msg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_pdu.h
+++ b/include/snmp_pdu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_session.h
+++ b/include/snmp_session.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_util.h
+++ b/include/snmp_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/snmp_vars.h
+++ b/include/snmp_vars.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/splay.h
+++ b/include/splay.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/squid.h
+++ b/include/squid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/sspwin32.h
+++ b/include/sspwin32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/unitTestMain.h
+++ b/include/unitTestMain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/util.h
+++ b/include/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/version.h
+++ b/include/version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/include/xusleep.h
+++ b/include/xusleep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/lib/Splay.cc
+++ b/lib/Splay.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/dirent.c
+++ b/lib/dirent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/encrypt.c
+++ b/lib/encrypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/getfullhostname.c
+++ b/lib/getfullhostname.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/getopt.c
+++ b/lib/getopt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/hash.cc
+++ b/lib/hash.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/heap.c
+++ b/lib/heap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/html_quote.c
+++ b/lib/html_quote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/iso3307.c
+++ b/lib/iso3307.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/libTrie/Makefile.am
+++ b/lib/libTrie/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/lib/libTrie/Trie.cc
+++ b/lib/libTrie/Trie.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/libTrie/Trie.h
+++ b/lib/libTrie/Trie.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/libTrie/TrieCharTransform.h
+++ b/lib/libTrie/TrieCharTransform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/libTrie/TrieNode.cc
+++ b/lib/libTrie/TrieNode.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/libTrie/TrieNode.h
+++ b/lib/libTrie/TrieNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/libTrie/test/Makefile.am
+++ b/lib/libTrie/test/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/lib/libTrie/test/trie.cc
+++ b/lib/libTrie/test/trie.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/md5-test.c
+++ b/lib/md5-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/ntlmauth/Makefile.am
+++ b/lib/ntlmauth/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/lib/ntlmauth/ntlmauth.cc
+++ b/lib/ntlmauth/ntlmauth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/ntlmauth/ntlmauth.h
+++ b/lib/ntlmauth/ntlmauth.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/ntlmauth/support_bits.cci
+++ b/lib/ntlmauth/support_bits.cci
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/ntlmauth/support_endian.h
+++ b/lib/ntlmauth/support_endian.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/radix.c
+++ b/lib/radix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfc1123.c
+++ b/lib/rfc1123.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfc1738.c
+++ b/lib/rfc1738.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfc2617.c
+++ b/lib/rfc2617.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/CHANGELOG
+++ b/lib/rfcnb/CHANGELOG
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/Makefile.am
+++ b/lib/rfcnb/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/lib/rfcnb/ReadMe.1st
+++ b/lib/rfcnb/ReadMe.1st
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/byteorder.h
+++ b/lib/rfcnb/byteorder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/notes
+++ b/lib/rfcnb/notes
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb-common.h
+++ b/lib/rfcnb/rfcnb-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb-error.h
+++ b/lib/rfcnb/rfcnb-error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb-io.c
+++ b/lib/rfcnb/rfcnb-io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb-io.h
+++ b/lib/rfcnb/rfcnb-io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb-priv.h
+++ b/lib/rfcnb/rfcnb-priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb-util.c
+++ b/lib/rfcnb/rfcnb-util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb-util.h
+++ b/lib/rfcnb/rfcnb-util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/rfcnb.h
+++ b/lib/rfcnb/rfcnb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/session.c
+++ b/lib/rfcnb/session.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/rfcnb/std-includes.h
+++ b/lib/rfcnb/std-includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/Changes
+++ b/lib/smblib/Changes
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/Makefile.am
+++ b/lib/smblib/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/lib/smblib/ReadMe.1st
+++ b/lib/smblib/ReadMe.1st
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/bad-chain.c
+++ b/lib/smblib/bad-chain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/exper.c
+++ b/lib/smblib/exper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/file.c
+++ b/lib/smblib/file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/find_password.c
+++ b/lib/smblib/find_password.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/md4.c
+++ b/lib/smblib/md4.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/md4.h
+++ b/lib/smblib/md4.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smb-errors.c
+++ b/lib/smblib/smb-errors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smbdes.c
+++ b/lib/smblib/smbdes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smbdes.h
+++ b/lib/smblib/smbdes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smbencrypt.c
+++ b/lib/smblib/smbencrypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smbencrypt.h
+++ b/lib/smblib/smbencrypt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smblib-api.c
+++ b/lib/smblib/smblib-api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smblib-common.h
+++ b/lib/smblib/smblib-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smblib-priv.h
+++ b/lib/smblib/smblib-priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smblib-util.c
+++ b/lib/smblib/smblib-util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smblib.c
+++ b/lib/smblib/smblib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/smblib.h
+++ b/lib/smblib/smblib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/smblib/std-defines.h
+++ b/lib/smblib/std-defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/Makefile.am
+++ b/lib/snmplib/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/lib/snmplib/asn1.c
+++ b/lib/snmplib/asn1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/coexistance.c
+++ b/lib/snmplib/coexistance.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/mib.c
+++ b/lib/snmplib/mib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/parse.c
+++ b/lib/snmplib/parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/snmp_api.c
+++ b/lib/snmplib/snmp_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/snmp_api_error.c
+++ b/lib/snmplib/snmp_api_error.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/snmp_error.c
+++ b/lib/snmplib/snmp_error.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/snmp_msg.c
+++ b/lib/snmplib/snmp_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/snmp_pdu.c
+++ b/lib/snmplib/snmp_pdu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/snmp_vars.c
+++ b/lib/snmplib/snmp_vars.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/snmplib/snmplib_debug.c
+++ b/lib/snmplib/snmplib_debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/sspwin32.cc
+++ b/lib/sspwin32.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/stub_memaccount.c
+++ b/lib/stub_memaccount.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/tests/testRFC1738.cc
+++ b/lib/tests/testRFC1738.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/tests/testRFC1738.h
+++ b/lib/tests/testRFC1738.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/util.c
+++ b/lib/util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/lib/xusleep.c
+++ b/lib/xusleep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/mkrelease.sh
+++ b/mkrelease.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/mksnapshot-cron.sh
+++ b/mksnapshot-cron.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/mksnapshot.sh
+++ b/mksnapshot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/AnnounceCache.pl
+++ b/scripts/AnnounceCache.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/PerUser.pl
+++ b/scripts/PerUser.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/Squid/ParseLog.pm
+++ b/scripts/Squid/ParseLog.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-# * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+# * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 # *
 # * Squid software is distributed under GPLv2+ license and includes
 # * contributions from numerous individuals and organizations.

--- a/scripts/access-log-matrix.pl
+++ b/scripts/access-log-matrix.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/boiler-mgr.pl
+++ b/scripts/boiler-mgr.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/boilerplate.h
+++ b/scripts/boilerplate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/scripts/cache-compare.pl
+++ b/scripts/cache-compare.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/cachetrace.pl
+++ b/scripts/cachetrace.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/calc-must-ids.pl
+++ b/scripts/calc-must-ids.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/calc-must-ids.sh
+++ b/scripts/calc-must-ids.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/check_cache.pl
+++ b/scripts/check_cache.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/convert.configure.to.os2
+++ b/scripts/convert.configure.to.os2
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/fileno-to-pathname.pl
+++ b/scripts/fileno-to-pathname.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/find-alive.pl
+++ b/scripts/find-alive.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/flag_truncs.pl
+++ b/scripts/flag_truncs.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/format-makefile-am.pl
+++ b/scripts/format-makefile-am.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/formater.pl
+++ b/scripts/formater.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/icp-test.pl
+++ b/scripts/icp-test.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/icpserver.pl
+++ b/scripts/icpserver.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/maintenance/HERE-obsolete
+++ b/scripts/maintenance/HERE-obsolete
@@ -1,6 +1,6 @@
 #!/usr/bin/awk -f
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/maintenance/sort-includes.pl
+++ b/scripts/maintenance/sort-includes.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/merge-cf.data.pre.awk
+++ b/scripts/merge-cf.data.pre.awk
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/merge-cf.data.pre.pl
+++ b/scripts/merge-cf.data.pre.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/mk-error-details-po.pl
+++ b/scripts/mk-error-details-po.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/remove-cfg.sh
+++ b/scripts/remove-cfg.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/split-cf.data.pre.pl
+++ b/scripts/split-cf.data.pre.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/tcp-banger.pl
+++ b/scripts/tcp-banger.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/trace-entry.pl
+++ b/scripts/trace-entry.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/trace-job.pl
+++ b/scripts/trace-job.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/trace-kid.pl
+++ b/scripts/trace-kid.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/trace-master.pl
+++ b/scripts/trace-master.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/udp-banger.pl
+++ b/scripts/udp-banger.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/update-pot.sh
+++ b/scripts/update-pot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/upgrade-1.0-store.pl
+++ b/scripts/upgrade-1.0-store.pl
@@ -1,6 +1,6 @@
 #!/usr/local/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/verify_errorpages.pl
+++ b/scripts/verify_errorpages.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/scripts/www/build-cfg-help.pl
+++ b/scripts/www/build-cfg-help.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 #
-# * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+# * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 # *
 # * Squid software is distributed under GPLv2+ license and includes
 # * contributions from numerous individuals and organizations.

--- a/scripts/www/template.html
+++ b/scripts/www/template.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta type="copyright" content="Copyright (C) 1996-2021 The Squid Software Foundation and contributors">
+    <meta type="copyright" content="Copyright (C) 1996-2022 The Squid Software Foundation and contributors">
     <title>Squid %version% Configuration File: %title%</title>
     <meta name="keywords" content="squid squid.conf config configure %name%" />
     <meta name="description" content="Squid %version%  %name% " />

--- a/squid.dox
+++ b/squid.dox
@@ -24,7 +24,7 @@
 # for the list of possible encodings.
 # The default value is: UTF-8.
 
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/AccessLogEntry.cc
+++ b/src/AccessLogEntry.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/AsyncEngine.cc
+++ b/src/AsyncEngine.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/AsyncEngine.h
+++ b/src/AsyncEngine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/AuthReg.cc
+++ b/src/AuthReg.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/AuthReg.h
+++ b/src/AuthReg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/BandwidthBucket.cc
+++ b/src/BandwidthBucket.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/BandwidthBucket.h
+++ b/src/BandwidthBucket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/BodyPipe.cc
+++ b/src/BodyPipe.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -133,12 +133,12 @@ BodyPipe::BodyPipe(Producer *aProducer): theBodySize(-1),
     // TODO: teach MemBuf to start with zero minSize
     // TODO: limit maxSize by theBodySize, when known?
     theBuf.init(2*1024, MaxCapacity);
-    debugs(91,7, HERE << "created BodyPipe" << status());
+    debugs(91,7, "created BodyPipe" << status());
 }
 
 BodyPipe::~BodyPipe()
 {
-    debugs(91,7, HERE << "destroying BodyPipe" << status());
+    debugs(91,7, "destroying BodyPipe" << status());
     assert(!theProducer);
     assert(!theConsumer);
     theBuf.clean();
@@ -155,7 +155,7 @@ void BodyPipe::setBodySize(uint64_t aBodySize)
     assert(!theConsumer);
 
     theBodySize = aBodySize;
-    debugs(91,7, HERE << "set body size" << status());
+    debugs(91,7, "set body size" << status());
 }
 
 uint64_t BodyPipe::bodySize() const
@@ -194,13 +194,13 @@ void
 BodyPipe::clearProducer(bool atEof)
 {
     if (theProducer.set()) {
-        debugs(91,7, HERE << "clearing BodyPipe producer" << status());
+        debugs(91,7, "clearing BodyPipe producer" << status());
         theProducer.clear();
         if (atEof) {
             if (!bodySizeKnown())
                 theBodySize = thePutSize;
             else if (bodySize() != thePutSize)
-                debugs(91,3, HERE << "aborting on premature eof" << status());
+                debugs(91,3, "aborting on premature eof" << status());
         } else {
             // asserta that we can detect the abort if the consumer joins later
             assert(!bodySizeKnown() || bodySize() != thePutSize);
@@ -241,7 +241,7 @@ BodyPipe::setConsumerIfNotLate(const Consumer::Pointer &aConsumer)
     Must(!abortedConsumption); // did not promise to never consume
 
     theConsumer = aConsumer;
-    debugs(91,7, HERE << "set consumer" << status());
+    debugs(91,7, "set consumer" << status());
     if (theBuf.hasContent())
         scheduleBodyDataNotification();
     if (!theProducer)
@@ -254,7 +254,7 @@ void
 BodyPipe::clearConsumer()
 {
     if (theConsumer.set()) {
-        debugs(91,7, HERE << "clearing consumer" << status());
+        debugs(91,7, "clearing consumer" << status());
         theConsumer.clear();
         // do not abort if we have not consumed so that HTTP or ICAP can retry
         // benign xaction failures due to persistent connection race conditions
@@ -316,7 +316,7 @@ void
 BodyPipe::enableAutoConsumption()
 {
     mustAutoConsume = true;
-    debugs(91,5, HERE << "enabled auto consumption" << status());
+    debugs(91,5, "enabled auto consumption" << status());
     startAutoConsumptionIfNeeded();
 }
 
@@ -336,7 +336,7 @@ BodyPipe::startAutoConsumptionIfNeeded()
 
     theConsumer = new BodySink(this);
     AsyncJob::Start(theConsumer);
-    debugs(91,7, HERE << "starting auto consumption" << status());
+    debugs(91,7, "starting auto consumption" << status());
     scheduleBodyDataNotification();
 }
 
@@ -381,7 +381,7 @@ BodyPipe::postConsume(size_t size)
 {
     assert(!isCheckedOut);
     theGetSize += size;
-    debugs(91,7, HERE << "consumed " << size << " bytes" << status());
+    debugs(91,7, "consumed " << size << " bytes" << status());
     if (mayNeedMoreData()) {
         AsyncCall::Pointer call=  asyncCall(91, 7,
                                             "BodyProducer::noteMoreBodySpaceAvailable",
@@ -396,7 +396,7 @@ BodyPipe::postAppend(size_t size)
 {
     assert(!isCheckedOut);
     thePutSize += size;
-    debugs(91,7, HERE << "added " << size << " bytes" << status());
+    debugs(91,7, "added " << size << " bytes" << status());
 
     // We should not consume here even if mustAutoConsume because the
     // caller may not be ready for the data to be consumed during this call.
@@ -492,7 +492,7 @@ BodyPipeCheckout::~BodyPipeCheckout()
         // Do not pipe.undoCheckOut(*this) because it asserts or throws
         // TODO: consider implementing the long-term solution discussed at
         // http://www.mail-archive.com/squid-dev@squid-cache.org/msg07910.html
-        debugs(91,2, HERE << "Warning: cannot undo BodyPipeCheckout");
+        debugs(91,2, "Warning: cannot undo BodyPipeCheckout");
         thePipe.checkIn(*this);
     }
 }

--- a/src/BodyPipe.h
+++ b/src/BodyPipe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CacheDigest.cc
+++ b/src/CacheDigest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CacheDigest.h
+++ b/src/CacheDigest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CacheManager.h
+++ b/src/CacheManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ClientDelayConfig.cc
+++ b/src/ClientDelayConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ClientDelayConfig.h
+++ b/src/ClientDelayConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ClientInfo.h
+++ b/src/ClientInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ClientRequestContext.h
+++ b/src/ClientRequestContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CollapsedForwarding.cc
+++ b/src/CollapsedForwarding.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CollapsedForwarding.h
+++ b/src/CollapsedForwarding.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CollapsingHistory.h
+++ b/src/CollapsingHistory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Comm.dox
+++ b/src/Comm.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CommCalls.cc
+++ b/src/CommCalls.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -108,7 +108,7 @@ CommIoCbParams::syncWithComm()
     // change parameters if the call was scheduled before comm_close but
     // is being fired after comm_close
     if ((conn->fd < 0 || fd_table[conn->fd].closing()) && flag != Comm::ERR_CLOSING) {
-        debugs(5, 3, HERE << "converting late call to Comm::ERR_CLOSING: " << conn);
+        debugs(5, 3, "converting late call to Comm::ERR_CLOSING: " << conn);
         flag = Comm::ERR_CLOSING;
     }
     return true; // now we are in sync and can handle the call

--- a/src/CommCalls.h
+++ b/src/CommCalls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CommRead.h
+++ b/src/CommRead.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CommandLine.cc
+++ b/src/CommandLine.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Common.am
+++ b/src/Common.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/CommonPool.h
+++ b/src/CommonPool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CompositePoolNode.h
+++ b/src/CompositePoolNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ConfigOption.cc
+++ b/src/ConfigOption.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ConfigOption.h
+++ b/src/ConfigOption.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CpuAffinity.cc
+++ b/src/CpuAffinity.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CpuAffinity.h
+++ b/src/CpuAffinity.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CpuAffinityMap.cc
+++ b/src/CpuAffinityMap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CpuAffinityMap.h
+++ b/src/CpuAffinityMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CpuAffinitySet.cc
+++ b/src/CpuAffinitySet.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/CpuAffinitySet.h
+++ b/src/CpuAffinitySet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -144,7 +144,7 @@ std::ostream& ForceAlert(std::ostream& s);
  *
  * Its purpose is to inactivate calls made following previous debugs()
  * guidelines such as
- * debugs(1,2, HERE << "some message");
+ * debugs(1,2, "some message");
  *
  * His former objective is now absorbed in the debugs call itself
  */

--- a/src/DebugMessages.h
+++ b/src/DebugMessages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayBucket.cc
+++ b/src/DelayBucket.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayBucket.h
+++ b/src/DelayBucket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayConfig.cc
+++ b/src/DelayConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayConfig.h
+++ b/src/DelayConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayId.h
+++ b/src/DelayId.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayIdComposite.h
+++ b/src/DelayIdComposite.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayPool.cc
+++ b/src/DelayPool.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayPool.h
+++ b/src/DelayPool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayPools.h
+++ b/src/DelayPools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelaySpec.cc
+++ b/src/DelaySpec.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelaySpec.h
+++ b/src/DelaySpec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayTagged.cc
+++ b/src/DelayTagged.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayTagged.h
+++ b/src/DelayTagged.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayUser.cc
+++ b/src/DelayUser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -117,7 +117,7 @@ DelayUser::id(CompositePoolNode::CompositeSelectionDetails &details)
     if (!details.user || !details.user->user() || !details.user->user()->username())
         return new NullDelayId;
 
-    debugs(77, 3, HERE << "Adding a slow-down for User '" << details.user->user()->username() << "'");
+    debugs(77, 3, "Adding a slow-down for User '" << details.user->user()->username() << "'");
     return new Id(this, details.user->user());
 }
 

--- a/src/DelayUser.h
+++ b/src/DelayUser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayVector.cc
+++ b/src/DelayVector.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DelayVector.h
+++ b/src/DelayVector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DescriptorSet.cc
+++ b/src/DescriptorSet.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DescriptorSet.h
+++ b/src/DescriptorSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/AIODiskFile.cc
+++ b/src/DiskIO/AIO/AIODiskFile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -64,12 +64,12 @@ AIODiskFile::open(int flags, mode_t, RefCount<IORequestor> callback)
     ioRequestor = callback;
 
     if (fd < 0) {
-        debugs(79, 3, HERE << ": got failure (" << errno << ")");
+        debugs(79, 3, "got failure (" << errno << ")");
         error(true);
     } else {
         closed = false;
         ++store_open_disk_fd;
-        debugs(79, 3, HERE << ": opened FD " << fd);
+        debugs(79, 3, "opened FD " << fd);
     }
 
     callback->ioCompletedNotification();

--- a/src/DiskIO/AIO/AIODiskFile.h
+++ b/src/DiskIO/AIO/AIODiskFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/AIODiskIOModule.cc
+++ b/src/DiskIO/AIO/AIODiskIOModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/AIODiskIOModule.h
+++ b/src/DiskIO/AIO/AIODiskIOModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/AIODiskIOStrategy.cc
+++ b/src/DiskIO/AIO/AIODiskIOStrategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/AIODiskIOStrategy.h
+++ b/src/DiskIO/AIO/AIODiskIOStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/Makefile.am
+++ b/src/DiskIO/AIO/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/aio_win32.cc
+++ b/src/DiskIO/AIO/aio_win32.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/aio_win32.h
+++ b/src/DiskIO/AIO/aio_win32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/AIO/async_io.h
+++ b/src/DiskIO/AIO/async_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Blocking/BlockingDiskIOModule.cc
+++ b/src/DiskIO/Blocking/BlockingDiskIOModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Blocking/BlockingDiskIOModule.h
+++ b/src/DiskIO/Blocking/BlockingDiskIOModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Blocking/BlockingFile.cc
+++ b/src/DiskIO/Blocking/BlockingFile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -110,7 +110,7 @@ BlockingFile::read(ReadRequest *aRequest)
     assert (fd > -1);
     assert (ioRequestor.getRaw());
     readRequest = aRequest;
-    debugs(79, 3, HERE << aRequest->len << " for FD " << fd << " at " << aRequest->offset);
+    debugs(79, 3, aRequest->len << " for FD " << fd << " at " << aRequest->offset);
     file_read(fd, aRequest->buf, aRequest->len, aRequest->offset, ReadDone, this);
 }
 
@@ -125,7 +125,7 @@ BlockingFile::ReadDone(int fd, const char *buf, int len, int errflag, void *my_d
 void
 BlockingFile::write(WriteRequest *aRequest)
 {
-    debugs(79, 3, HERE << aRequest->len << " for FD " << fd << " at " << aRequest->offset);
+    debugs(79, 3, aRequest->len << " for FD " << fd << " at " << aRequest->offset);
     writeRequest = aRequest;
     file_write(fd,
                aRequest->offset,
@@ -181,7 +181,7 @@ void
 BlockingFile::writeDone(int rvfd, int errflag, size_t len)
 {
     assert (rvfd == fd);
-    debugs(79, 3, HERE << "FD " << fd << ", len " << len);
+    debugs(79, 3, "FD " << fd << ", len " << len);
 
     WriteRequest::Pointer result = writeRequest;
     writeRequest = NULL;

--- a/src/DiskIO/Blocking/BlockingFile.h
+++ b/src/DiskIO/Blocking/BlockingFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Blocking/BlockingIOStrategy.cc
+++ b/src/DiskIO/Blocking/BlockingIOStrategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Blocking/BlockingIOStrategy.h
+++ b/src/DiskIO/Blocking/BlockingIOStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Blocking/DiskIOBlocking.cc
+++ b/src/DiskIO/Blocking/DiskIOBlocking.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Blocking/Makefile.am
+++ b/src/DiskIO/Blocking/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/DiskDaemonDiskIOModule.cc
+++ b/src/DiskIO/DiskDaemon/DiskDaemonDiskIOModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/DiskDaemonDiskIOModule.h
+++ b/src/DiskIO/DiskDaemon/DiskDaemonDiskIOModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/DiskdAction.cc
+++ b/src/DiskIO/DiskDaemon/DiskdAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -65,13 +65,13 @@ DiskdAction::Create(const Mgr::CommandPointer &aCmd)
 DiskdAction::DiskdAction(const Mgr::CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(79, 5, HERE);
+    debugs(79, 5, MYNAME);
 }
 
 void
 DiskdAction::add(const Action& action)
 {
-    debugs(79, 5, HERE);
+    debugs(79, 5, MYNAME);
     data += dynamic_cast<const DiskdAction&>(action).data;
 }
 
@@ -114,7 +114,7 @@ DiskdAction::collect()
 void
 DiskdAction::dump(StoreEntry* entry)
 {
-    debugs(79, 5, HERE);
+    debugs(79, 5, MYNAME);
     Must(entry != NULL);
     storeAppendPrintf(entry, "sent_count: %.0f\n", data.sent_count);
     storeAppendPrintf(entry, "recv_count: %.0f\n", data.recv_count);

--- a/src/DiskIO/DiskDaemon/DiskdAction.h
+++ b/src/DiskIO/DiskDaemon/DiskdAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/DiskdFile.cc
+++ b/src/DiskIO/DiskDaemon/DiskdFile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/DiskdFile.h
+++ b/src/DiskIO/DiskDaemon/DiskdFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/DiskdIOStrategy.cc
+++ b/src/DiskIO/DiskDaemon/DiskdIOStrategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/DiskdIOStrategy.h
+++ b/src/DiskIO/DiskDaemon/DiskdIOStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/Makefile.am
+++ b/src/DiskIO/DiskDaemon/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/diomsg.h
+++ b/src/DiskIO/DiskDaemon/diomsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskDaemon/diskd.cc
+++ b/src/DiskIO/DiskDaemon/diskd.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskFile.h
+++ b/src/DiskIO/DiskFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskIOModule.cc
+++ b/src/DiskIO/DiskIOModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskIOModule.h
+++ b/src/DiskIO/DiskIOModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskIOStrategy.h
+++ b/src/DiskIO/DiskIOStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/CommIO.cc
+++ b/src/DiskIO/DiskThreads/CommIO.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/CommIO.h
+++ b/src/DiskIO/DiskThreads/CommIO.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/DiskThreads.h
+++ b/src/DiskIO/DiskThreads/DiskThreads.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -188,7 +188,7 @@ DiskThreadsDiskFile::close()
         ioRequestor->closeCompleted();
         return;
     } else {
-        debugs(79, DBG_CRITICAL, HERE << "DiskThreadsDiskFile::close: " <<
+        debugs(79, DBG_CRITICAL, "DiskThreadsDiskFile::close: " <<
                "did NOT close because ioInProgress() is true.  now what?");
     }
 }

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskIOModule.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskIOModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskIOModule.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskIOModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/Makefile.am
+++ b/src/DiskIO/DiskThreads/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/aiops.cc
+++ b/src/DiskIO/DiskThreads/aiops.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/aiops_win32.cc
+++ b/src/DiskIO/DiskThreads/aiops_win32.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/DiskThreads/async_io.cc
+++ b/src/DiskIO/DiskThreads/async_io.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/IORequestor.h
+++ b/src/DiskIO/IORequestor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/IpcIo/IpcIoDiskIOModule.cc
+++ b/src/DiskIO/IpcIo/IpcIoDiskIOModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/IpcIo/IpcIoDiskIOModule.h
+++ b/src/DiskIO/IpcIo/IpcIoDiskIOModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -231,7 +231,7 @@ IpcIoFile::error() const
 void
 IpcIoFile::read(ReadRequest *readRequest)
 {
-    debugs(79,3, HERE << "(disker" << diskId << ", " << readRequest->len << ", " <<
+    debugs(79,3, "(disker" << diskId << ", " << readRequest->len << ", " <<
            readRequest->offset << ")");
 
     assert(ioRequestor != NULL);
@@ -252,7 +252,7 @@ IpcIoFile::readCompleted(ReadRequest *readRequest,
 {
     bool ioError = false;
     if (!response) {
-        debugs(79, 3, HERE << "error: timeout");
+        debugs(79, 3, "error: timeout");
         ioError = true; // I/O timeout does not warrant setting error_?
     } else {
         if (response->xerrno) {
@@ -279,7 +279,7 @@ IpcIoFile::readCompleted(ReadRequest *readRequest,
 void
 IpcIoFile::write(WriteRequest *writeRequest)
 {
-    debugs(79,3, HERE << "(disker" << diskId << ", " << writeRequest->len << ", " <<
+    debugs(79,3, "(disker" << diskId << ", " << writeRequest->len << ", " <<
            writeRequest->offset << ")");
 
     assert(ioRequestor != NULL);
@@ -321,7 +321,7 @@ IpcIoFile::writeCompleted(WriteRequest *writeRequest,
         (writeRequest->free_func)(const_cast<char*>(writeRequest->buf)); // broken API?
 
     if (!ioError) {
-        debugs(79,5, HERE << "wrote " << writeRequest->len << " to disker" <<
+        debugs(79,5, "wrote " << writeRequest->len << " to disker" <<
                diskId << " at " << writeRequest->offset);
     }
 
@@ -357,7 +357,7 @@ IpcIoFile::push(IpcIoPendingRequest *const pending)
         HandleResponses("before push");
     });
 
-    debugs(47, 7, HERE);
+    debugs(47, 7, MYNAME);
     Must(diskId >= 0);
     Must(pending);
     Must(pending->readRequest || pending->writeRequest);
@@ -386,7 +386,7 @@ IpcIoFile::push(IpcIoPendingRequest *const pending)
             memcpy(buf, pending->writeRequest->buf, ipcIo.len); // optimize away
         }
 
-        debugs(47, 7, HERE << "pushing " << SipcIo(KidIdentifier, ipcIo, diskId));
+        debugs(47, 7, "pushing " << SipcIo(KidIdentifier, ipcIo, diskId));
 
         // protect DiskerHandleRequest() from pop queue overflow
         if (pendingRequests() >= QueueCapacity)
@@ -442,7 +442,7 @@ IpcIoFile::canWait() const
             static_cast<time_msec_t>(expectedWait) < config.ioTimeout)
         return true; // expected wait time is acceptable
 
-    debugs(47,2, HERE << "cannot wait: " << expectedWait <<
+    debugs(47,2, "cannot wait: " << expectedWait <<
            " oldest: " << SipcIo(KidIdentifier, oldestIo, diskId));
     return false; // do not want to wait that long
 }
@@ -451,7 +451,7 @@ IpcIoFile::canWait() const
 void
 IpcIoFile::HandleOpenResponse(const Ipc::StrandMessage &response)
 {
-    debugs(47, 7, HERE << "coordinator response to open request");
+    debugs(47, 7, "coordinator response to open request");
     for (IpcIoFileList::iterator i = WaitingForOpen.begin();
             i != WaitingForOpen.end(); ++i) {
         if (response.strand.tag == (*i)->dbName) {
@@ -461,7 +461,7 @@ IpcIoFile::HandleOpenResponse(const Ipc::StrandMessage &response)
         }
     }
 
-    debugs(47, 4, HERE << "LATE disker response to open for " <<
+    debugs(47, 4, "LATE disker response to open for " <<
            response.strand.tag);
     // nothing we can do about it; completeIo() has been called already
 }
@@ -469,7 +469,7 @@ IpcIoFile::HandleOpenResponse(const Ipc::StrandMessage &response)
 void
 IpcIoFile::HandleResponses(const char *const when)
 {
-    debugs(47, 4, HERE << "popping all " << when);
+    debugs(47, 4, "popping all " << when);
     IpcIoMsg ipcIo;
     // get all responses we can: since we are not pushing, this will stop
     int diskId;
@@ -505,7 +505,7 @@ void
 IpcIoFile::Notify(const int peerId)
 {
     // TODO: Count and report the total number of notifications, pops, pushes.
-    debugs(47, 7, HERE << "kid" << peerId);
+    debugs(47, 7, "kid" << peerId);
     Ipc::TypedMsgHdr msg;
     msg.setType(Ipc::mtIpcIoNotification); // TODO: add proper message type?
     msg.putInt(KidIdentifier);
@@ -517,7 +517,7 @@ void
 IpcIoFile::HandleNotification(const Ipc::TypedMsgHdr &msg)
 {
     const int from = msg.getInt();
-    debugs(47, 7, HERE << "from " << from);
+    debugs(47, 7, "from " << from);
     queue->clearReaderSignal(from);
     if (IamDiskProcess())
         DiskerHandleRequests();
@@ -558,7 +558,7 @@ IpcIoFile::CheckTimeouts(void *const param)
 {
     Must(param);
     const int diskId = reinterpret_cast<uintptr_t>(param);
-    debugs(47, 7, HERE << "diskId=" << diskId);
+    debugs(47, 7, "diskId=" << diskId);
     const IpcIoFilesMap::const_iterator i = IpcIoFiles.find(diskId);
     if (i != IpcIoFiles.end())
         i->second->checkTimeouts();
@@ -715,7 +715,7 @@ diskerRead(IpcIoMsg &ipcIo)
 {
     if (!Ipc::Mem::GetPage(Ipc::Mem::PageId::ioPage, ipcIo.page)) {
         ipcIo.len = 0;
-        debugs(47,2, HERE << "run out of shared memory pages for IPC I/O");
+        debugs(47,2, "run out of shared memory pages for IPC I/O");
         return;
     }
 
@@ -727,13 +727,13 @@ diskerRead(IpcIoMsg &ipcIo)
     if (read >= 0) {
         ipcIo.xerrno = 0;
         const size_t len = static_cast<size_t>(read); // safe because read > 0
-        debugs(47,8, HERE << "disker" << KidIdentifier << " read " <<
+        debugs(47,8, "disker" << KidIdentifier << " read " <<
                (len == ipcIo.len ? "all " : "just ") << read);
         ipcIo.len = len;
     } else {
         ipcIo.xerrno = errno;
         ipcIo.len = 0;
-        debugs(47,5, HERE << "disker" << KidIdentifier << " read error: " <<
+        debugs(47,5, "disker" << KidIdentifier << " read error: " <<
                ipcIo.xerrno);
     }
 }
@@ -806,7 +806,7 @@ diskerWrite(IpcIoMsg &ipcIo)
 void
 IpcIoFile::DiskerHandleMoreRequests(void *source)
 {
-    debugs(47, 7, HERE << "resuming handling requests after " <<
+    debugs(47, 7, "resuming handling requests after " <<
            static_cast<const char *>(source));
     DiskerHandleMoreRequestsScheduled = false;
     IpcIoFile::DiskerHandleRequests();
@@ -844,7 +844,7 @@ IpcIoFile::WaitBeforePop()
     Ipc::QueueReader::Balance &balance = queue->localBalance();
     balance += static_cast<int64_t>(credit - debit);
 
-    debugs(47, 7, HERE << "rate limiting balance: " << balance << " after +" << credit << " -" << debit);
+    debugs(47, 7, "rate limiting balance: " << balance << " after +" << credit << " -" << debit);
 
     if (ipcIo.command == IpcIo::cmdWrite && balance > maxImbalance) {
         // if the next request is (likely) write and we accumulated
@@ -857,7 +857,7 @@ IpcIoFile::WaitBeforePop()
                    "I/O requests for " << (toSpend/1e3) << " seconds " <<
                    "to obey " << ioRate << "/sec rate limit");
 
-        debugs(47, 3, HERE << "rate limiting by " << toSpend << " ms to get" <<
+        debugs(47, 3, "rate limiting by " << toSpend << " ms to get" <<
                (1e3*maxRate) << "/sec rate");
         eventAdd("IpcIoFile::DiskerHandleMoreRequests",
                  &IpcIoFile::DiskerHandleMoreRequests,
@@ -903,7 +903,7 @@ IpcIoFile::DiskerHandleRequests()
                          minBreakSecs, 0, false);
                 DiskerHandleMoreRequestsScheduled = true;
             }
-            debugs(47, 3, HERE << "pausing after " << popped << " I/Os in " <<
+            debugs(47, 3, "pausing after " << popped << " I/Os in " <<
                    elapsedMsec << "ms; " << (elapsedMsec/popped) << "ms per I/O");
             break;
         }
@@ -926,7 +926,7 @@ IpcIoFile::DiskerHandleRequest(const int workerId, IpcIoMsg &ipcIo)
         return;
     }
 
-    debugs(47,5, HERE << "disker" << KidIdentifier <<
+    debugs(47,5, "disker" << KidIdentifier <<
            (ipcIo.command == IpcIo::cmdRead ? " reads " : " writes ") <<
            ipcIo.len << " at " << ipcIo.offset <<
            " ipcIo" << workerId << '.' << ipcIo.requestId);
@@ -941,7 +941,7 @@ IpcIoFile::DiskerHandleRequest(const int workerId, IpcIoMsg &ipcIo)
 
     assert(ipcIo.workerPid == workerPid);
 
-    debugs(47, 7, HERE << "pushing " << SipcIo(workerId, ipcIo, KidIdentifier));
+    debugs(47, 7, "pushing " << SipcIo(workerId, ipcIo, KidIdentifier));
 
     try {
         if (queue->push(workerId, ipcIo))
@@ -982,7 +982,7 @@ DiskerClose(const SBuf &path)
 {
     if (TheFile >= 0) {
         file_close(TheFile);
-        debugs(79,3, HERE << "rock db closed " << path << ": FD " << TheFile);
+        debugs(79,3, "rock db closed " << path << ": FD " << TheFile);
         TheFile = -1;
         --store_open_disk_fd;
     }

--- a/src/DiskIO/IpcIo/IpcIoFile.h
+++ b/src/DiskIO/IpcIo/IpcIoFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/IpcIo/IpcIoIOStrategy.cc
+++ b/src/DiskIO/IpcIo/IpcIoIOStrategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/IpcIo/IpcIoIOStrategy.h
+++ b/src/DiskIO/IpcIo/IpcIoIOStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/IpcIo/Makefile.am
+++ b/src/DiskIO/IpcIo/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/DiskIO/Makefile.am
+++ b/src/DiskIO/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/DiskIO/Mmapped/Makefile.am
+++ b/src/DiskIO/Mmapped/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/DiskIO/Mmapped/MmappedDiskIOModule.cc
+++ b/src/DiskIO/Mmapped/MmappedDiskIOModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Mmapped/MmappedDiskIOModule.h
+++ b/src/DiskIO/Mmapped/MmappedDiskIOModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Mmapped/MmappedFile.cc
+++ b/src/DiskIO/Mmapped/MmappedFile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -58,7 +58,7 @@ MmappedFile::MmappedFile(char const *aPath): fd(-1),
 {
     assert(aPath);
     path_ = xstrdup(aPath);
-    debugs(79,5, HERE << this << ' ' << path_);
+    debugs(79,5, this << ' ' << path_);
 }
 
 MmappedFile::~MmappedFile()
@@ -117,7 +117,7 @@ void MmappedFile::doClose()
 void
 MmappedFile::close()
 {
-    debugs(79, 3, HERE << this << " closing for " << ioRequestor);
+    debugs(79, 3, this << " closing for " << ioRequestor);
     doClose();
     assert(ioRequestor != NULL);
     ioRequestor->closeCompleted();
@@ -144,7 +144,7 @@ MmappedFile::error() const
 void
 MmappedFile::read(ReadRequest *aRequest)
 {
-    debugs(79,3, HERE << "(FD " << fd << ", " << aRequest->len << ", " <<
+    debugs(79,3, "(FD " << fd << ", " << aRequest->len << ", " <<
            aRequest->offset << ")");
 
     assert(fd >= 0);
@@ -174,7 +174,7 @@ MmappedFile::read(ReadRequest *aRequest)
 void
 MmappedFile::write(WriteRequest *aRequest)
 {
-    debugs(79,3, HERE << "(FD " << fd << ", " << aRequest->len << ", " <<
+    debugs(79,3, "(FD " << fd << ", " << aRequest->len << ", " <<
            aRequest->offset << ")");
 
     assert(fd >= 0);
@@ -192,7 +192,7 @@ MmappedFile::write(WriteRequest *aRequest)
         debugs(79, DBG_IMPORTANT, "ERROR: " << xstrerr(errno));
         error_ = true;
     } else if (static_cast<size_t>(written) != aRequest->len) {
-        debugs(79, DBG_IMPORTANT, HERE << "problem: " << written << " < " << aRequest->len);
+        debugs(79, DBG_IMPORTANT, "problem: " << written << " < " << aRequest->len);
         error_ = true;
     }
 
@@ -200,7 +200,7 @@ MmappedFile::write(WriteRequest *aRequest)
         (aRequest->free_func)(const_cast<char*>(aRequest->buf)); // broken API?
 
     if (!error_) {
-        debugs(79,5, HERE << "wrote " << aRequest->len << " to FD " << fd << " at " << aRequest->offset);
+        debugs(79,5, "wrote " << aRequest->len << " to FD " << fd << " at " << aRequest->offset);
     } else {
         doClose();
     }
@@ -240,7 +240,7 @@ Mmapping::map()
 
     if (buf == MAP_FAILED) {
         const int errNo = errno;
-        debugs(79,3, HERE << "error FD " << fd << "mmap(" << length << '+' <<
+        debugs(79,3, "error FD " << fd << "mmap(" << length << '+' <<
                delta << ", " << offset << '-' << delta << "): " << xstrerr(errNo));
         buf = NULL;
         return NULL;
@@ -252,7 +252,7 @@ Mmapping::map()
 bool
 Mmapping::unmap()
 {
-    debugs(79,9, HERE << "FD " << fd <<
+    debugs(79,9, "FD " << fd <<
            " munmap(" << buf << ", " << length << '+' << delta << ')');
 
     if (!buf) // forgot or failed to map
@@ -261,7 +261,7 @@ Mmapping::unmap()
     const bool error = munmap(buf, length + delta) != 0;
     if (error) {
         const int errNo = errno;
-        debugs(79,3, HERE << "error FD " << fd <<
+        debugs(79,3, "error FD " << fd <<
                " munmap(" << buf << ", " << length << '+' << delta << "): " <<
                "): " << xstrerr(errNo));
     }

--- a/src/DiskIO/Mmapped/MmappedFile.h
+++ b/src/DiskIO/Mmapped/MmappedFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Mmapped/MmappedIOStrategy.cc
+++ b/src/DiskIO/Mmapped/MmappedIOStrategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/Mmapped/MmappedIOStrategy.h
+++ b/src/DiskIO/Mmapped/MmappedIOStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/ReadRequest.cc
+++ b/src/DiskIO/ReadRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/ReadRequest.h
+++ b/src/DiskIO/ReadRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/WriteRequest.cc
+++ b/src/DiskIO/WriteRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/DiskIO/WriteRequest.h
+++ b/src/DiskIO/WriteRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Downloader.cc
+++ b/src/Downloader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Downloader.h
+++ b/src/Downloader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ETag.cc
+++ b/src/ETag.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ETag.h
+++ b/src/ETag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/EventLoop.cc
+++ b/src/EventLoop.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/EventLoop.h
+++ b/src/EventLoop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ExternalACLEntry.cc
+++ b/src/ExternalACLEntry.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ExternalACLEntry.h
+++ b/src/ExternalACLEntry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/FadingCounter.cc
+++ b/src/FadingCounter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/FadingCounter.h
+++ b/src/FadingCounter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/FileMap.h
+++ b/src/FileMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -111,7 +111,7 @@ FwdState::HandleStoreAbort(FwdState *fwd)
     if (Comm::IsConnOpen(fwd->serverConnection())) {
         fwd->closeServerConnection("store entry aborted");
     } else {
-        debugs(17, 7, HERE << "store entry aborted; no connection to close");
+        debugs(17, 7, "store entry aborted; no connection to close");
     }
     fwd->stopAndDestroy("store entry aborted");
 }
@@ -249,7 +249,7 @@ FwdState::selectPeerForIntercepted()
     p->remote = clientConn->local;
     getOutgoingAddress(request, p);
 
-    debugs(17, 3, HERE << "using client original destination: " << *p);
+    debugs(17, 3, "using client original destination: " << *p);
     destinations->addPath(p);
     destinations->destinationsFinalized = true;
     PeerSelectionInitiator::subscribed = false;
@@ -287,7 +287,7 @@ FwdState::completed()
     request->hier.stopPeerClock(false);
 
     if (EBIT_TEST(entry->flags, ENTRY_ABORTED)) {
-        debugs(17, 3, HERE << "entry aborted");
+        debugs(17, 3, "entry aborted");
         return ;
     }
 
@@ -391,7 +391,7 @@ FwdState::Start(const Comm::ConnectionPointer &clientConn, StoreEntry *entry, Ht
         }
     }
 
-    debugs(17, 3, HERE << "'" << entry->url() << "'");
+    debugs(17, 3, "'" << entry->url() << "'");
     /*
      * This seems like an odd place to bind mem_obj and request.
      * Might want to assert that request is NULL at this point
@@ -476,7 +476,7 @@ FwdState::useDestinations()
             return; // expect a noteDestination*() call
         }
 
-        debugs(17, 3, HERE << "Connection failed: " << entry->url());
+        debugs(17, 3, "Connection failed: " << entry->url());
         if (!err) {
             const auto anErr = new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request, al);
             fail(anErr);
@@ -510,7 +510,7 @@ FwdState::reactToZeroSizeObject()
     assert(err->type == ERR_ZERO_SIZE_OBJECT);
 
     if (pconnRace == racePossible) {
-        debugs(17, 5, HERE << "pconn race happened");
+        debugs(17, 5, "pconn race happened");
         pconnRace = raceHappened;
         if (destinationReceipt) {
             destinations->reinstatePath(destinationReceipt);
@@ -530,7 +530,7 @@ FwdState::reactToZeroSizeObject()
 void
 FwdState::unregister(Comm::ConnectionPointer &conn)
 {
-    debugs(17, 3, HERE << entry->url() );
+    debugs(17, 3, entry->url() );
     assert(serverConnection() == conn);
     assert(Comm::IsConnOpen(conn));
     comm_remove_close_handler(conn->fd, closeHandler);
@@ -543,7 +543,7 @@ FwdState::unregister(Comm::ConnectionPointer &conn)
 void
 FwdState::unregister(int fd)
 {
-    debugs(17, 3, HERE << entry->url() );
+    debugs(17, 3, entry->url() );
     assert(fd == serverConnection()->fd);
     unregister(serverConn);
 }
@@ -716,7 +716,7 @@ FwdState::checkRetry()
         return false;
 
     if (!self) { // we have aborted before the server called us back
-        debugs(17, 5, HERE << "not retrying because of earlier abort");
+        debugs(17, 5, "not retrying because of earlier abort");
         // we will be destroyed when the server clears its Pointer to us
         return false;
     }
@@ -795,7 +795,7 @@ void
 FwdState::retryOrBail()
 {
     if (checkRetry()) {
-        debugs(17, 3, HERE << "re-forwarding (" << n_tries << " tries, " << (squid_curtime - start_t) << " secs)");
+        debugs(17, 3, "re-forwarding (" << n_tries << " tries, " << (squid_curtime - start_t) << " secs)");
         useDestinations();
         return;
     }
@@ -827,7 +827,7 @@ FwdState::doneWithRetries()
 void
 FwdState::handleUnregisteredServerEnd()
 {
-    debugs(17, 2, HERE << "self=" << self << " err=" << err << ' ' << entry->url());
+    debugs(17, 2, "self=" << self << " err=" << err << ' ' << entry->url());
     assert(!Comm::IsConnOpen(serverConn));
     serverConn = nullptr;
     destinationReceipt = nullptr;
@@ -1332,7 +1332,7 @@ FwdState::reforward()
     StoreEntry *e = entry;
 
     if (EBIT_TEST(e->flags, ENTRY_ABORTED)) {
-        debugs(17, 3, HERE << "entry aborted");
+        debugs(17, 3, "entry aborted");
         return 0;
     }
 
@@ -1343,7 +1343,7 @@ FwdState::reforward()
     e->mem_obj->checkUrlChecksum();
 #endif
 
-    debugs(17, 3, HERE << e->url() << "?" );
+    debugs(17, 3, e->url() << "?" );
 
     if (request->flags.pinned && !pinnedCanRetry()) {
         debugs(17, 3, "pinned connection; cannot retry");
@@ -1351,7 +1351,7 @@ FwdState::reforward()
     }
 
     if (!EBIT_TEST(e->flags, ENTRY_FWD_HDR_WAIT)) {
-        debugs(17, 3, HERE << "No, ENTRY_FWD_HDR_WAIT isn't set");
+        debugs(17, 3, "No, ENTRY_FWD_HDR_WAIT isn't set");
         return 0;
     }
 
@@ -1362,12 +1362,12 @@ FwdState::reforward()
         return 0;
 
     if (destinations->empty() && !PeerSelectionInitiator::subscribed) {
-        debugs(17, 3, HERE << "No alternative forwarding paths left");
+        debugs(17, 3, "No alternative forwarding paths left");
         return 0;
     }
 
     const auto s = entry->mem().baseReply().sline.status();
-    debugs(17, 3, HERE << "status " << s);
+    debugs(17, 3, "status " << s);
     return reforwardableStatus(s);
 }
 

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Generic.h
+++ b/src/Generic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HierarchyLogEntry.h
+++ b/src/HierarchyLogEntry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpBody.cc
+++ b/src/HttpBody.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpBody.h
+++ b/src/HttpBody.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpControlMsg.cc
+++ b/src/HttpControlMsg.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpControlMsg.h
+++ b/src/HttpControlMsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrCc.h
+++ b/src/HttpHdrCc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrContRange.cc
+++ b/src/HttpHdrContRange.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrContRange.h
+++ b/src/HttpHdrContRange.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrRange.cc
+++ b/src/HttpHdrRange.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrSc.cc
+++ b/src/HttpHdrSc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrSc.h
+++ b/src/HttpHdrSc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrScTarget.cc
+++ b/src/HttpHdrScTarget.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHdrScTarget.h
+++ b/src/HttpHdrScTarget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeaderFieldInfo.h
+++ b/src/HttpHeaderFieldInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeaderFieldStat.h
+++ b/src/HttpHeaderFieldStat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeaderMask.h
+++ b/src/HttpHeaderMask.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeaderRange.h
+++ b/src/HttpHeaderRange.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeaderStat.h
+++ b/src/HttpHeaderStat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpHeaderTools.cc
+++ b/src/HttpHeaderTools.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -169,7 +169,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
     const char *end, *pos;
     val->clean();
     if (*start != '"') {
-        debugs(66, 2, HERE << "failed to parse a quoted-string header field near '" << start << "'");
+        debugs(66, 2, "failed to parse a quoted-string header field near '" << start << "'");
         return 0;
     }
     pos = start + 1;
@@ -179,7 +179,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         if (*pos =='\r') {
             ++pos;
             if ((pos-start) > len || *pos != '\n') {
-                debugs(66, 2, HERE << "failed to parse a quoted-string header field with '\\r' octet " << (start-pos)
+                debugs(66, 2, "failed to parse a quoted-string header field with '\\r' octet " << (start-pos)
                        << " bytes into '" << start << "'");
                 val->clean();
                 return 0;
@@ -189,14 +189,14 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         if (*pos == '\n') {
             ++pos;
             if ( (pos-start) > len || (*pos != ' ' && *pos != '\t')) {
-                debugs(66, 2, HERE << "failed to parse multiline quoted-string header field '" << start << "'");
+                debugs(66, 2, "failed to parse multiline quoted-string header field '" << start << "'");
                 val->clean();
                 return 0;
             }
             // TODO: replace the entire LWS with a space
             val->append(" ");
             ++pos;
-            debugs(66, 2, HERE << "len < pos-start => " << len << " < " << (pos-start));
+            debugs(66, 2, "len < pos-start => " << len << " < " << (pos-start));
             continue;
         }
 
@@ -204,7 +204,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         if (quoted) {
             ++pos;
             if (!*pos || (pos-start) > len) {
-                debugs(66, 2, HERE << "failed to parse a quoted-string header field near '" << start << "'");
+                debugs(66, 2, "failed to parse a quoted-string header field near '" << start << "'");
                 val->clean();
                 return 0;
             }
@@ -213,7 +213,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
         while (end < (start+len) && *end != '\\' && *end != '\"' && (unsigned char)*end > 0x1F && *end != 0x7F)
             ++end;
         if (((unsigned char)*end <= 0x1F && *end != '\r' && *end != '\n') || *end == 0x7F) {
-            debugs(66, 2, HERE << "failed to parse a quoted-string header field with CTL octet " << (start-pos)
+            debugs(66, 2, "failed to parse a quoted-string header field with CTL octet " << (start-pos)
                    << " bytes into '" << start << "'");
             val->clean();
             return 0;
@@ -223,7 +223,7 @@ httpHeaderParseQuotedString(const char *start, const int len, String *val)
     }
 
     if (*pos != '\"') {
-        debugs(66, 2, HERE << "failed to parse a quoted-string header field which did not end with \" ");
+        debugs(66, 2, "failed to parse a quoted-string header field which did not end with \" ");
         val->clean();
         return 0;
     }

--- a/src/HttpHeaderTools.h
+++ b/src/HttpHeaderTools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpReply.cc
+++ b/src/HttpReply.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -517,7 +517,7 @@ bool
 HttpReply::receivedBodyTooLarge(HttpRequest& request, int64_t receivedSize)
 {
     calcMaxBodySize(request);
-    debugs(58, 3, HERE << receivedSize << " >? " << bodySizeMax);
+    debugs(58, 3, receivedSize << " >? " << bodySizeMax);
     return bodySizeMax >= 0 && receivedSize > bodySizeMax;
 }
 
@@ -525,7 +525,7 @@ bool
 HttpReply::expectedBodyTooLarge(HttpRequest& request)
 {
     calcMaxBodySize(request);
-    debugs(58, 7, HERE << "bodySizeMax=" << bodySizeMax);
+    debugs(58, 7, "bodySizeMax=" << bodySizeMax);
 
     if (bodySizeMax < 0) // no body size limit
         return false;
@@ -534,7 +534,7 @@ HttpReply::expectedBodyTooLarge(HttpRequest& request)
     if (!expectingBody(request.method, expectedSize))
         return false;
 
-    debugs(58, 6, HERE << expectedSize << " >? " << bodySizeMax);
+    debugs(58, 6, expectedSize << " >? " << bodySizeMax);
 
     if (expectedSize < 0) // expecting body of an unknown length
         return false;
@@ -561,7 +561,7 @@ HttpReply::calcMaxBodySize(HttpRequest& request) const
     for (AclSizeLimit *l = Config.ReplyBodySize; l; l = l -> next) {
         /* if there is no ACL list or if the ACLs listed match use this size value */
         if (!l->aclList || ch.fastCheck(l->aclList).allowed()) {
-            debugs(58, 4, HERE << "bodySizeMax=" << bodySizeMax);
+            debugs(58, 4, "bodySizeMax=" << bodySizeMax);
             bodySizeMax = l->size; // may be -1
             break;
         }

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -54,7 +54,7 @@ HttpRequest::HttpRequest(const HttpRequestMethod& aMethod, AnyP::ProtocolType aP
 {
     assert(mx);
     static unsigned int id = 1;
-    debugs(93,7, HERE << "constructed, this=" << this << " id=" << ++id);
+    debugs(93,7, "constructed, this=" << this << " id=" << ++id);
     init();
     initHTTP(aMethod, aProtocol, aSchemeImg, aUrlpath);
 }
@@ -62,7 +62,7 @@ HttpRequest::HttpRequest(const HttpRequestMethod& aMethod, AnyP::ProtocolType aP
 HttpRequest::~HttpRequest()
 {
     clean();
-    debugs(93,7, HERE << "destructed, this=" << this);
+    debugs(93,7, "destructed, this=" << this);
 }
 
 void
@@ -273,7 +273,7 @@ HttpRequest::sanityCheckStartLine(const char *buf, const size_t hdr_len, Http::S
     if (hdr_len < 2) {
         // this is only a real error if the headers apparently complete.
         if (hdr_len > 0) {
-            debugs(58, 3, HERE << "Too large request header (" << hdr_len << " bytes)");
+            debugs(58, 3, "Too large request header (" << hdr_len << " bytes)");
             *scode = Http::scInvalidHeader;
         }
         return false;
@@ -392,7 +392,7 @@ HttpRequest::icapHistory() const
     if (!icapHistory_) {
         if (Log::TheConfig.hasIcapToken || IcapLogfileStatus == LOG_ENABLE) {
             icapHistory_ = new Adaptation::Icap::History();
-            debugs(93,4, HERE << "made " << icapHistory_ << " for " << this);
+            debugs(93,4, "made " << icapHistory_ << " for " << this);
         }
     }
 
@@ -406,7 +406,7 @@ HttpRequest::adaptHistory(bool createIfNone) const
 {
     if (!adaptHistory_ && createIfNone) {
         adaptHistory_ = new Adaptation::History();
-        debugs(93,4, HERE << "made " << adaptHistory_ << " for " << this);
+        debugs(93,4, "made " << adaptHistory_ << " for " << this);
     }
 
     return adaptHistory_;

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpUpgradeProtocolAccess.cc
+++ b/src/HttpUpgradeProtocolAccess.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/HttpUpgradeProtocolAccess.h
+++ b/src/HttpUpgradeProtocolAccess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ICP.h
+++ b/src/ICP.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Instance.cc
+++ b/src/Instance.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Instance.h
+++ b/src/Instance.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/IoStats.h
+++ b/src/IoStats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/LoadableModule.cc
+++ b/src/LoadableModule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/LoadableModule.h
+++ b/src/LoadableModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/LoadableModules.cc
+++ b/src/LoadableModules.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/LoadableModules.h
+++ b/src/LoadableModules.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/LogTags.cc
+++ b/src/LogTags.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/LogTags.h
+++ b/src/LogTags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.
@@ -1100,7 +1100,6 @@ tests_testRock_SOURCES = \
 	EventLoop.cc \
 	FadingCounter.cc \
 	FileMap.h \
-	tests/stub_fqdncache.cc \
 	tests/stub_HelperChildConfig.cc \
 	HttpBody.cc \
 	HttpBody.h \
@@ -1168,6 +1167,7 @@ tests_testRock_SOURCES = \
 	fde.cc \
 	fde.h \
 	filemap.cc \
+	tests/stub_fqdncache.cc \
 	fs_io.cc \
 	fs_io.h \
 	tests/stub_http.cc \
@@ -1275,7 +1275,6 @@ tests_testUfs_SOURCES = \
 	EventLoop.cc \
 	FadingCounter.cc \
 	FileMap.h \
-	tests/stub_fqdncache.cc \
 	tests/stub_HelperChildConfig.cc \
 	HttpBody.cc \
 	HttpBody.h \
@@ -1343,6 +1342,7 @@ tests_testUfs_SOURCES = \
 	fde.cc \
 	fde.h \
 	filemap.cc \
+	tests/stub_fqdncache.cc \
 	fs_io.cc \
 	fs_io.h \
 	tests/stub_helper.cc \
@@ -1624,7 +1624,6 @@ tests_testDiskIO_SOURCES = \
 	EventLoop.cc \
 	FadingCounter.cc \
 	FileMap.h \
-	tests/stub_fqdncache.cc \
 	tests/stub_HelperChildConfig.cc \
 	HttpBody.cc \
 	HttpBody.h \
@@ -1694,6 +1693,7 @@ tests_testDiskIO_SOURCES = \
 	fde.cc \
 	fde.h \
 	filemap.cc \
+	tests/stub_fqdncache.cc \
 	fs_io.cc \
 	fs_io.h \
 	tests/stub_helper.cc \
@@ -2824,13 +2824,13 @@ tests_testConfigParser_SOURCES = \
 	tests/testConfigParser.h
 nodist_tests_testConfigParser_SOURCES = \
 	ConfigParser.cc \
+	tests/stub_SBuf.cc \
 	String.cc \
 	tests/stub_acl.cc \
 	tests/stub_cache_cf.cc \
 	tests/stub_debug.cc \
 	tests/stub_fatal.cc \
-	tests/stub_libmem.cc \
-	tests/stub_SBuf.cc
+	tests/stub_libmem.cc
 tests_testConfigParser_LDADD = \
 	base/libbase.la \
 	$(LIBCPPUNIT_LIBS) \
@@ -2845,13 +2845,13 @@ tests_testEvent_SOURCES = \
 	tests/testEvent.cc \
 	tests/testEvent.h
 nodist_tests_testEvent_SOURCES = \
-	event.cc \
 	MemBuf.cc \
+	tests/stub_SBuf.cc \
 	tests/stub_cache_manager.cc \
 	tests/stub_cbdata.cc \
 	tests/stub_debug.cc \
+	event.cc \
 	tests/stub_libmem.cc \
-	tests/stub_SBuf.cc \
 	tests/stub_time.cc \
 	tests/stub_tools.cc
 tests_testEvent_LDADD = \

--- a/src/MasterXaction.cc
+++ b/src/MasterXaction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MasterXaction.h
+++ b/src/MasterXaction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MemBuf.cc
+++ b/src/MemBuf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MemBuf.h
+++ b/src/MemBuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -582,7 +582,7 @@ MemStore::shouldCache(StoreEntry &e) const
     }
 
     if (!e.memoryCachable()) {
-        debugs(20, 7, HERE << "Not memory cachable: " << e);
+        debugs(20, 7, "Not memory cachable: " << e);
         return false; // will not cache due to entry state or properties
     }
 
@@ -598,7 +598,7 @@ MemStore::shouldCache(StoreEntry &e) const
     const int64_t loadedSize = e.mem_obj->endOffset();
     const int64_t ramSize = max(loadedSize, expectedSize);
     if (ramSize > maxObjectSize()) {
-        debugs(20, 5, HERE << "Too big max(" <<
+        debugs(20, 5, "Too big max(" <<
                loadedSize << ", " << expectedSize << "): " << e);
         return false; // will not cache due to cachable entry size limits
     }
@@ -609,7 +609,7 @@ MemStore::shouldCache(StoreEntry &e) const
     }
 
     if (!map) {
-        debugs(20, 5, HERE << "No map to mem-cache " << e);
+        debugs(20, 5, "No map to mem-cache " << e);
         return false;
     }
 
@@ -628,7 +628,7 @@ MemStore::startCaching(StoreEntry &e)
     sfileno index = 0;
     Ipc::StoreMapAnchor *slot = map->openForWriting(reinterpret_cast<const cache_key *>(e.key), index);
     if (!slot) {
-        debugs(20, 5, HERE << "No room in mem-cache map to index " << e);
+        debugs(20, 5, "No room in mem-cache map to index " << e);
         return false;
     }
 

--- a/src/MemStore.h
+++ b/src/MemStore.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MessageBucket.cc
+++ b/src/MessageBucket.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MessageBucket.h
+++ b/src/MessageBucket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MessageDelayPools.cc
+++ b/src/MessageDelayPools.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MessageDelayPools.h
+++ b/src/MessageDelayPools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/MessageSizes.h
+++ b/src/MessageSizes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/NeighborTypeDomainList.h
+++ b/src/NeighborTypeDomainList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/NullDelayId.h
+++ b/src/NullDelayId.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Parsing.cc
+++ b/src/Parsing.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Parsing.h
+++ b/src/Parsing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/PeerDigest.h
+++ b/src/PeerDigest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/PeerPoolMgr.h
+++ b/src/PeerPoolMgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/PingData.h
+++ b/src/PingData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Pipeline.cc
+++ b/src/Pipeline.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/RefreshPattern.h
+++ b/src/RefreshPattern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/RemovalPolicy.cc
+++ b/src/RemovalPolicy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/RemovalPolicy.h
+++ b/src/RemovalPolicy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/RequestFlags.cc
+++ b/src/RequestFlags.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/RequestFlags.h
+++ b/src/RequestFlags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SBufStatsAction.cc
+++ b/src/SBufStatsAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SBufStatsAction.h
+++ b/src/SBufStatsAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SnmpRequest.h
+++ b/src/SnmpRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SquidConfig.cc
+++ b/src/SquidConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SquidIpc.h
+++ b/src/SquidIpc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SquidMath.cc
+++ b/src/SquidMath.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SquidMath.h
+++ b/src/SquidMath.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SquidString.h
+++ b/src/SquidString.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/SquidTime.h
+++ b/src/SquidTime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StatCounters.cc
+++ b/src/StatCounters.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StatCounters.h
+++ b/src/StatCounters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StatHist.cc
+++ b/src/StatHist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StatHist.h
+++ b/src/StatHist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Store.h
+++ b/src/Store.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreFileSystem.cc
+++ b/src/StoreFileSystem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreFileSystem.h
+++ b/src/StoreFileSystem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreIOBuffer.h
+++ b/src/StoreIOBuffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreIOState.cc
+++ b/src/StoreIOState.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreIOState.h
+++ b/src/StoreIOState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMeta.cc
+++ b/src/StoreMeta.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMeta.h
+++ b/src/StoreMeta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaMD5.cc
+++ b/src/StoreMetaMD5.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaMD5.h
+++ b/src/StoreMetaMD5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaObjSize.h
+++ b/src/StoreMetaObjSize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaSTD.cc
+++ b/src/StoreMetaSTD.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaSTD.h
+++ b/src/StoreMetaSTD.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaSTDLFS.cc
+++ b/src/StoreMetaSTDLFS.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaSTDLFS.h
+++ b/src/StoreMetaSTDLFS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaURL.cc
+++ b/src/StoreMetaURL.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaURL.h
+++ b/src/StoreMetaURL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaUnpacker.cc
+++ b/src/StoreMetaUnpacker.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaUnpacker.h
+++ b/src/StoreMetaUnpacker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaVary.cc
+++ b/src/StoreMetaVary.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreMetaVary.h
+++ b/src/StoreMetaVary.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreSearch.h
+++ b/src/StoreSearch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreStats.cc
+++ b/src/StoreStats.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreStats.h
+++ b/src/StoreStats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreSwapLogData.cc
+++ b/src/StoreSwapLogData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StoreSwapLogData.h
+++ b/src/StoreSwapLogData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StrList.cc
+++ b/src/StrList.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/StrList.h
+++ b/src/StrList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/String.cc
+++ b/src/String.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/TimeOrTag.h
+++ b/src/TimeOrTag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/WinSvc.cc
+++ b/src/WinSvc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/WinSvc.h
+++ b/src/WinSvc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/XactionInitiator.cc
+++ b/src/XactionInitiator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/XactionInitiator.h
+++ b/src/XactionInitiator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/XactionStep.h
+++ b/src/XactionStep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AclDenyInfoList.h
+++ b/src/acl/AclDenyInfoList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AclSizeLimit.cc
+++ b/src/acl/AclSizeLimit.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AclSizeLimit.h
+++ b/src/acl/AclSizeLimit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AdaptationService.cc
+++ b/src/acl/AdaptationService.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AdaptationService.h
+++ b/src/acl/AdaptationService.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AdaptationServiceData.cc
+++ b/src/acl/AdaptationServiceData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AdaptationServiceData.h
+++ b/src/acl/AdaptationServiceData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Address.cc
+++ b/src/acl/Address.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Address.h
+++ b/src/acl/Address.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AllOf.h
+++ b/src/acl/AllOf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnnotateClient.cc
+++ b/src/acl/AnnotateClient.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnnotateTransaction.cc
+++ b/src/acl/AnnotateTransaction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnnotateTransaction.h
+++ b/src/acl/AnnotateTransaction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnnotationData.cc
+++ b/src/acl/AnnotationData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnnotationData.h
+++ b/src/acl/AnnotationData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnyOf.cc
+++ b/src/acl/AnyOf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AnyOf.h
+++ b/src/acl/AnyOf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Arp.cc
+++ b/src/acl/Arp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Asn.h
+++ b/src/acl/Asn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/BoolOps.h
+++ b/src/acl/BoolOps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Certificate.cc
+++ b/src/acl/Certificate.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/CertificateData.cc
+++ b/src/acl/CertificateData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/CertificateData.h
+++ b/src/acl/CertificateData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/CharacterSetOption.h
+++ b/src/acl/CharacterSetOption.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -59,14 +59,14 @@ ACLChecklist::markFinished(const Acl::Answer &finalAnswer, const char *reason)
     assert (!finished() && !asyncInProgress());
     finished_ = true;
     answer_ = finalAnswer;
-    debugs(28, 3, HERE << this << " answer " << answer_ << " for " << reason);
+    debugs(28, 3, this << " answer " << answer_ << " for " << reason);
 }
 
 /// Called first (and once) by all checks to initialize their state
 void
 ACLChecklist::preCheck(const char *what)
 {
-    debugs(28, 3, HERE << this << " checking " << what);
+    debugs(28, 3, this << " checking " << what);
 
     // concurrent checks using the same Checklist are not supported
     assert(!occupied_);
@@ -372,7 +372,7 @@ ACLChecklist::calcImplicitAnswer()
     // else we saw no rules and will respond with ACCESS_DUNNO
 
     implicitRuleAnswer.implicit = true;
-    debugs(28, 3, HERE << this << " NO match found, last action " <<
+    debugs(28, 3, this << " NO match found, last action " <<
            lastAction << " so returning " << implicitRuleAnswer);
     markFinished(implicitRuleAnswer, "implicit rule won");
 }

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ChecklistFiller.h
+++ b/src/acl/ChecklistFiller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ConnMark.cc
+++ b/src/acl/ConnMark.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ConnectionsEncrypted.cc
+++ b/src/acl/ConnectionsEncrypted.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ConnectionsEncrypted.h
+++ b/src/acl/ConnectionsEncrypted.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Data.h
+++ b/src/acl/Data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/DestinationAsn.h
+++ b/src/acl/DestinationAsn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/DestinationDomain.h
+++ b/src/acl/DestinationDomain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/DomainData.cc
+++ b/src/acl/DomainData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -80,7 +80,7 @@ aclDomainCompare(T const &a, T const &b)
             bool d3big = (strlen(d3) > strlen(d4)); // Always suggest removing the longer one.
             debugs(28, DBG_IMPORTANT, "WARNING: '" << (d3big?d3:d4) << "' is a subdomain of '" << (d3big?d4:d3) << "'");
             debugs(28, DBG_IMPORTANT, "WARNING: You should remove '" << (d3big?d3:d4) << "' from the ACL named '" << AclMatchedName << "'");
-            debugs(28, 2, HERE << "Ignore '" << d3 << "' to keep splay tree searching predictable");
+            debugs(28, 2, "Ignore '" << d3 << "' to keep splay tree searching predictable");
         }
     } else if (ret == 0) {
         // It may be an exact duplicate. No problem. Just drop.

--- a/src/acl/DomainData.h
+++ b/src/acl/DomainData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Eui64.cc
+++ b/src/acl/Eui64.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ExtUser.cc
+++ b/src/acl/ExtUser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/FilledChecklist.cc
+++ b/src/acl/FilledChecklist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -65,7 +65,7 @@ ACLFilledChecklist::~ACLFilledChecklist()
     cbdataReferenceDone(sslErrors);
 #endif
 
-    debugs(28, 4, HERE << "ACLFilledChecklist destroyed " << this);
+    debugs(28, 4, "ACLFilledChecklist destroyed " << this);
 }
 
 static void

--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -48,11 +48,11 @@ aclGetDenyInfoPage(AclDenyInfoList ** head, const char *name, int redirect_allow
 
     AclDenyInfoList *A = NULL;
 
-    debugs(28, 8, HERE << "got called for " << name);
+    debugs(28, 8, "got called for " << name);
 
     for (A = *head; A; A = A->next) {
         if (!redirect_allowed && strchr(A->err_page_name, ':') ) {
-            debugs(28, 8, HERE << "Skip '" << A->err_page_name << "' 30x redirects not allowed as response here.");
+            debugs(28, 8, "Skip '" << A->err_page_name << "' 30x redirects not allowed as response here.");
             continue;
         }
 

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HasComponent.cc
+++ b/src/acl/HasComponent.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HasComponent.h
+++ b/src/acl/HasComponent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HasComponentData.cc
+++ b/src/acl/HasComponentData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HasComponentData.h
+++ b/src/acl/HasComponentData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HierCode.cc
+++ b/src/acl/HierCode.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HierCode.h
+++ b/src/acl/HierCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HierCodeData.cc
+++ b/src/acl/HierCodeData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HierCodeData.h
+++ b/src/acl/HierCodeData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpHeaderData.cc
+++ b/src/acl/HttpHeaderData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpHeaderData.h
+++ b/src/acl/HttpHeaderData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpRepHeader.cc
+++ b/src/acl/HttpRepHeader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpRepHeader.h
+++ b/src/acl/HttpRepHeader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpReqHeader.cc
+++ b/src/acl/HttpReqHeader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpReqHeader.h
+++ b/src/acl/HttpReqHeader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpStatus.cc
+++ b/src/acl/HttpStatus.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/HttpStatus.h
+++ b/src/acl/HttpStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/IntRange.cc
+++ b/src/acl/IntRange.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/IntRange.h
+++ b/src/acl/IntRange.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Ip.cc
+++ b/src/acl/Ip.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -464,7 +464,7 @@ acl_ip_data::FactoryParse(const char *t)
     if (changed)
         debugs(28, DBG_CRITICAL, "WARNING: aclIpParseIpData: Netmask masks away part of the specified IP in '" << t << "'");
 
-    debugs(28,9, HERE << "Parsed: " << q->addr1 << "-" << q->addr2 << "/" << q->mask << "(/" << q->mask.cidr() <<")");
+    debugs(28,9, "Parsed: " << q->addr1 << "-" << q->addr2 << "/" << q->mask << "(/" << q->mask.cidr() <<")");
 
     /* 1.2.3.4/255.255.255.0  --> 1.2.3.0 */
     /* Same as IPv6 (not so trivial to depict) */

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/LocalIp.cc
+++ b/src/acl/LocalIp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/LocalIp.h
+++ b/src/acl/LocalIp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/LocalPort.cc
+++ b/src/acl/LocalPort.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/LocalPort.h
+++ b/src/acl/LocalPort.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Makefile.am
+++ b/src/acl/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/MaxConnection.cc
+++ b/src/acl/MaxConnection.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Method.cc
+++ b/src/acl/Method.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Method.h
+++ b/src/acl/Method.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/MethodData.cc
+++ b/src/acl/MethodData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/MethodData.h
+++ b/src/acl/MethodData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/MyPortName.cc
+++ b/src/acl/MyPortName.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/MyPortName.h
+++ b/src/acl/MyPortName.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Note.cc
+++ b/src/acl/Note.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Note.h
+++ b/src/acl/Note.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/NoteData.cc
+++ b/src/acl/NoteData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/NoteData.h
+++ b/src/acl/NoteData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Options.cc
+++ b/src/acl/Options.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/PeerName.cc
+++ b/src/acl/PeerName.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/PeerName.h
+++ b/src/acl/PeerName.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Protocol.cc
+++ b/src/acl/Protocol.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Protocol.h
+++ b/src/acl/Protocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ProtocolData.cc
+++ b/src/acl/ProtocolData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ProtocolData.h
+++ b/src/acl/ProtocolData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Random.cc
+++ b/src/acl/Random.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/RegexData.cc
+++ b/src/acl/RegexData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/RegexData.h
+++ b/src/acl/RegexData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ReplyHeaderStrategy.h
+++ b/src/acl/ReplyHeaderStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ReplyMimeType.h
+++ b/src/acl/ReplyMimeType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/RequestHeaderStrategy.h
+++ b/src/acl/RequestHeaderStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/RequestMimeType.h
+++ b/src/acl/RequestMimeType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ServerCertificate.cc
+++ b/src/acl/ServerCertificate.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ServerName.cc
+++ b/src/acl/ServerName.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/ServerName.h
+++ b/src/acl/ServerName.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SourceAsn.h
+++ b/src/acl/SourceAsn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SourceIp.cc
+++ b/src/acl/SourceIp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SourceIp.h
+++ b/src/acl/SourceIp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SquidError.cc
+++ b/src/acl/SquidError.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SquidError.h
+++ b/src/acl/SquidError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SquidErrorData.cc
+++ b/src/acl/SquidErrorData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SquidErrorData.h
+++ b/src/acl/SquidErrorData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SslError.cc
+++ b/src/acl/SslError.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SslError.h
+++ b/src/acl/SslError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SslErrorData.cc
+++ b/src/acl/SslErrorData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/SslErrorData.h
+++ b/src/acl/SslErrorData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Strategised.cc
+++ b/src/acl/Strategised.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Strategised.h
+++ b/src/acl/Strategised.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Strategy.h
+++ b/src/acl/Strategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/StringData.cc
+++ b/src/acl/StringData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/StringData.h
+++ b/src/acl/StringData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Tag.cc
+++ b/src/acl/Tag.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Tag.h
+++ b/src/acl/Tag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Time.cc
+++ b/src/acl/Time.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Time.h
+++ b/src/acl/Time.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/TimeData.cc
+++ b/src/acl/TimeData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/TimeData.h
+++ b/src/acl/TimeData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/TransactionInitiator.cc
+++ b/src/acl/TransactionInitiator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/TransactionInitiator.h
+++ b/src/acl/TransactionInitiator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Tree.cc
+++ b/src/acl/Tree.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Url.cc
+++ b/src/acl/Url.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/Url.h
+++ b/src/acl/Url.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UrlLogin.cc
+++ b/src/acl/UrlLogin.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UrlLogin.h
+++ b/src/acl/UrlLogin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UrlPath.cc
+++ b/src/acl/UrlPath.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UrlPath.h
+++ b/src/acl/UrlPath.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UrlPort.cc
+++ b/src/acl/UrlPort.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UrlPort.h
+++ b/src/acl/UrlPort.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UserData.cc
+++ b/src/acl/UserData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/UserData.h
+++ b/src/acl/UserData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/AD_group/Makefile.am
+++ b/src/acl/external/AD_group/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/AD_group/ext_ad_group_acl.8
+++ b/src/acl/external/AD_group/ext_ad_group_acl.8
@@ -237,7 +237,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/AD_group/required.m4
+++ b/src/acl/external/AD_group/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/LDAP_group/ChangeLog
+++ b/src/acl/external/LDAP_group/ChangeLog
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/LDAP_group/Makefile.am
+++ b/src/acl/external/LDAP_group/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/LDAP_group/ext_ldap_group_acl.8
+++ b/src/acl/external/LDAP_group/ext_ldap_group_acl.8
@@ -242,7 +242,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/LDAP_group/ext_ldap_group_acl.cc
+++ b/src/acl/external/LDAP_group/ext_ldap_group_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/LDAP_group/required.m4
+++ b/src/acl/external/LDAP_group/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/LM_group/Makefile.am
+++ b/src/acl/external/LM_group/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/LM_group/ext_lm_group_acl.8
+++ b/src/acl/external/LM_group/ext_lm_group_acl.8
@@ -169,7 +169,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/LM_group/ext_lm_group_acl.cc
+++ b/src/acl/external/LM_group/ext_lm_group_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/LM_group/required.m4
+++ b/src/acl/external/LM_group/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/Makefile.am
+++ b/src/acl/external/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/SQL_session/Makefile.am
+++ b/src/acl/external/SQL_session/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/SQL_session/ext_sql_session_acl.pl.in
+++ b/src/acl/external/SQL_session/ext_sql_session_acl.pl.in
@@ -80,7 +80,7 @@ With assistance of Nishant Sharma <codemarauder@gmail.com>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/SQL_session/required.m4
+++ b/src/acl/external/SQL_session/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/delayer/Makefile.am
+++ b/src/acl/external/delayer/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/delayer/ext_delayer_acl.pl.in
+++ b/src/acl/external/delayer/ext_delayer_acl.pl.in
@@ -74,7 +74,7 @@ This software is written by Francesco Chemolli <kinkie@squid-cache.org>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/delayer/required.m4
+++ b/src/acl/external/delayer/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/eDirectory_userip/Makefile.am
+++ b/src/acl/external/eDirectory_userip/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.8
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.8
@@ -192,7 +192,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/eDirectory_userip/required.m4
+++ b/src/acl/external/eDirectory_userip/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/file_userip/Makefile.am
+++ b/src/acl/external/file_userip/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/file_userip/example.conf
+++ b/src/acl/external/file_userip/example.conf
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/file_userip/ext_file_userip_acl.8
+++ b/src/acl/external/file_userip/ext_file_userip_acl.8
@@ -80,7 +80,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/file_userip/required.m4
+++ b/src/acl/external/file_userip/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/helpers.m4
+++ b/src/acl/external/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/Makefile.am
+++ b/src/acl/external/kerberos_ldap_group/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/cert_tool
+++ b/src/acl/external/kerberos_ldap_group/cert_tool
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/kerberos_ldap_group.cc
+++ b/src/acl/external/kerberos_ldap_group/kerberos_ldap_group.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/required.m4
+++ b/src/acl/external/kerberos_ldap_group/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support.h
+++ b/src/acl/external/kerberos_ldap_group/support.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_group.cc
+++ b/src/acl/external/kerberos_ldap_group/support_group.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_krb5.cc
+++ b/src/acl/external/kerberos_ldap_group/support_krb5.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_ldap.cc
+++ b/src/acl/external/kerberos_ldap_group/support_ldap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_log.cc
+++ b/src/acl/external/kerberos_ldap_group/support_log.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_lserver.cc
+++ b/src/acl/external/kerberos_ldap_group/support_lserver.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_member.cc
+++ b/src/acl/external/kerberos_ldap_group/support_member.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_netbios.cc
+++ b/src/acl/external/kerberos_ldap_group/support_netbios.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_resolv.cc
+++ b/src/acl/external/kerberos_ldap_group/support_resolv.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_ldap_group/support_sasl.cc
+++ b/src/acl/external/kerberos_ldap_group/support_sasl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_sid_group/Makefile.am
+++ b/src/acl/external/kerberos_sid_group/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_sid_group/ext_kerberos_sid_group_acl.pl.in
+++ b/src/acl/external/kerberos_sid_group/ext_kerberos_sid_group_acl.pl.in
@@ -79,7 +79,7 @@ This manual was written by Markus Moeller <markus_moeller@compuserve.com>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/kerberos_sid_group/required.m4
+++ b/src/acl/external/kerberos_sid_group/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/session/Makefile.am
+++ b/src/acl/external/session/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/session/ext_session_acl.8
+++ b/src/acl/external/session/ext_session_acl.8
@@ -99,7 +99,7 @@ This program and documentation was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/session/required.m4
+++ b/src/acl/external/session/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/time_quota/Makefile.am
+++ b/src/acl/external/time_quota/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/time_quota/ext_time_quota_acl.8
+++ b/src/acl/external/time_quota/ext_time_quota_acl.8
@@ -217,7 +217,7 @@ This program and documentation was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/time_quota/required.m4
+++ b/src/acl/external/time_quota/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/unix_group/Makefile.am
+++ b/src/acl/external/unix_group/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/unix_group/check_group.cc
+++ b/src/acl/external/unix_group/check_group.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/unix_group/ext_unix_group_acl.8
+++ b/src/acl/external/unix_group/ext_unix_group_acl.8
@@ -72,7 +72,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/unix_group/required.m4
+++ b/src/acl/external/unix_group/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/wbinfo_group/Makefile.am
+++ b/src/acl/external/wbinfo_group/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/external/wbinfo_group/ext_wbinfo_group_acl.pl.in
+++ b/src/acl/external/wbinfo_group/ext_wbinfo_group_acl.pl.in
@@ -62,7 +62,7 @@ This manual was written by Amos Jeffries <amosjeffries@squid-cache.org>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/acl/external/wbinfo_group/required.m4
+++ b/src/acl/external/wbinfo_group/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/acl/forward.h
+++ b/src/acl/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/AccessCheck.cc
+++ b/src/adaptation/AccessCheck.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -39,7 +39,7 @@ Adaptation::AccessCheck::Start(Method method, VectPoint vp,
         return true;
     }
 
-    debugs(83, 3, HERE << "adaptation off, skipping");
+    debugs(83, 3, "adaptation off, skipping");
     return false;
 }
 
@@ -55,7 +55,7 @@ Adaptation::AccessCheck::AccessCheck(const ServiceFilter &aFilter,
         h->start("ACL");
 #endif
 
-    debugs(93, 5, HERE << "AccessCheck constructed for " <<
+    debugs(93, 5, "AccessCheck constructed for " <<
            methodStr(filter.method) << " " << vectPointStr(filter.point));
 }
 
@@ -87,11 +87,11 @@ Adaptation::AccessCheck::usedDynamicRules()
 
     DynamicGroupCfg services;
     if (!ah->extractFutureServices(services)) { // clears history
-        debugs(85,9, HERE << "no service-proposed rules stored");
+        debugs(85,9, "no service-proposed rules stored");
         return false; // earlier service did not plan for the future
     }
 
-    debugs(85,3, HERE << "using stored service-proposed rules: " << services);
+    debugs(85,3, "using stored service-proposed rules: " << services);
 
     ServiceGroupPointer g = new DynamicServiceChain(services, filter);
     callBack(g);
@@ -103,13 +103,13 @@ Adaptation::AccessCheck::usedDynamicRules()
 void
 Adaptation::AccessCheck::check()
 {
-    debugs(93, 4, HERE << "start checking");
+    debugs(93, 4, "start checking");
 
     typedef AccessRules::iterator ARI;
     for (ARI i = AllRules().begin(); i != AllRules().end(); ++i) {
         AccessRule *r = *i;
         if (isCandidate(*r)) {
-            debugs(93, 5, HERE << "check: rule '" << r->id << "' is a candidate");
+            debugs(93, 5, "check: rule '" << r->id << "' is a candidate");
             candidates.push_back(r->id);
         }
     }
@@ -125,7 +125,7 @@ Adaptation::AccessCheck::check()
 void
 Adaptation::AccessCheck::checkCandidates()
 {
-    debugs(93, 4, HERE << "has " << candidates.size() << " rules");
+    debugs(93, 4, "has " << candidates.size() << " rules");
 
     while (!candidates.empty()) {
         if (AccessRule *r = FindRule(topCandidate())) {
@@ -143,7 +143,7 @@ Adaptation::AccessCheck::checkCandidates()
         candidates.erase(candidates.begin()); // the rule apparently went away (reconfigure)
     }
 
-    debugs(93, 4, HERE << "NO candidates left");
+    debugs(93, 4, "NO candidates left");
     callBack(NULL);
     Must(done());
 }
@@ -151,7 +151,7 @@ Adaptation::AccessCheck::checkCandidates()
 void
 Adaptation::AccessCheck::AccessCheckCallbackWrapper(Acl::Answer answer, void *data)
 {
-    debugs(93, 8, HERE << "callback answer=" << answer);
+    debugs(93, 8, "callback answer=" << answer);
     AccessCheck *ac = (AccessCheck*)data;
 
     /* TODO: AYJ 2008-06-12: If answer == ACCESS_AUTH_REQUIRED
@@ -173,7 +173,7 @@ void
 Adaptation::AccessCheck::noteAnswer(Acl::Answer answer)
 {
     Must(!candidates.empty()); // the candidate we were checking must be there
-    debugs(93,5, HERE << topCandidate() << " answer=" << answer);
+    debugs(93,5, topCandidate() << " answer=" << answer);
 
     if (answer.allowed()) { // the rule matched
         ServiceGroupPointer g = topGroup();
@@ -194,7 +194,7 @@ Adaptation::AccessCheck::noteAnswer(Acl::Answer answer)
 void
 Adaptation::AccessCheck::callBack(const ServiceGroupPointer &g)
 {
-    debugs(93,3, HERE << g);
+    debugs(93,3, g);
     CallJobHere1(93, 5, theInitiator, Adaptation::Initiator,
                  noteAdaptationAclCheckDone, g);
     mustStop("done"); // called back or will never be able to call back
@@ -207,12 +207,12 @@ Adaptation::AccessCheck::topGroup() const
     if (candidates.size()) {
         if (AccessRule *r = FindRule(topCandidate())) {
             g = FindGroup(r->groupId);
-            debugs(93,5, HERE << "top group for " << r->id << " is " << g);
+            debugs(93,5, "top group for " << r->id << " is " << g);
         } else {
-            debugs(93,5, HERE << "no rule for " << topCandidate());
+            debugs(93,5, "no rule for " << topCandidate());
         }
     } else {
-        debugs(93,5, HERE << "no candidates"); // should not happen
+        debugs(93,5, "no candidates"); // should not happen
     }
 
     return g;
@@ -223,18 +223,18 @@ Adaptation::AccessCheck::topGroup() const
 bool
 Adaptation::AccessCheck::isCandidate(AccessRule &r)
 {
-    debugs(93,7,HERE << "checking candidacy of " << r.id << ", group " <<
+    debugs(93,7, "checking candidacy of " << r.id << ", group " <<
            r.groupId);
 
     ServiceGroupPointer g = FindGroup(r.groupId);
 
     if (!g) {
-        debugs(93,7,HERE << "lost " << r.groupId << " group in rule" << r.id);
+        debugs(93,7, "lost " << r.groupId << " group in rule" << r.id);
         return false;
     }
 
     const bool wants = g->wants(filter);
-    debugs(93,7,HERE << r.groupId << (wants ? " wants" : " ignores"));
+    debugs(93,7, r.groupId << (wants ? " wants" : " ignores"));
     return wants;
 }
 

--- a/src/adaptation/AccessCheck.h
+++ b/src/adaptation/AccessCheck.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/AccessRule.cc
+++ b/src/adaptation/AccessRule.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -36,7 +36,7 @@ void
 Adaptation::AccessRule::finalize()
 {
     if (!group()) { // no explicit group
-        debugs(93,7, HERE << "no service group: " << groupId);
+        debugs(93,7, "no service group: " << groupId);
         // try to add a one-service group
         if (FindService(groupId) != NULL) {
             ServiceGroupPointer g = new SingleService(groupId);

--- a/src/adaptation/AccessRule.h
+++ b/src/adaptation/AccessRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Answer.cc
+++ b/src/adaptation/Answer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -18,7 +18,7 @@ Adaptation::Answer::Error(bool final)
 {
     Answer answer(akError);
     answer.final = final;
-    debugs(93, 4, HERE << "error: " << final);
+    debugs(93, 4, "error: " << final);
     return answer;
 }
 
@@ -27,7 +27,7 @@ Adaptation::Answer::Forward(Http::Message *aMsg)
 {
     Answer answer(akForward);
     answer.message = aMsg;
-    debugs(93, 4, HERE << "forwarding: " << (void*)aMsg);
+    debugs(93, 4, "forwarding: " << (void*)aMsg);
     return answer;
 }
 
@@ -36,7 +36,7 @@ Adaptation::Answer::Block(const String &aRule)
 {
     Answer answer(akBlock);
     answer.ruleId = aRule;
-    debugs(93, 4, HERE << "blocking rule: " << aRule);
+    debugs(93, 4, "blocking rule: " << aRule);
     return answer;
 }
 

--- a/src/adaptation/Answer.h
+++ b/src/adaptation/Answer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Config.cc
+++ b/src/adaptation/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -120,14 +120,14 @@ Adaptation::Config::removeRule(const String& id)
 void
 Adaptation::Config::clear()
 {
-    debugs(93, 3, HERE << "rules: " << AllRules().size() << ", groups: " <<
+    debugs(93, 3, "rules: " << AllRules().size() << ", groups: " <<
            AllGroups().size() << ", services: " << serviceConfigs.size());
     typedef ServiceConfigs::const_iterator SCI;
     const ServiceConfigs& configs = serviceConfigs;
     for (SCI cfg = configs.begin(); cfg != configs.end(); ++cfg)
         removeService((*cfg)->key);
     serviceConfigs.clear();
-    debugs(93, 3, HERE << "rules: " << AllRules().size() << ", groups: " <<
+    debugs(93, 3, "rules: " << AllRules().size() << ", groups: " <<
            AllGroups().size() << ", services: " << serviceConfigs.size());
 }
 
@@ -207,7 +207,7 @@ Adaptation::Config::finalize()
         }
     }
 
-    debugs(93,3, HERE << "Created " << created << " adaptation services");
+    debugs(93,3, "Created " << created << " adaptation services");
 
     // services remember their configs; we do not have to
     serviceConfigs.clear();
@@ -223,7 +223,7 @@ FinalizeEach(Collection &collection, const char *label)
     for (CI i = collection.begin(); i != collection.end(); ++i)
         (*i)->finalize();
 
-    debugs(93,2, HERE << "Initialized " << collection.size() << ' ' << label);
+    debugs(93,2, "Initialized " << collection.size() << ' ' << label);
 }
 
 void

--- a/src/adaptation/Config.h
+++ b/src/adaptation/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/DynamicGroupCfg.cc
+++ b/src/adaptation/DynamicGroupCfg.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/DynamicGroupCfg.h
+++ b/src/adaptation/DynamicGroupCfg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Elements.cc
+++ b/src/adaptation/Elements.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Elements.h
+++ b/src/adaptation/Elements.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/History.cc
+++ b/src/adaptation/History.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -120,8 +120,8 @@ bool Adaptation::History::getXxRecord(String &name, String &value) const
 void Adaptation::History::updateNextServices(const String &services)
 {
     if (theNextServices != TheNullServices)
-        debugs(93,3, HERE << "old services: " << theNextServices);
-    debugs(93,3, HERE << "new services: " << services);
+        debugs(93,3, "old services: " << theNextServices);
+    debugs(93,3, "new services: " << services);
     Must(services != TheNullServices);
     theNextServices = services;
 }
@@ -155,8 +155,8 @@ void
 Adaptation::History::setFutureServices(const DynamicGroupCfg &services)
 {
     if (!theFutureServices.empty())
-        debugs(93,3, HERE << "old future services: " << theFutureServices);
-    debugs(93,3, HERE << "new future services: " << services);
+        debugs(93,3, "old future services: " << theFutureServices);
+    debugs(93,3, "new future services: " << services);
     theFutureServices = services; // may be empty
 }
 

--- a/src/adaptation/History.h
+++ b/src/adaptation/History.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Initiate.cc
+++ b/src/adaptation/Initiate.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -61,14 +61,14 @@ Adaptation::Initiate::initiator(const CbcPointer<Initiator> &i)
 // internal cleanup
 void Adaptation::Initiate::swanSong()
 {
-    debugs(93, 5, HERE << "swan sings" << status());
+    debugs(93, 5, "swan sings" << status());
 
     if (theInitiator.set()) {
-        debugs(93, 3, HERE << "fatal failure; sending abort notification");
+        debugs(93, 3, "fatal failure; sending abort notification");
         tellQueryAborted(true); // final by default
     }
 
-    debugs(93, 5, HERE << "swan sang" << status());
+    debugs(93, 5, "swan sang" << status());
 }
 
 void Adaptation::Initiate::clearInitiator()

--- a/src/adaptation/Initiate.h
+++ b/src/adaptation/Initiate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Initiator.cc
+++ b/src/adaptation/Initiator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Initiator.h
+++ b/src/adaptation/Initiator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Iterator.cc
+++ b/src/adaptation/Iterator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -71,7 +71,7 @@ void Adaptation::Iterator::start()
 void Adaptation::Iterator::step()
 {
     ++iterations;
-    debugs(93,5, HERE << '#' << iterations << " plan: " << thePlan);
+    debugs(93,5, '#' << iterations << " plan: " << thePlan);
 
     Must(!theLauncher);
 
@@ -97,7 +97,7 @@ void Adaptation::Iterator::step()
 
     ServicePointer service = thePlan.current();
     Must(service != NULL);
-    debugs(93,5, HERE << "using adaptation service: " << service->cfg().key);
+    debugs(93,5, "using adaptation service: " << service->cfg().key);
 
     if (Adaptation::Config::needHistory) {
         Adaptation::History::Pointer ah = request->adaptHistory(true);
@@ -139,7 +139,7 @@ Adaptation::Iterator::handleAdaptedHeader(Http::Message *aMsg)
                 // definitely sent request, now use it as the cause
                 theCause = cause; // moving the lock
                 theMsg = 0;
-                debugs(93,3, HERE << "in request satisfaction mode");
+                debugs(93,3, "in request satisfaction mode");
             }
         }
     }
@@ -165,7 +165,7 @@ void Adaptation::Iterator::noteInitiatorAborted()
 
 void Adaptation::Iterator::handleAdaptationBlock(const Answer &answer)
 {
-    debugs(93,5, HERE << "blocked by " << answer);
+    debugs(93,5, "blocked by " << answer);
     clearAdaptation(theLauncher);
     updatePlan(false);
     sendAnswer(answer);
@@ -174,7 +174,7 @@ void Adaptation::Iterator::handleAdaptationBlock(const Answer &answer)
 
 void Adaptation::Iterator::handleAdaptationError(bool final)
 {
-    debugs(93,5, HERE << "final: " << final << " plan: " << thePlan);
+    debugs(93,5, "final: " << final << " plan: " << thePlan);
     clearAdaptation(theLauncher);
     updatePlan(false);
 
@@ -184,18 +184,18 @@ void Adaptation::Iterator::handleAdaptationError(bool final)
     // can we ignore the failure (compute while thePlan is not exhausted)?
     Must(!thePlan.exhausted());
     const bool canIgnore = thePlan.current()->cfg().bypass;
-    debugs(85,5, HERE << "flags: " << srcIntact << canIgnore << adapted);
+    debugs(85,5, "flags: " << srcIntact << canIgnore << adapted);
 
     if (srcIntact) {
         if (thePlan.replacement(filter()) != NULL) {
-            debugs(93,3, HERE << "trying a replacement service");
+            debugs(93,3, "trying a replacement service");
             step();
             return;
         }
     }
 
     if (canIgnore && srcIntact && adapted) {
-        debugs(85,3, HERE << "responding with older adapted msg");
+        debugs(85,3, "responding with older adapted msg");
         sendAnswer(Answer::Forward(theMsg));
         mustStop("sent older adapted msg");
         return;
@@ -230,22 +230,22 @@ bool Adaptation::Iterator::updatePlan(bool adopt)
 
     Adaptation::History::Pointer ah = r->adaptHistory();
     if (!ah) {
-        debugs(85,9, HERE << "no history to store a service-proposed plan");
+        debugs(85,9, "no history to store a service-proposed plan");
         return false; // the feature is not enabled or is not triggered
     }
 
     String services;
     if (!ah->extractNextServices(services)) { // clears history
-        debugs(85,9, HERE << "no service-proposed plan received");
+        debugs(85,9, "no service-proposed plan received");
         return false; // the service did not provide a new plan
     }
 
     if (!adopt) {
-        debugs(85,3, HERE << "rejecting service-proposed plan");
+        debugs(85,3, "rejecting service-proposed plan");
         return false;
     }
 
-    debugs(85,3, HERE << "retiring old plan: " << thePlan);
+    debugs(85,3, "retiring old plan: " << thePlan);
 
     Adaptation::ServiceFilter f = this->filter();
     DynamicGroupCfg current, future;
@@ -253,13 +253,13 @@ bool Adaptation::Iterator::updatePlan(bool adopt)
 
     if (!future.empty()) {
         ah->setFutureServices(future);
-        debugs(85,3, HERE << "noted future service-proposed plan: " << future);
+        debugs(85,3, "noted future service-proposed plan: " << future);
     }
 
     // use the current config even if it is empty; we must replace the old plan
     theGroup = new DynamicServiceChain(current, f); // refcounted
     thePlan = ServicePlan(theGroup, f);
-    debugs(85,3, HERE << "adopted service-proposed plan: " << thePlan);
+    debugs(85,3, "adopted service-proposed plan: " << thePlan);
     return true;
 }
 

--- a/src/adaptation/Iterator.h
+++ b/src/adaptation/Iterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Makefile.am
+++ b/src/adaptation/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/adaptation/Message.cc
+++ b/src/adaptation/Message.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Message.h
+++ b/src/adaptation/Message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/Service.cc
+++ b/src/adaptation/Service.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -16,7 +16,7 @@
 Adaptation::Service::Service(const ServiceConfigPointer &aConfig): theConfig(aConfig)
 {
     Must(theConfig != NULL);
-    debugs(93,3, HERE << "creating adaptation service " << cfg().key);
+    debugs(93,3, "creating adaptation service " << cfg().key);
 }
 
 Adaptation::Service::~Service()

--- a/src/adaptation/Service.h
+++ b/src/adaptation/Service.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ServiceConfig.cc
+++ b/src/adaptation/ServiceConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -193,7 +193,7 @@ Adaptation::ServiceConfig::grokUri(const char *value)
     // AYJ: most of this is duplicate of AnyP::Uri::parse()
 
     if (!value || !*value) {
-        debugs(3, DBG_CRITICAL, HERE << cfg_filename << ':' << config_lineno << ": " <<
+        debugs(3, DBG_CRITICAL, cfg_filename << ':' << config_lineno << ": " <<
                "empty adaptation service URI");
         return false;
     }
@@ -206,7 +206,7 @@ Adaptation::ServiceConfig::grokUri(const char *value)
     if (schemeEnd != String::npos)
         protocol=uri.substr(0,schemeEnd);
 
-    debugs(3, 5, HERE << cfg_filename << ':' << config_lineno << ": " <<
+    debugs(3, 5, cfg_filename << ':' << config_lineno << ": " <<
            "service protocol is " << protocol);
 
     if (protocol.size() == 0)
@@ -282,7 +282,7 @@ Adaptation::ServiceConfig::grokUri(const char *value)
     len = e - s;
 
     if (len > 1024) {
-        debugs(3, DBG_CRITICAL, HERE << cfg_filename << ':' << config_lineno << ": " <<
+        debugs(3, DBG_CRITICAL, cfg_filename << ':' << config_lineno << ": " <<
                "long resource name (>1024), probably wrong");
     }
 
@@ -298,7 +298,7 @@ Adaptation::ServiceConfig::grokBool(bool &var, const char *name, const char *val
     else if (!strcmp(value, "1") || !strcmp(value, "on"))
         var = true;
     else {
-        debugs(3, DBG_CRITICAL, HERE << cfg_filename << ':' << config_lineno << ": " <<
+        debugs(3, DBG_CRITICAL, cfg_filename << ':' << config_lineno << ": " <<
                "wrong value for boolean " << name << "; " <<
                "'0', '1', 'on', or 'off' expected but got: " << value);
         return false;

--- a/src/adaptation/ServiceConfig.h
+++ b/src/adaptation/ServiceConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ServiceFilter.cc
+++ b/src/adaptation/ServiceFilter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ServiceFilter.h
+++ b/src/adaptation/ServiceFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ServiceGroups.cc
+++ b/src/adaptation/ServiceGroups.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -93,7 +93,7 @@ Adaptation::ServiceGroup::finalize()
             finalizeMsg("ERROR: Unknown adaptation name", serviceId, true);
         }
     }
-    debugs(93,7, HERE << "finalized " << kind << ": " << id);
+    debugs(93,7, "finalized " << kind << ": " << id);
 }
 
 /// checks that the service name or URI is not repeated later in the group
@@ -141,7 +141,7 @@ bool
 Adaptation::ServiceGroup::findService(const ServiceFilter &filter, Pos &pos) const
 {
     if (method != filter.method || point != filter.point) {
-        debugs(93,5,HERE << id << " serves another location");
+        debugs(93,5, id << " serves another location");
         return false; // assume other services have the same wrong location
     }
 
@@ -149,7 +149,7 @@ Adaptation::ServiceGroup::findService(const ServiceFilter &filter, Pos &pos) con
     bool foundEssential = false;
     Pos essPos = 0;
     for (; has(pos); ++pos) {
-        debugs(93,9,HERE << id << " checks service at " << pos);
+        debugs(93,9, id << " checks service at " << pos);
         ServicePointer service = at(pos);
 
         if (!service)
@@ -159,34 +159,34 @@ Adaptation::ServiceGroup::findService(const ServiceFilter &filter, Pos &pos) con
             continue; // the service is not interested
 
         if (service->up() || !service->probed()) {
-            debugs(93,9,HERE << id << " has matching service at " << pos);
+            debugs(93,9, id << " has matching service at " << pos);
             return true;
         }
 
         if (service->cfg().bypass) { // we can safely ignore bypassable downers
-            debugs(93,9,HERE << id << " has bypassable service at " << pos);
+            debugs(93,9, id << " has bypassable service at " << pos);
             continue;
         }
 
         if (!allServicesSame) { // cannot skip (i.e., find best) service
-            debugs(93,9,HERE << id << " has essential service at " << pos);
+            debugs(93,9, id << " has essential service at " << pos);
             return true;
         }
 
         if (!foundEssential) {
-            debugs(93,9,HERE << id << " searches for best essential service from " << pos);
+            debugs(93,9, id << " searches for best essential service from " << pos);
             foundEssential = true;
             essPos = pos;
         }
     }
 
     if (foundEssential) {
-        debugs(93,9,HERE << id << " has best essential service at " << essPos);
+        debugs(93,9, id << " has best essential service at " << essPos);
         pos = essPos;
         return true;
     }
 
-    debugs(93,5,HERE << id << " has no matching services");
+    debugs(93,5, id << " has no matching services");
     return false;
 }
 

--- a/src/adaptation/ServiceGroups.h
+++ b/src/adaptation/ServiceGroups.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/Config.cc
+++ b/src/adaptation/ecap/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/Config.h
+++ b/src/adaptation/ecap/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/Host.cc
+++ b/src/adaptation/ecap/Host.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/Host.h
+++ b/src/adaptation/ecap/Host.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/Makefile.am
+++ b/src/adaptation/ecap/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/MessageRep.cc
+++ b/src/adaptation/ecap/MessageRep.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/MessageRep.h
+++ b/src/adaptation/ecap/MessageRep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/MinimalAdapter.cc
+++ b/src/adaptation/ecap/MinimalAdapter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/Registry.h
+++ b/src/adaptation/ecap/Registry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/ServiceRep.cc
+++ b/src/adaptation/ecap/ServiceRep.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -194,7 +194,7 @@ Adaptation::Ecap::ServiceRep::finalize()
 void
 Adaptation::Ecap::ServiceRep::tryConfigureAndStart()
 {
-    debugs(93,2, HERE << "configuring eCAP service: " << theService->uri());
+    debugs(93,2, "configuring eCAP service: " << theService->uri());
     const ConfigRep cfgRep(dynamic_cast<const ServiceConfig&>(cfg()));
     theService->configure(cfgRep);
 

--- a/src/adaptation/ecap/ServiceRep.h
+++ b/src/adaptation/ecap/ServiceRep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/ecap/XactionRep.cc
+++ b/src/adaptation/ecap/XactionRep.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -351,7 +351,7 @@ Adaptation::Ecap::XactionRep::doneAll() const
 void
 Adaptation::Ecap::XactionRep::sinkVb(const char *reason)
 {
-    debugs(93,4, HERE << "sink for " << reason << "; status:" << status());
+    debugs(93,4, "sink for " << reason << "; status:" << status());
 
     // we reset raw().body_pipe when we are done, so use this one for checking
     const BodyPipePointer &permPipe = theVirginRep.raw().header->body_pipe;
@@ -365,7 +365,7 @@ Adaptation::Ecap::XactionRep::sinkVb(const char *reason)
 void
 Adaptation::Ecap::XactionRep::preserveVb(const char *reason)
 {
-    debugs(93,4, HERE << "preserve for " << reason << "; status:" << status());
+    debugs(93,4, "preserve for " << reason << "; status:" << status());
 
     // we reset raw().body_pipe when we are done, so use this one for checking
     const BodyPipePointer &permPipe = theVirginRep.raw().header->body_pipe;
@@ -381,7 +381,7 @@ Adaptation::Ecap::XactionRep::preserveVb(const char *reason)
 void
 Adaptation::Ecap::XactionRep::forgetVb(const char *reason)
 {
-    debugs(93,9, HERE << "forget vb " << reason << "; status:" << status());
+    debugs(93,9, "forget vb " << reason << "; status:" << status());
 
     BodyPipePointer &p = theVirginRep.raw().body_pipe;
     if (p != NULL && p->stillConsuming(this))
@@ -396,7 +396,7 @@ Adaptation::Ecap::XactionRep::forgetVb(const char *reason)
 void
 Adaptation::Ecap::XactionRep::useVirgin()
 {
-    debugs(93,3, HERE << status());
+    debugs(93,3, status());
     Must(proxyingAb == opUndecided);
     proxyingAb = opNever;
 
@@ -414,7 +414,7 @@ Adaptation::Ecap::XactionRep::useVirgin()
 void
 Adaptation::Ecap::XactionRep::useAdapted(const libecap::shared_ptr<libecap::Message> &m)
 {
-    debugs(93,3, HERE << status());
+    debugs(93,3, status());
     Must(m);
     theAnswerRep = m;
     Must(proxyingAb == opUndecided);
@@ -436,7 +436,7 @@ Adaptation::Ecap::XactionRep::useAdapted(const libecap::shared_ptr<libecap::Mess
         updateHistory(msg);
         sendAnswer(Answer::Forward(msg));
 
-        debugs(93,4, HERE << "adapter will produce body" << status());
+        debugs(93,4, "adapter will produce body" << status());
         theMaster->abMake(); // libecap will produce
     }
 }
@@ -444,7 +444,7 @@ Adaptation::Ecap::XactionRep::useAdapted(const libecap::shared_ptr<libecap::Mess
 void
 Adaptation::Ecap::XactionRep::blockVirgin()
 {
-    debugs(93,3, HERE << status());
+    debugs(93,3, status());
     Must(proxyingAb == opUndecided);
     proxyingAb = opNever;
 
@@ -587,7 +587,7 @@ Adaptation::Ecap::XactionRep::noteAbContentDone(bool atEnd)
     Must(proxyingAb == opOn && !abProductionFinished);
     abProductionFinished = true;
     abProductionAtEnd = atEnd; // store until ready to stop producing ourselves
-    debugs(93,5, HERE << "adapted body production ended");
+    debugs(93,5, "adapted body production ended");
     moveAbContent();
 }
 
@@ -612,7 +612,7 @@ Adaptation::Ecap::XactionRep::setAdaptedBodySize(const libecap::BodySize &size)
 void
 Adaptation::Ecap::XactionRep::adaptationDelayed(const libecap::Delay &d)
 {
-    debugs(93,3, HERE << "adapter needs time: " <<
+    debugs(93,3, "adapter needs time: " <<
            d.state << '/' << d.progress);
     // XXX: set timeout?
 }
@@ -679,11 +679,11 @@ Adaptation::Ecap::XactionRep::moveAbContent()
 {
     Must(proxyingAb == opOn);
     const libecap::Area c = theMaster->abContent(0, libecap::nsize);
-    debugs(93,5, HERE << "up to " << c.size << " bytes");
+    debugs(93,5, "up to " << c.size << " bytes");
     if (c.size == 0 && abProductionFinished) { // no ab now and in the future
         stopProducingFor(answer().body_pipe, abProductionAtEnd);
         proxyingAb = opComplete;
-        debugs(93,5, HERE << "last adapted body data retrieved");
+        debugs(93,5, "last adapted body data retrieved");
     } else if (c.size > 0) {
         if (const size_t used = answer().body_pipe->putMoreData(c.start, c.size))
             theMaster->abContentShift(used);

--- a/src/adaptation/ecap/XactionRep.h
+++ b/src/adaptation/ecap/XactionRep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/forward.h
+++ b/src/adaptation/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Client.cc
+++ b/src/adaptation/icap/Client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -12,7 +12,7 @@
 
 void Adaptation::Icap::InitModule()
 {
-    debugs(93,2, HERE << "module enabled.");
+    debugs(93,2, "module enabled.");
 }
 
 void Adaptation::Icap::CleanModule()

--- a/src/adaptation/icap/Client.h
+++ b/src/adaptation/icap/Client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Config.cc
+++ b/src/adaptation/icap/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Config.h
+++ b/src/adaptation/icap/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Elements.cc
+++ b/src/adaptation/icap/Elements.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Elements.h
+++ b/src/adaptation/icap/Elements.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/History.cc
+++ b/src/adaptation/icap/History.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -25,7 +25,7 @@ void Adaptation::Icap::History::start(const char *context)
     if (!concurrencyLevel++)
         currentStart = current_time;
 
-    debugs(93,4, HERE << "start " << context << " level=" << concurrencyLevel
+    debugs(93,4, "start " << context << " level=" << concurrencyLevel
            << " time=" << tvToMsec(pastTime) << ' ' << this);
 }
 
@@ -38,7 +38,7 @@ void Adaptation::Icap::History::stop(const char *context)
 
     struct timeval current;
     currentTime(current);
-    debugs(93,4, HERE << "stop " << context << " level=" << concurrencyLevel <<
+    debugs(93,4, "stop " << context << " level=" << concurrencyLevel <<
            " time=" << tvToMsec(pastTime) << '+' << tvToMsec(current) << ' ' << this);
 
     if (!--concurrencyLevel)
@@ -50,7 +50,7 @@ Adaptation::Icap::History::processingTime(timeval &total) const
 {
     currentTime(total);
     tvAssignAdd(total, pastTime);
-    debugs(93,7, HERE << " current total: " << tvToMsec(total) << ' ' << this);
+    debugs(93,7, " current total: " << tvToMsec(total) << ' ' << this);
 }
 
 void

--- a/src/adaptation/icap/History.h
+++ b/src/adaptation/icap/History.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/InOut.h
+++ b/src/adaptation/icap/InOut.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Launcher.cc
+++ b/src/adaptation/icap/Launcher.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -44,7 +44,7 @@ void Adaptation::Icap::Launcher::launchXaction(const char *xkind)
 {
     Must(!theXaction);
     ++theLaunches;
-    debugs(93,4, HERE << "launching " << xkind << " xaction #" << theLaunches);
+    debugs(93,4, "launching " << xkind << " xaction #" << theLaunches);
     Adaptation::Icap::Xaction *x = createXaction();
     x->attempts = theLaunches;
     if (theLaunches > 1) {
@@ -59,7 +59,7 @@ void Adaptation::Icap::Launcher::launchXaction(const char *xkind)
 
 void Adaptation::Icap::Launcher::noteAdaptationAnswer(const Answer &answer)
 {
-    debugs(93,5, HERE << "launches: " << theLaunches << " answer: " << answer);
+    debugs(93,5, "launches: " << theLaunches << " answer: " << answer);
 
     // XXX: akError is unused by ICAPXaction in favor of noteXactAbort()
     Must(answer.kind != Answer::akError);
@@ -80,7 +80,7 @@ void Adaptation::Icap::Launcher::noteInitiatorAborted()
 
 void Adaptation::Icap::Launcher::noteXactAbort(XactAbortInfo info)
 {
-    debugs(93,5, HERE << "theXaction:" << theXaction << " launches: " << theLaunches);
+    debugs(93,5, "theXaction:" << theXaction << " launches: " << theLaunches);
 
     // TODO: add more checks from FwdState::checkRetry()?
     if (canRetry(info)) {
@@ -90,7 +90,7 @@ void Adaptation::Icap::Launcher::noteXactAbort(XactAbortInfo info)
         clearAdaptation(theXaction);
         launchXaction("repeat");
     } else {
-        debugs(93,3, HERE << "cannot retry or repeat a failed transaction");
+        debugs(93,3, "cannot retry or repeat a failed transaction");
         clearAdaptation(theXaction);
         tellQueryAborted(false); // caller decides based on bypass, consumption
         Must(done());
@@ -122,15 +122,15 @@ bool Adaptation::Icap::Launcher::canRetry(Adaptation::Icap::XactAbortInfo &info)
 
 bool Adaptation::Icap::Launcher::canRepeat(Adaptation::Icap::XactAbortInfo &info) const
 {
-    debugs(93,9, HERE << shutting_down);
+    debugs(93,9, shutting_down);
     if (theLaunches >= TheConfig.repeat_limit || shutting_down)
         return false;
 
-    debugs(93,9, HERE << info.isRepeatable); // TODO: update and use status()
+    debugs(93,9, info.isRepeatable); // TODO: update and use status()
     if (!info.isRepeatable)
         return false;
 
-    debugs(93,9, HERE << info.icapReply);
+    debugs(93,9, info.icapReply);
     if (!info.icapReply) // did not get to read an ICAP reply; a timeout?
         return true;
 

--- a/src/adaptation/icap/Launcher.h
+++ b/src/adaptation/icap/Launcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Makefile.am
+++ b/src/adaptation/icap/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -82,7 +82,7 @@ Adaptation::Icap::ModXact::ModXact(Http::Message *virginHeader,
     icapReply = new HttpReply;
     icapReply->protoPrefix = "ICAP/"; // TODO: make an IcapReply class?
 
-    debugs(93,7, HERE << "initialized." << status());
+    debugs(93,7, "initialized." << status());
 }
 
 // initiator wants us to start
@@ -132,7 +132,7 @@ void Adaptation::Icap::ModXact::waitForService()
             disableRetries();
             disableRepeats("ICAP service is not available");
 
-            debugs(93, 7, HERE << "will not wait for the service to be available" <<
+            debugs(93, 7, "will not wait for the service to be available" <<
                    status());
 
             throw TexcHere("ICAP service is not available");
@@ -144,7 +144,7 @@ void Adaptation::Icap::ModXact::waitForService()
         comment = "to be available";
     }
 
-    debugs(93, 7, HERE << "will wait for the service " << comment <<  status());
+    debugs(93, 7, "will wait for the service " << comment <<  status());
     state.serviceWaiting = true; // after callWhenReady() which may throw
     state.waitedForService = true;
 }
@@ -197,7 +197,7 @@ void Adaptation::Icap::ModXact::startShoveling()
     requestBuf.init();
 
     makeRequestHeaders(requestBuf);
-    debugs(93, 9, HERE << "will write" << status() << ":\n" <<
+    debugs(93, 9, "will write" << status() << ":\n" <<
            (requestBuf.terminate(), requestBuf.content()));
 
     // write headers
@@ -208,7 +208,7 @@ void Adaptation::Icap::ModXact::startShoveling()
 
 void Adaptation::Icap::ModXact::handleCommWrote(size_t sz)
 {
-    debugs(93, 5, HERE << "Wrote " << sz << " bytes");
+    debugs(93, 5, "Wrote " << sz << " bytes");
 
     if (state.writing == State::writingHeaders)
         handleCommWroteHeaders();
@@ -238,7 +238,7 @@ void Adaptation::Icap::ModXact::handleCommWroteHeaders()
 
 void Adaptation::Icap::ModXact::writeMore()
 {
-    debugs(93, 5, HERE << "checking whether to write more" << status());
+    debugs(93, 5, "checking whether to write more" << status());
 
     if (writer != NULL) // already writing something
         return;
@@ -274,7 +274,7 @@ void Adaptation::Icap::ModXact::writeMore()
 
 void Adaptation::Icap::ModXact::writePreviewBody()
 {
-    debugs(93, 8, HERE << "will write Preview body from " <<
+    debugs(93, 8, "will write Preview body from " <<
            virgin.body_pipe << status());
     Must(state.writing == State::writingPreview);
     Must(virgin.body_pipe != NULL);
@@ -299,7 +299,7 @@ void Adaptation::Icap::ModXact::decideWritingAfterPreview(const char *kind)
     else
         stopWriting(true); // ICAP server reply implies no post-preview writing
 
-    debugs(93, 6, HERE << "decided on writing after " << kind << " preview" <<
+    debugs(93, 6, "decided on writing after " << kind << " preview" <<
            status());
 }
 
@@ -312,7 +312,7 @@ void Adaptation::Icap::ModXact::writePrimeBody()
     writeSomeBody("prime virgin body", size);
 
     if (virginBodyEndReached(virginBodyWriting)) {
-        debugs(93, 5, HERE << "wrote entire body");
+        debugs(93, 5, "wrote entire body");
         stopWriting(true);
     }
 }
@@ -321,7 +321,7 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
 {
     Must(!writer && state.writing < state.writingAlmostDone);
     Must(virgin.body_pipe != NULL);
-    debugs(93, 8, HERE << "will write up to " << size << " bytes of " <<
+    debugs(93, 8, "will write up to " << size << " bytes of " <<
            label);
 
     MemBuf writeBuf; // TODO: suggest a min size based on size and lastChunk
@@ -332,7 +332,7 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
     const size_t chunkSize = min(writableSize, size);
 
     if (chunkSize) {
-        debugs(93, 7, HERE << "will write " << chunkSize <<
+        debugs(93, 7, "will write " << chunkSize <<
                "-byte chunk of " << label);
 
         openChunk(writeBuf, chunkSize, false);
@@ -342,7 +342,7 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
         virginBodyWriting.progress(chunkSize);
         virginConsume();
     } else {
-        debugs(93, 7, HERE << "has no writable " << label << " content");
+        debugs(93, 7, "has no writable " << label << " content");
     }
 
     const bool wroteEof = virginBodyEndReached(virginBodyWriting);
@@ -353,11 +353,11 @@ void Adaptation::Icap::ModXact::writeSomeBody(const char *label, size_t size)
     }
 
     if (lastChunk) {
-        debugs(93, 8, HERE << "will write last-chunk of " << label);
+        debugs(93, 8, "will write last-chunk of " << label);
         addLastRequestChunk(writeBuf);
     }
 
-    debugs(93, 7, HERE << "will write " << writeBuf.contentSize()
+    debugs(93, 7, "will write " << writeBuf.contentSize()
            << " raw bytes of " << label);
 
     if (writeBuf.hasContent()) {
@@ -424,7 +424,7 @@ const char *Adaptation::Icap::ModXact::virginContentData(const Adaptation::Icap:
 
 void Adaptation::Icap::ModXact::virginConsume()
 {
-    debugs(93, 9, HERE << "consumption guards: " << !virgin.body_pipe << isRetriable <<
+    debugs(93, 9, "consumption guards: " << !virgin.body_pipe << isRetriable <<
            isRepeatable << canStartBypass << protectGroupBypass);
 
     if (!virgin.body_pipe)
@@ -444,7 +444,7 @@ void Adaptation::Icap::ModXact::virginConsume()
         // down. Not postponing may increase the number of ICAP errors
         // if the ICAP service fails. We may also use "potential" space to
         // postpone more aggressively. Should the trade-off be configurable?
-        debugs(93, 8, HERE << "postponing consumption from " << bp.status());
+        debugs(93, 8, "postponing consumption from " << bp.status());
         return;
     }
 
@@ -452,7 +452,7 @@ void Adaptation::Icap::ModXact::virginConsume()
     const uint64_t end = virginConsumed + have;
     uint64_t offset = end;
 
-    debugs(93, 9, HERE << "max virgin consumption offset=" << offset <<
+    debugs(93, 9, "max virgin consumption offset=" << offset <<
            " acts " << virginBodyWriting.active() << virginBodySending.active() <<
            " consumed=" << virginConsumed <<
            " from " << virgin.body_pipe->status());
@@ -466,7 +466,7 @@ void Adaptation::Icap::ModXact::virginConsume()
     Must(virginConsumed <= offset && offset <= end);
 
     if (const size_t size = static_cast<size_t>(offset - virginConsumed)) {
-        debugs(93, 8, HERE << "consuming " << size << " out of " << have <<
+        debugs(93, 8, "consuming " << size << " out of " << have <<
                " virgin body bytes");
         bp.consume(size);
         virginConsumed += size;
@@ -491,12 +491,12 @@ void Adaptation::Icap::ModXact::stopWriting(bool nicely)
 
     if (writer != NULL) {
         if (nicely) {
-            debugs(93, 7, HERE << "will wait for the last write" << status());
+            debugs(93, 7, "will wait for the last write" << status());
             state.writing = State::writingAlmostDone; // may already be set
             checkConsuming();
             return;
         }
-        debugs(93, 3, HERE << "will NOT wait for the last write" << status());
+        debugs(93, 3, "will NOT wait for the last write" << status());
 
         // Comm does not have an interface to clear the writer callback nicely,
         // but without clearing the writer we cannot recycle the connection.
@@ -507,7 +507,7 @@ void Adaptation::Icap::ModXact::stopWriting(bool nicely)
         ignoreLastWrite = true;
     }
 
-    debugs(93, 7, HERE << "will no longer write" << status());
+    debugs(93, 7, "will no longer write" << status());
     if (virginBodyWriting.active()) {
         virginBodyWriting.disable();
         virginConsume();
@@ -521,7 +521,7 @@ void Adaptation::Icap::ModXact::stopBackup()
     if (!virginBodySending.active())
         return;
 
-    debugs(93, 7, HERE << "will no longer backup" << status());
+    debugs(93, 7, "will no longer backup" << status());
     virginBodySending.disable();
     virginConsume();
 }
@@ -547,21 +547,21 @@ void Adaptation::Icap::ModXact::startReading()
 void Adaptation::Icap::ModXact::readMore()
 {
     if (reader != NULL || doneReading()) {
-        debugs(93,3,HERE << "returning from readMore because reader or doneReading()");
+        debugs(93,3, "returning from readMore because reader or doneReading()");
         return;
     }
 
     // do not fill readBuf if we have no space to store the result
     if (adapted.body_pipe != NULL &&
             !adapted.body_pipe->buf().hasPotentialSpace()) {
-        debugs(93,3,HERE << "not reading because ICAP reply pipe is full");
+        debugs(93,3, "not reading because ICAP reply pipe is full");
         return;
     }
 
     if (readBuf.length() < SQUID_TCP_SO_RCVBUF)
         scheduleRead();
     else
-        debugs(93,3,HERE << "cannot read with a full buffer");
+        debugs(93,3, "cannot read with a full buffer");
 }
 
 // comm module read a portion of the ICAP response for us
@@ -580,14 +580,14 @@ void Adaptation::Icap::ModXact::echoMore()
     Must(virginBodySending.active());
 
     const size_t sizeMax = virginContentSize(virginBodySending);
-    debugs(93,5, HERE << "will echo up to " << sizeMax << " bytes from " <<
+    debugs(93,5, "will echo up to " << sizeMax << " bytes from " <<
            virgin.body_pipe->status());
-    debugs(93,5, HERE << "will echo up to " << sizeMax << " bytes to   " <<
+    debugs(93,5, "will echo up to " << sizeMax << " bytes to   " <<
            adapted.body_pipe->status());
 
     if (sizeMax > 0) {
         const size_t size = adapted.body_pipe->putMoreData(virginContentData(virginBodySending), sizeMax);
-        debugs(93,5, HERE << "echoed " << size << " out of " << sizeMax <<
+        debugs(93,5, "echoed " << size << " out of " << sizeMax <<
                " bytes");
         virginBodySending.progress(size);
         disableRepeats("echoed content");
@@ -596,10 +596,10 @@ void Adaptation::Icap::ModXact::echoMore()
     }
 
     if (virginBodyEndReached(virginBodySending)) {
-        debugs(93, 5, HERE << "echoed all" << status());
+        debugs(93, 5, "echoed all" << status());
         stopSending(true);
     } else {
-        debugs(93, 5, HERE << "has " <<
+        debugs(93, 5, "has " <<
                virgin.body_pipe->buf().contentSize() << " bytes " <<
                "and expects more to echo" << status());
         // TODO: timeout if virgin or adapted pipes are broken
@@ -614,13 +614,13 @@ bool Adaptation::Icap::ModXact::doneSending() const
 // stop (or do not start) sending adapted message body
 void Adaptation::Icap::ModXact::stopSending(bool nicely)
 {
-    debugs(93, 7, HERE << "Enter stop sending ");
+    debugs(93, 7, "Enter stop sending ");
     if (doneSending())
         return;
-    debugs(93, 7, HERE << "Proceed with stop sending ");
+    debugs(93, 7, "Proceed with stop sending ");
 
     if (state.sending != State::sendingUndecided) {
-        debugs(93, 7, HERE << "will no longer send" << status());
+        debugs(93, 7, "will no longer send" << status());
         if (adapted.body_pipe != NULL) {
             virginBodySending.disable();
             // we may leave debts if we were echoing and the virgin
@@ -629,7 +629,7 @@ void Adaptation::Icap::ModXact::stopSending(bool nicely)
             stopProducingFor(adapted.body_pipe, nicely && !leftDebts);
         }
     } else {
-        debugs(93, 7, HERE << "will not start sending" << status());
+        debugs(93, 7, "will not start sending" << status());
         Must(!adapted.body_pipe);
     }
 
@@ -644,7 +644,7 @@ void Adaptation::Icap::ModXact::checkConsuming()
     if (!virgin.body_pipe || !state.doneConsumingVirgin())
         return;
 
-    debugs(93, 7, HERE << "will stop consuming" << status());
+    debugs(93, 7, "will stop consuming" << status());
     stopConsumingFrom(virgin.body_pipe);
 }
 
@@ -677,7 +677,7 @@ void Adaptation::Icap::ModXact::callException(const std::exception &e)
     }
 
     try {
-        debugs(93, 3, HERE << "bypassing " << inCall << " exception: " <<
+        debugs(93, 3, "bypassing " << inCall << " exception: " <<
                e.what() << ' ' << status());
         bypassFailure();
     } catch (const TextException &bypassTe) {
@@ -709,7 +709,7 @@ void Adaptation::Icap::ModXact::bypassFailure()
         reuseConnection = false; // be conservative
         cancelRead(); // may not work; and we cannot stop connecting either
         if (!doneWithIo())
-            debugs(93, 7, HERE << "Warning: bypass failed to stop I/O" << status());
+            debugs(93, 7, "Warning: bypass failed to stop I/O" << status());
     }
 
     service().noteFailure(); // we are bypassing, but this is still a failure
@@ -718,11 +718,11 @@ void Adaptation::Icap::ModXact::bypassFailure()
 void Adaptation::Icap::ModXact::disableBypass(const char *reason, bool includingGroupBypass)
 {
     if (canStartBypass) {
-        debugs(93,7, HERE << "will never start bypass because " << reason);
+        debugs(93,7, "will never start bypass because " << reason);
         canStartBypass = false;
     }
     if (protectGroupBypass && includingGroupBypass) {
-        debugs(93,7, HERE << "not protecting group bypass because " << reason);
+        debugs(93,7, "not protecting group bypass because " << reason);
         protectGroupBypass = false;
     }
 }
@@ -749,12 +749,12 @@ void Adaptation::Icap::ModXact::parseHeaders()
     Must(state.parsingHeaders());
 
     if (state.parsing == State::psIcapHeader) {
-        debugs(93, 5, HERE << "parse ICAP headers");
+        debugs(93, 5, "parse ICAP headers");
         parseIcapHead();
     }
 
     if (state.parsing == State::psHttpHeader) {
-        debugs(93, 5, HERE << "parse HTTP headers");
+        debugs(93, 5, "parse HTTP headers");
         parseHttpHead();
     }
 
@@ -801,7 +801,7 @@ void Adaptation::Icap::ModXact::parseIcapHead()
 
     static SBuf close("close", 5);
     if (httpHeaderHasConnDir(&icapReply->header, close)) {
-        debugs(93, 5, HERE << "found connection close");
+        debugs(93, 5, "found connection close");
         reuseConnection = false;
     }
 
@@ -932,11 +932,11 @@ void Adaptation::Icap::ModXact::handle206PartialContent()
     if (state.writing == State::writingPaused) {
         Must(preview.enabled());
         Must(state.allowedPreview206);
-        debugs(93, 7, HERE << "206 inside preview");
+        debugs(93, 7, "206 inside preview");
     } else {
         Must(state.writing > State::writingPaused);
         Must(state.allowedPostview206);
-        debugs(93, 7, HERE << "206 outside preview");
+        debugs(93, 7, "206 outside preview");
     }
     state.parsing = State::psHttpHeader;
     state.sending = State::sendingAdapted;
@@ -960,7 +960,7 @@ void Adaptation::Icap::ModXact::prepEchoing()
     // TODO: use Http::Message::clone()!
 
     Http::Message *oldHead = virgin.header;
-    debugs(93, 7, HERE << "cloning virgin message " << oldHead);
+    debugs(93, 7, "cloning virgin message " << oldHead);
 
     MemBuf httpBuf;
 
@@ -993,12 +993,12 @@ void Adaptation::Icap::ModXact::prepEchoing()
 
     httpBuf.clean();
 
-    debugs(93, 7, HERE << "cloned virgin message " << oldHead << " to " <<
+    debugs(93, 7, "cloned virgin message " << oldHead << " to " <<
            adapted.header);
 
     // setup adapted body pipe if needed
     if (oldHead->body_pipe != NULL) {
-        debugs(93, 7, HERE << "will echo virgin body from " <<
+        debugs(93, 7, "will echo virgin body from " <<
                oldHead->body_pipe);
         if (!virginBodySending.active())
             virginBodySending.plan(); // will throw if not possible
@@ -1010,10 +1010,10 @@ void Adaptation::Icap::ModXact::prepEchoing()
         makeAdaptedBodyPipe("echoed virgin response");
         if (oldHead->body_pipe->bodySizeKnown())
             adapted.body_pipe->setBodySize(oldHead->body_pipe->bodySize());
-        debugs(93, 7, HERE << "will echo virgin body to " <<
+        debugs(93, 7, "will echo virgin body to " <<
                adapted.body_pipe);
     } else {
-        debugs(93, 7, HERE << "no virgin body to echo");
+        debugs(93, 7, "no virgin body to echo");
         stopSending(true);
     }
 }
@@ -1027,7 +1027,7 @@ void Adaptation::Icap::ModXact::prepPartialBodyEchoing(uint64_t pos)
 
     setOutcome(xoPartEcho);
 
-    debugs(93, 7, HERE << "will echo virgin body suffix from " <<
+    debugs(93, 7, "will echo virgin body suffix from " <<
            virgin.header->body_pipe << " offset " << pos );
 
     // check that use-original-body=N does not point beyond buffered data
@@ -1042,7 +1042,7 @@ void Adaptation::Icap::ModXact::prepPartialBodyEchoing(uint64_t pos)
     if (virgin.header->body_pipe->bodySizeKnown())
         adapted.body_pipe->expectProductionEndAfter(virgin.header->body_pipe->bodySize() - pos);
 
-    debugs(93, 7, HERE << "will echo virgin body suffix to " <<
+    debugs(93, 7, "will echo virgin body suffix to " <<
            adapted.body_pipe);
 
     // Start echoing data
@@ -1142,7 +1142,7 @@ bool Adaptation::Icap::ModXact::expectIcapTrailers() const
 void Adaptation::Icap::ModXact::decideOnParsingBody()
 {
     if (expectHttpBody()) {
-        debugs(93, 5, HERE << "expecting a body");
+        debugs(93, 5, "expecting a body");
         state.parsing = State::psBody;
         replyHttpBodySize = 0;
         bodyParser = new Http1::TeChunkedParser;
@@ -1150,7 +1150,7 @@ void Adaptation::Icap::ModXact::decideOnParsingBody()
         makeAdaptedBodyPipe("adapted response from the ICAP server");
         Must(state.sending == State::sendingAdapted);
     } else {
-        debugs(93, 5, HERE << "not expecting a body");
+        debugs(93, 5, "not expecting a body");
         if (trailerParser)
             state.parsing = State::psIcapTrailer;
         else
@@ -1195,10 +1195,10 @@ void Adaptation::Icap::ModXact::parseBody()
         return;
     }
 
-    debugs(93,3,HERE << this << " needsMoreData = " << bodyParser->needsMoreData());
+    debugs(93,3, this << " needsMoreData = " << bodyParser->needsMoreData());
 
     if (bodyParser->needsMoreData()) {
-        debugs(93,3,HERE << this);
+        debugs(93,3, this);
         Must(mayReadMore());
         readMore();
     }
@@ -1293,7 +1293,7 @@ Adaptation::Icap::ModXact::~ModXact()
 // internal cleanup
 void Adaptation::Icap::ModXact::swanSong()
 {
-    debugs(93, 5, HERE << "swan sings" << status());
+    debugs(93, 5, "swan sings" << status());
 
     stopWriting(false);
     stopSending(false);
@@ -1638,7 +1638,7 @@ Adaptation::Icap::ModXact::packHead(MemBuf &httpBuf, const Http::Message *head)
 void Adaptation::Icap::ModXact::decideOnPreview()
 {
     if (!TheConfig.preview_enable) {
-        debugs(93, 5, HERE << "preview disabled by squid.conf");
+        debugs(93, 5, "preview disabled by squid.conf");
         return;
     }
 
@@ -1659,7 +1659,7 @@ void Adaptation::Icap::ModXact::decideOnPreview()
     else if (virginBody.knownSize())
         ad = min(static_cast<uint64_t>(ad), virginBody.size()); // not more than we have
 
-    debugs(93, 5, HERE << "should offer " << ad << "-byte preview " <<
+    debugs(93, 5, "should offer " << ad << "-byte preview " <<
            "(service wanted " << wantedSize << ")");
 
     preview.enable(ad);
@@ -1840,7 +1840,7 @@ void Adaptation::Icap::ModXact::estimateVirginBody()
     // expectingBody returns true for zero-sized bodies, but we will not
     // get a pipe for that body, so we treat the message as bodyless
     if (method != Http::METHOD_NONE && msg->expectingBody(method, size) && size) {
-        debugs(93, 6, HERE << "expects virgin body from " <<
+        debugs(93, 6, "expects virgin body from " <<
                virgin.body_pipe << "; size: " << size);
 
         virginBody.expect(size);
@@ -1854,7 +1854,7 @@ void Adaptation::Icap::ModXact::estimateVirginBody()
         // make sure TheBackupLimit is in-sync with the buffer size
         Must(TheBackupLimit <= static_cast<size_t>(msg->body_pipe->buf().max_capacity));
     } else {
-        debugs(93, 6, HERE << "does not expect virgin body");
+        debugs(93, 6, "does not expect virgin body");
         Must(msg->body_pipe == NULL);
         checkConsuming();
     }
@@ -1866,7 +1866,7 @@ void Adaptation::Icap::ModXact::makeAdaptedBodyPipe(const char *what)
     Must(!adapted.header->body_pipe);
     adapted.header->body_pipe = new BodyPipe(this);
     adapted.body_pipe = adapted.header->body_pipe;
-    debugs(93, 7, HERE << "will supply " << what << " via " <<
+    debugs(93, 7, "will supply " << what << " via " <<
            adapted.body_pipe << " pipe");
 }
 
@@ -2044,7 +2044,7 @@ Adaptation::Icap::Xaction *Adaptation::Icap::ModXactLauncher::createXaction()
 
 void Adaptation::Icap::ModXactLauncher::swanSong()
 {
-    debugs(93, 5, HERE << "swan sings");
+    debugs(93, 5, "swan sings");
     updateHistory(false);
     Adaptation::Icap::Launcher::swanSong();
 }

--- a/src/adaptation/icap/ModXact.h
+++ b/src/adaptation/icap/ModXact.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/OptXact.cc
+++ b/src/adaptation/icap/OptXact.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -44,7 +44,7 @@ void Adaptation::Icap::OptXact::startShoveling()
     MemBuf requestBuf;
     requestBuf.init();
     makeRequest(requestBuf);
-    debugs(93, 9, HERE << "request " << status() << ":\n" <<
+    debugs(93, 9, "request " << status() << ":\n" <<
            (requestBuf.terminate(), requestBuf.content()));
     icap_tio_start = current_time;
     scheduleWrite(requestBuf);
@@ -75,7 +75,7 @@ void Adaptation::Icap::OptXact::makeRequest(MemBuf &buf)
 
 void Adaptation::Icap::OptXact::handleCommWrote(size_t size)
 {
-    debugs(93, 9, HERE << "finished writing " << size <<
+    debugs(93, 9, "finished writing " << size <<
            "-byte request " << status());
 }
 
@@ -89,7 +89,7 @@ void Adaptation::Icap::OptXact::handleCommRead(size_t)
         // we leave readAll false which forces connection closure.
         readAll = icapReply->header.getByNameListMember("Encapsulated",
                   "opt-body", ',').isEmpty();
-        debugs(93, 7, HERE << "readAll=" << readAll);
+        debugs(93, 7, "readAll=" << readAll);
         icap_tio_finish = current_time;
         setOutcome(xoOpt);
         sendAnswer(Answer::Forward(icapReply.getRaw()));

--- a/src/adaptation/icap/OptXact.h
+++ b/src/adaptation/icap/OptXact.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Options.cc
+++ b/src/adaptation/icap/Options.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -151,7 +151,7 @@ void Adaptation::Icap::Options::cfgIntHeader(const HttpHeader *h, const char *fn
     else
         value = -1;
 
-    debugs(93,5, HERE << "int header: " << fname << ": " << value);
+    debugs(93,5, "int header: " << fname << ": " << value);
 }
 
 void Adaptation::Icap::Options::cfgTransferList(const HttpHeader *h, TransferList &list)
@@ -162,7 +162,7 @@ void Adaptation::Icap::Options::cfgTransferList(const HttpHeader *h, TransferLis
 
     if (foundStar) {
         theTransfers.byDefault = &list;
-        debugs(93,5, HERE << "set default transfer to " << list.name);
+        debugs(93,5, "set default transfer to " << list.name);
     }
 
     list.report(5, "Adaptation::Icap::Options::cfgTransferList: ");

--- a/src/adaptation/icap/Options.h
+++ b/src/adaptation/icap/Options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/ServiceRep.cc
+++ b/src/adaptation/icap/ServiceRep.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -95,7 +95,7 @@ Adaptation::Icap::ServiceRep::finalize()
 void Adaptation::Icap::ServiceRep::noteFailure()
 {
     const int failures = theSessionFailures.count(1);
-    debugs(93,4, HERE << " failure " << failures << " out of " <<
+    debugs(93,4, " failure " << failures << " out of " <<
            TheConfig.service_failure_limit << " allowed in " <<
            TheConfig.oldest_service_failure << "sec " << status());
 
@@ -139,7 +139,7 @@ Adaptation::Icap::ServiceRep::getIdleConnection(const bool retriableXact)
         theIdleConns->closeN(1);
 
     ++theBusyConns;
-    debugs(93,3, HERE << "got connection: " << connection);
+    debugs(93,3, "got connection: " << connection);
     return connection;
 }
 
@@ -149,10 +149,10 @@ void Adaptation::Icap::ServiceRep::putConnection(const Comm::ConnectionPointer &
     Must(Comm::IsConnOpen(conn));
     // do not pool an idle connection if we owe connections
     if (isReusable && excessConnections() == 0) {
-        debugs(93, 3, HERE << "pushing pconn" << comment);
+        debugs(93, 3, "pushing pconn" << comment);
         theIdleConns->push(conn);
     } else {
-        debugs(93, 3, HERE << (sendReset ? "RST" : "FIN") << "-closing " <<
+        debugs(93, 3, (sendReset ? "RST" : "FIN") << "-closing " <<
                comment);
         // comm_close called from Connection::close will clear timeout
         // TODO: add "bool sendReset = false" to Connection::close()?
@@ -177,7 +177,7 @@ void Adaptation::Icap::ServiceRep::noteConnectionUse(const Comm::ConnectionPoint
 
 void Adaptation::Icap::ServiceRep::noteConnectionFailed(const char *comment)
 {
-    debugs(93, 3, HERE << "Connection failed: " << comment);
+    debugs(93, 3, "Connection failed: " << comment);
     --theBusyConns;
 }
 
@@ -263,7 +263,7 @@ void Adaptation::Icap::ServiceRep::busyCheckpoint()
         freed = available - notifiedWaiters;
     }
 
-    debugs(93,7, HERE << "Available connections: " << available <<
+    debugs(93,7, "Available connections: " << available <<
            " freed slots: " << freed <<
            " waiting in queue: " << theNotificationWaiters.size());
 
@@ -279,7 +279,7 @@ void Adaptation::Icap::ServiceRep::busyCheckpoint()
 void Adaptation::Icap::ServiceRep::suspend(const char *reason)
 {
     if (isSuspended) {
-        debugs(93,4, HERE << "keeping suspended, also for " << reason);
+        debugs(93,4, "keeping suspended, also for " << reason);
     } else {
         isSuspended = reason;
         debugs(93, DBG_IMPORTANT, "suspending ICAP service for " << reason);
@@ -370,11 +370,11 @@ void Adaptation::Icap::ServiceRep::noteTimeToUpdate()
         updateScheduled = false;
 
     if (detached() || theOptionsFetcher.set()) {
-        debugs(93,5, HERE << "ignores options update " << status());
+        debugs(93,5, "ignores options update " << status());
         return;
     }
 
-    debugs(93,5, HERE << "performs a regular options update " << status());
+    debugs(93,5, "performs a regular options update " << status());
     startGettingOptions();
 }
 
@@ -382,7 +382,7 @@ void Adaptation::Icap::ServiceRep::noteTimeToNotify()
 {
     Must(!notifying);
     notifying = true;
-    debugs(93,7, HERE << "notifies " << theClients.size() << " clients " <<
+    debugs(93,7, "notifies " << theClients.size() << " clients " <<
            status());
 
     // note: we must notify even if we are invalidated
@@ -421,7 +421,7 @@ void Adaptation::Icap::ServiceRep::callWhenReady(AsyncCall::Pointer &cb)
 {
     Must(cb!=NULL);
 
-    debugs(93,5, HERE << "Adaptation::Icap::Service is asked to call " << *cb <<
+    debugs(93,5, "Adaptation::Icap::Service is asked to call " << *cb <<
            " when ready " << status());
 
     Must(!broken()); // we do not wait for a broken service
@@ -442,7 +442,7 @@ void Adaptation::Icap::ServiceRep::callWhenReady(AsyncCall::Pointer &cb)
 
 void Adaptation::Icap::ServiceRep::scheduleNotification()
 {
-    debugs(93,7, HERE << "will notify " << theClients.size() << " clients");
+    debugs(93,7, "will notify " << theClients.size() << " clients");
     CallJobHere(93, 5, this, Adaptation::Icap::ServiceRep, noteTimeToNotify);
 }
 
@@ -453,7 +453,7 @@ bool Adaptation::Icap::ServiceRep::needNewOptions() const
 
 void Adaptation::Icap::ServiceRep::changeOptions(Adaptation::Icap::Options *newOptions)
 {
-    debugs(93,8, HERE << "changes options from " << theOptions << " to " <<
+    debugs(93,8, "changes options from " << theOptions << " to " <<
            newOptions << ' ' << status());
 
     delete theOptions;
@@ -540,7 +540,7 @@ void Adaptation::Icap::ServiceRep::noteAdaptationAnswer(const Answer &answer)
     clearAdaptation(theOptionsFetcher);
 
     if (answer.kind == Answer::akError) {
-        debugs(93,3, HERE << "failed to fetch options " << status());
+        debugs(93,3, "failed to fetch options " << status());
         handleNewOptions(0);
         return;
     }
@@ -549,7 +549,7 @@ void Adaptation::Icap::ServiceRep::noteAdaptationAnswer(const Answer &answer)
     const Http::Message *msg = answer.message.getRaw();
     Must(msg);
 
-    debugs(93,5, HERE << "is interpreting new options " << status());
+    debugs(93,5, "is interpreting new options " << status());
 
     Adaptation::Icap::Options *newOptions = NULL;
     if (const HttpReply *r = dynamic_cast<const HttpReply*>(msg)) {
@@ -577,7 +577,7 @@ void Adaptation::Icap::ServiceRep::handleNewOptions(Adaptation::Icap::Options *n
     // new options may be NULL
     changeOptions(newOptions);
 
-    debugs(93,3, HERE << "got new options and is now " << status());
+    debugs(93,3, "got new options and is now " << status());
 
     scheduleUpdate(optionsFetchTime());
 
@@ -587,7 +587,7 @@ void Adaptation::Icap::ServiceRep::handleNewOptions(Adaptation::Icap::Options *n
     // if we owe connections and have idle pconns, close the latter
     if (excess && theIdleConns->count() > 0) {
         const int n = min(excess, theIdleConns->count());
-        debugs(93,5, HERE << "closing " << n << " pconns to relief debt");
+        debugs(93,5, "closing " << n << " pconns to relief debt");
         theIdleConns->closeN(n);
     }
 
@@ -597,7 +597,7 @@ void Adaptation::Icap::ServiceRep::handleNewOptions(Adaptation::Icap::Options *n
 void Adaptation::Icap::ServiceRep::startGettingOptions()
 {
     Must(!theOptionsFetcher);
-    debugs(93,6, HERE << "will get new options " << status());
+    debugs(93,6, "will get new options " << status());
 
     // XXX: "this" here is "self"; works until refcounting API changes
     theOptionsFetcher = initiateAdaptation(
@@ -609,7 +609,7 @@ void Adaptation::Icap::ServiceRep::startGettingOptions()
 void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
 {
     if (updateScheduled) {
-        debugs(93,7, HERE << "reschedules update");
+        debugs(93,7, "reschedules update");
         // XXX: check whether the event is there because AR saw
         // an unreproducible eventDelete assertion on 2007/06/18
         if (eventFind(&ServiceRep_noteTimeToUpdate, this))
@@ -619,9 +619,9 @@ void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
         updateScheduled = false;
     }
 
-    debugs(93,7, HERE << "raw OPTIONS fetch at " << when << " or in " <<
+    debugs(93,7, "raw OPTIONS fetch at " << when << " or in " <<
            (when - squid_curtime) << " sec");
-    debugs(93,9, HERE << "last fetched at " << theLastUpdate << " or " <<
+    debugs(93,9, "last fetched at " << theLastUpdate << " or " <<
            (squid_curtime - theLastUpdate) << " sec ago");
 
     /* adjust update time to prevent too-frequent updates */
@@ -635,7 +635,7 @@ void Adaptation::Icap::ServiceRep::scheduleUpdate(time_t when)
         when = theLastUpdate + minUpdateGap;
 
     const int delay = when - squid_curtime;
-    debugs(93,5, HERE << "will fetch OPTIONS in " << delay << " sec");
+    debugs(93,5, "will fetch OPTIONS in " << delay << " sec");
 
     eventAdd("Adaptation::Icap::ServiceRep::noteTimeToUpdate",
              &ServiceRep_noteTimeToUpdate, this, delay, 0, true);
@@ -648,7 +648,7 @@ Adaptation::Icap::ServiceRep::optionsFetchTime() const
 {
     if (theOptions && theOptions->valid()) {
         const time_t expire = theOptions->expire();
-        debugs(93,7, HERE << "options expire on " << expire << " >= " << squid_curtime);
+        debugs(93,7, "options expire on " << expire << " >= " << squid_curtime);
 
         // conservative estimate of how long the OPTIONS transaction will take
         // XXX: move hard-coded constants from here to Adaptation::Icap::TheConfig
@@ -717,7 +717,7 @@ const char *Adaptation::Icap::ServiceRep::status() const
 
 void Adaptation::Icap::ServiceRep::detach()
 {
-    debugs(93,3, HERE << "detaching ICAP service: " << cfg().uri <<
+    debugs(93,3, "detaching ICAP service: " << cfg().uri <<
            ' ' << status());
     isDetached = true;
 }

--- a/src/adaptation/icap/ServiceRep.h
+++ b/src/adaptation/icap/ServiceRep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -226,7 +226,7 @@ void Adaptation::Icap::Xaction::closeConnection()
 
         if (reuseConnection && !doneWithIo()) {
             //status() adds leading spaces.
-            debugs(93,5, HERE << "not reusing pconn due to pending I/O" << status());
+            debugs(93,5, "not reusing pconn due to pending I/O" << status());
             reuseConnection = false;
         }
 
@@ -304,7 +304,7 @@ Adaptation::Icap::Xaction::useIcapConnection(const Comm::ConnectionPointer &conn
 
 void Adaptation::Icap::Xaction::dieOnConnectionFailure()
 {
-    debugs(93, 2, HERE << typeName <<
+    debugs(93, 2, typeName <<
            " failed to connect to " << service().cfg().uri);
     service().noteConnectionFailed("failure");
     static const auto d = MakeNamedErrorDetail("ICAP_XACT_START");
@@ -333,7 +333,7 @@ void Adaptation::Icap::Xaction::noteCommWrote(const CommIoCbParams &io)
     if (ignoreLastWrite) {
         // a hack due to comm inability to cancel a pending write
         ignoreLastWrite = false;
-        debugs(93, 7, HERE << "ignoring last write; status: " << io.flag);
+        debugs(93, 7, "ignoring last write; status: " << io.flag);
     } else {
         Must(io.flag == Comm::OK);
         al.icap.bytesSent += io.size;
@@ -345,7 +345,7 @@ void Adaptation::Icap::Xaction::noteCommWrote(const CommIoCbParams &io)
 // communication timeout with the ICAP service
 void Adaptation::Icap::Xaction::noteCommTimedout(const CommTimeoutCbParams &)
 {
-    debugs(93, 2, HERE << typeName << " failed: timeout with " <<
+    debugs(93, 2, typeName << " failed: timeout with " <<
            theService->cfg().methodStr() << " " <<
            theService->cfg().uri << status());
     reuseConnection = false;
@@ -378,7 +378,7 @@ void Adaptation::Icap::Xaction::callException(const std::exception  &e)
 void Adaptation::Icap::Xaction::callEnd()
 {
     if (doneWithIo()) {
-        debugs(93, 5, HERE << typeName << " done with I/O" << status());
+        debugs(93, 5, typeName << " done with I/O" << status());
         closeConnection();
     }
     Adaptation::Initiate::callEnd(); // may destroy us
@@ -545,7 +545,7 @@ void Adaptation::Icap::Xaction::noteInitiatorAborted()
 {
 
     if (theInitiator.set()) {
-        debugs(93,4, HERE << "Initiator gone before ICAP transaction ended");
+        debugs(93,4, "Initiator gone before ICAP transaction ended");
         clearInitiator();
         static const auto d = MakeNamedErrorDetail("ICAP_INIT_GONE");
         detailError(d);
@@ -560,7 +560,7 @@ void Adaptation::Icap::Xaction::setOutcome(const Adaptation::Icap::XactOutcome &
     if (al.icap.outcome != xoUnknown) {
         debugs(93, 3, "WARNING: resetting outcome: from " << al.icap.outcome << " to " << xo);
     } else {
-        debugs(93, 4, HERE << xo);
+        debugs(93, 4, xo);
     }
     al.icap.outcome = xo;
 }

--- a/src/adaptation/icap/Xaction.h
+++ b/src/adaptation/icap/Xaction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/icap_log.cc
+++ b/src/adaptation/icap/icap_log.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/icap/icap_log.h
+++ b/src/adaptation/icap/icap_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/adaptation/notes.dox
+++ b/src/adaptation/notes.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/Makefile.am
+++ b/src/anyp/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/ProtocolType.h
+++ b/src/anyp/ProtocolType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/ProtocolVersion.h
+++ b/src/anyp/ProtocolVersion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/TrafficMode.h
+++ b/src/anyp/TrafficMode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/UriScheme.cc
+++ b/src/anyp/UriScheme.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/UriScheme.h
+++ b/src/anyp/UriScheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/anyp/forward.h
+++ b/src/anyp/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -60,7 +60,7 @@ AuthenticateAcl(ACLChecklist *ch)
     switch (result) {
 
     case AUTH_ACL_CANNOT_AUTHENTICATE:
-        debugs(28, 4, HERE << "returning " << ACCESS_DENIED << " user authenticated but not authorised.");
+        debugs(28, 4, "returning " << ACCESS_DENIED << " user authenticated but not authorised.");
         return ACCESS_DENIED;
 
     case AUTH_AUTHENTICATED:
@@ -75,7 +75,7 @@ AuthenticateAcl(ACLChecklist *ch)
         return ACCESS_DUNNO; // XXX: break this down into DUNNO, EXPIRED_OK, EXPIRED_BAD states
 
     case AUTH_ACL_CHALLENGE:
-        debugs(28, 4, HERE << "returning " << ACCESS_AUTH_REQUIRED << " sending authentication challenge.");
+        debugs(28, 4, "returning " << ACCESS_AUTH_REQUIRED << " sending authentication challenge.");
         /* Client is required to resend the request with correct authentication
          * credentials. (This may be part of a stateful auth protocol.)
          * The request is denied.

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/AclMaxUserIp.cc
+++ b/src/auth/AclMaxUserIp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -115,7 +115,7 @@ ProxyAuthLookup::checkForAsync(ACLChecklist *cl) const
 {
     ACLFilledChecklist *checklist = Filled(cl);
 
-    debugs(28, 3, HERE << "checking password via authenticator");
+    debugs(28, 3, "checking password via authenticator");
 
     /* make sure someone created auth_user_request for us */
     assert(checklist->auth_user_request != NULL);

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/AuthAclState.h
+++ b/src/auth/AuthAclState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Config.cc
+++ b/src/auth/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Config.h
+++ b/src/auth/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/CredentialState.h
+++ b/src/auth/CredentialState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/CredentialsCache.cc
+++ b/src/auth/CredentialsCache.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/CredentialsCache.h
+++ b/src/auth/CredentialsCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Gadgets.cc
+++ b/src/auth/Gadgets.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -44,7 +44,7 @@ authenticateActiveSchemeCount(void)
             ++rv;
     }
 
-    debugs(29, 9, HERE << rv << " active.");
+    debugs(29, 9, rv << " active.");
 
     return rv;
 }
@@ -54,7 +54,7 @@ authenticateSchemeCount(void)
 {
     int rv = Auth::Scheme::GetSchemes().size();
 
-    debugs(29, 9, HERE << rv << " active.");
+    debugs(29, 9, rv << " active.");
 
     return rv;
 }

--- a/src/auth/Gadgets.h
+++ b/src/auth/Gadgets.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Makefile.am
+++ b/src/auth/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/QueueNode.h
+++ b/src/auth/QueueNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Scheme.cc
+++ b/src/auth/Scheme.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Scheme.h
+++ b/src/auth/Scheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/SchemeConfig.cc
+++ b/src/auth/SchemeConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -33,7 +33,7 @@ Auth::UserRequest::Pointer
 Auth::SchemeConfig::CreateAuthUser(const char *proxy_auth, AccessLogEntry::Pointer &al)
 {
     assert(proxy_auth != NULL);
-    debugs(29, 9, HERE << "header = '" << proxy_auth << "'");
+    debugs(29, 9, "header = '" << proxy_auth << "'");
 
     Auth::SchemeConfig *config = Find(proxy_auth);
 

--- a/src/auth/SchemeConfig.h
+++ b/src/auth/SchemeConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/SchemesConfig.cc
+++ b/src/auth/SchemesConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/SchemesConfig.h
+++ b/src/auth/SchemesConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/State.cc
+++ b/src/auth/State.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/State.h
+++ b/src/auth/State.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/Type.h
+++ b/src/auth/Type.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -32,7 +32,7 @@ Auth::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm) :
 {
     proxy_match_cache.head = proxy_match_cache.tail = NULL;
     ip_list.head = ip_list.tail = NULL;
-    debugs(29, 5, HERE << "Initialised auth_user '" << this << "'.");
+    debugs(29, 5, "Initialised auth_user '" << this << "'.");
 }
 
 Auth::CredentialState
@@ -64,7 +64,7 @@ Auth::User::absorb(Auth::User::Pointer from)
      *  dlink_list proxy_match_cache;
      */
 
-    debugs(29, 5, HERE << "auth_user '" << from << "' into auth_user '" << this << "'.");
+    debugs(29, 5, "auth_user '" << from << "' into auth_user '" << this << "'.");
 
     // combine the helper response annotations. Ensuring no duplicates are copied.
     notes.appendNewOnly(&from->notes);
@@ -120,7 +120,7 @@ Auth::User::absorb(Auth::User::Pointer from)
 
 Auth::User::~User()
 {
-    debugs(29, 5, HERE << "Freeing auth_user '" << this << "'.");
+    debugs(29, 5, "Freeing auth_user '" << this << "'.");
     assert(LockCount() == 0);
 
     /* free cached acl results */
@@ -223,7 +223,7 @@ Auth::User::addIp(Ip::Address ipaddr)
 
     ++ipcount;
 
-    debugs(29, 2, HERE << "user '" << username() << "' has been seen at a new IP address (" << ipaddr << ")");
+    debugs(29, 2, "user '" << username() << "' has been seen at a new IP address (" << ipaddr << ")");
 }
 
 SBuf

--- a/src/auth/User.h
+++ b/src/auth/User.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/UserRequest.cc
+++ b/src/auth/UserRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -52,27 +52,27 @@ Auth::UserRequest::start(HttpRequest *request, AccessLogEntry::Pointer &al, AUTH
 bool
 Auth::UserRequest::valid() const
 {
-    debugs(29, 9, HERE << "Validating Auth::UserRequest '" << this << "'.");
+    debugs(29, 9, "Validating Auth::UserRequest '" << this << "'.");
 
     if (user() == NULL) {
-        debugs(29, 4, HERE << "No associated Auth::User data");
+        debugs(29, 4, "No associated Auth::User data");
         return false;
     }
 
     if (user()->auth_type == Auth::AUTH_UNKNOWN) {
-        debugs(29, 4, HERE << "Auth::User '" << user() << "' uses unknown scheme.");
+        debugs(29, 4, "Auth::User '" << user() << "' uses unknown scheme.");
         return false;
     }
 
     if (user()->auth_type == Auth::AUTH_BROKEN) {
-        debugs(29, 4, HERE << "Auth::User '" << user() << "' is broken for it's scheme.");
+        debugs(29, 4, "Auth::User '" << user() << "' is broken for it's scheme.");
         return false;
     }
 
     /* any other sanity checks that we need in the future */
 
     /* finally return ok */
-    debugs(29, 5, HERE << "Validated. Auth::UserRequest '" << this << "'.");
+    debugs(29, 5, "Validated. Auth::UserRequest '" << this << "'.");
     return true;
 }
 
@@ -94,13 +94,13 @@ Auth::UserRequest::UserRequest():
     message(NULL),
     lastReply(AUTH_ACL_CANNOT_AUTHENTICATE)
 {
-    debugs(29, 5, HERE << "initialised request " << this);
+    debugs(29, 5, "initialised request " << this);
 }
 
 Auth::UserRequest::~UserRequest()
 {
     assert(LockCount()==0);
-    debugs(29, 5, HERE << "freeing request " << this);
+    debugs(29, 5, "freeing request " << this);
 
     if (user() != NULL) {
         /* release our references to the user credentials */
@@ -289,7 +289,7 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
     /* a) can we find other credentials to use? and b) are they logged in already? */
     if (proxy_auth == NULL && !authenticateUserAuthenticated(authTryGetUser(*auth_user_request,conn,request))) {
         /* no header or authentication failed/got corrupted - restart */
-        debugs(29, 4, HERE << "No Proxy-Auth header and no working alternative. Requesting auth header.");
+        debugs(29, 4, "No Proxy-Auth header and no working alternative. Requesting auth header.");
 
         /* something wrong with the AUTH credentials. Force a new attempt */
 
@@ -327,11 +327,11 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
 
     /* we have a proxy auth header and as far as we know this connection has
      * not had bungled connection oriented authentication happen on it. */
-    debugs(29, 9, HERE << "header " << (proxy_auth ? proxy_auth : "-") << ".");
+    debugs(29, 9, "header " << (proxy_auth ? proxy_auth : "-") << ".");
 
     if (*auth_user_request == NULL) {
         if (conn != NULL) {
-            debugs(29, 9, HERE << "This is a new checklist test on:" << conn->clientConnection);
+            debugs(29, 9, "This is a new checklist test on:" << conn->clientConnection);
         }
 
         if (proxy_auth && request->auth_user_request == NULL && conn != NULL && conn->getAuth() != NULL) {
@@ -349,7 +349,7 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
 
         if (request->auth_user_request == NULL && (conn == NULL || conn->getAuth() == NULL)) {
             /* beginning of a new request check */
-            debugs(29, 4, HERE << "No connection authentication type");
+            debugs(29, 4, "No connection authentication type");
 
             *auth_user_request = Auth::SchemeConfig::CreateAuthUser(proxy_auth, al);
             if (*auth_user_request == NULL)
@@ -374,7 +374,7 @@ Auth::UserRequest::authenticate(Auth::UserRequest::Pointer * auth_user_request, 
                 *auth_user_request = conn->getAuth();
             } else {
                 /* failed connection based authentication */
-                debugs(29, 4, HERE << "Auth user request " << *auth_user_request << " conn-auth missing and failed to authenticate.");
+                debugs(29, 4, "Auth user request " << *auth_user_request << " conn-auth missing and failed to authenticate.");
                 *auth_user_request = NULL;
                 return AUTH_ACL_CHALLENGE;
             }
@@ -520,7 +520,7 @@ Auth::UserRequest::AddReplyAuthHeader(HttpReply * rep, Auth::UserRequest::Pointe
                     else
                         scheme->fixHeader(NULL, rep, type, request);
                 } else
-                    debugs(29, 4, HERE << "Configured scheme " << scheme->type() << " not Active");
+                    debugs(29, 4, "Configured scheme " << scheme->type() << " not Active");
             }
         }
 

--- a/src/auth/UserRequest.h
+++ b/src/auth/UserRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -59,11 +59,11 @@ bool
 Auth::Basic::Config::configured() const
 {
     if ((authenticateProgram != NULL) && (authenticateChildren.n_max != 0) && !realm.isEmpty()) {
-        debugs(29, 9, HERE << "returning configured");
+        debugs(29, 9, "returning configured");
         return true;
     }
 
-    debugs(29, 9, HERE << "returning unconfigured");
+    debugs(29, 9, "returning unconfigured");
     return false;
 }
 
@@ -193,7 +193,7 @@ Auth::Basic::Config::decodeCleartext(const char *httpAuthHeader, const HttpReque
          * Don't allow NL or CR in the credentials.
          * Oezguer Kesim <oec@codeblau.de>
          */
-        debugs(29, 9, HERE << "'" << cleartext << "'");
+        debugs(29, 9, "'" << cleartext << "'");
 
         if (strcspn(cleartext, "\r\n") != strlen(cleartext)) {
             debugs(29, DBG_IMPORTANT, "WARNING: Bad characters in authorization header '" << httpAuthHeader << "'");
@@ -247,11 +247,11 @@ Auth::Basic::Config::decode(char const *proxy_auth, const HttpRequest *request, 
     local_basic->username(cleartext);
 
     if (local_basic->passwd == NULL) {
-        debugs(29, 4, HERE << "no password in proxy authorization header '" << proxy_auth << "'");
+        debugs(29, 4, "no password in proxy authorization header '" << proxy_auth << "'");
         auth_user_request->setDenyMessage("no password was present in the HTTP [proxy-]authorization header. This is most likely a browser bug");
     } else {
         if (local_basic->passwd[0] == '\0') {
-            debugs(29, 4, HERE << "Disallowing empty password. User is '" << local_basic->username() << "'");
+            debugs(29, 4, "Disallowing empty password. User is '" << local_basic->username() << "'");
             safe_free(local_basic->passwd);
             auth_user_request->setDenyMessage("Request denied because you provided an empty password. Users MUST have a password.");
         }
@@ -271,7 +271,7 @@ Auth::Basic::Config::decode(char const *proxy_auth, const HttpRequest *request, 
     if (!(auth_user = Auth::Basic::User::Cache()->lookup(lb->userKey()))) {
         /* the user doesn't exist in the username cache yet */
         /* save the credentials */
-        debugs(29, 9, HERE << "Creating new user '" << lb->username() << "'");
+        debugs(29, 9, "Creating new user '" << lb->username() << "'");
         /* set the auth_user type */
         lb->auth_type = Auth::AUTH_BASIC;
         /* current time for timeouts */

--- a/src/auth/basic/Config.h
+++ b/src/auth/basic/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/DB/Makefile.am
+++ b/src/auth/basic/DB/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/DB/basic_db_auth.pl.in
+++ b/src/auth/basic/DB/basic_db_auth.pl.in
@@ -92,7 +92,7 @@ This manual was written by I<Henrik Nordstrom <henrik@henriknordstrom.net>>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/DB/passwd.sql
+++ b/src/auth/basic/DB/passwd.sql
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/DB/required.m4
+++ b/src/auth/basic/DB/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/LDAP/Makefile.am
+++ b/src/auth/basic/LDAP/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/LDAP/basic_ldap_auth.8
+++ b/src/auth/basic/LDAP/basic_ldap_auth.8
@@ -305,7 +305,7 @@ This manual is written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/LDAP/basic_ldap_auth.cc
+++ b/src/auth/basic/LDAP/basic_ldap_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/LDAP/required.m4
+++ b/src/auth/basic/LDAP/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/Makefile.am
+++ b/src/auth/basic/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/NCSA/Makefile.am
+++ b/src/auth/basic/NCSA/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/NCSA/basic_ncsa_auth.8
+++ b/src/auth/basic/NCSA/basic_ncsa_auth.8
@@ -57,7 +57,7 @@ Based on original documentation by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/NCSA/basic_ncsa_auth.cc
+++ b/src/auth/basic/NCSA/basic_ncsa_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/NCSA/crypt_md5.cc
+++ b/src/auth/basic/NCSA/crypt_md5.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/NCSA/crypt_md5.h
+++ b/src/auth/basic/NCSA/crypt_md5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/NCSA/required.m4
+++ b/src/auth/basic/NCSA/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/NIS/Makefile.am
+++ b/src/auth/basic/NIS/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/NIS/basic_nis_auth.cc
+++ b/src/auth/basic/NIS/basic_nis_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/NIS/nis_support.cc
+++ b/src/auth/basic/NIS/nis_support.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/NIS/nis_support.h
+++ b/src/auth/basic/NIS/nis_support.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/NIS/required.m4
+++ b/src/auth/basic/NIS/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/PAM/Makefile.am
+++ b/src/auth/basic/PAM/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/PAM/basic_pam_auth.8
+++ b/src/auth/basic/PAM/basic_pam_auth.8
@@ -81,7 +81,7 @@ This program and documentation was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/PAM/basic_pam_auth.cc
+++ b/src/auth/basic/PAM/basic_pam_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/PAM/required.m4
+++ b/src/auth/basic/PAM/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/POP3/Makefile.am
+++ b/src/auth/basic/POP3/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/POP3/basic_pop3_auth.pl.in
+++ b/src/auth/basic/POP3/basic_pop3_auth.pl.in
@@ -30,7 +30,7 @@ This manual was written by I<Amos Jeffries <squid3@treenet.co.nz>>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/POP3/required.m4
+++ b/src/auth/basic/POP3/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/RADIUS/Makefile.am
+++ b/src/auth/basic/RADIUS/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/RADIUS/basic_radius_auth.8
+++ b/src/auth/basic/RADIUS/basic_radius_auth.8
@@ -96,7 +96,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/RADIUS/basic_radius_auth.cc
+++ b/src/auth/basic/RADIUS/basic_radius_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/RADIUS/radius-util.cc
+++ b/src/auth/basic/RADIUS/radius-util.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/RADIUS/radius-util.h
+++ b/src/auth/basic/RADIUS/radius-util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/RADIUS/radius.h
+++ b/src/auth/basic/RADIUS/radius.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/RADIUS/required.m4
+++ b/src/auth/basic/RADIUS/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SASL/Makefile.am
+++ b/src/auth/basic/SASL/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SASL/basic_sasl_auth.8
+++ b/src/auth/basic/SASL/basic_sasl_auth.8
@@ -80,7 +80,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SASL/basic_sasl_auth.cc
+++ b/src/auth/basic/SASL/basic_sasl_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SASL/basic_sasl_auth.conf
+++ b/src/auth/basic/SASL/basic_sasl_auth.conf
@@ -1,5 +1,5 @@
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SASL/basic_sasl_auth.pam
+++ b/src/auth/basic/SASL/basic_sasl_auth.pam
@@ -1,6 +1,6 @@
 #%PAM-1.0
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SASL/required.m4
+++ b/src/auth/basic/SASL/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB/Makefile.am
+++ b/src/auth/basic/SMB/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB/basic_smb_auth.cc
+++ b/src/auth/basic/SMB/basic_smb_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB/basic_smb_auth.sh
+++ b/src/auth/basic/SMB/basic_smb_auth.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB/required.m4
+++ b/src/auth/basic/SMB/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB_LM/Makefile.am
+++ b/src/auth/basic/SMB_LM/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB_LM/msntauth.cc
+++ b/src/auth/basic/SMB_LM/msntauth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB_LM/msntauth.h
+++ b/src/auth/basic/SMB_LM/msntauth.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB_LM/required.m4
+++ b/src/auth/basic/SMB_LM/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB_LM/valid.cc
+++ b/src/auth/basic/SMB_LM/valid.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SMB_LM/valid.h
+++ b/src/auth/basic/SMB_LM/valid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SSPI/Makefile.am
+++ b/src/auth/basic/SSPI/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SSPI/basic_sspi_auth.8
+++ b/src/auth/basic/SSPI/basic_sspi_auth.8
@@ -134,7 +134,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SSPI/basic_sspi_auth.cc
+++ b/src/auth/basic/SSPI/basic_sspi_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SSPI/required.m4
+++ b/src/auth/basic/SSPI/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/SSPI/valid.cc
+++ b/src/auth/basic/SSPI/valid.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/SSPI/valid.h
+++ b/src/auth/basic/SSPI/valid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/Scheme.cc
+++ b/src/auth/basic/Scheme.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/Scheme.h
+++ b/src/auth/basic/Scheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/User.cc
+++ b/src/auth/basic/User.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -61,12 +61,12 @@ Auth::Basic::User::valid() const
 void
 Auth::Basic::User::updateCached(Auth::Basic::User *from)
 {
-    debugs(29, 9, HERE << "Found user '" << from->username() << "' already in the user cache as '" << this << "'");
+    debugs(29, 9, "Found user '" << from->username() << "' already in the user cache as '" << this << "'");
 
     assert(strcmp(from->username(), username()) == 0);
 
     if (strcmp(from->passwd, passwd)) {
-        debugs(29, 4, HERE << "new password found. Updating in user master record and resetting auth state to unchecked");
+        debugs(29, 4, "new password found. Updating in user master record and resetting auth state to unchecked");
         credentials(Auth::Unchecked);
         xfree(passwd);
         passwd = from->passwd;
@@ -74,7 +74,7 @@ Auth::Basic::User::updateCached(Auth::Basic::User *from)
     }
 
     if (credentials() == Auth::Failed) {
-        debugs(29, 4, HERE << "last attempt to authenticate this user failed, resetting auth state to unchecked");
+        debugs(29, 4, "last attempt to authenticate this user failed, resetting auth state to unchecked");
         credentials(Auth::Unchecked);
     }
 }

--- a/src/auth/basic/User.h
+++ b/src/auth/basic/User.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/UserRequest.cc
+++ b/src/auth/basic/UserRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -58,12 +58,12 @@ Auth::Basic::UserRequest::authenticate(HttpRequest *, ConnStateData *, Http::Hdr
 
     /* are we about to recheck the credentials externally? */
     if ((user()->expiretime + static_cast<Auth::Basic::Config*>(Auth::SchemeConfig::Find("basic"))->credentialsTTL) <= squid_curtime) {
-        debugs(29, 4, HERE << "credentials expired - rechecking");
+        debugs(29, 4, "credentials expired - rechecking");
         return;
     }
 
     /* we have been through the external helper, and the credentials haven't expired */
-    debugs(29, 9, HERE << "user '" << user()->username() << "' authenticated");
+    debugs(29, 9, "user '" << user()->username() << "' authenticated");
 
     /* Decode now takes care of finding the AuthUser struct in the cache */
     /* after external auth occurs anyway */
@@ -103,7 +103,7 @@ Auth::Basic::UserRequest::startHelperLookup(HttpRequest *request, AccessLogEntry
     assert(user()->auth_type == Auth::AUTH_BASIC);
     Auth::Basic::User *basic_auth = dynamic_cast<Auth::Basic::User *>(user().getRaw());
     assert(basic_auth != NULL);
-    debugs(29, 9, HERE << "'" << basic_auth->username() << ":" << basic_auth->passwd << "'");
+    debugs(29, 9, "'" << basic_auth->username() << ":" << basic_auth->passwd << "'");
 
     if (static_cast<Auth::Basic::Config*>(Auth::SchemeConfig::Find("basic"))->authenticateProgram == NULL) {
         debugs(29, DBG_CRITICAL, "ERROR: No Basic authentication program configured.");
@@ -155,7 +155,7 @@ Auth::Basic::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 {
     Auth::StateData *r = static_cast<Auth::StateData *>(data);
     void *cbdata;
-    debugs(29, 5, HERE << "reply=" << reply);
+    debugs(29, 5, "reply=" << reply);
 
     assert(r->auth_user_request != NULL);
     assert(r->auth_user_request->user()->auth_type == Auth::AUTH_BASIC);

--- a/src/auth/basic/UserRequest.h
+++ b/src/auth/basic/UserRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/fake/Makefile.am
+++ b/src/auth/basic/fake/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/fake/fake.cc
+++ b/src/auth/basic/fake/fake.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/fake/required.m4
+++ b/src/auth/basic/fake/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/getpwnam/Makefile.am
+++ b/src/auth/basic/getpwnam/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/getpwnam/basic_getpwnam_auth.8
+++ b/src/auth/basic/getpwnam/basic_getpwnam_auth.8
@@ -74,7 +74,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/getpwnam/basic_getpwnam_auth.cc
+++ b/src/auth/basic/getpwnam/basic_getpwnam_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/basic/getpwnam/required.m4
+++ b/src/auth/basic/getpwnam/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/basic/helpers.m4
+++ b/src/auth/basic/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/LDAP/Makefile.am
+++ b/src/auth/digest/LDAP/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/LDAP/digest_common.h
+++ b/src/auth/digest/LDAP/digest_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/LDAP/digest_pw_auth.cc
+++ b/src/auth/digest/LDAP/digest_pw_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/LDAP/ldap_backend.cc
+++ b/src/auth/digest/LDAP/ldap_backend.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/LDAP/ldap_backend.h
+++ b/src/auth/digest/LDAP/ldap_backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/LDAP/required.m4
+++ b/src/auth/digest/LDAP/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/Makefile.am
+++ b/src/auth/digest/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/Scheme.cc
+++ b/src/auth/digest/Scheme.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/Scheme.h
+++ b/src/auth/digest/Scheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/User.cc
+++ b/src/auth/digest/User.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/User.h
+++ b/src/auth/digest/User.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -288,7 +288,7 @@ Auth::Digest::UserRequest::startHelperLookup(HttpRequest *request, AccessLogEntr
     char buf[8192];
 
     assert(user() != NULL && user()->auth_type == Auth::AUTH_DIGEST);
-    debugs(29, 9, HERE << "'\"" << user()->username() << "\":\"" << realm << "\"'");
+    debugs(29, 9, "'\"" << user()->username() << "\":\"" << realm << "\"'");
 
     if (static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->authenticateProgram == NULL) {
         debugs(29, DBG_CRITICAL, "ERROR: No Digest authentication program configured.");
@@ -310,7 +310,7 @@ void
 Auth::Digest::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
 {
     Auth::StateData *replyData = static_cast<Auth::StateData *>(data);
-    debugs(29, 9, HERE << "reply=" << reply);
+    debugs(29, 9, "reply=" << reply);
 
     assert(replyData->auth_user_request != NULL);
     Auth::UserRequest::Pointer auth_user_request = replyData->auth_user_request;

--- a/src/auth/digest/UserRequest.h
+++ b/src/auth/digest/UserRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/Makefile.am
+++ b/src/auth/digest/eDirectory/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/digest_common.h
+++ b/src/auth/digest/eDirectory/digest_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/digest_pw_auth.cc
+++ b/src/auth/digest/eDirectory/digest_pw_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/edir_ldapext.cc
+++ b/src/auth/digest/eDirectory/edir_ldapext.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/edir_ldapext.h
+++ b/src/auth/digest/eDirectory/edir_ldapext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/ldap_backend.cc
+++ b/src/auth/digest/eDirectory/ldap_backend.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/ldap_backend.h
+++ b/src/auth/digest/eDirectory/ldap_backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/eDirectory/required.m4
+++ b/src/auth/digest/eDirectory/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/file/Makefile.am
+++ b/src/auth/digest/file/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/file/digest_common.h
+++ b/src/auth/digest/file/digest_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/file/digest_file_auth.8
+++ b/src/auth/digest/file/digest_file_auth.8
@@ -71,7 +71,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/file/digest_file_auth.cc
+++ b/src/auth/digest/file/digest_file_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/file/required.m4
+++ b/src/auth/digest/file/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/digest/file/text_backend.cc
+++ b/src/auth/digest/file/text_backend.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/file/text_backend.h
+++ b/src/auth/digest/file/text_backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/digest/helpers.m4
+++ b/src/auth/digest/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/forward.h
+++ b/src/auth/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -126,11 +126,11 @@ bool
 Auth::Negotiate::Config::configured() const
 {
     if (authenticateProgram && (authenticateChildren.n_max != 0)) {
-        debugs(29, 9, HERE << "returning configured");
+        debugs(29, 9, "returning configured");
         return true;
     }
 
-    debugs(29, 9, HERE << "returning unconfigured");
+    debugs(29, 9, "returning unconfigured");
     return false;
 }
 
@@ -146,7 +146,7 @@ Auth::Negotiate::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request,
 
     /* New request, no user details */
     if (auth_user_request == NULL) {
-        debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate'");
+        debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate'");
         httpHeaderPutStrf(&rep->header, reqType, "Negotiate");
 
         if (!keep_alive) {
@@ -172,11 +172,11 @@ Auth::Negotiate::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request,
              * Need to start over to give the client another chance.
              */
             if (negotiate_request->server_blob) {
-                debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
+                debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
                 httpHeaderPutStrf(&rep->header, reqType, "Negotiate %s", negotiate_request->server_blob);
                 safe_free(negotiate_request->server_blob);
             } else {
-                debugs(29, 9, HERE << "Connection authenticated");
+                debugs(29, 9, "Connection authenticated");
                 httpHeaderPutStrf(&rep->header, reqType, "Negotiate");
             }
             break;
@@ -184,13 +184,13 @@ Auth::Negotiate::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request,
         case Auth::Unchecked:
             /* semantic change: do not drop the connection.
              * 2.5 implementation used to keep it open - Kinkie */
-            debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate'");
+            debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate'");
             httpHeaderPutStrf(&rep->header, reqType, "Negotiate");
             break;
 
         case Auth::Handshake:
             /* we're waiting for a response from the client. Pass it the blob */
-            debugs(29, 9, HERE << "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
+            debugs(29, 9, "Sending type:" << reqType << " header: 'Negotiate " << negotiate_request->server_blob << "'");
             httpHeaderPutStrf(&rep->header, reqType, "Negotiate %s", negotiate_request->server_blob);
             safe_free(negotiate_request->server_blob);
             break;
@@ -226,7 +226,7 @@ Auth::Negotiate::Config::decode(char const *proxy_auth, const HttpRequest *, con
     auth_user_request->user()->BuildUserKey(proxy_auth, aRequestRealm);
 
     /* all we have to do is identify that it's Negotiate - the helper does the rest */
-    debugs(29, 9, HERE << "decode Negotiate authentication");
+    debugs(29, 9, "decode Negotiate authentication");
     return auth_user_request;
 }
 

--- a/src/auth/negotiate/Config.h
+++ b/src/auth/negotiate/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/Makefile.am
+++ b/src/auth/negotiate/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/SSPI/Makefile.am
+++ b/src/auth/negotiate/SSPI/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/SSPI/negotiate_sspi_auth.8
+++ b/src/auth/negotiate/SSPI/negotiate_sspi_auth.8
@@ -73,7 +73,7 @@ Based on prior work of
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
+++ b/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/SSPI/required.m4
+++ b/src/auth/negotiate/SSPI/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/Scheme.cc
+++ b/src/auth/negotiate/Scheme.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/Scheme.h
+++ b/src/auth/negotiate/Scheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/User.cc
+++ b/src/auth/negotiate/User.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -19,7 +19,7 @@ Auth::Negotiate::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRea
 
 Auth::Negotiate::User::~User()
 {
-    debugs(29, 5, HERE << "doing nothing to clear Negotiate scheme data for '" << this << "'");
+    debugs(29, 5, "doing nothing to clear Negotiate scheme data for '" << this << "'");
 }
 
 int32_t

--- a/src/auth/negotiate/User.h
+++ b/src/auth/negotiate/User.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/UserRequest.cc
+++ b/src/auth/negotiate/UserRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -58,11 +58,11 @@ int
 Auth::Negotiate::UserRequest::authenticated() const
 {
     if (user() != NULL && user()->credentials() == Auth::Ok) {
-        debugs(29, 9, HERE << "user authenticated.");
+        debugs(29, 9, "user authenticated.");
         return 1;
     }
 
-    debugs(29, 9, HERE << "user not fully authenticated.");
+    debugs(29, 9, "user not fully authenticated.");
     return 0;
 }
 
@@ -133,7 +133,7 @@ Auth::Negotiate::UserRequest::startHelperLookup(HttpRequest *, AccessLogEntry::P
         return;
     }
 
-    debugs(29, 8, HERE << "credentials state is '" << user()->credentials() << "'");
+    debugs(29, 8, "credentials state is '" << user()->credentials() << "'");
 
     const char *keyExtras = helperRequestKeyExtras(request, al);
     int printResult = 0;
@@ -178,7 +178,7 @@ Auth::Negotiate::UserRequest::releaseAuthServer()
         negotiateauthenticators->cancelReservation(reservationId);
         reservationId.clear();
     } else
-        debugs(29, 6, HERE << "No Negotiate auth server to release.");
+        debugs(29, 6, "No Negotiate auth server to release.");
 }
 
 void
@@ -199,7 +199,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
     }
 
     if (server_blob) {
-        debugs(29, 2, HERE << "need to challenge client '" << server_blob << "'!");
+        debugs(29, 2, "need to challenge client '" << server_blob << "'!");
         return;
     }
 
@@ -224,7 +224,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
 
     case Auth::Unchecked:
         /* we've received a negotiate request. pass to a helper */
-        debugs(29, 9, HERE << "auth state negotiate none. Received blob: '" << proxy_auth << "'");
+        debugs(29, 9, "auth state negotiate none. Received blob: '" << proxy_auth << "'");
         user()->credentials(Auth::Pending);
         safe_free(client_blob);
         client_blob=xstrdup(blob);
@@ -235,7 +235,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
         break;
 
     case Auth::Pending:
-        debugs(29, DBG_IMPORTANT, HERE << "need to ask helper");
+        debugs(29, DBG_IMPORTANT, "need to ask helper");
         break;
 
     case Auth::Handshake:
@@ -255,7 +255,7 @@ Auth::Negotiate::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData
 
     case Auth::Failed:
         /* we've failed somewhere in authentication */
-        debugs(29, 9, HERE << "auth state negotiate failed. " << proxy_auth);
+        debugs(29, 9, "auth state negotiate failed. " << proxy_auth);
         break;
     }
 }
@@ -308,7 +308,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
             lm_request->server_blob = xstrdup(tokenNote);
             auth_user_request->user()->credentials(Auth::Handshake);
             auth_user_request->setDenyMessage("Authentication in progress");
-            debugs(29, 4, HERE << "Need to challenge the client with a server token: '" << tokenNote << "'");
+            debugs(29, 4, "Need to challenge the client with a server token: '" << tokenNote << "'");
         } else {
             auth_user_request->user()->credentials(Auth::Failed);
             auth_user_request->setDenyMessage("Negotiate authentication requires a persistent connection");
@@ -333,7 +333,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
         lm_request->releaseAuthServer();
 
         /* connection is authenticated */
-        debugs(29, 4, HERE << "authenticated user " << auth_user_request->user()->username());
+        debugs(29, 4, "authenticated user " << auth_user_request->user()->username());
         auto local_auth_user = lm_request->user();
         auto cached_user = Auth::Negotiate::User::Cache()->lookup(auth_user_request->user()->userKey());
         if (!cached_user) {
@@ -352,7 +352,7 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
          * existing user or a new user */
         local_auth_user->expiretime = current_time.tv_sec;
         auth_user_request->user()->credentials(Auth::Ok);
-        debugs(29, 4, HERE << "Successfully validated user via Negotiate. Username '" << auth_user_request->user()->username() << "'");
+        debugs(29, 4, "Successfully validated user via Negotiate. Username '" << auth_user_request->user()->username() << "'");
     }
     break;
 

--- a/src/auth/negotiate/UserRequest.h
+++ b/src/auth/negotiate/UserRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/helpers.m4
+++ b/src/auth/negotiate/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/kerberos/Makefile.am
+++ b/src/auth/negotiate/kerberos/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/kerberos/negotiate_kerberos.h
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth_test.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_pac.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_pac.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/kerberos/required.m4
+++ b/src/auth/negotiate/kerberos/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/kerberos/test_negotiate_auth.sh
+++ b/src/auth/negotiate/kerberos/test_negotiate_auth.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/wrapper/Makefile.am
+++ b/src/auth/negotiate/wrapper/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/wrapper/negotiate_wrapper.cc
+++ b/src/auth/negotiate/wrapper/negotiate_wrapper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/negotiate/wrapper/required.m4
+++ b/src/auth/negotiate/wrapper/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -125,11 +125,11 @@ bool
 Auth::Ntlm::Config::configured() const
 {
     if ((authenticateProgram != NULL) && (authenticateChildren.n_max != 0)) {
-        debugs(29, 9, HERE << "returning configured");
+        debugs(29, 9, "returning configured");
         return true;
     }
 
-    debugs(29, 9, HERE << "returning unconfigured");
+    debugs(29, 9, "returning unconfigured");
     return false;
 }
 
@@ -147,7 +147,7 @@ Auth::Ntlm::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Http
 
     /* New request, no user details */
     if (auth_user_request == NULL) {
-        debugs(29, 9, HERE << "Sending type:" << hdrType << " header: 'NTLM'");
+        debugs(29, 9, "Sending type:" << hdrType << " header: 'NTLM'");
         httpHeaderPutStrf(&rep->header, hdrType, "NTLM");
 
         if (!keep_alive) {
@@ -175,13 +175,13 @@ Auth::Ntlm::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Http
         case Auth::Unchecked:
             /* semantic change: do not drop the connection.
              * 2.5 implementation used to keep it open - Kinkie */
-            debugs(29, 9, HERE << "Sending type:" << hdrType << " header: 'NTLM'");
+            debugs(29, 9, "Sending type:" << hdrType << " header: 'NTLM'");
             httpHeaderPutStrf(&rep->header, hdrType, "NTLM");
             break;
 
         case Auth::Handshake:
             /* we're waiting for a response from the client. Pass it the blob */
-            debugs(29, 9, HERE << "Sending type:" << hdrType << " header: 'NTLM " << ntlm_request->server_blob << "'");
+            debugs(29, 9, "Sending type:" << hdrType << " header: 'NTLM " << ntlm_request->server_blob << "'");
             httpHeaderPutStrf(&rep->header, hdrType, "NTLM %s", ntlm_request->server_blob);
             safe_free(ntlm_request->server_blob);
             break;
@@ -217,7 +217,7 @@ Auth::Ntlm::Config::decode(char const *proxy_auth, const HttpRequest *, const ch
     auth_user_request->user()->BuildUserKey(proxy_auth, aRequestRealm);
 
     /* all we have to do is identify that it's NTLM - the helper does the rest */
-    debugs(29, 9, HERE << "decode: NTLM authentication");
+    debugs(29, 9, "decode: NTLM authentication");
     return auth_user_request;
 }
 

--- a/src/auth/ntlm/Config.h
+++ b/src/auth/ntlm/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/Makefile.am
+++ b/src/auth/ntlm/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/SMB_LM/Makefile.am
+++ b/src/auth/ntlm/SMB_LM/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/SMB_LM/ntlm_smb_lm_auth.cc
+++ b/src/auth/ntlm/SMB_LM/ntlm_smb_lm_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/SMB_LM/required.m4
+++ b/src/auth/ntlm/SMB_LM/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/SSPI/Makefile.am
+++ b/src/auth/ntlm/SSPI/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/SSPI/ntlm_sspi_auth.8
+++ b/src/auth/ntlm/SSPI/ntlm_sspi_auth.8
@@ -101,7 +101,7 @@ This manual was written by
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/SSPI/ntlm_sspi_auth.cc
+++ b/src/auth/ntlm/SSPI/ntlm_sspi_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/SSPI/required.m4
+++ b/src/auth/ntlm/SSPI/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/Scheme.cc
+++ b/src/auth/ntlm/Scheme.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/Scheme.h
+++ b/src/auth/ntlm/Scheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/User.cc
+++ b/src/auth/ntlm/User.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -19,7 +19,7 @@ Auth::Ntlm::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm) :
 
 Auth::Ntlm::User::~User()
 {
-    debugs(29, 5, HERE << "doing nothing to clear NTLM scheme data for '" << this << "'");
+    debugs(29, 5, "doing nothing to clear NTLM scheme data for '" << this << "'");
 }
 
 int32_t

--- a/src/auth/ntlm/User.h
+++ b/src/auth/ntlm/User.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/UserRequest.cc
+++ b/src/auth/ntlm/UserRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -56,11 +56,11 @@ int
 Auth::Ntlm::UserRequest::authenticated() const
 {
     if (user() != NULL && user()->credentials() == Auth::Ok) {
-        debugs(29, 9, HERE << "user authenticated.");
+        debugs(29, 9, "user authenticated.");
         return 1;
     }
 
-    debugs(29, 9, HERE << "user not fully authenticated.");
+    debugs(29, 9, "user not fully authenticated.");
     return 0;
 }
 
@@ -128,7 +128,7 @@ Auth::Ntlm::UserRequest::startHelperLookup(HttpRequest *, AccessLogEntry::Pointe
         return;
     }
 
-    debugs(29, 8, HERE << "credentials state is '" << user()->credentials() << "'");
+    debugs(29, 8, "credentials state is '" << user()->credentials() << "'");
 
     const char *keyExtras = helperRequestKeyExtras(request, al);
     int printResult = 0;
@@ -171,7 +171,7 @@ Auth::Ntlm::UserRequest::releaseAuthServer()
         ntlmauthenticators->cancelReservation(reservationId);
         reservationId.clear();
     } else
-        debugs(29, 6, HERE << "No NTLM auth server to release.");
+        debugs(29, 6, "No NTLM auth server to release.");
 }
 
 void
@@ -192,7 +192,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
     }
 
     if (server_blob) {
-        debugs(29, 2, HERE << "need to challenge client '" << server_blob << "'!");
+        debugs(29, 2, "need to challenge client '" << server_blob << "'!");
         return;
     }
 
@@ -218,7 +218,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
 
     case Auth::Unchecked:
         /* we've received a ntlm request. pass to a helper */
-        debugs(29, 9, HERE << "auth state ntlm none. Received blob: '" << proxy_auth << "'");
+        debugs(29, 9, "auth state ntlm none. Received blob: '" << proxy_auth << "'");
         user()->credentials(Auth::Pending);
         safe_free(client_blob);
         client_blob=xstrdup(blob);
@@ -229,7 +229,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
         break;
 
     case Auth::Pending:
-        debugs(29, DBG_IMPORTANT, HERE << "need to ask helper");
+        debugs(29, DBG_IMPORTANT, "need to ask helper");
         break;
 
     case Auth::Handshake:
@@ -249,7 +249,7 @@ Auth::Ntlm::UserRequest::authenticate(HttpRequest * aRequest, ConnStateData * co
 
     case Auth::Failed:
         /* we've failed somewhere in authentication */
-        debugs(29, 9, HERE << "auth state ntlm failed. " << proxy_auth);
+        debugs(29, 9, "auth state ntlm failed. " << proxy_auth);
         break;
     }
 }
@@ -302,7 +302,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
             lm_request->server_blob = xstrdup(serverBlob);
             auth_user_request->user()->credentials(Auth::Handshake);
             auth_user_request->setDenyMessage("Authentication in progress");
-            debugs(29, 4, HERE << "Need to challenge the client with a server token: '" << serverBlob << "'");
+            debugs(29, 4, "Need to challenge the client with a server token: '" << serverBlob << "'");
         } else {
             auth_user_request->user()->credentials(Auth::Failed);
             auth_user_request->setDenyMessage("NTLM authentication requires a persistent connection");
@@ -324,9 +324,9 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
         safe_free(lm_request->server_blob);
         lm_request->releaseAuthServer();
 
-        debugs(29, 4, HERE << "Successfully validated user via NTLM. Username '" << userLabel << "'");
+        debugs(29, 4, "Successfully validated user via NTLM. Username '" << userLabel << "'");
         /* connection is authenticated */
-        debugs(29, 4, HERE << "authenticated user " << auth_user_request->user()->username());
+        debugs(29, 4, "authenticated user " << auth_user_request->user()->username());
         /* see if this is an existing user */
         auto local_auth_user = lm_request->user();
         auto cached_user = Auth::Ntlm::User::Cache()->lookup(auth_user_request->user()->userKey());
@@ -346,7 +346,7 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
          * existing user or a new user */
         local_auth_user->expiretime = current_time.tv_sec;
         auth_user_request->user()->credentials(Auth::Ok);
-        debugs(29, 4, HERE << "Successfully validated user via NTLM. Username '" << auth_user_request->user()->username() << "'");
+        debugs(29, 4, "Successfully validated user via NTLM. Username '" << auth_user_request->user()->username() << "'");
     }
     break;
 

--- a/src/auth/ntlm/UserRequest.h
+++ b/src/auth/ntlm/UserRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/fake/Makefile.am
+++ b/src/auth/ntlm/fake/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/fake/ntlm_fake_auth.cc
+++ b/src/auth/ntlm/fake/ntlm_fake_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/fake/ntlm_fake_auth.pl.in
+++ b/src/auth/ntlm/fake/ntlm_fake_auth.pl.in
@@ -1,6 +1,6 @@
 #!@PERL@
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/fake/required.m4
+++ b/src/auth/ntlm/fake/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/ntlm/helpers.m4
+++ b/src/auth/ntlm/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/auth/toUtf.cc
+++ b/src/auth/toUtf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/auth/toUtf.h
+++ b/src/auth/toUtf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/AsyncCall.cc
+++ b/src/base/AsyncCall.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -38,7 +38,7 @@ AsyncCall::~AsyncCall()
 void
 AsyncCall::make()
 {
-    debugs(debugSection, debugLevel, HERE << "make call " << name <<
+    debugs(debugSection, debugLevel, "make call " << name <<
            " [" << id << ']');
     if (canFire()) {
         fire();
@@ -48,14 +48,14 @@ AsyncCall::make()
     if (!isCanceled) // we did not cancel() when returning false from canFire()
         isCanceled = "unknown reason";
 
-    debugs(debugSection, debugLevel, HERE << "will not call " << name <<
+    debugs(debugSection, debugLevel, "will not call " << name <<
            " [" << id << ']' << " because of " << isCanceled);
 }
 
 bool
 AsyncCall::cancel(const char *reason)
 {
-    debugs(debugSection, debugLevel, HERE << "will not call " << name <<
+    debugs(debugSection, debugLevel, "will not call " << name <<
            " [" << id << "] " << (isCanceled ? "also " : "") <<
            "because " << reason);
 

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/AsyncCallQueue.cc
+++ b/src/base/AsyncCallQueue.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/AsyncCallQueue.h
+++ b/src/base/AsyncCallQueue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/AsyncCalls.dox
+++ b/src/base/AsyncCalls.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/AsyncCbdataCalls.h
+++ b/src/base/AsyncCbdataCalls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/AsyncJob.cc
+++ b/src/base/AsyncJob.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -104,7 +104,7 @@ bool AsyncJob::canBeCalled(AsyncCall &call) const
     if (inCall != NULL) {
         // This may happen when we have bugs or some module is not calling
         // us asynchronously (comm used to do that).
-        debugs(93, 5, HERE << inCall << " is in progress; " <<
+        debugs(93, 5, inCall << " is in progress; " <<
                call << " cannot reenter the job.");
         return call.cancel("reentrant job call");
     }
@@ -154,7 +154,7 @@ void AsyncJob::callEnd()
         delete this; // this is the only place where a started job is deleted
 
         // careful: this object does not exist any more
-        debugs(93, 6, HERE << *inCallSaved << " ended " << thisSaved);
+        debugs(93, 6, *inCallSaved << " ended " << thisSaved);
         return;
     }
 

--- a/src/base/AsyncJob.h
+++ b/src/base/AsyncJob.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -175,7 +175,7 @@ JobDialer<Job>::dial(AsyncCall &call)
         doDial();
     } catch (const std::exception &e) {
         debugs(call.debugSection, 3,
-               HERE << call.name << " threw exception: " << e.what());
+               call.name << " threw exception: " << e.what());
         job->callException(e);
     }
 

--- a/src/base/AsyncJobs.dox
+++ b/src/base/AsyncJobs.dox
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/ByteCounter.h
+++ b/src/base/ByteCounter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/CbDataList.h
+++ b/src/base/CbDataList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/CbcPointer.h
+++ b/src/base/CbcPointer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/CharacterSet.cc
+++ b/src/base/CharacterSet.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/CharacterSet.h
+++ b/src/base/CharacterSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/ClpMap.h
+++ b/src/base/ClpMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/CodeContext.cc
+++ b/src/base/CodeContext.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/EnumIterator.h
+++ b/src/base/EnumIterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/File.cc
+++ b/src/base/File.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/File.h
+++ b/src/base/File.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/HardFun.h
+++ b/src/base/HardFun.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/Here.cc
+++ b/src/base/Here.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/Here.h
+++ b/src/base/Here.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/InstanceId.cc
+++ b/src/base/InstanceId.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/InstanceId.h
+++ b/src/base/InstanceId.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/JobWait.cc
+++ b/src/base/JobWait.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2020 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/JobWait.h
+++ b/src/base/JobWait.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/Lock.h
+++ b/src/base/Lock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/LookupTable.h
+++ b/src/base/LookupTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/Packable.h
+++ b/src/base/Packable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/PackableStream.h
+++ b/src/base/PackableStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/Range.h
+++ b/src/base/Range.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/RegexPattern.cc
+++ b/src/base/RegexPattern.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/RegexPattern.h
+++ b/src/base/RegexPattern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/RunnersRegistry.cc
+++ b/src/base/RunnersRegistry.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/RunnersRegistry.h
+++ b/src/base/RunnersRegistry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/Subscription.h
+++ b/src/base/Subscription.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/TextException.cc
+++ b/src/base/TextException.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/TypeTraits.h
+++ b/src/base/TypeTraits.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/YesNoNone.h
+++ b/src/base/YesNoNone.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/base/forward.h
+++ b/src/base/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -599,7 +599,7 @@ parseConfigFileOrThrow(const char *file_name)
 {
     int err_count = 0;
 
-    debugs(5, 4, HERE);
+    debugs(5, 4, MYNAME);
 
     configFreeMemory();
 

--- a/src/cache_cf.h
+++ b/src/cache_cf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -67,9 +67,9 @@ CacheManager::registerProfile(const Mgr::ActionProfile::Pointer &profile)
     Must(profile != NULL);
     if (!CacheManager::findAction(profile->name)) {
         menu_.push_back(profile);
-        debugs(16, 3, HERE << "registered profile: " << *profile);
+        debugs(16, 3, "registered profile: " << *profile);
     } else {
-        debugs(16, 2, HERE << "skipped duplicate profile: " << *profile);
+        debugs(16, 2, "skipped duplicate profile: " << *profile);
     }
 }
 
@@ -82,7 +82,7 @@ CacheManager::registerProfile(const Mgr::ActionProfile::Pointer &profile)
 void
 CacheManager::registerProfile(char const * action, char const * desc, OBJH * handler, int pw_req_flag, int atomic)
 {
-    debugs(16, 3, HERE << "registering legacy " << action);
+    debugs(16, 3, "registering legacy " << action);
     const Mgr::ActionProfile::Pointer profile = new Mgr::ActionProfile(action,
             desc, pw_req_flag, atomic, new Mgr::FunActionCreator(handler));
     registerProfile(profile);

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/carp.h
+++ b/src/carp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/cbdata.cc
+++ b/src/cbdata.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/cbdata.h
+++ b/src/cbdata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/cf.data.sed
+++ b/src/cf.data.sed
@@ -1,4 +1,4 @@
-# Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+# Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/cf_gen.cc
+++ b/src/cf_gen.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -670,7 +670,7 @@ gen_dump(const EntryList &head, std::ostream &fout)
          "static void" << std::endl <<
          "dump_config(StoreEntry *entry)" << std::endl <<
          "{" << std::endl <<
-         "    debugs(5, 4, HERE);" << std::endl;
+         "    debugs(5, 4, MYNAME);" << std::endl;
 
     for (const auto &e : head) {
 
@@ -702,7 +702,7 @@ gen_free(const EntryList &head, std::ostream &fout)
          "static void" << std::endl <<
          "free_all(void)" << std::endl <<
          "{" << std::endl <<
-         "    debugs(5, 4, HERE);" << std::endl;
+         "    debugs(5, 4, MYNAME);" << std::endl;
 
     for (const auto &e : head) {
         if (!e.loc.size() || e.loc.compare("none") == 0)

--- a/src/cf_gen_defines
+++ b/src/cf_gen_defines
@@ -1,6 +1,6 @@
 #!/usr/bin/awk -f 
 
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.
@@ -10,7 +10,7 @@
 BEGIN {
 	print "/* Generated automatically from cf.data.pre DO NOT EDIT */"
 	print "/*"
-	print " * Copyright (C) 1996-2021 The Squid Software Foundation and contributors"
+	print " * Copyright (C) 1996-2022 The Squid Software Foundation and contributors"
 	print " *"
 	print " * Squid software is distributed under GPLv2+ license and includes"
 	print " * contributions from numerous individuals and organizations."

--- a/src/clientStream.cc
+++ b/src/clientStream.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clientStream.h
+++ b/src/clientStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clientStreamForward.h
+++ b/src/clientStreamForward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -456,7 +456,7 @@ snmp_meshCtblFn(variable_list * Var, snint * ErrP)
 
     *ErrP = SNMP_ERR_NOERROR;
     MemBuf tmp;
-    debugs(49, 6, HERE << "Current : length=" << Var->name_length << ": " << snmpDebugOid(Var->name, Var->name_length, tmp));
+    debugs(49, 6, "Current : length=" << Var->name_length << ": " << snmpDebugOid(Var->name, Var->name_length, tmp));
     if (Var->name_length == 16) {
         oid2addr(&(Var->name[12]), keyIp, 4);
     } else if (Var->name_length == 28) {
@@ -467,11 +467,11 @@ snmp_meshCtblFn(variable_list * Var, snint * ErrP)
     }
 
     keyIp.toStr(key, sizeof(key));
-    debugs(49, 5, HERE << "[" << key << "] requested!");
+    debugs(49, 5, "[" << key << "] requested!");
     c = (ClientInfo *) hash_lookup(client_table, key);
 
     if (c == NULL) {
-        debugs(49, 5, HERE << "not found.");
+        debugs(49, 5, "not found.");
         *ErrP = SNMP_ERR_NOSUCHNAME;
         return NULL;
     }

--- a/src/client_db.h
+++ b/src/client_db.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -1077,7 +1077,7 @@ clientReplyContext::storeOKTransferDone() const
     assert(http->storeEntry()->objectLen() >= 0);
     assert(http->storeEntry()->objectLen() >= headers_sz);
     if (http->out.offset >= http->storeEntry()->objectLen() - headers_sz) {
-        debugs(88,3,HERE << "storeOKTransferDone " <<
+        debugs(88,3, "storeOKTransferDone " <<
                " out.offset=" << http->out.offset <<
                " objectLen()=" << http->storeEntry()->objectLen() <<
                " headers_sz=" << headers_sz);
@@ -1124,7 +1124,7 @@ clientReplyContext::storeNotOKTransferDone() const
     if (http->out.size < expectedLength)
         return 0;
     else {
-        debugs(88,3,HERE << "storeNotOKTransferDone " <<
+        debugs(88,3, "storeNotOKTransferDone " <<
                " out.size=" << http->out.size <<
                " expectedLength=" << expectedLength);
         return 1;

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -529,7 +529,7 @@ ClientRequestContext::hostHeaderIpVerify(const ipcache_addrs* ia, const Dns::Loo
         http->doCallouts();
         return;
     }
-    debugs(85, 3, HERE << "FAIL: validate IP " << clientConn->local << " possible from Host:");
+    debugs(85, 3, "FAIL: validate IP " << clientConn->local << " possible from Host:");
     hostHeaderVerifyFailed("local IP", "any domain IP");
 }
 
@@ -586,7 +586,7 @@ ClientRequestContext::hostHeaderVerify()
     if (!host) {
         // TODO: dump out the HTTP/1.1 error about missing host header.
         // otherwise this is fine, can't forge a header value when its not even set.
-        debugs(85, 3, HERE << "validate skipped with no Host: header present.");
+        debugs(85, 3, "validate skipped with no Host: header present.");
         http->doCallouts();
         return;
     }
@@ -594,7 +594,7 @@ ClientRequestContext::hostHeaderVerify()
     if (http->request->flags.internal) {
         // TODO: kill this when URL handling allows partial URLs out of accel mode
         //       and we no longer screw with the URL just to add our internal host there
-        debugs(85, 6, HERE << "validate skipped due to internal composite URL.");
+        debugs(85, 6, "validate skipped due to internal composite URL.");
         http->doCallouts();
         return;
     }
@@ -715,7 +715,7 @@ ClientRequestContext::clientAccessCheck2()
         acl_checklist = clientAclChecklistCreate(Config.accessList.adapted_http, http);
         acl_checklist->nonBlockingCheck(clientAccessCheckDoneWrapper, this);
     } else {
-        debugs(85, 2, HERE << "No adapted_http_access configuration. default: ALLOW");
+        debugs(85, 2, "No adapted_http_access configuration. default: ALLOW");
         clientAccessCheckDone(ACCESS_ALLOWED);
     }
 }
@@ -818,7 +818,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
 void
 ClientHttpRequest::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer g)
 {
-    debugs(93,3,HERE << this << " adaptationAclCheckDone called");
+    debugs(93,3, this << " adaptationAclCheckDone called");
 
 #if ICAP_CLIENT
     Adaptation::Icap::History::Pointer ih = request->icapHistory();
@@ -837,7 +837,7 @@ ClientHttpRequest::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer g)
 #endif
 
     if (!g) {
-        debugs(85,3, HERE << "no adaptation needed");
+        debugs(85,3, "no adaptation needed");
         doCallouts();
         return;
     }
@@ -865,7 +865,7 @@ clientRedirectAccessCheckDone(Acl::Answer answer, void *data)
 void
 ClientRequestContext::clientRedirectStart()
 {
-    debugs(33, 5, HERE << "'" << http->uri << "'");
+    debugs(33, 5, "'" << http->uri << "'");
     http->al->syncNotes(http->request);
     if (Config.accessList.redirector) {
         acl_checklist = clientAclChecklistCreate(Config.accessList.redirector, http);
@@ -1180,7 +1180,7 @@ void
 ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
 {
     HttpRequest *old_request = http->request;
-    debugs(85, 5, HERE << "'" << http->uri << "' result=" << reply);
+    debugs(85, 5, "'" << http->uri << "' result=" << reply);
     assert(redirect_state == REDIRECT_PENDING);
     redirect_state = REDIRECT_DONE;
 
@@ -1266,7 +1266,7 @@ ClientRequestContext::clientRedirectDone(const Helper::Reply &reply)
                     // unlink bodypipe from the old request. Not needed there any longer.
                     if (old_request->body_pipe != NULL) {
                         old_request->body_pipe = NULL;
-                        debugs(61,2, HERE << "URL-rewriter diverts body_pipe " << new_request->body_pipe <<
+                        debugs(61,2, "URL-rewriter diverts body_pipe " << new_request->body_pipe <<
                                " from request " << old_request << " to " << new_request);
                     }
 
@@ -1401,7 +1401,7 @@ ClientRequestContext::sslBumpAccessCheck()
 
     // If SSL connection tunneling or bumping decision has been made, obey it.
     if (bumpMode != Ssl::bumpEnd) {
-        debugs(85, 5, HERE << "SslBump already decided (" << bumpMode <<
+        debugs(85, 5, "SslBump already decided (" << bumpMode <<
                "), " << "ignoring ssl_bump for " << http->getConn());
 
         // We need the following "if" for transparently bumped TLS connection,
@@ -1428,7 +1428,7 @@ ClientRequestContext::sslBumpAccessCheck()
             !Config.accessList.ssl_bump ||
             !http->getConn()->port->flags.tunnelSslBumping) {
         http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
-        debugs(85, 5, HERE << "cannot SslBump this request");
+        debugs(85, 5, "cannot SslBump this request");
         return false;
     }
 
@@ -1436,7 +1436,7 @@ ClientRequestContext::sslBumpAccessCheck()
     // if we delay a 407 response and respond with 200 OK to CONNECT.
     if (error && error->httpStatus == Http::scProxyAuthenticationRequired) {
         http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
-        debugs(85, 5, HERE << "no SslBump during proxy authentication");
+        debugs(85, 5, "no SslBump during proxy authentication");
         return false;
     }
 
@@ -1447,7 +1447,7 @@ ClientRequestContext::sslBumpAccessCheck()
         return false;
     }
 
-    debugs(85, 5, HERE << "SslBump possible, checking ACL");
+    debugs(85, 5, "SslBump possible, checking ACL");
 
     ACLFilledChecklist *aclChecklist = clientAclChecklistCreate(Config.accessList.ssl_bump, http);
     aclChecklist->nonBlockingCheck(sslBumpAccessCheckDoneWrapper, this);
@@ -1540,7 +1540,7 @@ ClientHttpRequest::httpStart()
 void
 ClientHttpRequest::sslBumpNeed(Ssl::BumpMode mode)
 {
-    debugs(83, 3, HERE << "sslBump required: "<< Ssl::bumpMode(mode));
+    debugs(83, 3, "sslBump required: "<< Ssl::bumpMode(mode));
     sslBumpNeed_ = mode;
 }
 
@@ -1549,7 +1549,7 @@ static void
 SslBumpEstablish(const Comm::ConnectionPointer &, char *, size_t, Comm::Flag errflag, int, void *data)
 {
     ClientHttpRequest *r = static_cast<ClientHttpRequest*>(data);
-    debugs(85, 5, HERE << "responded to CONNECT: " << r << " ? " << errflag);
+    debugs(85, 5, "responded to CONNECT: " << r << " ? " << errflag);
 
     assert(r && cbdataReferenceValid(r));
     r->sslBumpEstablish(errflag);
@@ -1563,7 +1563,7 @@ ClientHttpRequest::sslBumpEstablish(Comm::Flag errflag)
         return;
 
     if (errflag) {
-        debugs(85, 3, HERE << "CONNECT response failure in SslBump: " << errflag);
+        debugs(85, 3, "CONNECT response failure in SslBump: " << errflag);
         getConn()->clientConnection->close();
         return;
     }
@@ -1581,7 +1581,7 @@ ClientHttpRequest::sslBumpEstablish(Comm::Flag errflag)
 void
 ClientHttpRequest::sslBumpStart()
 {
-    debugs(85, 5, HERE << "Confirming " << Ssl::bumpMode(sslBumpNeed_) <<
+    debugs(85, 5, "Confirming " << Ssl::bumpMode(sslBumpNeed_) <<
            "-bumped CONNECT tunnel on FD " << getConn()->clientConnection);
     getConn()->sslBumpMode = sslBumpNeed_;
 
@@ -1734,14 +1734,14 @@ ClientHttpRequest::doCallouts()
     if (!calloutContext->error) {
         // CVE-2009-0801: verify the Host: header is consistent with other known details.
         if (!calloutContext->host_header_verify_done) {
-            debugs(83, 3, HERE << "Doing calloutContext->hostHeaderVerify()");
+            debugs(83, 3, "Doing calloutContext->hostHeaderVerify()");
             calloutContext->host_header_verify_done = true;
             calloutContext->hostHeaderVerify();
             return;
         }
 
         if (!calloutContext->http_access_done) {
-            debugs(83, 3, HERE << "Doing calloutContext->clientAccessCheck()");
+            debugs(83, 3, "Doing calloutContext->clientAccessCheck()");
             calloutContext->http_access_done = true;
             calloutContext->clientAccessCheck();
             return;
@@ -1761,7 +1761,7 @@ ClientHttpRequest::doCallouts()
             calloutContext->redirect_done = true;
 
             if (Config.Program.redirect) {
-                debugs(83, 3, HERE << "Doing calloutContext->clientRedirectStart()");
+                debugs(83, 3, "Doing calloutContext->clientRedirectStart()");
                 calloutContext->redirect_state = REDIRECT_PENDING;
                 calloutContext->clientRedirectStart();
                 return;
@@ -1769,7 +1769,7 @@ ClientHttpRequest::doCallouts()
         }
 
         if (!calloutContext->adapted_http_access_done) {
-            debugs(83, 3, HERE << "Doing calloutContext->clientAccessCheck2()");
+            debugs(83, 3, "Doing calloutContext->clientAccessCheck2()");
             calloutContext->adapted_http_access_done = true;
             calloutContext->clientAccessCheck2();
             return;
@@ -1787,7 +1787,7 @@ ClientHttpRequest::doCallouts()
         }
 
         if (!calloutContext->interpreted_req_hdrs) {
-            debugs(83, 3, HERE << "Doing clientInterpretRequestHeaders()");
+            debugs(83, 3, "Doing clientInterpretRequestHeaders()");
             calloutContext->interpreted_req_hdrs = 1;
             clientInterpretRequestHeaders(this);
         }
@@ -1796,7 +1796,7 @@ ClientHttpRequest::doCallouts()
             calloutContext->no_cache_done = true;
 
             if (Config.accessList.noCache && request->flags.cachable) {
-                debugs(83, 3, HERE << "Doing calloutContext->checkNoCache()");
+                debugs(83, 3, "Doing calloutContext->checkNoCache()");
                 calloutContext->checkNoCache();
                 return;
             }
@@ -1881,7 +1881,7 @@ ClientHttpRequest::doCallouts()
     headersLog(0, 1, request->method, request);
 #endif
 
-    debugs(83, 3, HERE << "calling processRequest()");
+    debugs(83, 3, "calling processRequest()");
     processRequest();
 
 #if ICAP_CLIENT
@@ -1967,7 +1967,7 @@ ClientHttpRequest::prepPartialResponseGeneration()
 void
 ClientHttpRequest::startAdaptation(const Adaptation::ServiceGroupPointer &g)
 {
-    debugs(85, 3, HERE << "adaptation needed for " << this);
+    debugs(85, 3, "adaptation needed for " << this);
     assert(!virginHeadSource);
     assert(!adaptedBodySource);
     virginHeadSource = initiateAdaptation(
@@ -2014,7 +2014,7 @@ ClientHttpRequest::handleAdaptedHeader(Http::Message *msg)
         resetRequest(new_req);
         assert(request->method.id());
     } else if (HttpReply *new_rep = dynamic_cast<HttpReply*>(msg)) {
-        debugs(85,3,HERE << "REQMOD reply is HTTP reply");
+        debugs(85,3, "REQMOD reply is HTTP reply");
 
         // subscribe to receive reply body
         if (new_rep->body_pipe != NULL) {
@@ -2121,7 +2121,7 @@ ClientHttpRequest::noteBodyProductionEnded(BodyPipe::Pointer)
 void
 ClientHttpRequest::endRequestSatisfaction()
 {
-    debugs(85,4, HERE << this << " ends request satisfaction");
+    debugs(85,4, this << " ends request satisfaction");
     assert(request_satisfaction_mode);
     stopConsumingFrom(adaptedBodySource);
 
@@ -2142,7 +2142,7 @@ ClientHttpRequest::noteBodyProducerAborted(BodyPipe::Pointer)
     assert(!virginHeadSource);
     stopConsumingFrom(adaptedBodySource);
 
-    debugs(85,3, HERE << "REQMOD body production failed");
+    debugs(85,3, "REQMOD body production failed");
     if (request_satisfaction_mode) { // too late to recover or serve an error
         static const auto d = MakeNamedErrorDetail("CLT_REQMOD_RESP_BODY");
         request->detailError(ERR_ICAP_FAILURE, d);
@@ -2158,20 +2158,20 @@ ClientHttpRequest::noteBodyProducerAborted(BodyPipe::Pointer)
 void
 ClientHttpRequest::handleAdaptationFailure(const ErrorDetail::Pointer &errDetail, bool bypassable)
 {
-    debugs(85,3, HERE << "handleAdaptationFailure(" << bypassable << ")");
+    debugs(85,3, "handleAdaptationFailure(" << bypassable << ")");
 
     const bool usedStore = storeEntry() && !storeEntry()->isEmpty();
     const bool usedPipe = request->body_pipe != NULL &&
                           request->body_pipe->consumedSize() > 0;
 
     if (bypassable && !usedStore && !usedPipe) {
-        debugs(85,3, HERE << "ICAP REQMOD callout failed, bypassing: " << calloutContext);
+        debugs(85,3, "ICAP REQMOD callout failed, bypassing: " << calloutContext);
         if (calloutContext)
             doCallouts();
         return;
     }
 
-    debugs(85,3, HERE << "ICAP REQMOD callout failed, responding with error");
+    debugs(85,3, "ICAP REQMOD callout failed, responding with error");
 
     clientStreamNode *node = (clientStreamNode *)client_stream.tail->prev->data;
     clientReplyContext *repContext = dynamic_cast<clientReplyContext *>(node->data.getRaw());

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -116,7 +116,7 @@ Client::virginReply() const
 HttpReply *
 Client::setVirginReply(HttpReply *rep)
 {
-    debugs(11,5, HERE << this << " setting virgin reply to " << rep);
+    debugs(11,5, this << " setting virgin reply to " << rep);
     assert(!theVirginReply);
     assert(rep);
     theVirginReply = rep;
@@ -136,7 +136,7 @@ Client::finalReply()
 HttpReply *
 Client::setFinalReply(HttpReply *rep)
 {
-    debugs(11,5, HERE << this << " setting final reply to " << rep);
+    debugs(11,5, this << " setting final reply to " << rep);
 
     assert(!theFinalReply);
     assert(rep);
@@ -180,7 +180,7 @@ Client::markParsedVirginReplyAsWhole(const char *reasonWeAreSure)
 void
 Client::serverComplete()
 {
-    debugs(11,5,HERE << "serverComplete " << this);
+    debugs(11,5, "serverComplete " << this);
 
     if (!doneWithServer()) {
         closeServer();
@@ -202,7 +202,7 @@ Client::serverComplete()
 void
 Client::serverComplete2()
 {
-    debugs(11,5,HERE << "serverComplete2 " << this);
+    debugs(11,5, "serverComplete2 " << this);
 
 #if USE_ADAPTATION
     if (virginBodyDestination != NULL)
@@ -230,7 +230,7 @@ bool Client::doneAll() const
 void
 Client::completeForwarding()
 {
-    debugs(11,5, HERE << "completing forwarding for "  << fwd);
+    debugs(11,5, "completing forwarding for "  << fwd);
     assert(fwd != NULL);
     doneWithFwd = "completeForwarding()";
     fwd->complete();
@@ -243,12 +243,12 @@ bool Client::startRequestBodyFlow()
     assert(r->body_pipe != NULL);
     requestBodySource = r->body_pipe;
     if (requestBodySource->setConsumerIfNotLate(this)) {
-        debugs(11,3, HERE << "expecting request body from " <<
+        debugs(11,3, "expecting request body from " <<
                requestBodySource->status());
         return true;
     }
 
-    debugs(11,3, HERE << "aborting on partially consumed request body: " <<
+    debugs(11,3, "aborting on partially consumed request body: " <<
            requestBodySource->status());
     requestBodySource = NULL;
     return false;
@@ -261,7 +261,7 @@ Client::abortOnBadEntry(const char *abortReason)
     if (entry->isAccepting())
         return false;
 
-    debugs(11,5, HERE << "entry is not Accepting!");
+    debugs(11,5, "entry is not Accepting!");
     abortOnData(abortReason);
     return true;
 }
@@ -322,7 +322,7 @@ Client::handleMoreRequestBodyAvailable()
     if (!requestSender)
         sendMoreRequestBody();
     else
-        debugs(9,3, HERE << "waiting for request body write to complete");
+        debugs(9,3, "waiting for request body write to complete");
 }
 
 // there will be no more handleMoreRequestBodyAvailable calls
@@ -333,14 +333,14 @@ Client::handleRequestBodyProductionEnded()
     if (!requestSender)
         doneSendingRequestBody();
     else
-        debugs(9,3, HERE << "waiting for request body write to complete");
+        debugs(9,3, "waiting for request body write to complete");
 }
 
 // called when we are done sending request body; kids extend this
 void
 Client::doneSendingRequestBody()
 {
-    debugs(9,3, HERE << "done sending request body");
+    debugs(9,3, "done sending request body");
     assert(requestBodySource != NULL);
     stopConsumingFrom(requestBodySource);
 
@@ -352,7 +352,7 @@ void
 Client::handleRequestBodyProducerAborted()
 {
     if (requestSender != NULL)
-        debugs(9,3, HERE << "fyi: request body aborted while we were sending");
+        debugs(9,3, "fyi: request body aborted while we were sending");
 
     fwd->dontRetry(true); // the problem is not with the server
     stopConsumingFrom(requestBodySource); // requestSender, if any, will notice
@@ -365,7 +365,7 @@ void
 Client::sentRequestBody(const CommIoCbParams &io)
 {
     debugs(11, 5, "sentRequestBody: FD " << io.fd << ": size " << io.size << ": errflag " << io.flag << ".");
-    debugs(32,3,HERE << "sentRequestBody called");
+    debugs(32,3, "sentRequestBody called");
 
     requestSender = NULL;
 
@@ -379,7 +379,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
         return;
 
     if (!requestBodySource) {
-        debugs(9,3, HERE << "detected while-we-were-sending abort");
+        debugs(9,3, "detected while-we-were-sending abort");
         return; // do nothing;
     }
 
@@ -406,7 +406,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     else if (receivedWholeRequestBody)
         doneSendingRequestBody();
     else
-        debugs(9,3, HERE << "waiting for body production end or abort");
+        debugs(9,3, "waiting for body production end or abort");
 }
 
 void
@@ -418,18 +418,18 @@ Client::sendMoreRequestBody()
     const Comm::ConnectionPointer conn = dataConnection();
 
     if (!Comm::IsConnOpen(conn)) {
-        debugs(9,3, HERE << "cannot send request body to closing " << conn);
+        debugs(9,3, "cannot send request body to closing " << conn);
         return; // wait for the kid's close handler; TODO: assert(closer);
     }
 
     MemBuf buf;
     if (getMoreRequestBody(buf) && buf.contentSize() > 0) {
-        debugs(9,3, HERE << "will write " << buf.contentSize() << " request body bytes");
+        debugs(9,3, "will write " << buf.contentSize() << " request body bytes");
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         requestSender = JobCallback(93,3, Dialer, this, Client::sentRequestBody);
         Comm::Write(conn, &buf, requestSender);
     } else {
-        debugs(9,3, HERE << "will wait for more request body bytes or eof");
+        debugs(9,3, "will wait for more request body bytes or eof");
         requestSender = NULL;
     }
 }
@@ -588,7 +588,7 @@ Client::startAdaptation(const Adaptation::ServiceGroupPointer &group, HttpReques
     if (vrep->expectingBody(cause->method, size) && size) {
         virginBodyDestination = new BodyPipe(this);
         vrep->body_pipe = virginBodyDestination;
-        debugs(93, 6, HERE << "will send virgin reply body to " <<
+        debugs(93, 6, "will send virgin reply body to " <<
                virginBodyDestination << "; size: " << size);
         if (size > 0)
             virginBodyDestination->setBodySize(size);
@@ -604,7 +604,7 @@ Client::startAdaptation(const Adaptation::ServiceGroupPointer &group, HttpReques
 // may be called multiple times
 void Client::cleanAdaptation()
 {
-    debugs(11,5, HERE << "cleaning ICAP; ACL: " << adaptationAccessCheckPending);
+    debugs(11,5, "cleaning ICAP; ACL: " << adaptationAccessCheckPending);
 
     if (virginBodyDestination != NULL)
         stopProducingFor(virginBodyDestination, false);
@@ -632,7 +632,7 @@ Client::adaptVirginReplyBody(const char *data, ssize_t len)
     assert(startedAdaptation);
 
     if (!virginBodyDestination) {
-        debugs(11,3, HERE << "ICAP does not want more virgin body");
+        debugs(11,3, "ICAP does not want more virgin body");
         return;
     }
 
@@ -731,7 +731,7 @@ Client::handleAdaptedHeader(Http::Message *msg)
 
     HttpReply *rep = dynamic_cast<HttpReply*>(msg);
     assert(rep);
-    debugs(11,5, HERE << this << " setting adapted reply to " << rep);
+    debugs(11,5, this << " setting adapted reply to " << rep);
     setFinalReply(rep);
 
     assert(!adaptedBodySource);
@@ -789,18 +789,18 @@ Client::handleMoreAdaptedBodyAvailable()
     }
 
     if (!spaceAvailable)  {
-        debugs(11, 5, HERE << "NOT storing " << contentSize << " bytes of adapted " <<
+        debugs(11, 5, "NOT storing " << contentSize << " bytes of adapted " <<
                "response body at offset " << adaptedBodySource->consumedSize());
         return;
     }
 
     if (spaceAvailable < contentSize ) {
-        debugs(11, 5, HERE << "postponing storage of " <<
+        debugs(11, 5, "postponing storage of " <<
                (contentSize - spaceAvailable) << " body bytes");
         contentSize = spaceAvailable;
     }
 
-    debugs(11,5, HERE << "storing " << contentSize << " bytes of adapted " <<
+    debugs(11,5, "storing " << contentSize << " bytes of adapted " <<
            "response body at offset " << adaptedBodySource->consumedSize());
 
     BodyPipeCheckout bpc(*adaptedBodySource);
@@ -866,7 +866,7 @@ void Client::handleAdaptedBodyProducerAborted()
 void
 Client::handleAdaptationCompleted()
 {
-    debugs(11,5, HERE << "handleAdaptationCompleted");
+    debugs(11,5, "handleAdaptationCompleted");
     cleanAdaptation();
 
     // We stop reading origin response because we have no place to put it(*) and
@@ -874,7 +874,7 @@ Client::handleAdaptationCompleted()
     // reuse more pconns, we can add code to discard unneeded origin responses.
     // (*) TODO: Is it possible that the adaptation xaction is still running?
     if (mayReadVirginReplyBody()) {
-        debugs(11,3, HERE << "closing origin conn due to ICAP completion");
+        debugs(11,3, "closing origin conn due to ICAP completion");
         closeServer();
     }
 
@@ -885,7 +885,7 @@ Client::handleAdaptationCompleted()
 void
 Client::handleAdaptationAborted(bool bypassable)
 {
-    debugs(11,5, HERE << "handleAdaptationAborted; bypassable: " << bypassable <<
+    debugs(11,5, "handleAdaptationAborted; bypassable: " << bypassable <<
            ", entry empty: " << entry->isEmpty());
 
     if (abortOnBadEntry("entry went bad while ICAP aborted"))
@@ -924,7 +924,7 @@ Client::handledEarlyAdaptationAbort()
 void
 Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
 {
-    debugs(11,5, HERE << answer.ruleId);
+    debugs(11,5, answer.ruleId);
 
     if (abortOnBadEntry("entry went bad while ICAP aborted"))
         return;
@@ -938,7 +938,7 @@ Client::handleAdaptationBlocked(const Adaptation::Answer &answer)
         return;
     }
 
-    debugs(11,7, HERE << "creating adaptation block response");
+    debugs(11,7, "creating adaptation block response");
 
     err_type page_id =
         aclGetDenyInfoPage(&Config.denyInfoList, answer.ruleId.termedBuf(), 1);
@@ -971,7 +971,7 @@ Client::noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer group)
     // TODO: Should we check receivedBodyTooLarge as well?
 
     if (!group) {
-        debugs(11,3, HERE << "no adapation needed");
+        debugs(11,3, "no adapation needed");
         setFinalReply(virginReply());
         processReplyBody();
         return;
@@ -1002,7 +1002,7 @@ Client::adaptOrFinalizeReply()
     adaptationAccessCheckPending = Adaptation::AccessCheck::Start(
                                        Adaptation::methodRespmod, Adaptation::pointPreCache,
                                        originalRequest().getRaw(), virginReply(), fwd->al, this);
-    debugs(11,5, HERE << "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
+    debugs(11,5, "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
     if (adaptationAccessCheckPending)
         return;
 #endif

--- a/src/clients/Client.h
+++ b/src/clients/Client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -461,7 +461,7 @@ Ftp::Gateway::listenForDataChannel(const Comm::ConnectionPointer &conn)
             debugs(5, DBG_CRITICAL, "ERROR: comm_open_listener failed:" << conn->local << " error: " << errno);
             return;
         }
-        debugs(9, 3, HERE << "Unconnected data socket created on " << conn);
+        debugs(9, 3, "Unconnected data socket created on " << conn);
     }
 
     conn->tos = ctrl.conn->tos;
@@ -882,7 +882,7 @@ Ftp::Gateway::parseListing()
     size_t len = data.readBuf->contentSize();
 
     if (!len) {
-        debugs(9, 3, HERE << "no content to parse for " << entry->url()  );
+        debugs(9, 3, "no content to parse for " << entry->url()  );
         return;
     }
 
@@ -898,21 +898,21 @@ Ftp::Gateway::parseListing()
 
     usable = end - sbuf;
 
-    debugs(9, 3, HERE << "usable = " << usable << " of " << len << " bytes.");
+    debugs(9, 3, "usable = " << usable << " of " << len << " bytes.");
 
     if (usable == 0) {
         if (buf[0] == '\0' && len == 1) {
-            debugs(9, 3, HERE << "NIL ends data from " << entry->url() << " transfer problem?");
+            debugs(9, 3, "NIL ends data from " << entry->url() << " transfer problem?");
             data.readBuf->consume(len);
         } else {
-            debugs(9, 3, HERE << "didn't find end for " << entry->url());
-            debugs(9, 3, HERE << "buffer remains (" << len << " bytes) '" << rfc1738_do_escape(buf,0) << "'");
+            debugs(9, 3, "didn't find end for " << entry->url());
+            debugs(9, 3, "buffer remains (" << len << " bytes) '" << rfc1738_do_escape(buf,0) << "'");
         }
         xfree(sbuf);
         return;
     }
 
-    debugs(9, 3, HERE << (unsigned long int)len << " bytes to play with");
+    debugs(9, 3, (unsigned long int)len << " bytes to play with");
 
     line = (char *)memAllocate(MEM_4K_BUF);
     ++end;
@@ -920,7 +920,7 @@ Ftp::Gateway::parseListing()
     s += strspn(s, crlf);
 
     for (; s < end; s += strcspn(s, crlf), s += strspn(s, crlf)) {
-        debugs(9, 7, HERE << "s = {" << s << "}");
+        debugs(9, 7, "s = {" << s << "}");
         linelen = strcspn(s, crlf) + 1;
 
         if (linelen < 2)
@@ -931,7 +931,7 @@ Ftp::Gateway::parseListing()
 
         xstrncpy(line, s, linelen);
 
-        debugs(9, 7, HERE << "{" << line << "}");
+        debugs(9, 7, "{" << line << "}");
 
         if (!strncmp(line, "total", 5))
             continue;
@@ -947,7 +947,7 @@ Ftp::Gateway::parseListing()
         }
     }
 
-    debugs(9, 7, HERE << "Done.");
+    debugs(9, 7, "Done.");
     data.readBuf->consume(usable);
     memFree(line, MEM_4K_BUF);
     xfree(sbuf);
@@ -995,7 +995,7 @@ Ftp::Gateway::processReplyBody()
         return;
     } else if (const int csize = data.readBuf->contentSize()) {
         writeReplyBody(data.readBuf->content(), csize);
-        debugs(9, 5, HERE << "consuming " << csize << " bytes of readBuf");
+        debugs(9, 5, "consuming " << csize << " bytes of readBuf");
         data.readBuf->consume(csize);
     }
 
@@ -1078,7 +1078,7 @@ Ftp::Gateway::checkUrlpath()
         const auto fullPath = request->url.path();
         const auto typecodePos = typeSpecStart + middle.length();
         typecode = (typecodePos < fullPath.length()) ?
-            static_cast<char>(xtoupper(fullPath[typecodePos])) : '\0';
+                   static_cast<char>(xtoupper(fullPath[typecodePos])) : '\0';
         request->url.path(fullPath.substr(0, typeSpecStart));
     }
 
@@ -1183,7 +1183,7 @@ static void
 ftpReadWelcome(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (ftpState->flags.pasv_only)
         ++ ftpState->login_att;
@@ -1292,7 +1292,7 @@ static void
 ftpReadUser(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code == 230) {
         ftpReadPass(ftpState);
@@ -1319,7 +1319,7 @@ static void
 ftpReadPass(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE << "code=" << code);
+    debugs(9, 3, "code=" << code);
 
     if (code == 230) {
         ftpSendType(ftpState);
@@ -1383,7 +1383,7 @@ ftpReadType(Ftp::Gateway * ftpState)
     int code = ftpState->ctrl.replycode;
     char *path;
     char *d, *p;
-    debugs(9, 3, HERE << "code=" << code);
+    debugs(9, 3, "code=" << code);
 
     if (code == 200) {
         p = path = SBufToCstring(ftpState->request->url.path());
@@ -1420,7 +1420,7 @@ ftpReadType(Ftp::Gateway * ftpState)
 static void
 ftpTraverseDirectory(Ftp::Gateway * ftpState)
 {
-    debugs(9, 4, HERE << (ftpState->filepath ? ftpState->filepath : "<NULL>"));
+    debugs(9, 4, (ftpState->filepath ? ftpState->filepath : "<NULL>"));
 
     safe_free(ftpState->dirpath);
     ftpState->dirpath = ftpState->filepath;
@@ -1429,7 +1429,7 @@ ftpTraverseDirectory(Ftp::Gateway * ftpState)
     /* Done? */
 
     if (ftpState->pathcomps == NULL) {
-        debugs(9, 3, HERE << "the final component was a directory");
+        debugs(9, 3, "the final component was a directory");
         ftpListDir(ftpState);
         return;
     }
@@ -1441,7 +1441,7 @@ ftpTraverseDirectory(Ftp::Gateway * ftpState)
     if (ftpState->pathcomps != NULL || ftpState->flags.isdir) {
         ftpSendCwd(ftpState);
     } else {
-        debugs(9, 3, HERE << "final component is probably a file");
+        debugs(9, 3, "final component is probably a file");
         ftpGetFile(ftpState);
         return;
     }
@@ -1456,7 +1456,7 @@ ftpSendCwd(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendCwd"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     path = ftpState->filepath;
 
@@ -1477,7 +1477,7 @@ static void
 ftpReadCwd(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code >= 200 && code < 300) {
         /* CWD OK */
@@ -1513,7 +1513,7 @@ ftpSendMkdir(Ftp::Gateway * ftpState)
         return;
 
     path = ftpState->filepath;
-    debugs(9, 3, HERE << "with path=" << path);
+    debugs(9, 3, "with path=" << path);
     snprintf(cbuf, CTRL_BUFLEN, "MKD %s\r\n", path);
     ftpState->writeCommand(cbuf);
     ftpState->state = Ftp::Client::SENT_MKDIR;
@@ -1525,7 +1525,7 @@ ftpReadMkdir(Ftp::Gateway * ftpState)
     char *path = ftpState->filepath;
     int code = ftpState->ctrl.replycode;
 
-    debugs(9, 3, HERE << "path " << path << ", code " << code);
+    debugs(9, 3, "path " << path << ", code " << code);
 
     if (code == 257) {      /* success */
         ftpSendCwd(ftpState);
@@ -1552,7 +1552,7 @@ static void
 ftpListDir(Ftp::Gateway * ftpState)
 {
     if (ftpState->flags.dir_slash) {
-        debugs(9, 3, HERE << "Directory path did not end in /");
+        debugs(9, 3, "Directory path did not end in /");
         ftpState->title_url.append("/");
         ftpState->flags.isdir = 1;
     }
@@ -1577,7 +1577,7 @@ static void
 ftpReadMdtm(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code == 213) {
         ftpState->mdtm = parse_iso3307_time(ftpState->ctrl.last_reply);
@@ -1615,7 +1615,7 @@ static void
 ftpReadSize(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code == 213) {
         ftpState->unhack();
@@ -1658,7 +1658,7 @@ ftpSendPassive(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendPassive"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     /** \par
       * Checks for 'HEAD' method request and passes off for special handling by Ftp::Gateway::processHeadResponse(). */
@@ -1677,7 +1677,7 @@ ftpSendPassive(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::processHeadResponse()
 {
-    debugs(9, 5, HERE << "handling HEAD response");
+    debugs(9, 5, "handling HEAD response");
     ftpSendQuit(this);
     appendSuccessHeader();
 
@@ -1693,7 +1693,7 @@ Ftp::Gateway::processHeadResponse()
 
 #if USE_ADAPTATION
     if (adaptationAccessCheckPending) {
-        debugs(9,3, HERE << "returning due to adaptationAccessCheckPending");
+        debugs(9,3, "returning due to adaptationAccessCheckPending");
         return;
     }
 #endif
@@ -1719,11 +1719,11 @@ ftpReadPasv(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::dataChannelConnected(const CommConnectCbParams &io)
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
     dataConnWait.finish();
 
     if (io.flag != Comm::OK) {
-        debugs(9, 2, HERE << "Failed to connect. Retrying via another method.");
+        debugs(9, 2, "Failed to connect. Retrying via another method.");
 
         // ABORT on timeouts. server may be waiting on a broken TCP link.
         if (io.xerrno == Comm::TIMEOUT)
@@ -1798,7 +1798,7 @@ ftpSendPORT(Ftp::Gateway * ftpState)
         return;
     }
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
     ftpState->flags.pasv_supported = 0;
     ftpOpenListenSocket(ftpState, 0);
 
@@ -1836,7 +1836,7 @@ static void
 ftpReadPORT(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code != 200) {
         /* Fall back on using the same port as the control connection */
@@ -1851,7 +1851,7 @@ static void
 ftpReadEPRT(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code != 200) {
         /* Failover to attempting old PORT command. */
@@ -1870,7 +1870,7 @@ ftpReadEPRT(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (!Comm::IsConnOpen(ctrl.conn)) { /*Close handlers will cleanup*/
         debugs(9, 5, "The control connection to the remote end is closed");
@@ -1933,7 +1933,7 @@ Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
     data.opened(io.conn, dataCloser());
     data.addr(io.conn->remote);
 
-    debugs(9, 3, HERE << "Connected data socket on " <<
+    debugs(9, 3, "Connected data socket on " <<
            io.conn << ". FD table says: " <<
            "ctrl-peer= " << fd_table[ctrl.conn->fd].ipaddr << ", " <<
            "data-peer= " << fd_table[data.conn->fd].ipaddr);
@@ -1947,7 +1947,7 @@ Ftp::Gateway::ftpAcceptDataConnection(const CommAcceptCbParams &io)
 static void
 ftpRestOrList(Ftp::Gateway * ftpState)
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (ftpState->typecode == 'D') {
         ftpState->flags.isdir = 1;
@@ -1974,7 +1974,7 @@ ftpSendStor(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendStor"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (ftpState->filepath != NULL) {
         /* Plain file upload */
@@ -2002,7 +2002,7 @@ ftpReadStor(Ftp::Gateway * ftpState)
 void Ftp::Gateway::readStor()
 {
     int code = ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code == 125 || (code == 150 && Comm::IsConnOpen(data.conn))) {
         if (!originalRequest()->body_pipe) {
@@ -2018,12 +2018,12 @@ void Ftp::Gateway::readStor()
         }
 
         /* When client status is 125, or 150 and the data connection is open, Begin data transfer. */
-        debugs(9, 3, HERE << "starting data transfer");
+        debugs(9, 3, "starting data transfer");
         switchTimeoutToDataChannel();
         sendMoreRequestBody();
         fwd->dontRetry(true); // do not permit re-trying if the body was sent.
         state = WRITING_DATA;
-        debugs(9, 3, HERE << "writing data channel");
+        debugs(9, 3, "writing data channel");
     } else if (code == 150) {
         /* When client code is 150 with no data channel, Accept data channel. */
         debugs(9, 3, "ftpReadStor: accepting data channel");
@@ -2041,7 +2041,7 @@ ftpSendRest(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendRest"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     snprintf(cbuf, CTRL_BUFLEN, "REST %" PRId64 "\r\n", ftpState->restart_offset);
     ftpState->writeCommand(cbuf);
@@ -2079,14 +2079,14 @@ static void
 ftpReadRest(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
     assert(ftpState->restart_offset > 0);
 
     if (code == 350) {
         ftpState->setCurrentOffset(ftpState->restart_offset);
         ftpSendRetr(ftpState);
     } else if (code > 0) {
-        debugs(9, 3, HERE << "REST not supported");
+        debugs(9, 3, "REST not supported");
         ftpState->flags.rest_supported = 0;
         ftpSendRetr(ftpState);
     } else {
@@ -2101,7 +2101,7 @@ ftpSendList(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendList"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (ftpState->filepath) {
         snprintf(cbuf, CTRL_BUFLEN, "LIST %s\r\n", ftpState->filepath);
@@ -2120,7 +2120,7 @@ ftpSendNlst(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendNlst"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     ftpState->flags.tried_nlst = 1;
 
@@ -2138,18 +2138,18 @@ static void
 ftpReadList(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code == 125 || (code == 150 && Comm::IsConnOpen(ftpState->data.conn))) {
         /* Begin data transfer */
-        debugs(9, 3, HERE << "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
+        debugs(9, 3, "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
         ftpState->switchTimeoutToDataChannel();
         ftpState->maybeReadVirginBody();
         ftpState->state = Ftp::Client::READING_DATA;
         return;
     } else if (code == 150) {
         /* Accept data channel */
-        debugs(9, 3, HERE << "accept data channel from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
+        debugs(9, 3, "accept data channel from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
         ftpState->listenForDataChannel(ftpState->data.conn);
         return;
     } else if (!ftpState->flags.tried_nlst && code > 300) {
@@ -2167,7 +2167,7 @@ ftpSendRetr(Ftp::Gateway * ftpState)
     if (!ftpState || !ftpState->haveControlChannel("ftpSendRetr"))
         return;
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     assert(ftpState->filepath != NULL);
     snprintf(cbuf, CTRL_BUFLEN, "RETR %s\r\n", ftpState->filepath);
@@ -2179,11 +2179,11 @@ static void
 ftpReadRetr(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code == 125 || (code == 150 && Comm::IsConnOpen(ftpState->data.conn))) {
         /* Begin data transfer */
-        debugs(9, 3, HERE << "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
+        debugs(9, 3, "begin data transfer from " << ftpState->data.conn->remote << " (" << ftpState->data.conn->local << ")");
         ftpState->switchTimeoutToDataChannel();
         ftpState->maybeReadVirginBody();
         ftpState->state = Ftp::Client::READING_DATA;
@@ -2225,7 +2225,7 @@ static void
 ftpReadTransferDone(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (code == 226 || code == 250) {
         /* Connection closed; retrieval done. */
@@ -2236,7 +2236,7 @@ ftpReadTransferDone(Ftp::Gateway * ftpState)
         ftpState->markParsedVirginReplyAsWhole("ftpReadTransferDone code 226 or 250");
         ftpSendQuit(ftpState);
     } else {            /* != 226 */
-        debugs(9, DBG_IMPORTANT, HERE << "Got code " << code << " after reading data");
+        debugs(9, DBG_IMPORTANT, "Got code " << code << " after reading data");
         ftpState->failed(ERR_FTP_FAILURE, 0);
         /* failed closes ctrl.conn and frees ftpState */
         return;
@@ -2248,7 +2248,7 @@ void
 Ftp::Gateway::handleRequestBodyProducerAborted()
 {
     Client::handleRequestBodyProducerAborted();
-    debugs(9, 3, HERE << "ftpState=" << this);
+    debugs(9, 3, "ftpState=" << this);
     failed(ERR_READ_ERROR, 0);
 }
 
@@ -2256,10 +2256,10 @@ static void
 ftpWriteTransferDone(Ftp::Gateway * ftpState)
 {
     int code = ftpState->ctrl.replycode;
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (!(code == 226 || code == 250)) {
-        debugs(9, DBG_IMPORTANT, HERE << "Got code " << code << " after sending data");
+        debugs(9, DBG_IMPORTANT, "Got code " << code << " after sending data");
         ftpState->failed(ERR_FTP_PUT_ERROR, 0);
         return;
     }
@@ -2296,7 +2296,7 @@ ftpTrySlashHack(Ftp::Gateway * ftpState)
     ftpState->flags.try_slash_hack = 1;
     /* Free old paths */
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (ftpState->pathcomps)
         wordlistDestroy(&ftpState->pathcomps);
@@ -2320,7 +2320,7 @@ ftpTrySlashHack(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::unhack()
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (old_request != NULL) {
         safe_free(old_request);
@@ -2336,7 +2336,7 @@ Ftp::Gateway::hackShortcut(FTPSM * nextState)
     restart_offset = 0;
     /* Save old error message & some state info */
 
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (old_request == NULL) {
         old_request = ctrl.last_command;
@@ -2438,10 +2438,10 @@ ftpSendReply(Ftp::Gateway * ftpState)
     Http::StatusCode http_code;
     err_type err_code = ERR_NONE;
 
-    debugs(9, 3, HERE << ftpState->entry->url() << ", code " << code);
+    debugs(9, 3, ftpState->entry->url() << ", code " << code);
 
     if (cbdataReferenceValid(ftpState))
-        debugs(9, 5, HERE << "ftpState (" << ftpState << ") is valid!");
+        debugs(9, 5, "ftpState (" << ftpState << ") is valid!");
 
     if (code == 226 || code == 250) {
         err_code = (ftpState->mdtm > 0) ? ERR_FTP_PUT_MODIFIED : ERR_FTP_PUT_CREATED;
@@ -2478,7 +2478,7 @@ ftpSendReply(Ftp::Gateway * ftpState)
 void
 Ftp::Gateway::appendSuccessHeader()
 {
-    debugs(9, 3, HERE);
+    debugs(9, 3, MYNAME);
 
     if (flags.http_header_sent)
         return;
@@ -2628,7 +2628,7 @@ Ftp::Gateway::printfReplyBody(const char *fmt, ...)
 void
 Ftp::Gateway::writeReplyBody(const char *dataToWrite, size_t dataLength)
 {
-    debugs(9, 5, HERE << "writing " << dataLength << " bytes to the reply");
+    debugs(9, 5, "writing " << dataLength << " bytes to the reply");
     addVirginReplyBody(dataToWrite, dataLength);
 }
 

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/HttpTunnelerAnswer.cc
+++ b/src/clients/HttpTunnelerAnswer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/HttpTunnelerAnswer.h
+++ b/src/clients/HttpTunnelerAnswer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/clients/Makefile.am
+++ b/src/clients/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/clients/forward.h
+++ b/src/clients/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -419,7 +419,7 @@ comm_init_opened(const Comm::ConnectionPointer &conn,
     assert(AI);
 
     /* update fdstat */
-    debugs(5, 5, HERE << conn << " is a new socket");
+    debugs(5, 5, conn << " is a new socket");
 
     assert(!isOpen(conn->fd)); // NP: global isOpen checks the fde entry for openness not the Comm::Connection
     fd_open(conn->fd, FD_SOCKET, note);
@@ -512,7 +512,7 @@ comm_import_opened(const Comm::ConnectionPointer &conn,
                    const char *note,
                    struct addrinfo *AI)
 {
-    debugs(5, 2, HERE << conn);
+    debugs(5, 2, conn);
     assert(Comm::IsConnOpen(conn));
     assert(AI);
 
@@ -550,7 +550,7 @@ comm_import_opened(const Comm::ConnectionPointer &conn,
 void
 commUnsetFdTimeout(int fd)
 {
-    debugs(5, 3, HERE << "Remove timeout for FD " << fd);
+    debugs(5, 3, "Remove timeout for FD " << fd);
     assert(fd >= 0);
     assert(fd < Squid_MaxFD);
     fde *F = &fd_table[fd];
@@ -563,7 +563,7 @@ commUnsetFdTimeout(int fd)
 int
 commSetConnTimeout(const Comm::ConnectionPointer &conn, int timeout, AsyncCall::Pointer &callback)
 {
-    debugs(5, 3, HERE << conn << " timeout " << timeout);
+    debugs(5, 3, conn << " timeout " << timeout);
     assert(Comm::IsConnOpen(conn));
     assert(conn->fd < Squid_MaxFD);
     fde *F = &fd_table[conn->fd];
@@ -589,7 +589,7 @@ commSetConnTimeout(const Comm::ConnectionPointer &conn, int timeout, AsyncCall::
 int
 commUnsetConnTimeout(const Comm::ConnectionPointer &conn)
 {
-    debugs(5, 3, HERE << "Remove timeout for " << conn);
+    debugs(5, 3, "Remove timeout for " << conn);
     AsyncCall::Pointer nil;
     return commSetConnTimeout(conn, -1, nil);
 }
@@ -611,7 +611,7 @@ comm_connect_addr(int sock, const Ip::Address &address)
 
     assert(address.port() != 0);
 
-    debugs(5, 9, HERE << "connecting socket FD " << sock << " to " << address << " (want family: " << F->sock_family << ")");
+    debugs(5, 9, "connecting socket FD " << sock << " to " << address << " (want family: " << F->sock_family << ")");
 
     /* Handle IPv6 over IPv4-only socket case.
      * this case must presently be handled here since the getAddrInfo asserts on bad mappings.
@@ -1290,12 +1290,12 @@ ClientInfo::quota()
         // Rounding errors do not accumulate here, but we round down to avoid
         // negative bucket sizes after write with rationedCount=1.
         rationedQuota = static_cast<int>(floor(bucketLevel/rationedCount));
-        debugs(77,5, HERE << "new rationedQuota: " << rationedQuota <<
+        debugs(77,5, "new rationedQuota: " << rationedQuota <<
                '*' << rationedCount);
     }
 
     --rationedCount;
-    debugs(77,7, HERE << "rationedQuota: " << rationedQuota <<
+    debugs(77,7, "rationedQuota: " << rationedQuota <<
            " rations remaining: " << rationedCount);
 
     // update 'last seen' time to prevent clientdb GC from dropping us
@@ -1550,7 +1550,7 @@ checkTimeouts(void)
 void
 commStartHalfClosedMonitor(int fd)
 {
-    debugs(5, 5, HERE << "adding FD " << fd << " to " << *TheHalfClosed);
+    debugs(5, 5, "adding FD " << fd << " to " << *TheHalfClosed);
     assert(isOpen(fd) && !commHasHalfClosedMonitor(fd));
     (void)TheHalfClosed->add(fd); // could also assert the result
     fd_table[fd].codeContext = CodeContext::Current();
@@ -1573,7 +1573,7 @@ static
 void
 commHalfClosedCheck(void *)
 {
-    debugs(5, 5, HERE << "checking " << *TheHalfClosed);
+    debugs(5, 5, "checking " << *TheHalfClosed);
 
     typedef DescriptorSet::const_iterator DSCI;
     const DSCI end = TheHalfClosed->end();
@@ -1607,7 +1607,7 @@ commHasHalfClosedMonitor(int fd)
 void
 commStopHalfClosedMonitor(int const fd)
 {
-    debugs(5, 5, HERE << "removing FD " << fd << " from " << *TheHalfClosed);
+    debugs(5, 5, "removing FD " << fd << " from " << *TheHalfClosed);
 
     // cancel the read if one was scheduled
     AsyncCall::Pointer reader = fd_table[fd].halfClosedReader;
@@ -1635,7 +1635,7 @@ commHalfClosedReader(const Comm::ConnectionPointer &conn, char *, size_t size, C
 
     // if read failed, close the connection
     if (flag != Comm::OK) {
-        debugs(5, 3, HERE << "closing " << conn);
+        debugs(5, 3, "closing " << conn);
         conn->close();
         return;
     }
@@ -1844,7 +1844,7 @@ comm_open_uds(int sock_type,
     AI.ai_canonname = NULL;
     AI.ai_next = NULL;
 
-    debugs(50, 3, HERE << "Attempt open socket for: " << addr->sun_path);
+    debugs(50, 3, "Attempt open socket for: " << addr->sun_path);
 
     if ((new_socket = socket(AI.ai_family, AI.ai_socktype, AI.ai_protocol)) < 0) {
         int xerrno = errno;
@@ -1864,7 +1864,7 @@ comm_open_uds(int sock_type,
     debugs(50, 3, "Opened UDS FD " << new_socket << " : family=" << AI.ai_family << ", type=" << AI.ai_socktype << ", protocol=" << AI.ai_protocol);
 
     /* update fdstat */
-    debugs(50, 5, HERE << "FD " << new_socket << " is a new socket");
+    debugs(50, 5, "FD " << new_socket << " is a new socket");
 
     assert(!isOpen(new_socket));
     fd_open(new_socket, FD_MSGHDR, addr->sun_path);

--- a/src/comm.h
+++ b/src/comm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/AcceptLimiter.h
+++ b/src/comm/AcceptLimiter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -364,12 +364,12 @@ Comm::ConnOpener::doConnect()
     switch (comm_connect_addr(temporaryFd_, conn_->remote) ) {
 
     case Comm::INPROGRESS:
-        debugs(5, 5, HERE << conn_ << ": Comm::INPROGRESS");
+        debugs(5, 5, conn_ << ": Comm::INPROGRESS");
         Comm::SetSelect(temporaryFd_, COMM_SELECT_WRITE, Comm::ConnOpener::InProgressConnectRetry, new Pointer(this), 0);
         break;
 
     case Comm::OK:
-        debugs(5, 5, HERE << conn_ << ": Comm::OK - connected");
+        debugs(5, 5, conn_ << ": Comm::OK - connected");
         connected();
         break;
 
@@ -381,12 +381,12 @@ Comm::ConnOpener::doConnect()
                Config.connect_retries << ": " << xstrerr(xerrno));
 
         if (failRetries_ < Config.connect_retries) {
-            debugs(5, 5, HERE << conn_ << ": * - try again");
+            debugs(5, 5, conn_ << ": * - try again");
             retrySleep();
             return;
         } else {
             // send ERROR back to the upper layer.
-            debugs(5, 5, HERE << conn_ << ": * - ERR tried too many times already.");
+            debugs(5, 5, conn_ << ": * - ERR tried too many times already.");
             sendAnswer(Comm::ERR_CONNECT, xerrno, "Comm::ConnOpener::doConnect");
         }
     }
@@ -442,7 +442,7 @@ Comm::ConnOpener::lookupLocalAddress()
 
     conn_->local = *addr;
     Ip::Address::FreeAddr(addr);
-    debugs(5, 6, HERE << conn_);
+    debugs(5, 6, conn_);
 }
 
 /** Abort connection attempt.
@@ -451,7 +451,7 @@ Comm::ConnOpener::lookupLocalAddress()
 void
 Comm::ConnOpener::earlyAbort(const CommCloseCbParams &io)
 {
-    debugs(5, 3, HERE << io.conn);
+    debugs(5, 3, io.conn);
     calls_.earlyAbort_ = NULL;
     // NP: is closing or shutdown better?
     sendAnswer(Comm::ERR_CLOSING, io.xerrno, "Comm::ConnOpener::earlyAbort");
@@ -464,7 +464,7 @@ Comm::ConnOpener::earlyAbort(const CommCloseCbParams &io)
 void
 Comm::ConnOpener::timeout(const CommTimeoutCbParams &)
 {
-    debugs(5, 5, HERE << conn_ << ": * - ERR took too long to receive response.");
+    debugs(5, 5, conn_ << ": * - ERR took too long to receive response.");
     calls_.timeout_ = NULL;
     sendAnswer(Comm::TIMEOUT, ETIMEDOUT, "Comm::ConnOpener::timeout");
 }

--- a/src/comm/ConnOpener.h
+++ b/src/comm/ConnOpener.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Flag.h
+++ b/src/comm/Flag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/IoCallback.cc
+++ b/src/comm/IoCallback.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/IoCallback.h
+++ b/src/comm/IoCallback.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Loops.h
+++ b/src/comm/Loops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Makefile.am
+++ b/src/comm/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/comm/ModDevPoll.cc
+++ b/src/comm/ModDevPoll.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -106,7 +106,7 @@ comm_flush_updates(void)
     debugs(
         5,
         DEBUG_DEVPOLL ? 0 : 8,
-        HERE << (devpoll_update.cur + 1) << " fds queued"
+        (devpoll_update.cur + 1) << " fds queued"
     );
 
     i = write(
@@ -134,7 +134,7 @@ comm_update_fd(int fd, int events)
     debugs(
         5,
         DEBUG_DEVPOLL ? 0 : 8,
-        HERE << "FD " << fd << ", events=" << events
+        "FD " << fd << ", events=" << events
     );
 
     /* Is the array already full and in need of flushing? */
@@ -224,7 +224,7 @@ void
 Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time_t timeout)
 {
     assert(fd >= 0);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 
@@ -351,7 +351,7 @@ Comm::DoSelect(int msec)
         debugs(
             5,
             DEBUG_DEVPOLL ? 0 : 8,
-            HERE << "got FD " << fd
+            "got FD " << fd
             << ",events=" << std::hex << do_poll.dp_fds[i].revents
             << ",monitoring=" << devpoll_state[fd].state
             << ",F->read_handler=" << F->read_handler
@@ -361,8 +361,8 @@ Comm::DoSelect(int msec)
         /* handle errors */
         if (do_poll.dp_fds[i].revents & (POLLERR | POLLHUP | POLLNVAL)) {
             debugs(5, DEBUG_DEVPOLL ? 0 : 8,
-                "ERROR: devpoll event failure: fd " << fd
-            );
+                   "ERROR: devpoll event failure: fd " << fd
+                  );
             continue;
         }
 
@@ -372,7 +372,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "Calling read handler on FD " << fd
+                    "Calling read handler on FD " << fd
                 );
                 F->read_handler = NULL;
                 hdl(fd, F->read_data);
@@ -381,7 +381,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "no read handler for FD " << fd
+                    "no read handler for FD " << fd
                 );
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_READ, NULL, NULL, 0);
@@ -394,7 +394,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "Calling write handler on FD " << fd
+                    "Calling write handler on FD " << fd
                 );
                 F->write_handler = NULL;
                 hdl(fd, F->write_data);
@@ -403,7 +403,7 @@ Comm::DoSelect(int msec)
                 debugs(
                     5,
                     DEBUG_DEVPOLL ? 0 : 8,
-                    HERE << "no write handler for FD " << fd
+                    "no write handler for FD " << fd
                 );
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_WRITE, NULL, NULL, 0);

--- a/src/comm/ModEpoll.cc
+++ b/src/comm/ModEpoll.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -112,7 +112,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     int epoll_ctl_type = 0;
 
     assert(fd >= 0);
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 
@@ -253,7 +253,7 @@ Comm::DoSelect(int msec)
         fd = cevents->data.fd;
         F = &fd_table[fd];
         CodeContext::Reset(F->codeContext);
-        debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "got FD " << fd << " events=" <<
+        debugs(5, DEBUG_EPOLL ? 0 : 8, "got FD " << fd << " events=" <<
                std::hex << cevents->events << " monitoring=" << F->epoll_state <<
                " F->read_handler=" << F->read_handler << " F->write_handler=" << F->write_handler);
 
@@ -261,12 +261,12 @@ Comm::DoSelect(int msec)
 
         if (cevents->events & (EPOLLIN|EPOLLHUP|EPOLLERR) || F->flags.read_pending) {
             if ((hdl = F->read_handler) != NULL) {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "Calling read handler on FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "Calling read handler on FD " << fd);
                 F->read_handler = NULL;
                 hdl(fd, F->read_data);
                 ++ statCounter.select_fds;
             } else {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "no read handler for FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "no read handler for FD " << fd);
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_READ, NULL, NULL, 0);
             }
@@ -274,12 +274,12 @@ Comm::DoSelect(int msec)
 
         if (cevents->events & (EPOLLOUT|EPOLLHUP|EPOLLERR)) {
             if ((hdl = F->write_handler) != NULL) {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "Calling write handler on FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "Calling write handler on FD " << fd);
                 F->write_handler = NULL;
                 hdl(fd, F->write_data);
                 ++ statCounter.select_fds;
             } else {
-                debugs(5, DEBUG_EPOLL ? 0 : 8, HERE << "no write handler for FD " << fd);
+                debugs(5, DEBUG_EPOLL ? 0 : 8, "no write handler for FD " << fd);
                 // remove interest since no handler exist for this event.
                 SetSelect(fd, COMM_SELECT_WRITE, NULL, NULL, 0);
             }

--- a/src/comm/ModKqueue.cc
+++ b/src/comm/ModKqueue.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -169,7 +169,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open || (!handler && !client_data && !timeout));
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/ModPoll.cc
+++ b/src/comm/ModPoll.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -125,7 +125,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open || (!handler && !client_data && !timeout));
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/ModSelect.cc
+++ b/src/comm/ModSelect.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -125,7 +125,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open || (!handler && !client_data && !timeout));
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/ModSelectWin32.cc
+++ b/src/comm/ModSelectWin32.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -119,7 +119,7 @@ Comm::SetSelect(int fd, unsigned int type, PF * handler, void *client_data, time
     fde *F = &fd_table[fd];
     assert(fd >= 0);
     assert(F->flags.open || (!handler && !client_data && !timeout));
-    debugs(5, 5, HERE << "FD " << fd << ", type=" << type <<
+    debugs(5, 5, "FD " << fd << ", type=" << type <<
            ", handler=" << handler << ", client_data=" << client_data <<
            ", timeout=" << timeout);
 

--- a/src/comm/Read.cc
+++ b/src/comm/Read.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Read.h
+++ b/src/comm/Read.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Tcp.cc
+++ b/src/comm/Tcp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -42,7 +42,7 @@ SetSocketOption(const int fd, const int level, const int optName, const Option &
 static bool
 SetBooleanSocketOption(const int fd, const int level, const int optName, const bool enable)
 {
-    const int optValue = enable ? 1 : 0;
+    const int optValue = enable ? 1 :0;
     return SetSocketOption(fd, level, optName, optValue);
 }
 

--- a/src/comm/Tcp.h
+++ b/src/comm/Tcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -58,7 +58,7 @@ Comm::TcpAcceptor::TcpAcceptor(const AnyP::PortCfgPointer &p, const char *, cons
 void
 Comm::TcpAcceptor::subscribe(const Subscription::Pointer &aSub)
 {
-    debugs(5, 5, HERE << status() << " AsyncCall Subscription: " << aSub);
+    debugs(5, 5, status() << " AsyncCall Subscription: " << aSub);
     unsubscribe("subscription change");
     theCallSub = aSub;
 }
@@ -66,7 +66,7 @@ Comm::TcpAcceptor::subscribe(const Subscription::Pointer &aSub)
 void
 Comm::TcpAcceptor::unsubscribe(const char *reason)
 {
-    debugs(5, 5, HERE << status() << " AsyncCall Subscription " << theCallSub << " removed: " << reason);
+    debugs(5, 5, status() << " AsyncCall Subscription " << theCallSub << " removed: " << reason);
     theCallSub = NULL;
 }
 
@@ -75,7 +75,7 @@ Comm::TcpAcceptor::start()
 {
     if (listenPort_)
         CodeContext::Reset(listenPort_);
-    debugs(5, 5, HERE << status() << " AsyncCall Subscription: " << theCallSub);
+    debugs(5, 5, status() << " AsyncCall Subscription: " << theCallSub);
 
     Must(IsConnOpen(conn));
 
@@ -108,7 +108,7 @@ Comm::TcpAcceptor::doneAll() const
 void
 Comm::TcpAcceptor::swanSong()
 {
-    debugs(5,5, HERE);
+    debugs(5,5, MYNAME);
     unsubscribe("swanSong");
     if (IsConnOpen(conn)) {
         if (closer_ != NULL)
@@ -212,7 +212,7 @@ void
 Comm::TcpAcceptor::doAccept(int fd, void *data)
 {
     try {
-        debugs(5, 2, HERE << "New connection on FD " << fd);
+        debugs(5, 2, "New connection on FD " << fd);
 
         Must(isOpen(fd));
         TcpAcceptor *afd = static_cast<TcpAcceptor*>(data);
@@ -278,7 +278,7 @@ Comm::TcpAcceptor::acceptOne()
 
     if (flag == Comm::COMM_ERROR) {
         // A non-recoverable error; notify the caller */
-        debugs(5, 5, HERE << "non-recoverable error:" << status() << " handler Subscription: " << theCallSub);
+        debugs(5, 5, "non-recoverable error:" << status() << " handler Subscription: " << theCallSub);
         if (intendedForUserConnections())
             logAcceptError(newConnDetails);
         notify(flag, newConnDetails);
@@ -306,7 +306,7 @@ void
 Comm::TcpAcceptor::acceptNext()
 {
     Must(IsConnOpen(conn));
-    debugs(5, 2, HERE << "connection on " << conn);
+    debugs(5, 2, "connection on " << conn);
     acceptOne();
 }
 

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/UdpOpenDialer.h
+++ b/src/comm/UdpOpenDialer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/Write.cc
+++ b/src/comm/Write.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -33,7 +33,7 @@ Comm::Write(const Comm::ConnectionPointer &conn, MemBuf *mb, AsyncCall::Pointer 
 void
 Comm::Write(const Comm::ConnectionPointer &conn, const char *buf, int size, AsyncCall::Pointer &callback, FREE * free_func)
 {
-    debugs(5, 5, HERE << conn << ": sz " << size << ": asynCall " << callback);
+    debugs(5, 5, conn << ": sz " << size << ": asynCall " << callback);
 
     /* Make sure we are open, not closing, and not writing */
     assert(fd_table[conn->fd].flags.open);
@@ -63,7 +63,7 @@ Comm::HandleWrite(int fd, void *data)
     assert(state->conn != NULL);
     assert(state->conn->fd == fd);
 
-    debugs(5, 5, HERE << state->conn << ": off " <<
+    debugs(5, 5, state->conn << ": off " <<
            (long int) state->offset << ", sz " << (long int) state->size << ".");
 
     nleft = state->size - state->offset;
@@ -83,7 +83,7 @@ Comm::HandleWrite(int fd, void *data)
     int xerrno = errno = 0;
     len = FD_WRITE_METHOD(fd, state->buf + state->offset, nleft);
     xerrno = errno;
-    debugs(5, 5, HERE << "write() returns " << len);
+    debugs(5, 5, "write() returns " << len);
 
 #if USE_DELAY_POOLS
     if (bucket) {

--- a/src/comm/Write.h
+++ b/src/comm/Write.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/comm_internal.h
+++ b/src/comm/comm_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm/forward.h
+++ b/src/comm/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/comm_poll.h
+++ b/src/comm_poll.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/defines.h
+++ b/src/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/delay_pools.cc
+++ b/src/delay_pools.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dlink.cc
+++ b/src/dlink.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dlink.h
+++ b/src/dlink.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/LookupDetails.cc
+++ b/src/dns/LookupDetails.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/LookupDetails.h
+++ b/src/dns/LookupDetails.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/Makefile.am
+++ b/src/dns/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/dns/forward.h
+++ b/src/dns/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/rfc1035.cc
+++ b/src/dns/rfc1035.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/rfc1035.h
+++ b/src/dns/rfc1035.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/rfc2671.cc
+++ b/src/dns/rfc2671.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/rfc2671.h
+++ b/src/dns/rfc2671.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/rfc3596.cc
+++ b/src/dns/rfc3596.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns/rfc3596.h
+++ b/src/dns/rfc3596.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -1214,7 +1214,7 @@ idnsGrokReply(const char *buf, size_t sz, int /*from_ns*/)
     q->pending = 0;
 
     if (message->tc) {
-        debugs(78, 3, HERE << "Resolver requested TC (" << q->query.name << ")");
+        debugs(78, 3, "Resolver requested TC (" << q->query.name << ")");
         rfc1035MessageDestroy(&message);
 
         if (!q->need_vc) {
@@ -1224,7 +1224,7 @@ idnsGrokReply(const char *buf, size_t sz, int /*from_ns*/)
         } else {
             // Strange: A TCP DNS response with the truncation bit (TC) set.
             // Return an error and cleanup; no point in trying TCP again.
-            debugs(78, 3, HERE << "TCP DNS response");
+            debugs(78, 3, "TCP DNS response");
             idnsCallback(q, "Truncated TCP DNS response");
         }
 
@@ -1472,7 +1472,7 @@ idnsReadVC(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm::Fla
     }
 
     assert(vc->ns < nameservers.size());
-    debugs(78, 3, HERE << conn << ": received " << vc->msg->contentSize() << " bytes via TCP from " << nameservers[vc->ns].S << ".");
+    debugs(78, 3, conn << ": received " << vc->msg->contentSize() << " bytes via TCP from " << nameservers[vc->ns].S << ".");
 
     idnsGrokReply(vc->msg->buf, vc->msg->contentSize(), vc->ns);
     vc->msg->clean();
@@ -1727,7 +1727,7 @@ idnsSendSlaveAAAAQuery(idns_query *master)
     q->query_id = idnsQueryID();
     q->sz = rfc3596BuildAAAAQuery(q->name, q->buf, sizeof(q->buf), q->query_id, &q->query, Config.dns.packet_max);
 
-    debugs(78, 3, HERE << "buf is " << q->sz << " bytes for " << q->name <<
+    debugs(78, 3, "buf is " << q->sz << " bytes for " << q->name <<
            ", id = 0x" << std::hex << q->query_id);
     if (!q->sz) {
         delete q;

--- a/src/enums.h
+++ b/src/enums.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/Detail.cc
+++ b/src/error/Detail.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/Detail.h
+++ b/src/error/Detail.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/Error.cc
+++ b/src/error/Error.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/Error.h
+++ b/src/error/Error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/ExceptionErrorDetail.h
+++ b/src/error/ExceptionErrorDetail.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/Makefile.am
+++ b/src/error/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/error/SysErrorDetail.h
+++ b/src/error/SysErrorDetail.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -408,7 +408,7 @@ TemplateFile::tryLoadTemplate(const char *lang)
     if ( strlen(lang) == 2) {
         /* TODO glob the error directory for sub-dirs matching: <tag> '-*'   */
         /* use first result. */
-        debugs(4,2, HERE << "wildcard fallback errors not coded yet.");
+        debugs(4,2, "wildcard fallback errors not coded yet.");
     }
 #endif
 
@@ -532,17 +532,17 @@ TemplateFile::loadFor(const HttpRequest *request)
     char lang[256];
     size_t pos = 0; // current parsing position in header string
 
-    debugs(4, 6, HERE << "Testing Header: '" << hdr << "'");
+    debugs(4, 6, "Testing Header: '" << hdr << "'");
 
     while ( strHdrAcptLangGetItem(hdr, lang, 256, pos) ) {
 
         /* wildcard uses the configured default language */
         if (lang[0] == '*' && lang[1] == '\0') {
-            debugs(4, 6, HERE << "Found language '" << lang << "'. Using configured default.");
+            debugs(4, 6, "Found language '" << lang << "'. Using configured default.");
             return false;
         }
 
-        debugs(4, 6, HERE << "Found language '" << lang << "', testing for available template");
+        debugs(4, 6, "Found language '" << lang << "', testing for available template");
 
         if (tryLoadTemplate(lang)) {
             /* store the language we found for the Content-Language reply header */
@@ -775,7 +775,7 @@ static void
 errorSendComplete(const Comm::ConnectionPointer &conn, char *, size_t size, Comm::Flag errflag, int, void *data)
 {
     ErrorState *err = static_cast<ErrorState *>(data);
-    debugs(4, 3, HERE << conn << ", size=" << size);
+    debugs(4, 3, conn << ", size=" << size);
 
     if (errflag != Comm::ERR_CLOSING) {
         if (err->callback) {

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Assign.cc
+++ b/src/esi/Assign.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Assign.h
+++ b/src/esi/Assign.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Attempt.h
+++ b/src/esi/Attempt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Context.cc
+++ b/src/esi/Context.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Context.h
+++ b/src/esi/Context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Element.h
+++ b/src/esi/Element.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -25,7 +25,7 @@ typedef enum {
 class ESIElement;
 
 struct esiTreeParent : public RefCountable {
-    virtual void provideData (ESISegment::Pointer /* data  */ , ESIElement * /* source */ ) {
+    virtual void provideData (ESISegment::Pointer /* data  */, ESIElement * /* source */ ) {
         /* make abstract when all functionality complete */
         assert (0);
     }

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -1384,7 +1384,7 @@ ESIContext::ParserState::popAll()
 void
 ESIContext::freeResources ()
 {
-    debugs(86, 5, HERE << "Freeing for this=" << this);
+    debugs(86, 5, "Freeing for this=" << this);
 
     rep = nullptr; // refcounted
 

--- a/src/esi/Esi.h
+++ b/src/esi/Esi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Except.h
+++ b/src/esi/Except.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/ExpatParser.cc
+++ b/src/esi/ExpatParser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/ExpatParser.h
+++ b/src/esi/ExpatParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Expression.cc
+++ b/src/esi/Expression.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Expression.h
+++ b/src/esi/Expression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -80,7 +80,7 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
     assert (receivedData.length <= sizeof(esiStream->localbuffer->buf));
     assert (!esiStream->finished);
 
-    debugs (86,5, HERE << "rep " << rep << " body " << receivedData.data << " len " << receivedData.length);
+    debugs (86,5, "rep " << rep << " body " << receivedData.data << " len " << receivedData.length);
     assert (node->readBuffer.offset == receivedData.offset || receivedData.length == 0);
 
     /* trivial case */
@@ -128,7 +128,7 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
     /* EOF / Read error /  aborted entry */
     if (rep == NULL && receivedData.data == NULL && receivedData.length == 0) {
         /* TODO: get stream status to test the entry for aborts */
-        debugs(86, 5, HERE << "Finished reading upstream data in subrequest");
+        debugs(86, 5, "Finished reading upstream data in subrequest");
         esiStream->include->subRequestDone (esiStream, true);
         esiStream->finished = 1;
         httpRequestFree (http);
@@ -171,7 +171,7 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
         tempBuffer.data = esiStream->buffer->buf;
         /* now just read into 'buffer' */
         clientStreamRead (node, http, tempBuffer);
-        debugs(86, 5, HERE << "Requested more data for ESI subrequest");
+        debugs(86, 5, "Requested more data for ESI subrequest");
     }
 
     break;
@@ -513,14 +513,14 @@ ESIInclude::subRequestDone (ESIStreamContext::Pointer stream, bool success)
          */
         if (parent.getRaw() == NULL) {
             debugs(86, DBG_CRITICAL, "ERROR: Squid Bug #951: ESIInclude::subRequestDone: Sub request completed "
-                    "after finish() called and parent unlinked. Unable to "
-                    "continue handling the request, and may be memory leaking. "
-                    "See http://www.squid-cache.org/bugs/show_bug.cgi?id=951 - we "
-                    "are looking for a reproducible test case. This will require "
-                    "an ESI template with includes, probably with alt-options, "
-                    "and we're likely to need traffic dumps to allow us to "
-                    "reconstruct the exact tcp handling sequences to trigger this "
-                    "rather elusive bug.");
+                   "after finish() called and parent unlinked. Unable to "
+                   "continue handling the request, and may be memory leaking. "
+                   "See http://www.squid-cache.org/bugs/show_bug.cgi?id=951 - we "
+                   "are looking for a reproducible test case. This will require "
+                   "an ESI template with includes, probably with alt-options, "
+                   "and we're likely to need traffic dumps to allow us to "
+                   "reconstruct the exact tcp handling sequences to trigger this "
+                   "rather elusive bug.");
             return;
         }
         assert (parent.getRaw());

--- a/src/esi/Include.h
+++ b/src/esi/Include.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Libxml2Parser.h
+++ b/src/esi/Libxml2Parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Literal.h
+++ b/src/esi/Literal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Makefile.am
+++ b/src/esi/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/esi/Parser.cc
+++ b/src/esi/Parser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Parser.h
+++ b/src/esi/Parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Segment.cc
+++ b/src/esi/Segment.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Segment.h
+++ b/src/esi/Segment.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Sequence.cc
+++ b/src/esi/Sequence.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Sequence.h
+++ b/src/esi/Sequence.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/Var.h
+++ b/src/esi/Var.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/esi/VarState.cc
+++ b/src/esi/VarState.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -28,7 +28,7 @@ char const * esiBrowsers[]= {"MSIE",
 CBDATA_CLASS_INIT(ESIVarState);
 
 void
-ESIVarState::Variable::eval(ESIVarState &state, char const * , char const *found_default) const
+ESIVarState::Variable::eval(ESIVarState &state, char const *, char const *found_default) const
 {
     /* No-op. We swallow it */
 

--- a/src/esi/VarState.h
+++ b/src/esi/VarState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/eui/Config.cc
+++ b/src/eui/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/eui/Config.h
+++ b/src/eui/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/eui/Eui48.cc
+++ b/src/eui/Eui48.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/eui/Eui48.h
+++ b/src/eui/Eui48.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/eui/Eui64.cc
+++ b/src/eui/Eui64.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/eui/Eui64.h
+++ b/src/eui/Eui64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/eui/Makefile.am
+++ b/src/eui/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/event.cc
+++ b/src/event.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -315,7 +315,7 @@ EventScheduler::schedule(const char *name, EVH * func, void *arg, double when, i
     ev_entry *event = new ev_entry(name, func, arg, timestamp, weight, cbdata);
 
     ev_entry **E;
-    debugs(41, 7, HERE << "schedule: Adding '" << name << "', in " << when << " seconds");
+    debugs(41, 7, "schedule: Adding '" << name << "', in " << when << " seconds");
     /* Insert after the last event with the same or earlier time */
 
     for (E = &tasks; *E; E = &(*E)->next) {

--- a/src/event.h
+++ b/src/event.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -598,7 +598,7 @@ copyResultsFromEntry(HttpRequest *req, const ExternalACLEntryPointer &entry)
 static Acl::Answer
 aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
 {
-    debugs(82, 9, HERE << "acl=\"" << acl->def->name << "\"");
+    debugs(82, 9, "acl=\"" << acl->def->name << "\"");
     ExternalACLEntryPointer entry = ch->extacl_entry;
 
     external_acl_message = "MISSING REQUIRED INFORMATION";
@@ -627,17 +627,17 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
     }
 
     if (!entry) {
-        debugs(82, 9, HERE << "No helper entry available");
+        debugs(82, 9, "No helper entry available");
 #if USE_AUTH
         if (acl->def->require_auth) {
             /* Make sure the user is authenticated */
-            debugs(82, 3, HERE << acl->def->name << " check user authenticated.");
+            debugs(82, 3, acl->def->name << " check user authenticated.");
             const auto ti = AuthenticateAcl(ch);
             if (!ti.allowed()) {
-                debugs(82, 2, HERE << acl->def->name << " user not authenticated (" << ti << ")");
+                debugs(82, 2, acl->def->name << " user not authenticated (" << ti << ")");
                 return ti;
             }
-            debugs(82, 3, HERE << acl->def->name << " user is authenticated.");
+            debugs(82, 3, acl->def->name << " user is authenticated.");
         }
 #endif
         const char *key = makeExternalAclKey(ch, acl);
@@ -656,19 +656,19 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
         if (entry != NULL && external_acl_grace_expired(acl->def, entry)) {
             // refresh in the background
             ExternalACLLookup::Start(ch, acl, true);
-            debugs(82, 4, HERE << "no need to wait for the refresh of '" <<
+            debugs(82, 4, "no need to wait for the refresh of '" <<
                    key << "' in '" << acl->def->name << "' (ch=" << ch << ").");
         }
 
         if (!entry) {
-            debugs(82, 2, HERE << acl->def->name << "(\"" << key << "\") = lookup needed");
+            debugs(82, 2, acl->def->name << "(\"" << key << "\") = lookup needed");
 
             // TODO: All other helpers allow temporary overload. Should not we?
             if (!acl->def->theHelper->willOverload()) {
-                debugs(82, 2, HERE << "\"" << key << "\": queueing a call.");
+                debugs(82, 2, "\"" << key << "\": queueing a call.");
                 if (!ch->goAsync(ExternalACLLookup::Instance()))
                     debugs(82, 2, "\"" << key << "\": no async support!");
-                debugs(82, 2, HERE << "\"" << key << "\": return -1.");
+                debugs(82, 2, "\"" << key << "\": return -1.");
                 return ACCESS_DUNNO; // expired cached or simply absent entry
             } else {
                 if (!staleEntry) {
@@ -686,19 +686,19 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
         }
     }
 
-    debugs(82, 4, HERE << "entry = { date=" <<
+    debugs(82, 4, "entry = { date=" <<
            (long unsigned int) entry->date <<
            ", result=" << entry->result <<
            " tag=" << entry->tag <<
            " log=" << entry->log << " }");
 #if USE_AUTH
-    debugs(82, 4, HERE << "entry user=" << entry->user);
+    debugs(82, 4, "entry user=" << entry->user);
 #endif
 
     external_acl_cache_touch(acl->def, entry);
     external_acl_message = entry->message.termedBuf();
 
-    debugs(82, 2, HERE << acl->def->name << " = " << entry->result);
+    debugs(82, 2, acl->def->name << " = " << entry->result);
     copyResultsFromEntry(ch->request, entry);
     return entry->result;
 }
@@ -848,7 +848,7 @@ external_acl_cache_add(external_acl * def, const char *key, ExternalACLEntryData
     ExternalACLEntryPointer entry;
 
     if (!def->maybeCacheable(data.result)) {
-        debugs(82,6, HERE);
+        debugs(82,6, MYNAME);
 
         if (data.result == ACCESS_DUNNO) {
             if (const ExternalACLEntryPointer oldentry = static_cast<ExternalACLEntry *>(hash_lookup(def->cache, key)))
@@ -956,7 +956,7 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
     externalAclState *next;
     ExternalACLEntryData entryData;
 
-    debugs(82, 2, HERE << "reply=" << reply);
+    debugs(82, 2, "reply=" << reply);
 
     if (reply.result == Helper::Okay)
         entryData.result = ACCESS_ALLOWED;
@@ -1028,7 +1028,7 @@ ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool i
     const char *key = makeExternalAclKey(ch, acl);
     assert(key); // XXX: will fail if EXT_ACL_IDENT case needs an async lookup
 
-    debugs(82, 2, HERE << (inBackground ? "bg" : "fg") << " lookup in '" <<
+    debugs(82, 2, (inBackground ? "bg" : "fg") << " lookup in '" <<
            def->name << "' for '" << key << "'");
 
     /* Check for a pending lookup to hook into */
@@ -1048,7 +1048,7 @@ ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool i
     // A background refresh has no need to piggiback on a pending request:
     // When the pending request completes, the cache will be refreshed anyway.
     if (oldstate && inBackground) {
-        debugs(82, 7, HERE << "'" << def->name << "' queue is already being refreshed (ch=" << ch << ")");
+        debugs(82, 7, "'" << def->name << "' queue is already being refreshed (ch=" << ch << ")");
         return;
     }
 
@@ -1072,7 +1072,7 @@ ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool i
         debugs(82, 4, "externalAclLookup: looking up for '" << key << "' in '" << def->name << "'.");
 
         if (!def->theHelper->trySubmit(buf.buf, externalAclHandleReply, state)) {
-            debugs(82, 7, HERE << "'" << def->name << "' submit to helper failed");
+            debugs(82, 7, "'" << def->name << "' submit to helper failed");
             assert(inBackground); // or the caller should have checked
             delete state;
             return;

--- a/src/fatal.cc
+++ b/src/fatal.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fatal.h
+++ b/src/fatal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fd.h
+++ b/src/fd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fde.cc
+++ b/src/fde.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fde.h
+++ b/src/fde.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/filemap.cc
+++ b/src/filemap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -36,7 +36,7 @@ FileMap::FileMap() :
     capacity_(FM_INITIAL_NUMBER), usedSlots_(0),
     nwords(capacity_ >> LONG_BIT_SHIFT)
 {
-    debugs(8, 3, HERE << "creating space for " << capacity_ << " files");
+    debugs(8, 3, "creating space for " << capacity_ << " files");
     debugs(8, 5, "--> " << nwords << " words of " << sizeof(*bitmap) << " bytes each");
     bitmap = (unsigned long *)xcalloc(nwords, sizeof(*bitmap));
 }
@@ -49,7 +49,7 @@ FileMap::grow()
     capacity_ <<= 1;
     assert(capacity_ <= (1 << 24)); /* swap_filen is 25 bits, signed */
     nwords = capacity_ >> LONG_BIT_SHIFT;
-    debugs(8, 3, HERE << " creating space for " << capacity_ << " files");
+    debugs(8, 3, " creating space for " << capacity_ << " files");
     debugs(8, 5, "--> " << nwords << " words of " << sizeof(*bitmap) << " bytes each");
     bitmap = (unsigned long *)xcalloc(nwords, sizeof(*bitmap));
     debugs(8, 3, "copying " << old_sz << " old bytes");

--- a/src/format/ByteCode.h
+++ b/src/format/ByteCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/format/Config.cc
+++ b/src/format/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/format/Config.h
+++ b/src/format/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -69,7 +69,7 @@ Format::Format::parse(const char *def)
     Token *new_lt, *last_lt;
     enum Quoting quote = LOG_QUOTE_NONE;
 
-    debugs(46, 2, HERE << "got definition '" << def << "'");
+    debugs(46, 2, "got definition '" << def << "'");
 
     if (format) {
         debugs(46, DBG_IMPORTANT, "WARNING: existing format for '" << name << " " << def << "'");
@@ -116,11 +116,11 @@ Format::AssembleOne(const char *token, MemBuf &mb, const AccessLogEntryPointer &
 void
 Format::Format::dump(StoreEntry * entry, const char *directiveName, bool eol) const
 {
-    debugs(46, 4, HERE);
+    debugs(46, 4, MYNAME);
 
     // loop rather than recursing to conserve stack space.
     for (const Format *fmt = this; fmt; fmt = fmt->next) {
-        debugs(46, 3, HERE << "Dumping format definition for " << fmt->name);
+        debugs(46, 3, "Dumping format definition for " << fmt->name);
         if (directiveName)
             storeAppendPrintf(entry, "%s %s ", directiveName, fmt->name);
 

--- a/src/format/Format.h
+++ b/src/format/Format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/format/Makefile.am
+++ b/src/format/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/format/Quoting.cc
+++ b/src/format/Quoting.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/format/Quoting.h
+++ b/src/format/Quoting.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/format/Token.cc
+++ b/src/format/Token.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -272,11 +272,11 @@ const char *
 Format::Token::scanForToken(TokenTableEntry const table[], const char *cur)
 {
     for (TokenTableEntry const *lte = table; lte->configTag != NULL; ++lte) {
-        debugs(46, 8, HERE << "compare tokens '" << lte->configTag << "' with '" << cur << "'");
+        debugs(46, 8, "compare tokens '" << lte->configTag << "' with '" << cur << "'");
         if (strncmp(lte->configTag, cur, strlen(lte->configTag)) == 0) {
             type = lte->tokenType;
             label = lte->configTag;
-            debugs(46, 7, HERE << "Found token '" << label << "'");
+            debugs(46, 7, "Found token '" << label << "'");
             return cur + strlen(lte->configTag);
         }
     }
@@ -434,16 +434,16 @@ Format::Token::parse(const char *def, Quoting *quoting)
             //     mistakes made with overlapping names. (Bug 3310)
 
             // Scan for various long tokens
-            debugs(46, 5, HERE << "scan for possible Misc token");
+            debugs(46, 5, "scan for possible Misc token");
             cur = scanForToken(TokenTableMisc, cur);
             // scan for 2-char tokens
             if (type == LFT_NONE) {
-                debugs(46, 5, HERE << "scan for possible 2C token");
+                debugs(46, 5, "scan for possible 2C token");
                 cur = scanForToken(TokenTable2C, cur);
             }
             // finally scan for 1-char tokens.
             if (type == LFT_NONE) {
-                debugs(46, 5, HERE << "scan for possible 1C token");
+                debugs(46, 5, "scan for possible 1C token");
                 cur = scanForToken(TokenTable1C, cur);
             }
         }

--- a/src/format/Token.h
+++ b/src/format/Token.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/format/TokenTableEntry.h
+++ b/src/format/TokenTableEntry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fqdncache.cc
+++ b/src/fqdncache.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fqdncache.h
+++ b/src/fqdncache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/Makefile.am
+++ b/src/fs/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/fs/Module.cc
+++ b/src/fs/Module.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/Module.h
+++ b/src/fs/Module.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/aufs/StoreFSaufs.cc
+++ b/src/fs/aufs/StoreFSaufs.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/diskd/StoreFSdiskd.cc
+++ b/src/fs/diskd/StoreFSdiskd.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockDbCell.cc
+++ b/src/fs/rock/RockDbCell.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockDbCell.h
+++ b/src/fs/rock/RockDbCell.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockHeaderUpdater.cc
+++ b/src/fs/rock/RockHeaderUpdater.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockHeaderUpdater.h
+++ b/src/fs/rock/RockHeaderUpdater.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockIoRequests.cc
+++ b/src/fs/rock/RockIoRequests.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockIoRequests.h
+++ b/src/fs/rock/RockIoRequests.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -301,7 +301,7 @@ Rock::IoState::writeToDisk()
     memcpy(wBuf, theBuf.mem, theBuf.size);
 
     const uint64_t diskOffset = dir->diskOffset(sidCurrent);
-    debugs(79, 5, HERE << swap_filen << " at " << diskOffset << '+' <<
+    debugs(79, 5, swap_filen << " at " << diskOffset << '+' <<
            theBuf.size);
     const auto id = ++requestsSent;
     WriteRequest *const r = new WriteRequest(
@@ -453,7 +453,7 @@ private:
 void
 Rock::IoState::callBack(int errflag)
 {
-    debugs(79,3, HERE << "errflag=" << errflag);
+    debugs(79,3, "errflag=" << errflag);
     theFile = NULL;
 
     AsyncCall::Pointer call = asyncCall(79,3, "SomeIoStateCloseCb",

--- a/src/fs/rock/RockIoState.h
+++ b/src/fs/rock/RockIoState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -441,7 +441,7 @@ Rock::Rebuild::loadingSteps()
         getCurrentTime();
         const double elapsedMsec = tvSubMsec(loopStart, current_time);
         if (elapsedMsec > maxSpentMsec || elapsedMsec < 0) {
-            debugs(47, 5, HERE << "pausing after " << loaded << " entries in " <<
+            debugs(47, 5, "pausing after " << loaded << " entries in " <<
                    elapsedMsec << "ms; " << (elapsedMsec/loaded) << "ms per entry");
             break;
         }
@@ -668,7 +668,7 @@ Rock::Rebuild::freeBadEntry(const sfileno fileno, const char *eDescription)
 void
 Rock::Rebuild::swanSong()
 {
-    debugs(47,3, HERE << "cache_dir #" << sd->index << " rebuild level: " <<
+    debugs(47,3, "cache_dir #" << sd->index << " rebuild level: " <<
            StoreController::store_dirs_rebuilding);
     storeRebuildComplete(&counts);
 }

--- a/src/fs/rock/RockRebuild.h
+++ b/src/fs/rock/RockRebuild.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockStoreFileSystem.cc
+++ b/src/fs/rock/RockStoreFileSystem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -47,7 +47,7 @@ Rock::StoreFileSystem::registerWithCacheManager()
 void
 Rock::StoreFileSystem::setup()
 {
-    debugs(92,2, HERE << "Will use Rock FS");
+    debugs(92,2, "Will use Rock FS");
 }
 
 void

--- a/src/fs/rock/RockStoreFileSystem.h
+++ b/src/fs/rock/RockStoreFileSystem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -215,11 +215,11 @@ Rock::SwapDir::create()
     assert(filePath);
 
     if (UsingSmp() && !IamDiskProcess()) {
-        debugs (47,3, HERE << "disker will create in " << path);
+        debugs (47,3, "disker will create in " << path);
         return;
     }
 
-    debugs (47,3, HERE << "creating in " << path);
+    debugs (47,3, "creating in " << path);
 
     struct stat dir_sb;
     if (::stat(path, &dir_sb) == 0) {
@@ -280,7 +280,7 @@ Rock::SwapDir::createError(const char *const msg)
 void
 Rock::SwapDir::init()
 {
-    debugs(47,2, HERE);
+    debugs(47,2, MYNAME);
 
     // XXX: SwapDirs aren't refcounted. We make IORequestor calls, which
     // are refcounted. We up our count once to avoid implicit delete's.
@@ -294,7 +294,7 @@ Rock::SwapDir::init()
 
     const char *ioModule = needsDiskStrand() ? "IpcIo" : "Blocking";
     if (DiskIOModule *m = DiskIOModule::Find(ioModule)) {
-        debugs(47,2, HERE << "Using DiskIO module: " << ioModule);
+        debugs(47,2, "Using DiskIO module: " << ioModule);
         io = m->createStrategy();
         io->init();
     } else {
@@ -598,7 +598,7 @@ Rock::SwapDir::canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load)
     // TODO: reserve page instead
     if (needsDiskStrand() &&
             Ipc::Mem::PageLevel(Ipc::Mem::PageId::ioPage) >= 0.9 * Ipc::Mem::PageLimit(Ipc::Mem::PageId::ioPage)) {
-        debugs(47, 5, HERE << "too few shared pages for IPC I/O left");
+        debugs(47, 5, "too few shared pages for IPC I/O left");
         return false;
     }
 
@@ -613,7 +613,7 @@ StoreIOState::Pointer
 Rock::SwapDir::createStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOState::STIOCB *cbIo, void *data)
 {
     if (!theFile || theFile->error()) {
-        debugs(47,4, HERE << theFile);
+        debugs(47,4, theFile);
         return NULL;
     }
 
@@ -621,7 +621,7 @@ Rock::SwapDir::createStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreI
     Ipc::StoreMapAnchor *const slot =
         map->openForWriting(reinterpret_cast<const cache_key *>(e.key), filen);
     if (!slot) {
-        debugs(47, 5, HERE << "map->add failed");
+        debugs(47, 5, "map->add failed");
         return NULL;
     }
 
@@ -638,7 +638,7 @@ Rock::SwapDir::createStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreI
     sio->swap_filen = filen;
     sio->writeableAnchor_ = slot;
 
-    debugs(47,5, HERE << "dir " << index << " created new filen " <<
+    debugs(47,5, "dir " << index << " created new filen " <<
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) <<
            sio->swap_filen << std::dec << " starting at " <<
            diskOffset(sio->swap_filen));
@@ -756,12 +756,12 @@ StoreIOState::Pointer
 Rock::SwapDir::openStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOState::STIOCB *cbIo, void *data)
 {
     if (!theFile || theFile->error()) {
-        debugs(47,4, HERE << theFile);
+        debugs(47,4, theFile);
         return NULL;
     }
 
     if (!e.hasDisk()) {
-        debugs(47,4, HERE << e);
+        debugs(47,4, e);
         return NULL;
     }
 
@@ -769,7 +769,7 @@ Rock::SwapDir::openStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOS
     // TODO: reserve page instead
     if (needsDiskStrand() &&
             Ipc::Mem::PageLevel(Ipc::Mem::PageId::ioPage) >= 0.9 * Ipc::Mem::PageLimit(Ipc::Mem::PageId::ioPage)) {
-        debugs(47, 5, HERE << "too few shared pages for IPC I/O left");
+        debugs(47, 5, "too few shared pages for IPC I/O left");
         return NULL;
     }
 
@@ -788,7 +788,7 @@ Rock::SwapDir::openStoreIO(StoreEntry &e, StoreIOState::STFNCB *cbFile, StoreIOS
     sio->readableAnchor_ = slot;
     sio->file(theFile);
 
-    debugs(47,5, HERE << "dir " << index << " has old filen: " <<
+    debugs(47,5, "dir " << index << " has old filen: " <<
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) <<
            sio->swap_filen);
 
@@ -978,7 +978,7 @@ Rock::SwapDir::maintain()
 void
 Rock::SwapDir::reference(StoreEntry &e)
 {
-    debugs(47, 5, HERE << &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
+    debugs(47, 5, &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
     if (repl && repl->Referenced)
         repl->Referenced(repl, &e, &e.repl);
 }
@@ -986,7 +986,7 @@ Rock::SwapDir::reference(StoreEntry &e)
 bool
 Rock::SwapDir::dereference(StoreEntry &e)
 {
-    debugs(47, 5, HERE << &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
+    debugs(47, 5, &e << ' ' << e.swap_dirn << ' ' << e.swap_filen);
     if (repl && repl->Dereferenced)
         repl->Dereferenced(repl, &e, &e.repl);
 
@@ -1025,7 +1025,7 @@ Rock::SwapDir::evictCached(StoreEntry &e)
 void
 Rock::SwapDir::trackReferences(StoreEntry &e)
 {
-    debugs(47, 5, HERE << e);
+    debugs(47, 5, e);
     if (repl)
         repl->Add(repl, &e, &e.repl);
 }
@@ -1033,7 +1033,7 @@ Rock::SwapDir::trackReferences(StoreEntry &e)
 void
 Rock::SwapDir::ignoreReferences(StoreEntry &e)
 {
-    debugs(47, 5, HERE << e);
+    debugs(47, 5, e);
     if (repl)
         repl->Remove(repl, &e, &e.repl);
 }

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/rock/forward.h
+++ b/src/fs/rock/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/RebuildState.cc
+++ b/src/fs/ufs/RebuildState.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -132,7 +132,7 @@ Fs::Ufs::RebuildState::rebuildStep()
         getCurrentTime();
         const double elapsedMsec = tvSubMsec(loopStart, current_time);
         if (elapsedMsec > maxSpentMsec || elapsedMsec < 0) {
-            debugs(47, 5, HERE << "pausing after " << n_read << " entries in " <<
+            debugs(47, 5, "pausing after " << n_read << " entries in " <<
                    elapsedMsec << "ms; " << (elapsedMsec/n_read) << "ms per entry");
             break;
         }
@@ -147,7 +147,7 @@ Fs::Ufs::RebuildState::rebuildFromDirectory()
 
     struct stat sb;
     int fd = -1;
-    debugs(47, 3, HERE << "DIR #" << sd->index);
+    debugs(47, 3, "DIR #" << sd->index);
 
     assert(fd == -1);
     sfileno filn = 0;
@@ -299,7 +299,7 @@ Fs::Ufs::RebuildState::rebuildFromSwapLog()
      */
     swapData.swap_filen &= 0x00FFFFFF;
 
-    debugs(47, 3, HERE << swap_log_op_str[(int) swapData.op]  << " " <<
+    debugs(47, 3, swap_log_op_str[(int) swapData.op]  << " " <<
            storeKeyText(swapData.key)  << " "<< std::setfill('0') <<
            std::hex << std::uppercase << std::setw(8) <<
            swapData.swap_filen);
@@ -358,7 +358,7 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
 {
     int fd = -1;
     int dirs_opened = 0;
-    debugs(47, 3, HERE << "flag=" << flags.init  << ", " <<
+    debugs(47, 3, "flag=" << flags.init  << ", " <<
            sd->index  << ": /"<< std::setfill('0') << std::hex <<
            std::uppercase << std::setw(2) << curlvl1  << "/" << std::setw(2) <<
            curlvl2);
@@ -399,8 +399,8 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
                 entry = readdir(td);
 
                 if (entry == NULL && errno == ENOENT)
-                    debugs(47, DBG_IMPORTANT, HERE << "WARNING: directory does not exist!");
-                debugs(47, 3, HERE << "Directory " << fullpath);
+                    debugs(47, DBG_IMPORTANT, "WARNING: directory does not exist!");
+                debugs(47, 3, "Directory " << fullpath);
             }
         }
 
@@ -408,12 +408,12 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
             ++in_dir;
 
             if (sscanf(entry->d_name, "%x", &fn) != 1) {
-                debugs(47, 3, HERE << "invalid entry " << entry->d_name);
+                debugs(47, 3, "invalid entry " << entry->d_name);
                 continue;
             }
 
             if (!UFSSwapDir::FilenoBelongsHere(fn, sd->index, curlvl1, curlvl2)) {
-                debugs(47, 3, HERE << std::setfill('0') <<
+                debugs(47, 3, std::setfill('0') <<
                        std::hex << std::uppercase << std::setw(8) << fn  <<
                        " does not belong in " << std::dec << sd->index  << "/" <<
                        curlvl1  << "/" << curlvl2);
@@ -422,13 +422,13 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
             }
 
             if (sd->mapBitTest(fn)) {
-                debugs(47, 3, HERE << "Locked, continuing with next.");
+                debugs(47, 3, "Locked, continuing with next.");
                 continue;
             }
 
             snprintf(fullfilename, sizeof(fullfilename), "%s/%s",
                      fullpath, entry->d_name);
-            debugs(47, 3, HERE << "Opening " << fullfilename);
+            debugs(47, 3, "Opening " << fullfilename);
             fd = file_open(fullfilename, O_RDONLY | O_BINARY);
 
             if (fd < 0) {

--- a/src/fs/ufs/RebuildState.h
+++ b/src/fs/ufs/RebuildState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/StoreFSufs.cc
+++ b/src/fs/ufs/StoreFSufs.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/StoreFSufs.h
+++ b/src/fs/ufs/StoreFSufs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/StoreSearchUFS.cc
+++ b/src/fs/ufs/StoreSearchUFS.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/StoreSearchUFS.h
+++ b/src/fs/ufs/StoreSearchUFS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/UFSStoreState.cc
+++ b/src/fs/ufs/UFSStoreState.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -64,7 +64,7 @@ void
 Fs::Ufs::UFSStoreState::openDone()
 {
     if (closing)
-        debugs(0, DBG_CRITICAL, HERE << "already closing in openDone()!?");
+        debugs(0, DBG_CRITICAL, "already closing in openDone()!?");
 
     if (theFile->error()) {
         tryClosing();
@@ -95,7 +95,7 @@ Fs::Ufs::UFSStoreState::closeCompleted()
            theFile->error());
 
     if (theFile->error()) {
-        debugs(79,3,HERE<< "theFile->error() ret " << theFile->error());
+        debugs(79,3, "theFile->error() ret " << theFile->error());
         doCloseCallback(DISK_ERROR);
     } else {
         doCloseCallback(DISK_OK);
@@ -163,7 +163,7 @@ Fs::Ufs::UFSStoreState::write(char const *buf, size_t size, off_t aOffset, FREE 
 
     if (theFile->error()) {
         debugs(79, DBG_IMPORTANT, "ERROR: avoid write on theFile with error");
-        debugs(79, DBG_IMPORTANT,HERE << "calling free_func for " << (void*) buf);
+        debugs(79, DBG_IMPORTANT, "calling free_func for " << (void*) buf);
         free_func((void*)buf);
         return false;
     }
@@ -272,7 +272,7 @@ Fs::Ufs::UFSStoreState::readCompleted(const char *buf, int len, int, RefCount<Re
 void
 Fs::Ufs::UFSStoreState::writeCompleted(int, size_t len, RefCount<WriteRequest>)
 {
-    debugs(79, 3, HERE << "dirno " << swap_dirn << ", fileno " <<
+    debugs(79, 3, "dirno " << swap_dirn << ", fileno " <<
            std::setfill('0') << std::hex << std::uppercase << std::setw(8) << swap_filen <<
            ", len " << len);
     /*
@@ -284,7 +284,7 @@ Fs::Ufs::UFSStoreState::writeCompleted(int, size_t len, RefCount<WriteRequest>)
     offset_ += len;
 
     if (theFile->error()) {
-        debugs(79,2,HERE << " detected an error, will try to close");
+        debugs(79,2, " detected an error, will try to close");
         tryClosing();
     }
 
@@ -429,13 +429,13 @@ Fs::Ufs::UFSStoreState::drainWriteQueue()
 void
 Fs::Ufs::UFSStoreState::tryClosing()
 {
-    debugs(79,3,HERE << this << " tryClosing()" <<
+    debugs(79,3, this << " tryClosing()" <<
            " closing = " << closing <<
            " flags.try_closing = " << flags.try_closing <<
            " ioInProgress = " << theFile->ioInProgress());
 
     if (theFile->ioInProgress()) {
-        debugs(79, 3, HERE << this <<
+        debugs(79, 3, this <<
                " won't close since ioInProgress is true, bailing");
         flags.try_closing = true;
         return;

--- a/src/fs/ufs/UFSStoreState.h
+++ b/src/fs/ufs/UFSStoreState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/UFSStrategy.cc
+++ b/src/fs/ufs/UFSStrategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -58,7 +58,7 @@ Fs::Ufs::UFSStrategy::open(SwapDir * SD, StoreEntry * e, StoreIOState::STFNCB *,
                            StoreIOState::STIOCB * aCallback, void *callback_data)
 {
     assert (((UFSSwapDir *)SD)->IO == this);
-    debugs(79, 3, HERE << "fileno "<< std::setfill('0') << std::hex
+    debugs(79, 3, "fileno "<< std::setfill('0') << std::hex
            << std::uppercase << std::setw(8) << e->swap_filen);
 
     /* to consider: make createstate a private UFSStrategy call */
@@ -96,7 +96,7 @@ Fs::Ufs::UFSStrategy::create(SwapDir * SD, StoreEntry * e, StoreIOState::STFNCB 
     assert (((UFSSwapDir *)SD)->IO == this);
     /* Allocate a number */
     sfileno filn = ((UFSSwapDir *)SD)->mapBitAllocate();
-    debugs(79, 3, HERE << "fileno "<< std::setfill('0') <<
+    debugs(79, 3, "fileno "<< std::setfill('0') <<
            std::hex << std::uppercase << std::setw(8) << filn);
 
     /* Shouldn't we handle a 'bitmap full' error here? */

--- a/src/fs/ufs/UFSStrategy.h
+++ b/src/fs/ufs/UFSStrategy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -272,7 +272,7 @@ Fs::Ufs::UFSSwapDir::getOptionTree() const
 void
 Fs::Ufs::UFSSwapDir::init()
 {
-    debugs(47, 3, HERE << "Initialising UFS SwapDir engine.");
+    debugs(47, 3, "Initialising UFS SwapDir engine.");
     /* Parsing must be finished by now - force to NULL, don't delete */
     currentIOOptions = NULL;
     static int started_clean_event = 0;
@@ -341,8 +341,8 @@ Fs::Ufs::UFSSwapDir::~UFSSwapDir()
 void
 Fs::Ufs::UFSSwapDir::dumpEntry(StoreEntry &e) const
 {
-    debugs(47, DBG_CRITICAL, HERE << "FILENO "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << e.swap_filen);
-    debugs(47, DBG_CRITICAL, HERE << "PATH " << fullPath(e.swap_filen, NULL)   );
+    debugs(47, DBG_CRITICAL, "FILENO "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << e.swap_filen);
+    debugs(47, DBG_CRITICAL, "PATH " << fullPath(e.swap_filen, NULL)   );
     e.dump(0);
 }
 
@@ -353,13 +353,13 @@ Fs::Ufs::UFSSwapDir::doubleCheck(StoreEntry & e)
     struct stat sb;
 
     if (::stat(fullPath(e.swap_filen, NULL), &sb) < 0) {
-        debugs(47, DBG_CRITICAL, HERE << "WARNING: Missing swap file");
+        debugs(47, DBG_CRITICAL, "WARNING: Missing swap file");
         dumpEntry(e);
         return true;
     }
 
     if ((off_t)e.swap_file_sz != sb.st_size) {
-        debugs(47, DBG_CRITICAL, HERE << "WARNING: Size Mismatch. Entry size: "
+        debugs(47, DBG_CRITICAL, "WARNING: Size Mismatch. Entry size: "
                << e.swap_file_sz << ", file size: " << sb.st_size);
         dumpEntry(e);
         return true;
@@ -524,7 +524,7 @@ Fs::Ufs::UFSSwapDir::maintain()
 void
 Fs::Ufs::UFSSwapDir::reference(StoreEntry &e)
 {
-    debugs(47, 3, HERE << "referencing " << &e << " " <<
+    debugs(47, 3, "referencing " << &e << " " <<
            e.swap_dirn << "/" << e.swap_filen);
 
     if (repl->Referenced)
@@ -534,7 +534,7 @@ Fs::Ufs::UFSSwapDir::reference(StoreEntry &e)
 bool
 Fs::Ufs::UFSSwapDir::dereference(StoreEntry & e)
 {
-    debugs(47, 3, HERE << "dereferencing " << &e << " " <<
+    debugs(47, 3, "dereferencing " << &e << " " <<
            e.swap_dirn << "/" << e.swap_filen);
 
     if (repl->Dereferenced)
@@ -749,7 +749,7 @@ Fs::Ufs::UFSSwapDir::openLog()
         fatal("UFSSwapDir::openLog: Failed to open swap log.");
     }
 
-    debugs(50, 3, HERE << "Cache Dir #" << index << " log opened on FD " << swaplog_fd);
+    debugs(50, 3, "Cache Dir #" << index << " log opened on FD " << swaplog_fd);
 }
 
 void
@@ -798,7 +798,7 @@ Fs::Ufs::UFSSwapDir::addDiskRestore(const cache_key * key,
                                     int)
 {
     StoreEntry *e = NULL;
-    debugs(47, 5, HERE << storeKeyText(key)  <<
+    debugs(47, 5, storeKeyText(key)  <<
            ", fileno="<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << file_number);
     /* if you call this you'd better be sure file_number is not
      * already in use! */
@@ -962,7 +962,7 @@ Fs::Ufs::UFSSwapDir::writeCleanStart()
 
     state->walker = repl->WalkInit(repl);
     ::unlink(state->cln.c_str());
-    debugs(47, 3, HERE << "opened " << state->newLog << ", FD " << state->fd);
+    debugs(47, 3, "opened " << state->newLog << ", FD " << state->fd);
 #if HAVE_FCHMOD
 
     if (::stat(state->cur.c_str(), &sb) == 0)
@@ -1163,7 +1163,7 @@ Fs::Ufs::UFSSwapDir::validFileno(sfileno filn, int flag) const
 void
 Fs::Ufs::UFSSwapDir::unlinkFile(sfileno f)
 {
-    debugs(79, 3, HERE << "unlinking fileno " <<  std::setfill('0') <<
+    debugs(79, 3, "unlinking fileno " <<  std::setfill('0') <<
            std::hex << std::uppercase << std::setw(8) << f << " '" <<
            fullPath(f,NULL) << "'");
     /* commonUfsDirMapBitReset(this, f); */
@@ -1209,7 +1209,7 @@ Fs::Ufs::UFSSwapDir::evictIfFound(const cache_key *)
 void
 Fs::Ufs::UFSSwapDir::replacementAdd(StoreEntry * e)
 {
-    debugs(47, 4, HERE << "added node " << e << " to dir " << index);
+    debugs(47, 4, "added node " << e << " to dir " << index);
     repl->Add(repl, e, &e->repl);
 }
 
@@ -1222,7 +1222,7 @@ Fs::Ufs::UFSSwapDir::replacementRemove(StoreEntry * e)
 
     assert (dynamic_cast<UFSSwapDir *>(SD.getRaw()) == this);
 
-    debugs(47, 4, HERE << "remove node " << e << " from dir " << index);
+    debugs(47, 4, "remove node " << e << " from dir " << index);
 
     repl->Remove(repl, e, &e->repl);
 }
@@ -1334,7 +1334,7 @@ Fs::Ufs::UFSSwapDir::DirClean(int swap_index)
 
     SBuf p1;
     p1.appendf("%s/%02X/%02X", SD->path, D1, D2);
-    debugs(36, 3, HERE << "Cleaning directory " << p1);
+    debugs(36, 3, "Cleaning directory " << p1);
     dir_pointer = opendir(p1.c_str());
 
     if (!dir_pointer) {
@@ -1377,14 +1377,14 @@ Fs::Ufs::UFSSwapDir::DirClean(int swap_index)
         k = 10;
 
     for (n = 0; n < k; ++n) {
-        debugs(36, 3, HERE << "Cleaning file "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << files[n]);
+        debugs(36, 3, "Cleaning file "<< std::setfill('0') << std::hex << std::uppercase << std::setw(8) << files[n]);
         SBuf p2(p1);
         p2.appendf("/%08X", files[n]);
         safeunlink(p2.c_str(), 0);
         ++statCounter.swap.files_cleaned;
     }
 
-    debugs(36, 3, HERE << "Cleaned " << k << " unused files from " << p1);
+    debugs(36, 3, "Cleaned " << k << " unused files from " << p1);
     return k;
 }
 

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/UFSSwapLogParser.cc
+++ b/src/fs/ufs/UFSSwapLogParser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs/ufs/UFSSwapLogParser.h
+++ b/src/fs/ufs/UFSSwapLogParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/fs_io.h
+++ b/src/fs_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ftp/Elements.cc
+++ b/src/ftp/Elements.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ftp/Elements.h
+++ b/src/ftp/Elements.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ftp/Makefile.am
+++ b/src/ftp/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/ftp/Parsing.cc
+++ b/src/ftp/Parsing.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ftp/Parsing.h
+++ b/src/ftp/Parsing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/gopher.cc
+++ b/src/gopher.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -602,7 +602,7 @@ gopherToHTML(GopherStateData * gopherState, char *inbuf, int len)
                             /* WWW link */
                             snprintf(tmpbuf, TEMP_BUF_SIZE, "<IMG border=\"0\" SRC=\"%s\"> <A HREF=\"http://%s/%s\">%s</A>\n",
                                      icon_url, host, rfc1738_escape_unescaped(selector + 5), html_quote(name));
-                         } else if (gtype == GOPHER_WWW) {
+                        } else if (gtype == GOPHER_WWW) {
                             snprintf(tmpbuf, TEMP_BUF_SIZE, "<IMG border=\"0\" SRC=\"%s\"> <A HREF=\"%s\">%s</A>\n",
                                      icon_url, rfc1738_escape_unescaped(selector), html_quote(name));
                         } else {
@@ -711,7 +711,7 @@ static void
 gopherTimeout(const CommTimeoutCbParams &io)
 {
     GopherStateData *gopherState = static_cast<GopherStateData *>(io.data);
-    debugs(10, 4, HERE << io.conn << ": '" << gopherState->entry->url() << "'" );
+    debugs(10, 4, io.conn << ": '" << gopherState->entry->url() << "'" );
 
     gopherState->fwd->fail(new ErrorState(ERR_READ_TIMEOUT, Http::scGatewayTimeout, gopherState->fwd->request, gopherState->fwd->al));
 
@@ -766,7 +766,7 @@ gopherReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Comm
         statCounter.server.other.kbytes_in += len;
     }
 
-    debugs(10, 5, HERE << conn << " read len=" << len);
+    debugs(10, 5, conn << " read len=" << len);
 
     if (flag == Comm::OK && len > 0) {
         AsyncCall::Pointer nil;
@@ -839,7 +839,7 @@ gopherSendComplete(const Comm::ConnectionPointer &conn, char *, size_t size, Com
 {
     GopherStateData *gopherState = (GopherStateData *) data;
     StoreEntry *entry = gopherState->entry;
-    debugs(10, 5, HERE << conn << " size: " << size << " errflag: " << errflag);
+    debugs(10, 5, conn << " size: " << size << " errflag: " << errflag);
 
     if (size > 0) {
         fd_bytes(conn->fd, size, FD_WRITE);

--- a/src/gopher.h
+++ b/src/gopher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -1555,12 +1555,12 @@ helper_server::checkForTimedOutRequests(bool const retry)
 void
 helper_server::requestTimeout(const CommTimeoutCbParams &io)
 {
-    debugs(26, 3, HERE << io.conn);
+    debugs(26, 3, io.conn);
     helper_server *srv = static_cast<helper_server *>(io.data);
 
     srv->checkForTimedOutRequests(srv->parent->retryTimedOut);
 
-    debugs(84, 3, HERE << io.conn << " establish new helper_server::requestTimeout");
+    debugs(84, 3, io.conn << " establish new helper_server::requestTimeout");
     AsyncCall::Pointer timeoutCall = commCbCall(84, 4, "helper_server::requestTimeout",
                                      CommTimeoutCbPtrFun(helper_server::requestTimeout, srv));
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/ChildConfig.cc
+++ b/src/helper/ChildConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/ChildConfig.h
+++ b/src/helper/ChildConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/Makefile.am
+++ b/src/helper/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/helper/Reply.cc
+++ b/src/helper/Reply.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/Reply.h
+++ b/src/helper/Reply.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/Request.h
+++ b/src/helper/Request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/ReservationId.cc
+++ b/src/helper/ReservationId.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/ReservationId.h
+++ b/src/helper/ReservationId.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/ResultCode.h
+++ b/src/helper/ResultCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/forward.h
+++ b/src/helper/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/helper/protocol_defines.h
+++ b/src/helper/protocol_defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/hier_code.h
+++ b/src/hier_code.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/htcp.h
+++ b/src/htcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http.cc
+++ b/src/http.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -83,7 +83,7 @@ HttpStateData::HttpStateData(FwdState *theFwdState) :
     payloadTruncated(0),
     sawDateGoBack(false)
 {
-    debugs(11,5,HERE << "HttpStateData " << this << " created");
+    debugs(11,5, "HttpStateData " << this << " created");
     ignoreCacheControl = false;
     surrogateNoStore = false;
     serverConnection = fwd->serverConnection();
@@ -130,7 +130,7 @@ HttpStateData::~HttpStateData()
 
     delete upgradeHeaderOut;
 
-    debugs(11,5, HERE << "HttpStateData " << this << " destroyed; " << serverConnection);
+    debugs(11,5, "HttpStateData " << this << " destroyed; " << serverConnection);
 }
 
 const Comm::ConnectionPointer &
@@ -395,12 +395,12 @@ HttpStateData::reusableReply(HttpStateData::ReuseDecision &decision)
         bool mayStore = false;
         // HTTPbis pt6 section 3.2: a response CC:public is present
         if (rep->cache_control->hasPublic()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:public");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:public");
             mayStore = true;
 
             // HTTPbis pt6 section 3.2: a response CC:must-revalidate is present
         } else if (rep->cache_control->hasMustRevalidate()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:must-revalidate");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:must-revalidate");
             mayStore = true;
 
 #if USE_HTTP_VIOLATIONS
@@ -409,13 +409,13 @@ HttpStateData::reusableReply(HttpStateData::ReuseDecision &decision)
             // some. The caching+revalidate is not exactly unsafe though with Squids interpretation of no-cache
             // (without parameters) as equivalent to must-revalidate in the reply.
         } else if (rep->cache_control->hasNoCacheWithoutParameters()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:no-cache (equivalent to must-revalidate)");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:no-cache (equivalent to must-revalidate)");
             mayStore = true;
 #endif
 
             // HTTPbis pt6 section 3.2: a response CC:s-maxage is present
         } else if (rep->cache_control->hasSMaxAge()) {
-            debugs(22, 3, HERE << "Authenticated but server reply Cache-Control:s-maxage");
+            debugs(22, 3, "Authenticated but server reply Cache-Control:s-maxage");
             mayStore = true;
         }
 
@@ -792,7 +792,7 @@ HttpStateData::handle1xx(HttpReply *reply)
             return drop1xx(reason);
     }
 
-    debugs(11, 2, HERE << "forwarding 1xx to client");
+    debugs(11, 2, "forwarding 1xx to client");
 
     // the Sink will use this to call us back after writing 1xx to the client
     typedef NullaryMemFunT<HttpStateData> CbDialer;
@@ -1124,7 +1124,7 @@ HttpStateData::statusIfComplete() const
 HttpStateData::ConnectionStatus
 HttpStateData::persistentConnStatus() const
 {
-    debugs(11, 3, HERE << serverConnection << " eof=" << eof);
+    debugs(11, 3, serverConnection << " eof=" << eof);
     if (eof) // already reached EOF
         return COMPLETE_NONPERSISTENT_MSG;
 
@@ -1282,7 +1282,7 @@ HttpStateData::processReply()
 {
 
     if (flags.handling1xx) { // we came back after handling a 1xx response
-        debugs(11, 5, HERE << "done with 1xx handling");
+        debugs(11, 5, "done with 1xx handling");
         flags.handling1xx = false;
         Must(!flags.headers_parsed);
     }
@@ -1312,7 +1312,7 @@ bool
 HttpStateData::continueAfterParsingHeader()
 {
     if (flags.handling1xx) {
-        debugs(11, 5, HERE << "wait for 1xx handling");
+        debugs(11, 5, "wait for 1xx handling");
         Must(!flags.headers_parsed);
         return false;
     }
@@ -1471,7 +1471,7 @@ HttpStateData::processReplyBody()
     }
 
 #if USE_ADAPTATION
-    debugs(11,5, HERE << "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
+    debugs(11,5, "adaptationAccessCheckPending=" << adaptationAccessCheckPending);
     if (adaptationAccessCheckPending)
         return;
 
@@ -1645,7 +1645,7 @@ HttpStateData::maybeMakeSpaceAvailable(bool doGrow)
 void
 HttpStateData::wroteLast(const CommIoCbParams &io)
 {
-    debugs(11, 5, HERE << serverConnection << ": size " << io.size << ": errflag " << io.flag << ".");
+    debugs(11, 5, serverConnection << ": size " << io.size << ": errflag " << io.flag << ".");
 #if URL_CHECKSUM_DEBUG
 
     entry->mem_obj->checkUrlChecksum();
@@ -1701,7 +1701,7 @@ HttpStateData::sendComplete()
 void
 HttpStateData::closeServer()
 {
-    debugs(11,5, HERE << "closing HTTP server " << serverConnection << " this " << this);
+    debugs(11,5, "closing HTTP server " << serverConnection << " this " << this);
 
     if (Comm::IsConnOpen(serverConnection)) {
         fwd->unregister(serverConnection);
@@ -2339,10 +2339,10 @@ HttpStateData::sendRequest()
 {
     MemBuf mb;
 
-    debugs(11, 5, HERE << serverConnection << ", request " << request << ", this " << this << ".");
+    debugs(11, 5, serverConnection << ", request " << request << ", this " << this << ".");
 
     if (!Comm::IsConnOpen(serverConnection)) {
-        debugs(11,3, HERE << "cannot send request to closing " << serverConnection);
+        debugs(11,3, "cannot send request to closing " << serverConnection);
         assert(closeHandler != NULL);
         return false;
     }
@@ -2487,7 +2487,7 @@ HttpStateData::finishingBrokenPost()
 {
 #if USE_HTTP_VIOLATIONS
     if (!Config.accessList.brokenPosts) {
-        debugs(11, 5, HERE << "No brokenPosts list");
+        debugs(11, 5, "No brokenPosts list");
         return false;
     }
 
@@ -2495,12 +2495,12 @@ HttpStateData::finishingBrokenPost()
     ch.al = fwd->al;
     ch.syncAle(originalRequest().getRaw(), nullptr);
     if (!ch.fastCheck().allowed()) {
-        debugs(11, 5, HERE << "didn't match brokenPosts");
+        debugs(11, 5, "didn't match brokenPosts");
         return false;
     }
 
     if (!Comm::IsConnOpen(serverConnection)) {
-        debugs(11, 3, HERE << "ignoring broken POST for closed " << serverConnection);
+        debugs(11, 3, "ignoring broken POST for closed " << serverConnection);
         assert(closeHandler != NULL);
         return true; // prevent caller from proceeding as if nothing happened
     }
@@ -2521,7 +2521,7 @@ bool
 HttpStateData::finishingChunkedRequest()
 {
     if (flags.sentLastChunk) {
-        debugs(11, 5, HERE << "already sent last-chunk");
+        debugs(11, 5, "already sent last-chunk");
         return false;
     }
 
@@ -2538,7 +2538,7 @@ void
 HttpStateData::doneSendingRequestBody()
 {
     Client::doneSendingRequestBody();
-    debugs(11,5, HERE << serverConnection);
+    debugs(11,5, serverConnection);
 
     // do we need to write something after the last body byte?
     if (flags.chunked_request && finishingChunkedRequest())
@@ -2557,7 +2557,7 @@ HttpStateData::handleMoreRequestBodyAvailable()
         // XXX: we should check this condition in other callbacks then!
         // TODO: Check whether this can actually happen: We should unsubscribe
         // as a body consumer when the above condition(s) are detected.
-        debugs(11, DBG_IMPORTANT, HERE << "Transaction aborted while reading HTTP body");
+        debugs(11, DBG_IMPORTANT, "Transaction aborted while reading HTTP body");
         return;
     }
 
@@ -2614,7 +2614,7 @@ HttpStateData::sentRequestBody(const CommIoCbParams &io)
 void
 HttpStateData::abortAll(const char *reason)
 {
-    debugs(11,5, HERE << "aborting transaction for " << reason <<
+    debugs(11,5, "aborting transaction for " << reason <<
            "; " << serverConnection << ", this " << this);
     mustStop(reason);
 }

--- a/src/http.h
+++ b/src/http.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/ContentLengthInterpreter.cc
+++ b/src/http/ContentLengthInterpreter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/ContentLengthInterpreter.h
+++ b/src/http/ContentLengthInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/Makefile.am
+++ b/src/http/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/Message.cc
+++ b/src/http/Message.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/Message.h
+++ b/src/http/Message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/MethodType.h
+++ b/src/http/MethodType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/ProtocolVersion.h
+++ b/src/http/ProtocolVersion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/RegisteredHeaders.cc
+++ b/src/http/RegisteredHeaders.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -34,7 +34,7 @@
 /* AUTO GENERATED FROM RegisteredHeadersHash.gperf. DO NOT EDIT */
 
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -2,7 +2,7 @@
 /* AUTO GENERATED FROM RegisteredHeadersHash.gperf. DO NOT EDIT */
 
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/RequestMethod.cc
+++ b/src/http/RequestMethod.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/RequestMethod.h
+++ b/src/http/RequestMethod.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/StateFlags.h
+++ b/src/http/StateFlags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/StatusCode.cc
+++ b/src/http/StatusCode.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/StatusCode.h
+++ b/src/http/StatusCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/StatusLine.cc
+++ b/src/http/StatusLine.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/StatusLine.h
+++ b/src/http/StatusLine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/Stream.h
+++ b/src/http/Stream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/forward.h
+++ b/src/http/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/Makefile.am
+++ b/src/http/one/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/one/Parser.cc
+++ b/src/http/one/Parser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/Parser.h
+++ b/src/http/one/Parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/RequestParser.cc
+++ b/src/http/one/RequestParser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/RequestParser.h
+++ b/src/http/one/RequestParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/ResponseParser.cc
+++ b/src/http/one/ResponseParser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/ResponseParser.h
+++ b/src/http/one/ResponseParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/TeChunkedParser.cc
+++ b/src/http/one/TeChunkedParser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/TeChunkedParser.h
+++ b/src/http/one/TeChunkedParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/Tokenizer.cc
+++ b/src/http/one/Tokenizer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/Tokenizer.h
+++ b/src/http/one/Tokenizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/one/forward.h
+++ b/src/http/one/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/LFS/Makefile.am
+++ b/src/http/url_rewriters/LFS/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/LFS/required.m4
+++ b/src/http/url_rewriters/LFS/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/LFS/rredir.cc
+++ b/src/http/url_rewriters/LFS/rredir.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
+++ b/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
@@ -94,7 +94,7 @@ First Version: 26. May 1997
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/Makefile.am
+++ b/src/http/url_rewriters/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/fake/Makefile.am
+++ b/src/http/url_rewriters/fake/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/fake/fake.cc
+++ b/src/http/url_rewriters/fake/fake.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/fake/required.m4
+++ b/src/http/url_rewriters/fake/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/fake/url_fake_rewrite.sh
+++ b/src/http/url_rewriters/fake/url_fake_rewrite.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/http/url_rewriters/helpers.m4
+++ b/src/http/url_rewriters/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/icmp/Icmp.cc
+++ b/src/icmp/Icmp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/Icmp.h
+++ b/src/icmp/Icmp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/Icmp4.cc
+++ b/src/icmp/Icmp4.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -134,7 +134,7 @@ Icmp4::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
     ((sockaddr_in*)S->ai_addr)->sin_port = 0;
     assert(icmp_pktsize <= MAX_PKT4_SZ);
 
-    debugs(42, 5, HERE << "Send ICMP packet to " << to << ".");
+    debugs(42, 5, "Send ICMP packet to " << to << ".");
 
     x = sendto(icmp_sock,
                (const void *) pkt,
@@ -166,7 +166,7 @@ Icmp4::Recv(void)
     static pingerReplyData preply;
 
     if (icmp_sock < 0) {
-        debugs(42, DBG_CRITICAL, HERE << "No socket! Recv() should not be called.");
+        debugs(42, DBG_CRITICAL, "No socket! Recv() should not be called.");
         return;
     }
 
@@ -199,7 +199,7 @@ Icmp4::Recv(void)
 
 #endif
 
-    debugs(42, 8, HERE << n << " bytes from " << preply.from);
+    debugs(42, 8, n << " bytes from " << preply.from);
 
     ip = (struct iphdr *) (void *) pkt;
 

--- a/src/icmp/Icmp4.h
+++ b/src/icmp/Icmp4.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/Icmp6.cc
+++ b/src/icmp/Icmp6.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -170,7 +170,7 @@ Icmp6::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     assert(icmp6_pktsize <= MAX_PKT6_SZ);
 
-    debugs(42, 5, HERE << "Send Icmp6 packet to " << to << ".");
+    debugs(42, 5, "Send Icmp6 packet to " << to << ".");
 
     x = sendto(icmp_sock,
                (const void *) pkt,
@@ -183,7 +183,7 @@ Icmp6::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
         int xerrno = errno;
         debugs(42, DBG_IMPORTANT, MYNAME << "ERROR: sending to ICMPv6 packet to " << to << ": " << xstrerr(xerrno));
     }
-    debugs(42,9, HERE << "x=" << x);
+    debugs(42,9, "x=" << x);
 
     Log(to, 0, NULL, 0, 0);
     Ip::Address::FreeAddr(S);
@@ -205,7 +205,7 @@ Icmp6::Recv(void)
     static pingerReplyData preply;
 
     if (icmp_sock < 0) {
-        debugs(42, DBG_CRITICAL, HERE << "dropping ICMPv6 read. No socket!?");
+        debugs(42, DBG_CRITICAL, "dropping ICMPv6 read. No socket!?");
         return;
     }
 
@@ -240,7 +240,7 @@ Icmp6::Recv(void)
 
 #endif
 
-    debugs(42, 8, HERE << n << " bytes from " << preply.from);
+    debugs(42, 8, n << " bytes from " << preply.from);
 
 // XXX: The IPv6 Header (ip6_hdr) is not available directly
 //
@@ -261,7 +261,7 @@ Icmp6::Recv(void)
         ip = (struct ip6_hdr *) pkt;
         //  += sizeof(ip6_hdr);
 
-    debugs(42, DBG_CRITICAL, HERE << "ip6_nxt=" << ip->ip6_nxt <<
+    debugs(42, DBG_CRITICAL, "ip6_nxt=" << ip->ip6_nxt <<
             ", ip6_plen=" << ip->ip6_plen <<
             ", ip6_hlim=" << ip->ip6_hlim <<
             ", ip6_hops=" << ip->ip6_hops   <<
@@ -281,7 +281,7 @@ Icmp6::Recv(void)
             break;
 
         default:
-            debugs(42, 8, HERE << preply.from << " said: " << icmp6header->icmp6_type << "/" << (int)icmp6header->icmp6_code << " " <<
+            debugs(42, 8, preply.from << " said: " << icmp6header->icmp6_type << "/" << (int)icmp6header->icmp6_code << " " <<
                    IcmpPacketType(icmp6header->icmp6_type));
         }
         Ip::Address::FreeAddr(from);
@@ -289,7 +289,7 @@ Icmp6::Recv(void)
     }
 
     if (icmp6header->icmp6_id != icmp_ident) {
-        debugs(42, 8, HERE << "dropping Icmp6 read. IDENT check failed. ident=='" << icmp_ident << "'=='" << icmp6header->icmp6_id << "'");
+        debugs(42, 8, "dropping Icmp6 read. IDENT check failed. ident=='" << icmp_ident << "'=='" << icmp6header->icmp6_id << "'");
         Ip::Address::FreeAddr(from);
         return;
     }

--- a/src/icmp/Icmp6.h
+++ b/src/icmp/Icmp6.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/IcmpConfig.cc
+++ b/src/icmp/IcmpConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/IcmpConfig.h
+++ b/src/icmp/IcmpConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -186,14 +186,14 @@ IcmpPinger::Recv(void)
     guess_size = n - (sizeof(pingerEchoData) - PINGER_PAYLOAD_SZ);
 
     if (guess_size != pecho.psize) {
-        debugs(42, 2, HERE << "size mismatch, guess=" << guess_size << ", psize=" << pecho.psize);
+        debugs(42, 2, "size mismatch, guess=" << guess_size << ", psize=" << pecho.psize);
         /* don't process this message, but keep running */
         return;
     }
 
     /* pass request for ICMPv6 handing */
     if (pecho.to.isIPv6()) {
-        debugs(42, 2, HERE << " Pass " << pecho.to << " off to ICMPv6 module.");
+        debugs(42, 2, " Pass " << pecho.to << " off to ICMPv6 module.");
         icmp6.SendEcho(pecho.to,
                        pecho.opcode,
                        pecho.payload,
@@ -202,7 +202,7 @@ IcmpPinger::Recv(void)
 
     /* pass the packet for ICMP handling */
     else if (pecho.to.isIPv4()) {
-        debugs(42, 2, HERE << " Pass " << pecho.to << " off to ICMPv4 module.");
+        debugs(42, 2, " Pass " << pecho.to << " off to ICMPv4 module.");
         icmp4.SendEcho(pecho.to,
                        pecho.opcode,
                        pecho.payload,
@@ -215,7 +215,7 @@ IcmpPinger::Recv(void)
 void
 IcmpPinger::SendResult(pingerReplyData &preply, int len)
 {
-    debugs(42, 2, HERE << "return result to squid. len=" << len);
+    debugs(42, 2, "return result to squid. len=" << len);
 
     if (send(socket_to_squid, &preply, len, 0) < 0) {
         int xerrno = errno;

--- a/src/icmp/IcmpPinger.h
+++ b/src/icmp/IcmpPinger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/IcmpSquid.cc
+++ b/src/icmp/IcmpSquid.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -56,7 +56,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     /** \li Does nothing if the pinger socket is not available. */
     if (icmp_sock < 0) {
-        debugs(37, 2, HERE << " Socket Closed. Aborted send to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
+        debugs(37, 2, " Socket Closed. Aborted send to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
         return;
     }
 
@@ -86,7 +86,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
 
     slen = sizeof(pingerEchoData) - PINGER_PAYLOAD_SZ + pecho.psize;
 
-    debugs(37, 2, HERE << "to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
+    debugs(37, 2, "to " << pecho.to << ", opcode " << opcode << ", len " << pecho.psize);
 
     x = comm_udp_send(icmp_sock, (char *)&pecho, slen, 0);
 
@@ -102,7 +102,7 @@ IcmpSquid::SendEcho(Ip::Address &to, int opcode, const char *payload, int len)
         }
         /** All other send errors are ignored. */
     } else if (x != slen) {
-        debugs(37, DBG_IMPORTANT, HERE << "Wrote " << x << " of " << slen << " bytes");
+        debugs(37, DBG_IMPORTANT, "Wrote " << x << " of " << slen << " bytes");
     }
 }
 
@@ -158,11 +158,11 @@ IcmpSquid::Recv()
     switch (preply.opcode) {
 
     case S_ICMP_ECHO:
-        debugs(37,4, HERE << " ICMP_ECHO of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
+        debugs(37,4, " ICMP_ECHO of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
         break;
 
     case S_ICMP_DOM:
-        debugs(37,4, HERE << " DomainPing of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
+        debugs(37,4, " DomainPing of " << preply.from << " gave: hops=" << preply.hops <<", rtt=" << preply.rtt);
         netdbHandlePingReply(F, preply.hops, preply.rtt);
         break;
 
@@ -178,7 +178,7 @@ void
 IcmpSquid::DomainPing(Ip::Address &to, const char *domain)
 {
 #if USE_ICMP
-    debugs(37, 4, HERE << "'" << domain << "' (" << to << ")");
+    debugs(37, 4, "'" << domain << "' (" << to << ")");
     SendEcho(to, S_ICMP_DOM, domain, 0);
 #else
     (void)to;
@@ -232,7 +232,7 @@ IcmpSquid::Open(void)
 
     commUnsetFdTimeout(icmp_sock);
 
-    debugs(37, DBG_IMPORTANT, HERE << "Pinger socket opened on FD " << icmp_sock);
+    debugs(37, DBG_IMPORTANT, "Pinger socket opened on FD " << icmp_sock);
 
     /* Tests the pinger immediately using localhost */
     if (Ip::EnableIpv6)
@@ -242,7 +242,7 @@ IcmpSquid::Open(void)
 
 #if _SQUID_WINDOWS_
 
-    debugs(37, 4, HERE << "Pinger handle: 0x" << std::hex << hIpc << std::dec << ", PID: " << pid);
+    debugs(37, 4, "Pinger handle: 0x" << std::hex << hIpc << std::dec << ", PID: " << pid);
 
 #endif /* _SQUID_WINDOWS_ */
     return icmp_sock;
@@ -259,7 +259,7 @@ IcmpSquid::Close(void)
     if (icmp_sock < 0)
         return;
 
-    debugs(37, DBG_IMPORTANT, HERE << "Closing Pinger socket on FD " << icmp_sock);
+    debugs(37, DBG_IMPORTANT, "Closing Pinger socket on FD " << icmp_sock);
 
 #if _SQUID_WINDOWS_
 
@@ -274,7 +274,7 @@ IcmpSquid::Close(void)
     if (hIpc) {
         if (WaitForSingleObject(hIpc, 12000) != WAIT_OBJECT_0) {
             getCurrentTime();
-            debugs(37, DBG_CRITICAL, HERE << "WARNING: (pinger," << pid << ") didn't exit in 12 seconds");
+            debugs(37, DBG_CRITICAL, "WARNING: (pinger," << pid << ") didn't exit in 12 seconds");
         }
 
         CloseHandle(hIpc);

--- a/src/icmp/IcmpSquid.h
+++ b/src/icmp/IcmpSquid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/net_db.h
+++ b/src/icmp/net_db.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icp_opcode.h
+++ b/src/icp_opcode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -45,7 +45,7 @@ void
 ACLIdent::parse()
 {
     if (!data) {
-        debugs(28, 3, HERE << "current is null. Creating");
+        debugs(28, 3, "current is null. Creating");
         data = new ACLUserData;
     }
 
@@ -102,7 +102,7 @@ IdentLookup::checkForAsync(ACLChecklist *cl)const
     const ConnStateData *conn = checklist->conn();
     // check that ACLIdent::match() tested this lookup precondition
     assert(conn && Comm::IsConnOpen(conn->clientConnection));
-    debugs(28, 3, HERE << "Doing ident lookup" );
+    debugs(28, 3, "Doing ident lookup" );
     Ident::Start(checklist->conn()->clientConnection, LookupDone, checklist);
 }
 

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ident/Config.h
+++ b/src/ident/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ident/Ident.cc
+++ b/src/ident/Ident.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -135,7 +135,7 @@ Ident::Close(const CommCloseCbParams &params)
 void
 Ident::Timeout(const CommTimeoutCbParams &io)
 {
-    debugs(30, 3, HERE << io.conn);
+    debugs(30, 3, io.conn);
     IdentStateData *state = (IdentStateData *)io.data;
     state->deleteThis("timeout");
 }
@@ -193,11 +193,11 @@ Ident::ConnectDone(const Comm::ConnectionPointer &conn, Comm::Flag status, int, 
 void
 Ident::WriteFeedback(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::Flag flag, int xerrno, void *data)
 {
-    debugs(30, 5, HERE << conn << ": Wrote IDENT request " << len << " bytes.");
+    debugs(30, 5, conn << ": Wrote IDENT request " << len << " bytes.");
 
     // TODO handle write errors better. retry or abort?
     if (flag != Comm::OK) {
-        debugs(30, 2, HERE << conn << " err-flags=" << flag << " IDENT write error: " << xstrerr(xerrno));
+        debugs(30, 2, conn << " err-flags=" << flag << " IDENT write error: " << xstrerr(xerrno));
         IdentStateData *state = (IdentStateData *)data;
         state->deleteThis("write error");
     }
@@ -231,7 +231,7 @@ Ident::ReadReply(const Comm::ConnectionPointer &conn, char *buf, size_t len, Com
     if ((t = strchr(buf, '\n')))
         *t = '\0';
 
-    debugs(30, 5, HERE << conn << ": Read '" << buf << "'");
+    debugs(30, 5, conn << ": Read '" << buf << "'");
 
     if (strstr(buf, "USERID")) {
         if ((ident = strrchr(buf, ':'))) {

--- a/src/ident/Ident.h
+++ b/src/ident/Ident.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ident/Makefile.am
+++ b/src/ident/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/int.cc
+++ b/src/int.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/int.h
+++ b/src/int.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/internal.h
+++ b/src/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -386,7 +386,7 @@ Ip::Address::lookupHostIP(const char *s, bool nodns)
     int err = 0;
     struct addrinfo *res = NULL;
     if ( (err = getaddrinfo(s, NULL, &want, &res)) != 0) {
-        debugs(14,3, HERE << "Given Non-IP '" << s << "': " << gai_strerror(err) );
+        debugs(14,3, "Given Non-IP '" << s << "': " << gai_strerror(err) );
         /* free the memory getaddrinfo() dynamically allocated. */
         if (res)
             freeaddrinfo(res);

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -167,7 +167,7 @@ Ip::Intercept::TproxyTransparent(const Comm::ConnectionPointer &newConn)
     /* Trust the user configured properly. If not no harm done.
      * We will simply attempt a bind outgoing on our own IP.
      */
-    debugs(89, 5, HERE << "address TPROXY: " << newConn);
+    debugs(89, 5, "address TPROXY: " << newConn);
     return true;
 #else
     (void)newConn;
@@ -183,7 +183,7 @@ Ip::Intercept::IpfwInterception(const Comm::ConnectionPointer &newConn)
      * There is no way to identify whether they came from NAT or not.
      * Trust the user configured properly.
      */
-    debugs(89, 5, HERE << "address NAT: " << newConn);
+    debugs(89, 5, "address NAT: " << newConn);
     return true;
 #else
     (void)newConn;
@@ -282,7 +282,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
             natfd = -1;
         }
 
-        debugs(89, 9, HERE << "address: " << newConn);
+        debugs(89, 9, "address: " << newConn);
         return false;
     } else {
 #if HAVE_STRUCT_NATLOOKUP_NL_REALIPADDR_IN6
@@ -294,7 +294,7 @@ Ip::Intercept::IpfInterception(const Comm::ConnectionPointer &newConn)
         newConn->local = natLookup.nl_realip;
 #endif
         newConn->local.port(ntohs(natLookup.nl_realport));
-        debugs(89, 5, HERE << "address NAT: " << newConn);
+        debugs(89, 5, "address NAT: " << newConn);
         return true;
     }
 
@@ -316,7 +316,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
      *
      * Trust the user configured properly.
      */
-    debugs(89, 5, HERE << "address NAT divert-to: " << newConn);
+    debugs(89, 5, "address NAT divert-to: " << newConn);
     return true;
 
 #else /* USE_NAT_DEVPF / --with-nat-devpf */
@@ -358,7 +358,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
             close(pffd);
             pffd = -1;
         }
-        debugs(89, 9, HERE << "address: " << newConn);
+        debugs(89, 9, "address: " << newConn);
         return false;
     } else {
         if (newConn->remote.isIPv6())
@@ -366,7 +366,7 @@ Ip::Intercept::PfInterception(const Comm::ConnectionPointer &newConn)
         else
             newConn->local = nl.rdaddr.v4;
         newConn->local.port(ntohs(nl.rdport));
-        debugs(89, 5, HERE << "address NAT: " << newConn);
+        debugs(89, 5, "address NAT: " << newConn);
         return true;
     }
 #endif /* --with-nat-devpf */
@@ -385,7 +385,7 @@ Ip::Intercept::Lookup(const Comm::ConnectionPointer &newConn, const Comm::Connec
     /* --enable-pf-transparent     */
 #if IPF_TRANSPARENT || LINUX_NETFILTER || IPFW_TRANSPARENT || PF_TRANSPARENT
 
-    debugs(89, 5, HERE << "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
+    debugs(89, 5, "address BEGIN: me/client= " << newConn->local << ", destination/me= " << newConn->remote);
 
     newConn->flags |= (listenConn->flags & (COMM_TRANSPARENT|COMM_INTERCEPTION));
 

--- a/src/ip/Intercept.h
+++ b/src/ip/Intercept.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/Makefile.am
+++ b/src/ip/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/ip/NfMarkConfig.cc
+++ b/src/ip/NfMarkConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/NfMarkConfig.h
+++ b/src/ip/NfMarkConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/forward.h
+++ b/src/ip/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/tools.cc
+++ b/src/ip/tools.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ip/tools.h
+++ b/src/ip/tools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -53,7 +53,7 @@ Ipc::StrandCoord* Ipc::Coordinator::findStrand(int kidId)
 
 void Ipc::Coordinator::registerStrand(const StrandCoord& strand)
 {
-    debugs(54, 3, HERE << "registering kid" << strand.kidId <<
+    debugs(54, 3, "registering kid" << strand.kidId <<
            ' ' << strand.tag);
     if (StrandCoord* found = findStrand(strand.kidId)) {
         const String oldTag = found->tag;
@@ -80,32 +80,32 @@ void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 {
     switch (message.rawType()) {
     case mtRegisterStrand:
-        debugs(54, 6, HERE << "Registration request");
+        debugs(54, 6, "Registration request");
         handleRegistrationRequest(StrandMessage(message));
         break;
 
     case mtFindStrand: {
         const StrandSearchRequest sr(message);
-        debugs(54, 6, HERE << "Strand search request: " << sr.requestorId <<
+        debugs(54, 6, "Strand search request: " << sr.requestorId <<
                " tag: " << sr.tag);
         handleSearchRequest(sr);
         break;
     }
 
     case mtSharedListenRequest:
-        debugs(54, 6, HERE << "Shared listen request");
+        debugs(54, 6, "Shared listen request");
         handleSharedListenRequest(SharedListenRequest(message));
         break;
 
     case mtCacheMgrRequest: {
-        debugs(54, 6, HERE << "Cache manager request");
+        debugs(54, 6, "Cache manager request");
         const Mgr::Request req(message);
         handleCacheMgrRequest(req);
     }
     break;
 
     case mtCacheMgrResponse: {
-        debugs(54, 6, HERE << "Cache manager response");
+        debugs(54, 6, "Cache manager response");
         const Mgr::Response resp(message);
         handleCacheMgrResponse(Mine(resp));
     }
@@ -113,14 +113,14 @@ void Ipc::Coordinator::receive(const TypedMsgHdr& message)
 
 #if SQUID_SNMP
     case mtSnmpRequest: {
-        debugs(54, 6, HERE << "SNMP request");
+        debugs(54, 6, "SNMP request");
         const Snmp::Request req(message);
         handleSnmpRequest(req);
     }
     break;
 
     case mtSnmpResponse: {
-        debugs(54, 6, HERE << "SNMP response");
+        debugs(54, 6, "SNMP response");
         const Snmp::Response resp(message);
         handleSnmpResponse(Mine(resp));
     }
@@ -146,14 +146,14 @@ void Ipc::Coordinator::handleRegistrationRequest(const StrandMessage& msg)
 void
 Ipc::Coordinator::handleSharedListenRequest(const SharedListenRequest& request)
 {
-    debugs(54, 4, HERE << "kid" << request.requestorId <<
+    debugs(54, 4, "kid" << request.requestorId <<
            " needs shared listen FD for " << request.params.addr);
     Listeners::const_iterator i = listeners.find(request.params);
     int errNo = 0;
     const Comm::ConnectionPointer c = (i != listeners.end()) ?
                                       i->second : openListenSocket(request, errNo);
 
-    debugs(54, 3, HERE << "sending shared listen " << c << " for " <<
+    debugs(54, 3, "sending shared listen " << c << " for " <<
            request.params.addr << " to kid" << request.requestorId <<
            " mapId=" << request.mapId);
 
@@ -166,7 +166,7 @@ Ipc::Coordinator::handleSharedListenRequest(const SharedListenRequest& request)
 void
 Ipc::Coordinator::handleCacheMgrRequest(const Mgr::Request& request)
 {
-    debugs(54, 4, HERE);
+    debugs(54, 4, MYNAME);
 
     try {
         Mgr::Action::Pointer action =
@@ -212,7 +212,7 @@ Ipc::Coordinator::handleSearchRequest(const Ipc::StrandSearchRequest &request)
     }
 
     searchers.push_back(request);
-    debugs(54, 3, HERE << "cannot yet tell kid" << request.requestorId <<
+    debugs(54, 3, "cannot yet tell kid" << request.requestorId <<
            " who " << request.tag << " is");
 }
 
@@ -220,7 +220,7 @@ void
 Ipc::Coordinator::notifySearcher(const Ipc::StrandSearchRequest &request,
                                  const StrandCoord& strand)
 {
-    debugs(54, 3, HERE << "tell kid" << request.requestorId << " that " <<
+    debugs(54, 3, "tell kid" << request.requestorId << " that " <<
            request.tag << " is kid" << strand.kidId);
     const StrandMessage response(strand, request.qid);
     TypedMsgHdr message;
@@ -232,7 +232,7 @@ Ipc::Coordinator::notifySearcher(const Ipc::StrandSearchRequest &request,
 void
 Ipc::Coordinator::handleSnmpRequest(const Snmp::Request& request)
 {
-    debugs(54, 4, HERE);
+    debugs(54, 4, MYNAME);
 
     Snmp::Response response(request.requestId);
     TypedMsgHdr message;
@@ -245,7 +245,7 @@ Ipc::Coordinator::handleSnmpRequest(const Snmp::Request& request)
 void
 Ipc::Coordinator::handleSnmpResponse(const Snmp::Response& response)
 {
-    debugs(54, 4, HERE);
+    debugs(54, 4, MYNAME);
     Snmp::Inquirer::HandleRemoteAck(response);
 }
 #endif
@@ -256,7 +256,7 @@ Ipc::Coordinator::openListenSocket(const SharedListenRequest& request,
 {
     const OpenListenerParams &p = request.params;
 
-    debugs(54, 6, HERE << "opening listen FD at " << p.addr << " for kid" <<
+    debugs(54, 6, "opening listen FD at " << p.addr << " for kid" <<
            request.requestorId);
 
     Comm::ConnectionPointer newConn = new Comm::Connection;
@@ -268,7 +268,7 @@ Ipc::Coordinator::openListenSocket(const SharedListenRequest& request,
     errNo = Comm::IsConnOpen(newConn) ? 0 : errno;
     leave_suid();
 
-    debugs(54, 6, HERE << "tried listening on " << newConn << " for kid" <<
+    debugs(54, 6, "tried listening on " << newConn << " for kid" <<
            request.requestorId);
 
     // cache positive results
@@ -282,7 +282,7 @@ void Ipc::Coordinator::broadcastSignal(int sig) const
 {
     typedef StrandCoords::const_iterator SCI;
     for (SCI iter = strands_.begin(); iter != strands_.end(); ++iter) {
-        debugs(54, 5, HERE << "signal " << sig << " to kid" << iter->kidId <<
+        debugs(54, 5, "signal " << sig << " to kid" << iter->kidId <<
                ", PID=" << iter->pid);
         kill(iter->pid, sig);
     }

--- a/src/ipc/Coordinator.h
+++ b/src/ipc/Coordinator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/FdNotes.cc
+++ b/src/ipc/FdNotes.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/FdNotes.h
+++ b/src/ipc/FdNotes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Forwarder.cc
+++ b/src/ipc/Forwarder.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -41,7 +41,7 @@ Ipc::Forwarder::~Forwarder()
 void
 Ipc::Forwarder::start()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
 
     typedef NullaryMemFunT<Forwarder> Dialer;
     AsyncCall::Pointer callback = JobCallback(54, 5, Dialer, this, Forwarder::handleRemoteAck);
@@ -68,7 +68,7 @@ Ipc::Forwarder::start()
 void
 Ipc::Forwarder::swanSong()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, MYNAME);
     removeTimeoutEvent();
     if (request->requestId > 0) {
         DequeueRequest(request->requestId);
@@ -79,7 +79,7 @@ Ipc::Forwarder::swanSong()
 bool
 Ipc::Forwarder::doneAll() const
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, MYNAME);
     return request->requestId == 0;
 }
 
@@ -87,7 +87,7 @@ Ipc::Forwarder::doneAll() const
 void
 Ipc::Forwarder::handleRemoteAck()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     request->requestId = 0;
     // Do not do entry->complete() because it will trigger our client side
     // processing when we no longer own the client-Squid connection.
@@ -99,7 +99,7 @@ Ipc::Forwarder::handleRemoteAck()
 void
 Ipc::Forwarder::RequestTimedOut(void* param)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     Must(param != NULL);
     Forwarder* fwdr = static_cast<Forwarder*>(param);
     // use async call to enable job call protection that time events lack
@@ -113,7 +113,7 @@ Ipc::Forwarder::RequestTimedOut(void* param)
 void
 Ipc::Forwarder::requestTimedOut()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     handleTimeout();
 }
 
@@ -133,7 +133,7 @@ Ipc::Forwarder::handleTimeout()
 void
 Ipc::Forwarder::handleException(const std::exception& e)
 {
-    debugs(54, 3, HERE << e.what());
+    debugs(54, 3, e.what());
     mustStop("exception");
 }
 
@@ -143,7 +143,7 @@ Ipc::Forwarder::callException(const std::exception& e)
     try {
         handleException(e);
     } catch (const std::exception& ex) {
-        debugs(54, DBG_CRITICAL, HERE << ex.what());
+        debugs(54, DBG_CRITICAL, ex.what());
     }
     AsyncJob::callException(e);
 }
@@ -152,7 +152,7 @@ Ipc::Forwarder::callException(const std::exception& e)
 AsyncCall::Pointer
 Ipc::Forwarder::DequeueRequest(const RequestId::Index requestId)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     Must(requestId != 0);
     AsyncCall::Pointer call;
     RequestsMap::iterator request = TheRequestsMap.find(requestId);
@@ -175,7 +175,7 @@ Ipc::Forwarder::removeTimeoutEvent()
 void
 Ipc::Forwarder::HandleRemoteAck(const RequestId requestId)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     Must(requestId != 0);
 
     AsyncCall::Pointer call = DequeueRequest(requestId);

--- a/src/ipc/Forwarder.h
+++ b/src/ipc/Forwarder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Inquirer.cc
+++ b/src/ipc/Inquirer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -36,7 +36,7 @@ Ipc::Inquirer::Inquirer(Request::Pointer aRequest, const StrandCoords& coords,
     codeContext(CodeContext::Current()),
     request(aRequest), strands(coords), pos(strands.begin()), timeout(aTimeout)
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, MYNAME);
 
     // order by ascending kid IDs; useful for non-aggregatable stats
     std::sort(strands.begin(), strands.end(), LesserStrandByKidId);
@@ -44,7 +44,7 @@ Ipc::Inquirer::Inquirer(Request::Pointer aRequest, const StrandCoords& coords,
 
 Ipc::Inquirer::~Inquirer()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, MYNAME);
     cleanup();
 }
 
@@ -74,7 +74,7 @@ Ipc::Inquirer::inquire()
         ++LastRequestId;
     request->requestId = LastRequestId;
     const int kidId = pos->kidId;
-    debugs(54, 4, HERE << "inquire kid: " << kidId << status());
+    debugs(54, 4, "inquire kid: " << kidId << status());
     TheRequestsMap[request->requestId] = callback;
     TypedMsgHdr message;
     request->pack(message);
@@ -87,7 +87,7 @@ Ipc::Inquirer::inquire()
 void
 Ipc::Inquirer::handleRemoteAck(Response::Pointer response)
 {
-    debugs(54, 4, HERE << status());
+    debugs(54, 4, status());
     request->requestId = 0;
     removeTimeoutEvent();
     if (aggregate(response)) {
@@ -102,7 +102,7 @@ Ipc::Inquirer::handleRemoteAck(Response::Pointer response)
 void
 Ipc::Inquirer::swanSong()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, MYNAME);
     removeTimeoutEvent();
     if (request->requestId > 0) {
         DequeueRequest(request->requestId);
@@ -121,18 +121,18 @@ Ipc::Inquirer::doneAll() const
 void
 Ipc::Inquirer::handleException(const std::exception& e)
 {
-    debugs(54, 3, HERE << e.what());
+    debugs(54, 3, e.what());
     mustStop("exception");
 }
 
 void
 Ipc::Inquirer::callException(const std::exception& e)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     try {
         handleException(e);
     } catch (const std::exception& ex) {
-        debugs(54, DBG_CRITICAL, HERE << ex.what());
+        debugs(54, DBG_CRITICAL, ex.what());
     }
     AsyncJob::callException(e);
 }
@@ -141,7 +141,7 @@ Ipc::Inquirer::callException(const std::exception& e)
 AsyncCall::Pointer
 Ipc::Inquirer::DequeueRequest(const RequestId::Index requestId)
 {
-    debugs(54, 3, HERE << " requestId " << requestId);
+    debugs(54, 3, " requestId " << requestId);
     Must(requestId != 0);
     AsyncCall::Pointer call;
     RequestsMap::iterator request = TheRequestsMap.find(requestId);
@@ -178,7 +178,7 @@ Ipc::Inquirer::removeTimeoutEvent()
 void
 Ipc::Inquirer::RequestTimedOut(void* param)
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     Must(param != NULL);
     Inquirer* cmi = static_cast<Inquirer*>(param);
     // use async call to enable job call protection that time events lack
@@ -191,7 +191,7 @@ Ipc::Inquirer::RequestTimedOut(void* param)
 void
 Ipc::Inquirer::requestTimedOut()
 {
-    debugs(54, 3, HERE);
+    debugs(54, 3, MYNAME);
     if (request->requestId != 0) {
         DequeueRequest(request->requestId);
         request->requestId = 0;

--- a/src/ipc/Inquirer.h
+++ b/src/ipc/Inquirer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Kid.cc
+++ b/src/ipc/Kid.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Kid.h
+++ b/src/ipc/Kid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Kids.cc
+++ b/src/ipc/Kids.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Kids.h
+++ b/src/ipc/Kids.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Makefile.am
+++ b/src/ipc/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/ipc/MemMap.cc
+++ b/src/ipc/MemMap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/MemMap.h
+++ b/src/ipc/MemMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Messages.h
+++ b/src/ipc/Messages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Port.cc
+++ b/src/ipc/Port.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -36,7 +36,7 @@ void Ipc::Port::start()
 
 void Ipc::Port::doListen()
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, MYNAME);
     buf.prepForReading();
     typedef CommCbMemFunT<Port, CommIoCbParams> Dialer;
     AsyncCall::Pointer readHandler = JobCallback(54, 6,
@@ -95,7 +95,7 @@ Ipc::Port::receiveOrIgnore(const TypedMsgHdr &message)
 
 void Ipc::Port::noteRead(const CommIoCbParams& params)
 {
-    debugs(54, 6, HERE << params.conn << " flag " << params.flag <<
+    debugs(54, 6, params.conn << " flag " << params.flag <<
            " [" << this << ']');
     if (params.flag == Comm::OK) {
         assert(params.buf == buf.raw());

--- a/src/ipc/Port.h
+++ b/src/ipc/Port.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/QuestionerId.cc
+++ b/src/ipc/QuestionerId.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/QuestionerId.h
+++ b/src/ipc/QuestionerId.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Queue.cc
+++ b/src/ipc/Queue.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -47,7 +47,7 @@ InstanceIdDefinitions(Ipc::QueueReader, "ipcQR");
 Ipc::QueueReader::QueueReader(): popBlocked(true), popSignal(false),
     rateLimit(0), balance(0)
 {
-    debugs(54, 7, HERE << "constructed " << id);
+    debugs(54, 7, "constructed " << id);
 }
 
 /* QueueReaders */

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -540,7 +540,7 @@ BaseMultiQueue::pop(int &remoteProcessId, Value &value)
         OneToOneUniQueue &queue = inQueue(theLastPopProcessId);
         if (queue.pop(value, &localReader())) {
             remoteProcessId = theLastPopProcessId;
-            debugs(54, 7, HERE << "popped from " << remoteProcessId << " to " << theLocalProcessId << " at " << queue.size());
+            debugs(54, 7, "popped from " << remoteProcessId << " to " << theLocalProcessId << " at " << queue.size());
             return true;
         }
     }
@@ -553,7 +553,7 @@ BaseMultiQueue::push(const int remoteProcessId, const Value &value)
 {
     OneToOneUniQueue &remoteQueue = outQueue(remoteProcessId);
     QueueReader &reader = remoteReader(remoteProcessId);
-    debugs(54, 7, HERE << "pushing from " << theLocalProcessId << " to " << remoteProcessId << " at " << remoteQueue.size());
+    debugs(54, 7, "pushing from " << theLocalProcessId << " to " << remoteProcessId << " at " << remoteQueue.size());
     return remoteQueue.push(value, &reader);
 }
 
@@ -604,14 +604,14 @@ FewToFewBiQueue::findOldest(const int remoteProcessId, Value &value) const
 
     // we need the oldest value, so start with the incoming, them-to-us queue:
     const OneToOneUniQueue &in = inQueue(remoteProcessId);
-    debugs(54, 2, HERE << "peeking from " << remoteProcessId << " to " <<
+    debugs(54, 2, "peeking from " << remoteProcessId << " to " <<
            theLocalProcessId << " at " << in.size());
     if (in.peek(value))
         return true;
 
     // if the incoming queue is empty, check the outgoing, us-to-them queue:
     const OneToOneUniQueue &out = outQueue(remoteProcessId);
-    debugs(54, 2, HERE << "peeking from " << theLocalProcessId << " to " <<
+    debugs(54, 2, "peeking from " << theLocalProcessId << " to " <<
            remoteProcessId << " at " << out.size());
     return out.peek(value);
 }

--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Request.h
+++ b/src/ipc/Request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/RequestId.cc
+++ b/src/ipc/RequestId.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/RequestId.h
+++ b/src/ipc/RequestId.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Response.h
+++ b/src/ipc/Response.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/SharedListen.cc
+++ b/src/ipc/SharedListen.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/SharedListen.h
+++ b/src/ipc/SharedListen.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StartListening.cc
+++ b/src/ipc/StartListening.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -58,7 +58,7 @@ Ipc::StartListening(int sock_type, int proto, const Comm::ConnectionPointer &lis
     cbd->errNo = Comm::IsConnOpen(cbd->conn) ? 0 : errno;
     leave_suid();
 
-    debugs(54, 3, HERE << "opened listen " << cbd->conn);
+    debugs(54, 3, "opened listen " << cbd->conn);
     ScheduleCallHere(callback);
 }
 

--- a/src/ipc/StartListening.h
+++ b/src/ipc/StartListening.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -51,7 +51,7 @@ void Ipc::Strand::start()
 
 void Ipc::Strand::registerSelf()
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, MYNAME);
     Must(!isRegistered);
 
     StrandMessage::NotifyCoordinator(mtRegisterStrand, nullptr);
@@ -145,20 +145,20 @@ void Ipc::Strand::handleCacheMgrResponse(const Mgr::Response& response)
 #if SQUID_SNMP
 void Ipc::Strand::handleSnmpRequest(const Snmp::Request& request)
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, MYNAME);
     Snmp::SendResponse(request.requestId, request.pdu);
 }
 
 void Ipc::Strand::handleSnmpResponse(const Snmp::Response& response)
 {
-    debugs(54, 6, HERE);
+    debugs(54, 6, MYNAME);
     Snmp::Forwarder::HandleRemoteAck(response.requestId);
 }
 #endif
 
 void Ipc::Strand::timedout()
 {
-    debugs(54, 6, HERE << isRegistered);
+    debugs(54, 6, isRegistered);
     if (!isRegistered)
         fatalf("kid%d registration timed out", KidIdentifier);
 }

--- a/src/ipc/Strand.h
+++ b/src/ipc/Strand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StrandCoord.cc
+++ b/src/ipc/StrandCoord.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StrandCoord.h
+++ b/src/ipc/StrandCoord.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StrandCoords.h
+++ b/src/ipc/StrandCoords.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StrandSearch.cc
+++ b/src/ipc/StrandSearch.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/StrandSearch.h
+++ b/src/ipc/StrandSearch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/TypedMsgHdr.cc
+++ b/src/ipc/TypedMsgHdr.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/TypedMsgHdr.h
+++ b/src/ipc/TypedMsgHdr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -21,12 +21,12 @@ Ipc::UdsOp::UdsOp(const String& pathAddr):
     address(PathToAddress(pathAddr)),
     options(COMM_NONBLOCKING)
 {
-    debugs(54, 5, HERE << '[' << this << "] pathAddr=" << pathAddr);
+    debugs(54, 5, '[' << this << "] pathAddr=" << pathAddr);
 }
 
 Ipc::UdsOp::~UdsOp()
 {
-    debugs(54, 5, HERE << '[' << this << ']');
+    debugs(54, 5, '[' << this << ']');
     if (Comm::IsConnOpen(conn_))
         conn_->close();
     conn_ = NULL;
@@ -117,7 +117,7 @@ bool Ipc::UdsSender::doneAll() const
 
 void Ipc::UdsSender::write()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, MYNAME);
     typedef CommCbMemFunT<UdsSender, CommIoCbParams> Dialer;
     AsyncCall::Pointer writeHandler = JobCallback(54, 5,
                                       Dialer, this, UdsSender::wrote);
@@ -127,7 +127,7 @@ void Ipc::UdsSender::write()
 
 void Ipc::UdsSender::wrote(const CommIoCbParams& params)
 {
-    debugs(54, 5, HERE << params.conn << " flag " << params.flag << " retries " << retries << " [" << this << ']');
+    debugs(54, 5, params.conn << " flag " << params.flag << " retries " << retries << " [" << this << ']');
     writing = false;
     if (params.flag != Comm::OK && retries-- > 0) {
         // perhaps a fresh connection and more time will help?
@@ -172,7 +172,7 @@ void Ipc::UdsSender::DelayedRetry(void *data)
 /// make another sending attempt after a pause
 void Ipc::UdsSender::delayedRetry()
 {
-    debugs(54, 5, HERE << sleeping);
+    debugs(54, 5, sleeping);
     if (sleeping) {
         sleeping = false;
         write(); // reopens the connection if needed
@@ -181,7 +181,7 @@ void Ipc::UdsSender::delayedRetry()
 
 void Ipc::UdsSender::timedout()
 {
-    debugs(54, 5, HERE);
+    debugs(54, 5, MYNAME);
     mustStop("timedout");
 }
 

--- a/src/ipc/UdsOp.h
+++ b/src/ipc/UdsOp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/forward.h
+++ b/src/ipc/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/FlexibleArray.h
+++ b/src/ipc/mem/FlexibleArray.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/Page.cc
+++ b/src/ipc/mem/Page.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/Page.h
+++ b/src/ipc/mem/Page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/PagePool.cc
+++ b/src/ipc/mem/PagePool.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/PagePool.h
+++ b/src/ipc/mem/PagePool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/PageStack.cc
+++ b/src/ipc/mem/PageStack.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/PageStack.h
+++ b/src/ipc/mem/PageStack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/Pages.cc
+++ b/src/ipc/mem/Pages.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/Pages.h
+++ b/src/ipc/mem/Pages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/Pointer.h
+++ b/src/ipc/mem/Pointer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/Segment.cc
+++ b/src/ipc/mem/Segment.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -145,7 +145,7 @@ Ipc::Mem::Segment::open(const bool unlinkWhenDone)
     theSize = statSize("Ipc::Mem::Segment::open");
     doUnlink = unlinkWhenDone;
 
-    debugs(54, 3, HERE << "opened " << theName << " segment: " << theSize);
+    debugs(54, 3, "opened " << theName << " segment: " << theSize);
 
     attach();
 }
@@ -314,7 +314,7 @@ Ipc::Mem::Segment::~Segment()
         delete [] static_cast<char *>(theMem);
         theMem = NULL;
         Segments.erase(theName);
-        debugs(54, 3, HERE << "unlinked " << theName << " fake segment");
+        debugs(54, 3, "unlinked " << theName << " fake segment");
     }
 }
 
@@ -339,7 +339,7 @@ Ipc::Mem::Segment::create(const off_t aSize)
     theSize = aSize;
     doUnlink = true;
 
-    debugs(54, 3, HERE << "created " << theName << " fake segment: " << theSize);
+    debugs(54, 3, "created " << theName << " fake segment: " << theSize);
 }
 
 void
@@ -356,14 +356,14 @@ Ipc::Mem::Segment::open()
     theMem = segment.theMem;
     theSize = segment.theSize;
 
-    debugs(54, 3, HERE << "opened " << theName << " fake segment: " << theSize);
+    debugs(54, 3, "opened " << theName << " fake segment: " << theSize);
 }
 
 void
 Ipc::Mem::Segment::checkSupport(const char *const context)
 {
     if (!Enabled()) {
-        debugs(54, 5, HERE << context <<
+        debugs(54, 5, context <<
                ": True shared memory segments are not supported. "
                "Cannot fake shared segments in SMP config.");
         fatalf("Ipc::Mem::Segment: Cannot fake shared segments in SMP config (%s)\n",

--- a/src/ipc/mem/Segment.h
+++ b/src/ipc/mem/Segment.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc/mem/forward.h
+++ b/src/ipc/mem/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ipcache.h
+++ b/src/ipcache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/Config.cc
+++ b/src/log/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/Config.h
+++ b/src/log/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/CustomLog.h
+++ b/src/log/CustomLog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/DB/Makefile.am
+++ b/src/log/DB/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/log/DB/doc/date_day_column.sql
+++ b/src/log/DB/doc/date_day_column.sql
@@ -1,4 +1,4 @@
--- Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+-- Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 --
 -- Squid software is distributed under GPLv2+ license and includes
 -- contributions from numerous individuals and organizations.

--- a/src/log/DB/doc/views.sql
+++ b/src/log/DB/doc/views.sql
@@ -1,4 +1,4 @@
--- Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+-- Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 --
 -- Squid software is distributed under GPLv2+ license and includes
 -- contributions from numerous individuals and organizations.

--- a/src/log/DB/log_db_daemon.pl.in
+++ b/src/log/DB/log_db_daemon.pl.in
@@ -288,7 +288,7 @@ I<Amos Jeffries <amosjeffries@squid-cache.org>>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/DB/required.m4
+++ b/src/log/DB/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/log/File.cc
+++ b/src/log/File.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/File.h
+++ b/src/log/File.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormatHttpdCombined.cc
+++ b/src/log/FormatHttpdCombined.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormatHttpdCommon.cc
+++ b/src/log/FormatHttpdCommon.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormatSquidCustom.cc
+++ b/src/log/FormatSquidCustom.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormatSquidIcap.cc
+++ b/src/log/FormatSquidIcap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormatSquidNative.cc
+++ b/src/log/FormatSquidNative.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormatSquidReferer.cc
+++ b/src/log/FormatSquidReferer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormatSquidUseragent.cc
+++ b/src/log/FormatSquidUseragent.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/Formats.h
+++ b/src/log/Formats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormattedLog.cc
+++ b/src/log/FormattedLog.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/FormattedLog.h
+++ b/src/log/FormattedLog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/Makefile.am
+++ b/src/log/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/log/ModDaemon.cc
+++ b/src/log/ModDaemon.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/ModDaemon.h
+++ b/src/log/ModDaemon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/ModStdio.cc
+++ b/src/log/ModStdio.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/ModStdio.h
+++ b/src/log/ModStdio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/ModSyslog.cc
+++ b/src/log/ModSyslog.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/ModSyslog.h
+++ b/src/log/ModSyslog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/ModUdp.h
+++ b/src/log/ModUdp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/TcpLogger.cc
+++ b/src/log/TcpLogger.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/TcpLogger.h
+++ b/src/log/TcpLogger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/access_log.h
+++ b/src/log/access_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/file/Makefile.am
+++ b/src/log/file/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/log/file/log_file_daemon.cc
+++ b/src/log/file/log_file_daemon.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/file/required.m4
+++ b/src/log/file/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/log/forward.h
+++ b/src/log/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/log/helpers.m4
+++ b/src/log/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/lookup_t.h
+++ b/src/lookup_t.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/AllocatorProxy.cc
+++ b/src/mem/AllocatorProxy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/AllocatorProxy.h
+++ b/src/mem/AllocatorProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/Makefile.am
+++ b/src/mem/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/mem/Meter.h
+++ b/src/mem/Meter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/Pool.cc
+++ b/src/mem/Pool.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/PoolChunked.cc
+++ b/src/mem/PoolChunked.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/PoolChunked.h
+++ b/src/mem/PoolChunked.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/PoolMalloc.cc
+++ b/src/mem/PoolMalloc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/PoolMalloc.h
+++ b/src/mem/PoolMalloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/PoolingAllocator.h
+++ b/src/mem/PoolingAllocator.h
@@ -1,5 +1,5 @@
 /*
-+ * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
++ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 + *
 + * Squid software is distributed under GPLv2+ license and includes
 + * contributions from numerous individuals and organizations.

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem_node.cc
+++ b/src/mem_node.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mem_node.h
+++ b/src/mem_node.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Action.cc
+++ b/src/mgr/Action.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -67,7 +67,7 @@ Mgr::Action::add(const Action &)
 void
 Mgr::Action::respond(const Request &request)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 
     // Assume most kid classes are fully aggregatable (i.e., they do not dump
     // local info at all). Do not import the remote HTTP fd into our Comm
@@ -90,7 +90,7 @@ Mgr::Action::sendResponse(const Ipc::RequestId requestId)
 void
 Mgr::Action::run(StoreEntry* entry, bool writeHttpHeader)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     collect();
     fillEntry(entry, writeHttpHeader);
 }
@@ -98,7 +98,7 @@ Mgr::Action::run(StoreEntry* entry, bool writeHttpHeader)
 void
 Mgr::Action::fillEntry(StoreEntry* entry, bool writeHttpHeader)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     entry->buffer();
 
     if (writeHttpHeader) {

--- a/src/mgr/Action.h
+++ b/src/mgr/Action.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ActionCreator.h
+++ b/src/mgr/ActionCreator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ActionParams.cc
+++ b/src/mgr/ActionParams.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ActionParams.h
+++ b/src/mgr/ActionParams.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ActionPasswordList.cc
+++ b/src/mgr/ActionPasswordList.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ActionPasswordList.h
+++ b/src/mgr/ActionPasswordList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ActionProfile.h
+++ b/src/mgr/ActionProfile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ActionWriter.cc
+++ b/src/mgr/ActionWriter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -20,13 +20,13 @@ Mgr::ActionWriter::ActionWriter(const Action::Pointer &anAction, const Comm::Con
     StoreToCommWriter(conn, anAction->createStoreEntry()),
     action(anAction)
 {
-    debugs(16, 5, HERE << conn << " action: " << action);
+    debugs(16, 5, conn << " action: " << action);
 }
 
 void
 Mgr::ActionWriter::start()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(action != NULL);
 
     StoreToCommWriter::start();

--- a/src/mgr/ActionWriter.h
+++ b/src/mgr/ActionWriter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/BasicActions.cc
+++ b/src/mgr/BasicActions.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -27,13 +27,13 @@ Mgr::IndexAction::Create(const Command::Pointer &cmd)
 
 Mgr::IndexAction::IndexAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::IndexAction::dump(StoreEntry *)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 Mgr::MenuAction::Pointer
@@ -44,13 +44,13 @@ Mgr::MenuAction::Create(const Command::Pointer &cmd)
 
 Mgr::MenuAction::MenuAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::MenuAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
 
     typedef CacheManager::Menu::const_iterator Iterator;
@@ -71,7 +71,7 @@ Mgr::ShutdownAction::Create(const Command::Pointer &cmd)
 
 Mgr::ShutdownAction::ShutdownAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
@@ -90,7 +90,7 @@ Mgr::ReconfigureAction::Create(const Command::Pointer &cmd)
 Mgr::ReconfigureAction::ReconfigureAction(const Command::Pointer &aCmd):
     Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
@@ -109,7 +109,7 @@ Mgr::RotateAction::Create(const Command::Pointer &cmd)
 
 Mgr::RotateAction::RotateAction(const Command::Pointer &aCmd): Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
@@ -133,7 +133,7 @@ Mgr::OfflineToggleAction::Create(const Command::Pointer &cmd)
 Mgr::OfflineToggleAction::OfflineToggleAction(const Command::Pointer &aCmd):
     Action(aCmd)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void

--- a/src/mgr/BasicActions.h
+++ b/src/mgr/BasicActions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Command.cc
+++ b/src/mgr/Command.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Command.h
+++ b/src/mgr/Command.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/CountersAction.cc
+++ b/src/mgr/CountersAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -103,27 +103,27 @@ Mgr::CountersAction::Create(const CommandPointer &cmd)
 Mgr::CountersAction::CountersAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::CountersAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     data += dynamic_cast<const CountersAction&>(action).data;
 }
 
 void
 Mgr::CountersAction::collect()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     GetCountersStats(data);
 }
 
 void
 Mgr::CountersAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
     DumpCountersStats(data, entry);
 }

--- a/src/mgr/CountersAction.h
+++ b/src/mgr/CountersAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Filler.cc
+++ b/src/mgr/Filler.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -24,13 +24,13 @@ Mgr::Filler::Filler(const Action::Pointer &anAction, const Comm::ConnectionPoint
     action(anAction),
     requestId(aRequestId)
 {
-    debugs(16, 5, HERE << conn << " action: " << action);
+    debugs(16, 5, conn << " action: " << action);
 }
 
 void
 Mgr::Filler::start()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(requestId != 0);
     Must(action != NULL);
 
@@ -41,7 +41,7 @@ Mgr::Filler::start()
 void
 Mgr::Filler::swanSong()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     action->sendResponse(requestId);
     StoreToCommWriter::swanSong();
 }

--- a/src/mgr/Filler.h
+++ b/src/mgr/Filler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Forwarder.cc
+++ b/src/mgr/Forwarder.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -34,7 +34,7 @@ Mgr::Forwarder::Forwarder(const Comm::ConnectionPointer &aConn, const ActionPara
     Ipc::Forwarder(new Request(KidIdentifier, Ipc::RequestId(/*XXX*/), aConn, aParams), 10),
     httpRequest(aRequest), entry(anEntry), conn(aConn), ale(anAle)
 {
-    debugs(16, 5, HERE << conn);
+    debugs(16, 5, conn);
     Must(Comm::IsConnOpen(conn));
     Must(httpRequest != NULL);
     Must(entry != NULL);
@@ -99,7 +99,7 @@ Mgr::Forwarder::handleException(const std::exception &e)
 void
 Mgr::Forwarder::noteCommClosed(const CommCloseCbParams &)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     closer = nullptr;
     if (conn) {
         conn->noteClosure();
@@ -112,7 +112,7 @@ Mgr::Forwarder::noteCommClosed(const CommCloseCbParams &)
 void
 Mgr::Forwarder::sendError(ErrorState *error)
 {
-    debugs(16, 3, HERE);
+    debugs(16, 3, MYNAME);
     Must(error != NULL);
     Must(entry != NULL);
     Must(httpRequest != NULL);

--- a/src/mgr/Forwarder.h
+++ b/src/mgr/Forwarder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/FunAction.cc
+++ b/src/mgr/FunAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -31,13 +31,13 @@ Mgr::FunAction::FunAction(const Command::Pointer &aCmd, OBJH* aHandler):
     Action(aCmd), handler(aHandler)
 {
     Must(handler != NULL);
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::FunAction::respond(const Request& request)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Ipc::ImportFdIntoComm(request.conn, SOCK_STREAM, IPPROTO_TCP, Ipc::fdnHttpSocket);
     Must(Comm::IsConnOpen(request.conn));
     Must(request.requestId != 0);
@@ -47,7 +47,7 @@ Mgr::FunAction::respond(const Request& request)
 void
 Mgr::FunAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
     if (UsingSmp())
         storeAppendPrintf(entry, "by kid%d {\n", KidIdentifier);

--- a/src/mgr/FunAction.h
+++ b/src/mgr/FunAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/InfoAction.cc
+++ b/src/mgr/InfoAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -111,20 +111,20 @@ Mgr::InfoAction::Create(const CommandPointer &cmd)
 Mgr::InfoAction::InfoAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::InfoAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     data += dynamic_cast<const InfoAction&>(action).data;
 }
 
 void
 Mgr::InfoAction::respond(const Request& request)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Ipc::ImportFdIntoComm(request.conn, SOCK_STREAM, IPPROTO_TCP, Ipc::fdnHttpSocket);
     Must(Comm::IsConnOpen(request.conn));
     Must(request.requestId != 0);
@@ -140,7 +140,7 @@ Mgr::InfoAction::collect()
 void
 Mgr::InfoAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
 
 #if XMALLOC_STATISTICS

--- a/src/mgr/InfoAction.h
+++ b/src/mgr/InfoAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Inquirer.cc
+++ b/src/mgr/Inquirer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -39,7 +39,7 @@ Mgr::Inquirer::Inquirer(Action::Pointer anAction,
     conn = aCause.conn;
     Ipc::ImportFdIntoComm(conn, SOCK_STREAM, IPPROTO_TCP, Ipc::fdnHttpSocket);
 
-    debugs(16, 5, HERE << conn << " action: " << aggrAction);
+    debugs(16, 5, conn << " action: " << aggrAction);
 
     closer = asyncCall(16, 5, "Mgr::Inquirer::noteCommClosed",
                        CommCbMemFunT<Inquirer, CommCloseCbParams>(this, &Inquirer::noteCommClosed));
@@ -68,7 +68,7 @@ Mgr::Inquirer::removeCloseHandler()
 void
 Mgr::Inquirer::start()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Ipc::Inquirer::start();
     Must(Comm::IsConnOpen(conn));
     Must(aggrAction != NULL);
@@ -96,7 +96,7 @@ Mgr::Inquirer::start()
 void
 Mgr::Inquirer::noteWroteHeader(const CommIoCbParams& params)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     writer = NULL;
     Must(params.flag == Comm::OK);
     Must(params.conn.getRaw() == conn.getRaw());
@@ -109,7 +109,7 @@ Mgr::Inquirer::noteWroteHeader(const CommIoCbParams& params)
 void
 Mgr::Inquirer::noteCommClosed(const CommCloseCbParams &)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     closer = nullptr;
     if (conn) {
         conn->noteClosure();
@@ -176,9 +176,9 @@ Mgr::Inquirer::applyQueryParams(const Ipc::StrandCoords& aStrands, const QueryPa
         }
     }
 
-    debugs(16, 4, HERE << "strands kid IDs = ");
+    debugs(16, 4, "strands kid IDs = ");
     for (Ipc::StrandCoords::const_iterator iter = sc.begin(); iter != sc.end(); ++iter) {
-        debugs(16, 4, HERE << iter->kidId);
+        debugs(16, 4, iter->kidId);
     }
 
     return sc;

--- a/src/mgr/Inquirer.h
+++ b/src/mgr/Inquirer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/IntParam.cc
+++ b/src/mgr/IntParam.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/IntParam.h
+++ b/src/mgr/IntParam.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/IntervalAction.cc
+++ b/src/mgr/IntervalAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -128,13 +128,13 @@ Mgr::IntervalAction::Create60min(const CommandPointer &cmd)
 Mgr::IntervalAction::IntervalAction(const CommandPointer &aCmd, int aMinutes, int aHours):
     Action(aCmd), minutes(aMinutes), hours(aHours), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::IntervalAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     data += dynamic_cast<const IntervalAction&>(action).data;
 }
 
@@ -147,7 +147,7 @@ Mgr::IntervalAction::collect()
 void
 Mgr::IntervalAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
     DumpAvgStat(data, entry);
 }

--- a/src/mgr/IntervalAction.h
+++ b/src/mgr/IntervalAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/IoAction.cc
+++ b/src/mgr/IoAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -51,13 +51,13 @@ Mgr::IoAction::Create(const CommandPointer &cmd)
 Mgr::IoAction::IoAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::IoAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     data += dynamic_cast<const IoAction&>(action).data;
 }
 
@@ -70,7 +70,7 @@ Mgr::IoAction::collect()
 void
 Mgr::IoAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
     DumpIoStats(data, entry);
 }

--- a/src/mgr/IoAction.h
+++ b/src/mgr/IoAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Makefile.am
+++ b/src/mgr/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/mgr/QueryParam.h
+++ b/src/mgr/QueryParam.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/QueryParams.cc
+++ b/src/mgr/QueryParams.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/QueryParams.h
+++ b/src/mgr/QueryParams.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Registration.cc
+++ b/src/mgr/Registration.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Registration.h
+++ b/src/mgr/Registration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Request.cc
+++ b/src/mgr/Request.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Request.h
+++ b/src/mgr/Request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Response.cc
+++ b/src/mgr/Response.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/Response.h
+++ b/src/mgr/Response.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/ServiceTimesAction.cc
+++ b/src/mgr/ServiceTimesAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -63,27 +63,27 @@ Mgr::ServiceTimesAction::Create(const CommandPointer &cmd)
 Mgr::ServiceTimesAction::ServiceTimesAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::ServiceTimesAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     data += dynamic_cast<const ServiceTimesAction&>(action).data;
 }
 
 void
 Mgr::ServiceTimesAction::collect()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     GetServiceTimesStats(data);
 }
 
 void
 Mgr::ServiceTimesAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
     DumpServiceTimesStats(data, entry);
 }

--- a/src/mgr/ServiceTimesAction.h
+++ b/src/mgr/ServiceTimesAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/StoreIoAction.cc
+++ b/src/mgr/StoreIoAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -41,13 +41,13 @@ Mgr::StoreIoAction::Create(const CommandPointer &cmd)
 Mgr::StoreIoAction::StoreIoAction(const CommandPointer &aCmd):
     Action(aCmd), data()
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
 }
 
 void
 Mgr::StoreIoAction::add(const Action& action)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     data += dynamic_cast<const StoreIoAction&>(action).data;
 }
 
@@ -63,7 +63,7 @@ Mgr::StoreIoAction::collect()
 void
 Mgr::StoreIoAction::dump(StoreEntry* entry)
 {
-    debugs(16, 5, HERE);
+    debugs(16, 5, MYNAME);
     Must(entry != NULL);
     storeAppendPrintf(entry, "Store IO Interface Stats\n");
     storeAppendPrintf(entry, "create.calls %.0f\n", data.create_calls);

--- a/src/mgr/StoreIoAction.h
+++ b/src/mgr/StoreIoAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/StoreToCommWriter.cc
+++ b/src/mgr/StoreToCommWriter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -25,7 +25,7 @@ Mgr::StoreToCommWriter::StoreToCommWriter(const Comm::ConnectionPointer &conn, S
     AsyncJob("Mgr::StoreToCommWriter"),
     clientConnection(conn), entry(anEntry), sc(NULL), writeOffset(0), closer(NULL)
 {
-    debugs(16, 6, HERE << clientConnection);
+    debugs(16, 6, clientConnection);
     closer = asyncCall(16, 5, "Mgr::StoreToCommWriter::noteCommClosed",
                        CommCbMemFunT<StoreToCommWriter, CommCloseCbParams>(this, &StoreToCommWriter::noteCommClosed));
     comm_add_close_handler(clientConnection->fd, closer);
@@ -33,7 +33,7 @@ Mgr::StoreToCommWriter::StoreToCommWriter(const Comm::ConnectionPointer &conn, S
 
 Mgr::StoreToCommWriter::~StoreToCommWriter()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     assert(!entry);
     assert(!sc);
     close();
@@ -55,7 +55,7 @@ Mgr::StoreToCommWriter::close()
 void
 Mgr::StoreToCommWriter::start()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     Must(Comm::IsConnOpen(clientConnection));
     Must(entry != NULL);
     AsyncCall::Pointer call = asyncCall(16, 4, "StoreToCommWriter::Abort", cbdataDialer(&StoreToCommWriter::HandleStoreAbort, this));
@@ -70,7 +70,7 @@ Mgr::StoreToCommWriter::start()
 void
 Mgr::StoreToCommWriter::scheduleStoreCopy()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     Must(entry != NULL);
     Must(sc != NULL);
     StoreIOBuffer readBuf(sizeof(buffer), writeOffset, buffer);
@@ -93,7 +93,7 @@ Mgr::StoreToCommWriter::NoteStoreCopied(void* data, StoreIOBuffer ioBuf)
 void
 Mgr::StoreToCommWriter::noteStoreCopied(StoreIOBuffer ioBuf)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     Must(!ioBuf.flags.error);
     if (ioBuf.length > 0)
         scheduleCommWrite(ioBuf); // write received action results to client
@@ -104,7 +104,7 @@ Mgr::StoreToCommWriter::noteStoreCopied(StoreIOBuffer ioBuf)
 void
 Mgr::StoreToCommWriter::scheduleCommWrite(const StoreIOBuffer& ioBuf)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     Must(Comm::IsConnOpen(clientConnection));
     Must(ioBuf.data != NULL);
     // write filled buffer
@@ -118,7 +118,7 @@ Mgr::StoreToCommWriter::scheduleCommWrite(const StoreIOBuffer& ioBuf)
 void
 Mgr::StoreToCommWriter::noteCommWrote(const CommIoCbParams& params)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     Must(params.flag == Comm::OK);
     Must(clientConnection != NULL && params.fd == clientConnection->fd);
     Must(params.size != 0);
@@ -130,7 +130,7 @@ Mgr::StoreToCommWriter::noteCommWrote(const CommIoCbParams& params)
 void
 Mgr::StoreToCommWriter::noteCommClosed(const CommCloseCbParams &)
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     if (clientConnection) {
         clientConnection->noteClosure();
         clientConnection = nullptr;
@@ -142,7 +142,7 @@ Mgr::StoreToCommWriter::noteCommClosed(const CommCloseCbParams &)
 void
 Mgr::StoreToCommWriter::swanSong()
 {
-    debugs(16, 6, HERE);
+    debugs(16, 6, MYNAME);
     if (entry != NULL) {
         if (sc != NULL) {
             storeUnregister(sc, entry, this);

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/StringParam.cc
+++ b/src/mgr/StringParam.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/StringParam.h
+++ b/src/mgr/StringParam.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mgr/forward.h
+++ b/src/mgr/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mime.conf.default
+++ b/src/mime.conf.default
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/mime.h
+++ b/src/mime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mime_header.cc
+++ b/src/mime_header.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mime_header.h
+++ b/src/mime_header.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/mk-globals-c.awk
+++ b/src/mk-globals-c.awk
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/mk-string-arrays.awk
+++ b/src/mk-string-arrays.awk
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/multicast.cc
+++ b/src/multicast.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/multicast.h
+++ b/src/multicast.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -347,7 +347,7 @@ getRoundRobinParent(PeerSelector *ps)
     if (q)
         ++ q->rr_count;
 
-    debugs(15, 3, HERE << "returning " << (q ? q->host : "NULL"));
+    debugs(15, 3, "returning " << (q ? q->host : "NULL"));
 
     return q;
 }

--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/parser/BinaryTokenizer.cc
+++ b/src/parser/BinaryTokenizer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/parser/BinaryTokenizer.h
+++ b/src/parser/BinaryTokenizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/parser/Makefile.am
+++ b/src/parser/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/parser/Tokenizer.cc
+++ b/src/parser/Tokenizer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/parser/forward.h
+++ b/src/parser/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -73,12 +73,12 @@ IdleConnList::findIndexOf(const Comm::ConnectionPointer &conn) const
 {
     for (int index = size_ - 1; index >= 0; --index) {
         if (conn->fd == theList_[index]->fd) {
-            debugs(48, 3, HERE << "found " << conn << " at index " << index);
+            debugs(48, 3, "found " << conn << " at index " << index);
             return index;
         }
     }
 
-    debugs(48, 2, HERE << conn << " NOT FOUND!");
+    debugs(48, 2, conn << " NOT FOUND!");
     return -1;
 }
 
@@ -113,10 +113,10 @@ void
 IdleConnList::closeN(size_t n)
 {
     if (n < 1) {
-        debugs(48, 2, HERE << "Nothing to do.");
+        debugs(48, 2, "Nothing to do.");
         return;
     } else if (n >= (size_t)size_) {
-        debugs(48, 2, HERE << "Closing all entries.");
+        debugs(48, 2, "Closing all entries.");
         while (size_ > 0) {
             const Comm::ConnectionPointer conn = theList_[--size_];
             theList_[size_] = NULL;
@@ -126,7 +126,7 @@ IdleConnList::closeN(size_t n)
                 parent_->noteConnectionRemoved();
         }
     } else { //if (n < size_)
-        debugs(48, 2, HERE << "Closing " << n << " of " << size_ << " entries.");
+        debugs(48, 2, "Closing " << n << " of " << size_ << " entries.");
 
         size_t index;
         // ensure the first N entries are closed
@@ -159,7 +159,7 @@ IdleConnList::closeN(size_t n)
 void
 IdleConnList::clearHandlers(const Comm::ConnectionPointer &conn)
 {
-    debugs(48, 3, HERE << "removing close handler for " << conn);
+    debugs(48, 3, "removing close handler for " << conn);
     comm_read_cancel(conn->fd, IdleConnList::Read, this);
     commUnsetConnTimeout(conn);
 }
@@ -168,7 +168,7 @@ void
 IdleConnList::push(const Comm::ConnectionPointer &conn)
 {
     if (size_ == capacity_) {
-        debugs(48, 3, HERE << "growing idle Connection array");
+        debugs(48, 3, "growing idle Connection array");
         capacity_ <<= 1;
         const Comm::ConnectionPointer *oldList = theList_;
         theList_ = new Comm::ConnectionPointer[capacity_];
@@ -297,10 +297,10 @@ IdleConnList::findAndClose(const Comm::ConnectionPointer &conn)
 void
 IdleConnList::Read(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::Flag flag, int, void *data)
 {
-    debugs(48, 3, HERE << len << " bytes from " << conn);
+    debugs(48, 3, len << " bytes from " << conn);
 
     if (flag == Comm::ERR_CLOSING) {
-        debugs(48, 3, HERE << "Comm::ERR_CLOSING from " << conn);
+        debugs(48, 3, "Comm::ERR_CLOSING from " << conn);
         /* Bail out on Comm::ERR_CLOSING - may happen when shutdown aborts our idle FD */
         return;
     }
@@ -313,7 +313,7 @@ IdleConnList::Read(const Comm::ConnectionPointer &conn, char *, size_t len, Comm
 void
 IdleConnList::Timeout(const CommTimeoutCbParams &io)
 {
-    debugs(48, 3, HERE << io.conn);
+    debugs(48, 3, io.conn);
     IdleConnList *list = static_cast<IdleConnList *>(io.data);
     /* may delete list/data */
     list->findAndClose(io.conn);
@@ -412,12 +412,12 @@ void
 PconnPool::push(const Comm::ConnectionPointer &conn, const char *domain)
 {
     if (fdUsageHigh()) {
-        debugs(48, 3, HERE << "Not many unused FDs");
+        debugs(48, 3, "Not many unused FDs");
         conn->close();
         return;
     } else if (shutting_down) {
         conn->close();
-        debugs(48, 3, HERE << "Squid is shutting down. Refusing to do anything");
+        debugs(48, 3, "Squid is shutting down. Refusing to do anything");
         return;
     }
     // TODO: also close used pconns if we exceed peer max-conn limit
@@ -439,7 +439,7 @@ PconnPool::push(const Comm::ConnectionPointer &conn, const char *domain)
     LOCAL_ARRAY(char, desc, FD_DESC_SZ);
     snprintf(desc, FD_DESC_SZ, "Idle server: %s", aKey);
     fd_note(conn->fd, desc);
-    debugs(48, 3, HERE << "pushed " << conn << " for " << aKey);
+    debugs(48, 3, "pushed " << conn << " for " << aKey);
 
     // successful push notifications resume multi-connection opening sequence
     notifyManager("push");
@@ -471,7 +471,7 @@ PconnPool::popStored(const Comm::ConnectionPointer &dest, const char *domain, co
 
     IdleConnList *list = (IdleConnList *)hash_lookup(table, aKey);
     if (list == NULL) {
-        debugs(48, 3, HERE << "lookup for key {" << aKey << "} failed.");
+        debugs(48, 3, "lookup for key {" << aKey << "} failed.");
         // failure notifications resume standby conn creation after fdUsageHigh
         notifyManager("pop lookup failure");
         return Comm::ConnectionPointer();

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/peer_proxy_negotiate_auth.cc
+++ b/src/peer_proxy_negotiate_auth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -174,14 +174,14 @@ int check_gss_err(OM_uint32 major_status, OM_uint32 minor_status,
             }
             gss_release_buffer(&min_stat, &status_string);
         }
-        debugs(11, 5, HERE << function << "failed: " << buf);
+        debugs(11, 5, function << "failed: " << buf);
         return (1);
     }
     return (0);
 }
 
 void krb5_cleanup() {
-    debugs(11, 5, HERE << "Cleanup kerberos context");
+    debugs(11, 5, "Cleanup kerberos context");
     if (kparam.context) {
         if (kparam.cc)
             krb5_cc_destroy(kparam.context, kparam.cc);
@@ -251,7 +251,7 @@ restart:
                                       &creds2.client);
             if (code) {
                 debugs(11, 5,
-                       HERE <<
+
                        "Error while getting principal from credential cache : "
                        << error_message(code));
                 return (1);
@@ -267,7 +267,7 @@ restart:
                                     (krb5_const_realm)&client_realm, NULL);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while getting krbtgt principal : " <<
+                       "Error while getting krbtgt principal : " <<
                        error_message(code));
                 return (1);
             }
@@ -284,7 +284,7 @@ restart:
                     goto restart;
                 }
                 debugs(11, 5,
-                       HERE << "Error while get credentials : " <<
+                       "Error while get credentials : " <<
                        error_message(code));
                 return (1);
             }
@@ -295,7 +295,7 @@ restart:
             code = krb5_init_context(&kparam.context);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while initialising Kerberos library : "
+                       "Error while initialising Kerberos library : "
                        << error_message(code));
                 return (1);
             }
@@ -306,7 +306,7 @@ restart:
             if (profile)
                 profile_release(profile);
             debugs(11, 5,
-                   HERE << "Error while getting profile : " <<
+                   "Error while getting profile : " <<
                    error_message(code));
             return (1);
         }
@@ -317,7 +317,7 @@ restart:
             profile_release(profile);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while getting clockskew : " <<
+                   "Error while getting clockskew : " <<
                    error_message(code));
             return (1);
         }
@@ -345,7 +345,7 @@ restart:
         code = krb5_kt_resolve(kparam.context, keytab_filename, &keytab);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while resolving keytab filename " <<
+                   "Error while resolving keytab filename " <<
                    keytab_filename << " : " << error_message(code));
             return (1);
         }
@@ -354,7 +354,7 @@ restart:
             code = krb5_kt_start_seq_get(kparam.context, keytab, &cursor);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while starting keytab scan : " <<
+                       "Error while starting keytab scan : " <<
                        error_message(code));
                 return (1);
             }
@@ -364,7 +364,7 @@ restart:
                                 &principal);
             if (code && code != KRB5_KT_END) {
                 debugs(11, 5,
-                       HERE << "Error while scanning keytab : " <<
+                       "Error while scanning keytab : " <<
                        error_message(code));
                 return (1);
             }
@@ -372,7 +372,7 @@ restart:
             code = krb5_kt_end_seq_get(kparam.context, keytab, &cursor);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while ending keytab scan : " <<
+                       "Error while ending keytab scan : " <<
                        error_message(code));
                 return (1);
             }
@@ -383,7 +383,7 @@ restart:
 #endif
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while freeing keytab entry : " <<
+                       "Error while freeing keytab entry : " <<
                        error_message(code));
                 return (1);
             }
@@ -397,7 +397,7 @@ restart:
                 krb5_parse_name(kparam.context, principal_name, &principal);
             if (code) {
                 debugs(11, 5,
-                       HERE << "Error while parsing principal name " <<
+                       "Error while parsing principal name " <<
                        principal_name << " : " << error_message(code));
                 return (1);
             }
@@ -413,7 +413,7 @@ restart:
         code = krb5_string_to_deltat((char *) MAX_RENEW_TIME, &rlife);
         if (code != 0 || rlife == 0) {
             debugs(11, 5,
-                   HERE << "Error bad lifetime value " << MAX_RENEW_TIME <<
+                   "Error bad lifetime value " << MAX_RENEW_TIME <<
                    " : " << error_message(code));
             return (1);
         }
@@ -435,7 +435,7 @@ restart:
 #endif
         if (code) {
             debugs(11, 5,
-                   HERE <<
+
                    "Error while initializing credentials from keytab : " <<
                    error_message(code));
             return (1);
@@ -469,14 +469,14 @@ restart:
         xfree(mem_cache);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while resolving memory credential cache : "
+                   "Error while resolving memory credential cache : "
                    << error_message(code));
             return (1);
         }
         code = krb5_cc_initialize(kparam.context, kparam.cc, principal);
         if (code) {
             debugs(11, 5,
-                   HERE <<
+
                    "Error while initializing memory credential cache : " <<
                    error_message(code));
             return (1);
@@ -484,7 +484,7 @@ restart:
         code = krb5_cc_store_cred(kparam.context, kparam.cc, creds);
         if (code) {
             debugs(11, 5,
-                   HERE << "Error while storing credentials : " <<
+                   "Error while storing credentials : " <<
                    error_message(code));
             return (1);
         }
@@ -513,19 +513,19 @@ char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags) {
     setbuf(stdin, NULL);
 
     if (!proxy) {
-        debugs(11, 5, HERE << "Error : No proxy server name");
+        debugs(11, 5, "Error : No proxy server name");
         return NULL;
     }
 
     if (!(flags & PEER_PROXY_NEGOTIATE_NOKEYTAB)) {
         if (principal_name)
             debugs(11, 5,
-                   HERE << "Creating credential cache for " << principal_name);
+                   "Creating credential cache for " << principal_name);
         else
-            debugs(11, 5, HERE << "Creating credential cache");
+            debugs(11, 5, "Creating credential cache");
         rc = krb5_create_cache(NULL, principal_name);
         if (rc) {
-            debugs(11, 5, HERE << "Error : Failed to create Kerberos cache");
+            debugs(11, 5, "Error : Failed to create Kerberos cache");
             krb5_cleanup();
             return NULL;
         }
@@ -536,14 +536,14 @@ char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags) {
              "%s@%s", "HTTP", proxy);
     service.length = strlen((char *) service.value);
 
-    debugs(11, 5, HERE << "Import gss name");
+    debugs(11, 5, "Import gss name");
     major_status = gss_import_name(&minor_status, &service,
                                    gss_nt_service_name, &server_name);
 
     if (check_gss_err(major_status, minor_status, "gss_import_name()"))
         goto cleanup;
 
-    debugs(11, 5, HERE << "Initialize gss security context");
+    debugs(11, 5, "Initialize gss security context");
     major_status = gss_init_sec_context(&minor_status,
                                         GSS_C_NO_CREDENTIAL,
                                         &gss_context,
@@ -557,7 +557,7 @@ char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags) {
     if (check_gss_err(major_status, minor_status, "gss_init_sec_context()"))
         goto cleanup;
 
-    debugs(11, 5, HERE << "Got token with length " << output_token.length);
+    debugs(11, 5, "Got token with length " << output_token.length);
     if (output_token.length) {
         static char b64buf[8192]; // XXX: 8KB only because base64_encode_bin() used to.
         struct base64_encode_ctx ctx;

--- a/src/peer_proxy_negotiate_auth.h
+++ b/src/peer_proxy_negotiate_auth.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/peer_select.cc
+++ b/src/peer_select.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/peer_sourcehash.h
+++ b/src/peer_sourcehash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/peer_userhash.h
+++ b/src/peer_userhash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/protos.h
+++ b/src/protos.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/proxyp/Elements.cc
+++ b/src/proxyp/Elements.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/proxyp/Elements.h
+++ b/src/proxyp/Elements.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/proxyp/Header.cc
+++ b/src/proxyp/Header.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/proxyp/Header.h
+++ b/src/proxyp/Header.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/proxyp/Makefile.am
+++ b/src/proxyp/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/proxyp/Parser.cc
+++ b/src/proxyp/Parser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/proxyp/Parser.h
+++ b/src/proxyp/Parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/proxyp/forward.h
+++ b/src/proxyp/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -80,7 +80,7 @@ static void
 redirectHandleReply(void *data, const Helper::Reply &reply)
 {
     RedirectStateData *r = static_cast<RedirectStateData *>(data);
-    debugs(61, 5, HERE << "reply=" << reply);
+    debugs(61, 5, "reply=" << reply);
 
     // XXX: This function is now kept only to check for and display the garbage use-case
     // and to map the old helper response format(s) into new format result code and key=value pairs
@@ -275,7 +275,7 @@ constructHelperQuery(const char *name, helper *hlp, HLPCB *replyHandler, ClientH
         return;
     }
 
-    debugs(61,6, HERE << "sending '" << buf << "' to the " << name << " helper");
+    debugs(61,6, "sending '" << buf << "' to the " << name << " helper");
     helperSubmit(hlp, buf, replyHandler, r);
 }
 

--- a/src/redirect.h
+++ b/src/redirect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/refresh.h
+++ b/src/refresh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/repl/Makefile.am
+++ b/src/repl/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/repl/heap/store_heap_replacement.cc
+++ b/src/repl/heap/store_heap_replacement.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/repl/heap/store_heap_replacement.h
+++ b/src/repl/heap/store_heap_replacement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/repl/heap/store_repl_heap.cc
+++ b/src/repl/heap/store_repl_heap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/repl/lru/store_repl_lru.cc
+++ b/src/repl/lru/store_repl_lru.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/repl_modules.h
+++ b/src/repl_modules.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/repl_modules.sh
+++ b/src/repl_modules.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/sbuf/Algorithms.cc
+++ b/src/sbuf/Algorithms.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/Algorithms.h
+++ b/src/sbuf/Algorithms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/DetailedStats.cc
+++ b/src/sbuf/DetailedStats.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/DetailedStats.h
+++ b/src/sbuf/DetailedStats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/List.cc
+++ b/src/sbuf/List.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/List.h
+++ b/src/sbuf/List.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/Makefile.am
+++ b/src/sbuf/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/sbuf/MemBlob.cc
+++ b/src/sbuf/MemBlob.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -51,7 +51,7 @@ MemBlobStats::dump(std::ostream &os) const
 MemBlob::MemBlob(const MemBlob::size_type reserveSize) :
     mem(NULL), capacity(0), size(0) // will be set by memAlloc
 {
-    debugs(MEMBLOB_DEBUGSECTION,9, HERE << "constructed, this="
+    debugs(MEMBLOB_DEBUGSECTION,9, "constructed, this="
            << static_cast<void*>(this) << " id=" << id
            << " reserveSize=" << reserveSize);
     memAlloc(reserveSize);
@@ -60,7 +60,7 @@ MemBlob::MemBlob(const MemBlob::size_type reserveSize) :
 MemBlob::MemBlob(const char *buffer, const MemBlob::size_type bufSize) :
     mem(NULL), capacity(0), size(0) // will be set by memAlloc
 {
-    debugs(MEMBLOB_DEBUGSECTION,9, HERE << "constructed, this="
+    debugs(MEMBLOB_DEBUGSECTION,9, "constructed, this="
            << static_cast<void*>(this) << " id=" << id
            << " buffer=" << static_cast<const void*>(buffer)
            << " bufSize=" << bufSize);
@@ -76,7 +76,7 @@ MemBlob::~MemBlob()
     --Stats.live;
     recordMemBlobSizeAtDestruct(capacity);
 
-    debugs(MEMBLOB_DEBUGSECTION,9, HERE << "destructed, this="
+    debugs(MEMBLOB_DEBUGSECTION,9, "destructed, this="
            << static_cast<void*>(this) << " id=" << id
            << " capacity=" << capacity
            << " size=" << size);

--- a/src/sbuf/MemBlob.h
+++ b/src/sbuf/MemBlob.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/SBuf.cc
+++ b/src/sbuf/SBuf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/SBuf.h
+++ b/src/sbuf/SBuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/Stats.cc
+++ b/src/sbuf/Stats.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/Stats.h
+++ b/src/sbuf/Stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/Stream.h
+++ b/src/sbuf/Stream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -9,8 +9,8 @@
 #ifndef SQUID_SBUFSTREAM_H
 #define SQUID_SBUFSTREAM_H
 
-#include "sbuf/SBuf.h"
 #include "base/PackableStream.h"
+#include "sbuf/SBuf.h"
 
 /** Stream interface to write to a SBuf.
  *

--- a/src/sbuf/StringConvert.h
+++ b/src/sbuf/StringConvert.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/sbuf/forward.h
+++ b/src/sbuf/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/CertError.h
+++ b/src/security/CertError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/CommunicationSecrets.cc
+++ b/src/security/CommunicationSecrets.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/CommunicationSecrets.h
+++ b/src/security/CommunicationSecrets.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Context.h
+++ b/src/security/Context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/EncryptorAnswer.cc
+++ b/src/security/EncryptorAnswer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/EncryptorAnswer.h
+++ b/src/security/EncryptorAnswer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/ErrorDetail.h
+++ b/src/security/ErrorDetail.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Handshake.cc
+++ b/src/security/Handshake.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Io.cc
+++ b/src/security/Io.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Io.h
+++ b/src/security/Io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/KeyData.h
+++ b/src/security/KeyData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/KeyLog.cc
+++ b/src/security/KeyLog.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/KeyLog.h
+++ b/src/security/KeyLog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/KeyLogger.cc
+++ b/src/security/KeyLogger.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/KeyLogger.h
+++ b/src/security/KeyLogger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/LockingPointer.h
+++ b/src/security/LockingPointer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Makefile.am
+++ b/src/security/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/NegotiationHistory.cc
+++ b/src/security/NegotiationHistory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/NegotiationHistory.h
+++ b/src/security/NegotiationHistory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/Session.h
+++ b/src/security/Session.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/Makefile.am
+++ b/src/security/cert_generators/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/file/Makefile.am
+++ b/src/security/cert_generators/file/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/file/certificate_db.cc
+++ b/src/security/cert_generators/file/certificate_db.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/file/certificate_db.h
+++ b/src/security/cert_generators/file/certificate_db.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/file/required.m4
+++ b/src/security/cert_generators/file/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/file/security_file_certgen.8.in
+++ b/src/security/cert_generators/file/security_file_certgen.8.in
@@ -157,7 +157,7 @@ and
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/file/security_file_certgen.cc
+++ b/src/security/cert_generators/file/security_file_certgen.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/cert_generators/helpers.m4
+++ b/src/security/cert_generators/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/cert_validators/Makefile.am
+++ b/src/security/cert_validators/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/cert_validators/fake/Makefile.am
+++ b/src/security/cert_validators/fake/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/cert_validators/fake/required.m4
+++ b/src/security/cert_validators/fake/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/cert_validators/fake/security_fake_certverify.pl.in
+++ b/src/security/cert_validators/fake/security_fake_certverify.pl.in
@@ -46,7 +46,7 @@ I<Christos Tsantilas <chtsanti@users.sourceforge.net>>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/security/cert_validators/helpers.m4
+++ b/src/security/cert_validators/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/send-announce.cc
+++ b/src/send-announce.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/send-announce.h
+++ b/src/send-announce.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/servers/FtpServer.h
+++ b/src/servers/FtpServer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/servers/Makefile.am
+++ b/src/servers/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/servers/Server.h
+++ b/src/servers/Server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/servers/forward.h
+++ b/src/servers/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Forwarder.cc
+++ b/src/snmp/Forwarder.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -26,7 +26,7 @@ Snmp::Forwarder::Forwarder(const Pdu& aPdu, const Session& aSession, int aFd,
     Ipc::Forwarder(new Request(KidIdentifier, Ipc::RequestId(), aPdu, aSession, aFd, anAddress), 2),
     fd(aFd)
 {
-    debugs(49, 5, HERE << "FD " << aFd);
+    debugs(49, 5, "FD " << aFd);
     Must(fd >= 0);
     closer = asyncCall(49, 5, "Snmp::Forwarder::noteCommClosed",
                        CommCbMemFunT<Forwarder, CommCloseCbParams>(this, &Forwarder::noteCommClosed));
@@ -51,7 +51,7 @@ Snmp::Forwarder::swanSong()
 void
 Snmp::Forwarder::noteCommClosed(const CommCloseCbParams& params)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, MYNAME);
     Must(fd == params.fd);
     closer = nullptr;
     fd = -1;
@@ -68,7 +68,7 @@ Snmp::Forwarder::handleTimeout()
 void
 Snmp::Forwarder::handleException(const std::exception& e)
 {
-    debugs(49, 3, HERE << e.what());
+    debugs(49, 3, e.what());
     sendError(SNMP_ERR_GENERR);
     Ipc::Forwarder::handleException(e);
 }
@@ -77,7 +77,7 @@ Snmp::Forwarder::handleException(const std::exception& e)
 void
 Snmp::Forwarder::sendError(int error)
 {
-    debugs(49, 3, HERE);
+    debugs(49, 3, MYNAME);
 
     if (fd < 0)
         return; // client gone
@@ -94,7 +94,7 @@ Snmp::Forwarder::sendError(int error)
 void
 Snmp::SendResponse(const Ipc::RequestId requestId, const Pdu &pdu)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, MYNAME);
     // snmpAgentResponse() can modify arg
     Pdu tmp = pdu;
     Snmp::Response response(requestId);
@@ -105,7 +105,7 @@ Snmp::SendResponse(const Ipc::RequestId requestId, const Pdu &pdu)
         response.pdu = static_cast<Pdu&>(*response_pdu);
         snmp_free_pdu(response_pdu);
     } catch (const std::exception& e) {
-        debugs(49, DBG_CRITICAL, HERE << e.what());
+        debugs(49, DBG_CRITICAL, e.what());
         response.pdu.command = SNMP_PDU_RESPONSE;
         response.pdu.errstat = SNMP_ERR_GENERR;
     }

--- a/src/snmp/Forwarder.h
+++ b/src/snmp/Forwarder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Inquirer.cc
+++ b/src/snmp/Inquirer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -29,7 +29,7 @@ Snmp::Inquirer::Inquirer(const Request& aRequest, const Ipc::StrandCoords& coord
     conn->fd = aRequest.fd;
     ImportFdIntoComm(conn, SOCK_DGRAM, IPPROTO_UDP, Ipc::fdnInSnmpSocket);
 
-    debugs(49, 5, HERE);
+    debugs(49, 5, MYNAME);
     closer = asyncCall(49, 5, "Snmp::Inquirer::noteCommClosed",
                        CommCbMemFunT<Inquirer, CommCloseCbParams>(this, &Inquirer::noteCommClosed));
     comm_add_close_handler(conn->fd, closer);
@@ -56,7 +56,7 @@ Snmp::Inquirer::cleanup()
 void
 Snmp::Inquirer::start()
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, MYNAME);
     Ipc::Inquirer::start();
     Must(Comm::IsConnOpen(conn));
     inquire();
@@ -86,7 +86,7 @@ Snmp::Inquirer::aggregate(Response::Pointer aResponse)
 void
 Snmp::Inquirer::noteCommClosed(const CommCloseCbParams& params)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, MYNAME);
     Must(!Comm::IsConnOpen(conn) || conn->fd == params.conn->fd);
     closer = nullptr;
     if (conn) {
@@ -105,7 +105,7 @@ Snmp::Inquirer::doneAll() const
 void
 Snmp::Inquirer::sendResponse()
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, MYNAME);
 
     if (!Comm::IsConnOpen(conn))
         return; // client gone

--- a/src/snmp/Inquirer.h
+++ b/src/snmp/Inquirer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Makefile.am
+++ b/src/snmp/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/snmp/Pdu.cc
+++ b/src/snmp/Pdu.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Pdu.h
+++ b/src/snmp/Pdu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Request.cc
+++ b/src/snmp/Request.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Request.h
+++ b/src/snmp/Request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Response.cc
+++ b/src/snmp/Response.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Response.h
+++ b/src/snmp/Response.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Session.cc
+++ b/src/snmp/Session.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Session.h
+++ b/src/snmp/Session.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Var.cc
+++ b/src/snmp/Var.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/Var.h
+++ b/src/snmp/Var.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp/forward.h
+++ b/src/snmp/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp_agent.cc
+++ b/src/snmp_agent.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp_agent.h
+++ b/src/snmp_agent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -389,7 +389,7 @@ snmpDecodePacket(SnmpRequest * rq)
         return;
     }
 
-    debugs(49, 5, HERE << "Called.");
+    debugs(49, 5, "Called.");
     PDU = snmp_pdu_create(0);
     /* Always answer on SNMPv1 */
     rq->session.Version = SNMP_VERSION_1;
@@ -568,7 +568,7 @@ snmpTreeGet(oid * Current, snint CurrentLen)
 AggrType
 snmpAggrType(oid* Current, snint CurrentLen)
 {
-    debugs(49, 5, HERE);
+    debugs(49, 5, MYNAME);
 
     mib_tree_entry* mibTreeEntry = mib_tree_head;
     AggrType type = atNone;
@@ -781,7 +781,7 @@ client_Inst(oid * name, snint * len, mib_tree_entry * current, oid_ParseFn ** Fn
         else
             size = sizeof(in6_addr);
 
-        debugs(49, 6, HERE << "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", size=" << size);
+        debugs(49, 6, "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", size=" << size);
 
         instance = (oid *)xmalloc(sizeof(*name) * (*len + size ));
         memcpy(instance, name, (sizeof(*name) * (*len)));
@@ -805,7 +805,7 @@ client_Inst(oid * name, snint * len, mib_tree_entry * current, oid_ParseFn ** Fn
             else
                 newshift = sizeof(in6_addr);
 
-            debugs(49, 6, HERE << "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", newshift=" << newshift);
+            debugs(49, 6, "len" << *len << ", current-len" << current->len << ", addr=" << laddr << ", newshift=" << newshift);
 
             instance = (oid *)xmalloc(sizeof(*name) * (current->len +  newshift));
             memcpy(instance, name, (sizeof(*name) * (current->len)));

--- a/src/snmp_core.h
+++ b/src/snmp_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/squid.8.in
+++ b/src/squid.8.in
@@ -256,7 +256,7 @@ see CREDITS for a list of major code contributing copyright holders.
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/Config.cc
+++ b/src/ssl/Config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/Config.h
+++ b/src/ssl/Config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/ErrorDetail.cc
+++ b/src/ssl/ErrorDetail.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/ErrorDetail.h
+++ b/src/ssl/ErrorDetail.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -106,7 +106,7 @@ Ssl::ErrorDetailsList::Pointer Ssl::ErrorDetailsManager::getCachedDetails(const 
     Cache::iterator it;
     it = cache.find(lang);
     if (it != cache.end()) {
-        debugs(83, 8, HERE << "Found template details in cache for language: " << lang);
+        debugs(83, 8, "Found template details in cache for language: " << lang);
         return it->second;
     }
 
@@ -136,12 +136,12 @@ Ssl::ErrorDetailsManager::getErrorDetail(Security::ErrorCode value, const HttpRe
         errDetails = getCachedDetails(lang); // search in cache
 
         if (!errDetails) { // Else try to load from disk
-            debugs(83, 8, HERE << "Creating new ErrDetailList to read from disk");
+            debugs(83, 8, "Creating new ErrDetailList to read from disk");
             errDetails = new ErrorDetailsList();
             ErrorDetailFile detailTmpl(errDetails);
             if (detailTmpl.loadFor(request.getRaw())) {
                 if (detailTmpl.language()) {
-                    debugs(83, 8, HERE << "Found details on disk for language " << detailTmpl.language());
+                    debugs(83, 8, "Found details on disk for language " << detailTmpl.language());
                     errDetails->errLanguage = detailTmpl.language();
                     cacheDetails(errDetails);
                 }
@@ -157,7 +157,7 @@ Ssl::ErrorDetailsManager::getErrorDetail(Security::ErrorCode value, const HttpRe
 
     // else try the default
     if (theDefaultErrorDetails->getRecord(value, entry)) {
-        debugs(83, 8, HERE << "Found default details record for error: " << GetErrorName(value));
+        debugs(83, 8, "Found default details record for error: " << GetErrorName(value));
         return true;
     }
 

--- a/src/ssl/ErrorDetailManager.h
+++ b/src/ssl/ErrorDetailManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/Makefile.am
+++ b/src/ssl/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/ProxyCerts.h
+++ b/src/ssl/ProxyCerts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/ServerBump.cc
+++ b/src/ssl/ServerBump.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -48,9 +48,9 @@ Ssl::ServerBump::ServerBump(ClientHttpRequest *http, StoreEntry *e, Ssl::BumpMod
 
 Ssl::ServerBump::~ServerBump()
 {
-    debugs(33, 4, HERE << "destroying");
+    debugs(33, 4, "destroying");
     if (entry) {
-        debugs(33, 4, HERE << *entry);
+        debugs(33, 4, *entry);
         storeUnregister(sc, entry, this);
         entry->unlock("Ssl::ServerBump");
     }

--- a/src/ssl/ServerBump.h
+++ b/src/ssl/ServerBump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/cert_validate_message.cc
+++ b/src/ssl/cert_validate_message.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/cert_validate_message.h
+++ b/src/ssl/cert_validate_message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/context_storage.cc
+++ b/src/ssl/context_storage.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/context_storage.h
+++ b/src/ssl/context_storage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/crtd_message.cc
+++ b/src/ssl/crtd_message.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/crtd_message.h
+++ b/src/ssl/crtd_message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/gadgets.h
+++ b/src/ssl/gadgets.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/helper.cc
+++ b/src/ssl/helper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/helper.h
+++ b/src/ssl/helper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/stub_libsslutil.cc
+++ b/src/ssl/stub_libsslutil.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ssl/support.h
+++ b/src/ssl/support.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/stat.h
+++ b/src/stat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/stmem.cc
+++ b/src/stmem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -60,7 +60,7 @@ mem_hdr::freeContent()
 {
     nodes.destroy();
     inmem_hi = 0;
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << inmem_hi);
 }
 
 bool
@@ -121,15 +121,15 @@ mem_hdr::writeAvailable(mem_node *aNode, int64_t location, size_t amount, char c
 
     memcpy(aNode->nodeBuffer.data + aNode->nodeBuffer.length, source, copyLen);
 
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << inmem_hi);
     if (inmem_hi <= location)
         inmem_hi = location + copyLen;
 
     /* Adjust the ptr and len according to what was deposited in the page */
     aNode->nodeBuffer.length += copyLen;
 
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
-    debugs(19, 9, HERE << this << " hi: " << endOffset());
+    debugs(19, 9, this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << endOffset());
     return copyLen;
 }
 
@@ -369,7 +369,7 @@ mem_hdr::write (StoreIOBuffer const &writeBuffer)
 
 mem_hdr::mem_hdr() : inmem_hi(0)
 {
-    debugs(19, 9, HERE << this << " hi: " << inmem_hi);
+    debugs(19, 9, this << " hi: " << inmem_hi);
 }
 
 mem_hdr::~mem_hdr()

--- a/src/stmem.h
+++ b/src/stmem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store.cc
+++ b/src/store.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -311,7 +311,7 @@ StoreEntry::storeClientType() const
 
         if (mem_obj->inmem_lo == 0 && !isEmpty()) {
             if (swappedOut()) {
-                debugs(20,7, HERE << mem_obj << " lo: " << mem_obj->inmem_lo << " hi: " << mem_obj->endOffset() << " size: " << mem_obj->object_sz);
+                debugs(20,7, mem_obj << " lo: " << mem_obj->inmem_lo << " hi: " << mem_obj->endOffset() << " size: " << mem_obj->object_sz);
                 if (mem_obj->endOffset() == mem_obj->object_sz) {
                     /* hot object fully swapped in (XXX: or swapped out?) */
                     return STORE_MEM_CLIENT;
@@ -415,7 +415,7 @@ StoreEntry::destroyMemObject()
 void
 destroyStoreEntry(void *data)
 {
-    debugs(20, 3, HERE << "destroyStoreEntry: destroying " <<  data);
+    debugs(20, 3, "destroyStoreEntry: destroying " <<  data);
     StoreEntry *e = static_cast<StoreEntry *>(static_cast<hash_link *>(data));
     assert(e != NULL);
 

--- a/src/store/Controlled.h
+++ b/src/store/Controlled.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -453,7 +453,7 @@ Store::Controller::peek(const cache_key *key)
 
     if (sharedMemStore) {
         if (StoreEntry *e = sharedMemStore->get(key)) {
-            debugs(20, 3, HERE << "got mem-cached entry: " << *e);
+            debugs(20, 3, "got mem-cached entry: " << *e);
             return e;
         }
     }
@@ -599,7 +599,7 @@ Store::Controller::memoryOut(StoreEntry &e, const bool preserveSwappable)
     else if (localMemStore)
         keepInLocalMemory = keepForLocalMemoryCache(e);
 
-    debugs(20, 7, HERE << "keepInLocalMemory: " << keepInLocalMemory);
+    debugs(20, 7, "keepInLocalMemory: " << keepInLocalMemory);
 
     if (!keepInLocalMemory)
         e.trimMemory(preserveSwappable);
@@ -689,12 +689,12 @@ Store::Controller::handleIdleEntry(StoreEntry &e)
     // An idle, unlocked entry that only belongs to a SwapDir which controls
     // its own index, should not stay in the global store_table.
     if (!dereferenceIdle(e, keepInLocalMemory)) {
-        debugs(20, 5, HERE << "destroying unlocked entry: " << &e << ' ' << e);
+        debugs(20, 5, "destroying unlocked entry: " << &e << ' ' << e);
         destroyStoreEntry(static_cast<hash_link*>(&e));
         return;
     }
 
-    debugs(20, 5, HERE << "keepInLocalMemory: " << keepInLocalMemory);
+    debugs(20, 5, "keepInLocalMemory: " << keepInLocalMemory);
 
     // formerly known as "WARNING: found KEY_PRIVATE"
     assert(!EBIT_TEST(e.flags, KEY_PRIVATE));

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/Disk.cc
+++ b/src/store/Disk.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -163,7 +163,7 @@ Store::Disk::objectSizeIsAcceptable(int64_t objsize) const
 bool
 Store::Disk::canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const
 {
-    debugs(47,8, HERE << "cache_dir[" << index << "]: needs " <<
+    debugs(47,8, "cache_dir[" << index << "]: needs " <<
            diskSpaceNeeded << " <? " << max_objsize);
 
     if (EBIT_TEST(e.flags, ENTRY_SPECIAL))

--- a/src/store/Disk.h
+++ b/src/store/Disk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/Disks.cc
+++ b/src/store/Disks.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/LocalSearch.cc
+++ b/src/store/LocalSearch.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/LocalSearch.h
+++ b/src/store/LocalSearch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/Makefile.am
+++ b/src/store/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/store/Storage.h
+++ b/src/store/Storage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/forward.h
+++ b/src/store/forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/id_rewriters/Makefile.am
+++ b/src/store/id_rewriters/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/store/id_rewriters/file/Makefile.am
+++ b/src/store/id_rewriters/file/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/store/id_rewriters/file/required.m4
+++ b/src/store/id_rewriters/file/required.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/store/id_rewriters/file/storeid_file_rewrite.pl.in
+++ b/src/store/id_rewriters/file/storeid_file_rewrite.pl.in
@@ -44,7 +44,7 @@ Based on prior work by I<Eliezer Croitoru <eliezer@ngtech.co.il>>
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store/id_rewriters/helpers.m4
+++ b/src/store/id_rewriters/helpers.m4
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -360,7 +360,7 @@ store_client::doCopy(StoreEntry *anEntry)
 
     if (!moreToSend()) {
         /* There is no more to send! */
-        debugs(33, 3, HERE << "There is no more to send!");
+        debugs(33, 3, "There is no more to send!");
         callback(0);
         flags.store_copying = false;
         return;

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_digest.h
+++ b/src/store_digest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_io.cc
+++ b/src/store_io.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -65,13 +65,13 @@ void
 storeClose(StoreIOState::Pointer sio, int how)
 {
     if (sio->flags.closing) {
-        debugs(20,3,HERE << "storeClose: flags.closing already set, bailing");
+        debugs(20,3, "storeClose: flags.closing already set, bailing");
         return;
     }
 
     sio->flags.closing = true;
 
-    debugs(20,3,HERE << "storeClose: calling sio->close(" << how << ")");
+    debugs(20,3, "storeClose: calling sio->close(" << how << ")");
     sio->close(how);
 }
 

--- a/src/store_key_md5.cc
+++ b/src/store_key_md5.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_key_md5.h
+++ b/src/store_key_md5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_log.cc
+++ b/src/store_log.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_log.h
+++ b/src/store_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_rebuild.cc
+++ b/src/store_rebuild.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -330,7 +330,7 @@ storeRebuildParseEntry(MemBuf &buf, StoreEntry &tmpe, cache_key *key,
     int swap_hdr_len = 0;
     StoreMetaUnpacker aBuilder(buf.content(), buf.contentSize(), &swap_hdr_len);
     if (aBuilder.isBufferZero()) {
-        debugs(47,5, HERE << "skipping empty record.");
+        debugs(47,5, "skipping empty record.");
         return false;
     }
 

--- a/src/store_rebuild.h
+++ b/src/store_rebuild.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -29,7 +29,7 @@ storeSwapInStart(store_client * sc)
     }
 
     if (e->mem_status != NOT_IN_MEMORY)
-        debugs(20, 3, HERE << "already IN_MEMORY");
+        debugs(20, 3, "already IN_MEMORY");
 
     debugs(20, 3, *e << " " <<  e->getMD5Text());
 

--- a/src/store_swapin.h
+++ b/src/store_swapin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_swapmeta.cc
+++ b/src/store_swapmeta.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -183,16 +183,16 @@ StoreEntry::swapOut()
     // Aborted entries have STORE_OK, but swapoutPossible rejects them. Thus,
     // store_status == STORE_OK below means we got everything we wanted.
 
-    debugs(20, 7, HERE << "storeSwapOut: mem->inmem_lo = " << mem_obj->inmem_lo);
-    debugs(20, 7, HERE << "storeSwapOut: mem->endOffset() = " << mem_obj->endOffset());
-    debugs(20, 7, HERE << "storeSwapOut: swapout.queue_offset = " << mem_obj->swapout.queue_offset);
+    debugs(20, 7, "storeSwapOut: mem->inmem_lo = " << mem_obj->inmem_lo);
+    debugs(20, 7, "storeSwapOut: mem->endOffset() = " << mem_obj->endOffset());
+    debugs(20, 7, "storeSwapOut: swapout.queue_offset = " << mem_obj->swapout.queue_offset);
 
     if (mem_obj->swapout.sio != NULL)
         debugs(20, 7, "storeSwapOut: storeOffset() = " << mem_obj->swapout.sio->offset()  );
 
     int64_t const lowest_offset = mem_obj->lowestMemReaderOffset();
 
-    debugs(20, 7, HERE << "storeSwapOut: lowest_offset = " << lowest_offset);
+    debugs(20, 7, "storeSwapOut: lowest_offset = " << lowest_offset);
 
 #if SIZEOF_OFF_T <= 4
 
@@ -307,7 +307,7 @@ storeSwapOutFileClosed(void *data, int errflag, StoreIOState::Pointer self)
         debugs(20, 3, "storeSwapOutFileClosed: SwapOut complete: '" << e->url() << "' to " <<
                e->swap_dirn  << ", " << std::hex << std::setw(8) << std::setfill('0') <<
                std::uppercase << e->swap_filen);
-        debugs(20, 5, HERE << "swap_file_sz = " <<
+        debugs(20, 5, "swap_file_sz = " <<
                e->objectLen() << " + " << mem->swap_hdr_sz);
 
         e->swap_file_sz = e->objectLen() + mem->swap_hdr_sz;
@@ -347,7 +347,7 @@ StoreEntry::mayStartSwapOut()
 
     // if we decided that starting is not possible, do not repeat same checks
     if (decision == MemObject::SwapOut::swImpossible) {
-        debugs(20, 3, HERE << " already rejected");
+        debugs(20, 3, " already rejected");
         return false;
     }
 
@@ -379,13 +379,13 @@ StoreEntry::mayStartSwapOut()
     }
 
     if (!checkCachable()) {
-        debugs(20, 3,  HERE << "not cachable");
+        debugs(20, 3, "not cachable");
         swapOutDecision(MemObject::SwapOut::swImpossible);
         return false;
     }
 
     if (EBIT_TEST(flags, ENTRY_SPECIAL)) {
-        debugs(20, 3,  HERE  << url() << " SPECIAL");
+        debugs(20, 3, url() << " SPECIAL");
         swapOutDecision(MemObject::SwapOut::swImpossible);
         return false;
     }
@@ -408,9 +408,9 @@ StoreEntry::mayStartSwapOut()
 
         // use guaranteed maximum if it is known
         const int64_t expectedEnd = mem_obj->expectedReplySize();
-        debugs(20, 7,  HERE << "expectedEnd = " << expectedEnd);
+        debugs(20, 7, "expectedEnd = " << expectedEnd);
         if (expectedEnd > store_maxobjsize) {
-            debugs(20, 3,  HERE << "will not fit: " << expectedEnd <<
+            debugs(20, 3, "will not fit: " << expectedEnd <<
                    " > " << store_maxobjsize);
             swapOutDecision(MemObject::SwapOut::swImpossible);
             return false; // known to outgrow the limit eventually
@@ -419,7 +419,7 @@ StoreEntry::mayStartSwapOut()
         // use current minimum (always known)
         const int64_t currentEnd = mem_obj->endOffset();
         if (currentEnd > store_maxobjsize) {
-            debugs(20, 3,  HERE << "does not fit: " << currentEnd <<
+            debugs(20, 3, "does not fit: " << currentEnd <<
                    " > " << store_maxobjsize);
             swapOutDecision(MemObject::SwapOut::swImpossible);
             return false; // already does not fit and may only get bigger

--- a/src/swap_log_op.h
+++ b/src/swap_log_op.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/test_cache_digest.cc
+++ b/src/test_cache_digest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/CapturingStoreEntry.h
+++ b/src/tests/CapturingStoreEntry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/SBufFindTest.cc
+++ b/src/tests/SBufFindTest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/SBufFindTest.h
+++ b/src/tests/SBufFindTest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/STUB.h
+++ b/src/tests/STUB.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/Stub.am
+++ b/src/tests/Stub.am
@@ -1,5 +1,5 @@
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.
@@ -30,6 +30,7 @@ STUB_SOURCE = \
     tests/stub_external_acl.cc \
     tests/stub_fatal.cc \
     tests/stub_fd.cc \
+    tests/stub_fqdncache.cc \
     tests/stub_gopher.cc \
     tests/stub_helper.cc \
     tests/stub_HelperChildConfig.cc \

--- a/src/tests/TestSwapDir.cc
+++ b/src/tests/TestSwapDir.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/TestSwapDir.h
+++ b/src/tests/TestSwapDir.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_CacheDigest.cc
+++ b/src/tests/stub_CacheDigest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_CachePeer.cc
+++ b/src/tests/stub_CachePeer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_CollapsedForwarding.cc
+++ b/src/tests/stub_CollapsedForwarding.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_CommIO.cc
+++ b/src/tests/stub_CommIO.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_DelayId.cc
+++ b/src/tests/stub_DelayId.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_ETag.cc
+++ b/src/tests/stub_ETag.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_EventLoop.cc
+++ b/src/tests/stub_EventLoop.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_HelperChildConfig.cc
+++ b/src/tests/stub_HelperChildConfig.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_HttpControlMsg.cc
+++ b/src/tests/stub_HttpControlMsg.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_HttpReply.cc
+++ b/src/tests/stub_HttpReply.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_HttpRequest.cc
+++ b/src/tests/stub_HttpRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_HttpUpgradeProtocolAccess.cc
+++ b/src/tests/stub_HttpUpgradeProtocolAccess.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_IpcIoFile.cc
+++ b/src/tests/stub_IpcIoFile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_MemBuf.cc
+++ b/src/tests/stub_MemBuf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_MemObject.cc
+++ b/src/tests/stub_MemObject.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_MemStore.cc
+++ b/src/tests/stub_MemStore.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_Port.cc
+++ b/src/tests/stub_Port.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_SBuf.cc
+++ b/src/tests/stub_SBuf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_SBufDetailedStats.cc
+++ b/src/tests/stub_SBufDetailedStats.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_StatHist.cc
+++ b/src/tests/stub_StatHist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -18,7 +18,7 @@ void StatHist::dump(StoreEntry *, StatHistBinDumper *) const STUB
 void StatHist::enumInit(unsigned int) STUB_NOP
 void StatHist::count(double) {/* STUB_NOP */}
 double statHistDeltaMedian(const StatHist &, const StatHist &) STUB_RETVAL(0.0)
-double statHistDeltaPctile(const StatHist & , const StatHist & , double) STUB_RETVAL(0.0)
+double statHistDeltaPctile(const StatHist &, const StatHist &, double) STUB_RETVAL(0.0)
 void StatHist::logInit(unsigned int, double, double) STUB_NOP
 void statHistIntDumper(StoreEntry *, int, double, double, int) STUB
 

--- a/src/tests/stub_StoreMeta.cc
+++ b/src/tests/stub_StoreMeta.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_UdsOp.cc
+++ b/src/tests/stub_UdsOp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_access_log.cc
+++ b/src/tests/stub_access_log.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_acl.cc
+++ b/src/tests/stub_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_cache_cf.cc
+++ b/src/tests/stub_cache_cf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_cache_manager.cc
+++ b/src/tests/stub_cache_manager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_carp.cc
+++ b/src/tests/stub_carp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_cbdata.cc
+++ b/src/tests/stub_cbdata.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_client_db.cc
+++ b/src/tests/stub_client_db.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_client_side.cc
+++ b/src/tests/stub_client_side.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_client_side_request.cc
+++ b/src/tests/stub_client_side_request.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_comm.cc
+++ b/src/tests/stub_comm.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_errorpage.cc
+++ b/src/tests/stub_errorpage.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_event.cc
+++ b/src/tests/stub_event.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_external_acl.cc
+++ b/src/tests/stub_external_acl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_fatal.cc
+++ b/src/tests/stub_fatal.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_fd.cc
+++ b/src/tests/stub_fd.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_fqdncache.cc
+++ b/src/tests/stub_fqdncache.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_gopher.cc
+++ b/src/tests/stub_gopher.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_helper.cc
+++ b/src/tests/stub_helper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_http.cc
+++ b/src/tests/stub_http.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_icp.cc
+++ b/src/tests/stub_icp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_internal.cc
+++ b/src/tests/stub_internal.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_ipc.cc
+++ b/src/tests/stub_ipc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_ipc_Forwarder.cc
+++ b/src/tests/stub_ipc_Forwarder.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_ipc_TypedMsgHdr.cc
+++ b/src/tests/stub_ipc_TypedMsgHdr.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_ipcache.cc
+++ b/src/tests/stub_ipcache.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libanyp.cc
+++ b/src/tests/stub_libanyp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libauth.cc
+++ b/src/tests/stub_libauth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libdiskio.cc
+++ b/src/tests/stub_libdiskio.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libeui.cc
+++ b/src/tests/stub_libeui.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libformat.cc
+++ b/src/tests/stub_libformat.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libicmp.cc
+++ b/src/tests/stub_libicmp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libip.cc
+++ b/src/tests/stub_libip.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_liblog.cc
+++ b/src/tests/stub_liblog.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libmgr.cc
+++ b/src/tests/stub_libmgr.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_main_cc.cc
+++ b/src/tests/stub_main_cc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_mem_node.cc
+++ b/src/tests/stub_mem_node.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_mime.cc
+++ b/src/tests/stub_mime.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_neighbors.cc
+++ b/src/tests/stub_neighbors.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_pconn.cc
+++ b/src/tests/stub_pconn.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_redirect.cc
+++ b/src/tests/stub_redirect.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_stat.cc
+++ b/src/tests/stub_stat.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_stmem.cc
+++ b/src/tests/stub_stmem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_store_client.cc
+++ b/src/tests/stub_store_client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -8,10 +8,10 @@
 
 #include "squid.h"
 #include "repl_modules.h"
+#include "Store.h"
 #include "store_digest.h"
 #include "store_log.h"
 #include "store_rebuild.h"
-#include "Store.h"
 #include "StoreClient.h"
 
 #define STUB_API "store_client.cc"

--- a/src/tests/stub_store_digest.cc
+++ b/src/tests/stub_store_digest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_store_rebuild.cc
+++ b/src/tests/stub_store_rebuild.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_store_stats.cc
+++ b/src/tests/stub_store_stats.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_store_swapout.cc
+++ b/src/tests/stub_store_swapout.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_time.cc
+++ b/src/tests/stub_time.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_tools.cc
+++ b/src/tests/stub_tools.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_tunnel.cc
+++ b/src/tests/stub_tunnel.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_wccp2.cc
+++ b/src/tests/stub_wccp2.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_whois.cc
+++ b/src/tests/stub_whois.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/stub_wordlist.cc
+++ b/src/tests/stub_wordlist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testACLMaxUserIP.h
+++ b/src/tests/testACLMaxUserIP.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testAuth.cc
+++ b/src/tests/testAuth.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testAuth.h
+++ b/src/tests/testAuth.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testBoilerplate.cc
+++ b/src/tests/testBoilerplate.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testBoilerplate.h
+++ b/src/tests/testBoilerplate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testCacheManager.cc
+++ b/src/tests/testCacheManager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testCacheManager.h
+++ b/src/tests/testCacheManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testCharacterSet.cc
+++ b/src/tests/testCharacterSet.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testCharacterSet.h
+++ b/src/tests/testCharacterSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testConfigParser.cc
+++ b/src/tests/testConfigParser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testConfigParser.h
+++ b/src/tests/testConfigParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testDiskIO.cc
+++ b/src/tests/testDiskIO.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testDiskIO.h
+++ b/src/tests/testDiskIO.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testEnumIterator.cc
+++ b/src/tests/testEnumIterator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testEnumIterator.h
+++ b/src/tests/testEnumIterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testEvent.h
+++ b/src/tests/testEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testEventLoop.cc
+++ b/src/tests/testEventLoop.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testEventLoop.h
+++ b/src/tests/testEventLoop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttp1Parser.cc
+++ b/src/tests/testHttp1Parser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttp1Parser.h
+++ b/src/tests/testHttp1Parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttpReply.cc
+++ b/src/tests/testHttpReply.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttpReply.h
+++ b/src/tests/testHttpReply.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttpRequest.h
+++ b/src/tests/testHttpRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttpRequestMethod.cc
+++ b/src/tests/testHttpRequestMethod.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testHttpRequestMethod.h
+++ b/src/tests/testHttpRequestMethod.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testIcmp.cc
+++ b/src/tests/testIcmp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testIcmp.h
+++ b/src/tests/testIcmp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testIpAddress.cc
+++ b/src/tests/testIpAddress.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testIpAddress.h
+++ b/src/tests/testIpAddress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testLookupTable.cc
+++ b/src/tests/testLookupTable.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testLookupTable.h
+++ b/src/tests/testLookupTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testMem.cc
+++ b/src/tests/testMem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testMem.h
+++ b/src/tests/testMem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testNetDb.cc
+++ b/src/tests/testNetDb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testNetDb.h
+++ b/src/tests/testNetDb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testPackableStream.cc
+++ b/src/tests/testPackableStream.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testPackableStream.h
+++ b/src/tests/testPackableStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testRFC1035.cc
+++ b/src/tests/testRFC1035.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testRFC1035.h
+++ b/src/tests/testRFC1035.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testRefCount.cc
+++ b/src/tests/testRefCount.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testRefCount.h
+++ b/src/tests/testRefCount.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testRock.h
+++ b/src/tests/testRock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testSBuf.cc
+++ b/src/tests/testSBuf.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testSBuf.h
+++ b/src/tests/testSBuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testSBufList.cc
+++ b/src/tests/testSBufList.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testSBufList.h
+++ b/src/tests/testSBufList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStatHist.cc
+++ b/src/tests/testStatHist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStatHist.h
+++ b/src/tests/testStatHist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStore.cc
+++ b/src/tests/testStore.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStore.h
+++ b/src/tests/testStore.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStoreController.cc
+++ b/src/tests/testStoreController.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStoreController.h
+++ b/src/tests/testStoreController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStoreHashIndex.cc
+++ b/src/tests/testStoreHashIndex.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStoreHashIndex.h
+++ b/src/tests/testStoreHashIndex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStoreSupport.cc
+++ b/src/tests/testStoreSupport.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testStoreSupport.h
+++ b/src/tests/testStoreSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testString.cc
+++ b/src/tests/testString.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testString.h
+++ b/src/tests/testString.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testTokenizer.cc
+++ b/src/tests/testTokenizer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testTokenizer.h
+++ b/src/tests/testTokenizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testURL.cc
+++ b/src/tests/testURL.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testURL.h
+++ b/src/tests/testURL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testUfs.h
+++ b/src/tests/testUfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testUriScheme.cc
+++ b/src/tests/testUriScheme.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testUriScheme.h
+++ b/src/tests/testUriScheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testYesNoNone.cc
+++ b/src/tests/testYesNoNone.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/testYesNoNone.h
+++ b/src/tests/testYesNoNone.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tests/test_http_range.cc
+++ b/src/tests/test_http_range.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/time.cc
+++ b/src/time.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -493,7 +493,7 @@ getMyHostname(void)
 const char *
 uniqueHostname(void)
 {
-    debugs(21, 3, HERE << " Config: '" << Config.uniqueHostname << "'");
+    debugs(21, 3, " Config: '" << Config.uniqueHostname << "'");
     return Config.uniqueHostname ? Config.uniqueHostname : getMyHostname();
 }
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -474,7 +474,7 @@ TunnelStateData::Connection::bytesWanted(int lowerbound, int upperbound) const
 void
 TunnelStateData::Connection::bytesIn(int const &count)
 {
-    debugs(26, 3, HERE << "len=" << len << " + count=" << count);
+    debugs(26, 3, "len=" << len << " + count=" << count);
 #if USE_DELAY_POOLS
     delayId.bytesIn(count);
 #endif
@@ -513,7 +513,7 @@ TunnelStateData::ReadServer(const Comm::ConnectionPointer &c, char *buf, size_t 
 {
     TunnelStateData *tunnelState = (TunnelStateData *)data;
     assert(cbdataReferenceValid(tunnelState));
-    debugs(26, 3, HERE << c);
+    debugs(26, 3, c);
 
     tunnelState->readServer(buf, len, errcode, xerrno);
 }
@@ -521,7 +521,7 @@ TunnelStateData::ReadServer(const Comm::ConnectionPointer &c, char *buf, size_t 
 void
 TunnelStateData::readServer(char *, size_t len, Comm::Flag errcode, int xerrno)
 {
-    debugs(26, 3, HERE << server.conn << ", read " << len << " bytes, err=" << errcode);
+    debugs(26, 3, server.conn << ", read " << len << " bytes, err=" << errcode);
     server.delayedLoops=0;
 
     /*
@@ -546,7 +546,7 @@ TunnelStateData::readServer(char *, size_t len, Comm::Flag errcode, int xerrno)
 void
 TunnelStateData::Connection::error(int const xerrno)
 {
-    debugs(50, debugLevelForError(xerrno), HERE << conn << ": read/write failure: " << xstrerr(xerrno));
+    debugs(50, debugLevelForError(xerrno), conn << ": read/write failure: " << xstrerr(xerrno));
 
     if (!ignoreErrno(xerrno))
         conn->close();
@@ -565,7 +565,7 @@ TunnelStateData::ReadClient(const Comm::ConnectionPointer &, char *buf, size_t l
 void
 TunnelStateData::readClient(char *, size_t len, Comm::Flag errcode, int xerrno)
 {
-    debugs(26, 3, HERE << client.conn << ", read " << len << " bytes, err=" << errcode);
+    debugs(26, 3, client.conn << ", read " << len << " bytes, err=" << errcode);
     client.delayedLoops=0;
 
     /*
@@ -590,7 +590,7 @@ TunnelStateData::readClient(char *, size_t len, Comm::Flag errcode, int xerrno)
 bool
 TunnelStateData::keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, Connection &from, Connection &to)
 {
-    debugs(26, 3, HERE << "from={" << from.conn << "}, to={" << to.conn << "}");
+    debugs(26, 3, "from={" << from.conn << "}, to={" << to.conn << "}");
 
     /* I think this is to prevent free-while-in-a-callback behaviour
      * - RBC 20030229
@@ -616,7 +616,7 @@ TunnelStateData::keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, 
     if (errcode)
         from.error (xerrno);
     else if (len == 0 || !Comm::IsConnOpen(to.conn)) {
-        debugs(26, 3, HERE << "Nothing to write or client gone. Terminate the tunnel.");
+        debugs(26, 3, "Nothing to write or client gone. Terminate the tunnel.");
         from.conn->close();
 
         /* Only close the remote end if we've finished queueing data to it */
@@ -633,7 +633,7 @@ TunnelStateData::keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, 
 void
 TunnelStateData::copy(size_t len, Connection &from, Connection &to, IOCB *completion)
 {
-    debugs(26, 3, HERE << "Schedule Write");
+    debugs(26, 3, "Schedule Write");
     AsyncCall::Pointer call = commCbCall(5,5, "TunnelBlindCopyWriteHandler",
                                          CommIoCbPtrFun(completion, this));
     to.write(from.buf, len, call, NULL);
@@ -653,7 +653,7 @@ TunnelStateData::WriteServerDone(const Comm::ConnectionPointer &, char *buf, siz
 void
 TunnelStateData::writeServerDone(char *, size_t len, Comm::Flag flag, int xerrno)
 {
-    debugs(26, 3, HERE  << server.conn << ", " << len << " bytes written, flag=" << flag);
+    debugs(26, 3, server.conn << ", " << len << " bytes written, flag=" << flag);
 
     if (flag == Comm::ERR_CLOSING)
         return;
@@ -669,7 +669,7 @@ TunnelStateData::writeServerDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* EOF? */
     if (len == 0) {
-        debugs(26, 4, HERE << "No read input. Closing server connection.");
+        debugs(26, 4, "No read input. Closing server connection.");
         server.conn->close();
         return;
     }
@@ -681,7 +681,7 @@ TunnelStateData::writeServerDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* If the other end has closed, so should we */
     if (!Comm::IsConnOpen(client.conn)) {
-        debugs(26, 4, HERE << "Client gone away. Shutting down server connection.");
+        debugs(26, 4, "Client gone away. Shutting down server connection.");
         server.conn->close();
         return;
     }
@@ -706,7 +706,7 @@ TunnelStateData::WriteClientDone(const Comm::ConnectionPointer &, char *buf, siz
 void
 TunnelStateData::Connection::dataSent(size_t amount)
 {
-    debugs(26, 3, HERE << "len=" << len << " - amount=" << amount);
+    debugs(26, 3, "len=" << len << " - amount=" << amount);
     assert(amount == (size_t)len);
     len =0;
     /* increment total object size */
@@ -748,7 +748,7 @@ TunnelStateData::Connection::noteClosure()
 void
 TunnelStateData::writeClientDone(char *, size_t len, Comm::Flag flag, int xerrno)
 {
-    debugs(26, 3, HERE << client.conn << ", " << len << " bytes written, flag=" << flag);
+    debugs(26, 3, client.conn << ", " << len << " bytes written, flag=" << flag);
 
     if (flag == Comm::ERR_CLOSING)
         return;
@@ -762,7 +762,7 @@ TunnelStateData::writeClientDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* EOF? */
     if (len == 0) {
-        debugs(26, 4, HERE << "Closing client connection due to 0 byte read.");
+        debugs(26, 4, "Closing client connection due to 0 byte read.");
         client.conn->close();
         return;
     }
@@ -773,7 +773,7 @@ TunnelStateData::writeClientDone(char *, size_t len, Comm::Flag flag, int xerrno
 
     /* If the other end has closed, so should we */
     if (!Comm::IsConnOpen(server.conn)) {
-        debugs(26, 4, HERE << "Server has gone away. Terminating client connection.");
+        debugs(26, 4, "Server has gone away. Terminating client connection.");
         client.conn->close();
         return;
     }
@@ -788,7 +788,7 @@ static void
 tunnelTimeout(const CommTimeoutCbParams &io)
 {
     TunnelStateData *tunnelState = static_cast<TunnelStateData *>(io.data);
-    debugs(26, 3, HERE << io.conn);
+    debugs(26, 3, io.conn);
     /* Temporary lock to protect our own feets (comm_close -> tunnelClientClosed -> Free) */
     CbcPointer<TunnelStateData> safetyLock(tunnelState);
 
@@ -942,7 +942,7 @@ static void
 tunnelConnectedWriteDone(const Comm::ConnectionPointer &conn, char *, size_t len, Comm::Flag flag, int, void *data)
 {
     TunnelStateData *tunnelState = (TunnelStateData *)data;
-    debugs(26, 3, HERE << conn << ", flag=" << flag);
+    debugs(26, 3, conn << ", flag=" << flag);
     tunnelState->client.writer = NULL;
 
     if (flag != Comm::OK) {
@@ -1025,7 +1025,7 @@ static void
 tunnelErrorComplete(int fd/*const Comm::ConnectionPointer &*/, void *data, size_t)
 {
     TunnelStateData *tunnelState = (TunnelStateData *)data;
-    debugs(26, 3, HERE << "FD " << fd);
+    debugs(26, 3, "FD " << fd);
     assert(tunnelState != NULL);
     /* temporary lock to save our own feets (comm_close -> tunnelClientClosed -> Free) */
     CbcPointer<TunnelStateData> safetyLock(tunnelState);
@@ -1101,7 +1101,7 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
 void
 tunnelStart(ClientHttpRequest * http)
 {
-    debugs(26, 3, HERE);
+    debugs(26, 3, MYNAME);
     /* Create state structure. */
     TunnelStateData *tunnelState = NULL;
     ErrorState *err = NULL;
@@ -1125,7 +1125,7 @@ tunnelStart(ClientHttpRequest * http)
         ch.my_addr = request->my_addr;
         ch.syncAle(request, http->log_uri);
         if (ch.fastCheck().denied()) {
-            debugs(26, 4, HERE << "MISS access forbidden.");
+            debugs(26, 4, "MISS access forbidden.");
             err = new ErrorState(ERR_FORWARDING_DENIED, Http::scForbidden, request, http->al);
             http->al->http.code = Http::scForbidden;
             errorSend(http->getConn()->clientConnection, err);

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/ufsdump.cc
+++ b/src/ufsdump.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/unlinkd.cc
+++ b/src/unlinkd.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/unlinkd.h
+++ b/src/unlinkd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/unlinkd_daemon.cc
+++ b/src/unlinkd_daemon.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/urn.h
+++ b/src/urn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/wccp.cc
+++ b/src/wccp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/wccp.h
+++ b/src/wccp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -1225,344 +1225,344 @@ wccp2HandleUdp(int sock, void *)
         Must3(ntohs(wccp2_i_see_you.version) == WCCP2_VERSION, "WCCP version unsupported", Here());
         Must3(ntohl(wccp2_i_see_you.type) == WCCP2_I_SEE_YOU, "WCCP packet type unsupported", Here());
 
-    // XXX: drop conversion boundary
-    from_tmp.getSockAddr(from);
+        // XXX: drop conversion boundary
+        from_tmp.getSockAddr(from);
 
-    debugs(80, 3, "Incoming WCCPv2 I_SEE_YOU length " << ntohs(wccp2_i_see_you.length) << ".");
+        debugs(80, 3, "Incoming WCCPv2 I_SEE_YOU length " << ntohs(wccp2_i_see_you.length) << ".");
 
-    /* Record the total data length */
-    const auto data_length = ntohs(wccp2_i_see_you.length);
-    Must3(data_length <= len - message_header_size,
-          "malformed packet claiming it's bigger than received data", Here());
+        /* Record the total data length */
+        const auto data_length = ntohs(wccp2_i_see_you.length);
+        Must3(data_length <= len - message_header_size,
+              "malformed packet claiming it's bigger than received data", Here());
 
-    size_t offset = 0;
+        size_t offset = 0;
 
-    /* Go through the data structure */
-    while (offset + sizeof(struct wccp2_item_header_t) <= data_length) {
+        /* Go through the data structure */
+        while (offset + sizeof(struct wccp2_item_header_t) <= data_length) {
 
-        char *data = wccp2_i_see_you.data;
+            char *data = wccp2_i_see_you.data;
 
-        const auto itemHeader = reinterpret_cast<const wccp2_item_header_t*>(&data[offset]);
-        const auto itemSize = CheckFieldDataLength(itemHeader, ntohs(itemHeader->length),
-                              data, data_length, "truncated record");
-        // XXX: Check "The specified length must be a multiple of 4 octets"
-        // requirement to avoid unaligned memory reads after the first item.
+            const auto itemHeader = reinterpret_cast<const wccp2_item_header_t*>(&data[offset]);
+            const auto itemSize = CheckFieldDataLength(itemHeader, ntohs(itemHeader->length),
+                                  data, data_length, "truncated record");
+            // XXX: Check "The specified length must be a multiple of 4 octets"
+            // requirement to avoid unaligned memory reads after the first item.
 
-        switch (ntohs(itemHeader->type)) {
+            switch (ntohs(itemHeader->type)) {
 
-        case WCCP2_SECURITY_INFO:
-            Must3(!security_info, "duplicate security definition", Here());
-            SetField(security_info, itemHeader, itemHeader, itemSize,
-                     "security definition truncated");
-            break;
+            case WCCP2_SECURITY_INFO:
+                Must3(!security_info, "duplicate security definition", Here());
+                SetField(security_info, itemHeader, itemHeader, itemSize,
+                         "security definition truncated");
+                break;
 
-        case WCCP2_SERVICE_INFO:
-            Must3(!service_info, "duplicate service_info definition", Here());
-            SetField(service_info, itemHeader, itemHeader, itemSize,
-                     "service_info definition truncated");
-            break;
+            case WCCP2_SERVICE_INFO:
+                Must3(!service_info, "duplicate service_info definition", Here());
+                SetField(service_info, itemHeader, itemHeader, itemSize,
+                         "service_info definition truncated");
+                break;
 
-        case WCCP2_ROUTER_ID_INFO:
-            Must3(!router_identity_info, "duplicate router_identity_info definition", Here());
-            SetField(router_identity_info, itemHeader, itemHeader, itemSize,
-                     "router_identity_info definition truncated");
-            break;
+            case WCCP2_ROUTER_ID_INFO:
+                Must3(!router_identity_info, "duplicate router_identity_info definition", Here());
+                SetField(router_identity_info, itemHeader, itemHeader, itemSize,
+                         "router_identity_info definition truncated");
+                break;
 
-        case WCCP2_RTR_VIEW_INFO:
-            Must3(!router_view_header, "duplicate router_view definition", Here());
-            SetField(router_view_header, itemHeader, itemHeader, itemSize,
-                     "router_view definition truncated");
-            break;
+            case WCCP2_RTR_VIEW_INFO:
+                Must3(!router_view_header, "duplicate router_view definition", Here());
+                SetField(router_view_header, itemHeader, itemHeader, itemSize,
+                         "router_view definition truncated");
+                break;
 
-        case WCCP2_CAPABILITY_INFO: {
-            Must3(!router_capability_header, "duplicate router_capability definition", Here());
-            SetField(router_capability_header, itemHeader, itemHeader, itemSize,
-                     "router_capability definition truncated");
+            case WCCP2_CAPABILITY_INFO: {
+                Must3(!router_capability_header, "duplicate router_capability definition", Here());
+                SetField(router_capability_header, itemHeader, itemHeader, itemSize,
+                         "router_capability definition truncated");
 
-            CheckFieldDataLength(router_capability_header, ntohs(router_capability_header->capability_info_length),
-                                 itemHeader, itemSize, "capability info truncated");
-            router_capability_data_start = reinterpret_cast<char*>(router_capability_header) +
-                                           sizeof(*router_capability_header);
-            break;
+                CheckFieldDataLength(router_capability_header, ntohs(router_capability_header->capability_info_length),
+                                     itemHeader, itemSize, "capability info truncated");
+                router_capability_data_start = reinterpret_cast<char*>(router_capability_header) +
+                                               sizeof(*router_capability_header);
+                break;
+            }
+
+            /* Nothing to do for the types below */
+
+            case WCCP2_ASSIGN_MAP:
+            case WCCP2_REDIRECT_ASSIGNMENT:
+                break;
+
+            default:
+                debugs(80, DBG_IMPORTANT, "ERROR: Unknown record type in WCCPv2 Packet (" << ntohs(itemHeader->type) << ").");
+            }
+
+            offset += itemSize;
+            assert(offset <= data_length && "CheckFieldDataLength(itemHeader...) established that");
         }
 
-        /* Nothing to do for the types below */
+        Must3(security_info, "packet missing security definition", Here());
+        Must3(service_info, "packet missing service_info definition", Here());
+        Must3(router_identity_info, "packet missing router_identity_info definition", Here());
+        Must3(router_view_header, "packet missing router_view definition", Here());
 
-        case WCCP2_ASSIGN_MAP:
-        case WCCP2_REDIRECT_ASSIGNMENT:
-            break;
+        debugs(80, 5, "Complete packet received");
 
-        default:
-            debugs(80, DBG_IMPORTANT, "ERROR: Unknown record type in WCCPv2 Packet (" << ntohs(itemHeader->type) << ").");
+        /* Check that the service in the packet is configured on this router */
+        service_list_ptr = wccp2_service_list_head;
+
+        while (service_list_ptr != NULL) {
+            if (service_info->service_id == service_list_ptr->service_info->service_id) {
+                break;
+            }
+
+            service_list_ptr = service_list_ptr->next;
         }
 
-        offset += itemSize;
-        assert(offset <= data_length && "CheckFieldDataLength(itemHeader...) established that");
-    }
-
-    Must3(security_info, "packet missing security definition", Here());
-    Must3(service_info, "packet missing service_info definition", Here());
-    Must3(router_identity_info, "packet missing router_identity_info definition", Here());
-    Must3(router_view_header, "packet missing router_view definition", Here());
-
-    debugs(80, 5, "Complete packet received");
-
-    /* Check that the service in the packet is configured on this router */
-    service_list_ptr = wccp2_service_list_head;
-
-    while (service_list_ptr != NULL) {
-        if (service_info->service_id == service_list_ptr->service_info->service_id) {
-            break;
-        }
-
-        service_list_ptr = service_list_ptr->next;
-    }
-
-    if (service_list_ptr == NULL) {
-        debugs(80, DBG_IMPORTANT, "ERROR: WCCPv2 Unknown service received from router (" << service_info->service_id << ")");
-        return;
-    }
-
-    if (ntohl(security_info->security_option) != ntohl(service_list_ptr->security_info->security_option)) {
-        debugs(80, DBG_IMPORTANT, "ERROR: Invalid security option in WCCPv2 Packet (" << ntohl(security_info->security_option) << " vs " << ntohl(service_list_ptr->security_info->security_option) << ").");
-        return;
-    }
-
-    if (!wccp2_check_security(service_list_ptr, (char *) security_info, (char *) &wccp2_i_see_you, len)) {
-        debugs(80, DBG_IMPORTANT, "ERROR: Received WCCPv2 Packet failed authentication");
-        return;
-    }
-
-    /* Check that the router address is configured on this router */
-    for (router_list_ptr = &service_list_ptr->router_list_head; router_list_ptr->next != NULL; router_list_ptr = router_list_ptr->next) {
-        if (router_list_ptr->router_sendto_address.s_addr == from.sin_addr.s_addr)
-            break;
-    }
-
-    Must3(router_list_ptr->next, "packet received from unknown router", Here());
-
-    /* Set the router id */
-    router_list_ptr->info->router_address = router_identity_info->router_id_element.router_address;
-
-    /* Increment the received id in the packet */
-    if (ntohl(router_list_ptr->info->received_id) != ntohl(router_identity_info->router_id_element.received_id)) {
-        debugs(80, 3, "Incoming WCCP2_I_SEE_YOU Received ID old=" << ntohl(router_list_ptr->info->received_id) << " new=" << ntohl(router_identity_info->router_id_element.received_id) << ".");
-        router_list_ptr->info->received_id = router_identity_info->router_id_element.received_id;
-    }
-
-    /* TODO: check return/forwarding methods */
-    if (router_capability_header == NULL) {
-        if ((Config.Wccp2.return_method != WCCP2_PACKET_RETURN_METHOD_GRE) || (Config.Wccp2.forwarding_method != WCCP2_FORWARDING_METHOD_GRE)) {
-            debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router does not support the forwarding method specified, only GRE supported");
-            wccp2ConnectionClose();
+        if (service_list_ptr == NULL) {
+            debugs(80, DBG_IMPORTANT, "ERROR: WCCPv2 Unknown service received from router (" << service_info->service_id << ")");
             return;
         }
-    } else {
 
-        const auto router_capability_data_length = ntohs(router_capability_header->capability_info_length);
-        assert(router_capability_data_start);
-        const auto router_capability_data_end = router_capability_data_start +
-                                                router_capability_data_length;
-        for (auto router_capability_data_current = router_capability_data_start;
-                router_capability_data_current < router_capability_data_end;) {
-
-            SetField(router_capability_element, router_capability_data_current,
-                     router_capability_data_start, router_capability_data_length,
-                     "capability element header truncated");
-            const auto elementSize = CheckFieldDataLength(
-                                         router_capability_element, ntohs(router_capability_element->capability_length),
-                                         router_capability_data_start, router_capability_data_length,
-                                         "capability element truncated");
-
-            switch (ntohs(router_capability_element->capability_type)) {
-
-            case WCCP2_CAPABILITY_FORWARDING_METHOD:
-
-                if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.forwarding_method)) {
-                    debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different forwarding method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.forwarding_method);
-                    wccp2ConnectionClose();
-                    return;
-                }
-
-                break;
-
-            case WCCP2_CAPABILITY_ASSIGNMENT_METHOD:
-
-                if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.assignment_method)) {
-                    debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different assignment method " << ntohl(router_capability_element->capability_value) << ", expected "<< Config.Wccp2.assignment_method);
-                    wccp2ConnectionClose();
-                    return;
-                }
-
-                break;
-
-            case WCCP2_CAPABILITY_RETURN_METHOD:
-
-                if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.return_method)) {
-                    debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different return method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.return_method);
-                    wccp2ConnectionClose();
-                    return;
-                }
-
-                break;
-
-            case 4:
-            case 5:
-                break; // ignore silently for now
-
-            default:
-                debugs(80, DBG_IMPORTANT, "ERROR: Unknown capability type in WCCPv2 Packet (" << ntohs(router_capability_element->capability_type) << ").");
-            }
-
-            router_capability_data_current += elementSize;
+        if (ntohl(security_info->security_option) != ntohl(service_list_ptr->security_info->security_option)) {
+            debugs(80, DBG_IMPORTANT, "ERROR: Invalid security option in WCCPv2 Packet (" << ntohl(security_info->security_option) << " vs " << ntohl(service_list_ptr->security_info->security_option) << ").");
+            return;
         }
-    }
 
-    debugs(80, 5, "Cleaning out cache list");
-    /* clean out the old cache list */
-
-    for (cache_list_ptr = &router_list_ptr->cache_list_head; cache_list_ptr; cache_list_ptr = cache_list_ptr_next) {
-        cache_list_ptr_next = cache_list_ptr->next;
-
-        if (cache_list_ptr != &router_list_ptr->cache_list_head) {
-            xfree(cache_list_ptr);
+        if (!wccp2_check_security(service_list_ptr, (char *) security_info, (char *) &wccp2_i_see_you, len)) {
+            debugs(80, DBG_IMPORTANT, "ERROR: Received WCCPv2 Packet failed authentication");
+            return;
         }
-    }
 
-    router_list_ptr->num_caches = htonl(0);
-    num_caches = 0;
-
-    /* Check to see if we're the master cache and update the cache list */
-    bool found = false;
-    service_list_ptr->lowest_ip = 1;
-    cache_list_ptr = &router_list_ptr->cache_list_head;
-
-    /* to find the list of caches, we start at the end of the router view header */
-
-    ptr = (char *) (router_view_header) + sizeof(struct router_view_t);
-    const auto router_view_size = sizeof(struct router_view_t) +
-                                  ntohs(router_view_header->header.length);
-
-    /* Then we read the number of routers */
-    const uint32_t *routerCountRaw = nullptr;
-    SetField(routerCountRaw, ptr, router_view_header, router_view_size,
-             "malformed packet (truncated router view info w/o number of routers)");
-
-    /* skip the number plus all the ip's */
-    ptr += sizeof(*routerCountRaw);
-    const auto ipCount = ntohl(*routerCountRaw);
-    const auto ipsSize = ipCount * sizeof(struct in_addr); // we check for unsigned overflow below
-    Must3(ipsSize / sizeof(struct in_addr) != ipCount, "huge IP address count", Here());
-    CheckSectionLength(ptr, ipsSize, router_view_header, router_view_size, "invalid IP address count");
-    ptr += ipsSize;
-
-    /* Then read the number of caches */
-    const uint32_t *cacheCountRaw = nullptr;
-    SetField(cacheCountRaw, ptr, router_view_header, router_view_size,
-             "malformed packet (truncated router view info w/o cache count)");
-    memcpy(&tmp, cacheCountRaw, sizeof(tmp)); // TODO: Replace tmp with cacheCount
-    ptr += sizeof(tmp);
-
-    if (ntohl(tmp) != 0) {
-        /* search through the list of received-from ip addresses */
-
-        for (num_caches = 0; num_caches < (int) ntohl(tmp); ++num_caches) {
-            /* Get a copy of the ip */
-            memset(&cache_address, 0, sizeof(cache_address)); // Make GCC happy
-
-            switch (Config.Wccp2.assignment_method) {
-
-            case WCCP2_ASSIGNMENT_METHOD_HASH:
-
-                SetField(cache_identity, ptr, router_view_header, router_view_size,
-                         "malformed packet (truncated router view info cache w/o assignment hash)");
-
-                ptr += sizeof(struct wccp2_cache_identity_info_t);
-
-                memcpy(&cache_address, &cache_identity->addr, sizeof(struct in_addr));
-
-                cache_list_ptr->weight = ntohs(cache_identity->weight);
+        /* Check that the router address is configured on this router */
+        for (router_list_ptr = &service_list_ptr->router_list_head; router_list_ptr->next != NULL; router_list_ptr = router_list_ptr->next) {
+            if (router_list_ptr->router_sendto_address.s_addr == from.sin_addr.s_addr)
                 break;
+        }
 
-            case WCCP2_ASSIGNMENT_METHOD_MASK:
+        Must3(router_list_ptr->next, "packet received from unknown router", Here());
 
-                SetField(cache_mask_info, ptr, router_view_header, router_view_size,
-                         "malformed packet (truncated router view info cache w/o assignment mask)");
+        /* Set the router id */
+        router_list_ptr->info->router_address = router_identity_info->router_id_element.router_address;
 
-                /* The mask assignment has an undocumented variable length entry here */
+        /* Increment the received id in the packet */
+        if (ntohl(router_list_ptr->info->received_id) != ntohl(router_identity_info->router_id_element.received_id)) {
+            debugs(80, 3, "Incoming WCCP2_I_SEE_YOU Received ID old=" << ntohl(router_list_ptr->info->received_id) << " new=" << ntohl(router_identity_info->router_id_element.received_id) << ".");
+            router_list_ptr->info->received_id = router_identity_info->router_id_element.received_id;
+        }
 
-                if (ntohl(cache_mask_info->num1) == 3) {
+        /* TODO: check return/forwarding methods */
+        if (router_capability_header == NULL) {
+            if ((Config.Wccp2.return_method != WCCP2_PACKET_RETURN_METHOD_GRE) || (Config.Wccp2.forwarding_method != WCCP2_FORWARDING_METHOD_GRE)) {
+                debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router does not support the forwarding method specified, only GRE supported");
+                wccp2ConnectionClose();
+                return;
+            }
+        } else {
 
-                    SetField(cache_mask_identity, ptr, router_view_header, router_view_size,
-                             "malformed packet (truncated router view info cache w/o assignment mask identity)");
+            const auto router_capability_data_length = ntohs(router_capability_header->capability_info_length);
+            assert(router_capability_data_start);
+            const auto router_capability_data_end = router_capability_data_start +
+                                                    router_capability_data_length;
+            for (auto router_capability_data_current = router_capability_data_start;
+                    router_capability_data_current < router_capability_data_end;) {
 
-                    ptr += sizeof(struct wccp2_cache_mask_identity_info_t);
+                SetField(router_capability_element, router_capability_data_current,
+                         router_capability_data_start, router_capability_data_length,
+                         "capability element header truncated");
+                const auto elementSize = CheckFieldDataLength(
+                                             router_capability_element, ntohs(router_capability_element->capability_length),
+                                             router_capability_data_start, router_capability_data_length,
+                                             "capability element truncated");
 
-                    memcpy(&cache_address, &cache_mask_identity->addr, sizeof(struct in_addr));
-                } else {
+                switch (ntohs(router_capability_element->capability_type)) {
 
-                    ptr += sizeof(struct cache_mask_info_t);
+                case WCCP2_CAPABILITY_FORWARDING_METHOD:
 
-                    memcpy(&cache_address, &cache_mask_info->addr, sizeof(struct in_addr));
+                    if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.forwarding_method)) {
+                        debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different forwarding method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.forwarding_method);
+                        wccp2ConnectionClose();
+                        return;
+                    }
+
+                    break;
+
+                case WCCP2_CAPABILITY_ASSIGNMENT_METHOD:
+
+                    if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.assignment_method)) {
+                        debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different assignment method " << ntohl(router_capability_element->capability_value) << ", expected "<< Config.Wccp2.assignment_method);
+                        wccp2ConnectionClose();
+                        return;
+                    }
+
+                    break;
+
+                case WCCP2_CAPABILITY_RETURN_METHOD:
+
+                    if (!(ntohl(router_capability_element->capability_value) & Config.Wccp2.return_method)) {
+                        debugs(80, DBG_IMPORTANT, "ERROR: wccp2HandleUdp: fatal error - A WCCP router has specified a different return method " << ntohl(router_capability_element->capability_value) << ", expected " << Config.Wccp2.return_method);
+                        wccp2ConnectionClose();
+                        return;
+                    }
+
+                    break;
+
+                case 4:
+                case 5:
+                    break; // ignore silently for now
+
+                default:
+                    debugs(80, DBG_IMPORTANT, "ERROR: Unknown capability type in WCCPv2 Packet (" << ntohs(router_capability_element->capability_type) << ").");
                 }
 
-                cache_list_ptr->weight = 0;
-                break;
-
-            default:
-                fatalf("Unknown Wccp2 assignment method\n");
+                router_capability_data_current += elementSize;
             }
+        }
+
+        debugs(80, 5, "Cleaning out cache list");
+        /* clean out the old cache list */
+
+        for (cache_list_ptr = &router_list_ptr->cache_list_head; cache_list_ptr; cache_list_ptr = cache_list_ptr_next) {
+            cache_list_ptr_next = cache_list_ptr->next;
+
+            if (cache_list_ptr != &router_list_ptr->cache_list_head) {
+                xfree(cache_list_ptr);
+            }
+        }
+
+        router_list_ptr->num_caches = htonl(0);
+        num_caches = 0;
+
+        /* Check to see if we're the master cache and update the cache list */
+        bool found = false;
+        service_list_ptr->lowest_ip = 1;
+        cache_list_ptr = &router_list_ptr->cache_list_head;
+
+        /* to find the list of caches, we start at the end of the router view header */
+
+        ptr = (char *) (router_view_header) + sizeof(struct router_view_t);
+        const auto router_view_size = sizeof(struct router_view_t) +
+                                      ntohs(router_view_header->header.length);
+
+        /* Then we read the number of routers */
+        const uint32_t *routerCountRaw = nullptr;
+        SetField(routerCountRaw, ptr, router_view_header, router_view_size,
+                 "malformed packet (truncated router view info w/o number of routers)");
+
+        /* skip the number plus all the ip's */
+        ptr += sizeof(*routerCountRaw);
+        const auto ipCount = ntohl(*routerCountRaw);
+        const auto ipsSize = ipCount * sizeof(struct in_addr); // we check for unsigned overflow below
+        Must3(ipsSize / sizeof(struct in_addr) != ipCount, "huge IP address count", Here());
+        CheckSectionLength(ptr, ipsSize, router_view_header, router_view_size, "invalid IP address count");
+        ptr += ipsSize;
+
+        /* Then read the number of caches */
+        const uint32_t *cacheCountRaw = nullptr;
+        SetField(cacheCountRaw, ptr, router_view_header, router_view_size,
+                 "malformed packet (truncated router view info w/o cache count)");
+        memcpy(&tmp, cacheCountRaw, sizeof(tmp)); // TODO: Replace tmp with cacheCount
+        ptr += sizeof(tmp);
+
+        if (ntohl(tmp) != 0) {
+            /* search through the list of received-from ip addresses */
+
+            for (num_caches = 0; num_caches < (int) ntohl(tmp); ++num_caches) {
+                /* Get a copy of the ip */
+                memset(&cache_address, 0, sizeof(cache_address)); // Make GCC happy
+
+                switch (Config.Wccp2.assignment_method) {
+
+                case WCCP2_ASSIGNMENT_METHOD_HASH:
+
+                    SetField(cache_identity, ptr, router_view_header, router_view_size,
+                             "malformed packet (truncated router view info cache w/o assignment hash)");
+
+                    ptr += sizeof(struct wccp2_cache_identity_info_t);
+
+                    memcpy(&cache_address, &cache_identity->addr, sizeof(struct in_addr));
+
+                    cache_list_ptr->weight = ntohs(cache_identity->weight);
+                    break;
+
+                case WCCP2_ASSIGNMENT_METHOD_MASK:
+
+                    SetField(cache_mask_info, ptr, router_view_header, router_view_size,
+                             "malformed packet (truncated router view info cache w/o assignment mask)");
+
+                    /* The mask assignment has an undocumented variable length entry here */
+
+                    if (ntohl(cache_mask_info->num1) == 3) {
+
+                        SetField(cache_mask_identity, ptr, router_view_header, router_view_size,
+                                 "malformed packet (truncated router view info cache w/o assignment mask identity)");
+
+                        ptr += sizeof(struct wccp2_cache_mask_identity_info_t);
+
+                        memcpy(&cache_address, &cache_mask_identity->addr, sizeof(struct in_addr));
+                    } else {
+
+                        ptr += sizeof(struct cache_mask_info_t);
+
+                        memcpy(&cache_address, &cache_mask_info->addr, sizeof(struct in_addr));
+                    }
+
+                    cache_list_ptr->weight = 0;
+                    break;
+
+                default:
+                    fatalf("Unknown Wccp2 assignment method\n");
+                }
+
+                /* Update the cache list */
+                cache_list_ptr->cache_ip = cache_address;
+
+                cache_list_ptr->next = (wccp2_cache_list_t*) xcalloc(1, sizeof(struct wccp2_cache_list_t));
+
+                cache_list_ptr = cache_list_ptr->next;
+
+                cache_list_ptr->next = NULL;
+
+                debugs (80, 5,  "checking cache list: (" << std::hex << cache_address.s_addr << ":" <<  router_list_ptr->local_ip.s_addr << ")");
+
+                /* Check to see if it's the master, or us */
+                found = found || (cache_address.s_addr == router_list_ptr->local_ip.s_addr);
+
+                if (cache_address.s_addr < router_list_ptr->local_ip.s_addr) {
+                    service_list_ptr->lowest_ip = 0;
+                }
+            }
+        } else {
+            debugs(80, 5, "Adding ourselves as the only cache");
 
             /* Update the cache list */
-            cache_list_ptr->cache_ip = cache_address;
+            cache_list_ptr->cache_ip = router_list_ptr->local_ip;
 
             cache_list_ptr->next = (wccp2_cache_list_t*) xcalloc(1, sizeof(struct wccp2_cache_list_t));
-
             cache_list_ptr = cache_list_ptr->next;
-
             cache_list_ptr->next = NULL;
 
-            debugs (80, 5,  "checking cache list: (" << std::hex << cache_address.s_addr << ":" <<  router_list_ptr->local_ip.s_addr << ")");
+            service_list_ptr->lowest_ip = 1;
+            found = true;
+            num_caches = 1;
+        }
 
-            /* Check to see if it's the master, or us */
-            found = found || (cache_address.s_addr == router_list_ptr->local_ip.s_addr);
+        wccp2SortCacheList(&router_list_ptr->cache_list_head);
 
-            if (cache_address.s_addr < router_list_ptr->local_ip.s_addr) {
-                service_list_ptr->lowest_ip = 0;
+        router_list_ptr->num_caches = htonl(num_caches);
+
+        if (found && (service_list_ptr->lowest_ip == 1)) {
+            if (ntohl(router_view_header->change_number) != router_list_ptr->member_change) {
+                debugs(80, 4, "Change detected - queueing up new assignment");
+                router_list_ptr->member_change = ntohl(router_view_header->change_number);
+                eventDelete(wccp2AssignBuckets, NULL);
+                eventAdd("wccp2AssignBuckets", wccp2AssignBuckets, NULL, 15.0, 1);
+            } else {
+                debugs(80, 5, "Change not detected (" << ntohl(router_view_header->change_number) << " = " << router_list_ptr->member_change << ")");
             }
-        }
-    } else {
-        debugs(80, 5, "Adding ourselves as the only cache");
-
-        /* Update the cache list */
-        cache_list_ptr->cache_ip = router_list_ptr->local_ip;
-
-        cache_list_ptr->next = (wccp2_cache_list_t*) xcalloc(1, sizeof(struct wccp2_cache_list_t));
-        cache_list_ptr = cache_list_ptr->next;
-        cache_list_ptr->next = NULL;
-
-        service_list_ptr->lowest_ip = 1;
-        found = true;
-        num_caches = 1;
-    }
-
-    wccp2SortCacheList(&router_list_ptr->cache_list_head);
-
-    router_list_ptr->num_caches = htonl(num_caches);
-
-    if (found && (service_list_ptr->lowest_ip == 1)) {
-        if (ntohl(router_view_header->change_number) != router_list_ptr->member_change) {
-            debugs(80, 4, "Change detected - queueing up new assignment");
-            router_list_ptr->member_change = ntohl(router_view_header->change_number);
-            eventDelete(wccp2AssignBuckets, NULL);
-            eventAdd("wccp2AssignBuckets", wccp2AssignBuckets, NULL, 15.0, 1);
         } else {
-            debugs(80, 5, "Change not detected (" << ntohl(router_view_header->change_number) << " = " << router_list_ptr->member_change << ")");
+            eventDelete(wccp2AssignBuckets, NULL);
+            debugs(80, 5, "I am not the lowest ip cache - not assigning buckets");
         }
-    } else {
-        eventDelete(wccp2AssignBuckets, NULL);
-        debugs(80, 5, "I am not the lowest ip cache - not assigning buckets");
-    }
 
     } catch (...) {
         debugs(80, DBG_IMPORTANT, "ERROR: Ignoring WCCPv2 message: " << CurrentException);

--- a/src/wccp2.h
+++ b/src/wccp2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.
@@ -87,7 +87,7 @@ static void
 whoisTimeout(const CommTimeoutCbParams &io)
 {
     WhoisState *p = static_cast<WhoisState *>(io.data);
-    debugs(75, 3, HERE << io.conn << ", URL " << p->entry->url());
+    debugs(75, 3, io.conn << ", URL " << p->entry->url());
     io.conn->close();
 }
 
@@ -116,7 +116,7 @@ WhoisState::readReply(const Comm::ConnectionPointer &conn, char *aBuffer, size_t
         return;
 
     aBuffer[aBufferLength] = '\0';
-    debugs(75, 3, HERE << conn << " read " << aBufferLength << " bytes");
+    debugs(75, 3, conn << " read " << aBufferLength << " bytes");
     debugs(75, 5, "{" << aBuffer << "}");
 
     // TODO: Honor delay pools.

--- a/src/whois.h
+++ b/src/whois.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/wordlist.cc
+++ b/src/wordlist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/src/wordlist.h
+++ b/src/wordlist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 ##
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/ESIExpressions.cc
+++ b/test-suite/ESIExpressions.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/VirtualDeleteOperator.cc
+++ b/test-suite/VirtualDeleteOperator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/basic_test.sh
+++ b/test-suite/basic_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtest.sh
+++ b/test-suite/buildtest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtests/layer-00-default.opts
+++ b/test-suite/buildtests/layer-00-default.opts
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtests/os-debian.opts
+++ b/test-suite/buildtests/os-debian.opts
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtests/os-mingw.opts
+++ b/test-suite/buildtests/os-mingw.opts
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/buildtests/os-ubuntu.opts
+++ b/test-suite/buildtests/os-ubuntu.opts
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/debug.cc
+++ b/test-suite/debug.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/htcp-client.pl
+++ b/test-suite/htcp-client.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/mem_hdr_test.cc
+++ b/test-suite/mem_hdr_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/mem_node_test.cc
+++ b/test-suite/mem_node_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/negotiate_test.sh
+++ b/test-suite/negotiate_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/ntlm_test.sh
+++ b/test-suite/ntlm_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/pconn-banger.c
+++ b/test-suite/pconn-banger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/run_negotiate_test.sh
+++ b/test-suite/run_negotiate_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/run_ntlm_test.sh
+++ b/test-suite/run_ntlm_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/splay.cc
+++ b/test-suite/splay.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/external_acl_type
+++ b/test-suite/squidconf/external_acl_type
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/mgr_passwd
+++ b/test-suite/squidconf/mgr_passwd
@@ -1,4 +1,4 @@
-# Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+# Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/regex
+++ b/test-suite/squidconf/regex
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/regressions-3.3
+++ b/test-suite/squidconf/regressions-3.3
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/regressions-3.4.0.1
+++ b/test-suite/squidconf/regressions-3.4.0.1
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/regressions-3.5.0.2
+++ b/test-suite/squidconf/regressions-3.5.0.2
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/regressions-4.0.18
+++ b/test-suite/squidconf/regressions-4.0.18
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/squidconf/time_units
+++ b/test-suite/squidconf/time_units
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/syntheticoperators.cc
+++ b/test-suite/syntheticoperators.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/tcp-banger2.c
+++ b/test-suite/tcp-banger2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/tcp-banger3.c
+++ b/test-suite/tcp-banger3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/test_tools.cc
+++ b/test-suite/test_tools.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/test-suite/testheaders.sh
+++ b/test-suite/testheaders.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/test-suite/waiter.c
+++ b/test-suite/waiter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/apparmor/Makefile.am
+++ b/tools/apparmor/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/apparmor/usr.sbin.squid
+++ b/tools/apparmor/usr.sbin.squid
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/cachemgr.cgi.8.in
+++ b/tools/cachemgr.cgi.8.in
@@ -54,7 +54,7 @@ the National Science Foundation.
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/cachemgr.conf
+++ b/tools/cachemgr.conf
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/helper-mux/Makefile.am
+++ b/tools/helper-mux/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/helper-mux/helper-mux.pl.in
+++ b/tools/helper-mux/helper-mux.pl.in
@@ -54,7 +54,7 @@ It is not yet able to manage dying helpers.
 
 =head1 COPYRIGHT
 
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/helper-ok-dying.pl
+++ b/tools/helper-ok-dying.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/helper-ok.pl
+++ b/tools/helper-ok.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/purge/Makefile.am
+++ b/tools/purge/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/purge/conffile.cc
+++ b/tools/purge/conffile.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/conffile.hh
+++ b/tools/purge/conffile.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/convert.cc
+++ b/tools/purge/convert.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/convert.hh
+++ b/tools/purge/convert.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/copyout.cc
+++ b/tools/purge/copyout.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/copyout.hh
+++ b/tools/purge/copyout.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/purge.1
+++ b/tools/purge/purge.1
@@ -260,7 +260,7 @@ Based on original squidpurge README.
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/purge.cc
+++ b/tools/purge/purge.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/signal.cc
+++ b/tools/purge/signal.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/signal.hh
+++ b/tools/purge/signal.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/socket.cc
+++ b/tools/purge/socket.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/socket.hh
+++ b/tools/purge/socket.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/squid-tlv.cc
+++ b/tools/purge/squid-tlv.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/purge/squid-tlv.hh
+++ b/tools/purge/squid-tlv.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/Makefile.am
+++ b/tools/squidclient/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/squidclient/Parameters.h
+++ b/tools/squidclient/Parameters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/Ping.cc
+++ b/tools/squidclient/Ping.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/Ping.h
+++ b/tools/squidclient/Ping.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/Transport.cc
+++ b/tools/squidclient/Transport.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/Transport.h
+++ b/tools/squidclient/Transport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/gssapi_support.cc
+++ b/tools/squidclient/gssapi_support.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/gssapi_support.h
+++ b/tools/squidclient/gssapi_support.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/squidclient.1
+++ b/tools/squidclient/squidclient.1
@@ -236,7 +236,7 @@ numerous individuals from the internet community.
 .
 .SH COPYRIGHT
 .PP
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/squidclient/squidclient.cc
+++ b/tools/squidclient/squidclient.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
  *
  * Squid software is distributed under GPLv2+ license and includes
  * contributions from numerous individuals and organizations.

--- a/tools/systemd/Makefile.am
+++ b/tools/systemd/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/systemd/squid.service
+++ b/tools/systemd/squid.service
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/sysvinit/Makefile.am
+++ b/tools/sysvinit/Makefile.am
@@ -1,4 +1,4 @@
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.

--- a/tools/sysvinit/squid.rc
+++ b/tools/sysvinit/squid.rc
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-## Copyright (C) 1996-2021 The Squid Software Foundation and contributors
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
 ##
 ## Squid software is distributed under GPLv2+ license and includes
 ## contributions from numerous individuals and organizations.


### PR DESCRIPTION
Besides routine formatting enforcement, this change contains flag-day
updates and code polishing from code removals performed in the latter
half of 2021 (e.g., HERE removal).


(summary) log from the script execution:

 UPDATE COPYRIGHT for ...
 NOTICE: File ... changed: by scripts/maintenance/HERE-obsolete
 NOTICE: File src/Makefile.am changed: by
   scripts/format-makefile-am.pl
 NOTICE: File src/sbuf/Stream.h changed: by
   scripts/maintenance/sort-includes.pl
 NOTICE: File src/tests/stub_store_client.cc changed: by
   scripts/maintenance/sort-includes.pl


If you are worried about hitting all this at once when rebasing a
 large patch you can split the rebase into steps as follows:

    git fetch --all
    git rebase [ commit ID prior to this one ]
    git rebase [ this commit's ID ]
    git rebase master
