### PR TITLE
Bug 5192: esi_parser default is incorrect

### DIFF
--- a/src/esi/Module.cc
+++ b/src/esi/Module.cc
@@ -22,8 +22,6 @@ static ESIParser::Register *prExpat = 0;
 
 void Esi::Init()
 {
-    // register in reverse order of preference.
-    // The latest registered parser will be used as default.
 #if HAVE_LIBEXPAT
     assert(!prExpat); // we should be called once
     prExpat = new ESIParser::Register("expat", &ESIExpatParser::NewParser);

--- a/src/esi/Parser.cc
+++ b/src/esi/Parser.cc
@@ -28,24 +28,24 @@ ESIParser::NewParser(ESIParserClient *aClient)
 {
     if (!Parser) {
         // if esi_parser is configured, use that
-        const char *use = Type;
-        if (!use || strcasecmp(use, "auto") == 0) {
+        const char *selectParserName = Type;
+        if (!selectParserName || strcasecmp(selectParserName, "auto") == 0) {
 #if HAVE_LIBXML2
             // libxml2 is the more secure. prefer when possible
-            use = "libxml2";
+            selectParserName = "libxml2";
 #else
             // expat is more widely available
-            use = "expat";
+            selectParserName = "expat";
 #endif
         }
 
         for (auto *p : GetRegistry()) {
-            if (p && strcasecmp(p->name, use) == 0)
+            if (p && strcasecmp(p->name, selectParserName) == 0)
                 Parser = p;
         }
 
         if (!Parser)
-            fatalf("Unknown ESI Parser type '%s'", use);
+            fatalf("Unknown ESI Parser type '%s'", selectParserName);
         debugs(86, 2, "Starting " << Parser->name << " ESI parser.");
     }
 

--- a/src/esi/Parser.cc
+++ b/src/esi/Parser.cc
@@ -27,11 +27,9 @@ ESIParser::Pointer
 ESIParser::NewParser(ESIParserClient *aClient)
 {
     if (!Parser) {
-        const char *use;
-        if (strcasecmp(Type, "auto") != 0) {
-            // if esi_parser is configured, use that
-            use = Type;
-        } else {
+        // if esi_parser is configured, use that
+        const char *use = Type;
+        if (!use || strcasecmp(use, "auto") == 0) {
 #if HAVE_LIBXML2
             // libxml2 is the more secure. prefer when possible
             use = "libxml2";

--- a/src/esi/Parser.cc
+++ b/src/esi/Parser.cc
@@ -9,7 +9,6 @@
 /* DEBUG: section 86    ESI processing */
 
 #include "squid.h"
-#include "base/TextException.h"
 #include "Debug.h"
 #include "esi/Parser.h"
 #include "fatal.h"

--- a/src/esi/Parser.cc
+++ b/src/esi/Parser.cc
@@ -46,7 +46,7 @@ ESIParser::NewParser(ESIParserClient *aClient)
 
         if (!Parser)
             fatalf("Unknown ESI Parser type '%s'", selectParserName);
-        debugs(86, 2, "Starting " << Parser->name << " ESI parser.");
+        debugs(86, 2, "selected ESI parser: " << Parser->name);
     }
 
     return (Parser->newParser)(aClient);


### PR DESCRIPTION
Since commit f5f7786 reversed the internal list order of ESI parser
registry, the esi_parser documentation and code comment in esi/Module.cc
have been incorrect.

Return ESI parsers to the documented default behaviour and make that
default explicit in the code selecting which Parser to initialize.

Also fixed an inverted test that resulted in the esi_parser configured
library _not_ to be the one used.
