### PR TITLE
Refactor HttpStateData::ReuseDecision

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -2620,7 +2620,7 @@ HttpStateData::abortAll(const char *reason)
 }
 
 HttpStateData::ReuseDecision::ReuseDecision(const StoreEntry *e, const Http::StatusCode code)
-    : answer(HttpStateData::ReuseDecision::reuseNot), reason(nullptr), entry(e), statusCode(code) {}
+    : entry(e), statusCode(code) {}
 
 HttpStateData::ReuseDecision::Answers
 HttpStateData::ReuseDecision::make(const HttpStateData::ReuseDecision::Answers ans, const char *why)

--- a/src/http.h
+++ b/src/http.h
@@ -32,13 +32,14 @@ public:
         enum Answers { reuseNot = 0, cachePositively, cacheNegatively, doNotCacheButShare };
 
         ReuseDecision(const StoreEntry *e, const Http::StatusCode code);
+        ReuseDecision() = delete;
         /// stores the corresponding decision
         Answers make(const Answers ans, const char *why);
 
-        Answers answer; ///< the decision id
-        const char *reason; ///< the decision reason
-        const StoreEntry *entry; ///< entry for debugging
-        const Http::StatusCode statusCode; ///< HTTP status for debugging
+        Answers answer = reuseNot; ///< the decision id
+        const char *reason = nullptr; ///< the decision reason
+        const StoreEntry *entry = nullptr;
+        const Http::StatusCode statusCode = Http::StatusCode::scNone;
     };
 
     HttpStateData(FwdState *);

--- a/src/http.h
+++ b/src/http.h
@@ -32,7 +32,6 @@ public:
         enum Answers { reuseNot = 0, cachePositively, cacheNegatively, doNotCacheButShare };
 
         ReuseDecision(const StoreEntry *e, const Http::StatusCode code);
-        ReuseDecision() = delete;
         /// stores the corresponding decision
         Answers make(const Answers ans, const char *why);
 


### PR DESCRIPTION
Add in-class initializers for HttpStateData::ReuseDecision
to ensure all data members are initialised on each instantiation