### PR TITLE
Use xmlCtxtUseOptions instead of xmlSetFeature

### DIFF
--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -118,7 +118,6 @@ ESILibxml2Parser::ESILibxml2Parser(ESIParserClient *aClient) : theClient (aClien
 
     /* TODO: grab the document encoding from the headers */
     parser = xmlCreatePushParserCtxt(&sax, static_cast<void *>(this), NULL, 0, NULL);
-    xmlSetFeature(parser, "substitute entities", 0);
 
     if (entity_doc == NULL)
         entity_doc = htmlNewDoc(NULL, NULL);


### PR DESCRIPTION
xmlSetFeature has been deprecated for 10+ years and will eventually be
removed from libxml2. Use xmlCtxtUseOptions instead. Despite the
misleading name, XML_PARSE_NOENT enables substitution of entities
(no entity nodes in the result tree).