### PR TITLE
Remove SUID by default for bootstrapConfig Runners

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1584,7 +1584,9 @@ SquidMain(int argc, char **argv)
 
         Format::Token::Init(); // XXX: temporary. Use a runners registry of pre-parse runners instead.
 
+        leave_suid();
         RunRegisteredHere(RegisteredRunner::bootstrapConfig);
+        enter_suid(); // TODO remove. parser should handle SUID level (if needed at all)
 
         try {
             parse_err = parseConfigFile(ConfigFile);


### PR DESCRIPTION
This RunnersRegistry hook appears to be unused currently so we
can easily convert it now and prevent future Runners being given
high privileges.