### PR TITLE
Cleanup libexpat variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -815,25 +815,23 @@ AC_ARG_ENABLE(esi,
                   Enabling ESI will cause squid reverse proxies to be capable
                   of the Edge Acceleration Specification (www.esi.org).]),
                  [squid_opt_use_esi=$enableval],[])
-HAVE_LIBEXPAT=0
-EXPATLIB=
 
 # ESI support libraries: expat
+AH_TEMPLATE(HAVE_LIBEXPAT,[Define to 1 if you have the expat library])
 SQUID_AUTO_LIB(expat,[ESI expat library],[LIBEXPAT])
 AS_IF([test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno"],[
-  AC_CHECK_LIB([expat], [main], [EXPATLIB="-lexpat"; HAVE_LIBEXPAT=1])
-  AC_CHECK_HEADERS([expat.h])
-  AC_DEFINE_UNQUOTED(HAVE_LIBEXPAT, $HAVE_LIBEXPAT, [Define to 1 if you have the expat library])
-  AS_IF([test "x$HAVE_LIBEXPAT" = "x1"],[
-    squid_opt_use_esi=yes
-  ],[
-    AS_IF([test "x$with_expat" = "xyes"],[
-      AC_MSG_ERROR([Required library expat not found.])
-    ],[
-      AC_MSG_NOTICE([Library expat not found.])
-    ])
+  AC_CHECK_LIB([expat],[main],[
+    LIBEXPAT_LIBS="-lexpat"
+    AC_CHECK_HEADERS([expat.h])
+    AC_DEFINE(HAVE_LIBEXPAT,1,[Define to 1 if you have the expat library])
   ])
+  AS_IF([test "x$LIBEXPAT_LIBS" != "x"],[squid_opt_use_esi=yes],
+    [test "x$with_expat" = "xyes"],[AC_MSG_ERROR([Required library expat not found.])],
+    [AC_MSG_NOTICE([Library expat not found.])]
+  )
 ])
+AM_CONDITIONAL(ENABLE_LIBEXPAT,[test "x$LIBEXPAT_LIBS" != "x"])
+AC_SUBST(LIBEXPAT_LIBS)
 
 # ESI support libraries: xml2
 AH_TEMPLATE(HAVE_LIBXML2,[Define to 1 if you have the xml2 library])
@@ -862,10 +860,10 @@ AM_CONDITIONAL(ENABLE_LIBXML2,[test "x$LIBXML2_LIBS" != "x"])
 AC_SUBST(LIBXML2_LIBS)
 
 AS_IF([test "x$squid_opt_use_esi" = "xyes"],[
-  AS_IF(test "x$LIBXML2_LIBS" = "x" -a "x$HAVE_LIBEXPAT" = "x0",[
+  AS_IF([test "x$LIBXML2_LIBS" = "x" -a "x$LIBEXPAT_LIBS" = "x"],[
     AC_MSG_ERROR([ESI processor requires libxml2 or libexpat])
   ])
-  AC_MSG_NOTICE([Enabling ESI processor: $EXPATLIB $LIBXML2_LIBS])
+  AC_MSG_NOTICE([Enabling ESI processor: $LIBEXPAT_LIBS $LIBXML2_LIBS])
   AC_DEFINE(USE_SQUID_ESI,1,[Compile the ESI processor])
 ],[
   AS_IF(test "x$squid_opt_use_esi" = "xno",[
@@ -875,8 +873,6 @@ AS_IF([test "x$squid_opt_use_esi" = "xyes"],[
   ])
 ])
 AM_CONDITIONAL(ENABLE_ESI, test "x$squid_opt_use_esi" = "xyes")
-AM_CONDITIONAL(ENABLE_LIBEXPAT, test "x$HAVE_LIBEXPAT" = "x1")
-AC_SUBST(EXPATLIB)
 
 AC_ARG_ENABLE(icap-client,
   AS_HELP_STRING([--disable-icap-client],[Disable the ICAP client.]),[

--- a/configure.ac
+++ b/configure.ac
@@ -820,12 +820,18 @@ AC_ARG_ENABLE(esi,
 AH_TEMPLATE(HAVE_LIBEXPAT,[Define to 1 if you have the expat library])
 SQUID_AUTO_LIB(expat,[ESI expat library],[LIBEXPAT])
 AS_IF([test "x$squid_opt_use_esi" != "xno" -a "x$with_expat" != "xno"],[
-  AC_CHECK_LIB([expat],[main],[
-    LIBEXPAT_LIBS="-lexpat"
-    AC_CHECK_HEADERS([expat.h])
-    AC_DEFINE(HAVE_LIBEXPAT,1,[Define to 1 if you have the expat library])
+  SQUID_STATE_SAVE(squid_expat_state)
+  PKG_CHECK_MODULES([LIBEXPAT],[expat],[],[
+    AC_CHECK_LIB([expat],[main],[LIBEXPAT_LIBS="-lexpat"])
   ])
-  AS_IF([test "x$LIBEXPAT_LIBS" != "x"],[squid_opt_use_esi=yes],
+  CPPFLAGS="$LIBEXPAT_CFLAGS $CPPFLAGS"
+  AC_CHECK_HEADERS(expat.h)
+  SQUID_STATE_ROLLBACK(squid_expat_state)
+  AS_IF([test "x$LIBEXPAT_LIBS" != "x"],[
+      squid_opt_use_esi=yes
+      LIBEXPAT_LIBS="$LIBEXPAT_PATH $LIBEXPAT_LIBS"
+      AC_DEFINE(HAVE_LIBEXPAT,1,[Define to 1 if you have the expat library])
+    ],
     [test "x$with_expat" = "xyes"],[AC_MSG_ERROR([Required library expat not found.])],
     [AC_MSG_NOTICE([Library expat not found.])]
   )

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,8 +64,8 @@ SUBDIRS += esi
 ESI_LIBS = \
 	esi/libesi.la \
 	$(top_builddir)/lib/libTrie/libTrie.a \
-	$(LIBXML2_LIBS) \
-	$(EXPATLIB)
+	$(LIBEXPAT_LIBS) \
+	$(LIBXML2_LIBS)
 else
 ESI_LIBS =
 endif


### PR DESCRIPTION
... to use pkg-config compatible naming and take advantage of
squid provided macros better.

Also, add support for pkg-config library auto-detection.