### PR TITLE
Fix 'AC_LINK_IFELSE was called before AC_USE_SYSTEM_EXTENSIONS'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,8 +52,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX
 
-# this needs to be before any test is run, to have more standard
-# functions available on some Unix sysems (e.g. Solaris)
+# AC_USE_SYSTEM_EXTENSIONS should be called before any macros that run the C compiler.
 AS_IF([test "x$squid_host_os" = "solaris" -a "x$GCC" = "xyes"],[
   AC_USE_SYSTEM_EXTENSIONS
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -35,12 +35,30 @@ PRESET_LDFLAGS="$LDFLAGS"
 dnl Set default LDFLAGS
 AS_IF([test "x$LDFLAGS" = "x"],[LDFLAGS="-g"])
 
-# Check for GNU cc
+# check for host OS detail
+AC_CANONICAL_HOST
+AC_MSG_CHECKING([simplified host os])
+simple_host_os=`echo $host_os|sed 's/[0-9].*//g;s/-.*//g'`
+squid_host_os_version=`echo $host_os|tr -d "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"`
+AS_IF([test -n "$squid_host_os_version"],[
+  squid_host_os="`echo $simple_host_os| sed s/$squid_host_os_version//g`"
+],[
+  squid_host_os="$simple_host_os"
+])
+AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
+# on windows squid_host_os is either mingw or cygwin, version is 32
+
+# Find available compilers
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX
 AC_LANG([C++])
-AC_CANONICAL_HOST
+
+# this needs to be before any test is run, to have more standard
+# functions available on some Unix sysems (e.g. Solaris)
+AS_IF([test "x$squid_host_os" = "solaris" -a "x$ac_cv_c_compiler_gnu" = "xyes"],[
+  AC_USE_SYSTEM_EXTENSIONS
+])
 
 # Clang 3.2 on some CPUs requires -march-native to detect correctly.
 # GCC 4.3+ can also produce faster executables when its used.
@@ -73,23 +91,6 @@ AS_IF([test "x$BUILDCXX" = "x"],[
   ])
 ])
 AC_SUBST(BUILDCXX)
-
-AC_MSG_CHECKING([simplified host os])
-simple_host_os=`echo $host_os|sed 's/[0-9].*//g;s/-.*//g'`
-squid_host_os_version=`echo $host_os|tr -d "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"`
-AS_IF([test -n "$squid_host_os_version"],[
-  squid_host_os="`echo $simple_host_os| sed s/$squid_host_os_version//g`"
-],[
-  squid_host_os="$simple_host_os"
-])
-AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
-# on windows squid_host_os is either mingw or cygwin, version is 32
-
-# this needs to be before any test is run, to have more standard
-# functions available on some Unix sysems (e.g. Solaris)
-AS_IF([test "x$squid_host_os" = "solaris" -a "x$GCC" != "x"],[
-  AC_USE_SYSTEM_EXTENSIONS
-])
 
 # If the user did not specify a C++ version.
 user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "\-std="`
@@ -573,7 +574,7 @@ for module in $squid_disk_module_candidates none; do
             ],[
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT"
-              AS_IF([test "x$GCC" = "xyes" -a "x$PRESET_LDFLAGS" = "x"],[LDFLAGS="$LDFLAGS -pthread"])
+              AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes" -a "x$PRESET_LDFLAGS" = "x"],[LDFLAGS="$LDFLAGS -pthread"])
             ])
           ],
 
@@ -589,7 +590,7 @@ for module in $squid_disk_module_candidates none; do
           ],
 
           [solaris],[
-            AS_IF([test "x$GCC" = "xyes"],[
+            AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes"],[
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT -pthreads"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT -pthreads"
               AC_CHECK_LIB(pthread, pthread_create ,[LIBPTHREADS="-lpthread"], [
@@ -2198,7 +2199,7 @@ AS_IF([test "x$buildmodel" = "xdefault" -o "x$buildmodel" = "x"],[
 #   "-Xa" is supported only by Sun cc, so we need to remove it when using gcc
 #   For gcc "-xarch=generic64" must be replaced with "-m64"
 #   The 'sun' define is needed by ipfilter includes, so we must remove "-Usun"
-    AS_IF([test "x$GCC" = "xyes"],[
+    AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes"],[
       AC_MSG_NOTICE([Removing -Xa for gcc/g++ on $host])
       CFLAGS="`echo $CFLAGS | sed -e 's/-Xa//'`"
       CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-Xa//'`"
@@ -2851,7 +2852,7 @@ AS_CASE(["$host"],
   ],
 
   [i386-*-solaris2.*],[
-    AS_IF([test "x$GCC" = "xyes"],[
+    AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes"],[
       AC_MSG_NOTICE([Removing -O for gcc on $host])
       CFLAGS="`echo $CFLAGS | sed -e 's/-O[[0-9g]]*//'`"
     ])

--- a/configure.ac
+++ b/configure.ac
@@ -51,13 +51,14 @@ AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX
-AC_LANG([C++])
 
 # this needs to be before any test is run, to have more standard
 # functions available on some Unix sysems (e.g. Solaris)
-AS_IF([test "x$squid_host_os" = "solaris" -a "x$ac_cv_c_compiler_gnu" = "xyes"],[
+AS_IF([test "x$squid_host_os" = "solaris" -a "x$GCC" = "xyes"],[
   AC_USE_SYSTEM_EXTENSIONS
 ])
+
+AC_LANG([C++])
 
 # Clang 3.2 on some CPUs requires -march-native to detect correctly.
 # GCC 4.3+ can also produce faster executables when its used.
@@ -573,7 +574,7 @@ for module in $squid_disk_module_candidates none; do
             ],[
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT"
-              AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes" -a "x$PRESET_LDFLAGS" = "x"],[LDFLAGS="$LDFLAGS -pthread"])
+              AS_IF([test "x$GCC" = "xyes" -a "x$PRESET_LDFLAGS" = "x"],[LDFLAGS="$LDFLAGS -pthread"])
             ])
           ],
 
@@ -589,7 +590,7 @@ for module in $squid_disk_module_candidates none; do
           ],
 
           [solaris],[
-            AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes"],[
+            AS_IF([test "x$GCC" = "xyes"],[
               SQUID_CFLAGS="$SQUID_CFLAGS -D_REENTRANT -pthreads"
               SQUID_CXXFLAGS="$SQUID_CXXFLAGS -D_REENTRANT -pthreads"
               AC_CHECK_LIB(pthread, pthread_create ,[LIBPTHREADS="-lpthread"], [
@@ -2198,7 +2199,7 @@ AS_IF([test "x$buildmodel" = "xdefault" -o "x$buildmodel" = "x"],[
 #   "-Xa" is supported only by Sun cc, so we need to remove it when using gcc
 #   For gcc "-xarch=generic64" must be replaced with "-m64"
 #   The 'sun' define is needed by ipfilter includes, so we must remove "-Usun"
-    AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes"],[
+    AS_IF([test "x$GCC" = "xyes"],[
       AC_MSG_NOTICE([Removing -Xa for gcc/g++ on $host])
       CFLAGS="`echo $CFLAGS | sed -e 's/-Xa//'`"
       CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-Xa//'`"
@@ -2851,7 +2852,7 @@ AS_CASE(["$host"],
   ],
 
   [i386-*-solaris2.*],[
-    AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes"],[
+    AS_IF([test "x$GCC" = "xyes"],[
       AC_MSG_NOTICE([Removing -O for gcc on $host])
       CFLAGS="`echo $CFLAGS | sed -e 's/-O[[0-9g]]*//'`"
     ])

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,6 @@ AS_IF([test -n "$squid_host_os_version"],[
 AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
 
-# Find available compilers
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX


### PR DESCRIPTION
... produced during bootstrap.sh by autoconf 2.71

AC_USE_SYSTEM_EXTENSIONS needs to be placed after detecting
which OS and compiler are being used. But before any of the
checks detecting capabilities of those OS and compilers.

AC_CANONICAL_HOST is a prerequisite of the simple_host_os logic.
Attach it to that code block instead of the compiler detection
block.

Replace deprecated '$GCC' variable with autoconf cached
'$ac_cv_c_compiler_gnu' variable used as the real source for the
yes/no value of GCC usability after AC_PROG_CC.