### PR TITLE
Fix ignore-cc/act-as-origin in wildcard split-stack ports

### DIFF
--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -57,7 +57,7 @@ AnyP::PortCfg::~PortCfg()
 }
 
 AnyP::PortCfg::PortCfg(const PortCfg &other):
-    next(),
+    next(), // special case; see assert() below
     s(other.s),
     transport(other.transport),
     name(other.name ? xstrdup(other.name) : nullptr),
@@ -73,7 +73,7 @@ AnyP::PortCfg::PortCfg(const PortCfg &other):
     disable_pmtu_discovery(other.disable_pmtu_discovery),
     workerQueues(other.workerQueues),
     tcp_keepalive(other.tcp_keepalive),
-    listenConn(),
+    listenConn(), // special case; see assert() below
     secure(other.secure)
 {
     // to simplify, we only support port copying during parsing

--- a/src/anyp/PortCfg.cc
+++ b/src/anyp/PortCfg.cc
@@ -8,6 +8,7 @@
 
 #include "squid.h"
 #include "anyp/PortCfg.h"
+#include "anyp/UriScheme.h"
 #include "comm.h"
 #include "fatal.h"
 #include "security/PeerOptions.h"
@@ -55,29 +56,39 @@ AnyP::PortCfg::~PortCfg()
     safe_free(defaultsite);
 }
 
-AnyP::PortCfgPointer
-AnyP::PortCfg::clone() const
+AnyP::PortCfg::PortCfg(const PortCfg &other):
+    next(),
+    s(other.s),
+    transport(other.transport),
+    name(other.name ? xstrdup(other.name) : nullptr),
+    defaultsite(other.defaultsite ? xstrdup(other.defaultsite) : nullptr),
+    flags(other.flags),
+    allow_direct(other.allow_direct),
+    vhost(other.vhost),
+    actAsOrigin(other.actAsOrigin),
+    ignore_cc(other.ignore_cc),
+    connection_auth_disabled(other.connection_auth_disabled),
+    ftp_track_dirs(other.ftp_track_dirs),
+    vport(other.vport),
+    disable_pmtu_discovery(other.disable_pmtu_discovery),
+    workerQueues(other.workerQueues),
+    tcp_keepalive(other.tcp_keepalive),
+    listenConn(),
+    secure(other.secure)
 {
-    AnyP::PortCfgPointer b = new AnyP::PortCfg();
-    b->s = s;
-    if (name)
-        b->name = xstrdup(name);
-    if (defaultsite)
-        b->defaultsite = xstrdup(defaultsite);
+    // to simplify, we only support port copying during parsing
+    assert(!other.next);
+    assert(!other.listenConn);
+}
 
-    b->transport = transport;
-    b->flags = flags;
-    b->allow_direct = allow_direct;
-    b->vhost = vhost;
-    b->vport = vport;
-    b->connection_auth_disabled = connection_auth_disabled;
-    b->workerQueues = workerQueues;
-    b->ftp_track_dirs = ftp_track_dirs;
-    b->disable_pmtu_discovery = disable_pmtu_discovery;
-    b->tcp_keepalive = tcp_keepalive;
-    b->secure = secure;
-
-    return b;
+AnyP::PortCfg *
+AnyP::PortCfg::ipV4clone() const
+{
+    const auto clone = new PortCfg(*this);
+    clone->s.setIPv4();
+    debugs(3, 3, AnyP::UriScheme(transport.protocol).image() << "_port: " <<
+           "cloned wildcard address for split-stack: " << s << " and " << clone->s);
+    return clone;
 }
 
 ScopedId

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -25,8 +25,11 @@ class PortCfg : public CodeContext
 {
 public:
     PortCfg();
+    PortCfg(PortCfg &&) = delete; // all other forms of copying prohibited
     ~PortCfg();
-    AnyP::PortCfgPointer clone() const;
+
+    /// creates the same port configuration but listening on any IPv4 address
+    PortCfg *ipV4clone() const;
 
     /* CodeContext API */
     virtual ScopedId codeContextGist() const override;
@@ -65,6 +68,9 @@ public:
 
     /// TLS configuration options for this listening port
     Security::ServerOptions secure;
+
+private:
+    explicit PortCfg(const PortCfg &other); // for ipV4clone() needs only!
 };
 
 } // namespace AnyP

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -25,7 +25,8 @@ class PortCfg : public CodeContext
 {
 public:
     PortCfg();
-    PortCfg(PortCfg &&) = delete; // all other forms of copying prohibited
+    // no public copying/moving but see ipV4clone()
+    PortCfg(PortCfg &&) = delete;
     ~PortCfg();
 
     /// creates the same port configuration but listening on any IPv4 address

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3833,10 +3833,7 @@ parsePortCfg(AnyP::PortCfgPointer *head, const char *optionName)
 
     // *_port line should now be fully valid so we can clone it if necessary
     if (Ip::EnableIpv6&IPV6_SPECIAL_SPLITSTACK && s->s.isAnyAddr()) {
-        // clone the port options from *s to *(s->next)
-        s->next = s->clone();
-        s->next->s.setIPv4();
-        debugs(3, 3, AnyP::UriScheme(s->transport.protocol).image() << "_port: clone wildcard address for split-stack: " << s->s << " and " << s->next->s);
+        s->next = s->ipV4clone();
     }
 
     while (*head != NULL)


### PR DESCRIPTION
The PortCfg::clone() hack (and clone_http_port_list() before it) forgot
to copy those two flags to the IPv4 port variant.

Compilers will now be able to warn us if copying misses future members.

Also prohibited other forms of copying, nearly restricting copying to
the parsing code with special needs.