### PR TITLE
Honor assertions during shutdown

### DIFF
--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -22,9 +22,6 @@
 #include <functional>
 #include <memory>
 
-/* for shutting_down flag in xassert() */
-#include "globals.h"
-
 char *Debug::debugOptions = NULL;
 int Debug::override_X = 0;
 bool Debug::log_syslog = false;
@@ -1219,12 +1216,8 @@ xassert(const char *msg, const char *file, int line)
 
     debugs(0, DBG_CRITICAL, "FATAL: assertion failed: " << file << ":" << line << ": \"" << msg << "\"");
 
-    if (!shutting_down) {
-        Debug::PrepareToDie();
-        abort();
-    }
-
-    Asserting_ = false;
+    Debug::PrepareToDie();
+    abort();
 }
 
 Debug::Context *Debug::Current = nullptr;


### PR DESCRIPTION
From code correctness/guarantees point of view, it is much better to
assert than to exhibit undefined behavior, especially since the
asserting code is usually not shutdown-specific and the shutdown state
often lasts through hundreds of transactions.

We are not aware of any frequent assertions during shutdown, and we want
to fix the ones that do exist (instead of not knowing about them). Thus,
this change is unlikely to introduce a lot of problems and might trigger
other positive changes.

Bypassing assertion failures does not guarantee the code will keep
running: In many (most?) cases, the asserting code will still crash or
seriously misbehave. In those cases, this change clearly improves Squid.

We ignored assertion failures during shutdown since Squid started
customizing assert() in commit 54f742e. Back in 1998, Squid was known to
often crash while shutting down, the crashes were often "benign" (the
code was just mishandling disappearing modules), and Squid could not
always start after a crash, complicating startup scripts. With a focus
on adding new features, we probably felt it is best to ignore these
usually minor but often annoying failures.

This change reduces libdebug dependency on globals.cc, addressing commit
6249367 TODO, and improving libdebug reusability.