### PR TITLE
Fix Ubuntu Xenial clang build broken by commit b2188e4

### DIFF
--- a/src/CpuAffinitySet.cc
+++ b/src/CpuAffinitySet.cc
@@ -37,8 +37,7 @@ CpuAffinitySet::apply()
                "this process: " << xstrerr(xerrno));
     } else {
         cpu_set_t cpuSet;
-        memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
-        CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+        CPU_AND(&cpuSet, &theCpuSet, &theOrigCpuSet);
         if (CPU_COUNT(&cpuSet) <= 0) {
             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
                    "PID " << getpid() << ", may be caused by an invalid core in "


### PR DESCRIPTION
    CpuAffinitySet.cc:41: expression result unused [-Wunused-value]

On Ubuntu Xenial, clang expands CPU_AND() into a loop containing an unused
expression. Commit 7ec6d51 added (void) to quiet the corresponding warning.
Commit b2188e4 removed that decoration to fix FreeBSD 14 build because there
CPU_AND() expands into a do-while loop which cannot be prefixed by (void).
