### PR TITLE
Initialise default_keytab in negotiate_kerberos_auth

### DIFF
--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -370,6 +370,7 @@ main(int argc, char *const argv[])
     const unsigned char *spnegoToken = NULL;
     size_t spnegoTokenLength = 0;
 
+    default_keytab[0] = '\0';
     setbuf(stdout, NULL);
     setbuf(stdin, NULL);
 

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -349,7 +349,7 @@ main(int argc, char *const argv[])
     char *service_principal = NULL;
     char *keytab_name = NULL;
     char *keytab_name_env = NULL;
-    char default_keytab[MAXPATHLEN];
+    char default_keytab[MAXPATHLEN] = {};
 #if HAVE_KRB5_MEMORY_KEYTAB
     char *memory_keytab_name = NULL;
     char *memory_keytab_name_env = NULL;
@@ -370,7 +370,6 @@ main(int argc, char *const argv[])
     const unsigned char *spnegoToken = NULL;
     size_t spnegoTokenLength = 0;
 
-    default_keytab[0] = '\0';
     setbuf(stdout, NULL);
     setbuf(stdin, NULL);
 


### PR DESCRIPTION
Address a Coverity-identified issue, where default_keytab might be read
when uninitialised in negotiate_kerberos_auth.
Ensure it is initialised at declaration.

Detected by Coverity, CID 1503291 (Uninitialized scalar variable)