### PR TITLE
Rename ./configure option --with-libcap to --with-cap

### DIFF
--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -81,8 +81,8 @@ int main(int argc, char **argv)
 
 dnl check that we have functional libcap2 headers
 dnl sets squid_cv_sys_capability_works to "yes" or "no"
-
 AC_DEFUN([SQUID_CHECK_FUNCTIONAL_LIBCAP2],[
+  AC_CHECK_HEADERS([sys/capability.h])
   AC_CACHE_CHECK([for operational libcap2 headers],
                  squid_cv_sys_capability_works,
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[

--- a/compat/os/linux.h
+++ b/compat/os/linux.h
@@ -45,23 +45,6 @@
 #endif
 
 /*
- * sys/capability.h is only needed in Linux apparently.
- *
- * HACK: LIBCAP_BROKEN Ugly glue to get around linux header madness colliding with glibc
- */
-#if HAVE_SYS_CAPABILITY_H
-
-#if LIBCAP_BROKEN
-#undef _POSIX_SOURCE
-#define _LINUX_TYPES_H
-#define _LINUX_FS_H
-typedef uint32_t __u32;
-#endif
-
-#include <sys/capability.h>
-#endif /* HAVE_SYS_CAPABILITY_H */
-
-/*
  * glob.h is provided by GNU on Linux and contains some unavoidable preprocessor
  * logic errors in its 64-bit definitions which are hit by non-GCC compilers.
  *

--- a/configure.ac
+++ b/configure.ac
@@ -2670,7 +2670,8 @@ AS_IF([test "x$with_cap" != "xno"],[
   AS_IF([test "x$LIBCAP_LIBS" != "x"],[
     with_cap=yes
     CPPFLAGS="$LIBCAP_CFLAGS $CPPFLAGS"
-    LDFLAGS="$LIBCAP_PATH $LDFLAGS"
+    LIBCAP_LIBS="$LIBCAP_PATH $LIBCAP_LIBS"
+    AC_DEFINE(USE_LIBCAP,1,[Linux capabilities library support])
   ],[test "x$with_cap" = "xyes"],[
     AC_MSG_ERROR([Required library libcap not found])
   ],[
@@ -2678,8 +2679,7 @@ AS_IF([test "x$with_cap" != "xno"],[
     with_cap=no
   ])
 ])
-SQUID_DEFINE_BOOL(USE_LIBCAP,${with_cap:=yes},[Linux capabilities support])
-AC_MSG_NOTICE([Linux capabilities support enabled: ${with_cap} ${LIBCAP_PATH} ${LIBCAP_LIBS}])
+AC_MSG_NOTICE([Linux capabilities support enabled: ${with_cap} ${LIBCAP_LIBS}])
 
 dnl Check for needed libraries
 AC_SEARCH_LIBS([gethostbyname],[nsl resolv bind])

--- a/configure.ac
+++ b/configure.ac
@@ -2675,12 +2675,11 @@ AS_IF([test "x$with_cap" != "xno"],[
     AC_MSG_ERROR([Required library libcap not found])
   ],[
     AC_MSG_NOTICE([Library libcap not found])
+    with_cap=no
   ])
 ])
 SQUID_DEFINE_BOOL(USE_LIBCAP,${with_cap:=yes},[Linux capabilities support])
 AC_MSG_NOTICE([Linux capabilities support enabled: ${with_cap} ${LIBCAP_PATH} ${LIBCAP_LIBS}])
-SQUID_DEFINE_BOOL(LIBCAP_BROKEN,${squid_cv_sys_capability_works:=no},
-   [libcap2 headers are broken and clashing with glibc])
 
 dnl Check for needed libraries
 AC_SEARCH_LIBS([gethostbyname],[nsl resolv bind])

--- a/configure.ac
+++ b/configure.ac
@@ -2669,7 +2669,7 @@ AS_IF([test "x$with_cap" != "xno"],[
 
   AS_IF([test "x$LIBCAP_LIBS" != "x"],[
     with_cap=yes
-    CXXFLAGS="$LIBCAP_CFLAGS $CXXFLAGS"
+    CPPFLAGS="$LIBCAP_CFLAGS $CPPFLAGS"
     LDFLAGS="$LIBCAP_PATH $LDFLAGS"
   ],[test "x$with_cap" = "xyes"],[
     AC_MSG_ERROR([Required library libcap not found])

--- a/configure.ac
+++ b/configure.ac
@@ -2653,39 +2653,34 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 dnl Check for special functions
 AC_FUNC_ALLOCA
 
-
-# TODO: remove this 'lib' prefix to match coding standard
-SQUID_AUTO_LIB(libcap,[Linux capabilities],[LIBCAP])
-AS_IF([test "x$with_libcap" != "xno"],[
+SQUID_AUTO_LIB(cap,[Linux capabilities],[LIBCAP])
+AS_IF([test "x$with_cap" != "xno"],[
+  SQUID_STATE_SAVE(squid_libcap_state)
   CXXFLAGS="$LIBCAP_CFLAGS $CXXFLAGS"
   LDFLAGS="$LIBCAP_PATH $LDFLAGS"
-  # cap_clear_flag is the most recent libcap function we require
-  AC_CHECK_HEADERS(sys/capability.h)
-  AC_CHECK_LIB(cap, cap_clear_flag)
+  PKG_CHECK_MODULES([LIBCAP],[libcap >= 2.09],[],[
+    # cap_clear_flag is the most recent libcap function we require
+    AC_CHECK_LIB([cap],[cap_clear_flag],[LIBCAP_LIBS="$LIBCAP_LIBS -lcap"])
+  ])
   SQUID_CHECK_FUNCTIONAL_LIBCAP2
+  AC_MSG_NOTICE([libcap headers are ok: $squid_cv_sys_capability_works])
+  AS_IF([test "x$squid_cv_sys_capability_works" = "xno"],[LIBCAP_LIBS=""])
+  SQUID_STATE_ROLLBACK(squid_libcap_state)
 
-  # if it can't be supported..
-  AS_IF([test "x$ac_cv_header_sys_capability_h" = "xno" -o \
-     "x$ac_cv_lib_cap_cap_clear_flag" = "xno"],[
-    # and it was forced on: error
-    AS_IF([test "x$with_libcap" = "xyes"],[
-      AC_MSG_ERROR([libcap forced enabled but not available or not usable, requires libcap-2.09 or later])
-    ],[
-      # or it can't be supported: disable
-      with_libcap=no
-    ])
+  AS_IF([test "x$LIBCAP_LIBS" != "x"],[
+    with_cap=yes
+    CXXFLAGS="$LIBCAP_CFLAGS $CXXFLAGS"
+    LDFLAGS="$LIBCAP_PATH $LDFLAGS"
+  ],[test "x$with_cap" = "xyes"],[
+    AC_MSG_ERROR([Required library libcap not found])
   ],[
-    with_libcap=yes
+    AC_MSG_NOTICE([Library libcap not found])
   ])
 ])
-
-SQUID_DEFINE_BOOL(USE_LIBCAP,$with_libcap,
-   [use libcap to set capabilities required for TPROXY])
-AC_MSG_NOTICE([libcap support enabled: $with_libcap])
+SQUID_DEFINE_BOOL(USE_LIBCAP,${with_cap:=yes},[Linux capabilities support])
+AC_MSG_NOTICE([Linux capabilities support enabled: ${with_cap} ${LIBCAP_PATH} ${LIBCAP_LIBS}])
 SQUID_DEFINE_BOOL(LIBCAP_BROKEN,${squid_cv_sys_capability_works:=no},
    [libcap2 headers are broken and clashing with glibc])
-AC_MSG_NOTICE([libcap2 headers are ok: $squid_cv_sys_capability_works])
-
 
 dnl Check for needed libraries
 AC_SEARCH_LIBS([gethostbyname],[nsl resolv bind])
@@ -3149,13 +3144,13 @@ SQUID_DEFINE_BOOL(LINUX_NETFILTER,$enable_linux_netfilter,
 
 dnl Netfilter TPROXY depends on libcap but the NAT parts can still work.
 AC_MSG_NOTICE([Support for Netfilter-based interception proxy requested: $enable_linux_netfilter])
-AS_IF([test "x$enable_linux_netfilter" = "xyes" -a "x$with_libcap" != "xyes"],[
+AS_IF([test "x$enable_linux_netfilter" = "xyes" -a "x$with_cap" != "xyes"],[
   AC_MSG_WARN([Missing needed capabilities (libcap 2.09+) for TPROXY])
   AC_MSG_WARN([Linux Transparent Proxy (version 4+) support WILL NOT be enabled])
   AC_MSG_WARN([Reduced support to NAT Interception Proxy])
   # AC_DEFINEd later
 ])
-AS_IF([test "x$with_netfilter_conntrack" = "xyes" -a "x$with_libcap" != "xyes"],[
+AS_IF([test "x$with_netfilter_conntrack" = "xyes" -a "x$with_cap" != "xyes"],[
   AC_MSG_WARN([Missing needed capabilities (libcap 2.09+) for netfilter mark support])
   AC_MSG_WARN([Linux netfilter marking support WILL NOT be enabled])
   with_netfilter_conntrack=no

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -103,6 +103,9 @@ This section gives an account of those changes in three categories:
 <sect1>New options<label id="newoptions">
 <p>
 <descrip>
+	<tag>--with-cap</tag>
+	<p>Replacement for <em>--with-libcap</em>.
+
 	<tag>--with-xml2</tag>
 	<p>Replacement for <em>--with-libxml2</em>.
 
@@ -125,6 +128,9 @@ This section gives an account of those changes in three categories:
 
 	<tag>--disable-loadable-modules</tag>
 	<p>This option was performing the same duties as <em>--disable-shared</em>.
+
+	<tag>--with-libcap</tag>
+	<p>Replaced by <em>--with-cap</em>.
 
 	<tag>--with-libxml2</tag>
 	<p>Replaced by <em>--with-xml2</em>.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -525,6 +525,7 @@ squid_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
+	$(LIBCAP_LIBS) \
 	$(SSLLIB) \
 	$(EPOLL_LIBS) \
 	$(MINGW_LIBS) \
@@ -1957,6 +1958,7 @@ tests_test_http_range_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
+	$(LIBCAP_LIBS) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
@@ -2341,6 +2343,7 @@ tests_testHttpRequest_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
+	$(LIBCAP_LIBS) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
@@ -2639,6 +2642,7 @@ tests_testCacheManager_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
+	$(LIBCAP_LIBS) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(KRB5LIBS) \

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -62,6 +62,7 @@ pinger_LDADD=\
 	$(top_builddir)/src/time/libtime.la \
 	$(top_builddir)/src/base/libbase.la \
 	$(top_builddir)/src/mem/libminimal.la \
+	$(LIBCAP_LIBS) \
 	$(COMPAT_LIB) \
 	$(SSLLIB) \
 	$(XTRA_LIBS)

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -50,6 +50,10 @@
 #include "ip/tools.h"
 #include "time/gadgets.h"
 
+#if HAVE_SYS_CAPABILITY_H
+#include <sys/capability.h>
+#endif
+
 #if _SQUID_WINDOWS_
 
 #if HAVE_WINSOCK2_H
@@ -58,6 +62,7 @@
 #include <winsock.h>
 #endif
 #include <process.h>
+
 #include "fde.h"
 
 #define PINGER_TIMEOUT 5

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -33,6 +33,9 @@
 #include "wordlist.h"
 
 #include <cerrno>
+#if HAVE_SYS_CAPABILITY_H
+#include <sys/capability.h>
+#endif
 #if HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #endif

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -97,6 +97,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
  \
 	--without-pthreads \
 	--without-aio \
+	--without-cap \
 	--without-dl \
 	--without-large-files \
 	--without-nettle \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -44,6 +44,7 @@ MAKETEST="distcheck"
 #   --with-valgrind-debug \
 #   --with-gnutls \
 #   --with-tdb \
+#   --with-cap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
 #

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -33,6 +33,7 @@ MAKETEST="distcheck"
 #   --with-openssl=PATH \
 #   --with-po2html=PATH \
 #   --with-tags=TAGS \
+#   --with-cap \
 #
 #	Following features require special support from other optional packages.
 #	We can't test them automatically everywhere without detecting those


### PR DESCRIPTION
The 'lib' prefix is supposed to be omitted from --with/--without
names but libcap was not correctly named.

Also, add support for pkg-config library auto-detection.