### PR TITLE
Fix configure --disable-strict-error-checking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,9 @@ AS_IF([test "$squid_cv_cc_simplified" = "gcc-4"],[
     AC_MSG_NOTICE([skipping -Wextra on $squid_cv_cc_simplified])
 ],[
     # -Werror must be first
-    SQUID_CC_ADD_CXXFLAG_IF_SUPPORTED([-Werror])
+    if test "x$enable_strict_error_checking" = "xyes" ; then
+        SQUID_CC_ADD_CXXFLAG_IF_SUPPORTED([-Werror])
+    fi
     SQUID_CC_ADD_CXXFLAG_IF_SUPPORTED([-Wextra])
     # -Wunused-private-field causes a huge number of false positives
     #    in unit tests. Disable that


### PR DESCRIPTION
configure.ac tests --disable-strict-error-checking, but
then it doesn't check it when deciding whether to set
the -Werror flag. Fix it.


Test case:
do-build --do-all  --log ../build.log --parallel 10 --pass=--disable-strict-error-checking

=======
without this PR:
```
[..]

running /home/kinkie/src/squid/configure --cache-file=/tmp/config-gcc.cache          --enable-loadable-modules         --disable-gnuregex         --enable-optimizations         --enable-inline         --enable-debug-cbdata         --enable-xmalloc-statistics         --enable-async-io         --enable-disk-io         --enable-removal-policies         --enable-icmp         --enable-delay-pools         --enable-icap-client         --enable-useragent-log         --enable-referer-log         --enable-wccp         --enable-wccpv2         --enable-kill-parent-hack         --enable-snmp         --enable-cachemgr-hostname         --enable-eui         --enable-htcp          --enable-ssl --with-openssl         --enable-forw-via-db         --enable-cache-digests         --enable-poll         --enable-select         --enable-http-violations         --enable-ipfw-transparent         --enable-leakfinder         --enable-follow-x-forwarded-for         --enable-ident-lookups         --enable-internal-dns         --enable-default-hostsfile         --enable-auth         --enable-basic-auth-helpers         --enable-ntlm-auth-helpers         --enable-negotiate-auth-helpers         --enable-digest-auth-helpers         --enable-ntlm-fail-open         --enable-external-acl-helpers         --enable-url-rewrite-helpers         --enable-mempools         --enable-unlinkd         --enable-stacktraces         --enable-vary         --enable-x-accelerator-vary         --enable-ipv6         --disable-auto-locale         --disable-translation         --enable-zph-qos         --enable-esi         --with-aio         --with-build-environment=default         --with-dl         --with-dns-cname         --with-gnu-ld         --with-ipv6-split-stack         --with-large-files         --with-pic         --with-pthreads         --disable-arch-native         --enable-strict-error-checking       --with-po2html=off --with-po2txt=off           --prefix=/home/kinkie/squid/install --without-netfilter-conntrack --disable-build-info --disable-strict-error-checking

[...]

configure: strict error checking enabled: no

[..]

/bin/bash ../../libtool  --tag=CXX   --mode=compile ccache g++ -DHAVE_CONFIG_H -DDEFAULT_CONFIG_FILE=\"/home/kinkie/squid/install/etc/squid.conf\" -DDEFAULT_SQUID_DATA_DIR=\"/home/kinkie/squid/install/share\" -DDEFAULT_SQUID_CONFIG_DIR=\"/home/kinkie/squid/install/etc\"   -I../.. -I../../include -I../../lib -I../../src -I../../include    -I/usr/include/libxml2 **-Werror** -Wextra -Wno-unused-private-field -Wimplicit-fallthrough=2 -Wpointer-arith -Wwrite-strings -Wcomments -Wshadow -Wmissing-declarations -Woverloaded-virtual -pipe -D_REENTRANT -I/usr/include/libxml2 -I/usr/include/p11-kit-1  -g -O2 -MT Assure.lo -MD -MP -MF $depbase.Tpo -c -o Assure.lo Assure.cc &&\
```
===========

With the PR:

```
running /home/kinkie/src/squid/configure --cache-file=/tmp/config-gcc.cache          --enable-loadable-modules         --disa
ble-gnuregex         --enable-optimizations         --enable-inline         --enable-debug-cbdata         --enable-xmalloc-st
atistics         --enable-async-io         --enable-disk-io         --enable-removal-policies         --enable-icmp         -
-enable-delay-pools         --enable-icap-client         --enable-useragent-log         --enable-referer-log         --enable
-wccp         --enable-wccpv2         --enable-kill-parent-hack         --enable-snmp         --enable-cachemgr-hostname
    --enable-eui         --enable-htcp          --enable-ssl --with-openssl         --enable-forw-via-db         --enable-cac
he-digests         --enable-poll         --enable-select         --enable-http-violations         --enable-ipfw-transparent
       --enable-leakfinder         --enable-follow-x-forwarded-for         --enable-ident-lookups         --enable-internal-d
ns         --enable-default-hostsfile         --enable-auth         --enable-basic-auth-helpers         --enable-ntlm-auth-he
lpers         --enable-negotiate-auth-helpers         --enable-digest-auth-helpers         --enable-ntlm-fail-open         --
enable-external-acl-helpers         --enable-url-rewrite-helpers         --enable-mempools         --enable-unlinkd         -
-enable-stacktraces         --enable-vary         --enable-x-accelerator-vary         --enable-ipv6         --disable-auto-lo
cale         --disable-translation         --enable-zph-qos         --enable-esi         --with-aio         --with-build-envi
ronment=default         --with-dl         --with-dns-cname         --with-gnu-ld         --with-ipv6-split-stack         --wi
th-large-files         --with-pic         --with-pthreads         --disable-arch-native         --enable-strict-error-checkin
g       --with-po2html=off --with-po2txt=off           --prefix=/home/kinkie/squid/install --without-netfilter-conntrack --di
sable-build-info --disable-strict-error-checking


[..]

configure: strict error checking enabled: no

[..]

/bin/bash ../libtool  --tag=CXX   --mode=compile ccache g++ -DHAVE_CONFIG_H -DDEFAULT_CONFIG_FILE=\"/home/kinkie/squid/install/etc/squid.conf\" -DDEFAULT_SQUID_DATA_DIR=\"/home/kinkie/squid/install/share\" -DDEFAULT_SQUID_CONFIG_DIR=\"/home/kinkie/squid/install/etc\"   -I.. -I../include -I../lib -I../src -I../include    -I/usr/include/libxml2 -Wextra -Wno-unused-private-field -Wimplicit-fallthrough=2 -Wpointer-arith -Wwrite-strings -Wcomments -Wshadow -Wmissing-declarations -Woverloaded-virtual -pipe -D_REENTRANT -I/usr/include/libxml2 -I/usr/include/p11-kit-1  -g -O2 -MT debug.lo -MD -MP -MF $depbase.Tpo -c -o debug.lo debug.cc &&\


```