### PR TITLE
Fix SQUID-MIB smilint errors

### DIFF
--- a/include/cache_snmp.h
+++ b/include/cache_snmp.h
@@ -230,7 +230,7 @@ enum {
     MESH_END
 };
 
-/* CachePeerTableEntry (version 3) */
+/* CachePeerEntry (version 3) */
 enum {
     MESH_PTBL_START     = 0,
     MESH_PTBL_INDEX     = 1,  /* cachePeerIndex  */

--- a/src/mib.txt
+++ b/src/mib.txt
@@ -3,7 +3,7 @@
 SQUID-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
-	enterprises, Unsigned32, TimeTicks, Gauge32, Counter32,
+	enterprises, TimeTicks, Gauge32, Counter32,
 	MODULE-IDENTITY, OBJECT-TYPE, Integer32
         	FROM SNMPv2-SMI
 
@@ -14,46 +14,55 @@ IMPORTS
         	FROM INET-ADDRESS-MIB;
 
 squid MODULE-IDENTITY
-    LAST-UPDATED "200812240200Z"
-    ORGANIZATION "National Laboratory for Applied Network Research"
-    CONTACT-INFO
-            "        Squid Developers
+        LAST-UPDATED "202204151000Z"
+        ORGANIZATION "National Laboratory for Applied Network Research"
+        CONTACT-INFO
+                "Squid Developers
 
-             E-mail: squid@squid-cache.org"
-    DESCRIPTION
-		"Squid MIB defined for the management of the Squid
-		proxy server. See http://www.squid-cache.org/."
+                E-mail: squid@squid-cache.org"
+        DESCRIPTION
+                "Squid MIB defined for the management of the Squid
+                proxy server. See http://www.squid-cache.org/."
 
-    REVISION      "200812240200Z"
-    DESCRIPTION
-		"Corrected MIB strictness requirements. Mapped
-		valid port ranges"
-    
-    REVISION      "200712140000Z"
-    DESCRIPTION
-		"Added support for IPv6 Technology."
+        REVISION      "202204151000Z"
+        DESCRIPTION
+                "Reorganized cachePeerTable and related objects to
+                fix smilint errors.
 
-    REVISION      "9901010000Z"
-    DESCRIPTION
-		"Added objects and corrected asn.1 syntax and
-		descriptions."
+                Removed unused import of Unsigned32.
+                
+                Improve formatting consistency."
 
-    REVISION      "9809220000Z"
-    DESCRIPTION
-		"Move to SMIv2. Prepare to split into proxy/squid."
-		
-    ::= { nlanr 1 }
+        REVISION      "200812240200Z"
+        DESCRIPTION
+                "Corrected MIB strictness requirements. Mapped
+                valid port ranges"
+
+        REVISION      "200712140000Z"
+        DESCRIPTION
+                "Added support for IPv6 Technology."
+
+        REVISION      "9901010000Z"
+        DESCRIPTION
+                "Added objects and corrected asn.1 syntax and
+                descriptions."
+
+        REVISION      "9809220000Z"
+        DESCRIPTION
+                "Move to SMIv2. Prepare to split into proxy/squid."
+
+        ::= { nlanr 1 }
 
 --
 -- OID Assignments
 --
-	nlanr OBJECT IDENTIFIER ::= { enterprises 3495 }
+
+	nlanr           OBJECT IDENTIFIER ::= { enterprises 3495 }
 	cacheSystem	OBJECT IDENTIFIER ::= { squid 1 }
 	cacheConfig  	OBJECT IDENTIFIER ::= { squid 2 }
 	cachePerf	OBJECT IDENTIFIER ::= { squid 3 }
 	cacheNetwork	OBJECT IDENTIFIER ::= { squid 4 }
 	cacheMesh	OBJECT IDENTIFIER ::= { squid 5 }
-
 
 --
 -- cacheSystem group { squid 1 }
@@ -64,7 +73,7 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-only
 		STATUS current
 		DESCRIPTION
-			" Storage Mem size in KB "
+			"Storage Mem size in KB"
 	::= { cacheSystem 1 }
 
 	cacheSysStorage OBJECT-TYPE
@@ -72,7 +81,7 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Storage Swap size in KB "
+                        "Storage Swap size in KB"
         ::= { cacheSystem 2 }
 
 	cacheUptime  OBJECT-TYPE
@@ -80,7 +89,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " The Uptime of the cache in timeticks "
+                        "The Uptime of the cache in timeticks"
 	::= { cacheSystem 3 }
 
 --
@@ -94,7 +103,7 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Cache Administrator E-Mail address "
+                        "Cache Administrator E-Mail address"
 	::= { cacheConfig 1 }
 
         cacheSoftware OBJECT-TYPE
@@ -102,7 +111,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Cache Software Name "
+                        "Cache Software Name"
         ::= { cacheConfig 2 }
 
         cacheVersionId OBJECT-TYPE
@@ -110,7 +119,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Cache Software Version "
+                        "Cache Software Version"
         ::= { cacheConfig 3 }
 
 	cacheLoggingFacility OBJECT-TYPE
@@ -118,12 +127,14 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-write
 		STATUS current
 		DESCRIPTION
-			" Logging Facility. An informational string
+			"Logging Facility. An informational string
 			  indicating logging info like debug level,
-			  local/syslog/remote logging etc "
+			  local/syslog/remote logging etc"
 	::= { cacheConfig 4 }
 
--- cacheStorageConfig group
+        --
+        -- cacheStorageConfig group
+        --
 
 	cacheStorageConfig OBJECT IDENTIFIER ::= { cacheConfig 5 }
 
@@ -132,7 +143,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " The value of the cache_mem parameter in MB "
+                        "The value of the cache_mem parameter in MB"
         ::= { cacheStorageConfig 1 }
 
         cacheSwapMaxSize OBJECT-TYPE
@@ -140,7 +151,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " The total of the cache_dir space allocated in MB "
+                        "The total of the cache_dir space allocated in MB"
         ::= { cacheStorageConfig 2 }
 
         cacheSwapHighWM OBJECT-TYPE
@@ -148,7 +159,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Cache Swap High Water Mark "
+                        "Cache Swap High Water Mark"
         ::= { cacheStorageConfig 3 }
 
         cacheSwapLowWM OBJECT-TYPE
@@ -156,19 +167,20 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Cache Swap Low Water Mark "
+                        "Cache Swap Low Water Mark"
         ::= { cacheStorageConfig 4 }
 
--- end of  cacheStorageConfig group
+        --
+        -- end of  cacheStorageConfig group
+        --
 
 	cacheUniqName OBJECT-TYPE
 		SYNTAX DisplayString
 		MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Cache unique host name "
+                        "Cache unique host name"
 	::= { cacheConfig 6 }
-
 
 --
 -- cachePerformance group { squid 3 }
@@ -186,7 +198,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Page faults with physical i/o "
+                        "Page faults with physical i/o"
         ::= { cacheSysPerf 1 }
 
         cacheSysNumReads OBJECT-TYPE
@@ -194,7 +206,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " HTTP I/O number of reads "
+                        "HTTP I/O number of reads"
        	::= { cacheSysPerf 2 }
 
 	cacheMemUsage OBJECT-TYPE
@@ -202,7 +214,7 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-only
 		STATUS 	current
 		DESCRIPTION
-			" Total memory accounted for KB "
+			"Total memory accounted for KB"
 	::= { cacheSysPerf 3 }
 
 	cacheCpuTime OBJECT-TYPE
@@ -210,7 +222,7 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-only
                 STATUS  current
                 DESCRIPTION
-                        " Amount of cpu seconds consumed "
+                        "Amount of cpu seconds consumed"
 	::= { cacheSysPerf 4 }
 
 	cacheCpuUsage OBJECT-TYPE
@@ -218,7 +230,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS  current
                 DESCRIPTION
-                        " The percentage use of the CPU "
+                        "The percentage use of the CPU"
         ::= { cacheSysPerf 5 }
 
 	cacheMaxResSize OBJECT-TYPE
@@ -226,7 +238,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS  current
                 DESCRIPTION
-                        " Maximum Resident Size in KB "
+                        "Maximum Resident Size in KB"
         ::= { cacheSysPerf 6 }
 
 	cacheNumObjCount OBJECT-TYPE
@@ -234,7 +246,7 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-only
                 STATUS  current
                 DESCRIPTION
-                        " Number of objects stored by the cache "
+                        "Number of objects stored by the cache"
         ::= { cacheSysPerf 7 }
 
         cacheCurrentLRUExpiration OBJECT-TYPE
@@ -242,7 +254,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Storage LRU Expiration Age "
+			"Storage LRU Expiration Age"
         ::= { cacheSysPerf 8 }
 
         cacheCurrentUnlinkRequests OBJECT-TYPE
@@ -250,7 +262,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Requests given to unlinkd "
+			"Requests given to unlinkd"
         ::= { cacheSysPerf 9 }
 
         cacheCurrentUnusedFDescrCnt OBJECT-TYPE
@@ -258,7 +270,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Available number of file descriptors "
+			"Available number of file descriptors"
         ::= { cacheSysPerf 10 }
 
 	cacheCurrentResFileDescrCnt  OBJECT-TYPE
@@ -266,7 +278,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Reserved number of file descriptors "
+			"Reserved number of file descriptors"
         ::= { cacheSysPerf 11 }
 
 	cacheCurrentFileDescrCnt  OBJECT-TYPE
@@ -274,7 +286,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of file descriptors in use "
+			"Number of file descriptors in use"
         ::= { cacheSysPerf 12 }
 
 	cacheCurrentFileDescrMax  OBJECT-TYPE
@@ -282,15 +294,16 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Highest file descriptors in use "
+			"Highest file descriptors in use"
         ::= { cacheSysPerf 13 }
 
-	--
-	-- cacheProtoStats
-	--
+--
+-- cacheProtoStats
+--
 
-		-- cacheProtoAggregateStats
-		--
+        --
+        -- cacheProtoAggregateStats
+        --
 
 	cacheProtoAggregateStats OBJECT IDENTIFIER ::= { cacheProtoStats 1 }
 
@@ -300,7 +313,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of HTTP requests received "
+			"Number of HTTP requests received"
         ::= { cacheProtoAggregateStats 1 }
 
         cacheHttpHits OBJECT-TYPE
@@ -308,7 +321,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of HTTP Hits "
+			"Number of HTTP Hits"
         ::= { cacheProtoAggregateStats 2 }
 
         cacheHttpErrors OBJECT-TYPE
@@ -316,7 +329,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of HTTP Errors "
+			"Number of HTTP Errors"
         ::= { cacheProtoAggregateStats 3 }
 
         cacheHttpInKb OBJECT-TYPE
@@ -324,7 +337,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of HTTP KB's received "
+			"Number of HTTP KB's received"
         ::= { cacheProtoAggregateStats 4 }
 
         cacheHttpOutKb OBJECT-TYPE
@@ -332,7 +345,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Number of HTTP KB's transmitted "
+                        "Number of HTTP KB's transmitted"
         ::= { cacheProtoAggregateStats 5 }
 
 	cacheIcpPktsSent OBJECT-TYPE
@@ -340,7 +353,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Number of ICP messages sent "
+                        "Number of ICP messages sent"
         ::= { cacheProtoAggregateStats 6 }
 
 	cacheIcpPktsRecv OBJECT-TYPE
@@ -348,7 +361,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Number of ICP messages received "
+                        "Number of ICP messages received"
         ::= { cacheProtoAggregateStats 7 }
 
         cacheIcpKbSent OBJECT-TYPE
@@ -356,7 +369,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Number of ICP KB's transmitted "
+                        "Number of ICP KB's transmitted"
         ::= { cacheProtoAggregateStats 8 }
 
         cacheIcpKbRecv OBJECT-TYPE
@@ -364,7 +377,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Number of ICP KB's received "
+                        "Number of ICP KB's received"
         ::= { cacheProtoAggregateStats 9 }
 
         cacheServerRequests OBJECT-TYPE
@@ -372,7 +385,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " All requests from the client for the cache server "
+                        "All requests from the client for the cache server"
         ::= { cacheProtoAggregateStats 10 }
 
         cacheServerErrors OBJECT-TYPE
@@ -380,7 +393,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " All errors for the cache server from client requests "
+                        "All errors for the cache server from client requests"
         ::= { cacheProtoAggregateStats 11 }
 
 	cacheServerInKb OBJECT-TYPE
@@ -388,7 +401,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " KB's of traffic received from servers "
+                        "KB's of traffic received from servers"
         ::= { cacheProtoAggregateStats 12 }
 
         cacheServerOutKb OBJECT-TYPE
@@ -396,7 +409,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " KB's of traffic sent to servers "
+                        "KB's of traffic sent to servers"
         ::= { cacheProtoAggregateStats 13 }
 
 	cacheCurrentSwapSize OBJECT-TYPE
@@ -404,7 +417,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Storage Swap size "
+                        "Storage Swap size"
         ::= { cacheProtoAggregateStats 14 }
 
        cacheClients OBJECT-TYPE
@@ -412,7 +425,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Number of clients accessing cache "
+                        "Number of clients accessing cache"
         ::= { cacheProtoAggregateStats 15 }
 
 	--
@@ -426,7 +439,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS not-accessible
                 STATUS current
                 DESCRIPTION
-                        " CacheMedianSvcTable "
+                        "CacheMedianSvcTable"
 	::= { cacheProtoStats 2 }
 
         cacheMedianSvcEntry OBJECT-TYPE
@@ -434,7 +447,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS not-accessible
                 STATUS current
                 DESCRIPTION
-                        " An entry in cacheMedianSvcTable "
+                        "An entry in cacheMedianSvcTable"
                 INDEX   { cacheMedianTime }
         ::= { cacheMedianSvcTable 1 }
 
@@ -457,7 +470,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS not-accessible
                 STATUS current
 		DESCRIPTION
-                        " The value used to index the table 1/5/60"
+                        "The value used to index the table 1/5/60"
         ::= { cacheMedianSvcEntry 1 }
 
 	cacheHttpAllSvcTime OBJECT-TYPE
@@ -465,7 +478,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " HTTP all service time "
+                        "HTTP all service time"
         ::= { cacheMedianSvcEntry 2 }
 
 	cacheHttpMissSvcTime OBJECT-TYPE
@@ -473,7 +486,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " HTTP miss service time "
+                        "HTTP miss service time"
         ::= { cacheMedianSvcEntry 3 }
 
 	cacheHttpNmSvcTime OBJECT-TYPE
@@ -481,7 +494,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " HTTP hit not-modified service time "
+                        "HTTP hit not-modified service time"
         ::= { cacheMedianSvcEntry 4 }
 
 	cacheHttpHitSvcTime OBJECT-TYPE
@@ -489,7 +502,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " HTTP hit service time "
+                        "HTTP hit service time"
         ::= { cacheMedianSvcEntry 5 }
 
 	cacheIcpQuerySvcTime OBJECT-TYPE
@@ -497,7 +510,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " ICP query service time "
+                        "ICP query service time"
         ::= { cacheMedianSvcEntry 6 }
 
 	cacheIcpReplySvcTime OBJECT-TYPE
@@ -505,7 +518,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " ICP reply service time "
+                        "ICP reply service time"
         ::= { cacheMedianSvcEntry 7 }
 
 	cacheDnsSvcTime OBJECT-TYPE
@@ -513,7 +526,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " DNS service time "
+                        "DNS service time"
         ::= { cacheMedianSvcEntry 8 }
 
         cacheRequestHitRatio OBJECT-TYPE
@@ -521,7 +534,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Request Hit Ratios "
+                        "Request Hit Ratios"
         ::= { cacheMedianSvcEntry 9 }
 
         cacheRequestByteRatio OBJECT-TYPE
@@ -529,7 +542,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " Byte Hit Ratios "
+                        "Byte Hit Ratios"
         ::= { cacheMedianSvcEntry 10 }
 
 	cacheHttpNhSvcTime OBJECT-TYPE
@@ -537,7 +550,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-                        " HTTP refresh hit service time "
+                        "HTTP refresh hit service time"
         ::= { cacheMedianSvcEntry 11 }
 
 --
@@ -560,7 +573,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" IP Cache Entries "
+			"IP Cache Entries"
         ::= { cacheIpCache 1 }
 
 	cacheIpRequests OBJECT-TYPE
@@ -568,7 +581,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of IP Cache requests "
+			"Number of IP Cache requests"
         ::= { cacheIpCache 2 }
 
 	cacheIpHits OBJECT-TYPE
@@ -576,7 +589,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of IP Cache hits "
+			"Number of IP Cache hits"
         ::= { cacheIpCache 3 }
 
 	cacheIpPendingHits OBJECT-TYPE
@@ -584,7 +597,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of IP Cache pending hits "
+			"Number of IP Cache pending hits"
         ::= { cacheIpCache 4 }
 
 	cacheIpNegativeHits OBJECT-TYPE
@@ -592,7 +605,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of IP Cache negative hits "
+			"Number of IP Cache negative hits"
         ::= { cacheIpCache 5 }
 
 	cacheIpMisses OBJECT-TYPE
@@ -600,7 +613,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of IP Cache misses "
+			"Number of IP Cache misses"
         ::= { cacheIpCache 6 }
 
 	cacheBlockingGetHostByName OBJECT-TYPE
@@ -608,7 +621,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of blocking gethostbyname requests "
+			"Number of blocking gethostbyname requests"
         ::= { cacheIpCache 7 }
 
 	cacheAttemptReleaseLckEntries OBJECT-TYPE
@@ -616,7 +629,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of attempts to release locked IP Cache entries "
+			"Number of attempts to release locked IP Cache entries"
         ::= { cacheIpCache 8 }
 
 --
@@ -628,7 +641,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" FQDN Cache entries "
+			"FQDN Cache entries"
         ::= { cacheFqdnCache 1 }
 
 	cacheFqdnRequests OBJECT-TYPE
@@ -636,7 +649,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of FQDN Cache requests "
+			"Number of FQDN Cache requests"
         ::= { cacheFqdnCache 2 }
 
 	cacheFqdnHits OBJECT-TYPE
@@ -644,7 +657,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of FQDN Cache hits "
+			"Number of FQDN Cache hits"
         ::= { cacheFqdnCache 3 }
 
 	cacheFqdnPendingHits OBJECT-TYPE
@@ -652,7 +665,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of FQDN Cache pending hits "
+			"Number of FQDN Cache pending hits"
         ::= { cacheFqdnCache 4 }
 
 	cacheFqdnNegativeHits OBJECT-TYPE
@@ -660,7 +673,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of FQDN Cache negative hits "
+			"Number of FQDN Cache negative hits"
         ::= { cacheFqdnCache 5 }
 
 	cacheFqdnMisses OBJECT-TYPE
@@ -668,7 +681,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of FQDN Cache misses "
+			"Number of FQDN Cache misses"
         ::= { cacheFqdnCache 6 }
 
 	cacheBlockingGetHostByAddr OBJECT-TYPE
@@ -676,7 +689,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of blocking gethostbyaddr requests "
+			"Number of blocking gethostbyaddr requests"
         ::= { cacheFqdnCache 7 }
 
 --
@@ -688,7 +701,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of external DNS server requests "
+			"Number of external DNS server requests"
         ::= { cacheDns 1 }
 
 	cacheDnsReplies OBJECT-TYPE
@@ -696,7 +709,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of external DNS server replies "
+			"Number of external DNS server replies"
         ::= { cacheDns 2 }
 
 	cacheDnsNumberServers OBJECT-TYPE
@@ -704,79 +717,78 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of external DNS server processes "
+			"Number of external DNS server processes"
         ::= { cacheDns 3 }
 	
 --
 -- cacheMesh group { squid 5 }
 --
 
+	CachePeerTableIndex ::= TEXTUAL-CONVENTION
+                DISPLAY-HINT "d"
+                STATUS current
+                DESCRIPTION
+                        "A unique value, greater than zero for each
+                        cache peer instance in the managed
+                        system. It is recommended that values are assigned
+                        contiguously starting from 1. The value for each
+                        cache peer index must remain constant
+                        at least from one re-initialization of the entity's
+                        network management system to the next
+                        re-initialization."
+                SYNTAX       Integer32 (1..2147483647)
+
+	ValidPort ::= TEXTUAL-CONVENTION
+                DISPLAY-HINT "d"
+                STATUS current
+                DESCRIPTION
+                        "A integer value from 1 to 65535 to indicate 
+                        the appropriate port number for the connection."
+                SYNTAX       Integer32 (1..65535)
+
 	cachePeerTable OBJECT-TYPE
-		SYNTAX SEQUENCE OF CachePeerTableEntry
+		SYNTAX SEQUENCE OF CachePeerEntry
 		MAX-ACCESS not-accessible
 		STATUS current
 		DESCRIPTION
-			" This table contains an enumeration of
-			  the peer caches, complete with info "
+			"This table contains an enumeration of
+			the peer caches, complete with info"
         ::= { cacheMesh 1 }
 
 	cachePeerEntry OBJECT-TYPE
-		SYNTAX CachePeerTableEntry
+		SYNTAX CachePeerEntry
 		MAX-ACCESS not-accessible
 		STATUS current
 		DESCRIPTION
-			" An entry in cachePeerTable (version 3) "
+			"An entry in cachePeerTable (version 3)"
 		INDEX 	{ cachePeerIndex }
 	::= { cachePeerTable 3 }
 
-	CachePeerTableEntry ::= SEQUENCE {
-	  cachePeerIndex	CachePeerTableIndex, 
-	  cachePeerName		DisplayString,
-	  cachePeerAddressType  InetAddressType,
-	  cachePeerAddress      InetAddress,
-	  cachePeerPortHttp 	ValidPort,
-	  cachePeerPortIcp	ValidPort,
-	  cachePeerType 	Integer32,
-	  cachePeerState	Integer32,
-	  cachePeerPingsSent	Counter32,
-	  cachePeerPingsAcked	Counter32,
-	  cachePeerFetches	Counter32,
-	  cachePeerRtt		Integer32,
-	  cachePeerIgnored	Counter32,
-	  cachePeerKeepAlSent	Counter32,
-	  cachePeerKeepAlRecv	Counter32
+	CachePeerEntry ::= SEQUENCE {
+                cachePeerIndex	        CachePeerTableIndex, 
+                cachePeerName		DisplayString,
+                cachePeerAddressType    InetAddressType,
+                cachePeerAddress        InetAddress,
+                cachePeerPortHttp 	ValidPort,
+                cachePeerPortIcp	ValidPort,
+                cachePeerType   	Integer32,
+                cachePeerState	        Integer32,
+                cachePeerPingsSent	Counter32,
+                cachePeerPingsAcked	Counter32,
+                cachePeerFetches	Counter32,
+                cachePeerRtt		Integer32,
+                cachePeerIgnored	Counter32,
+                cachePeerKeepAlSent	Counter32,
+                cachePeerKeepAlRecv	Counter32
 	}
 	
-	ValidPort ::= TEXTUAL-CONVENTION
-             DISPLAY-HINT "d"
-             STATUS       current
-             DESCRIPTION
-				"A integer value from 1 to 65535 to indicate 
-				the appropriate port number for the connection."
-			SYNTAX       Integer32 (1..65535)
-	
-	CachePeerTableIndex ::= TEXTUAL-CONVENTION
-             DISPLAY-HINT "d"
-             STATUS       current
-             DESCRIPTION
-               "A unique value, greater than zero for each
-               cache peer instance in the managed
-               system. It is recommended that values are assigned
-               contiguously starting from 1. The value for each
-               cache peer index must remain constant
-               at least from one re-initialization of the entity's
-               network management system to the next
-               re-initialization."
-             SYNTAX       Integer32 (1..2147483647)
-
-
 	cachePeerIndex OBJECT-TYPE
 		SYNTAX CachePeerTableIndex
 		MAX-ACCESS read-only
 		STATUS current
 		DESCRIPTION
-			   "A unique non-zero value identifying
-			     the particular cache Peer."
+                        "A unique non-zero value identifying
+                        the particular cache Peer."
 	::= { cachePeerEntry 1 }
 
 	cachePeerName OBJECT-TYPE
@@ -784,44 +796,43 @@ squid MODULE-IDENTITY
 		MAX-ACCESS read-only
 		STATUS current
 		DESCRIPTION
-			  " The FQDN name or internal alias for the
-		      	    peer cache "
+                        "The FQDN name or internal alias for the
+                        peer cache"
 	::= { cachePeerEntry 2 }
 
 	cachePeerAddressType OBJECT-TYPE
-	SYNTAX      InetAddressType
-	MAX-ACCESS  read-only
-	STATUS      current
-	DESCRIPTION
-		"The type of Internet address by which the peer
-		cache is reachable."
-
-	::= { cachePeerEntry 3 }
+                SYNTAX InetAddressType
+                MAX-ACCESS read-only
+                STATUS current
+                DESCRIPTION
+                        "The type of Internet address by which the peer
+                        cache is reachable."
+        ::= { cachePeerEntry 3 }
 
 	cachePeerAddress OBJECT-TYPE
-	SYNTAX      InetAddress (SIZE (1..64))
-	MAX-ACCESS  read-only
-	STATUS      current
-	DESCRIPTION
-	"The Internet address for the peer cache.  The type of this
-	 address is determined by the value of the peerAddressType
-         object.  Note that implementations must limit themselves
-         to a single entry in this table per reachable peer.
-         The peerAddress may not be empty due to the SIZE
-         restriction.
+                SYNTAX InetAddress (SIZE (1..64))
+                MAX-ACCESS read-only
+                STATUS current
+                DESCRIPTION
+                        "The Internet address for the peer cache.  The type of this
+                        address is determined by the value of the peerAddressType
+                        object.  Note that implementations must limit themselves
+                        to a single entry in this table per reachable peer.
+                        The peerAddress may not be empty due to the SIZE
+                        restriction.
 
-         If a row is created administratively by an SNMP
-         operation and the address type value is dns(16), then
-         the agent stores the DNS name internally.  A DNS name
-         lookup must be performed on the internally stored DNS
-         name whenever it is being used to contact the peer.
+                        If a row is created administratively by an SNMP
+                        operation and the address type value is dns(16), then
+                        the agent stores the DNS name internally.  A DNS name
+                        lookup must be performed on the internally stored DNS
+                        name whenever it is being used to contact the peer.
 
-         If a row is created by the managed entity itself and
-         the address type value is dns(16), then the agent
-         stores the IP address internally.  A DNS reverse lookup
-         must be performed on the internally stored IP address
-         whenever the value is retrieved via SNMP."
-	 ::= { cachePeerEntry 4 }
+                        If a row is created by the managed entity itself and
+                        the address type value is dns(16), then the agent
+                        stores the IP address internally.  A DNS reverse lookup
+                        must be performed on the internally stored IP address
+                        whenever the value is retrieved via SNMP."
+        ::= { cachePeerEntry 4 }
 
 
 	cachePeerPortHttp OBJECT-TYPE
@@ -829,7 +840,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" The port the peer listens for HTTP requests "
+			"The port the peer listens for HTTP requests"
         ::= { cachePeerEntry 5 }
 
 	cachePeerPortIcp OBJECT-TYPE
@@ -837,8 +848,8 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" The port the peer listens for ICP requests
-			  should be 0 if not configured to send ICP requests "
+			"The port the peer listens for ICP requests
+			should be 0 if not configured to send ICP requests"
         ::= { cachePeerEntry 6 }
 
 	cachePeerType OBJECT-TYPE
@@ -846,7 +857,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
                 DESCRIPTION
-                        " Peer Type "
+                        "Peer Type"
 	::= { cachePeerEntry 7 }
 
 	cachePeerState OBJECT-TYPE
@@ -854,7 +865,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" The operational state of this peer "
+			"The operational state of this peer"
         ::= { cachePeerEntry 8 }
 
         cachePeerPingsSent OBJECT-TYPE
@@ -862,7 +873,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of pings sent to peer "
+			"Number of pings sent to peer"
         ::= { cachePeerEntry 9 }
 
         cachePeerPingsAcked OBJECT-TYPE
@@ -870,7 +881,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of pings received from peer "
+			"Number of pings received from peer"
         ::= {  cachePeerEntry 10 }
 
         cachePeerFetches OBJECT-TYPE
@@ -878,7 +889,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of times this peer was selected  "
+			"Number of times this peer was selected"
         ::= { cachePeerEntry 11 }
 
         cachePeerRtt OBJECT-TYPE
@@ -886,7 +897,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Last known round-trip time to the peer (in ms) "
+		        "Last known round-trip time to the peer (in ms)"
         ::= { cachePeerEntry 12 }
 
         cachePeerIgnored OBJECT-TYPE
@@ -894,7 +905,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" How many times this peer was ignored "
+                        "How many times this peer was ignored"
         ::= { cachePeerEntry 13 }
 
         cachePeerKeepAlSent OBJECT-TYPE
@@ -902,7 +913,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of keepalives sent "
+			"Number of keepalives sent"
         ::= { cachePeerEntry 14 }
 
         cachePeerKeepAlRecv OBJECT-TYPE
@@ -910,7 +921,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
 		DESCRIPTION
-			" Number of keepalives received "
+			"Number of keepalives received"
         ::= { cachePeerEntry 15 }
 
 ---
@@ -919,20 +930,20 @@ squid MODULE-IDENTITY
 ---	
 
         cacheClientTable OBJECT-TYPE
-           SYNTAX  SEQUENCE OF CacheClientEntry
-           MAX-ACCESS  not-accessible
-           STATUS  current
-           DESCRIPTION
-                    "A list of cache client entries."
+                SYNTAX SEQUENCE OF CacheClientEntry
+                MAX-ACCESS not-accessible
+                STATUS current
+                DESCRIPTION
+                        "A list of cache client entries"
        	::= { cacheMesh 2 }
 
 	cacheClientEntry OBJECT-TYPE
-           SYNTAX CacheClientEntry
-           MAX-ACCESS  not-accessible
-           STATUS  current
-           DESCRIPTION
-                    "An IP entry in cacheClientTable "
-	   INDEX { cacheClientAddress }
+                SYNTAX CacheClientEntry
+                MAX-ACCESS not-accessible
+                STATUS current
+                DESCRIPTION
+                        "An IP entry in cacheClientTable"
+                INDEX { cacheClientAddress }
 	::= { cacheClientTable 2 }
 
 	CacheClientEntry ::= SEQUENCE {
@@ -953,32 +964,32 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    "The client's IP address "
+                    "The client's IP address"
         ::= { cacheClientEntry 1 }
 
 	cacheClientAddress OBJECT-TYPE
-	SYNTAX      InetAddress (SIZE (1..64))
-	MAX-ACCESS  read-only
-	STATUS      current
-	DESCRIPTION
-	"The Internet address for the client.  The type of this
-	 address is determined by the value of the peerAddressType
-         object.  Note that implementations must limit themselves
-         to a single entry in this table per reachable peer.
-         The peerAddress may not be empty due to the SIZE
-         restriction.
+                SYNTAX      InetAddress (SIZE (1..64))
+                MAX-ACCESS  read-only
+                STATUS      current
+                DESCRIPTION
+                        "The Internet address for the client.  The type of this
+                        address is determined by the value of the peerAddressType
+                        object.  Note that implementations must limit themselves
+                        to a single entry in this table per reachable peer.
+                        The peerAddress may not be empty due to the SIZE
+                        restriction.
 
-         If a row is created administratively by an SNMP
-         operation and the address type value is dns(16), then
-         the agent stores the DNS name internally.  A DNS name
-         lookup must be performed on the internally stored DNS
-         name whenever it is being used to contact the peer.
+                        If a row is created administratively by an SNMP
+                        operation and the address type value is dns(16), then
+                        the agent stores the DNS name internally.  A DNS name
+                        lookup must be performed on the internally stored DNS
+                        name whenever it is being used to contact the peer.
 
-         If a row is created by the managed entity itself and
-         the address type value is dns(16), then the agent
-         stores the IP address internally.  A DNS reverse lookup
-         must be performed on the internally stored IP address
-         whenever the value is retrieved via SNMP."
+                        If a row is created by the managed entity itself and
+                        the address type value is dns(16), then the agent
+                        stores the IP address internally.  A DNS reverse lookup
+                        must be performed on the internally stored IP address
+                        whenever the value is retrieved via SNMP."
 	 ::= { cacheClientEntry 2 }
 
 	cacheClientHttpRequests OBJECT-TYPE
@@ -986,7 +997,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Number of HTTP requests received from client "
+                        "Number of HTTP requests received from client"
         ::= { cacheClientEntry 3 }
 
 	cacheClientHttpKb OBJECT-TYPE
@@ -994,7 +1005,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Amount of total HTTP traffic to this client  "
+                        "Amount of total HTTP traffic to this client"
         ::= { cacheClientEntry 4 }
 
         cacheClientHttpHits OBJECT-TYPE
@@ -1002,7 +1013,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Number of hits in response to this client's HTTP requests "
+                        "Number of hits in response to this client's HTTP requests"
         ::= { cacheClientEntry 5 }
 
         cacheClientHTTPHitKb OBJECT-TYPE
@@ -1010,7 +1021,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Amount of HTTP hit traffic in KB "
+                        "Amount of HTTP hit traffic in KB"
         ::= { cacheClientEntry 6 }
 
 	cacheClientIcpRequests OBJECT-TYPE
@@ -1018,7 +1029,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Number of ICP requests received from client "
+                        "Number of ICP requests received from client"
         ::= { cacheClientEntry 7 }
 
 	cacheClientIcpKb OBJECT-TYPE
@@ -1026,7 +1037,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Amount of total ICP traffic to this client (child) "
+                        "Amount of total ICP traffic to this client (child)"
         ::= { cacheClientEntry 8 }
 
         cacheClientIcpHits OBJECT-TYPE
@@ -1034,7 +1045,7 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Number of hits in response to this client's ICP requests "
+                        "Number of hits in response to this client's ICP requests"
         ::= { cacheClientEntry 9 }
 
         cacheClientIcpHitKb OBJECT-TYPE
@@ -1042,15 +1053,15 @@ squid MODULE-IDENTITY
                 MAX-ACCESS read-only
                 STATUS current
            	DESCRIPTION
-                    " Amount of ICP hit traffic in KB "
+                        "Amount of ICP hit traffic in KB"
         ::= { cacheClientEntry 10 }
 
 	-- end of cacheClientTable
 
-
     -- end of cacheMesh group
 
+--
 -- end of SQUID-MIB
 --
-END
 
+END

--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -212,7 +212,7 @@ snmpInit(void)
     /* cachePeerTable - 1.3.6.1.4.1.3495.1.5.1 */
     snmpAddNodeStr("1.3.6.1.4.1.3495.1.5", MESH_PTBL, NULL, NULL);
 
-    /* CachePeerTableEntry (version 3) - 1.3.6.1.4.1.3495.1.5.1.3 */
+    /* CachePeerEntry (version 3) - 1.3.6.1.4.1.3495.1.5.1.3 */
     snmpAddNodeStr("1.3.6.1.4.1.3495.1.5.1", 3, NULL, NULL);
     snmpAddNodeStr("1.3.6.1.4.1.3495.1.5.1.3", MESH_PTBL_INDEX, snmp_meshPtblFn, peer_Inst);
     snmpAddNodeStr("1.3.6.1.4.1.3495.1.5.1.3", MESH_PTBL_NAME, snmp_meshPtblFn, peer_Inst);


### PR DESCRIPTION
- Reorganized `cachePeerTable` and related objects to fix `smilint` errors which prevent importing the MIB in compilers with more strict validation (e.g. MGsoft).

- Import of `Unsigned32` from `SNMPv2-SMI` was removed as it was not being used.
                
- Improved formatting consistency.