### PR TITLE
Fix PeerConnector::handleNegotiationResult() error debugging

### DIFF
--- a/src/base/IoManip.h
+++ b/src/base/IoManip.h
@@ -9,6 +9,8 @@
 #ifndef SQUID_SRC_BASE_IO_MANIP_H
 #define SQUID_SRC_BASE_IO_MANIP_H
 
+#include "debug/Stream.h"
+
 #include <iostream>
 #include <iomanip>
 
@@ -18,8 +20,14 @@ class RawPointerT {
 public:
     RawPointerT(const char *aLabel, const Pointer &aPtr):
         label(aLabel), ptr(aPtr) {}
+
+    /// Report the pointed-to-object on a dedicated Debug::Extra line.
+    /// Report nothing if the pointer is nil.
+    RawPointerT<Pointer> &asExtra() { onExtraLine = true; return *this; }
+
     const char *label; /// the name or description of the being-debugged object
     const Pointer &ptr; /// a possibly nil pointer to the being-debugged object
+    bool onExtraLine = false;
 };
 
 /// convenience wrapper for creating  RawPointerT<> objects
@@ -35,7 +43,14 @@ template <class Pointer>
 inline std::ostream &
 operator <<(std::ostream &os, const RawPointerT<Pointer> &pd)
 {
-    os << pd.label << '=';
+    if (pd.onExtraLine) {
+        if (!pd.ptr)
+            return os;
+        os << Debug::Extra << pd.label << ": ";
+    } else {
+        os << pd.label << '=';
+    }
+
     if (pd.ptr)
         os << *pd.ptr;
     else

--- a/src/base/IoManip.h
+++ b/src/base/IoManip.h
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <iomanip>
 
-/// Safely prints an object pointed to by the given pointer: <label><object>
+/// Safely prints an object pointed to by the given pointer: [label]<object>
 /// Prints nothing at all if the pointer is nil.
 template <class Pointer>
 class RawPointerT {
@@ -49,7 +49,9 @@ operator <<(std::ostream &os, const RawPointerT<Pointer> &pd)
     if (pd.onExtraLine)
         os << Debug::Extra;
 
-    os << pd.label;
+    if (pd.label)
+        os << pd.label;
+
     os << *pd.ptr;
 
     return os;

--- a/src/base/IoManip.h
+++ b/src/base/IoManip.h
@@ -14,7 +14,8 @@
 #include <iostream>
 #include <iomanip>
 
-/// debugs objects pointed by possibly nil pointers: <label><object>
+/// Safely prints an object pointed to by the given pointer: <label><object>
+/// Prints nothing at all if the pointer is nil.
 template <class Pointer>
 class RawPointerT {
 public:
@@ -22,7 +23,6 @@ public:
         label(aLabel), ptr(aPtr) {}
 
     /// Report the pointed-to-object on a dedicated Debug::Extra line.
-    /// Report nothing if the pointer is nil.
     RawPointerT<Pointer> &asExtra() { onExtraLine = true; return *this; }
 
     const char *label; /// the name or description of the being-debugged object
@@ -43,18 +43,15 @@ template <class Pointer>
 inline std::ostream &
 operator <<(std::ostream &os, const RawPointerT<Pointer> &pd)
 {
-    if (pd.onExtraLine) {
-        if (!pd.ptr)
-            return os;
+    if (!pd.ptr)
+        return os;
+
+    if (pd.onExtraLine)
         os << Debug::Extra;
-    }
 
     os << pd.label;
+    os << *pd.ptr;
 
-    if (pd.ptr)
-        os << *pd.ptr;
-    else
-        os << "[nil]";
     return os;
 }
 

--- a/src/base/IoManip.h
+++ b/src/base/IoManip.h
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <iomanip>
 
-/// debugs objects pointed by possibly nil pointers: label=object
+/// debugs objects pointed by possibly nil pointers: <label><object>
 template <class Pointer>
 class RawPointerT {
 public:
@@ -46,10 +46,10 @@ operator <<(std::ostream &os, const RawPointerT<Pointer> &pd)
     if (pd.onExtraLine) {
         if (!pd.ptr)
             return os;
-        os << Debug::Extra << pd.label << ": ";
-    } else {
-        os << pd.label << '=';
+        os << Debug::Extra;
     }
+
+    os << pd.label;
 
     if (pd.ptr)
         os << *pd.ptr;

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -273,8 +273,9 @@ Security::PeerConnector::handleNegotiationResult(const Security::IoResult &resul
     }
 
     // TODO: Honor result.important when working in a reverse proxy role?
-    debugs(83, 2, "ERROR: " << result.errorDescription <<
-           " while establishing TLS connection on FD: " << serverConnection()->fd << result.errorDetail);
+    debugs(83, 2, "ERROR: Cannot establish a TLS connection to " << serverConnection() << ':' <<
+           Debug::Extra << "problem: " << result.errorDescription <<
+           Debug::Extra << "detail: " << result.errorDetail);
     recordNegotiationDetails();
     noteNegotiationError(result.errorDetail);
 }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -275,7 +275,7 @@ Security::PeerConnector::handleNegotiationResult(const Security::IoResult &resul
     // TODO: Honor result.important when working in a reverse proxy role?
     debugs(83, 2, "ERROR: Cannot establish a TLS connection to " << serverConnection() << ':' <<
            Debug::Extra << "problem: " << result.errorDescription <<
-           Debug::Extra << RawPointer("detail", result.errorDetail));
+           RawPointer("detail", result.errorDetail).asExtra());
     recordNegotiationDetails();
     noteNegotiationError(result.errorDetail);
 }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -337,7 +337,7 @@ Security::PeerConnector::sslCrtvdHandleReply(Ssl::CertValidationResponse::Pointe
     if (Debug::Enabled(83, 5)) {
         Security::SessionPointer ssl(fd_table[serverConnection()->fd].ssl);
         SBuf *server = static_cast<SBuf *>(SSL_get_ex_data(ssl.get(), ssl_ex_index_server));
-        debugs(83, 5, RawPointer("host=", server) << " cert validation result: " << validationResponse->resultCode);
+        debugs(83, 5, "cert validation result: " << validationResponse->resultCode << RawPointer(" host: ", server));
     }
 
     if (validationResponse->resultCode == ::Helper::Error) {

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -275,7 +275,7 @@ Security::PeerConnector::handleNegotiationResult(const Security::IoResult &resul
     // TODO: Honor result.important when working in a reverse proxy role?
     debugs(83, 2, "ERROR: Cannot establish a TLS connection to " << serverConnection() << ':' <<
            Debug::Extra << "problem: " << result.errorDescription <<
-           Debug::Extra << "detail: " << result.errorDetail);
+           Debug::Extra << RawPointer("detail", result.errorDetail));
     recordNegotiationDetails();
     noteNegotiationError(result.errorDetail);
 }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -275,7 +275,7 @@ Security::PeerConnector::handleNegotiationResult(const Security::IoResult &resul
     // TODO: Honor result.important when working in a reverse proxy role?
     debugs(83, 2, "ERROR: Cannot establish a TLS connection to " << serverConnection() << ':' <<
            Debug::Extra << "problem: " << result.errorDescription <<
-           RawPointer("detail", result.errorDetail).asExtra());
+           RawPointer("detail: ", result.errorDetail).asExtra());
     recordNegotiationDetails();
     noteNegotiationError(result.errorDetail);
 }
@@ -337,7 +337,7 @@ Security::PeerConnector::sslCrtvdHandleReply(Ssl::CertValidationResponse::Pointe
     if (Debug::Enabled(83, 5)) {
         Security::SessionPointer ssl(fd_table[serverConnection()->fd].ssl);
         SBuf *server = static_cast<SBuf *>(SSL_get_ex_data(ssl.get(), ssl_ex_index_server));
-        debugs(83,5, RawPointer("host", server) << " cert validation result: " << validationResponse->resultCode);
+        debugs(83, 5, RawPointer("host=", server) << " cert validation result: " << validationResponse->resultCode);
     }
 
     if (validationResponse->resultCode == ::Helper::Error) {


### PR DESCRIPTION
    ERROR: failure while establishing TLS connection on FD: 70x123456*1

* FD value was malformed. Now report all Connection details instead.
* Error details were not reported (a pointer value was reported).

Also, for error message prefix, use a single/constant phrase instead of
error-dependent phrases. This principle is for level-0/1 messages, but
it is OK to apply it here as well, especially given the related TODO.

Also improved RawPointer reporting so that we can use it for this fix.
Some of these changes are not necessary (for the final code state), but
all of them except the last one were necessary at some point during the
work on this fix, and they all may become handy in the future:

* Print nothing if ptr is nil. Both existing callers benefit from this.
* Allow the caller to set the label/object delimiter. Also faster.
* Support reporting object values on a dedicated Debug::Extra line.
* Support (and do not attempt to print) nil RawPointer() labels.