### PR TITLE
Do not tell admins that we are replacing their .* with our .*

### DIFF
--- a/src/acl/RegexData.cc
+++ b/src/acl/RegexData.cc
@@ -79,6 +79,9 @@ ACLRegexData::dump() const
 static const char *
 removeUnnecessaryWildcards(char * t)
 {
+    if (strcmp(t, ".*") == 0) // we cannot simplify that further
+        return t; // avoid "WARNING: ... Using '.*' instead" below
+
     char * orig = t;
 
     if (strncmp(t, "^.*", 3) == 0)


### PR DESCRIPTION
    acl hasHeaderFoo req_header Foo .*

    2022/08/12 11:43:27| WARNING: regular expression '.*' has only
    wildcards and matches all strings. Using '.*' instead.

Broken since RE optimization inception (commit 6564dae), but the
excessive WARNING was "invisible" to many admins until 61be1d8 started
saving early level-0/1 messages to cache.log.