### PR TITLE
Unbreak test build around CPU_AND

### DIFF
--- a/src/CpuAffinitySet.cc
+++ b/src/CpuAffinitySet.cc
@@ -38,7 +38,12 @@ CpuAffinitySet::apply()
     } else {
         cpu_set_t cpuSet;
         memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
+// clang on Ubuntu Xenial complains about an unused return
+// value. We can't make use of it or freebsd will break
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
         CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+#pragma clang diagnostic pop
         if (CPU_COUNT(&cpuSet) <= 0) {
             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
                    "PID " << getpid() << ", may be caused by an invalid core in "


### PR DESCRIPTION
On FreeBSD, CPU_AND is a do-while macro
On Ubuntu Xenial, clang complains that CPU_AND returns a value
which is then ignored

Disable the build-breaking warning around that line
via a clang specific pragma directive