### PR TITLE
Improve Ipc::Mem page limits accounting

### DIFF
--- a/src/ipc/mem/Pages.cc
+++ b/src/ipc/mem/Pages.cc
@@ -21,7 +21,7 @@
 // TODO: make pool id more unique so it does not conflict with other Squids?
 static const char *PagePoolId = "squid-page-pool";
 static Ipc::Mem::PagePool *ThePagePool = 0;
-static int TheLimits[Ipc::Mem::PageId::maxPurpose];
+static int TheLimits[Ipc::Mem::PageId::maxPurpose+1];
 
 // TODO: make configurable to avoid waste when mem-cached objects are small/big
 size_t

--- a/src/ipc/mem/Pages.cc
+++ b/src/ipc/mem/Pages.cc
@@ -55,7 +55,7 @@ size_t
 Ipc::Mem::PageLimit()
 {
     size_t limit = 0;
-    for (int i = 0; i < PageId::maxPurpose; ++i)
+    for (int i = 0; i <= PageId::maxPurpose; ++i)
         limit += PageLimit(i);
     return limit;
 }


### PR DESCRIPTION
Undocumented Ipc::Mem::PageId::maxPurpose is used to mark freed pages.
Freed pages do not participate in estimating future memory needs, so the
Limits array does not need to store their needs. However, some of the
needs estimation code is written without that assumption in mind because
maxPurpose is a legitimate/used purpose value (rather than an enum end
marker). This change improves this code in case our assumption change.

Detected by Coverity:
* CID 1504262: Out-of-bounds write (OVERRUN)
* CID 1504263: Out-of-bounds read (OVERRUN)
