### PR TITLE
Break long store_client call chains with async calls

### DIFF
--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -168,7 +168,7 @@ struct LowestMemReader : public unary_function<store_client, void> {
     LowestMemReader(int64_t seed):current(seed) {}
 
     void operator() (store_client const &x) {
-        if (x.reliesOnReadingFromMemory())
+        if (x.getType() == STORE_MEM_CLIENT)
             current = std::min(current, x.readOffset());
     }
 

--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -168,8 +168,8 @@ struct LowestMemReader : public unary_function<store_client, void> {
     LowestMemReader(int64_t seed):current(seed) {}
 
     void operator() (store_client const &x) {
-        if (x.memReaderHasLowerOffset(current))
-            current = x.copyInto.offset;
+        if (x.reliesOnReadingFromMemory())
+            current = std::min(current, x.readOffset());
     }
 
     int64_t current;
@@ -468,7 +468,7 @@ MemObject::mostBytesAllowed() const
     for (dlink_node *node = clients.head; node; node = node->next) {
         store_client *sc = (store_client *) node->data;
 
-        j = sc->delayId.bytesWanted(0, sc->copyInto.length);
+        j = sc->bytesWanted();
 
         if (j > jmax) {
             jmax = j;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -61,12 +61,6 @@ public:
     store_client(StoreEntry *);
     ~store_client();
 
-    /// Whether this Store client requires memory-stored response content.
-    /// \retval false does not mean the client never reads from memory, only
-    /// that it has other means of getting that content (e.g., from disk) and,
-    /// hence, will keep working even if unread content is purged from memory.
-    bool reliesOnReadingFromMemory() const;
-
     /// \retval +N is the offset of the stored response that the client wants to read next.
     /// \retval 0 means the client wants to read HTTP response headers.
     // TODO: the callers do not expect negative offset. Check that it cannot be negative

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -10,6 +10,7 @@
 #define SQUID_STORECLIENT_H
 
 #include "acl/ChecklistFiller.h"
+#include "base/AsyncCall.h"
 #include "base/forward.h"
 #include "dlink.h"
 #include "StoreIOBuffer.h"
@@ -59,14 +60,32 @@ class store_client
 public:
     store_client(StoreEntry *);
     ~store_client();
-    bool memReaderHasLowerOffset(int64_t) const;
+
+    /// Whether this Store client requires memory-stored response content.
+    /// \retval false does not mean the client never reads from memory, only
+    /// that it has other means of getting that content (e.g., from disk) and,
+    /// hence, will keep working even if unread content is purged from memory.
+    bool reliesOnReadingFromMemory() const;
+
+    /// The offset of the stored response that the client wants to read next.
+    /// \retval 0 means the client wants to read HTTP response headers.
+    int64_t readOffset() const { return copyInto.offset; }
+
     int getType() const;
-    void fail();
-    void callback(ssize_t len, bool error = false);
+
+    /// React to the end of reading the response from disk. There will be no
+    /// (more) readHeader() and readBody() callbacks for the current storeRead()
+    /// swapin after this notification.
+    void noteSwapInDone(bool error);
+
     void doCopy (StoreEntry *e);
     void readHeader(const char *buf, ssize_t len);
     void readBody(const char *buf, ssize_t len);
+
+    /// Request StoreIOBuffer-described response data via an asynchronous STCB
+    /// callback. At most one outstanding request is allowed per store_client.
     void copy(StoreEntry *, StoreIOBuffer, STCB *, void *);
+
     void dumpStats(MemBuf * output, int clientNumber) const;
 
     int64_t cmp_offset;
@@ -79,19 +98,27 @@ public:
     StoreIOState::Pointer swapin_sio;
 
     struct {
+        /// whether we are expecting a response to be swapped in from disk
+        /// (i.e. whether async storeRead() is currently in progress)
         bool disk_io_pending;
+
+        /// whether store_client::doCopy() is currently in progress
         bool store_copying;
-        bool copy_event_pending;
     } flags;
 
 #if USE_DELAY_POOLS
     DelayId delayId;
+
+    /// The maximum number of bytes the Store client can read/copy next without
+    /// overflowing its buffer and without violating delay pool limits. Store
+    /// I/O is not rate-limited, but we assume that the same number of bytes may
+    /// be read from the Squid-to-server connection that may be rate-limited.
+    int bytesWanted() const;
+
     void setDelayId(DelayId delay_id);
 #endif
 
     dlink_node node;
-    /* Below here is private - do no alter outside storeClient calls */
-    StoreIOBuffer copyInto;
 
 private:
     bool moreToSend() const;
@@ -103,8 +130,24 @@ private:
     bool startSwapin();
     bool unpackHeader(char const *buf, ssize_t len);
 
+    void fail();
+    void callback(ssize_t);
+    void noteCopiedBytes(size_t);
+    void noteEof();
+    void noteNews();
+    void finishCallback();
+    static void FinishCallback(store_client *);
+
     int type;
     bool object_ok;
+
+    /// Storage and metadata associated with the current copy() request. Ought
+    /// to be ignored when not answering a copy() request.
+    StoreIOBuffer copyInto;
+
+    /// The number of bytes loaded from Store into copyInto while answering the
+    /// current copy() request. Ought to be ignored when not answering.
+    size_t copiedSize;
 
     /* Until we finish stuffing code into store_client */
 
@@ -114,10 +157,18 @@ public:
         Callback ():callback_handler(NULL), callback_data(NULL) {}
 
         Callback (STCB *, void *);
+
+        /// Whether the copy() answer is needed/expected (by the client) and has
+        /// not been computed (by us). False during (asynchronous) answer
+        /// delivery to the STCB callback_handler.
         bool pending() const;
+
         STCB *callback_handler;
         void *callback_data;
         CodeContextPointer codeContext; ///< Store client context
+
+        /// a scheduled asynchronous finishCallback() call (or nil)
+        AsyncCall::Pointer notifier;
     } _callback;
 };
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -67,14 +67,16 @@ public:
     /// hence, will keep working even if unread content is purged from memory.
     bool reliesOnReadingFromMemory() const;
 
-    /// The offset of the stored response that the client wants to read next.
+    /// \retval +N is the offset of the stored response that the client wants to read next.
     /// \retval 0 means the client wants to read HTTP response headers.
+    // TODO: the callers do not expect negative offset. Check that it cannot be negative
+    // and convert to unsigned in this case.
     int64_t readOffset() const { return copyInto.offset; }
 
     int getType() const;
 
     /// React to the end of reading the response from disk. There will be no
-    /// (more) readHeader() and readBody() callbacks for the current storeRead()
+    /// more readHeader() and readBody() callbacks for the current storeRead()
     /// swapin after this notification.
     void noteSwapInDone(bool error);
 
@@ -100,9 +102,11 @@ public:
     struct {
         /// whether we are expecting a response to be swapped in from disk
         /// (i.e. whether async storeRead() is currently in progress)
+        // TODO: a better name reflecting the 'in' scope of the flag
         bool disk_io_pending;
 
-        /// whether store_client::doCopy() is currently in progress
+        /// whether the store_client::doCopy()-initiated STCB sequence is
+        /// currently in progress
         bool store_copying;
     } flags;
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -61,10 +61,14 @@ public:
     store_client(StoreEntry *);
     ~store_client();
 
-    /// \retval +N is the offset of the stored response that the client wants to read next.
+    /// An offset into the stored response bytes, including the HTTP response
+    /// headers (if any). Note that this offset does not include Store entry
+    /// metadata, because it is not a part of the stored response.
     /// \retval 0 means the client wants to read HTTP response headers.
-    // TODO: the callers do not expect negative offset. Check that it cannot be negative
-    // and convert to unsigned in this case.
+    /// \retval +N the response byte that the client wants to read next.
+    /// \retval -N should not occur.
+    // TODO: Callers do not expect negative offset. Verify that the return
+    // value cannot be negative and convert to unsigned in this case.
     int64_t readOffset() const { return copyInto.offset; }
 
     int getType() const;

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -85,12 +85,6 @@ StoreClient::startCollapsingOn(const StoreEntry &e, const bool doingRevalidation
 
 /* store_client */
 
-bool
-store_client::reliesOnReadingFromMemory() const
-{
-    return getType() == STORE_MEM_CLIENT;
-}
-
 int
 store_client::getType() const
 {

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -338,7 +338,7 @@ static void
 storeClientCopy2(StoreEntry * e, store_client * sc)
 {
     /* reentrancy not allowed  - note this could lead to
-     * dropped events
+     * dropped notifications about response data availability
      */
 
     if (sc->flags.store_copying) {

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -56,7 +56,7 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
 
     if (sc->_callback.pending()) {
         assert (errflag <= 0);
-        sc->noteSwapInDone(errflag ? true : false);
+        sc->noteSwapInDone(errflag);
     }
 
     ++statCounter.swap.ins;

--- a/src/store_swapin.cc
+++ b/src/store_swapin.cc
@@ -56,7 +56,7 @@ storeSwapInFileClosed(void *data, int errflag, StoreIOState::Pointer)
 
     if (sc->_callback.pending()) {
         assert (errflag <= 0);
-        sc->callback(0, errflag ? true : false);
+        sc->noteSwapInDone(errflag ? true : false);
     }
 
     ++statCounter.swap.ins;

--- a/src/tests/stub_store_client.cc
+++ b/src/tests/stub_store_client.cc
@@ -24,7 +24,11 @@ void storeLogOpen(void) STUB
 void storeDigestInit(void) STUB
 void storeRebuildStart(void) STUB
 void storeReplSetup(void) STUB
-bool store_client::memReaderHasLowerOffset(int64_t) const STUB_RETVAL(false)
+bool store_client::reliesOnReadingFromMemory() const STUB_RETVAL(false)
+void store_client::noteSwapInDone(bool) STUB
+#if USE_DELAY_POOLS
+int store_client::bytesWanted() const STUB_RETVAL(0)
+#endif
 void store_client::dumpStats(MemBuf *, int) const STUB
 int store_client::getType() const STUB_RETVAL(0)
 

--- a/src/tests/stub_store_client.cc
+++ b/src/tests/stub_store_client.cc
@@ -24,7 +24,6 @@ void storeLogOpen(void) STUB
 void storeDigestInit(void) STUB
 void storeRebuildStart(void) STUB
 void storeReplSetup(void) STUB
-bool store_client::reliesOnReadingFromMemory() const STUB_RETVAL(false)
 void store_client::noteSwapInDone(bool) STUB
 #if USE_DELAY_POOLS
 int store_client::bytesWanted() const STUB_RETVAL(0)


### PR DESCRIPTION
The store_client class design created very long call chains spanning
Squid-client and Squid-server processing and multiple transactions.
These call chains also create ideal conditions for dangerous recursive
relationships between communicating classes (a.k.a. "reentrancy" among
Squid developers). For example, storeClientCopy() enters store_client
and triggers disk I/O that triggers invokeHandlers() that re-enters the
same store_client object and starts competing with the original
storeClientCopy() processing state.

The official code prevented the worst recursion cases with three(!)
boolean flags and time-based events abused to break some of the call
chains, but that approach did not solve all of the problems while also
losing transaction context information across time-based events.

This change effectively makes STCB storeClientCopy() callbacks
asynchronous, eliminating the need for time-based events and one of the
flags. It shortens many call chains and preserves transaction context.
The remaining problems can and should be eliminated by converting
store_client into AsyncJob, but those changes deserve a dedicated PR.

store_client orchestrates cooperation of multiple asynchronous players:

* Sink: A Store client requests a STCB callback via a
  storeClientCopy()/copy() call. A set _callback.callback_handler
  implies that the client is waiting for this callback.

* Source1: A Store disk reading subsystem activated by the storeRead()
  call "spontaneously" delivers response bytes via storeClientRead*()
  callbacks. The disk_io_pending flag implies waiting for them.

* Source2: Store memory subsystem activated by storeClientListAdd()
  "spontaneously" delivers response bytes via invokeHandlers().

* Source3: Store disk subsystem activated by storeSwapInStart()
  "spontaneously" notifies of EOF/error by calling noteSwapInDone().

* Source4: A store_client object owner may delete the object by
  "spontaneously" calling storeUnregister(). The official code was
  converting this event into an error-notifying callback.

We continue to answer each storeClientCopy() request with the first
available information even though several SourceN calls are possible
while we are waiting to complete the STCB callback. The StoreIOBuffer
API and STCB recipients do not support data+error/eof combinations, and
future code will move this wait to the main event loop anyway. This
first-available approach means that the creation of the notifier call
effectively ends answer processing -- store_client just waits for that
call to fire so that it can relay the answer to still-synchronous STCB.
When STCB itself becomes asynchronous, this logic will continue to work.

Also stopped calling STCB from storeUnregister(). Conceptually, the
storeUnregister() and storeClientCopy() callers ought to represent the
same get-content-from-Store task; there should be no need to notify that
task about what it is doing. Technically, analysis of STCB callbacks
showed that many such notifications would be dangerous (if they are or
become reachable). At the time of the storeUnregister() call, the STCB
callbacks are usually unset (e.g., when storeUnregister() is called from
the destructor, after that object has finished copying -- a very common
case) or do not do anything (useful).

Also removed callback_data from the Callback::pending() condition. It is
conceptually wrong to require non-nil callback parameter, and it is
never cleared separately from the callback_handler data member anyway.

Also hid copyInto into the private store_client section to make sure it
is not modified while we are waiting to complete the STCB callback. This
move required adding a couple of read-only wrapper methods like
bytesWanted() and noteSwapInDone().

Also simplified error/EOF/bytes handling on copy()-STCB path using
dedicated methods (e.g., store_client::callback() API is no longer
mixing EOF and error signals).