### PR TITLE
Fix 'warning: stray \ before -'

### DIFF
--- a/acinclude/krb5.m4
+++ b/acinclude/krb5.m4
@@ -192,7 +192,7 @@ main(void)
         return 0;
 }
   ]])],  [ squid_cv_working_gssapi=yes ], [ squid_cv_working_gssapi=no ], [:])])
-  AS_IF([test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "\-L"` -gt 0],[
+  AS_IF([test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "[-]L"` -gt 0],[
     AC_MSG_NOTICE([Check Runtime library path !])
   ])
 ])
@@ -284,7 +284,7 @@ main(void)
         return 0;
 }
   ]])], [ squid_cv_working_krb5=yes ], [ squid_cv_working_krb5=no ],[:])])
-  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "\-L"` -gt 0],[
+  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "[-]L"` -gt 0],[
     AC_MSG_NOTICE([Check Runtime library path !])
   ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AS_IF([test "x$squid_host_os" = "solaris" -a "x$GCC" != "x"],[
 ])
 
 # If the user did not specify a C++ version.
-user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "\-std="`
+user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "[-]std="`
 AS_IF([test "x$user_cxx" = "x"],[
   # Check for C++11 compiler support
   AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -53,7 +53,7 @@ translate-warn:
 
 $(TRANSLATE_LANGUAGES): $(ERROR_TEMPLATES)
 
-NOTIDY=`$(PO2HTML) --help | grep -o "\--notidy"`
+NOTIDY=`$(PO2HTML) --help | grep -o "[-]-notidy"`
 
 .po.lang:
 	if test "$(PO2HTML)" != "" && test "$(PO2HTML)" != "no" && test "$(PO2HTML)" != "off" && test -f $(top_srcdir)/errors/en.po; then \

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -53,7 +53,7 @@ translate-warn:
 
 $(TRANSLATE_LANGUAGES): $(ERROR_TEMPLATES)
 
-NOTIDY=`$(PO2HTML) --help | grep -o "\-\-notidy"`
+NOTIDY=`$(PO2HTML) --help | grep -o "\--notidy"`
 
 .po.lang:
 	if test "$(PO2HTML)" != "" && test "$(PO2HTML)" != "no" && test "$(PO2HTML)" != "off" && test -f $(top_srcdir)/errors/en.po; then \

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -17,10 +17,10 @@ MAKETEST="distcheck"
 #
 #
 # The options for this level can be easily generated semi-automatically from configure.ac by:
-#	grep -E "^AC_ARG_ENABLE" ./configure.ac | grep -o -E "[0-9a-z\-]+[,]" | grep -o -E "[^,]+" >disable.opts
+#	grep -E "^AC_ARG_ENABLE" ./configure.ac | grep -o -E "[0-9a-z-]+[,]" | grep -o -E "[^,]+" >disable.opts
 # followed by insertion of '	--disable-' and '\' strings
 #
-# 	grep -E "^AC_ARG_WITH" ./configure.ac | grep -o -E "[0-9a-z\-]+[,]" | grep -o -E "[^,]+" >without.opts
+# 	grep -E "^AC_ARG_WITH" ./configure.ac | grep -o -E "[0-9a-z-]+[,]" | grep -o -E "[^,]+" >without.opts
 # followed by insertion of '	--without-' and ' \' strings
 #
 # sometimes it's just too automatic.. Following options should be just stripped

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -17,10 +17,10 @@ MAKETEST="distcheck"
 #
 #
 # The options for this level can be easily generated semi-automatically from configure.ac by:
-#	grep -E "^AC_ARG_ENABLE" ./configure.ac | grep -o -E "[0-9a-z\-]+[,]" | grep -o -E "[^,]+" >disable.opts
+#	grep -E "^AC_ARG_ENABLE" ./configure.ac | grep -o -E "[0-9a-z-]+[,]" | grep -o -E "[^,]+" >disable.opts
 # followed by insertion of '	--enable-' and '\' strings
 #
-# 	grep -E "^AC_ARG_WITH" ./configure.ac | grep -o -E "[0-9a-z\-]+[,]" | grep -o -E "[^,]+" >without.opts
+# 	grep -E "^AC_ARG_WITH" ./configure.ac | grep -o -E "[0-9a-z-]+[,]" | grep -o -E "[^,]+" >without.opts
 # followed by insertion of '	--with-' and ' \' strings
 #
 # sometimes it's just too automatic..

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -17,10 +17,10 @@ MAKETEST="distcheck"
 #
 #
 # The options for this level can be easily generated semi-automatically from configure.ac by:
-#	grep -E "^AC_ARG_ENABLE" ./configure.ac | grep -o -E "[0-9a-z\-]+[,]" | grep -o -E "[^,]+" >disable.opts
+#	grep -E "^AC_ARG_ENABLE" ./configure.ac | grep -o -E "[0-9a-z-]+[,]" | grep -o -E "[^,]+" >disable.opts
 # followed by insertion of '	--enable-' and '\' strings
 #
-# 	grep -E "^AC_ARG_WITH" ./configure.ac | grep -o -E "[0-9a-z\-]+[,]" | grep -o -E "[^,]+" >without.opts
+# 	grep -E "^AC_ARG_WITH" ./configure.ac | grep -o -E "[0-9a-z-]+[,]" | grep -o -E "[^,]+" >without.opts
 # followed by insertion of '	--with-' and ' \' strings
 #
 # sometimes it's just too automatic..


### PR DESCRIPTION
grep 3.8 started detecting overly-escaped regex patterns