### PR TITLE
Make COMM_ORPHANED and COMM_REUSEPORT values distinct

### DIFF
--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -51,7 +51,7 @@ namespace Comm
 #define COMM_INTERCEPTION       0x20  // arrived via NAT
 #define COMM_REUSEPORT          0x40 //< needs SO_REUSEPORT
 /// not registered with Comm and not owned by any connection-closing code
-#define COMM_ORPHANED           0x40
+#define COMM_ORPHANED           0x80
 
 /**
  * Store data about the physical and logical attributes of a connection.


### PR DESCRIPTION
Broken since inception (commit 1c2b446). The exact runtime effects (if
any) of this bug are difficult to ascertain, but it is possible that
some COMM_REUSEPORT (i.e. worker-queues port) listening connections were
not reported as incorrectly orphaned when they should have been.