### PR TITLE
Ensure null-termination of string in negotiate_wrapper

### DIFF
--- a/src/auth/negotiate/wrapper/negotiate_wrapper.cc
+++ b/src/auth/negotiate/wrapper/negotiate_wrapper.cc
@@ -257,6 +257,7 @@ processingLoop(FILE *FDKIN, FILE *FDKOUT, FILE *FDNIN, FILE *FDNOUT)
                 return 0;
             }
         }
+        buff[sizeof(buff)-1] = '\0';
         fprintf(stdout,"%s",buff);
         if (debug_enabled)
             fprintf(stderr, "%s| %s: Return '%s'\n",

--- a/src/auth/negotiate/wrapper/negotiate_wrapper.cc
+++ b/src/auth/negotiate/wrapper/negotiate_wrapper.cc
@@ -257,7 +257,7 @@ processingLoop(FILE *FDKIN, FILE *FDKOUT, FILE *FDNIN, FILE *FDNOUT)
                 return 0;
             }
         }
-        buff[sizeof(buff)-1] = '\0';
+        buff[sizeof(buff)-1] = '\0'; // paranoid; already terminated correctly
         fprintf(stdout,"%s",buff);
         if (debug_enabled)
             fprintf(stderr, "%s| %s: Return '%s'\n",


### PR DESCRIPTION
Coverity identified a theoretical chance that a buffer may not be
null-terminated in negotiate_wrapper. The code flow is clean, adding a
forced null termination to apply defensive programming practices.