### PR TITLE
ESI: Drop incorrect and unnecessary xmlSetFeature() call

### DIFF
--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -118,7 +118,6 @@ ESILibxml2Parser::ESILibxml2Parser(ESIParserClient *aClient) : theClient (aClien
 
     /* TODO: grab the document encoding from the headers */
     parser = xmlCreatePushParserCtxt(&sax, static_cast<void *>(this), NULL, 0, NULL);
-    xmlSetFeature(parser, "substitute entities", 0);
 
     if (entity_doc == NULL)
         entity_doc = htmlNewDoc(NULL, NULL);


### PR DESCRIPTION
xmlSetFeature() has been deprecated for 10+ years and will eventually be
removed from libxml2. Squid calls xmlSetFeature() with the wrong
argument: a nil `value` pointer instead of a pointer to a zero value.
When called with a nil `value`, the function does nothing but returning
an error. Squid does not check whether xmlSetFeature() call is
successful, and the bug went unnoticed since libxml2 support was added
in commit 964b44c.

Since libxml2 does not substitute entities by default, the call can be
removed to achieve the intended effect.