### PR TITLE
ext_session_acl: fix TDB key lookup

### DIFF
--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -194,13 +194,16 @@ copyValue(void *dst, const DB_ENTRY *src, size_t sz)
 #endif
 }
 
-static int session_active(char *details, size_t len)
+static int session_active(const char *details, size_t len)
 {
 #if USE_BERKLEYDB
     DBT key = {(void *)details, len};
     DBT data = {};
 #elif USE_TRIVIALDB
-    TDB_DATA key = {reinterpret_cast<decltype(key.dptr)>(details), len};
+    TDB_DATA key = {
+        reinterpret_cast<decltype(key.dptr)>(const_cast<char*>(details)),
+        len
+        };
     TDB_DATA data = {};
 #else
     (void)len;

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -197,14 +197,11 @@ copyValue(void *dst, const DB_ENTRY *src, size_t sz)
 static int session_active(const char *details, size_t len)
 {
 #if USE_BERKLEYDB
-    DBT key = {};
+    DBT key = {(void *)details, len};
     DBT data = {};
-    key.data = (void *)details;
-    key.size = len;
 #elif USE_TRIVIALDB
-    TDB_DATA key = {};
+    TDB_DATA key = {(unsigned char *)details, len};
     TDB_DATA data = {};
-    (void)len;
 #else
     (void)len;
 #endif

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -197,7 +197,10 @@ copyValue(void *dst, const DB_ENTRY *src, size_t sz)
 static int session_active(const char *details, size_t len)
 {
 #if USE_BERKLEYDB
-    DBT key = {(void *)details, len};
+    DBT key = {};
+    key.data = const_cast<char*>(details);
+    key.size = len;
+
     DBT data = {};
 #elif USE_TRIVIALDB
     TDB_DATA key = {

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -202,8 +202,8 @@ static int session_active(const char *details, size_t len)
     key.data = (void *)details;
     key.size = len;
 #elif USE_TRIVIALDB
-    TDB_DATA key;
-    TDB_DATA data;
+    TDB_DATA key = {};
+    TDB_DATA data = {};
     (void)len;
 #else
     (void)len;

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -203,10 +203,10 @@ static int session_active(const char *details, size_t len)
 
     DBT data = {};
 #elif USE_TRIVIALDB
-    TDB_DATA key = {
-        reinterpret_cast<decltype(key.dptr)>(const_cast<char*>(details)),
-        len
-        };
+    TDB_DATA key = {};
+    key.dptr = reinterpret_cast<decltype(key.dptr)>(const_cast<char*>(details));
+    key.dsize = len;
+
     TDB_DATA data = {};
 #else
     (void)len;

--- a/src/acl/external/session/ext_session_acl.cc
+++ b/src/acl/external/session/ext_session_acl.cc
@@ -194,13 +194,13 @@ copyValue(void *dst, const DB_ENTRY *src, size_t sz)
 #endif
 }
 
-static int session_active(const char *details, size_t len)
+static int session_active(char *details, size_t len)
 {
 #if USE_BERKLEYDB
     DBT key = {(void *)details, len};
     DBT data = {};
 #elif USE_TRIVIALDB
-    TDB_DATA key = {(unsigned char *)details, len};
+    TDB_DATA key = {reinterpret_cast<decltype(key.dptr)>(details), len};
     TDB_DATA data = {};
 #else
     (void)len;


### PR DESCRIPTION
When built with Samba TrivialDB, ext_session_acl would never
successfully look a session up due to an uninitialized key argument. As
a result, the helper would be unable to validate that an user had logged
in. Broken since TrivialDB support was added in acd207a.

Detected by Coverity. CID 1441979:  Uninitialized scalar variable
(UNINIT).
