### PR TITLE
RFC 9218 Priority header registration

### DIFF
--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -76,6 +76,7 @@ enum HdrType {
     /*OVERWRITE,*/                  /* RFC 2518 */
     ORIGIN,                         /* CORS Draft specification (see http://www.w3.org/TR/cors/) */
     PRAGMA,                         /**< RFC 7234 */
+    PRIORITY,                       /**< RFC 9218 */
     PROXY_AUTHENTICATE,             /**< RFC 7235 */
     PROXY_AUTHENTICATION_INFO,      /**< RFC 2617 */
     PROXY_AUTHORIZATION,            /**< RFC 7235 */

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -44,14 +44,14 @@
 class HeaderTableRecord;
     enum
 {
-    TOTAL_KEYWORDS = 88,
+    TOTAL_KEYWORDS = 89,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 25,
     MIN_HASH_VALUE = 5,
-    MAX_HASH_VALUE = 109
+    MAX_HASH_VALUE = 114
 };
 
-/* maximum key range = 105, duplicates = 0 */
+/* maximum key range = 110, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
@@ -111,32 +111,32 @@ HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
 {
     static const unsigned char asso_values[] =
     {
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110,   0, 110, 110,  13, 110, 110, 110, 110,
-        12, 110, 110,  41, 110, 110, 110, 110,  26, 110,
-        110, 110, 110, 110, 110,  16,  10,  10,  20,   4,
-        10,  47,  50,  62, 110,   0,  38,  30,   1,   2,
-        33,  30,  32,  14,   0,  21,   5,  23,  19,  36,
-        110, 110, 110, 110, 110, 110, 110,  16,  10,  10,
-        20,   4,  10,  47,  50,  62, 110,   0,  38,  30,
-        1,   2,  33,  30,  32,  14,   0,  21,   5,  23,
-        19,  36, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
-        110, 110, 110, 110, 110, 110
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115,   7, 115, 115,  13, 115, 115, 115, 115,
+        12, 115, 115,  41, 115, 115, 115, 115,  14, 115,
+        115, 115, 115, 115, 115,  16,  10,  10,  20,   4,
+        10,  47,  58,  62, 115,   0,  38,  30,   1,   2,
+        33,  25,  32,  14,   0,  14,   5,  23,  19,  36,
+        115, 115, 115, 115, 115, 115, 115,  16,  10,  10,
+        20,   4,  10,  47,  58,  62, 115,   0,  38,  30,
+        1,   2,  33,  25,  32,  14,   0,  14,   5,  23,
+        19,  36, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115, 115, 115, 115, 115,
+        115, 115, 115, 115, 115, 115
     };
     unsigned int hval = len;
 
@@ -144,7 +144,7 @@ HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
     {
     default:
         hval += asso_values[static_cast<unsigned char>(str[8])];
-    /* [[fallthrough]] */
+    /*FALLTHROUGH*/
     case 8:
     case 7:
     case 6:
@@ -163,12 +163,13 @@ static const unsigned char lengthtable[] =
 {
     0,  0,  0,  0,  0,  4,  2,  0,  4,  5,  5,  3,  6,  0,
     10, 10,  6, 12,  4,  8, 16,  7, 19, 10, 18,  8,  6, 12,
-    14, 25, 13, 19,  0,  9, 15,  3,  4, 10,  6,  6,  0, 19,
+    14, 25, 13, 19, 10,  9, 15,  3,  4,  0,  6,  6,  0, 19,
     8, 11,  7, 15, 10, 16, 13,  7, 13, 15, 12, 13,  7,  7,
     16, 12,  7, 16, 18, 12, 13, 13,  9, 21,  5,  4, 16,  6,
-    6,  8,  4, 15, 14,  3, 10, 15, 10, 13, 11,  9,  6, 11,
+    6, 10,  4, 15, 13,  3, 10, 15,  6,  8, 11,  9, 14, 11,
     0, 11,  7,  0,  0,  0, 13, 17, 20, 17,  0,  0, 17,  0,
-    19,  0,  0,  0, 18, 14,  0,  0, 13, 13,  0, 13
+    19,  0,  0,  0, 18,  0,  0,  0,  8, 13,  0, 13,  0, 14,
+    0,  0, 13
 };
 
 static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
@@ -176,14 +177,14 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {""}, {""}, {""}, {""}, {""},
 #line 67 "RegisteredHeadersHash.gperf"
     {"Link", Http::HdrType::LINK, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
-#line 87 "RegisteredHeadersHash.gperf"
+#line 88 "RegisteredHeadersHash.gperf"
     {"TE", Http::HdrType::TE, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
     {""},
 #line 51 "RegisteredHeadersHash.gperf"
     {"Date", Http::HdrType::DATE, Http::HdrFieldType::ftDate_1123, HdrKind::GeneralHeader},
-#line 88 "RegisteredHeadersHash.gperf"
+#line 89 "RegisteredHeadersHash.gperf"
     {"Title", Http::HdrType::TITLE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 80 "RegisteredHeadersHash.gperf"
+#line 81 "RegisteredHeadersHash.gperf"
     {"Range", Http::HdrType::RANGE, Http::HdrFieldType::ftPRange, HdrKind::RequestHeader},
 #line 31 "RegisteredHeadersHash.gperf"
     {"Age", Http::HdrType::AGE, Http::HdrFieldType::ftInt, HdrKind::ReplyHeader},
@@ -192,7 +193,7 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {""},
 #line 39 "RegisteredHeadersHash.gperf"
     {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 94 "RegisteredHeadersHash.gperf"
+#line 95 "RegisteredHeadersHash.gperf"
     {"User-Agent", Http::HdrType::USER_AGENT, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 26 "RegisteredHeadersHash.gperf"
     {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
@@ -202,41 +203,41 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Host", Http::HdrType::HOST, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 68 "RegisteredHeadersHash.gperf"
     {"Location", Http::HdrType::LOCATION, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 77 "RegisteredHeadersHash.gperf"
+#line 78 "RegisteredHeadersHash.gperf"
     {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
 #line 50 "RegisteredHeadersHash.gperf"
     {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 76 "RegisteredHeadersHash.gperf"
+#line 77 "RegisteredHeadersHash.gperf"
     {"Proxy-Authorization", Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
 #line 64 "RegisteredHeadersHash.gperf"
     {"Keep-Alive", Http::HdrType::KEEP_ALIVE, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 74 "RegisteredHeadersHash.gperf"
+#line 75 "RegisteredHeadersHash.gperf"
     {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 62 "RegisteredHeadersHash.gperf"
     {"If-Range", Http::HdrType::IF_RANGE, Http::HdrFieldType::ftDate_1123_or_ETag, HdrKind::None},
-#line 79 "RegisteredHeadersHash.gperf"
+#line 80 "RegisteredHeadersHash.gperf"
     {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 40 "RegisteredHeadersHash.gperf"
     {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
 #line 58 "RegisteredHeadersHash.gperf"
     {"HTTP2-Settings", Http::HdrType::HTTP2_SETTINGS, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader},
-#line 75 "RegisteredHeadersHash.gperf"
+#line 76 "RegisteredHeadersHash.gperf"
     {"Proxy-Authentication-Info", Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
 #line 35 "RegisteredHeadersHash.gperf"
     {"Authorization", Http::HdrType::AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 34 "RegisteredHeadersHash.gperf"
     {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-    {""},
-#line 91 "RegisteredHeadersHash.gperf"
+#line 114 "RegisteredHeadersHash.gperf"
+    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
+#line 92 "RegisteredHeadersHash.gperf"
     {"Translate", Http::HdrType::TRANSLATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 103 "RegisteredHeadersHash.gperf"
+#line 104 "RegisteredHeadersHash.gperf"
     {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 96 "RegisteredHeadersHash.gperf"
+#line 97 "RegisteredHeadersHash.gperf"
     {"Via", Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
 #line 56 "RegisteredHeadersHash.gperf"
     {"From", Http::HdrType::FROM, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 113 "RegisteredHeadersHash.gperf"
-    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
+    {""},
 #line 73 "RegisteredHeadersHash.gperf"
     {"Pragma", Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
 #line 53 "RegisteredHeadersHash.gperf"
@@ -246,23 +247,23 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Content-Disposition", Http::HdrType::CONTENT_DISPOSITION, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 38 "RegisteredHeadersHash.gperf"
     {"CDN-Loop", Http::HdrType::CDN_LOOP, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 83 "RegisteredHeadersHash.gperf"
+#line 84 "RegisteredHeadersHash.gperf"
     {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 109 "RegisteredHeadersHash.gperf"
+#line 110 "RegisteredHeadersHash.gperf"
     {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 29 "RegisteredHeadersHash.gperf"
     {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 111 "RegisteredHeadersHash.gperf"
+#line 112 "RegisteredHeadersHash.gperf"
     {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 98 "RegisteredHeadersHash.gperf"
+#line 99 "RegisteredHeadersHash.gperf"
     {"WWW-Authenticate", Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 78 "RegisteredHeadersHash.gperf"
+#line 79 "RegisteredHeadersHash.gperf"
     {"Proxy-support", Http::HdrType::PROXY_SUPPORT, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 81 "RegisteredHeadersHash.gperf"
+#line 82 "RegisteredHeadersHash.gperf"
     {"Referer", Http::HdrType::REFERER, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 47 "RegisteredHeadersHash.gperf"
     {"Content-Range", Http::HdrType::CONTENT_RANGE, Http::HdrFieldType::ftPContRange, HdrKind::EntityHeader},
-#line 106 "RegisteredHeadersHash.gperf"
+#line 107 "RegisteredHeadersHash.gperf"
     {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 37 "RegisteredHeadersHash.gperf"
     {"Cache-Status", Http::HdrType::CACHE_STATUS, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
@@ -270,13 +271,13 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Accept-Ranges", Http::HdrType::ACCEPT_RANGES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 54 "RegisteredHeadersHash.gperf"
     {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
-#line 89 "RegisteredHeadersHash.gperf"
+#line 90 "RegisteredHeadersHash.gperf"
     {"Trailer", Http::HdrType::TRAILER, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
 #line 45 "RegisteredHeadersHash.gperf"
     {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
 #line 70 "RegisteredHeadersHash.gperf"
     {"Mime-Version", Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::GeneralHeader},
-#line 93 "RegisteredHeadersHash.gperf"
+#line 94 "RegisteredHeadersHash.gperf"
     {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
 #line 43 "RegisteredHeadersHash.gperf"
     {"Content-Language", Http::HdrType::CONTENT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
@@ -286,11 +287,11 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Max-Forwards", Http::HdrType::MAX_FORWARDS, Http::HdrFieldType::ftInt64, HdrKind::RequestHeader},
 #line 36 "RegisteredHeadersHash.gperf"
     {"Cache-Control", Http::HdrType::CACHE_CONTROL, Http::HdrFieldType::ftPCc, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 101 "RegisteredHeadersHash.gperf"
+#line 102 "RegisteredHeadersHash.gperf"
     {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 71 "RegisteredHeadersHash.gperf"
     {"Negotiate", Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 92 "RegisteredHeadersHash.gperf"
+#line 93 "RegisteredHeadersHash.gperf"
     {"Unless-Modified-Since", Http::HdrType::UNLESS_MODIFIED_SINCE, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 32 "RegisteredHeadersHash.gperf"
     {"Allow", Http::HdrType::ALLOW, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
@@ -300,47 +301,47 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
 #line 72 "RegisteredHeadersHash.gperf"
     {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
-#line 84 "RegisteredHeadersHash.gperf"
+#line 85 "RegisteredHeadersHash.gperf"
     {"Server", Http::HdrType::SERVER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 59 "RegisteredHeadersHash.gperf"
-    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 95 "RegisteredHeadersHash.gperf"
+#line 111 "RegisteredHeadersHash.gperf"
+    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
+#line 96 "RegisteredHeadersHash.gperf"
     {"Vary", Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 28 "RegisteredHeadersHash.gperf"
     {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
-#line 27 "RegisteredHeadersHash.gperf"
-    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 83 "RegisteredHeadersHash.gperf"
+    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
 #line 65 "RegisteredHeadersHash.gperf"
     {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 85 "RegisteredHeadersHash.gperf"
+#line 86 "RegisteredHeadersHash.gperf"
     {"Set-Cookie", Http::HdrType::SET_COOKIE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 99 "RegisteredHeadersHash.gperf"
+#line 100 "RegisteredHeadersHash.gperf"
     {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 110 "RegisteredHeadersHash.gperf"
-    {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
-#line 82 "RegisteredHeadersHash.gperf"
-    {"Request-Range", Http::HdrType::REQUEST_RANGE, Http::HdrFieldType::ftPRange, HdrKind::None},
-#line 107 "RegisteredHeadersHash.gperf"
+#line 113 "RegisteredHeadersHash.gperf"
+    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 59 "RegisteredHeadersHash.gperf"
+    {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
+#line 108 "RegisteredHeadersHash.gperf"
     {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 55 "RegisteredHeadersHash.gperf"
     {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
-#line 112 "RegisteredHeadersHash.gperf"
-    {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
+#line 27 "RegisteredHeadersHash.gperf"
+    {"Accept-Charset", Http::HdrType::ACCEPT_CHARSET, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 46 "RegisteredHeadersHash.gperf"
     {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
     {""},
-#line 86 "RegisteredHeadersHash.gperf"
+#line 87 "RegisteredHeadersHash.gperf"
     {"Set-Cookie2", Http::HdrType::SET_COOKIE2, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 97 "RegisteredHeadersHash.gperf"
+#line 98 "RegisteredHeadersHash.gperf"
     {"Warning", Http::HdrType::WARNING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
     {""}, {""}, {""},
-#line 108 "RegisteredHeadersHash.gperf"
+#line 109 "RegisteredHeadersHash.gperf"
     {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None},
-#line 105 "RegisteredHeadersHash.gperf"
+#line 106 "RegisteredHeadersHash.gperf"
     {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 104 "RegisteredHeadersHash.gperf"
+#line 105 "RegisteredHeadersHash.gperf"
     {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 90 "RegisteredHeadersHash.gperf"
+#line 91 "RegisteredHeadersHash.gperf"
     {"Transfer-Encoding", Http::HdrType::TRANSFER_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
     {""}, {""},
 #line 60 "RegisteredHeadersHash.gperf"
@@ -349,18 +350,22 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
 #line 63 "RegisteredHeadersHash.gperf"
     {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
     {""}, {""}, {""},
-#line 102 "RegisteredHeadersHash.gperf"
+#line 103 "RegisteredHeadersHash.gperf"
     {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
+    {""}, {""}, {""},
+#line 74 "RegisteredHeadersHash.gperf"
+    {"Priority", Http::HdrType::PRIORITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
+#line 101 "RegisteredHeadersHash.gperf"
+    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+    {""},
+#line 66 "RegisteredHeadersHash.gperf"
+    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
+    {""},
 #line 44 "RegisteredHeadersHash.gperf"
     {"Content-Length", Http::HdrType::CONTENT_LENGTH, Http::HdrFieldType::ftInt64, HdrKind::EntityHeader},
     {""}, {""},
 #line 61 "RegisteredHeadersHash.gperf"
-    {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 100 "RegisteredHeadersHash.gperf"
-    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-    {""},
-#line 66 "RegisteredHeadersHash.gperf"
-    {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader}
+    {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader}
 };
 
 const class HeaderTableRecord *
@@ -381,5 +386,5 @@ const class HeaderTableRecord *
     }
     return 0;
 }
-#line 114 "RegisteredHeadersHash.gperf"
+#line 115 "RegisteredHeadersHash.gperf"
 

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -71,6 +71,7 @@ Mime-Version, Http::HdrType::MIME_VERSION, Http::HdrFieldType::ftStr, HdrKind::G
 Negotiate, Http::HdrType::NEGOTIATE, Http::HdrFieldType::ftStr, HdrKind::None
 Origin, Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader
 Pragma, Http::HdrType::PRAGMA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
+Priority, Http::HdrType::PRIORITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
 Proxy-Authenticate, Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader
 Proxy-Authentication-Info, Http::HdrType::PROXY_AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader
 Proxy-Authorization, Http::HdrType::PROXY_AUTHORIZATION, Http::HdrFieldType::ftStr, HdrKind::RequestHeader|HdrKind::HopByHopHeader


### PR DESCRIPTION
This allows the Priority header to more efficiently be added and
removed by reverse-proxy administrators using the
reply_header_add, reply_header_access, reply_header_replace
directives.