### PR TITLE
Bug 5232: Fix GCC v12 build [-Wuse-after-free]

### DIFF
--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -151,7 +151,7 @@ private:
 };
 
 template <class Dialer>
-inline RefCount< AsyncCallT<Dialer> >
+RefCount< AsyncCallT<Dialer> >
 asyncCall(int aDebugSection, int aDebugLevel, const char *aName,
           const Dialer &aDialer)
 {


### PR DESCRIPTION
This warning is a false positive. Introduced in GCC v12, use-after-free
checks have attracted dozens of bug reports, with several reports still
open as of GCC v12.2, including one that looks very similar to our case:
https://gcc.gnu.org/bugzilla//show_bug.cgi?id=106776

Removing (excessive) "inline" works around this GCC bug. We do not have
a better workaround right now. If we see more false positives like this,
we may disable -Wuse-after-free until its support matures.
