### PR TITLE
Use std::optional where available

### DIFF
--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -44,6 +44,7 @@ libcompatsquid_la_SOURCES = \
 	memrchr.h \
 	mswindows.cc \
 	openssl.h \
+	optional.h \
 	os/aix.h \
 	os/android.h \
 	os/dragonfly.h \

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -55,6 +55,7 @@
 #define __STDC_FORMAT_MACROS
 
 #include "compat/types.h"
+#include "compat/optional.h"
 
 /*****************************************************/
 /* per-OS hacks. One file per OS.                    */

--- a/compat/optional.h
+++ b/compat/optional.h
@@ -9,13 +9,12 @@
 #ifndef SQUID__COMPAT_OPTIONAL_H
 #define SQUID__COMPAT_OPTIONAL_H
 
-#if __cplusplus
-#if __has_include(<optional>)
+#if __cplusplus > 201701L
 
 #include <optional>
 template<class T> using Optional = std::optional<T>;
 
-#else
+#elif __cplusplus
 
 #include <exception>
 #include <type_traits>
@@ -129,5 +128,4 @@ private:
     bool hasValue_ = false;
 };
 #endif
-#endif /* __cplusplus */
 #endif /* SQUID__COMPAT_OPTIONAL_H */

--- a/compat/optional.h
+++ b/compat/optional.h
@@ -6,8 +6,16 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-#ifndef SQUID__SRC_BASE_OPTIONAL_H
-#define SQUID__SRC_BASE_OPTIONAL_H
+#ifndef SQUID__COMPAT_OPTIONAL_H
+#define SQUID__COMPAT_OPTIONAL_H
+
+#if __cplusplus
+#if __has_include(<optional>)
+
+#include <optional>
+template<class T> using Optional = std::optional<T>;
+
+#else
 
 #include <exception>
 #include <type_traits>
@@ -120,6 +128,6 @@ private:
 
     bool hasValue_ = false;
 };
-
-#endif /* SQUID__SRC_BASE_OPTIONAL_H */
-
+#endif
+#endif /* __cplusplus */
+#endif /* SQUID__COMPAT_OPTIONAL_H */

--- a/src/SquidMath.h
+++ b/src/SquidMath.h
@@ -10,7 +10,6 @@
 #define _SQUID_SRC_SQUIDMATH_H
 
 #include "base/forward.h"
-#include "base/Optional.h"
 
 #include <limits>
 #include <type_traits>

--- a/src/base/ClpMap.h
+++ b/src/base/ClpMap.h
@@ -9,7 +9,6 @@
 #ifndef SQUID__SRC_BASE_CLPMAP_H
 #define SQUID__SRC_BASE_CLPMAP_H
 
-#include "base/Optional.h"
 #include "mem/PoolingAllocator.h"
 #include "SquidMath.h"
 #include "time/gadgets.h"

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -48,7 +48,6 @@ libbase_la_SOURCES = \
 	JobWait.h \
 	Lock.h \
 	LookupTable.h \
-	Optional.h \
 	Packable.h \
 	PackableStream.h \
 	RandomUuid.cc \

--- a/src/base/forward.h
+++ b/src/base/forward.h
@@ -20,8 +20,6 @@ class BadOptionalAccess;
 class Raw;
 class RegexPattern;
 
-template <typename Value> class Optional;
-
 template<class Cbc> class CbcPointer;
 template<class RefCountableKid> class RefCount;
 template<class Job> class JobWait;

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -9,7 +9,6 @@
 /* DEBUG: section 00    Debug Routines */
 
 #include "squid.h"
-#include "base/Optional.h"
 #include "base/TextException.h"
 #include "debug/Stream.h"
 #include "fd.h"

--- a/src/log/FormattedLog.h
+++ b/src/log/FormattedLog.h
@@ -10,7 +10,6 @@
 #define SQUID_LOG_FORMATTEDLOG_H_
 
 #include "acl/forward.h"
-#include "base/Optional.h"
 #include "log/Formats.h"
 #include "log/forward.h"
 

--- a/src/tests/testMath.cc
+++ b/src/tests/testMath.cc
@@ -7,7 +7,6 @@
  */
 
 #include "squid.h"
-#include "base/Optional.h"
 #include "compat/cppunit.h"
 #include "SquidMath.h"
 #include "unitTestMain.h"


### PR DESCRIPTION
Our class Optional is a portability replacement for std::optional on
older compilers.