### PR TITLE
Moved regcomp(3)-specific RegexPattern code inside RegexPattern     Also moved non-ACL regex configuration parsing code inside ConfigParser. It is possible to move ACL (data) regex configuration parsing code as well, but that move is a lot more complex due to regex-pattern-joining optimizations, and there are no immediate plans to support non-regcomp(3) regexes in ACL data. We may do that move later as we get more experience with non-regcomp(3) regexes and decide to join them too.     These moves clean up existing regex-using code and allow adding support for non-regcomp(3) regexes (e.g., regexes based on C++11 <regex>) without adjusting ConfigParser::regex() callers. Such support would also require "virtualizing" RegexPattern. To avoid increasing complexity and hurting performance, that (simpler) step should be done only if we decide to actually add support for non-regcomp(3) regexes.

### DIFF
--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "acl/Gadgets.h"
 #include "base/Here.h"
+#include "base/RegexPattern.h"
 #include "cache_cf.h"
 #include "ConfigParser.h"
 #include "Debug.h"
@@ -477,17 +478,29 @@ ConfigParser::RegexStrtokFile()
     return token;
 }
 
-char *
-ConfigParser::RegexPattern()
+RegexPattern *
+ConfigParser::regex(const char *expectedRegexDescription)
 {
-    if (ConfigParser::RecognizeQuotedValues) {
-        debugs(3, DBG_CRITICAL, "FATAL: Can not read regex expression while configuration_includes_quoted_values is enabled");
-        self_destruct();
-    }
+    if (RecognizeQuotedValues)
+        throw TextException("Cannot read regex expression while configuration_includes_quoted_values is enabled", Here());
+
+    SBuf pattern;
+    int flags = REG_EXTENDED | REG_NOSUB;
+
     ConfigParser::RecognizeQuotedPair_ = true;
-    char * token = NextToken();
+    const auto flagOrPattern = token(expectedRegexDescription);
+    if (flagOrPattern.cmp("-i") == 0) {
+        flags |= REG_ICASE;
+        pattern = token(expectedRegexDescription);
+    } else if (flagOrPattern.cmp("+i") == 0) {
+        flags &= ~REG_ICASE;
+        pattern = token(expectedRegexDescription);
+    } else {
+        pattern = flagOrPattern;
+    }
     ConfigParser::RecognizeQuotedPair_ = false;
-    return token;
+
+    return new RegexPattern(pattern.c_str(), flags);
 }
 
 char *

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -500,7 +500,7 @@ ConfigParser::regex(const char *expectedRegexDescription)
     }
     ConfigParser::RecognizeQuotedPair_ = false;
 
-    return std::unique_ptr<RegexPattern>(new RegexPattern(pattern.c_str(), flags));
+    return std::unique_ptr<RegexPattern>(new RegexPattern(pattern, flags));
 }
 
 char *

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -478,7 +478,7 @@ ConfigParser::RegexStrtokFile()
     return token;
 }
 
-RegexPattern *
+std::unique_ptr<RegexPattern>
 ConfigParser::regex(const char *expectedRegexDescription)
 {
     if (RecognizeQuotedValues)
@@ -500,7 +500,7 @@ ConfigParser::regex(const char *expectedRegexDescription)
     }
     ConfigParser::RecognizeQuotedPair_ = false;
 
-    return new RegexPattern(pattern.c_str(), flags);
+    return std::unique_ptr<RegexPattern>(new RegexPattern(pattern.c_str(), flags));
 }
 
 char *

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -14,6 +14,7 @@
 #include "sbuf/forward.h"
 #include "SquidString.h"
 
+#include <memory>
 #include <queue>
 #include <stack>
 #include <string>
@@ -73,7 +74,7 @@ public:
     Acl::Tree *optionalAclList();
 
     /// extracts and returns a regex (including any optional flags)
-    RegexPattern *regex(const char *expectedRegexDescription);
+    std::unique_ptr<RegexPattern> regex(const char *expectedRegexDescription);
 
     static void ParseUShort(unsigned short *var);
     static void ParseBool(bool *var);

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -10,6 +10,7 @@
 #define SQUID_CONFIGPARSER_H
 
 #include "acl/forward.h"
+#include "base/forward.h"
 #include "sbuf/forward.h"
 #include "SquidString.h"
 
@@ -71,6 +72,9 @@ public:
     /// parses an [if [!]<acl>...] construct
     Acl::Tree *optionalAclList();
 
+    /// extracts and returns a regex (including any optional flags)
+    RegexPattern *regex(const char *expectedRegexDescription);
+
     static void ParseUShort(unsigned short *var);
     static void ParseBool(bool *var);
     static const char *QuoteString(const String &var);
@@ -97,12 +101,6 @@ public:
      * set to 'off' this interprets the quoted tokens as filenames.
      */
     static char *RegexStrtokFile();
-
-    /**
-     * Parse the next token as a regex pattern. The regex patterns are non quoted
-     * tokens.
-     */
-    static char *RegexPattern();
 
     /**
      * Parse the next token with support for quoted values enabled even if

--- a/src/RefreshPattern.h
+++ b/src/RefreshPattern.h
@@ -93,9 +93,9 @@ private:
 };
 
 inline std::ostream &
-operator <<(std::ostream &os, const RefreshPattern &rp)
+operator <<(std::ostream &os, const RefreshPattern &r)
 {
-    rp.printHead(os);
+    r.printHead(os);
     return os;
 }
 

--- a/src/RefreshPattern.h
+++ b/src/RefreshPattern.h
@@ -11,6 +11,8 @@
 
 #include "base/RegexPattern.h"
 
+#include <memory>
+
 /// a representation of a refresh pattern.
 class RefreshPattern
 {
@@ -26,11 +28,15 @@ public:
      */
 #define REFRESH_DEFAULT_MAX static_cast<time_t>(259200)
 
-    RefreshPattern(const char *aPattern, const decltype(RegexPattern::flags) &reFlags) :
-        pattern(reFlags, aPattern),
+    using RegexPointer = std::unique_ptr<RegexPattern>;
+
+    // If given a regex, becomes its owner, creating an explicit refresh_pattern
+    // rule. Otherwise, creates an implicit/default refresh_pattern rule.
+    explicit RefreshPattern(RegexPointer regex):
         min(0), pct(0.20), max(REFRESH_DEFAULT_MAX),
         next(NULL),
-        max_stale(0)
+        max_stale(0),
+        regex_(std::move(regex))
     {
         memset(&flags, 0, sizeof(flags));
     }
@@ -42,9 +48,7 @@ public:
             delete t;
         }
     }
-    // ~RefreshPattern() default destructor is fine
 
-    RegexPattern pattern;
     time_t min;
     double pct;
     time_t max;
@@ -72,7 +76,28 @@ public:
         uint64_t matchCount;
         // TODO: some stats to indicate how useful/less the flags are would be nice.
     } stats;
+
+    /// reports configuration excluding trailing options
+    void printHead(std::ostream &) const;
+
+    /// reports the configured pattern or a fake pattern of the implicit rule
+    void printPattern(std::ostream &os) const;
+
+    // TODO: Refactor external refresh_pattern rules iterators to make private.
+    /// configured regex; do not use except when iterating configured rules
+    const RegexPattern &regex() const;
+
+private:
+    /// configured regex or, for the implicit refresh_pattern rule, nil
+    RegexPointer regex_;
 };
+
+inline std::ostream &
+operator <<(std::ostream &os, const RefreshPattern &rp)
+{
+    rp.printHead(os);
+    return os;
+}
 
 #endif /* SQUID_REFRESHPATTERN_H_ */
 

--- a/src/acl/RegexData.cc
+++ b/src/acl/RegexData.cc
@@ -125,7 +125,7 @@ compileREs(std::list<RegexPattern> &curlist, const SBufList &RE, int flags)
  * The ultimate goal is to have only one RE per ACL so that match() is
  * called only once per ACL.
  */
-static int
+static void
 compileOptimisedREs(std::list<RegexPattern> &curlist, const SBufList &sl, const int flagsAtLineStart)
 {
     std::list<RegexPattern> newlist;
@@ -195,8 +195,6 @@ compileOptimisedREs(std::list<RegexPattern> &curlist, const SBufList &sl, const 
         debugs(28, (opt_parse_cfg_only?DBG_IMPORTANT:2), "WARNING: there are more than 100 regular expressions. " <<
                "Consider using less REs or use rules without expressions like 'dstdomain'.");
     }
-
-    return 1;
 }
 
 static void
@@ -216,7 +214,8 @@ compileUnoptimisedREs(std::list<RegexPattern> &curlist, const SBufList &sl, cons
             } catch (...) {
                 // TODO: Make these configuration failures fatal (by default).
                 debugs(28, DBG_CRITICAL, "ERROR: Skipping regular expression: '" << configurationLineWord << "'" <<
-                       Debug::Extra << "compilation failure: " << CurrentException);
+                       Debug::Extra << "configuration: " << cfg_filename << " line " << config_lineno << ": " << config_input_line <<
+                       Debug::Extra << "regex compilation failure: " << CurrentException);
             }
         }
     }
@@ -247,7 +246,9 @@ ACLRegexData::parse()
         compileOptimisedREs(data, sl, flagsAtLineStart);
     } catch (...) {
         debugs(28, DBG_IMPORTANT, "WARNING: optimisation of regular expressions failed; using fallback method without optimisation" <<
+               Debug::Extra << "configuration: " << cfg_filename << " line " << config_lineno << ": " << config_input_line <<
                Debug::Extra << "optimisation failure: " << CurrentException);
+
         compileUnoptimisedREs(data, sl, flagsAtLineStart);
     }
 }

--- a/src/base/RegexPattern.cc
+++ b/src/base/RegexPattern.cc
@@ -8,18 +8,54 @@
 
 #include "squid.h"
 #include "base/RegexPattern.h"
+#include "base/TextException.h"
+#include "Debug.h"
+#include "sbuf/Stream.h"
+
+#include <iostream>
 #include <utility>
 
-RegexPattern::RegexPattern(int aFlags, const char *aPattern) :
-    flags(aFlags),
-    pattern(xstrdup(aPattern))
+RegexPattern::RegexPattern(const char * const aPattern, const int aFlags):
+    pattern(xstrdup(aPattern)),
+    flags(aFlags)
 {
-    memset(&regex, 0, sizeof(regex));
+    memset(&regex, 0, sizeof(regex)); // paranoid; POSIX does not require this
+    if (const auto errCode = regcomp(&regex, pattern, flags)) {
+        char errBuf[256];
+        // for simplicity, ignore any error message truncation
+        (void)regerror(errCode, &regex, errBuf, sizeof(errBuf));
+        // POSIX examples show no regfree(&regex) after a regcomp() error;
+        // presumably, regcom() frees any allocated memory on failures
+        throw TextException(ToSBuf("POSIX regcomp(3) failure: (", errCode, ") ", errBuf,
+            Debug::Extra, "regular expression: ", pattern), Here());
+        // XXX: Leaking pattern
+    }
+
+    debugs(28, 2, *this);
 }
 
 RegexPattern::~RegexPattern()
 {
     xfree(pattern);
     regfree(&regex);
+}
+
+void
+RegexPattern::print(std::ostream &os, const RegexPattern * const previous) const
+{
+    // report context-dependent explicit options and delimiters
+    if (!previous) {
+        // do not report default settings
+        if (!caseSensitive())
+            os << "-i ";
+    } else {
+        os << ' '; // separate us from the previous value
+
+        // do not report same-as-previous (i.e. inherited) settings
+        if (previous->flags != flags)
+            os << (caseSensitive() ? "+i " : "-i ");
+    }
+
+    os << pattern;
 }
 

--- a/src/base/RegexPattern.cc
+++ b/src/base/RegexPattern.cc
@@ -27,7 +27,7 @@ RegexPattern::RegexPattern(const SBuf &aPattern, const int aFlags):
         // POSIX examples show no regfree(&regex) after a regcomp() error;
         // presumably, regcom() frees any allocated memory on failures
         throw TextException(ToSBuf("POSIX regcomp(3) failure: (", errCode, ") ", errBuf,
-            Debug::Extra, "regular expression: ", pattern), Here());
+                                   Debug::Extra, "regular expression: ", pattern), Here());
     }
 
     debugs(28, 2, *this);

--- a/src/base/RegexPattern.cc
+++ b/src/base/RegexPattern.cc
@@ -17,29 +17,9 @@ RegexPattern::RegexPattern(int aFlags, const char *aPattern) :
     memset(&regex, 0, sizeof(regex));
 }
 
-RegexPattern::RegexPattern(RegexPattern &&o) :
-    flags(std::move(o.flags)),
-    regex(std::move(o.regex)),
-    pattern(std::move(o.pattern))
-{
-    memset(&o.regex, 0, sizeof(o.regex));
-    o.pattern = nullptr;
-}
-
 RegexPattern::~RegexPattern()
 {
     xfree(pattern);
     regfree(&regex);
-}
-
-RegexPattern &
-RegexPattern::operator =(RegexPattern &&o)
-{
-    flags = std::move(o.flags);
-    regex = std::move(o.regex);
-    memset(&o.regex, 0, sizeof(o.regex));
-    pattern = std::move(o.pattern);
-    o.pattern = nullptr;
-    return *this;
 }
 

--- a/src/base/RegexPattern.cc
+++ b/src/base/RegexPattern.cc
@@ -15,12 +15,12 @@
 #include <iostream>
 #include <utility>
 
-RegexPattern::RegexPattern(const char * const aPattern, const int aFlags):
-    pattern(xstrdup(aPattern)),
+RegexPattern::RegexPattern(const SBuf &aPattern, const int aFlags):
+    pattern(aPattern),
     flags(aFlags)
 {
     memset(&regex, 0, sizeof(regex)); // paranoid; POSIX does not require this
-    if (const auto errCode = regcomp(&regex, pattern, flags)) {
+    if (const auto errCode = regcomp(&regex, pattern.c_str(), flags)) {
         char errBuf[256];
         // for simplicity, ignore any error message truncation
         (void)regerror(errCode, &regex, errBuf, sizeof(errBuf));
@@ -28,7 +28,6 @@ RegexPattern::RegexPattern(const char * const aPattern, const int aFlags):
         // presumably, regcom() frees any allocated memory on failures
         throw TextException(ToSBuf("POSIX regcomp(3) failure: (", errCode, ") ", errBuf,
             Debug::Extra, "regular expression: ", pattern), Here());
-        // XXX: Leaking pattern
     }
 
     debugs(28, 2, *this);
@@ -36,7 +35,6 @@ RegexPattern::RegexPattern(const char * const aPattern, const int aFlags):
 
 RegexPattern::~RegexPattern()
 {
-    xfree(pattern);
     regfree(&regex);
 }
 

--- a/src/base/RegexPattern.h
+++ b/src/base/RegexPattern.h
@@ -22,21 +22,44 @@ class RegexPattern
 
 public:
     RegexPattern() = delete;
-    RegexPattern(int aFlags, const char *aPattern);
+    RegexPattern(const char *aPattern, int aFlags);
     ~RegexPattern();
 
     RegexPattern(RegexPattern &&) = delete; // no copying of any kind
 
     const char * c_str() const {return pattern;}
+
+    /// whether the regex differentiates letter case
+    bool caseSensitive() const { return !(flags & REG_ICASE); }
+
+    /// Whether this is an "any single character" regex ("."). In some contexts,
+    /// that regex is (ab)used as a special "should match anything" default.
+    bool isDot() const { return *pattern == '.' && !*pattern; }
+
     bool match(const char *str) const {return regexec(&regex,str,0,NULL,0)==0;}
 
-public:
-    int flags;
-    regex_t regex;
+    /// Attempts to reproduce this regex (context-sensitive) configuration.
+    /// If the previous regex is nil, may not report default flags.
+    /// Otherwise, may not report same-as-previous flags (and prepends a space).
+    void print(std::ostream &os, const RegexPattern *previous = nullptr) const;
 
 private:
-    char *pattern;
+    /// a regular expression in the text form, suitable for regcomp(3)
+    char * const pattern;
+
+    /// bitmask of REG_* flags for regcomp(3)
+    const int flags;
+
+    /// a "compiled pattern buffer" filled by regcomp(3) for regexec(3)
+    regex_t regex;
 };
+
+inline std::ostream &
+operator <<(std::ostream &os, const RegexPattern &rp)
+{
+    rp.print(os);
+    return os;
+}
 
 #endif /* SQUID_SRC_BASE_REGEXPATTERN_H */
 

--- a/src/base/RegexPattern.h
+++ b/src/base/RegexPattern.h
@@ -11,6 +11,7 @@
 
 #include "compat/GnuRegex.h"
 #include "mem/forward.h"
+#include "sbuf/SBuf.h"
 
 /**
  * A regular expression,
@@ -22,19 +23,17 @@ class RegexPattern
 
 public:
     RegexPattern() = delete;
-    RegexPattern(const char *aPattern, int aFlags);
+    RegexPattern(const SBuf &aPattern, int aFlags);
     ~RegexPattern();
 
     RegexPattern(RegexPattern &&) = delete; // no copying of any kind
-
-    const char * c_str() const {return pattern;}
 
     /// whether the regex differentiates letter case
     bool caseSensitive() const { return !(flags & REG_ICASE); }
 
     /// Whether this is an "any single character" regex ("."). In some contexts,
     /// that regex is (ab)used as a special "should match anything" default.
-    bool isDot() const { return *pattern == '.' && !*pattern; }
+    bool isDot() const { return pattern.length() == 1 && pattern[0] == '.'; }
 
     bool match(const char *str) const {return regexec(&regex,str,0,NULL,0)==0;}
 
@@ -45,7 +44,7 @@ public:
 
 private:
     /// a regular expression in the text form, suitable for regcomp(3)
-    char * const pattern;
+    SBuf pattern;
 
     /// bitmask of REG_* flags for regcomp(3)
     const int flags;

--- a/src/base/RegexPattern.h
+++ b/src/base/RegexPattern.h
@@ -25,12 +25,7 @@ public:
     RegexPattern(int aFlags, const char *aPattern);
     ~RegexPattern();
 
-    // regex type varies by library, usually not safe to copy
-    RegexPattern(const RegexPattern &) = delete;
-    RegexPattern &operator =(const RegexPattern &) = delete;
-
-    RegexPattern(RegexPattern &&);
-    RegexPattern &operator =(RegexPattern &&);
+    RegexPattern(RegexPattern &&) = delete; // no copying of any kind
 
     const char * c_str() const {return pattern;}
     bool match(const char *str) const {return regexec(&regex,str,0,NULL,0)==0;}

--- a/src/base/forward.h
+++ b/src/base/forward.h
@@ -15,6 +15,7 @@ class CallDialer;
 class CodeContext;
 class ScopedId;
 class BadOptionalAccess;
+class RegexPattern;
 
 template <typename Value> class Optional;
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2779,7 +2779,7 @@ parse_refreshpattern(RefreshPattern ** head)
     int i;
     RefreshPattern *t;
 
-    RefreshPattern::RegexPointer regex(LegacyParser.regex("refresh_pattern regex"));
+    auto regex = LegacyParser.regex("refresh_pattern regex");
 
     i = GetInteger();       /* token: min */
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2713,13 +2713,11 @@ static void
 dump_refreshpattern(StoreEntry * entry, const char *name, RefreshPattern * head)
 {
     while (head != NULL) {
-        storeAppendPrintf(entry, "%s%s %s %d %d%% %d",
-                          name,
-                          head->pattern.flags&REG_ICASE ? " -i" : null_string,
-                          head->pattern.c_str(),
-                          (int) head->min / 60,
-                          (int) (100.0 * head->pct + 0.5),
-                          (int) head->max / 60);
+        SBufStream os;
+        os << name << ' ';
+        head->printHead(os);
+        const auto prefix = os.buf();
+        entry->append(prefix.rawContent(), prefix.length());
 
         if (head->max_stale >= 0)
             storeAppendPrintf(entry, " max-stale=%d", head->max_stale);
@@ -2761,7 +2759,6 @@ static void
 parse_refreshpattern(RefreshPattern ** head)
 {
     char *token;
-    char *pattern;
     time_t min = 0;
     double pct = 0.0;
     time_t max = 0;
@@ -2781,29 +2778,8 @@ parse_refreshpattern(RefreshPattern ** head)
 
     int i;
     RefreshPattern *t;
-    regex_t comp;
-    int errcode;
-    int flags = REG_EXTENDED | REG_NOSUB;
 
-    if ((token = ConfigParser::RegexPattern()) != NULL) {
-
-        if (strcmp(token, "-i") == 0) {
-            flags |= REG_ICASE;
-            token = ConfigParser::RegexPattern();
-        } else if (strcmp(token, "+i") == 0) {
-            flags &= ~REG_ICASE;
-            token = ConfigParser::RegexPattern();
-        }
-
-    }
-
-    if (token == NULL) {
-        debugs(3, DBG_CRITICAL, "FATAL: refresh_pattern missing the regex pattern parameter");
-        self_destruct();
-        return;
-    }
-
-    pattern = xstrdup(token);
+    RefreshPattern::RegexPointer regex(LegacyParser.regex("refresh_pattern regex"));
 
     i = GetInteger();       /* token: min */
 
@@ -2870,22 +2846,12 @@ parse_refreshpattern(RefreshPattern ** head)
                   ) {
             debugs(22, DBG_PARSE_NOTE(2), "UPGRADE: refresh_pattern option '" << token << "' is obsolete. Remove it.");
         } else
-            debugs(22, DBG_CRITICAL, "ERROR: refreshAddToList: Unknown option '" << pattern << "': " << token);
-    }
-
-    if ((errcode = regcomp(&comp, pattern, flags)) != 0) {
-        char errbuf[256];
-        regerror(errcode, &comp, errbuf, sizeof errbuf);
-        debugs(22, DBG_CRITICAL, "" << cfg_filename << " line " << config_lineno << ": " << config_input_line);
-        debugs(22, DBG_CRITICAL, "ERROR: refreshAddToList: Invalid regular expression '" << pattern << "': " << errbuf);
-        xfree(pattern);
-        return;
+            debugs(22, DBG_CRITICAL, "ERROR: Unknown refresh_pattern option: " << token);
     }
 
     pct = pct < 0.0 ? 0.0 : pct;
     max = max < 0 ? 0 : max;
-    t = new RefreshPattern(pattern, flags);
-    t->pattern.regex = comp;
+    t = new RefreshPattern(std::move(regex));
     t->min = min;
     t->pct = pct;
     t->max = max;
@@ -2925,8 +2891,6 @@ parse_refreshpattern(RefreshPattern ** head)
         head = &(*head)->next;
 
     *head = t;
-
-    xfree(pattern);
 }
 
 static void

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -740,10 +740,10 @@ RefreshPattern::printHead(std::ostream &os) const
 {
     printPattern(os);
     os <<
-        // these adjustments are safe: raw values were configured using integers
-        ' ' << intmax_t(min/60) << // to minutes
-        ' ' << intmax_t(100.0 * pct + 0.5) << '%' << // to percentage points
-        ' ' << intmax_t(max/60); // to minutes
+       // these adjustments are safe: raw values were configured using integers
+       ' ' << intmax_t(min/60) << // to minutes
+       ' ' << intmax_t(100.0 * pct + 0.5) << '%' << // to percentage points
+       ' ' << intmax_t(max/60); // to minutes
 }
 
 static void


### PR DESCRIPTION
The above changes allowed us to improve RegexData error reporting: Squid
no longer reports REs _optimization_ failure when it is an individual RE
that is broken (and reported as such). Squid still ignores the fact that
broken REs can be "optimized" into a completely "different" valid
combined RE: We do not compile individual REs unless optimization fails.

Also simplified and polished affected code.