### PR TITLE
Remove --disable-loadable-modules build option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,26 +181,9 @@ AC_ARG_ENABLE(strict-error-checking,
 ])
 AC_MSG_NOTICE([strict error checking enabled: ${enable_strict_error_checking:=yes}])
 
-AC_MSG_CHECKING(whether to use loadable modules)
-AC_ARG_ENABLE(loadable-modules,
-  AS_HELP_STRING([--disable-loadable-modules],[do not support loadable modules]) , [
-  SQUID_YESNO([$enableval],
-    [Unrecognized argument to --disable-loadable-modules: $enableval])
-])
-AM_CONDITIONAL(ENABLE_LOADABLE_MODULES, test "x${enable_loadable_modules:=yes}" = "xyes")
-AC_MSG_RESULT([$enable_loadable_modules])
-
-if test "x$enable_loadable_modules" = "xyes";
-then
-  AC_DEFINE(USE_LOADABLE_MODULES, 1, [Support Loadable Modules])
-  AC_ENABLE_SHARED
-else
-  AC_DISABLE_SHARED
-fi
-
 # LT_INIT requires libtool v2, might as well state it loud
 LT_PREREQ([2.2])
-LT_INIT([dlopen],[disable-shared])
+LT_INIT([dlopen])
 if ! test "${ac_top_build_prefix}" = "";
 then
 	# LTDL v3-v7 macros assume the autoconf 2.62 variable top_build_prefix is defined
@@ -217,6 +200,11 @@ LT_LIB_DLLOAD
 # Do we need these unconditionally for "make distcheck" to work?
 AC_SUBST(INCLTDL)
 AC_SUBST(LIBLTDL)
+
+AC_MSG_CHECKING(whether to use loadable modules)
+AS_IF([test "x${enable_shared:=yes}" = "xyes"],[AC_DEFINE(USE_LOADABLE_MODULES,1,[Support Loadable Modules])])
+AM_CONDITIONAL(ENABLE_LOADABLE_MODULES, test "x${enable_shared:=yes}" = "xyes")
+AC_MSG_RESULT([$enable_shared])
 
 SQUID_CC_GUESS_VARIANT
 SQUID_CC_GUESS_OPTIONS
@@ -1019,9 +1007,9 @@ dnl Perform configuration consistency checks for eCAP
 if test "x$squid_opt_use_ecap" != "xno";
 then
   dnl eCAP support requires loadable modules, which are enabled by default
-  if test "x$enable_loadable_modules" != "xyes"
+  if test "x$enable_shared" != "xyes"
   then
-    AC_MSG_ERROR([eCAP support requires loadable modules. Please do not use --disable-loadable-modules with --enable-ecap.])
+    AC_MSG_ERROR([eCAP support requires loadable modules. Please do not use --disable-shared with --enable-ecap.])
   fi
 
   if test -n "$PKG_CONFIG"; then

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -123,6 +123,9 @@ This section gives an account of those changes in three categories:
 	<p>This feature has been unreliable for many years. Other tools such as
 	   oprofile provide better tracking and should be used instead.
 
+	<tag>--disable-loadable-modules</tag>
+	<p>This option was performing the same duties as <em>--disable-shared</em>.
+
 </descrip>
 
 

--- a/src/cf_gen_defines
+++ b/src/cf_gen_defines
@@ -39,7 +39,7 @@ BEGIN {
 	define["USE_HTTP_VIOLATIONS"]="--enable-http-violations"
 	define["USE_ICMP"]="--enable-icmp"
 	define["USE_IDENT"]="--enable-ident-lookups"
-	define["USE_LOADABLE_MODULES"]="--enable-loadable-modules"
+	define["USE_LOADABLE_MODULES"]="--enable-shared"
 	define["USE_OPENSSL"]="--with-openssl"
 	define["USE_QOS_TOS"]="--enable-zph-qos"
 	define["USE_SQUID_ESI"]="--enable-esi"

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -38,7 +38,7 @@ MAKETEST="distcheck"
 #     we use it to perform the same duty between our nested scripts.
 DISTCHECK_CONFIGURE_FLAGS=" \
 	--disable-build-info \
-	--disable-loadable-modules \
+	--disable-shared \
 	--disable-gnuregex \
 	--disable-debug-cbdata \
 	--disable-xmalloc-statistics \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -52,7 +52,7 @@ MAKETEST="distcheck"
 #     distcheck target recursive tests beteen scripted runs.
 #     we use it to perform the same duty between our nested scripts.
 DISTCHECK_CONFIGURE_FLAGS=" \
-	--enable-loadable-modules \
+	--enable-shared \
 	--enable-gnuregex \
 	--enable-optimizations \
 	--enable-debug-cbdata \

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -51,7 +51,7 @@ MAKETEST="distcheck"
 #     distcheck target recursive tests beteen scripted runs.
 #     we use it to perform the same duty between our nested scripts.
 DISTCHECK_CONFIGURE_FLAGS=" \
-	--enable-loadable-modules \
+	--enable-shared \
 	--enable-gnuregex \
 	--enable-optimizations \
 	--enable-inline \


### PR DESCRIPTION
 ... in favour of libtool --enable/disable-shared option which
provides the same functionality.

This has the nice side effect of simplifying the LT_INIT and
related autoconf sequences which were being modified by
--disable-loadable-modules.