### PR TITLE
Remove temporary MasterXaction objects

### DIFF
--- a/src/client_side.h
+++ b/src/client_side.h
@@ -84,7 +84,7 @@ class ConnStateData:
 {
 
 public:
-    explicit ConnStateData(const MasterXactionPointer &xact);
+    explicit ConnStateData(const AnyP::PortCfgPointer &, const Comm::ConnectionPointer &);
     virtual ~ConnStateData();
 
     /* ::Server API */

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -238,7 +238,6 @@ Ftp::Relay::updateMaster()
         if (Ftp::Server *srv = dynamic_cast<Ftp::Server*>(mgr.get()))
             return *srv->master;
     }
-    // this code will not be necessary once the master is inside MasterXaction
     debugs(9, 3, "our server side is gone: " << mgr);
     static Ftp::MasterState Master;
     Master = Ftp::MasterState();

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -27,7 +27,6 @@
 #include "ip/Intercept.h"
 #include "ip/QosConfig.h"
 #include "log/access_log.h"
-#include "MasterXaction.h"
 #include "SquidConfig.h"
 #include "StatCounters.h"
 
@@ -288,7 +287,6 @@ Comm::TcpAcceptor::acceptOne()
         /* register interest again */
         debugs(5, 5, "try later: " << conn << " handler Subscription: " << theCallSub);
     } else {
-        // TODO: When ALE, MasterXaction merge, use them or ClientConn instead.
         CallBack(newConnDetails, [&] {
             debugs(5, 5, "Listener: " << conn <<
                    " accepted new connection " << newConnDetails <<

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -50,9 +50,9 @@ static bool SupportedCommand(const SBuf &name);
 static bool CommandHasPathParameter(const SBuf &cmd);
 };
 
-Ftp::Server::Server(const MasterXaction::Pointer &xact):
+Ftp::Server::Server(const AnyP::PortCfgPointer &listenPort, const Comm::ConnectionPointer &client):
     AsyncJob("Ftp::Server"),
-    ConnStateData(xact),
+    ConnStateData(listenPort, client),
     master(new MasterState),
     uri(),
     host(),
@@ -254,11 +254,7 @@ Ftp::Server::AcceptCtrlConnection(const CommAcceptCbParams &params)
     debugs(33, 4, params.conn << ": accepted");
     fd_note(params.conn->fd, "client ftp connect");
 
-    const auto xact = MasterXaction::MakePortful(params.port);
-    xact->tcpClient = params.conn;
-
-    AsyncJob::Start(new Server(xact));
-    // XXX: do not abandon the MasterXaction object
+    AsyncJob::Start(new Server(params.port, params.conn));
 }
 
 void

--- a/src/servers/FtpServer.h
+++ b/src/servers/FtpServer.h
@@ -35,8 +35,6 @@ typedef enum {
     fssError
 } ServerState;
 
-// TODO: This should become a part of MasterXaction when we start sending
-// master transactions to the clients/ code.
 /// Transaction information shared among our FTP client and server jobs.
 class MasterState: public RefCountable
 {
@@ -59,7 +57,7 @@ class Server: public ConnStateData
     CBDATA_CHILD(Server);
 
 public:
-    explicit Server(const MasterXaction::Pointer &xact);
+    explicit Server(const AnyP::PortCfgPointer &, const Comm::ConnectionPointer &);
     virtual ~Server() override;
 
     /* AsyncJob API */
@@ -74,8 +72,8 @@ public:
     /// responding to the FTP client and closing the data connection.
     void stopWaitingForOrigin(int status);
 
-    // This is a pointer in hope to minimize future changes when MasterState
-    // becomes a part of MasterXaction. Guaranteed not to be nil.
+    // This is a pointer in hope to minimize future changes.
+    // Guaranteed not to be nil.
     MasterState::Pointer master; ///< info shared among our FTP client and server jobs
 
 protected:

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -24,9 +24,9 @@
 
 CBDATA_NAMESPACED_CLASS_INIT(Http1, Server);
 
-Http::One::Server::Server(const MasterXaction::Pointer &xact, bool beHttpsServer):
+Http::One::Server::Server(const AnyP::PortCfgPointer &listener, const Comm::ConnectionPointer &client, bool beHttpsServer):
     AsyncJob("Http1::Server"),
-    ConnStateData(xact),
+    ConnStateData(listener, client),
     isHttpsServer(beHttpsServer)
 {
 }
@@ -392,14 +392,14 @@ Http::One::Server::noteTakeServerConnectionControl(ServerConnectionContext serve
 }
 
 ConnStateData *
-Http::NewServer(const MasterXaction::Pointer &xact)
+Http::NewServer(const AnyP::PortCfgPointer &listener, const Comm::ConnectionPointer &client)
 {
-    return new Http1::Server(xact, false);
+    return new Http1::Server(listener, client, false);
 }
 
 ConnStateData *
-Https::NewServer(const MasterXaction::Pointer &xact)
+Https::NewServer(const AnyP::PortCfgPointer &listener, const Comm::ConnectionPointer &client)
 {
-    return new Http1::Server(xact, true);
+    return new Http1::Server(listener, client, true);
 }
 

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -22,7 +22,7 @@ class Server: public ConnStateData
     CBDATA_CLASS(Server);
 
 public:
-    Server(const MasterXaction::Pointer &xact, const bool beHttpsServer);
+    Server(const AnyP::PortCfgPointer &, const Comm::ConnectionPointer &, const bool beHttpsServer);
     virtual ~Server() {}
 
     void readSomeHttpData();

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -23,11 +23,11 @@
 #include "StatCounters.h"
 #include "tools.h"
 
-Server::Server(const MasterXaction::Pointer &xact) :
+Server::Server(const AnyP::PortCfgPointer &listener, const Comm::ConnectionPointer &client) :
     AsyncJob("::Server"), // kids overwrite
-    clientConnection(xact->tcpClient),
-    transferProtocol(xact->squidPort->transport),
-    port(xact->squidPort),
+    clientConnection(client),
+    transferProtocol(listener->transport),
+    port(listener),
     receivedFirstByte_(false)
 {
     clientConnection->leaveOrphanage();

--- a/src/servers/Server.h
+++ b/src/servers/Server.h
@@ -29,7 +29,7 @@
 class Server : virtual public AsyncJob, public BodyProducer
 {
 public:
-    Server(const MasterXactionPointer &xact);
+    Server(const AnyP::PortCfgPointer &, const Comm::ConnectionPointer &);
     virtual ~Server() {}
 
     /* AsyncJob API */

--- a/src/servers/forward.h
+++ b/src/servers/forward.h
@@ -9,9 +9,8 @@
 #ifndef SQUID_SERVERS_FORWARD_H
 #define SQUID_SERVERS_FORWARD_H
 
-class MasterXaction;
-template <class C> class RefCount;
-typedef RefCount<MasterXaction> MasterXactionPointer;
+#include "anyp/forward.h"
+#include "comm/forward.h"
 
 class ConnStateData;
 
@@ -24,7 +23,7 @@ class Server;
 } // namespace One
 
 /// create a new HTTP connection handler; never returns NULL
-ConnStateData *NewServer(const MasterXaction::Pointer &xact);
+ConnStateData *NewServer(const AnyP::PortCfgPointer &, const Comm::ConnectionPointer &);
 
 } // namespace Http
 
@@ -32,7 +31,7 @@ namespace Https
 {
 
 /// create a new HTTPS connection handler; never returns NULL
-ConnStateData *NewServer(const MasterXaction::Pointer &xact);
+ConnStateData *NewServer(const AnyP::PortCfgPointer &, const Comm::ConnectionPointer &);
 
 } // namespace Https
 


### PR DESCRIPTION
The ::Server hierarchy and Foo::NewServer() construction
parameters taking MasterXactionPointer existed only as
preparation for the vetoed PR #865 change.

With that implementation no longer happening this code now
results in unnecessary memory allocation of MasterXaction
objects which will be dropped immediately. Revert to original
(circa Squid-3) construction parameters and remove TODOs which
are no longer be relevant without the rejected design.