### PR TITLE
Defensive coding for ESI stackmember

### DIFF
--- a/src/esi/Expression.cc
+++ b/src/esi/Expression.cc
@@ -63,15 +63,15 @@ typedef enum {
 } literalhint;
 
 struct _stackmember {
-    evaluate *eval;
+    evaluate *eval = nullptr;
     union {
-        char *string;
+        char *string = nullptr;
         double floating;
         int integral;
     } value;
-    literalhint valuestored;
-    evaltype valuetype;
-    int precedence;
+    literalhint valuestored = ESI_LITERAL_INVALID;
+    evaltype valuetype = ESI_EXPR_INVALID;
+    int precedence = 0;
 };
 
 static void cleanmember(stackmember *);


### PR DESCRIPTION
Add default initializer for POD struct stackmember in ESI,
to ensure all its fields are initialised in all instantiations

Coverity issue 1494364; likely a false positive