### PR TITLE
Fix mingw-cross build

### DIFF
--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -624,7 +624,7 @@ inet_ntop(int af, const void *src, char *dst, size_t size)
 {
 #if HAVE_DECL_INETNTOPA
     return (char*)InetNtopA(af, const_cast<void*>(src), dst, size);
-#else // HAVE_DECL_INET_NTOP 
+#else // HAVE_DECL_INET_NTOP
     return ::inet_ntop(af, src, dst, size);
 #endif
 }

--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -618,17 +618,20 @@ getsockopt(int s, int l, int o, void * v, socklen_t * n)
 }
 #define getsockopt(s,l,o,v,n) Squid::getsockopt(s,l,o,v,n)
 
+#if HAVE_DECL_INETNTOPA || HAVE_DECL_INET_NTOP
 inline char *
 inet_ntop(int af, const void *src, char *dst, size_t size)
 {
 #if HAVE_DECL_INETNTOPA
     return (char*)InetNtopA(af, const_cast<void*>(src), dst, size);
-#else
+#else // HAVE_DECL_INET_NTOP 
     return ::inet_ntop(af, src, dst, size);
 #endif
 }
 #define inet_ntop(a,s,d,l) Squid::inet_ntop(a,s,d,l)
+#endif // let compat/inet_ntop.h deal with it
 
+#if HAVE_DECL_INETPTONA || HAVE_DECL_INET_PTON
 inline char *
 inet_pton(int af, const void *src, char *dst)
 {
@@ -639,6 +642,7 @@ inet_pton(int af, const void *src, char *dst)
 #endif
 }
 #define inet_pton(a,s,d) Squid::inet_pton(a,s,d)
+#endif // let compat/inet_pton.h deal with it
 
 /* Simple ioctl() emulation */
 inline int

--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -637,7 +637,7 @@ inet_pton(int af, const void *src, char *dst)
 {
 #if HAVE_DECL_INETPTONA
     return (char*)InetPtonA(af, const_cast<void*>(src), dst);
-#else
+#else // HAVE_DECL_INET_PTON
     return ::inet_pton(af, src, dst);
 #endif
 }


### PR DESCRIPTION
    compat/os/mswindows.h:640: ::inet_pton has not been declared