### PR TITLE
Improve coredump_dir on FreeBSD and Solaris based OS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2701,6 +2701,7 @@ AC_CHECK_HEADERS( \
   netinet/tcp.h \
   paths.h \
   poll.h \
+  priv.h \
   pwd.h \
   regex.h \
   sched.h \
@@ -2718,6 +2719,7 @@ AC_CHECK_HEADERS( \
   sys/ipc.cc \
   sys/param.h \
   sys/prctl.h \
+  sys/procctl.h \
   sys/md5.h \
   sys/mman.h \
   sys/msg.h \
@@ -3187,6 +3189,7 @@ AC_CHECK_FUNCS(\
 	mstats \
 	poll \
 	prctl \
+	procctl \
 	pthread_attr_setschedparam \
 	pthread_attr_setscope \
 	pthread_setschedparam \
@@ -3203,6 +3206,7 @@ AC_CHECK_FUNCS(\
 	select \
 	seteuid \
 	setgroups \
+	setpflags \
 	setpgrp \
 	setsid \
 	sigaction \

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -5639,6 +5639,12 @@ DOC_START
 	that exists, Squid will chdir() to that directory at startup
 	and coredump files will be left there.
 
+	Linux, FreeBSD, Solaris/Illumos:
+
+	Note on supported platforms, the processes permissions are updated
+	to be able to be traced in order to be able to generate a core
+	file.
+
 CONFIG_START
 
 # Leave coredumps in the first cache dir

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -5642,9 +5642,7 @@ DOC_START
 	In addition to changing the directory, the process permissions are updated
 	to enable process tracing and/or coredump file generation. The details are
 	OS-specific, but look for prctl(2) PR_SET_DUMPABLE and procctl(2)
-	PROC_TRACE_CTL documentation as guiding examples. If Squid does not know
-	how to update relevant process permissions in your build environment, it
-	logs an ENOSYS-based ERROR message.
+	PROC_TRACE_CTL documentation as guiding examples.
 
 CONFIG_START
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -5639,11 +5639,12 @@ DOC_START
 	that exists, Squid will chdir() to that directory at startup
 	and coredump files will be left there.
 
-	Linux, FreeBSD, Solaris/Illumos:
-
-	Note on supported platforms, the processes permissions are updated
-	to be able to be traced in order to be able to generate a core
-	file.
+	In addition to changing the directory, the process permissions are updated
+	to enable process tracing and/or coredump file generation. The details are
+	OS-specific, but look for prctl(2) PR_SET_DUMPABLE and procctl(2)
+	PROC_TRACE_CTL documentation as guiding examples. If Squid does not know
+	how to update relevant process permissions in your build environment, it
+	logs an ENOSYS-based ERROR message.
 
 CONFIG_START
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -302,6 +302,7 @@ makeTraceable()
         handleError("setpflags(__PROC_PROTECT)", errno);
 #else
     debugs(50, 2, "WARNING: Assuming this process is traceable");
+    (void)handleError; // just "use" the variable; there is no error here
 #endif
 }
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -283,7 +283,7 @@ rusage_pagefaults(struct rusage *r)
 /// Traceable processes may support attachment via ptrace(2) or ktrace(2),
 /// debugging sysctls, hwpmc(4), dtrace(1) and core dumping.
 static void
-makeTraceable(void)
+makeTraceable()
 {
     const auto handleError = [](const char * const syscall, const int savedErrno) {
         throw TextException(ToSBuf(syscall, " failure: ", xstrerr(savedErrno)), Here());
@@ -292,9 +292,9 @@ makeTraceable(void)
     if (prctl(PR_SET_DUMPABLE, 1) != 0)
         handleError("prctl(PR_SET_DUMPABLE)", errno);
 #elif HAVE_PROCCTL && defined(PROC_TRACE_CTL)
-	// TODO: when FreeBSD 14 becomes the lowest version, we can
-	// possibly save one getpid syscall, for now still necessary.
-	int traceable = PROC_TRACE_CTL_ENABLE;
+    // TODO: when FreeBSD 14 becomes the lowest version, we can
+    // possibly save one getpid syscall, for now still necessary.
+    int traceable = PROC_TRACE_CTL_ENABLE;
     if (procctl(P_PID, getpid(), PROC_TRACE_CTL, &traceable) != 0)
         handleError("procctl(PROC_TRACE_CTL_ENABLE)", errno);
 #elif HAVE_SETPFLAGS
@@ -305,7 +305,8 @@ makeTraceable(void)
 #endif
 }
 
-/// Make the process traceable if necessary. \sa makeTraceable()
+/// Make the process traceable if necessary.
+/// \sa makeTraceable()
 static void
 setTraceability()
 {
@@ -631,7 +632,6 @@ enter_suid(void)
         debugs(21, 3, "setuid(0) failed: " << xstrerr(xerrno));
     }
 #endif
-
 
     setTraceability();
 }

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -279,9 +279,8 @@ rusage_pagefaults(struct rusage *r)
 #endif
 }
 
-// Traceable processes may support attachment via ptrace(2) or ktrace(2)
-// debugging sysctls, hwpmc(4), dtrace(1) and core dumping.
-
+/// Traceable processes may support attachment via ptrace(2) or ktrace(2),
+/// debugging sysctls, hwpmc(4), dtrace(1) and core dumping.
 static int
 makeTraceable(void)
 {

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -279,9 +279,11 @@ rusage_pagefaults(struct rusage *r)
 #endif
 }
 
-int
+// Traceable processes may support attachment via ptrace(2) or ktrace(2)
+// debugging sysctls, hwpmc(4), dtrace(1) and core dumping.
 
-proc_settraceable(void)
+static int
+makeTraceable(void)
 {
 #if HAVE_PRCTL && defined(PR_SET_DUMPABLE)
 	return prctl(PR_SET_DUMPABLE, 1);
@@ -588,9 +590,9 @@ leave_suid(void)
 
     restoreCapabilities(true);
 
-    if (Config.coredump_dir && proc_settraceable() != 0) {
+    if (Config.coredump_dir && makeTraceable() != 0) {
         int xerrno = errno;
-        debugs(50, 2, "ALERT: proc_settraceable: " << xstrerr(xerrno));
+        debugs(50, DBG_IMPORTANT, "ERROR: failed to make the process traceable:" << xstrerr(xerrno));
     }
 }
 
@@ -612,9 +614,9 @@ enter_suid(void)
     }
 #endif
 
-    if (Config.coredump_dir && proc_settraceable() != 0) {
+    if (Config.coredump_dir && makeTraceable() != 0) {
         int xerrno = errno;
-        debugs(50, 2, "ALERT: proc_settraceable: " << xstrerr(xerrno));
+        debugs(50, DBG_IMPORTANT, "ERROR: failed to make the process traceable:" << xstrerr(xerrno));
     }
 }
 
@@ -641,9 +643,9 @@ no_suid(void)
 
     restoreCapabilities(false);
 
-    if (Config.coredump_dir && proc_settraceable() != 0) {
+    if (Config.coredump_dir && makeTraceable() != 0) {
         int xerrno = errno;
-        debugs(50, 2, "ALERT: proc_settraceable: " << xstrerr(xerrno));
+        debugs(50, DBG_IMPORTANT, "ERROR: failed to make the process traceable:" << xstrerr(xerrno));
     }
 }
 


### PR DESCRIPTION
Disclose that coredump_dir may also make the process "traceable",
including enabling core dumps and ptrace(2) attachments in certain
environments.

Add support for making the process traceable in FreeBSD- and
Solaris-like environments.

When Squid does not know how to make the process traceable in a given
environment, it does nothing under the assumption that the process is
already traceable enough (by default) to dump cores. Alternatively, we
could warn the admin about the lack of tracing support for that
environment. It is not clear which option is better, but we are betting
on the processes being traceable by default in most not explicitly
covered environments.
