### PR TITLE
comm/libminimal.la to facilitate helper use of convenience libs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -614,7 +614,6 @@ ufsdump_SOURCES = \
 	cbdata.h \
 	dlink.cc \
 	dlink.h \
-	tests/stub_fd.cc \
 	fd.h \
 	helper/ChildConfig.h \
 	int.cc \
@@ -637,6 +636,7 @@ ufsdump_LDADD = \
 	ipc/libipc.la \
 	mgr/libmgr.la \
 	debug/libdebug.la \
+	comm/libminimal.la \
 	$(XTRA_OBJS) \
 	$(REPL_OBJS) \
 	$(NETTLELIB) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -614,6 +614,7 @@ ufsdump_SOURCES = \
 	cbdata.h \
 	dlink.cc \
 	dlink.h \
+	tests/stub_fd.cc \
 	fd.h \
 	helper/ChildConfig.h \
 	int.cc \
@@ -636,7 +637,6 @@ ufsdump_LDADD = \
 	ipc/libipc.la \
 	mgr/libmgr.la \
 	debug/libdebug.la \
-	comm/libminimal.la \
 	$(XTRA_OBJS) \
 	$(REPL_OBJS) \
 	$(NETTLELIB) \

--- a/src/comm/Makefile.am
+++ b/src/comm/Makefile.am
@@ -8,7 +8,9 @@
 include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/src/TestHeaders.am
 
-noinst_LTLIBRARIES = libcomm.la
+noinst_LTLIBRARIES = \
+	libcomm.la \
+	libminimal.la
 
 ## Library holding comm socket handlers
 libcomm_la_SOURCES = \
@@ -39,3 +41,7 @@ libcomm_la_SOURCES = \
 	Write.h \
 	comm_internal.h \
 	forward.h
+
+# a bare-bones implementation of few Comm APIs sufficient for helpers use
+libminimal_la_SOURCES = \
+	minimal.cc

--- a/src/comm/minimal.cc
+++ b/src/comm/minimal.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "debug/Stream.h"
+#include "fd.h"
+
+void
+fd_open(const int fd, unsigned int, const char *description)
+{
+    debugs(51, 3, "FD " << fd << ' ' << description);
+}
+
+void
+fd_close(const int fd)
+{
+    debugs(51, 3, "FD " << fd);
+}
+

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -38,7 +38,6 @@ libicmp_la_LIBADD= libicmpcore.la
 COPIED_SOURCE= \
 	globals.cc \
 	SquidConfig.cc \
-	tests/stub_fd.cc \
 	tests/stub_HelperChildConfig.cc \
 	tests/STUB.h \
 	time.cc
@@ -60,6 +59,7 @@ pinger_LDADD=\
 	$(top_builddir)/src/ip/libip.la \
 	$(top_builddir)/src/sbuf/libsbuf.la \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 	$(top_builddir)/src/base/libbase.la \
 	$(top_builddir)/src/mem/libminimal.la \
 	$(COMPAT_LIB) \
@@ -94,9 +94,6 @@ SquidConfig.cc: $(top_srcdir)/src/SquidConfig.cc
 
 tests/stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc | tests
 	cp $(top_srcdir)/src/tests/stub_HelperChildConfig.cc $@
-
-tests/stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc | tests
-	cp $(top_srcdir)/src/tests/stub_fd.cc $@
 
 tests/STUB.h: $(top_srcdir)/src/tests/STUB.h | tests
 	cp $(top_srcdir)/src/tests/STUB.h $@

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -63,7 +63,6 @@ STUBS = \
 	stub_SBuf.cc \
 	stub_tools.cc \
 	stub_fatal.cc \
-	stub_fd.cc \
 	STUB.h
 DEBUG_SOURCE = test_tools.cc $(STUBS)
 CLEANFILES += $(STUBS) stub_libmem.cc
@@ -83,9 +82,6 @@ stub_tools.cc: $(top_srcdir)/src/tests/stub_tools.cc
 stub_fatal.cc: $(top_srcdir)/src/tests/stub_fatal.cc
 	cp $(top_srcdir)/src/tests/stub_fatal.cc $@
 
-stub_fd.cc: $(top_srcdir)/src/tests/stub_fd.cc
-	cp $(top_srcdir)/src/tests/stub_fd.cc $@
-
 stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc STUB.h
 	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 	
@@ -98,6 +94,7 @@ ESIExpressions_SOURCES = \
 	stub_libmem.cc
 ESIExpressions_LDADD = $(top_builddir)/src/esi/Expression.o \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 		$(LDADD)
 
 mem_node_test_SOURCES = \
@@ -107,6 +104,7 @@ mem_node_test_LDADD = \
 	$(top_builddir)/src/mem_node.o \
 	$(top_builddir)/src/mem/libmem.la \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 	$(LDADD)
 
 mem_hdr_test_SOURCES = \
@@ -117,6 +115,7 @@ mem_hdr_test_LDADD = \
 	$(top_builddir)/src/mem_node.o \
 	$(top_builddir)/src/mem/libmem.la \
 	$(top_builddir)/src/debug/libdebug.la \
+	$(top_builddir)/src/comm/libminimal.la \
 	$(LDADD)
 
 splay_SOURCES = \


### PR DESCRIPTION
Helpers may not (want to) use fd_open() and fd_close() directly, but
they (want to) use libdebug which does use fd_open() and fd_close().

Currently, the Comm "importing" fd_open() and Comm "delisting"
fd_close() APIs are not implemented inside src/comm/ but they do belong
to the Comm module and use its internals. Moving fd.h to src/comm/ will
require a lot of noisy out-of-scope changes deserving a dedicated PR.

Despite their names, the minimally-implemented functions do not open(2)
and close(2) file descriptors in their full implementations either: That
full implementation just updates fd-associated Squid-specific metadata
that Squid helpers do not need/use.

Do not use stub_fd.cc in the deployed/non-test pinger program.

Avoid build-breaking copying of stub_fd.cc source file in test-suite/.