### PR TITLE
Maintenance: Fix cf_gen build warnings with clang v12

### DIFF
--- a/src/cf_gen.cc
+++ b/src/cf_gen.cc
@@ -370,7 +370,6 @@ main(int argc, char *argv[])
                 } else if (strcmp(buff, "CONFIG_START") == 0) {
                     state = sCFGLINES;
                 } else {
-                    assert(buff != NULL);
                     entries.back().doc.push_back(buff);
                 }
                 break;
@@ -379,7 +378,6 @@ main(int argc, char *argv[])
                 if (strcmp(buff, "CONFIG_END") == 0) {
                     state = sDOC;
                 } else {
-                    assert(buff != NULL);
                     entries.back().cfgLines.push_back(buff);
                 }
                 break;


### PR DESCRIPTION
    cf_gen.cc:... warning: comparison of array 'buff' not equal to a
    null pointer is always true [-Wtautological-pointer-compare]

These conditions are not just always true but a bit odd or misleading
because they check the pointer after it was dereferenced. They were
added in c1f8bbd which misinterpreted the "else" conditions. The two
"regular DOC/CONFIG line" conditions are self-documented well enough.