### PR TITLE
Fix CID 1503308: Logically dead code (DEADCODE)

### DIFF
--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -31,9 +31,6 @@ EVP_PKEY * Ssl::createSslPrivateKey()
     if (!RSA_generate_key_ex(rsa.get(), num, bn.get(), NULL))
         return NULL;
 
-    if (!rsa)
-        return NULL;
-
     if (!EVP_PKEY_assign_RSA(pkey.get(), (rsa.get())))
         return NULL;
 


### PR DESCRIPTION
The rsa variable has already been checked for nil and
cannot be unset before this extra check.

Detected by Coverity Scan