### PR TITLE
Use SBuf for Fs::Ufs::RebuildState file paths

### DIFF
--- a/src/fs/ufs/RebuildState.cc
+++ b/src/fs/ufs/RebuildState.cc
@@ -43,8 +43,6 @@ Fs::Ufs::RebuildState::RebuildState(RefCount<UFSSwapDir> aSwapDir) :
     _done(false),
     cbdata(NULL)
 {
-    *fullpath = 0;
-    *fullfilename = 0;
 
     /*
      * If the swap.state file exists in the cache_dir, then
@@ -379,14 +377,14 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
         }
 
         if (0 == in_dir) {  /* we need to read in a new directory */
-            snprintf(fullpath, sizeof(fullpath), "%s/%02X/%02X",
+            fullpath.Printf("%s/%02X/%02X",
                      sd->path,
                      curlvl1, curlvl2);
 
             if (dirs_opened)
                 return -1;
 
-            td = opendir(fullpath);
+            td = opendir(fullpath.c_str());
 
             ++dirs_opened;
 
@@ -425,10 +423,10 @@ Fs::Ufs::RebuildState::getNextFile(sfileno * filn_p, int *)
                 continue;
             }
 
-            snprintf(fullfilename, sizeof(fullfilename), "%s/%s",
-                     fullpath, entry->d_name);
+            fullfilename.Printf(SQUIDSBUFPH "/%s",
+                         SQUIDSBUFPRINT(fullpath), entry->d_name);
             debugs(47, 3, "Opening " << fullfilename);
-            fd = file_open(fullfilename, O_RDONLY | O_BINARY);
+            fd = file_open(fullfilename.c_str(), O_RDONLY | O_BINARY);
 
             if (fd < 0) {
                 int xerrno = errno;

--- a/src/fs/ufs/RebuildState.h
+++ b/src/fs/ufs/RebuildState.h
@@ -53,8 +53,8 @@ public:
 
     dirent_t *entry;
     DIR *td;
-    char fullpath[MAXPATHLEN];
-    char fullfilename[MAXPATHLEN*2];
+    SBuf fullpath;
+    SBuf fullfilename;
 
     StoreRebuildData counts;
 


### PR DESCRIPTION
In theory, a combination of a non-terminating-on-overflows snprintf()
and an incorrectly guessed MAXPATHLEN (or a cache_dir root path being at
the edge of a correctly guessed MAXPATHLEN) may result in non-terminated
fullpath. Use SBuf to avoid these particular headaches.

Detected by Coverity. CID 1461166: Copy of overlapping memory
(OVERLAPPING_COPY).
