### PR TITLE
Maintenance: Remove unused data members

### DIFF
--- a/src/ipc/SharedListen.cc
+++ b/src/ipc/SharedListen.cc
@@ -80,14 +80,12 @@ Ipc::SharedListenRequest::SharedListenRequest(const OpenListenerParams &aParams,
 Ipc::SharedListenRequest::SharedListenRequest(const TypedMsgHdr &hdrMsg)
 {
     hdrMsg.checkType(mtSharedListenRequest);
-    // XXX: our handlerSubscription is not a POD!
     hdrMsg.getPod(*this);
 }
 
 void Ipc::SharedListenRequest::pack(TypedMsgHdr &hdrMsg) const
 {
     hdrMsg.setType(mtSharedListenRequest);
-    // XXX: our handlerSubscription is not a POD!
     hdrMsg.putPod(*this);
 }
 
@@ -191,7 +189,6 @@ void Ipc::SharedListenJoined(const SharedListenResponse &response)
     }
 
     cbd->errNo = response.errNo;
-    cbd->handlerSubscription = por.params.handlerSubscription;
     ScheduleCallHere(por.callback);
 
     kickDelayedRequest();

--- a/src/ipc/SharedListen.h
+++ b/src/ipc/SharedListen.h
@@ -36,9 +36,6 @@ public:
     // bits to re-create the listener Comm::Connection descriptor
     Ip::Address addr; ///< will be memset and memcopied
     int flags = 0;
-
-    /// handler to subscribe to Comm::ConnAcceptor when we get the response
-    Subscription::Pointer handlerSubscription;
 };
 
 class TypedMsgHdr;

--- a/src/ipc/StartListening.h
+++ b/src/ipc/StartListening.h
@@ -35,7 +35,6 @@ public:
 public:
     Comm::ConnectionPointer conn; ///< opened listening socket
     int errNo; ///< errno value from the comm_open_listener() call
-    Subscription::Pointer handlerSubscription; ///< The subscription we will pass on to the ConnAcceptor
 };
 
 /// Depending on whether SMP is on, either ask Coordinator to send us

--- a/src/ipc/TypedMsgHdr.h
+++ b/src/ipc/TypedMsgHdr.h
@@ -23,6 +23,8 @@
 #include <sys/un.h>
 #endif
 
+#include <type_traits>
+
 class String;
 
 namespace Ipc
@@ -116,8 +118,7 @@ void
 Ipc::TypedMsgHdr::getPod(Pod &pod) const
 {
 #if HAVE_STD_IS_TRIVIALLY_COPYABLE
-    // TODO: Enable after fixing Ipc::SharedListenRequest::SharedListenRequest()
-    //static_assert(std::is_trivially_copyable<Pod>::value, "getPod() used for a POD");
+    static_assert(std::is_trivially_copyable<Pod>::value, "getPod() used for a POD");
 #endif
     getFixed(&pod, sizeof(pod));
 }
@@ -127,8 +128,7 @@ void
 Ipc::TypedMsgHdr::putPod(const Pod &pod)
 {
 #if HAVE_STD_IS_TRIVIALLY_COPYABLE
-    // TODO: Enable after fixing Ipc::SharedListenRequest::pack()
-    //static_assert(std::is_trivially_copyable<Pod>::value, "putPod() used for a POD");
+    static_assert(std::is_trivially_copyable<Pod>::value, "putPod() used for a POD");
 #endif
     putFixed(&pod, sizeof(pod));
 }


### PR DESCRIPTION
These handlerSubscription fields blocked quite useful static assertions.
They are in the way of callback improvements; that work has discovered
that they are unused (since inception in merge commit 1c8f25b).