### PR TITLE
Fixed StoreMap.cc "anchorAt(anchorId).reading()" assertions

### DIFF
--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -594,7 +594,7 @@ MemStore::shouldCache(StoreEntry &e) const
     }
 
     // To avoid SMP workers releasing each other caching attempts, restrict disk
-    // caching to StoreEntry publisher . This check goes before memoryCachable()
+    // caching to StoreEntry publisher. This check goes before memoryCachable()
     // that may incorrectly release() publisher's entry via checkCachable().
     if (Store::Root().transientsReader(e)) {
         debugs(20, 5, "yield to entry publisher: " << e);

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -515,7 +515,7 @@ MemStore::copyFromShm(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnc
 
     if (anchor.writerHalted) {
         debugs(20, 5, "mem-loaded aborted " << e.mem_obj->endOffset() << '/' <<
-           anchor.basics.swap_file_sz << " bytes of " << e);
+               anchor.basics.swap_file_sz << " bytes of " << e);
         return false;
     }
 

--- a/src/Store.h
+++ b/src/Store.h
@@ -93,6 +93,8 @@ public:
     void memOutDecision(const bool willCacheInRam);
     // called when a decision to cache on disk has been made
     void swapOutDecision(const MemObject::SwapOut::Decision &decision);
+    /// called when a store writer ends its work (successfully or not)
+    void storeWriterDone();
 
     void abort();
     bool makePublic(const KeyScope keyScope = ksDefault);
@@ -303,7 +305,7 @@ public:
 protected:
     typedef Store::EntryGuard EntryGuard;
 
-    void transientsAbandonmentCheck();
+    void storeWritingCheckpoint();
     /// does nothing except throwing if disk-associated data members are inconsistent
     void checkDisk() const;
 

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -19,10 +19,11 @@
 
 typedef Ipc::StoreMap TransientsMap;
 
-/// Keeps track of store entries being delivered to clients that arrived before
-/// those entries were [fully] cached. This SMP-shared table is necessary to
-/// * sync an entry-writing worker with entry-reading worker(s); and
-/// * sync an entry-deleting worker with both entry-reading/writing workers.
+/// A Transients entry allows workers to Broadcast() DELETE requests and swapout
+/// progress updates. In a collapsed forwarding context, it also represents a CF
+/// initiating worker promise to either cache the response or inform the waiting
+/// slaves (via false EntryStatus::hasWriter) that caching will not happen. A
+/// Transients entry itself does not carry response- or Store-specific metadata.
 class Transients: public Store::Controlled, public Ipc::StoreMapCleaner
 {
 public:
@@ -30,7 +31,7 @@ public:
     class EntryStatus
     {
     public:
-        bool abortedByWriter = false; ///< whether the entry was aborted
+        bool hasWriter = false; ///< whether some worker is storing the entry
         bool waitingToBeFreed = false; ///< whether the entry was marked for deletion
         bool collapsed = false; ///< whether the entry allows collapsing
     };

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -103,6 +103,8 @@ Rock::IoState::read_(char *buf, size_t len, off_t coreOff, STRCB *cb, void *data
     assert(theFile != nullptr);
     assert(coreOff >= 0);
 
+    bool writerLeft = readAnchor().writerHalted; // before the sidCurrent change
+
     // if we are dealing with the first read or
     // if the offset went backwords, start searching from the beginning
     if (sidCurrent < 0 || coreOff < objOffset) {
@@ -112,6 +114,7 @@ Rock::IoState::read_(char *buf, size_t len, off_t coreOff, STRCB *cb, void *data
     }
 
     while (sidCurrent >= 0 && coreOff >= objOffset + currentReadableSlice().size) {
+        writerLeft = readAnchor().writerHalted; // before the sidCurrent change
         objOffset += currentReadableSlice().size;
         sidCurrent = currentReadableSlice().next;
     }
@@ -120,6 +123,13 @@ Rock::IoState::read_(char *buf, size_t len, off_t coreOff, STRCB *cb, void *data
     assert(read.callback_data == nullptr);
     read.callback = cb;
     read.callback_data = cbdataReference(data);
+
+    // quit if we cannot read what they want, and the writer cannot add more
+    if (sidCurrent < 0 && writerLeft) {
+        debugs(79, 5, "quitting at " << coreOff << " in " << *e);
+        callReaderBack(buf, -1);
+        return;
+    }
 
     // punt if read offset is too big (because of client bugs or collapsing)
     if (sidCurrent < 0) {

--- a/src/store.cc
+++ b/src/store.cc
@@ -1752,7 +1752,7 @@ StoreEntry::storeWritingCheckpoint()
         return;
     }
 
-    const bool doneWithDiskCache =
+    const auto doneWithDiskCache =
         // will not start
         (mem_obj->swapout.decision == MemObject::SwapOut::swImpossible) ||
         // or has started but finished already

--- a/src/store.cc
+++ b/src/store.cc
@@ -1732,37 +1732,62 @@ StoreEntry::getSerialisedMetaData(size_t &length) const
 }
 
 /**
- * Abandon the transient entry our worker has created if neither the shared
- * memory cache nor the disk cache wants to store it. Collapsed requests, if
- * any, should notice and use Plan B instead of getting stuck waiting for us
- * to start swapping the entry out.
+ * If needed, signal transient entry readers that no more cache changes are
+ * expected and, hence, they should switch to Plan B instead of getting stuck
+ * waiting for us to start or finish storing the entry.
  */
 void
-StoreEntry::transientsAbandonmentCheck()
+StoreEntry::storeWritingCheckpoint()
 {
-    if (mem_obj && !Store::Root().transientsReader(*this) && // this worker is responsible
-            hasTransients() && // other workers may be interested
-            !hasMemStore() && // rejected by the shared memory cache
-            mem_obj->swapout.decision == MemObject::SwapOut::swImpossible) {
-        debugs(20, 7, "cannot be shared: " << *this);
-        if (!shutting_down) // Store::Root() is FATALly missing during shutdown
-            Store::Root().stopSharing(*this);
+    if (!hasTransients())
+        return; // no SMP complications
+
+    // writers become readers but only after completeWriting() which we trigger
+    if (Store::Root().transientsReader(*this))
+        return; // readers do not need to inform
+
+    assert(mem_obj);
+    if (mem_obj->memCache.io != Store::ioDone) {
+        debugs(20, 7, "not done with mem-caching " << *this);
+        return;
     }
+
+    const bool doneWithDiskCache =
+        // will not start
+        (mem_obj->swapout.decision == MemObject::SwapOut::swImpossible) ||
+        // or has started but finished already
+        (mem_obj->swapout.decision == MemObject::SwapOut::swStarted && !swappingOut());
+    if (!doneWithDiskCache) {
+        debugs(20, 7, "not done with disk-caching " << *this);
+        return;
+    }
+
+    debugs(20, 7, "done with writing " << *this);
+    if (!shutting_down) // Store::Root() is FATALly missing during shutdown
+        Store::Root().noteStoppedSharedWriting(*this);
 }
 
 void
-StoreEntry::memOutDecision(const bool)
+StoreEntry::memOutDecision(const bool willCacheInRam)
 {
-    transientsAbandonmentCheck();
+    if (!willCacheInRam)
+        return storeWritingCheckpoint();
+    assert(mem_obj->memCache.io != Store::ioDone);
+    // and wait for storeWriterDone()
 }
 
 void
 StoreEntry::swapOutDecision(const MemObject::SwapOut::Decision &decision)
 {
-    // Abandon our transient entry if neither shared memory nor disk wants it.
     assert(mem_obj);
     mem_obj->swapout.decision = decision;
-    transientsAbandonmentCheck();
+    storeWritingCheckpoint();
+}
+
+void
+StoreEntry::storeWriterDone()
+{
+    storeWritingCheckpoint();
 }
 
 void

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -114,8 +114,8 @@ public:
     /// Update local intransit entry after changes made by appending worker.
     void syncCollapsed(const sfileno);
 
-    /// stop any current (and prevent any future) SMP sharing of the given entry
-    void stopSharing(StoreEntry &);
+    /// adjust shared state after this worker stopped changing the entry
+    void noteStoppedSharedWriting(StoreEntry &);
 
     /// number of the transient entry readers some time ago
     int transientReaders(const StoreEntry &) const;

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -108,9 +108,6 @@ public:
     /// whether the entry is in "writing to Transients" I/O state
     bool transientsWriter(const StoreEntry &) const;
 
-    /// marks the entry completed for collapsed requests
-    void transientsCompleteWriting(StoreEntry &);
-
     /// Update local intransit entry after changes made by appending worker.
     void syncCollapsed(const sfileno);
 

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -352,19 +352,18 @@ StoreEntry::mayStartSwapOut()
         return false;
     }
 
+    // If we have started swapping out, do not start over. Most likely, we have
+    // finished swapping out by now because we are not currently swappingOut().
+    if (decision == MemObject::SwapOut::swStarted) {
+        debugs(20, 3, "already started");
+        return false;
+    }
+
     // TODO: Store::Root() is FATALly missing during shutdown
-    // TODO: Move lower to avoid checking multiple times.
     // if there is a usable disk entry already, do not start over
     if (hasDisk() || Store::Root().hasReadableDiskEntry(*this)) {
         debugs(20, 3, "already did"); // we or somebody else created that entry
         swapOutDecision(MemObject::SwapOut::swImpossible);
-        return false;
-    }
-
-    // if we have just stared swapping out (attachToDisk() has not been
-    // called), do not start over
-    if (decision == MemObject::SwapOut::swStarted) {
-        debugs(20, 3, "already started");
         return false;
     }
 

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -47,7 +47,6 @@ storeSwapOutStart(StoreEntry * e)
     debugs(20, 5, "storeSwapOutStart: Begin SwapOut '" << e->url() << "' to dirno " <<
            e->swap_dirn << ", fileno " << std::hex << std::setw(8) << std::setfill('0') <<
            std::uppercase << e->swap_filen);
-    e->swapOutDecision(MemObject::SwapOut::swStarted);
     /* If we start swapping out objects with OutOfBand Metadata,
      * then this code needs changing
      */
@@ -81,6 +80,8 @@ storeSwapOutStart(StoreEntry * e)
     e->lock("storeSwapOutStart");
     /* Pick up the file number if it was assigned immediately */
     e->attachToDisk(mem->swapout.sio->swap_dirn, mem->swapout.sio->swap_filen, SWAPOUT_WRITING);
+
+    e->swapOutDecision(MemObject::SwapOut::swStarted); // after SWAPOUT_WRITING
 
     /* write out the swap metadata */
     storeIOWrite(mem->swapout.sio, buf, mem->swap_hdr_sz, 0, xfree_cppwrapper);
@@ -326,9 +327,9 @@ storeSwapOutFileClosed(void *data, int errflag, StoreIOState::Pointer self)
         ++statCounter.swap.outs;
     }
 
-    Store::Root().transientsCompleteWriting(*e);
     debugs(20, 3, "storeSwapOutFileClosed: " << __FILE__ << ":" << __LINE__);
     mem->swapout.sio = nullptr;
+    e->storeWriterDone(); // after updating swap_status
     e->unlock("storeSwapOutFileClosed");
 }
 
@@ -351,9 +352,11 @@ StoreEntry::mayStartSwapOut()
         return false;
     }
 
-    // if we are swapping out or swapped out already, do not start over
+    // TODO: Store::Root() is FATALly missing during shutdown
+    // TODO: Move lower to avoid checking multiple times.
+    // if there is a usable disk entry already, do not start over
     if (hasDisk() || Store::Root().hasReadableDiskEntry(*this)) {
-        debugs(20, 3, "already did");
+        debugs(20, 3, "already did"); // we or somebody else created that entry
         swapOutDecision(MemObject::SwapOut::swImpossible);
         return false;
     }
@@ -362,7 +365,6 @@ StoreEntry::mayStartSwapOut()
     // called), do not start over
     if (decision == MemObject::SwapOut::swStarted) {
         debugs(20, 3, "already started");
-        swapOutDecision(MemObject::SwapOut::swImpossible);
         return false;
     }
 
@@ -376,6 +378,15 @@ StoreEntry::mayStartSwapOut()
     if (decision == MemObject::SwapOut::swPossible) {
         debugs(20, 3, "already allowed");
         return true;
+    }
+
+    // To avoid SMP workers releasing each other caching attempts, restrict disk
+    // caching to StoreEntry publisher . This check goes before checkCachable()
+    // that may incorrectly release() publisher's entry.
+    if (Store::Root().transientsReader(*this)) {
+        debugs(20, 5, "yield to entry publisher");
+        swapOutDecision(MemObject::SwapOut::swImpossible);
+        return false;
     }
 
     if (!checkCachable()) {

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -160,6 +160,10 @@ doPages(StoreEntry *anEntry)
 void
 StoreEntry::swapOut()
 {
+    // Store::Root() in many swapout checks is FATALly missing during shutdown
+    if (shutting_down)
+        return;
+
     if (!mem_obj)
         return;
 
@@ -359,7 +363,6 @@ StoreEntry::mayStartSwapOut()
         return false;
     }
 
-    // TODO: Store::Root() is FATALly missing during shutdown
     // if there is a usable disk entry already, do not start over
     if (hasDisk() || Store::Root().hasReadableDiskEntry(*this)) {
         debugs(20, 3, "already did"); // we or somebody else created that entry

--- a/src/store_swapout.cc
+++ b/src/store_swapout.cc
@@ -383,7 +383,7 @@ StoreEntry::mayStartSwapOut()
     }
 
     // To avoid SMP workers releasing each other caching attempts, restrict disk
-    // caching to StoreEntry publisher . This check goes before checkCachable()
+    // caching to StoreEntry publisher. This check goes before checkCachable()
     // that may incorrectly release() publisher's entry.
     if (Store::Root().transientsReader(*this)) {
         debugs(20, 5, "yield to entry publisher");

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -47,9 +47,8 @@ void Controller::addReading(StoreEntry *, const cache_key *) STUB
 void Controller::addWriting(StoreEntry *, const cache_key *) STUB
 bool Controller::transientsReader(const StoreEntry &) const STUB_RETVAL(false)
 bool Controller::transientsWriter(const StoreEntry &) const STUB_RETVAL(false)
-void Controller::transientsCompleteWriting(StoreEntry &) STUB
 void Controller::syncCollapsed(const sfileno) STUB
-void Controller::stopSharing(StoreEntry &) STUB
+void Controller::noteStoppedSharedWriting(StoreEntry &) STUB
 int Controller::transientReaders(const StoreEntry &) const STUB_RETVAL(0)
 void Controller::transientsDisconnect(StoreEntry &) STUB
 void Controller::transientsClearCollapsingRequirement(StoreEntry &) STUB


### PR DESCRIPTION
Squid asserted because the code could switch a transient entry from
writing to reading while the corresponding store entry was still being
(or could still be) written to the shared memory cache. For example:

1. We start as a collapsed writer.
2. We get a response and start writing to disk and shared memory caches.
3. Disk swapout fails (for any reason, including out-of-slots errors).
4. storeSwapOutFileClosed() calls transientsCompleteWriting().
5. transientsCompleteWriting() switches the entry into reading mode
   ... but we are still writing to the memory cache!

There was a somewhat related XXX in transientsCompleteWriting(), but
what that comment did not say is that if we are writing to two stores in
parallel, then the first transientsCompleteWriting() call (made when one
of the two swapouts ends) makes us a reader prematurely.

An incorrect reader status allows a Controller::syncCollapsed()
notification (to, say, a shared memory cache writer) slip past the
transients->isWriter() guard, eventually reaching the reading()
assertion.

Properly detecting the end of all store writing is difficult because the
two mostly independent writing "threads" may start/finish at seemingly
random times, in many code places, and even in different workers. To
simplify this task, Squid now limits cache writing to the worker
transaction that made the StoreEntry object public. That transaction
creates a writing Transients entry. Other transactions start as
Transients readers. The writer switches to reader when neither memory
nor disk caching can start or continue.

Also simplified Transients entry state. Squid relayed swapout errors via
the Transient entries themselves, but that is not necessary (and it
prevented the cache entry from recovering by writing to another store).
Each store entry can take care of its own swapout status/results. The
readers just need to know whether somebody may start (or is still)
writing, and we relay that info by keeping the Transients entry locked
for writing (appending, to be precise) while that condition is true.

Also fixed shared caches to recognize that no more data will be coming
in because the remote entry writer is gone. Readers still try to deliver
what they have, even if they know that the response will be truncated.

Also tried to follow the "broadcast after change, in the same context as
the change" principle in the modified code instead of relying on the
caller to broadcast after all changes. This approach may increase the
number of broadcasts, but it reduces the probability that we will miss
an important Broadcast() call. We can (and should) optimize repeated,
useless broadcasts, but that work is outside this project scope.

Also improved StoreEntry::swapOut() shutdown safety and
mayStartSwapOut() checks descriptions/order.

Also added an out-of-scope XXX.