### PR TITLE
Support non-trivial Optional values

### DIFF
--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -58,7 +58,11 @@ public:
         return *this;
     }
 
-    Optional(Optional<Value> &&other) { *this = std::move(other); }
+    Optional(Optional<Value> &&other): Optional()
+    {
+        if (other.hasValue_)
+            *this = std::move(other);
+    }
 
     Optional &operator =(Optional<Value> &&other)
     {

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -49,7 +49,7 @@ public:
     Optional &operator =(const Optional &other)
     {
         if (this != &other) {
-            if (other.has_value()) {
+            if (other.hasValue_) {
                 *this = other.value_;
             } else {
                 reset();
@@ -68,7 +68,7 @@ public:
     Optional &operator =(Optional<Value> &&other)
     {
         if (this != &other) {
-            if (other.has_value()) {
+            if (other.hasValue_) {
                 *this = std::move(other.value_);
                 // no other.reset() per std::optional move semantics
             } else {

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -50,7 +50,7 @@ public:
         if (this != &other) {
             if (other.has_value()) {
                 *this = std::move(other.value_);
-                other.reset();
+                // no other.reset() per std::optional move semantics
             } else {
                 reset();
             }

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -86,7 +86,6 @@ public:
         if (hasValue_) {
             hasValue_ = false;
             value_.~Value();
-            dummy_ = 0;
         }
     }
 

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -43,7 +43,7 @@ public:
     constexpr Optional(const Optional &other): Optional()
     {
         if (other.hasValue_)
-            *this = other;
+            *this = other.value_;
     }
 
     Optional &operator =(const Optional &other)
@@ -60,8 +60,9 @@ public:
 
     Optional(Optional<Value> &&other): Optional()
     {
+        // no other.reset() per std::optional move semantics
         if (other.hasValue_)
-            *this = std::move(other);
+            *this = std::move(other.value_);
     }
 
     Optional &operator =(Optional<Value> &&other)

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -40,8 +40,23 @@ public:
         reset();
     }
 
-    constexpr Optional(const Optional &other) = default;
-    Optional &operator =(const Optional &other) = default;
+    constexpr Optional(const Optional &other): Optional()
+    {
+        if (other.hasValue_)
+            *this = other;
+    }
+
+    Optional &operator =(const Optional &other)
+    {
+        if (this != &other) {
+            if (other.has_value()) {
+                *this = other.value_;
+            } else {
+                reset();
+            }
+        }
+        return *this;
+    }
 
     Optional(Optional<Value> &&other) { *this = std::move(other); }
 

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -49,20 +49,20 @@ public:
     Optional &operator =(const Optional &other)
     {
         if (this != &other) {
-            if (other.hasValue_) {
+            if (other.hasValue_)
                 *this = other.value_;
-            } else {
+            else
                 reset();
-            }
         }
         return *this;
     }
 
     Optional(Optional<Value> &&other): Optional()
     {
-        // no other.reset() per std::optional move semantics
-        if (other.hasValue_)
+        if (other.hasValue_) {
             *this = std::move(other.value_);
+            // no other.reset() per std::optional move semantics
+        }
     }
 
     Optional &operator =(Optional<Value> &&other)

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -28,7 +28,7 @@ template <typename Value>
 class Optional
 {
 public:
-    constexpr Optional() noexcept: dummy_(0) {}
+    constexpr Optional() noexcept: dummy_() {}
     constexpr explicit Optional(const Value &v): value_(v), hasValue_(true) {}
 
     ~Optional()
@@ -92,7 +92,7 @@ public:
 private:
     union {
         /// unused member that helps satisfy various C++ union requirements
-        unsigned char dummy_;
+        struct {} dummy_;
 
         /// stored value; inaccessible/uninitialized unless hasValue_
         Value value_;

--- a/src/base/Optional.h
+++ b/src/base/Optional.h
@@ -40,7 +40,7 @@ public:
         reset();
     }
 
-    constexpr Optional(const Optional &other): Optional()
+    Optional(const Optional &other): Optional()
     {
         if (other.hasValue_)
             *this = other.value_;


### PR DESCRIPTION
Commit 7224761 skipped this std::optional feature when adding initial
Optional implementation because that feature is difficult to support.
However, several in-progress projects now need to make non-trivial
objects Optional. This implementation maintains key Optional invariants,
matching those of std::optional:

* A valueless Optional object does not construct or destruct the value.
* A valued Optional object supports move/copy ops supported by value.

Maintaining the first invariant is tricky:

* Union prevents value construction/destruction in a valueless Optional.
* Explicit destructor call destructs the value in a _valued_ Optional.
* A dummy union member works around a C++ requirement for constexpr
  unions to have at least one active (i.e. initialized) member. Since a
  valueless Optional cannot initialize the value, we need another union
  member that we can initialize.
* We use an _anonymous_ union because C++ places more requirements on
  named unions, triggering a more complex implementation with
  placement-new and to-be-deprecated std::aligned_storage_t tricks!

XXX: This simplified implementation violates the following std::optional
invariant. We believe that this violation does not hurt the current and
foreseeable Squid code. In our tests, optimizing compilers still
optimize Optional<Trivial> destructors away.

* std::optional<Value> is trivially destructible if Value is.