### PR TITLE
Remove reference to deprecated std::binary_function

### DIFF
--- a/src/HttpHeaderTools.h
+++ b/src/HttpHeaderTools.h
@@ -67,7 +67,7 @@ public:
 private:
     /// Case-insensitive std::string "less than" comparison functor.
     /// Fast version recommended by Meyers' "Effective STL" for ASCII c-strings.
-    class NoCaseLessThan: public std::binary_function<std::string, std::string, bool>
+    class NoCaseLessThan
     {
     public:
         bool operator()(const std::string &lhs, const std::string &rhs) const {


### PR DESCRIPTION
C++11 deprecates std::binary_function. C++17 removes it.
It only provides typedefs that are unused since C++11.
