### PR TITLE
Drop redundant LIBADD_DL overwrite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,13 +218,6 @@ LT_LIB_DLLOAD
 AC_SUBST(INCLTDL)
 AC_SUBST(LIBLTDL)
 
-if test "x$enable_loadable_modules" = "xyes";
-then
-  # Why is this needed? Should not LT_INIT (or LT_LIB_DLLOAD) from libtool do that?
-  LIBADD_DL=${lt_cv_dlopen_libs}
-  AC_SUBST([LIBADD_DL])
-fi
-
 SQUID_CC_GUESS_VARIANT
 SQUID_CC_GUESS_OPTIONS
 


### PR DESCRIPTION
The removed code questions whether it is needed.

The answer is no. LIBADD_DL is already set by one of the LT_INIT
macros to the same value we are overwriting it to.

Except, in the case where the user has supplied a custom libdl
location this code broke their build.