### PR TITLE
Fix uninitalised var in eDirectory digest helper

### DIFF
--- a/src/auth/digest/eDirectory/ldap_backend.cc
+++ b/src/auth/digest/eDirectory/ldap_backend.cc
@@ -203,8 +203,10 @@ getpassword(char *login, char *realm)
     char **value = NULL;
     char *password = NULL;
     int retry = 0;
-    char filter[8192] = "";
-    char searchbase[8192] = "";
+    char filter[8192];
+    *filter='\0';
+    char searchbase[8192]
+    *searchbase='\0';
     char *universal_password = NULL;
     size_t universal_password_len = 256;
     int nmas_res = 0;

--- a/src/auth/digest/eDirectory/ldap_backend.cc
+++ b/src/auth/digest/eDirectory/ldap_backend.cc
@@ -203,8 +203,8 @@ getpassword(char *login, char *realm)
     char **value = NULL;
     char *password = NULL;
     int retry = 0;
-    char filter[8192] = {};
-    char searchbase[8192] = {};
+    char filter[8192] = "";
+    char searchbase[8192] = "";
     char *universal_password = NULL;
     size_t universal_password_len = 256;
     int nmas_res = 0;
@@ -213,8 +213,10 @@ getpassword(char *login, char *realm)
         if (usersearchfilter) {
             char escaped_login[1024];
             snprintf(searchbase, sizeof(searchbase), "%s", userbasedn);
+            searchbase[sizeof(searchbase)] = '\0';
             ldap_escape_value(escaped_login, sizeof(escaped_login), login);
             snprintf(filter, sizeof(filter), usersearchfilter, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login);
+            filter[sizeof(filter)] = '\0';
 
 retrysrch:
             debug("user filter '%s', searchbase '%s'\n", filter, searchbase);

--- a/src/auth/digest/eDirectory/ldap_backend.cc
+++ b/src/auth/digest/eDirectory/ldap_backend.cc
@@ -216,10 +216,8 @@ getpassword(char *login, char *realm)
         if (usersearchfilter) {
             char escaped_login[1024];
             std::snprintf(searchbase, sizeof(searchbase), "%s", userbasedn);
-            searchbase[sizeof(searchbase)-1] = '\0';
             ldap_escape_value(escaped_login, sizeof(escaped_login), login);
             std::snprintf(filter, sizeof(filter), usersearchfilter, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login);
-            filter[sizeof(filter)-1] = '\0';
 
 retrysrch:
             debug("user filter '%s', searchbase '%s'\n", filter, searchbase);

--- a/src/auth/digest/eDirectory/ldap_backend.cc
+++ b/src/auth/digest/eDirectory/ldap_backend.cc
@@ -11,13 +11,14 @@
  */
 #include "squid.h"
 
+#include <cstdio>
+
 #define LDAP_DEPRECATED 1
 
 #include "auth/digest/eDirectory/ldap_backend.h"
 
 #if _SQUID_WINDOWS_ && !_SQUID_CYGWIN_
 
-#define snprintf _snprintf
 #include <windows.h>
 #include <winldap.h>
 #ifndef LDAPAPI
@@ -177,7 +178,7 @@ ldap_escape_value(char *escaped, int size, const char *src)
             if (size > 0) {
                 *escaped = '\\';
                 ++escaped;
-                snprintf(escaped, 3, "%02x", (int) *src);
+                std::snprintf(escaped, 3, "%02x", (int) *src);
                 ++src;
                 escaped += 2;
             }
@@ -204,9 +205,9 @@ getpassword(char *login, char *realm)
     char *password = NULL;
     int retry = 0;
     char filter[8192];
-    *filter='\0';
+    *filter = '\0';
     char searchbase[8192]
-    *searchbase='\0';
+    *searchbase = '\0';
     char *universal_password = NULL;
     size_t universal_password_len = 256;
     int nmas_res = 0;
@@ -214,11 +215,11 @@ getpassword(char *login, char *realm)
     if (ld) {
         if (usersearchfilter) {
             char escaped_login[1024];
-            snprintf(searchbase, sizeof(searchbase), "%s", userbasedn);
-            searchbase[sizeof(searchbase)] = '\0';
+            std::snprintf(searchbase, sizeof(searchbase), "%s", userbasedn);
+            searchbase[sizeof(searchbase)-1] = '\0';
             ldap_escape_value(escaped_login, sizeof(escaped_login), login);
-            snprintf(filter, sizeof(filter), usersearchfilter, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login);
-            filter[sizeof(filter)] = '\0';
+            std::snprintf(filter, sizeof(filter), usersearchfilter, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login, escaped_login);
+            filter[sizeof(filter)-1] = '\0';
 
 retrysrch:
             debug("user filter '%s', searchbase '%s'\n", filter, searchbase);
@@ -253,7 +254,7 @@ retrysrch:
                 }
             }
         } else if (userdnattr) {
-            snprintf(searchbase, 8192, "%s=%s, %s", userdnattr, login, userbasedn);
+            std::snprintf(searchbase, 8192, "%s=%s, %s", userdnattr, login, userbasedn);
 
 retrydnattr:
             debug("searchbase '%s'\n", searchbase);
@@ -466,7 +467,7 @@ LDAPArguments(int argc, char **argv)
             if (ldapServer) {
                 int len = strlen(ldapServer) + 1 + strlen(value) + 1;
                 char *newhost = static_cast<char*>(xmalloc(len));
-                snprintf(newhost, len, "%s %s", ldapServer, value);
+                std::snprintf(newhost, len, "%s %s", ldapServer, value);
                 free(ldapServer);
                 ldapServer = newhost;
             } else {
@@ -595,7 +596,7 @@ LDAPArguments(int argc, char **argv)
         if (ldapServer) {
             int len = strlen(ldapServer) + 1 + strlen(value) + 1;
             char *newhost = static_cast<char*>(xmalloc(len));
-            snprintf(newhost, len, "%s %s", ldapServer, value);
+            std::snprintf(newhost, len, "%s %s", ldapServer, value);
             free(ldapServer);
             ldapServer = newhost;
         } else {

--- a/src/auth/digest/eDirectory/ldap_backend.cc
+++ b/src/auth/digest/eDirectory/ldap_backend.cc
@@ -206,7 +206,7 @@ getpassword(char *login, char *realm)
     int retry = 0;
     char filter[8192];
     *filter = '\0';
-    char searchbase[8192]
+    char searchbase[8192];
     *searchbase = '\0';
     char *universal_password = NULL;
     size_t universal_password_len = 256;

--- a/src/auth/digest/eDirectory/ldap_backend.cc
+++ b/src/auth/digest/eDirectory/ldap_backend.cc
@@ -203,8 +203,8 @@ getpassword(char *login, char *realm)
     char **value = NULL;
     char *password = NULL;
     int retry = 0;
-    char filter[8192];
-    char searchbase[8192];
+    char filter[8192] = {};
+    char searchbase[8192] = {};
     char *universal_password = NULL;
     size_t universal_password_len = 256;
     int nmas_res = 0;


### PR DESCRIPTION
In certain conditions, some string pointers in the eDirecotry digest
helper might be read before they are initialized. Initialize them.

Detected by Coverity, CID 1494358 (Uninitialized scalar variable).