### PR TITLE
Improve debugs() handling in helpers

### DIFF
--- a/src/debug/Stream.h
+++ b/src/debug/Stream.h
@@ -88,6 +88,7 @@ public:
     static int override_X;
     static bool log_syslog;
 
+    // TODO: Convert all helpers to use debugs() and NameThisHelper() APIs.
     /// Use the given name for debugs() messages from this helper process.
     /// Side effect: Commits to using helper-appropriate debug levels/channels.
     /// \sa NameThisKid()

--- a/src/debug/Stream.h
+++ b/src/debug/Stream.h
@@ -88,6 +88,15 @@ public:
     static int override_X;
     static bool log_syslog;
 
+    /// Use the given name for debugs() messages from this helper process.
+    /// Side effect: Commits to using helper-appropriate debug levels/channels.
+    /// \sa NameThisKid()
+    static void NameThisHelper(const char *name);
+
+    /// Use the given ID for debugs() messages from this SMP kid process.
+    /// \sa NameThisHelper()
+    static void NameThisKid(int kidIdentifier);
+
     static void parseOptions(char const *);
 
     /// minimum level required by the current debugs() call

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -386,6 +386,11 @@ Debug::NameThisHelper(const char * const name)
 {
     LabelThisProcess(name);
 
+    if (const auto parentProcessDebugOptions = getenv("SQUID_DEBUG")) {
+        assert(!debugOptions);
+        debugOptions = xstrdup(parentProcessDebugOptions);
+    }
+
     // do not restrict helper (i.e. stderr) logging beyond debug_options
     EnsureDefaultStderrLevel(DBG_DATA);
 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -394,7 +394,10 @@ Debug::NameThisHelper(const char * const name)
     // do not restrict helper (i.e. stderr) logging beyond debug_options
     EnsureDefaultStderrLevel(DBG_DATA);
 
+    // helpers do not write to cache.log directly; instead, ipcCreate()
+    // diverts helper stderr output to cache.log of the parent process
     BanCacheLogUse();
+
     SettleStderr();
     SettleSyslog();
 }

--- a/src/icmp/Icmp4.cc
+++ b/src/icmp/Icmp4.cc
@@ -74,7 +74,7 @@ Icmp4::Open(void)
     }
 
     icmp_ident = getpid() & 0xffff;
-    debugs(42, DBG_IMPORTANT, "pinger: ICMP socket opened.");
+    debugs(42, DBG_IMPORTANT, "ICMP socket opened.");
 
     return icmp_sock;
 }

--- a/src/icmp/Icmp6.cc
+++ b/src/icmp/Icmp6.cc
@@ -106,7 +106,7 @@ Icmp6::Open(void)
     }
 
     icmp_ident = getpid() & 0xffff;
-    debugs(42, DBG_IMPORTANT, "pinger: ICMPv6 socket opened");
+    debugs(42, DBG_IMPORTANT, "ICMPv6 socket opened");
 
     return icmp_sock;
 }

--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -130,7 +130,7 @@ IcmpPinger::Open(void)
     }
 
     getCurrentTime();
-    debugs(42, DBG_IMPORTANT, "pinger: Squid socket opened");
+    debugs(42, DBG_IMPORTANT, "Squid socket opened");
 
     /* windows uses a socket stream as a dual-direction channel */
     socket_to_squid = icmp_sock;
@@ -222,7 +222,7 @@ IcmpPinger::SendResult(pingerReplyData &preply, int len)
 
     if (send(socket_to_squid, &preply, len, 0) < 0) {
         int xerrno = errno;
-        debugs(42, DBG_CRITICAL, "FATAL: pinger: send failure: " << xstrerr(xerrno));
+        debugs(42, DBG_CRITICAL, "FATAL: send failure: " << xstrerr(xerrno));
         Close();
         exit(EXIT_FAILURE);
     }

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -115,9 +115,8 @@ main(int, char **)
     int icmp6_worker = -1;
     int squid_link = -1;
 
-    /** start by initializing the pinger debug cache.log-pinger. */
-    const auto envOptions = getenv("SQUID_DEBUG");
-    Debug::debugOptions = xstrdup(envOptions ? envOptions : "ALL,10");
+    if (const auto envOptions = getenv("SQUID_DEBUG"))
+        Debug::debugOptions = xstrdup(envOptions);
     Debug::NameThisHelper("pinger");
 
     getCurrentTime();

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -118,13 +118,12 @@ main(int, char **)
     /** start by initializing the pinger debug cache.log-pinger. */
     const auto envOptions = getenv("SQUID_DEBUG");
     Debug::debugOptions = xstrdup(envOptions ? envOptions : "ALL,10");
+    Debug::NameThisHelper("pinger");
 
     getCurrentTime();
 
     // determine IPv4 or IPv6 capabilities before using sockets.
     Ip::ProbeTransport();
-
-    Debug::BanCacheLogUse();
 
     debugs(42, DBG_CRITICAL, "pinger: Initialising ICMP pinger ...");
 

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -124,30 +124,30 @@ main(int, char **)
     // determine IPv4 or IPv6 capabilities before using sockets.
     Ip::ProbeTransport();
 
-    debugs(42, DBG_CRITICAL, "pinger: Initialising ICMP pinger ...");
+    debugs(42, DBG_CRITICAL, "Initialising ICMP pinger ...");
 
     icmp4_worker = icmp4.Open();
     if (icmp4_worker < 0) {
-        debugs(42, DBG_CRITICAL, "ERROR: pinger: Unable to start ICMP pinger.");
+        debugs(42, DBG_CRITICAL, "ERROR: Unable to start ICMP pinger.");
     }
     max_fd = max(max_fd, icmp4_worker);
 
 #if USE_IPV6
     icmp6_worker = icmp6.Open();
     if (icmp6_worker <0 ) {
-        debugs(42, DBG_CRITICAL, "ERROR: pinger: Unable to start ICMPv6 pinger.");
+        debugs(42, DBG_CRITICAL, "ERROR: Unable to start ICMPv6 pinger.");
     }
     max_fd = max(max_fd, icmp6_worker);
 #endif
 
     /** abort if neither worker could open a socket. */
     if (icmp4_worker < 0 && icmp6_worker < 0) {
-        debugs(42, DBG_CRITICAL, "FATAL: pinger: Unable to open any ICMP sockets.");
+        debugs(42, DBG_CRITICAL, "FATAL: Unable to open any ICMP sockets.");
         exit(EXIT_FAILURE);
     }
 
     if ( (squid_link = control.Open()) < 0) {
-        debugs(42, DBG_CRITICAL, "FATAL: pinger: Unable to setup Pinger control sockets.");
+        debugs(42, DBG_CRITICAL, "FATAL: Unable to setup Pinger control sockets.");
         icmp4.Close();
         icmp6.Close();
         exit(EXIT_FAILURE); // fatal error if the control channel fails.
@@ -156,14 +156,14 @@ main(int, char **)
 
     if (setgid(getgid()) < 0) {
         int xerrno = errno;
-        debugs(42, DBG_CRITICAL, "FATAL: pinger: setgid(" << getgid() << ") failed: " << xstrerr(xerrno));
+        debugs(42, DBG_CRITICAL, "FATAL: setgid(" << getgid() << ") failed: " << xstrerr(xerrno));
         icmp4.Close();
         icmp6.Close();
         exit(EXIT_FAILURE);
     }
     if (setuid(getuid()) < 0) {
         int xerrno = errno;
-        debugs(42, DBG_CRITICAL, "FATAL: pinger: setuid(" << getuid() << ") failed: " << xstrerr(xerrno));
+        debugs(42, DBG_CRITICAL, "FATAL: setuid(" << getuid() << ") failed: " << xstrerr(xerrno));
         icmp4.Close();
         icmp6.Close();
         exit(EXIT_FAILURE);
@@ -177,7 +177,7 @@ main(int, char **)
     caps = cap_init();
     if (!caps) {
         int xerrno = errno;
-        debugs(42, DBG_CRITICAL, "FATAL: pinger: cap_init() failed: " << xstrerr(xerrno));
+        debugs(42, DBG_CRITICAL, "FATAL: cap_init() failed: " << xstrerr(xerrno));
         icmp4.Close();
         icmp6.Close();
         exit(EXIT_FAILURE);
@@ -185,7 +185,7 @@ main(int, char **)
         if (cap_set_proc(caps) != 0) {
             int xerrno = errno;
             // cap_set_proc(cap_init()) is expected to never fail
-            debugs(42, DBG_CRITICAL, "FATAL: pinger: cap_set_proc(none) failed: " << xstrerr(xerrno));
+            debugs(42, DBG_CRITICAL, "FATAL: cap_set_proc(none) failed: " << xstrerr(xerrno));
             cap_free(caps);
             icmp4.Close();
             icmp6.Close();
@@ -232,7 +232,7 @@ main(int, char **)
 
         if (PINGER_TIMEOUT + last_check_time < squid_curtime) {
             if (send(LINK_TO_SQUID, &tv, 0, 0) < 0) {
-                debugs(42, DBG_CRITICAL, "pinger: Closing. No requests in last " << PINGER_TIMEOUT << " seconds.");
+                debugs(42, DBG_CRITICAL, "Closing. No requests in last " << PINGER_TIMEOUT << " seconds.");
                 control.Close();
                 exit(EXIT_FAILURE);
             }

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -115,8 +115,6 @@ main(int, char **)
     int icmp6_worker = -1;
     int squid_link = -1;
 
-    if (const auto envOptions = getenv("SQUID_DEBUG"))
-        Debug::debugOptions = xstrdup(envOptions);
     Debug::NameThisHelper("pinger");
 
     getCurrentTime();

--- a/src/main.cc
+++ b/src/main.cc
@@ -1419,6 +1419,7 @@ ConfigureCurrentKid(const CommandLine &cmdLine)
         TheKidName.assign(APP_SHORTNAME);
         KidIdentifier = 0;
     }
+    Debug::NameThisKid(KidIdentifier);
 }
 
 /// Start directing debugs() messages to the configured cache.log.


### PR DESCRIPTION
This change also reduces libdebug dependency on globals.cc, improving
libdebug reusability.

Also do not default-reset debug sections after they were explicitly set:

* In most sbin/squid contexts, DebugModule constructor is called before
  Debug::parseOptions(). That call order results in the Levels array
  being reset to default values before it is reset to configured values.
  No problem.

* In sbin/squid -X context, DebugModule constructor is called after
  Debug::parseOptions(), but the override_X flag protected the Levels
  array from being reset to default values in this case. No problem.

* In helper contexts, DebugModule constructor may be called after
  Debug::parseOptions(), and the override_X flag stays false. This order
  results in the parseOptions() effects erased by ResetSections() called
  from the constructor.

This bug was detected while trying to understand why pinger's hard-coded
(and wrong) ALL,10 default has no effect on pinger's debugging. The two
bugs cancelled each other.


The following changes affect pinger (now) and other helpers that will
eventually use libdebug and its new NameThisHelper() API:

* Label helper debugs() lines with the helper name (e.g., "pinger"),
  similar to how we already label SMP debugs() lines with "kidN". This
  change improves cache.log readability, distinguishes output from
  different helpers, and distinguishes helper output from sbin/squid
  output in non-SMP logs.

* Make sure level-1 debugs() messages are logged.

* Stop pointless accumulation of cache.log and syslog channel messages.

* Automatically honor SQUID_DEBUG environment variable set by the parent
  Squid process. The pinger helper was already honoring it.


The following changes are specific to pinger:

* Removed the now-duplicated references to "pinger" in pinger debugs().

* Do not default pinger debugging levels to ALL,10. The default pinger
  debugging levels should be the same as the default Squid debugging
  levels (i.e. "ALL,1"). Bugs in the debugging module prevented the
  hard-coded "ALL,10" (or any other elevated setting) from having an
  effect, but we now fixed the last of those bugs. AFAICT, the change of
  default from ALL,1 to ALL,10 in commit cc192b5 was accidental.