### PR TITLE
Bug 5208: Part 1: Restart kids killed by SIGKILL

### DIFF
--- a/src/ipc/Kid.cc
+++ b/src/ipc/Kid.cc
@@ -100,7 +100,6 @@ bool Kid::shouldRestart() const
              exitedHappy() ||
              hopeless() ||
              shutting_down ||
-             signaled(SIGKILL) || // squid -k kill
              signaled(SIGINT) || // unexpected forced shutdown
              signaled(SIGTERM)); // unexpected forced shutdown
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -564,6 +564,7 @@ mainHandleCommandLineOption(const int optId, const char *optValue)
             /** \li On interrupt send SIGINT. */
             opt_send_signal = SIGINT;
         else if (!strncmp(optValue, "kill", strlen(optValue)))
+            // XXX: In SMP mode, uncatchable SIGKILL only kills the master process
             /** \li On kill send SIGKILL. */
             opt_send_signal = SIGKILL;
 


### PR DESCRIPTION
OOM killer uses SIGKILL. Squid did not restart kids killed by SIGKILL.
Kids are essential Squid components. Essential components should be
revived (by default) because providing a service without an essential
component would violate Squid functionality requirements.

Squid did not revive a kid killed by SIGKILL because we thought that
doing so will interfere with the "squid -k kill" feature that uses that
signal to kill the whole Squid instance. However, that feature does not
actually work[^1] -- the signal is sent to (and kills) the master
process only, the process which PID is in squid.pid file. This change is
orthogonal to fixing "squid -k kill" (a difficult out-of-scope project).

[^1]: Except in the special case of the no-daemon (squid -N) mode.