### PR TITLE
Update status code 413 compliance

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1713,7 +1713,7 @@ clientProcessRequest(ConnStateData *conn, const Http1::RequestParserPointer &hp,
             assert (repContext);
             conn->quitAfterError(request.getRaw());
             repContext->setReplyToError(ERR_TOO_BIG,
-                                        Http::scPayloadTooLarge, nullptr,
+                                        Http::scContentTooLarge, nullptr,
                                         conn, http->request, nullptr, nullptr);
             assert(context->http->out.offset == 0);
             context->pullData();
@@ -2098,7 +2098,7 @@ ConnStateData::abortChunkedRequestBody(const err_type error)
         clientReplyContext *repContext = dynamic_cast<clientReplyContext*>(node->data.getRaw());
         assert(repContext);
         const Http::StatusCode scode = (error == ERR_TOO_BIG) ?
-                                       Http::scPayloadTooLarge : HTTP_BAD_REQUEST;
+                                       Http::scContentTooLarge : HTTP_BAD_REQUEST;
         repContext->setReplyToError(error, scode,
                                     repContext->http->uri,
                                     CachePeer,

--- a/src/http.cc
+++ b/src/http.cc
@@ -523,7 +523,7 @@ HttpStateData::reusableReply(HttpStateData::ReuseDecision &decision)
     case Http::scConflict: // TODO: is this shareable?
     case Http::scLengthRequired:
     case Http::scPreconditionFailed:
-    case Http::scPayloadTooLarge:
+    case Http::scContentTooLarge:
     case Http::scUnsupportedMediaType:
     case Http::scUnprocessableEntity:
     case Http::scLocked: // TODO: is this shareable?

--- a/src/http/StatusCode.cc
+++ b/src/http/StatusCode.cc
@@ -164,8 +164,8 @@ Http::StatusCodeString(const Http::StatusCode status)
         return "Precondition Failed";
         break;
 
-    case Http::scPayloadTooLarge:
-        return "Payload Too Large";
+    case Http::scContentTooLarge:
+        return "Content Too Large";
         break;
 
     case Http::scUriTooLong:

--- a/src/http/StatusCode.h
+++ b/src/http/StatusCode.h
@@ -54,7 +54,7 @@ typedef enum {
     scGone = 410,
     scLengthRequired = 411,
     scPreconditionFailed = 412,
-    scPayloadTooLarge = 413,
+    scContentTooLarge = 413,
     scUriTooLong = 414,
     scUnsupportedMediaType = 415,
     scRequestedRangeNotSatisfied = 416,


### PR DESCRIPTION
The latest HTTP specification requires the data
transmitted in HTTP messages be called 'content'.

The official reason text for status code 413 has
been altered to comply.