### PR TITLE
Remove use of deprecated std::iterator

### DIFF
--- a/src/base/EnumIterator.h
+++ b/src/base/EnumIterator.h
@@ -20,7 +20,7 @@
  * \see EnumIterator, ReverseEnumIterator
  */
 template <typename EnumType>
-class EnumIteratorBase : public std::iterator<std::bidirectional_iterator_tag, EnumType>
+class EnumIteratorBase
 {
 protected:
 #if HAVE_STD_UNDERLYING_TYPE
@@ -30,6 +30,12 @@ protected:
 #endif
 
 public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = EnumType;
+    using difference_type = std::ptrdiff_t;
+    using pointer = EnumType *;
+    using reference = EnumType &;
+
     explicit EnumIteratorBase(EnumType e) : current(static_cast<iterator_type>(e)) {}
 
     bool operator==(const EnumIteratorBase &i) const {

--- a/src/sbuf/SBuf.h
+++ b/src/sbuf/SBuf.h
@@ -45,9 +45,16 @@ class CharacterSet;
  * Please note that any operation on the underlying SBuf may invalidate
  * all iterators over it, resulting in undefined behavior by them.
  */
-class SBufIterator : public std::iterator<std::input_iterator_tag, char>
+class SBufIterator
 {
 public:
+    // iterator traits
+    using iterator_category = std::input_iterator_tag;
+    using value_type = char;
+    using difference_type = std::ptrdiff_t;
+    using pointer = char*;
+    using reference = char&;
+
     friend class SBuf;
     typedef MemBlob::size_type size_type;
     bool operator==(const SBufIterator &s) const;


### PR DESCRIPTION
c++17 deprecates std::iterator.
Explicitly declare traits in our iterator classes instead of
using std::iterator