### PR TITLE
Fix FreeBSD 14 build

### DIFF
--- a/src/CpuAffinitySet.cc
+++ b/src/CpuAffinitySet.cc
@@ -38,7 +38,7 @@ CpuAffinitySet::apply()
     } else {
         cpu_set_t cpuSet;
         memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
-        (void) CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+        CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
         if (CPU_COUNT(&cpuSet) <= 0) {
             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
                    "PID " << getpid() << ", may be caused by an invalid core in "

--- a/src/comm/Tcp.cc
+++ b/src/comm/Tcp.cc
@@ -15,6 +15,9 @@
 #if HAVE_NETINET_TCP_H
 #include <netinet/tcp.h>
 #endif
+#if HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
 #if HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif


### PR DESCRIPTION
FreeBSD 14 defines 3-parameter CPU_AND() macro as a `do {} while` loop.
Our (void) in front of that loop creates a syntax error.

    CpuAffinitySet.cc:41:16: error: expected expression 
    (void) CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);

That (void) was added in commit 7ec6d51 to "remove GNU-specific syntax",
but we cannot tell what specific problem that 10-year old change solved.
Known 3-parameter CPU_AND(3) documentation says the call returns void.

Also included a missing header providing IPPROTO_TCP definition.