### PR TITLE
Fix libntlmauth build on current Fedora Rawhide

### DIFF
--- a/lib/ntlmauth/ntlmauth.cc
+++ b/lib/ntlmauth/ntlmauth.cc
@@ -12,6 +12,7 @@
 #include "squid.h"
 
 #include <cstring>
+#include <ctime>
 #include <random>
 #if HAVE_STRINGS_H
 #include <strings.h>


### PR DESCRIPTION
    ntlmauth.cc:187: error: 'time' was not declared in this scope
