### PR TITLE
Move generatingConnect flag to HttpRequest

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -247,6 +247,7 @@ HttpRequest::inheritProperties(const Http::Message *aMsg)
     myportname = aReq->myportname;
 
     forcedBodyContinuation = aReq->forcedBodyContinuation;
+    generatingConnect = aReq->generatingConnect;
 
     // main property is which connection the request was received on (if any)
     clientConnectionManager = aReq->clientConnectionManager;

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -193,6 +193,9 @@ public:
     /// whether we have responded with HTTP 100 or FTP 150 already
     bool forcedBodyContinuation;
 
+    /// whether we are currently creating a CONNECT header (to be sent to peer)
+    bool generatingConnect = false;
+
 public:
     bool multipartRangeRequest() const;
 

--- a/src/MasterXaction.h
+++ b/src/MasterXaction.h
@@ -55,9 +55,6 @@ public:
     /// the initiator of this transaction
     XactionInitiator initiator;
 
-    /// whether we are currently creating a CONNECT header (to be sent to peer)
-    bool generatingConnect = false;
-
     // TODO: add state from other Jobs in the transaction
 };
 

--- a/src/acl/AtStep.cc
+++ b/src/acl/AtStep.cc
@@ -42,12 +42,7 @@ ACLAtStepStrategy::match(ACLData<XactionStep> * &data, ACLFilledChecklist *check
         if (!checklist->request)
             return 0; // we have warned about the missing request earlier
 
-        if (!checklist->request->masterXaction) {
-            debugs(28, DBG_IMPORTANT, "ERROR: Squid BUG: at_step GeneratingCONNECT ACL is missing master transaction info. Assuming mismatch.");
-            return 0;
-        }
-
-        return checklist->request->masterXaction->generatingConnect ? 1 : 0;
+        return checklist->request->generatingConnect ? 1 : 0;
     }
 
     return 0;

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -154,7 +154,7 @@ Http::Tunneler::writeRequest()
     MemBuf mb;
 
     try {
-        request->masterXaction->generatingConnect = true;
+        request->generatingConnect = true;
 
         mb.init();
         mb.appendf("CONNECT %s HTTP/1.1\r\n", url.c_str());
@@ -168,10 +168,10 @@ Http::Tunneler::writeRequest()
         hdr_out.clean();
         mb.append("\r\n", 2);
 
-        request->masterXaction->generatingConnect = false;
+        request->generatingConnect = false;
     } catch (...) {
         // TODO: Add scope_guard; do not wait until it is in the C++ standard.
-        request->masterXaction->generatingConnect = false;
+        request->generatingConnect = false;
         throw;
     }
 


### PR DESCRIPTION
It is a flag to control ACL matching against the HttpRequest data
and should not have been directly part of MasterXaction at all.