### PR TITLE
Refactor Half-Closed FD monitoring logic

### DIFF
--- a/src/comm.h
+++ b/src/comm.h
@@ -85,17 +85,6 @@ int comm_udp_recv(int fd, void *buf, size_t len, int flags);
 ssize_t comm_udp_send(int s, const void *buf, size_t len, int flags);
 bool comm_has_incomplete_write(int);
 
-/** The read channel has closed and the caller does not expect more data
- * but needs to detect connection aborts. The current detection method uses
- * 0-length reads: We read until the error occurs or the writer closes
- * the connection. If there is a read error, we close the connection.
- */
-void commStartHalfClosedMonitor(int fd);
-bool commHasHalfClosedMonitor(int fd);
-// XXX: remove these wrappers which minimize client_side.cc changes in a commit
-inline void commMarkHalfClosed(int fd) { commStartHalfClosedMonitor(fd); }
-inline bool commIsHalfClosed(int fd) { return commHasHalfClosedMonitor(fd); }
-
 /* A comm engine that calls comm_select */
 
 class CommSelectEngine : public AsyncEngine

--- a/src/comm/Read.cc
+++ b/src/comm/Read.cc
@@ -13,6 +13,7 @@
 #include "comm/IoCallback.h"
 #include "comm/Loops.h"
 #include "comm/Read.h"
+#include "comm/Write.h"
 #include "comm_internal.h"
 #include "CommCalls.h"
 #include "debug/Stream.h"
@@ -67,7 +68,7 @@ comm_read_base(const Comm::ConnectionPointer &conn, char *buf, int size, AsyncCa
     if (ccb->active()) {
         // if the assertion below fails, we have an active comm_read conflict
         assert(fd_table[conn->fd].halfClosedReader != NULL);
-        commStopHalfClosedMonitor(conn->fd);
+        Comm::StopWriteOnly(conn);
         assert(!ccb->active());
     }
     ccb->conn = conn;

--- a/src/comm/Write.h
+++ b/src/comm/Write.h
@@ -17,6 +17,14 @@ class MemBuf;
 namespace Comm
 {
 
+/// switch to write-only mode.
+/// Read will be monitored and any input will close
+/// the connection.
+void SetWriteOnly(const Comm::ConnectionPointer &);
+
+/// switch out of write-only mode.
+void StopWriteOnly(const Comm::ConnectionPointer &);
+
 /**
  * Queue a write. callback is scheduled when the write
  * completes, on error, or on file descriptor close.

--- a/src/comm/comm_internal.h
+++ b/src/comm/comm_internal.h
@@ -12,7 +12,6 @@
 /* misc collection of bits shared by Comm code, but not needed by the rest of Squid. */
 
 bool isOpen(const int fd);
-void commStopHalfClosedMonitor(int fd);
 
 #endif
 

--- a/src/fde.h
+++ b/src/fde.h
@@ -129,6 +129,8 @@ public:
         bool read_pending = false;
         //bool write_pending; //XXX seems not to be used
         bool transparent = false;
+        /// true if a half-closed FD monitor is supposed to be active
+        bool write_only = false;
     } flags;
 
     int64_t bytes_read = 0;

--- a/src/http.cc
+++ b/src/http.cc
@@ -1205,7 +1205,6 @@ HttpStateData::readReply(const CommIoCbParams &io)
      * Don't reset the timeout value here. The value should be
      * counting Config.Timeout.request and applies to the request
      * as a whole, not individual read() calls.
-     * Plus, it breaks our lame *HalfClosed() detection
      */
 
     Must(maybeMakeSpaceAvailable(true));

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -122,7 +122,6 @@ Server::doClientRead(const CommIoCbParams &io)
      * Don't reset the timeout value here. The value should be
      * counting Config.Timeout.request and applies to the request
      * as a whole, not individual read() calls.
-     * Plus, it breaks our lame *HalfClosed() detection
      */
 
     maybeMakeSpaceAvailable();
@@ -159,8 +158,8 @@ Server::doClientRead(const CommIoCbParams &io)
 
         /* It might be half-closed, we can't tell */
         fd_table[io.conn->fd].flags.socket_eof = true;
-        commMarkHalfClosed(io.conn->fd);
-        fd_note(io.conn->fd, "half-closed");
+        Comm::SetWriteOnly(io.conn);
+        fd_note(io.conn->fd, "write-only");
 
         /* There is one more close check at the end, to detect aborted
          * (partial) requests. At this point we can't tell if the request

--- a/src/tests/stub_comm.cc
+++ b/src/tests/stub_comm.cc
@@ -66,7 +66,5 @@ int comm_udp_recvfrom(int, void *, size_t, int, Ip::Address &) STUB_RETVAL(-1)
 int comm_udp_recv(int, void *, size_t, int) STUB_RETVAL(-1)
 ssize_t comm_udp_send(int, const void *, size_t, int) STUB_RETVAL(-1)
 bool comm_has_incomplete_write(int) STUB_RETVAL(false)
-void commStartHalfClosedMonitor(int) STUB
-bool commHasHalfClosedMonitor(int) STUB_RETVAL(false)
 int CommSelectEngine::checkEvents(int) STUB_RETVAL(0)
 

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -80,6 +80,8 @@ void Comm::TcpAcceptor::notify(const Comm::Flag, const Comm::ConnectionPointer &
 void Comm::ApplyTcpKeepAlive(int, const TcpKeepAlive &) STUB
 
 #include "comm/Write.h"
+void Comm::SetWriteOnly(const Comm::ConnectionPointer &) STUB
+void Comm::StopWriteOnly(const Comm::ConnectionPointer &) STUB
 void Comm::Write(const Comm::ConnectionPointer &, const char *, int, AsyncCall::Pointer &, FREE *) STUB
 void Comm::Write(const Comm::ConnectionPointer &, MemBuf *, AsyncCall::Pointer &) STUB
 void Comm::WriteCancel(const Comm::ConnectionPointer &, const char *) STUB


### PR DESCRIPTION
The complex event handler to determine when half-closed FDs have
lost their read handler can be replaced with a fd_table flag set
when the mode is enabled and unset on disable.

This flag can be tested by the read handler to re-schedule
monitoring correctly even when the mode is disabled while that
Call is pending in the Async dialer queue.

It also provides a far simpler method for other comm related
logic to test for write-only (half-closed) status without the
current complex registry lookup.

The DescriptorSet registry already duplicated the fd_table
halfClosedReader member. Now with the write_only flag it is
fully redundant and can be removed.