### PR TITLE
Added a debugging tool: scripts/trace-context.pl

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST	= AnnounceCache.pl access-log-matrix.pl cache-compare.pl \
 		cachetrace.pl check_cache.pl convert.configure.to.os2 \
 		fileno-to-pathname.pl flag_truncs.pl icp-test.pl \
 		find-alive.pl trace-job.pl trace-master.pl \
+		trace-context.pl \
 		icpserver.pl tcp-banger.pl udp-banger.pl upgrade-1.0-store.pl \
 		calc-must-ids.pl calc-must-ids.sh
 

--- a/scripts/trace-context.pl
+++ b/scripts/trace-context.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/perl -w
+#
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+# Reads cache.log and displays lines that correspond to a given CodeContext.
+
+use strict;
+use warnings;
+
+die("usage: $0 <CodeContext id> [log filename]\n") unless @ARGV;
+my $ContextId = shift;
+
+my $inside = 0;
+
+while (<>) {
+    if (/\bCodeContext.*?\bEntering: (\S+)/) {
+        my $wasInside = $inside;
+        $inside = $1 eq $ContextId;
+
+        # switched from our CodeContext to another
+        print "\n" if $wasInside && !$inside;
+    }
+
+    my $external = !$inside && /\b$ContextId\b/o;
+
+    print $_ if $inside || $external;
+    print "\n" if $external;
+
+    if ($inside && /\bCodeContext.*?\bLeaving:/) {
+        $inside = 0;
+        print "\n";
+    }
+}
+
+exit(0);

--- a/scripts/trace-context.pl
+++ b/scripts/trace-context.pl
@@ -21,7 +21,7 @@ my $inside = 0;
 my $currentGroup = 0;
 my $lastReportedGroup = undef();
 while (<>) {
-    if (/\bCodeContext.*?\bEntering: (\S+)/) {
+    if (/\bCodeContext.*?\bEntering: (.*)/) {
         my $wasInside = $inside;
         $inside = $1 eq $ContextId;
 

--- a/scripts/trace-context.pl
+++ b/scripts/trace-context.pl
@@ -40,7 +40,7 @@ while (<>) {
         ++$currentGroup;
     }
 
-    if ($inside && /\bCodeContext.*?\bLeaving:/) {
+    if ($inside && /\bCodeContext.*?\bLeaving: /) {
         $inside = 0;
         ++$currentGroup;
     }


### PR DESCRIPTION
This debugging script finds cache.log lines that belong to the given
CodeContext, identified by its gist (e.g., "conn123" or "master42").

Like other debugging scripts added in commit e83fd25, this one requires
maintenance as the cache.log format changes.