### PR TITLE
libcomm pt2: Convert Comm::iocb_table to a std::map

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1141,9 +1141,6 @@ comm_init(void)
     /* make sure the accept() socket FIFO delay queue exists */
     Comm::AcceptLimiter::Instance();
 
-    // make sure the IO pending callback table exists
-    Comm::CallbackTableInit();
-
     /* XXX account fd_table */
     /* Keep a few file descriptors free so that we don't run out of FD's
      * after accepting a client but before it opens a socket or a file.
@@ -1161,8 +1158,6 @@ comm_exit(void)
 {
     delete TheHalfClosed;
     TheHalfClosed = NULL;
-
-    Comm::CallbackTableDestruct();
 }
 
 #if USE_DELAY_POOLS

--- a/src/comm/IoCallback.cc
+++ b/src/comm/IoCallback.cc
@@ -16,30 +16,7 @@
 #include "fde.h"
 #include "globals.h"
 
-Comm::CbEntry *Comm::iocb_table;
-
-void
-Comm::CallbackTableInit()
-{
-    // XXX: convert this to a std::map<> ?
-    iocb_table = static_cast<CbEntry*>(xcalloc(Squid_MaxFD, sizeof(CbEntry)));
-    for (int pos = 0; pos < Squid_MaxFD; ++pos) {
-        iocb_table[pos].fd = pos;
-        iocb_table[pos].readcb.type = IOCB_READ;
-        iocb_table[pos].writecb.type = IOCB_WRITE;
-    }
-}
-
-void
-Comm::CallbackTableDestruct()
-{
-    // release any Comm::Connections being held.
-    for (int pos = 0; pos < Squid_MaxFD; ++pos) {
-        iocb_table[pos].readcb.conn = NULL;
-        iocb_table[pos].writecb.conn = NULL;
-    }
-    safe_free(iocb_table);
-}
+Comm::IocbTableType Comm::iocb_table;
 
 /**
  * Configure Comm::Callback for I/O

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -49,9 +49,7 @@ Comm::ConnOpener::ConnOpener(const Comm::ConnectionPointer &, const AsyncCall::P
     void Comm::IoCallback::selectOrQueueWrite() STUB
     void Comm::IoCallback::cancel(const char *) STUB
     void Comm::IoCallback::finish(Comm::Flag, int) STUB
-    Comm::CbEntry *Comm::iocb_table = NULL;
-void Comm::CallbackTableInit() STUB
-void Comm::CallbackTableDestruct() STUB
+//Comm::IocbTableType Comm::iocb_table;
 
 #include "comm/Loops.h"
 void Comm::SelectLoopInit(void) STUB


### PR DESCRIPTION
Implementing an old TODO and removing the need to
initialize and destruct the map on startup/shutdown.