### PR TITLE
Maintenance: Trigger -Wswitch in more build environments

### DIFF
--- a/src/store/SwapMeta.h
+++ b/src/store/SwapMeta.h
@@ -136,7 +136,11 @@ RawSwapMetaTypeTop()
     // marker because it does not force us to add that marker to every switch
     // statement, with an assert(false) or similar "unreachable code" handler.
     // Optimizing compilers optimize this statement away into a constant.
-    switch (STORE_META_VOID) {
+    // The non-constant variable is needed for older compilers.
+
+    // always use the last/maximum enum value here
+    auto top = STORE_META_OBJSIZE;
+    switch (top) {
     case STORE_META_VOID:
     case STORE_META_KEY_MD5:
     case STORE_META_URL:
@@ -144,9 +148,9 @@ RawSwapMetaTypeTop()
     case STORE_META_VARY_HEADERS:
     case STORE_META_STD_LFS:
     case STORE_META_OBJSIZE:
-        // always return the last/maximum enum value
-        return STORE_META_OBJSIZE;
+        break;
     }
+    return top;
 }
 
 /// Whether the given raw swap meta field type represents a type that we should


### PR DESCRIPTION
When a developer forgets to update RawSwapMetaTypeTop() after adding a
new SwapMetaType item, the function should produce a -Wswitch compiler
warning (at least). However, we discovered that many compilers remain
silent, apparently confused by the constant switch expression:

* GCC warns only starting with v9.1;
* clang does not warn at all (up to v14, inclusive).

Adding a non-constant variable triggers the expected -Wswitch warnings
in clang and earlier GCC versions. Optimizing compilers (-O1) remove the
otherwise unused variable so adding it has no runtime cost.

Declaring the variable outside the switch statement is required to avoid
an unwanted -Wunused-variable warning with GCC v4.8 and clang v3.0.0.

A post-switch return statement is required to avoid an unwanted
-Wreturn-type warning with GCC v4.9.

Tests: https://gcc.godbolt.org/z/d1czs4c8e