### PR TITLE
Fix build on arm32

### DIFF
--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -334,7 +334,7 @@ static struct ssl_option {
 #endif
 #if defined(SSL_OP_ALL)
     {
-        "ALL", (long)SSL_OP_ALL
+        "ALL", SSL_OP_ALL
     },
 #endif
 #if defined(SSL_OP_SINGLE_DH_USE)

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -145,7 +145,7 @@ StoreSearch *NewLocalSearch() STUB_RETVAL(nullptr)
 
 #include "store/SwapMetaIn.h"
 size_t Store::UnpackSwapMetaSize(const SBuf &) STUB_RETVAL(0)
-uint64_t Store::UnpackIndexSwapMeta(const MemBuf &, StoreEntry &, cache_key *) STUB_RETVAL(0)
+size_t Store::UnpackIndexSwapMeta(const MemBuf &, StoreEntry &, cache_key *) STUB_RETVAL(0)
 void Store::UnpackHitSwapMeta(char const *, ssize_t, StoreEntry &) STUB
 
 #include "store/SwapMetaOut.h"


### PR DESCRIPTION
On arm32, size_t and long are 32 bits in size, exposing these bugs.