### PR TITLE
Initialize all HttpStateData data members

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -75,14 +75,8 @@ static void copyOneHeaderFromClientsideRequestToUpstreamRequest(const HttpHeader
         HttpHeader * hdr_out, const int we_do_ranges, const Http::StateFlags &);
 
 HttpStateData::HttpStateData(FwdState *theFwdState) :
-    _peer(nullptr),
     AsyncJob("HttpStateData"),
-    Client(theFwdState),
-    httpChunkDecoder(NULL),
-    lastChunk(0),
-    payloadSeen(0),
-    payloadTruncated(0),
-    sawDateGoBack(false)
+    Client(theFwdState)
 {
     debugs(11,5, "HttpStateData " << this << " created");
     ignoreCacheControl = false;

--- a/src/http.cc
+++ b/src/http.cc
@@ -79,11 +79,9 @@ HttpStateData::HttpStateData(FwdState *theFwdState) :
     Client(theFwdState)
 {
     debugs(11,5, "HttpStateData " << this << " created");
-    ignoreCacheControl = false;
-    surrogateNoStore = false;
     serverConnection = fwd->serverConnection();
 
-    if (fwd->serverConnection())
+    if (fwd->serverConnection() != NULL)
         _peer = cbdataReference(fwd->serverConnection()->getPeer());         /* might be NULL */
 
     flags.peering =  _peer;

--- a/src/http.cc
+++ b/src/http.cc
@@ -75,10 +75,11 @@ static void copyOneHeaderFromClientsideRequestToUpstreamRequest(const HttpHeader
         HttpHeader * hdr_out, const int we_do_ranges, const Http::StateFlags &);
 
 HttpStateData::HttpStateData(FwdState *theFwdState) :
+    _peer(nullptr),
     AsyncJob("HttpStateData"),
     Client(theFwdState),
-    lastChunk(0),
     httpChunkDecoder(NULL),
+    lastChunk(0),
     payloadSeen(0),
     payloadTruncated(0),
     sawDateGoBack(false)
@@ -88,7 +89,7 @@ HttpStateData::HttpStateData(FwdState *theFwdState) :
     surrogateNoStore = false;
     serverConnection = fwd->serverConnection();
 
-    if (fwd->serverConnection() != NULL)
+    if (fwd->serverConnection())
         _peer = cbdataReference(fwd->serverConnection()->getPeer());         /* might be NULL */
 
     flags.peering =  _peer;

--- a/src/http.h
+++ b/src/http.h
@@ -61,14 +61,13 @@ public:
     // Checks whether the response is cacheable/shareable.
     ReuseDecision::Answers reusableReply(ReuseDecision &decision);
 
-    CachePeer *_peer;       /* CachePeer request made to */
-    int eof;            /* reached end-of-object? */
-    int lastChunk;      /* reached last chunk of a chunk-encoded reply */
+    CachePeer *_peer = nullptr;       /* CachePeer request made to */
+    int eof = 0;            /* reached end-of-object? */
+    int lastChunk = 0;      /* reached last chunk of a chunk-encoded reply */
     Http::StateFlags flags;
-    size_t read_sz;
     SBuf inBuf;                ///< I/O buffer for receiving server responses
-    bool ignoreCacheControl;
-    bool surrogateNoStore;
+    bool ignoreCacheControl = false;
+    bool surrogateNoStore = false;
 
     /// Upgrade header value sent to the origin server or cache peer.
     String *upgradeHeaderOut = nullptr;
@@ -147,16 +146,16 @@ private:
 
     /// Parser being used at present to parse the HTTP/ICY server response.
     Http1::ResponseParserPointer hp;
-    Http1::TeChunkedParser *httpChunkDecoder;
+    Http1::TeChunkedParser *httpChunkDecoder = nullptr;
 
     /// amount of message payload/body received so far.
-    int64_t payloadSeen;
+    int64_t payloadSeen = 0;
     /// positive when we read more than we wanted
-    int64_t payloadTruncated;
+    int64_t payloadTruncated = 0;
 
     /// Whether we received a Date header older than that of a matching
     /// cached response.
-    bool sawDateGoBack;
+    bool sawDateGoBack = false;
 };
 
 std::ostream &operator <<(std::ostream &os, const HttpStateData::ReuseDecision &d);


### PR DESCRIPTION
If fwd->serverConnection is null, _peer is read before being
initialized. We now make sure all HttpStateData data members are
initialized (using in-class member initialization).

Detected by Coverity. CID 1494356: Uninitialized pointer read (UNINIT).

Also removed HttpStateData::read_sz as unused.
