### PR TITLE
Bug 3193 pt2: NTLM decoder truncating strings

### DIFF
--- a/lib/ntlmauth/ntlmauth.cc
+++ b/lib/ntlmauth/ntlmauth.cc
@@ -108,10 +108,19 @@ ntlm_fetch_string(const ntlmhdr *packet, const int32_t packet_size, const strhdr
     int32_t o = le32toh(str->offset);
     // debug("ntlm_fetch_string(plength=%d,l=%d,o=%d)\n",packet_size,l,o);
 
-    if (l < 0 || l > NTLM_MAX_FIELD_LENGTH || o + l > packet_size || o == 0) {
-        debug("ntlm_fetch_string: insane data (pkt-sz: %d, fetch len: %d, offset: %d)\n", packet_size,l,o);
+    if (l < 0 || NTLM_MAX_FIELD_LENGTH < l) {
+        debug("ntlm_fetch_string: insane string length (pkt-sz: %d, fetch len: %d, offset: %d)\n", packet_size,l,o);
         return rv;
     }
+    else if (o <= 0 || packet_size < o) {
+        debug("ntlm_fetch_string: insane string offset (pkt-sz: %d, fetch len: %d, offset: %d)\n", packet_size,l,o);
+        return rv;
+    }
+    else if (l > packet_size - o) {
+        debug("ntlm_fetch_string: truncated string data (pkt-sz: %d, fetch len: %d, offset: %d)\n", packet_size,l,o);
+        return rv;
+    }
+
     rv.str = (char *)packet + o;
     rv.l = 0;
     if ((flags & NTLM_NEGOTIATE_ASCII) == 0) {

--- a/lib/ntlmauth/ntlmauth.cc
+++ b/lib/ntlmauth/ntlmauth.cc
@@ -108,11 +108,11 @@ ntlm_fetch_string(const ntlmhdr *packet, const int32_t packet_size, const strhdr
     int32_t o = le32toh(str->offset);
     // debug("ntlm_fetch_string(plength=%d,l=%d,o=%d)\n",packet_size,l,o);
 
-    if (l < 0 || NTLM_MAX_FIELD_LENGTH < l) {
+    if (l < 0 || l > NTLM_MAX_FIELD_LENGTH) {
         debug("ntlm_fetch_string: insane string length (pkt-sz: %d, fetch len: %d, offset: %d)\n", packet_size,l,o);
         return rv;
     }
-    else if (o <= 0 || packet_size < o) {
+    else if (o <= 0 || o > packet_size) {
         debug("ntlm_fetch_string: insane string offset (pkt-sz: %d, fetch len: %d, offset: %d)\n", packet_size,l,o);
         return rv;
     }


### PR DESCRIPTION
The initial bug fix overlooked large 'offset' causing integer
wrap to extract a too-short length string.

Improve debugs and checks sequence to clarify cases and ensure
that all are handled correctly.