### PR TITLE
Bug 5186: noteDestinationsEnd check failed: transportWait

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -641,7 +641,6 @@ FwdState::noteDestination(Comm::ConnectionPointer path)
     if (transporting())
         return; // and continue to receive destinations for backup
 
-    // This is the first path candidate we have seen. Use it.
     useDestinations();
 }
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -656,10 +656,7 @@ FwdState::noteDestinationsEnd(ErrorState *selectionError)
             debugs(17, 3, "Will abort forwarding because path selection has failed.");
             Must(!err); // if we tried to connect, then path selection succeeded
             fail(selectionError);
-        }
-        else if (err)
-            debugs(17, 3, "Will abort forwarding because all found paths have failed.");
-        else
+        } else
             debugs(17, 3, "Will abort forwarding because path selection found no paths.");
 
         useDestinations(); // will detect and handle the lack of paths

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -656,10 +656,9 @@ FwdState::noteDestinationsEnd(ErrorState *selectionError)
             debugs(17, 3, "Will abort forwarding because path selection has failed.");
             Must(!err); // if we tried to connect, then path selection succeeded
             fail(selectionError);
-        } else
-            debugs(17, 3, "Will abort forwarding because path selection found no paths.");
+        }
 
-        useDestinations(); // will detect and handle the lack of paths
+        stopAndDestroy("path selection found no paths");
         return;
     }
     // else continue to use one of the previously noted destinations;
@@ -672,7 +671,16 @@ FwdState::noteDestinationsEnd(ErrorState *selectionError)
         return; // and continue to wait for FwdState::noteConnection() callback
     }
 
-    Must(transporting()); // or we would be stuck with nothing to do or wait for
+    if (transporting()) {
+        // We are already using a previously opened connection (but were also
+        // receiving more destinations in case we need to re-forward).
+        debugs(17, 7, "keep transporting");
+        return;
+    }
+
+    // destinationsFound, but none of them worked, and we were waiting for more
+    assert(err);
+    stopAndDestroy("all found paths have failed");
 }
 
 /// makes sure connection opener knows that the destinations have changed

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -98,7 +98,8 @@ public:
         return (server.conn != NULL && server.conn->getPeer() ? server.conn->getPeer()->host : request->url.host());
     };
 
-    /// start owning the given to-server connection; do not look for any other
+    /// store the given to-server connection; prohibit retries and do not look
+    /// for any other destinations
     void commitToServer(const Comm::ConnectionPointer &);
 
     /// Whether the client sent a CONNECT request to us.

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -190,7 +190,7 @@ public:
     /// was unexpectedly closed
     bool retriable;
 
-    /// whether we will not consider using any other server
+    /// whether the decision to tunnel to a particular destination was final
     bool committedToServer;
 
     // TODO: remove after fixing deferred reads in TunnelStateData::copyRead()

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1308,7 +1308,9 @@ TunnelStateData::noteDestinationsEnd(ErrorState *selectionError)
 bool
 TunnelStateData::usingDestination() const
 {
-    return encryptionWait || peerWait || Comm::IsConnOpen(server.conn);
+    // server.conn->close() does not end usingDestination(); we may receive new
+    // paths while server.conn is closing (XXX: and client is still writing)
+    return encryptionWait || peerWait || server.conn;
 }
 
 /// remembers an error to be used if there will be no more connection attempts

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1295,6 +1295,7 @@ TunnelStateData::noteDestinationsEnd(ErrorState *selectionError)
     if (usingDestination()) {
         // We are already using a previously opened connection (but were also
         // receiving more destinations in case we need to re-forward).
+        debugs(17, 7, "keep transporting");
         return;
     }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1275,8 +1275,9 @@ TunnelStateData::noteDestinationsEnd(ErrorState *selectionError)
         if (selectionError)
             return sendError(selectionError, "path selection has failed");
 
+        // TODO: Merge with FwdState and remove this likely unnecessary check.
         if (savedError)
-            return sendError(savedError, "early error (TODO: impossible?) and no paths to try");
+            return sendError(savedError, "path selection found no paths (with an impossible early error)");
 
         return sendError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al),
                          "path selection found no paths");

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1297,6 +1297,7 @@ TunnelStateData::noteDestinationsEnd(ErrorState *selectionError)
 
     // destinationsFound, but none of them worked, and we were waiting for more
     assert(savedError);
+    // XXX: Honor clientExpectsConnectResponse() before replying.
     sendError(savedError, "all found paths have failed");
 }
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1269,8 +1269,6 @@ TunnelStateData::noteDestination(Comm::ConnectionPointer path)
         return; // and continue to wait for tunnelConnectDone() callback
     }
 
-    // the current commitToServer()-based code cannot receive new destinations
-    // while transporting(), but future enhancements may enable this code path
     if (transporting())
         return; // and continue to receive destinations for backup
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1286,15 +1286,17 @@ TunnelStateData::noteDestinationsEnd(ErrorState *selectionError)
     // if all of them fail, tunneling as whole will fail
     Must(!selectionError); // finding at least one path means selection succeeded
 
-    if (usingDestination()) {
-        // We are already using a previously opened connection but also
-        // receiving destinations in case we need to re-forward.
-        Must(!transportWait);
-        return;
+    if (transportWait) {
+        assert(!usingDestination());
+        notifyConnOpener();
+        return; // and continue to wait for the noteConnection() callback
     }
 
-    if (transportWait)
-        return notifyConnOpener();
+    if (usingDestination()) {
+        // We are already using a previously opened connection (but were also
+        // receiving more destinations in case we need to re-forward).
+        return;
+    }
 
     // destinationsFound, but none of them worked, and we were waiting for more
     assert(savedError);


### PR DESCRIPTION
When the "no more destinations to try" notification comes after the last
forwarding/tunneling attempt has failed, the !destinationsFound block
does not run (because destinations were found), the usingDestination()
block does not run (because we are done with that last/failed
destination), but transportWait is false (for the same reason).

Also applied Bug 5090 (master/v6 commit 15bde30) FwdState protections to
tunnel.cc code. Tunnels may continue writing to the client while the
to-server connection is closing or closed, so TunnelStateData can be
potentially exposed to bug 5090 "no server connection but still
transporting" concerns. TunnelStateData never _retries_ successfully
established tunnels and, hence, can (and now does) stop receiving spare
destinations after committedToServer becomes true, but future tunnels
may start reforwarding in many cases, and most of the code does not need
to know about this (temporary?) simplification.

Also re-unified and polished related FwdState and TunnelStateData code,
including fixing lying source code comments and debug messages.