### PR TITLE
Fix CID 1461131 Invalid type in argument to printf

### DIFF
--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -444,7 +444,7 @@ DisplayConf()
     if (edui_conf.mode & EDUI_MODE_PERSIST) {
         local_printfx("	Persistent mode: ON\n");
         if (edui_conf.persist_timeout > 0)
-            local_printfx("	Persistent mode idle timeout: %d\n", static_cast<int>(edui_conf.persist_timeout));
+            local_printfx("	Persistent mode idle timeout: %ld\n", static_cast<long int>(edui_conf.persist_timeout));
         else
             local_printfx("	Persistent mode idle timeout: OFF\n");
     } else

--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -444,7 +444,7 @@ DisplayConf()
     if (edui_conf.mode & EDUI_MODE_PERSIST) {
         local_printfx("	Persistent mode: ON\n");
         if (edui_conf.persist_timeout > 0)
-            local_printfx("	Persistent mode idle timeout: %d\n", edui_conf.persist_timeout);
+            local_printfx("	Persistent mode idle timeout: %d\n", static_cast<int>(edui_conf.persist_timeout));
         else
             local_printfx("	Persistent mode idle timeout: OFF\n");
     } else


### PR DESCRIPTION
in ext_edirecory_userip, persist_timeout is defined
as a time_t, wihich doesn't fly well with printf.
Cast it to int for printing; since it is set using atoi
it is guaranteed not to overflow anyway