### PR TITLE
Bug 5194: Remove all unused debug sections

### DIFF
--- a/doc/debug-sections.txt
+++ b/doc/debug-sections.txt
@@ -109,14 +109,10 @@ section 54    Windows Interprocess Communication
 section 55    HTTP Header
 section 57    HTTP Status-line
 section 58    HTTP Reply (Response)
-section 59    auto-growing Memory Buffer with printf
 section 61    Redirector
-section 62    Generic Histogram
-section 63    Low Level Memory Pool Management
 section 64    HTTP Range Header
 section 65    HTTP Cache Control Header
 section 66    HTTP Header Tools
-section 67    String
 section 68    HTTP Content-Range Header
 section 70    Cache Digest
 section 71    Store Digest Manager

--- a/doc/debug-sections.txt
+++ b/doc/debug-sections.txt
@@ -107,7 +107,6 @@ section 53    Radix Tree data structure implementation
 section 54    Interprocess Communication
 section 54    Windows Interprocess Communication
 section 55    HTTP Header
-section 56    HTTP Message Body
 section 57    HTTP Status-line
 section 58    HTTP Reply (Response)
 section 59    auto-growing Memory Buffer with printf

--- a/src/HttpBody.cc
+++ b/src/HttpBody.cc
@@ -6,8 +6,6 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-/* DEBUG: section 56    HTTP Message Body */
-
 #include "squid.h"
 #include "base/Packable.h"
 #include "HttpBody.h"

--- a/src/MemBuf.cc
+++ b/src/MemBuf.cc
@@ -6,8 +6,6 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-/* DEBUG: section 59    auto-growing Memory Buffer with printf */
-
 /**
  \verbatim
  * Rationale:

--- a/src/StatHist.cc
+++ b/src/StatHist.cc
@@ -6,8 +6,6 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-/* DEBUG: section 62    Generic Histogram */
-
 #include "squid.h"
 #include "StatHist.h"
 

--- a/src/String.cc
+++ b/src/String.cc
@@ -6,8 +6,6 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-/* DEBUG: section 67    String */
-
 #include "squid.h"
 #include "base/TextException.h"
 #include "mgr/Registration.h"

--- a/src/mem/Pool.cc
+++ b/src/mem/Pool.cc
@@ -7,7 +7,6 @@
  */
 
 /*
- * DEBUG: section 63    Low Level Memory Pool Management
  * AUTHOR: Alex Rousskov, Andres Kroonmaa, Robert Collins
  */
 

--- a/src/mem/PoolChunked.cc
+++ b/src/mem/PoolChunked.cc
@@ -7,7 +7,6 @@
  */
 
 /*
- * DEBUG: section 63    Low Level Memory Pool Management
  * AUTHOR: Alex Rousskov, Andres Kroonmaa, Robert Collins
  */
 

--- a/src/mem/PoolMalloc.cc
+++ b/src/mem/PoolMalloc.cc
@@ -7,7 +7,6 @@
  */
 
 /*
- * DEBUG: section 63    Low Level Memory Pool Management
  * AUTHOR: Alex Rousskov, Andres Kroonmaa, Robert Collins, Henrik Nordstrom
  */
 


### PR DESCRIPTION
... that we can find quickly.

Naming/documenting debugging sections is a good idea, but that should
not be done in every source code file that relies on that section. We
cannot remove all such DEBUG: declarations without developing a proper
way to name/document sections, but we can (and, given Bug 5194
existence, probably should) remove the unused ones -- their removal does
not remove any immediately usable info.

Bug 5194 report was specific to Section 56: Folks misinterpret section
56 "HTTP Message Body" title as promising to dump message bodies to
cache.log, which is not a functionality that should be driven by a
debugging section. Currently, Squid lacks such functionality.