### PR TITLE
Replaced FDECB callback with a basic async call

### DIFF
--- a/src/CommCalls.cc
+++ b/src/CommCalls.cc
@@ -138,13 +138,6 @@ CommTimeoutCbParams::CommTimeoutCbParams(void *aData):
 {
 }
 
-/* FdeCbParams */
-
-FdeCbParams::FdeCbParams(void *aData):
-    CommCommonCbParams(aData)
-{
-}
-
 /* CommAcceptCbPtrFun */
 
 CommAcceptCbPtrFun::CommAcceptCbPtrFun(IOACB *aHandler,
@@ -259,28 +252,6 @@ CommTimeoutCbPtrFun::dial()
 
 void
 CommTimeoutCbPtrFun::print(std::ostream &os) const
-{
-    os << '(';
-    params.print(os);
-    os << ')';
-}
-
-/* FdeCbPtrFun */
-
-FdeCbPtrFun::FdeCbPtrFun(FDECB *aHandler, const FdeCbParams &aParams) :
-    CommDialerParamsT<FdeCbParams>(aParams),
-    handler(aHandler)
-{
-}
-
-void
-FdeCbPtrFun::dial()
-{
-    handler(params);
-}
-
-void
-FdeCbPtrFun::print(std::ostream &os) const
 {
     os << '(';
     params.print(os);

--- a/src/CommCalls.h
+++ b/src/CommCalls.h
@@ -25,8 +25,6 @@
  *     - I/O (IOCB)
  *     - timeout (CTCB)
  *     - close (CLCB)
- * and a special callback kind for passing pipe FD, disk FD or fd_table index 'FD' to the handler:
- *     - FD passing callback (FDECB)
  */
 
 class CommAcceptCbParams;
@@ -40,9 +38,6 @@ typedef void CTCB(const CommTimeoutCbParams &params);
 
 class CommCloseCbParams;
 typedef void CLCB(const CommCloseCbParams &params);
-
-class FdeCbParams;
-typedef void FDECB(const FdeCbParams &params);
 
 /*
  * TODO: When there are no function-pointer-based callbacks left, all
@@ -139,16 +134,6 @@ class CommTimeoutCbParams: public  CommCommonCbParams
 {
 public:
     CommTimeoutCbParams(void *aData);
-};
-
-/// Special Calls parameter, for direct use of an FD without a controlling Comm::Connection
-/// This is used for pipe() FD with helpers, and internally by Comm when handling some special FD actions.
-class FdeCbParams: public CommCommonCbParams
-{
-public:
-    FdeCbParams(void *aData);
-    // TODO make this a standalone object with FD value and pointer to fde table entry.
-    // that requires all the existing Comm handlers to be updated first though
 };
 
 // Interface to expose comm callback parameters of all comm dialers.
@@ -285,21 +270,6 @@ public:
 
 public:
     CTCB *handler;
-};
-
-/// FD event (FDECB) dialer
-class FdeCbPtrFun: public CallDialer,
-    public CommDialerParamsT<FdeCbParams>
-{
-public:
-    typedef FdeCbParams Params;
-
-    FdeCbPtrFun(FDECB *aHandler, const Params &aParams);
-    void dial();
-    virtual void print(std::ostream &os) const;
-
-public:
-    FDECB *handler;
 };
 
 // AsyncCall to comm handlers implemented as global functions.

--- a/src/base/AsyncFunCalls.h
+++ b/src/base/AsyncFunCalls.h
@@ -30,5 +30,37 @@ private:
     Handler *handler; ///< the function to call (or nil)
 };
 
+/// CallDialer for single-parameter stand-alone functions
+template <typename Argument1>
+class UnaryFunDialer: public CallDialer
+{
+public:
+    // stand-alone function that receives our answer
+    using Handler = void (Argument1);
+
+    UnaryFunDialer(Handler * const aHandler, Argument1 anArg1):
+        handler(aHandler),
+        arg1(anArg1)
+    {}
+    virtual ~UnaryFunDialer() = default;
+
+    /* CallDialer API */
+    bool canDial(AsyncCall &) { return bool(handler); }
+    void dial(AsyncCall &) { handler(std::move(arg1)); }
+    virtual void print(std::ostream &os) const final { os << '(' << arg1 << ')'; }
+
+private:
+    Handler *handler; ///< the function to call
+    Argument1 arg1; ///< actual call parameter
+};
+
+/// helper function to simplify UnaryFunDialer creation
+template <typename Argument1>
+UnaryFunDialer<Argument1>
+callDialer(void (*handler)(Argument1), Argument1 arg1)
+{
+    return UnaryFunDialer<Argument1>(handler, arg1);
+}
+
 #endif /* SQUID_BASE_ASYNCFUNCALLS_H */
 

--- a/src/base/AsyncFunCalls.h
+++ b/src/base/AsyncFunCalls.h
@@ -35,7 +35,7 @@ template <typename Argument1>
 class UnaryFunDialer: public CallDialer
 {
 public:
-    // stand-alone function that receives our answer
+    /// a stand-alone function that receives the parameter given to us
     using Handler = void (Argument1);
 
     UnaryFunDialer(Handler * const aHandler, Argument1 anArg1):

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -9,8 +9,8 @@
 /* DEBUG: section 05    Socket Functions */
 
 #include "squid.h"
-#include "ClientInfo.h"
 #include "base/AsyncFunCalls.h"
+#include "ClientInfo.h"
 #include "comm/AcceptLimiter.h"
 #include "comm/comm_internal.h"
 #include "comm/Connection.h"


### PR DESCRIPTION
The "FD passing callback" was misleading because it was not used as a
callback. We just need an async call with a known-to-the-caller
parameter instead. Simplifying CommCalls (by removing this "special
callback") helps improve that API.