### PR TITLE
Silence GnuRegex warnings on gcc 12.1

### DIFF
--- a/compat/GnuRegex.c
+++ b/compat/GnuRegex.c
@@ -40,6 +40,12 @@
 
 #if USE_GNUREGEX /* only if squid needs it. Usually not */
 
+/* recent GCC 12.1 does not like array magic done here */
+#if __GNUC__ >= 12 && __GNUC_MINOR__ >= 1
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
+
 #if !HAVE_ALLOCA
 #define REGEX_MALLOC 1
 #endif

--- a/compat/GnuRegex.c
+++ b/compat/GnuRegex.c
@@ -40,8 +40,9 @@
 
 #if USE_GNUREGEX /* only if squid needs it. Usually not */
 
-/* recent GCC 12.1 does not like array magic done here */
-#if __GNUC__ >= 12 && __GNUC_MINOR__ >= 1
+/* Starting with v12.1, GCC warns of various problems with this ancient code. */
+/* GCC versions prior to v12.1 do not support these pragmas. */
+#if (__GNUC__ == 12 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 12)
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wuse-after-free"
 #endif


### PR DESCRIPTION
GnuRegex does pointer magic that gcc 12.1 doesn't like.

    compat/GnuRegex.c: error: array subscript -1 is outside array bounds
    of 'const char[]' [-Werror=array-bounds]

    compat/GnuRegex.c: error: pointer may be used after 'realloc'
    [-Werror=use-after-free]

A long term fix is to unship GnuRegex which is an old
snapshot and is not maintained.
