### PR TITLE
Make libntlm a dynamic module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2485,7 +2485,10 @@ dnl This list will not be needed when each auth library has its own Makefile
 dnl this is to be placed AFTER each auth module's handler
 AUTH_LIBS_TO_BUILD=
 for module in $AUTH_MODULES; do
+  # NTLM now builds a dynamic library
+  AS_IF([! test "x$module" = "xntlm"],[
     AUTH_LIBS_TO_BUILD="$AUTH_LIBS_TO_BUILD ${module}/lib${module}.la"
+  ])
 done
 AC_SUBST(AUTH_MODULES)
 AC_SUBST(AUTH_LIBS_TO_BUILD)

--- a/src/AuthReg.cc
+++ b/src/AuthReg.cc
@@ -20,9 +20,6 @@
 #if HAVE_AUTH_MODULE_NEGOTIATE
 #include "auth/negotiate/Scheme.h"
 #endif
-#if HAVE_AUTH_MODULE_NTLM
-#include "auth/ntlm/Scheme.h"
-#endif
 
 #include "debug/Stream.h"
 
@@ -45,10 +42,6 @@ Auth::Init()
 #if HAVE_AUTH_MODULE_NEGOTIATE
     static const char *negotiate_type = Auth::Negotiate::Scheme::GetInstance()->type();
     debugs(29,DBG_IMPORTANT,"Startup: Initialized Authentication Scheme '" << negotiate_type << "'");
-#endif
-#if HAVE_AUTH_MODULE_NTLM
-    static const char *ntlm_type = Auth::Ntlm::Scheme::GetInstance()->type();
-    debugs(29,DBG_IMPORTANT,"Startup: Initialized Authentication Scheme '" << ntlm_type << "'");
 #endif
     debugs(29,DBG_IMPORTANT,"Startup: Initialized Authentication.");
 }

--- a/src/LoadableModules.cc
+++ b/src/LoadableModules.cc
@@ -13,7 +13,7 @@
 #include "LoadableModules.h"
 #include "wordlist.h"
 
-static void
+void
 LoadModule(const char *fname)
 {
     debugs(1, DBG_IMPORTANT, "Loading Squid module from '" << fname << "'");
@@ -24,13 +24,3 @@ LoadModule(const char *fname)
 
     //TODO: TheModules.push_back(m);
 }
-
-void
-LoadableModulesConfigure(const wordlist *names)
-{
-    int count = 0;
-    for (const wordlist *i = names; i; i = i->next, ++count)
-        LoadModule(i->key);
-    debugs(1, Important(25), "Squid plugin modules loaded: " << count);
-}
-

--- a/src/LoadableModules.h
+++ b/src/LoadableModules.h
@@ -12,8 +12,7 @@
 // TODO: add reporting for cachemgr
 // TODO: add reconfiguration support
 
-class wordlist;
-void LoadableModulesConfigure(const wordlist *names);
+void LoadModule(const char *name);
 
 #endif /* SQUID_LOADABLE_MODULES_H */
 

--- a/src/auth/Gadgets.cc
+++ b/src/auth/Gadgets.cc
@@ -130,10 +130,6 @@ authenticateCachedUsersList()
     if (Auth::SchemeConfig::Find("negotiate"))
         u1 = Auth::Negotiate::User::Cache()->sortedUsersList();
 #endif
-#if HAVE_AUTH_MODULE_NTLM
-    if (Auth::SchemeConfig::Find("ntlm"))
-        u2 = Auth::Ntlm::User::Cache()->sortedUsersList();
-#endif
     if (u1.size() > 0 || u2.size() > 0) {
         v2.reserve(u1.size()+u2.size());
         std::merge(u1.begin(), u1.end(),u2.begin(), u2.end(),

--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -242,6 +242,7 @@ Auth::User::BuildUserKey(const char *username, const char *realm)
 void
 Auth::User::CredentialsCacheStats(StoreEntry *output)
 {
+    // XXX: dump scheme caches individually instead of merging
     auto userlist = authenticateCachedUsersList();
     storeAppendPrintf(output, "Cached Usernames: %d", static_cast<int32_t>(userlist.size()));
     storeAppendPrintf(output, "\n%-15s %-9s %-9s %-9s %s\t%s\n",

--- a/src/auth/ntlm/Makefile.am
+++ b/src/auth/ntlm/Makefile.am
@@ -12,7 +12,7 @@ DIST_SUBDIRS= fake SMB_LM SSPI
 SUBDIRS= $(NTLM_AUTH_HELPERS)
 EXTRA_DIST= helpers.m4
 
-noinst_LTLIBRARIES = libntlm.la
+pkglib_LTLIBRARIES = libntlm.la
 
 libntlm_la_SOURCES = \
 	Config.cc \
@@ -23,3 +23,5 @@ libntlm_la_SOURCES = \
 	User.h \
 	UserRequest.cc \
 	UserRequest.h
+
+libntlm_la_LDFLAGS = -module -Wl,-soname,libntlm.so.$(PACKAGE_VERSION)

--- a/src/auth/ntlm/Scheme.cc
+++ b/src/auth/ntlm/Scheme.cc
@@ -17,9 +17,9 @@
 class NtlmAuthRr : public RegisteredRunner
 {
 public:
-    void bootstrapConfig() {
+    void bootstrapModule() {
         const char *type = Auth::Ntlm::Scheme::GetInstance()->type();
-        debugs(29,  DBG_IMPORTANT, "Initialized Authentication Scheme '" << type << "'");
+        debugs(29, DBG_IMPORTANT, "Initialized Authentication Scheme '" << type << "'");
     }
 };
 RunnerRegistrationEntry(NtlmAuthRr);

--- a/src/auth/ntlm/Scheme.cc
+++ b/src/auth/ntlm/Scheme.cc
@@ -9,16 +9,27 @@
 #include "squid.h"
 #include "auth/ntlm/Config.h"
 #include "auth/ntlm/Scheme.h"
+#include "base/RunnersRegistry.h"
 #include "debug/Messages.h"
 #include "debug/Stream.h"
 #include "helper.h"
 
-Auth::Scheme::Pointer Auth::Ntlm::Scheme::_instance = NULL;
+class NtlmAuthRr : public RegisteredRunner
+{
+public:
+    void bootstrapConfig() {
+        const char *type = Auth::Ntlm::Scheme::GetInstance()->type();
+        debugs(29,  DBG_IMPORTANT, "Initialized Authentication Scheme '" << type << "'");
+    }
+};
+RunnerRegistrationEntry(NtlmAuthRr);
 
 Auth::Scheme::Pointer
 Auth::Ntlm::Scheme::GetInstance()
 {
-    if (_instance == NULL) {
+    static Auth::Scheme::Pointer _instance;
+
+    if (!_instance) {
         _instance = new Auth::Ntlm::Scheme();
         AddScheme(_instance);
     }
@@ -34,10 +45,7 @@ Auth::Ntlm::Scheme::type() const
 void
 Auth::Ntlm::Scheme::shutdownCleanup()
 {
-    if (_instance == NULL)
-        return;
-
-    _instance = NULL;
+    // TODO: destruct any active Ntlm::Config objects via runner
     debugs(29, Critical(61), "Shutdown: NTLM authentication.");
 }
 

--- a/src/auth/ntlm/Scheme.h
+++ b/src/auth/ntlm/Scheme.h
@@ -35,13 +35,6 @@ public:
     /* Not implemented */
     Scheme (Scheme const &);
     Scheme &operator=(Scheme const &);
-
-private:
-    /**
-     * Main instance of this authentication Scheme.
-     * NULL when the scheme is not being used.
-     */
-    static Auth::Scheme::Pointer _instance;
 };
 
 } // namespace Ntlm

--- a/src/base/RunnersRegistry.h
+++ b/src/base/RunnersRegistry.h
@@ -45,6 +45,11 @@ public:
     /// Meant for initializing/preparing configuration parsing facilities.
     virtual void bootstrapConfig() {}
 
+    /// Called after parsing loadable_modules directive
+    /// Meant for initializing/preparing configuration parsing facilities
+    /// located in dynamic libraries [modules].
+    virtual void bootstrapModule() {}
+
     /// Called after parsing squid.conf.
     /// Meant for setting configuration options that depend on other
     /// configuration options and were not explicitly configured.

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -47,6 +47,7 @@
 #include "ipc/Kids.h"
 #include "log/Config.h"
 #include "log/CustomLog.h"
+#include "LoadableModules.h"
 #include "MemBuf.h"
 #include "MessageDelayPools.h"
 #include "mgr/ActionPasswordList.h"
@@ -3181,6 +3182,21 @@ check_null_acl_access(acl_access * a)
 #define free_wordlist wordlistDestroy
 
 #define free_uri_whitespace free_int
+
+static void
+parse_modules(wordlist **list)
+{
+    while (auto *token = ConfigParser::NextQuotedToken()) {
+#if USE_LOADABLE_MODULES
+        LoadModule(token);
+        RunRegisteredHere(RegisteredRunner::bootstrapModule);
+#endif
+        wordlistAdd(list, token);
+    }
+}
+
+#define dump_modules dump_wordlist
+#define free_modules wordlistDestroy
 
 static void
 parse_uri_whitespace(int *var)

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -15,7 +15,7 @@ acl_b_size_t		acl
 acl_tos			acl
 acl_nfmark		acl
 address
-authparam
+authparam		loadable_modules
 AuthSchemes		acl auth_param
 b_int64_t
 b_size_t

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -53,7 +53,7 @@ icap_class_type		icap_service
 icap_service_type
 icap_service_failure_limit
 icmp
-ecap_service_type
+ecap_service_type	loadable_modules
 int
 int64_t
 kb_int64_t
@@ -61,6 +61,7 @@ kb_size_t
 logformat
 YesNoNone
 memcachemode
+modules
 note			acl
 obsolete
 onoff

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -437,6 +437,24 @@ DOC_START
 DOC_END
 
 COMMENT_START
+ OPTIONS FOR PROCESS MANAGEMENT
+ -----------------------------------------------------------------------------
+COMMENT_END
+
+NAME: loadable_modules
+TYPE: modules
+IFDEF: USE_LOADABLE_MODULES
+LOC: Config.loadable_module_names
+DEFAULT: none
+DOC_START
+	Instructs Squid to load the specified dynamic module(s) or activate
+	preloaded module(s).
+
+	Example:
+	  loadable_modules @DEFAULT_PREFIX@/lib/MinimalAdapter.so
+DOC_END
+
+COMMENT_START
  OPTIONS FOR SMP
  -----------------------------------------------------------------------------
 COMMENT_END
@@ -9740,18 +9758,6 @@ DOC_START
 Example:
 ecap_service s1 reqmod_precache ecap://filters.R.us/leakDetector?on_error=block bypass=off
 ecap_service s2 respmod_precache ecap://filters.R.us/virusFilter config=/etc/vf.cfg bypass=on
-DOC_END
-
-NAME: loadable_modules
-TYPE: wordlist
-IFDEF: USE_LOADABLE_MODULES
-LOC: Config.loadable_module_names
-DEFAULT: none
-DOC_START
-	Instructs Squid to load the specified dynamic module(s) or activate
-	preloaded module(s).
-Example:
-loadable_modules @DEFAULT_PREFIX@/lib/MinimalAdapter.so
 DOC_END
 
 COMMENT_START

--- a/src/main.cc
+++ b/src/main.cc
@@ -956,10 +956,6 @@ mainReconfigureFinish(void *)
     errorInitialize();      /* reload error pages */
     accessLogInit();
 
-#if USE_LOADABLE_MODULES
-    LoadableModulesConfigure(Config.loadable_module_names);
-#endif
-
 #if USE_ADAPTATION
     bool enableAdaptation = false;
 #if ICAP_CLIENT
@@ -1294,10 +1290,6 @@ mainInitialize(void)
 #endif
 
     memCheckInit();
-
-#if USE_LOADABLE_MODULES
-    LoadableModulesConfigure(Config.loadable_module_names);
-#endif
 
 #if USE_ADAPTATION
     bool enableAdaptation = false;


### PR DESCRIPTION
Demonstration dynamic module for Squid.
Requires PR #1051 and #1052

Moves the NTLM auth scheme logic to /usr/lib/squid/libntlm.so
which can be loaded using:
   loadable_modules /usr/lib/squid/libntlm.so
