### PR TITLE
Work around broken CPU_AND API on Ubuntu Xenial and clang

### DIFF
--- a/src/CpuAffinitySet.cc
+++ b/src/CpuAffinitySet.cc
@@ -38,7 +38,10 @@ CpuAffinitySet::apply()
     } else {
         cpu_set_t cpuSet;
         memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
-        CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+        // hack for clang on ubuntu-xenial, where CPU_AND returns a value
+        // which under very strict compiler checks fails the build
+        auto s = CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+        (void) s;
         if (CPU_COUNT(&cpuSet) <= 0) {
             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
                    "PID " << getpid() << ", may be caused by an invalid core in "


### PR DESCRIPTION
At very high levels of compiler strictness checks, the CPU_AND system interface exposes a broken API.
Hack around the breakage, by explicitly instructing the compiler to disregard the non-standard return value

Fully tested in https://build.squid-cache.org/job/anybranch-amd64-matrix/48/