### PR TITLE
Cleanup mixins

### DIFF
--- a/src/HttpUpgradeProtocolAccess.h
+++ b/src/HttpUpgradeProtocolAccess.h
@@ -10,6 +10,7 @@
 #define SQUID_HTTP_UPGRADE_H
 
 #include "acl/forward.h"
+#include "base/TypeTraits.h"
 #include "sbuf/SBuf.h"
 
 #include <map>
@@ -41,12 +42,11 @@ vAinB(const ProtocolView &a, const ProtocolView &b)
 }
 
 /// Allows or blocks HTTP Upgrade protocols (see http_upgrade_request_protocols)
-class HttpUpgradeProtocolAccess
+class HttpUpgradeProtocolAccess : NonCopyable
 {
 public:
     HttpUpgradeProtocolAccess() = default;
     ~HttpUpgradeProtocolAccess();
-    HttpUpgradeProtocolAccess(HttpUpgradeProtocolAccess &&) = delete; // no copying of any kind
 
     /// \returns the ACLs matching the given "name[/version]" protocol (or nil)
     const acl_access *findGuard(const SBuf &proto) const;
@@ -63,11 +63,10 @@ public:
 
 private:
     /// a single configured access rule for an explicitly named protocol
-    class NamedGuard
+    class NamedGuard : NonCopyable
     {
     public:
         NamedGuard(const char *rawProtocol, acl_access*);
-        NamedGuard(const NamedGuard &&) = delete; // no copying of any kind
         ~NamedGuard();
 
         const SBuf protocol; ///< configured protocol name (and version)

--- a/src/Store.h
+++ b/src/Store.h
@@ -348,7 +348,8 @@ namespace Store {
 
 /// a smart pointer similar to std::unique_ptr<> that automatically
 /// release()s and unlock()s the guarded Entry on stack-unwinding failures
-class EntryGuard {
+class EntryGuard : NonCopyable /* for now */
+{
 public:
     /// \param entry either nil or a locked Entry to manage
     /// \param context default unlock() message
@@ -363,8 +364,6 @@ public:
             onException();
         }
     }
-
-    EntryGuard(EntryGuard &&) = delete; // no copying or moving (for now)
 
     /// like std::unique_ptr::get()
     /// \returns nil or the guarded (locked) entry

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -11,6 +11,7 @@
 
 #include "acl/forward.h"
 #include "acl/Options.h"
+#include "base/TypeTraits.h"
 #include "cbdata.h"
 #include "defines.h"
 #include "dlink.h"
@@ -36,7 +37,7 @@ void RegisterMaker(TypeName typeName, Maker maker);
 /// Can evaluate itself in FilledChecklist context.
 /// Does not change during evaluation.
 /// \ingroup ACLAPI
-class ACL
+class ACL : NonCopyable
 {
 
 public:
@@ -48,7 +49,6 @@ public:
     static ACL *FindByName(const char *name);
 
     ACL();
-    ACL(ACL &&) = delete; // no copying of any kind
     virtual ~ACL();
 
     /// sets user-specified ACL name and squid.conf context

--- a/src/acl/Data.h
+++ b/src/acl/Data.h
@@ -10,16 +10,16 @@
 #define SQUID_ACLDATA_H
 
 #include "acl/Options.h"
+#include "base/TypeTraits.h"
 #include "sbuf/List.h"
 
 /// Configured ACL parameter(s) (e.g., domain names in dstdomain ACL).
 template <class M>
-class ACLData
+class ACLData : NonCopyable
 {
 
 public:
     ACLData() = default;
-    ACLData(ACLData<M> &&) = delete; // no copying of any kind
     virtual ~ACLData() {}
 
     /// supported ACL "line" options (e.g., "-i")

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -21,12 +21,10 @@
 namespace AnyP
 {
 
-class PortCfg : public CodeContext
+class PortCfg : public CodeContext, NonCopyable
 {
 public:
     PortCfg();
-    // no public copying/moving but see ipV4clone()
-    PortCfg(PortCfg &&) = delete;
     ~PortCfg();
 
     /// creates the same port configuration but listening on any IPv4 address

--- a/src/auth/Config.h
+++ b/src/auth/Config.h
@@ -18,13 +18,9 @@
 namespace Auth
 {
 
-class Config
+class Config : NonCopyable
 {
 public:
-    Config() = default;
-    Config(Config &&) = delete; // no support for copying of any kind
-    ~Config() = default;
-
     /// set of auth_params directives
     Auth::ConfigVector schemes;
 

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -11,6 +11,7 @@
 
 #include "base/InstanceId.h"
 #include "base/RefCount.h"
+#include "base/TypeTraits.h"
 
 #include <iosfwd>
 
@@ -90,14 +91,11 @@ std::ostream &CurrentCodeContextDetail(std::ostream &os);
 
 /// Convenience class that automatically restores the current/outer CodeContext
 /// when leaving the scope of the new-context following/inner code. \see Run().
-class CodeContextGuard
+class CodeContextGuard : NonCopyable
 {
 public:
     CodeContextGuard(const CodeContext::Pointer &newContext): savedCodeContext(CodeContext::Current()) { CodeContext::Reset(newContext); }
     ~CodeContextGuard() { CodeContext::Reset(savedCodeContext); }
-
-    // no copying of any kind (for simplicity and to prevent accidental copies)
-    CodeContextGuard(CodeContextGuard &&) = delete;
 
     CodeContext::Pointer savedCodeContext;
 };

--- a/src/base/JobWait.h
+++ b/src/base/JobWait.h
@@ -16,14 +16,11 @@
 
 /// Manages waiting for an AsyncJob callback. Use type-safe JobWait instead.
 /// This base class does not contain code specific to the actual Job type.
-class JobWaitBase
+class JobWaitBase : NonCopyable /* each waiting context needs a dedicated AsyncCall */
 {
 public:
     JobWaitBase();
     ~JobWaitBase();
-
-    /// no copying of any kind: each waiting context needs a dedicated AsyncCall
-    JobWaitBase(JobWaitBase &&) = delete;
 
     explicit operator bool() const { return waiting(); }
 

--- a/src/base/RegexPattern.h
+++ b/src/base/RegexPattern.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_SRC_BASE_REGEXPATTERN_H
 #define SQUID_SRC_BASE_REGEXPATTERN_H
 
+#include "base/TypeTraits.h"
 #include "compat/GnuRegex.h"
 #include "mem/forward.h"
 #include "sbuf/SBuf.h"
@@ -17,7 +18,7 @@
  * A regular expression,
  * plain text and compiled representations
  */
-class RegexPattern
+class RegexPattern : NonCopyable
 {
     MEMPROXY_CLASS(RegexPattern);
 
@@ -25,8 +26,6 @@ public:
     RegexPattern() = delete;
     RegexPattern(const SBuf &aPattern, int aFlags);
     ~RegexPattern();
-
-    RegexPattern(RegexPattern &&) = delete; // no copying of any kind
 
     /// whether the regex differentiates letter case
     bool caseSensitive() const { return !(flags & REG_ICASE); }

--- a/src/base/TypeTraits.h
+++ b/src/base/TypeTraits.h
@@ -33,9 +33,18 @@ protected: // prevents accidental creation of Interface instances
     Interface(Interface &&) = default;
 };
 
+/// convenience base for any class to prohibit default move and copy
+class NonCopyable
+{
+protected:
+    NonCopyable() = default;
+    NonCopyable(NonCopyable &&) = delete;
+};
+
 } // namespace TypeTraits_
 
 using Interface = TypeTraits_::Interface;
+using NonCopyable = TypeTraits_::NonCopyable;
 
 #endif /* SQUID_SRC_BASE_TYPETRAITS_H */
 

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -30,9 +30,9 @@ class MemObject;
 /* client_side_request.c - client side request related routines (pure logic) */
 int clientBeginRequest(const HttpRequestMethod&, char const *, CSCB *, CSD *, ClientStreamData, HttpHeader const *, char *, size_t, const MasterXactionPointer &);
 
-class ClientHttpRequest
+class ClientHttpRequest : NonCopyable
 #if USE_ADAPTATION
-    : public Adaptation::Initiator, // to start adaptation transactions
+    , public Adaptation::Initiator, // to start adaptation transactions
       public BodyConsumer     // to receive reply bodies in request satisf. mode
 #endif
 {
@@ -40,7 +40,6 @@ class ClientHttpRequest
 
 public:
     ClientHttpRequest(ConnStateData *);
-    ClientHttpRequest(ClientHttpRequest &&) = delete;
     ~ClientHttpRequest();
 
     String rangeBoundaryStr() const;

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -67,7 +67,7 @@ namespace Comm
  * These objects should not be passed around directly,
  * but a Comm::ConnectionPointer should be passed instead.
  */
-class Connection: public CodeContext
+class Connection: public CodeContext, NonCopyable /* use cloneProfile instead */
 {
     MEMPROXY_CLASS(Comm::Connection);
 
@@ -76,10 +76,6 @@ public:
 
     /** Clear the connection properties and close any open socket. */
     virtual ~Connection();
-
-    /// To prevent accidental copying of Connection objects that we started to
-    /// open or that are open, use cloneProfile() instead.
-    Connection(const Connection &&) = delete;
 
     /// Create a new closed Connection with the same configuration as this one.
     ConnectionPointer cloneProfile() const;

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "base/Optional.h"
 #include "base/TextException.h"
+#include "base/TypeTraits.h"
 #include "debug/Stream.h"
 #include "fd.h"
 #include "ipc/Kids.h"
@@ -78,12 +79,11 @@ static void ResetSections(const int level = DBG_IMPORTANT);
 static bool DidResetSections = false;
 
 /// a named FILE with very-early/late usage safety mechanisms
-class DebugFile
+class DebugFile : NonCopyable
 {
 public:
     DebugFile() {}
     ~DebugFile() { clear(); }
-    DebugFile(DebugFile &&) = delete; // no copying or moving of any kind
 
     /// switches to the new pair, absorbing FILE and duping the name
     void reset(FILE *newFile, const char *newName);
@@ -143,16 +143,13 @@ public:
 using CompiledDebugMessages = std::deque<CompiledDebugMessage>;
 
 /// a receiver of debugs() messages (e.g., stderr or cache.log)
-class DebugChannel
+class DebugChannel : NonCopyable
 {
 public:
     using EarlyMessages = std::unique_ptr<CompiledDebugMessages>;
 
     explicit DebugChannel(const char *aName);
     virtual ~DebugChannel() = default;
-
-    // no copying or moving or any kind (for simplicity sake and to prevent accidental copies)
-    DebugChannel(DebugChannel &&) = delete;
 
     /// whether we are still expecting (and buffering) early messages
     bool collectingEarlyMessages() const { return bool(earlyMessages); }

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -65,7 +65,8 @@ const SBuf ErrorState::LogformatMagic("@Squid{");
 /* local types */
 
 /// an error page created from admin-configurable metadata (e.g. deny_info)
-class ErrorDynamicPageInfo {
+class ErrorDynamicPageInfo : NonCopyable
+{
 public:
     ErrorDynamicPageInfo(const int anId, const char *aName, const SBuf &aCfgLocation);
     ~ErrorDynamicPageInfo() { xfree(page_name); }
@@ -90,10 +91,6 @@ public:
     // XXX: Misnamed. Not just for redirects.
     /// admin-configured HTTP status code
     Http::StatusCode page_redirect;
-
-private:
-    // no copying of any kind
-    ErrorDynamicPageInfo(ErrorDynamicPageInfo &&) = delete;
 };
 
 namespace ErrorPage {

--- a/src/fs/rock/RockRebuild.cc
+++ b/src/fs/rock/RockRebuild.cc
@@ -158,7 +158,7 @@ private:
 
 /// information about store entries being loaded from disk (and their slots)
 /// used for identifying partially stored/loaded entries
-class LoadingParts
+class LoadingParts : NonCopyable
 {
 public:
     using Sizes = Ipc::StoreMapItems<uint64_t>;
@@ -168,9 +168,6 @@ public:
 
     LoadingParts(const SwapDir &dir, const bool resuming);
     ~LoadingParts();
-
-    // lacking copying/moving code and often too huge to copy
-    LoadingParts(LoadingParts&&) = delete;
 
     Sizes &sizes() const { return *sizesOwner->object(); }
     Versions &versions() const { return *versionsOwner->object(); }

--- a/src/log/FormattedLog.h
+++ b/src/log/FormattedLog.h
@@ -21,13 +21,11 @@ class ConfigParser;
 /// A single-destination, single-record-format log.
 /// The customizable destination is based on Logfile "logging modules" API.
 /// Some logs allow the admin to select or specify the record format.
-class FormattedLog
+class FormattedLog : NonCopyable
 {
 public:
     FormattedLog() = default;
     ~FormattedLog();
-
-    FormattedLog(FormattedLog &&) = delete; // no need to support copying of any kind
 
     /// \returns whether the daemon module is used for this log
     bool usesDaemon() const;

--- a/src/ssl/ProxyCerts.h
+++ b/src/ssl/ProxyCerts.h
@@ -14,11 +14,10 @@
 #include "acl/Gadgets.h"
 #include "ssl/gadgets.h"
 
-class sslproxy_cert_sign
+class sslproxy_cert_sign : NonCopyable
 {
 public:
     sslproxy_cert_sign() = default;
-    sslproxy_cert_sign(sslproxy_cert_sign &&) = delete; // prohibit all copy/move
     ~sslproxy_cert_sign() {
         while (const auto first = next) {
             next = first->next;
@@ -35,11 +34,10 @@ public:
     sslproxy_cert_sign *next = nullptr;
 };
 
-class sslproxy_cert_adapt
+class sslproxy_cert_adapt : NonCopyable
 {
 public:
     sslproxy_cert_adapt() = default;
-    sslproxy_cert_adapt(sslproxy_cert_adapt &&) = delete; // prohibit all copy/move
     ~sslproxy_cert_adapt() {
         while (const auto first = next) {
             next = first->next;


### PR DESCRIPTION
Partially implement
```TODO: Extract reusable paradigms into other mixins (e.g., NonCopyable).```

Future work:
 * identify other classes which can use this mixin.
 * identify other mixins that match this TODO