### PR TITLE
Cleanup libnettle detection

### DIFF
--- a/acinclude/nettle.m4
+++ b/acinclude/nettle.m4
@@ -1,0 +1,36 @@
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+dnl check whether libnettle Base64 uses the nettle 3.4 API
+dnl which matters on 64-bit systems
+dnl Defines HAVE_NETTLE34_BASE64 based on the result
+dnl
+AC_DEFUN([SQUID_CHECK_NETTLE_BASE64],[
+  AC_CHECK_HEADERS(nettle/base64.h)
+  AC_MSG_CHECKING([for Nettle 3.4 API compatibility])
+  AH_TEMPLATE(HAVE_NETTLE34_BASE64,[set to 1 if Nettle 3.4 API will link])
+  SQUID_STATE_SAVE(squid_nettle_base64_state)
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#   include <cstddef>
+#   include <cstdint>
+#   include <nettle/base64.h>
+  ]],[[
+    char inData[10]; inData[0] = '\0';
+    size_t srcLen = 0;
+    struct base64_decode_ctx ctx;
+    base64_decode_init(&ctx);
+    uint8_t outData[10];
+    size_t dstLen = 0;
+    if (!base64_decode_update(&ctx, &dstLen, outData, srcLen, inData) ||
+            !base64_decode_final(&ctx)) {
+        return 1;
+    }
+  ]])],[AC_MSG_RESULT(yes)
+    AC_DEFINE(HAVE_NETTLE34_BASE64,1,[set to 1 if Nettle 3.4 API will link])
+  ],[AC_MSG_RESULT(no)])
+  SQUID_STATE_ROLLBACK(squid_nettle_base64_state)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1089,9 +1089,10 @@ AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 # Cryptograhic libraries
 SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
 AS_IF(test "x$with_nettle" != "xno"],[
+  SQUID_STATE_SAVE(nettle)
   CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
   AC_CHECK_LIB(nettle, nettle_md5_init,[
-    NETTLELIB="$LIBNETTLE_PATH -lnettle"
+    LIBNETTLE_LIBS="$LIBNETTLE_PATH -lnettle"
     AC_CHECK_HEADERS(nettle/md5.h)
   ],[with_nettle=no])
   AS_IF([test "x$with_nettle" != "xno"],[
@@ -1118,9 +1119,10 @@ AS_IF(test "x$with_nettle" != "xno"],[
       AC_DEFINE(HAVE_NETTLE34_BASE64,1,[set to 1 if Nettle 3.4 API will link])
     ],[AC_MSG_RESULT(no)])
   ])
+  SQUID_STATE_ROLLBACK(nettle)
 ])
 AC_MSG_NOTICE([Using Nettle cryptographic library: ${with_nettle:=yes}])
-AC_SUBST(NETTLELIB)
+AC_SUBST(LIBNETTLE_LIBS)
 
 dnl Check for libcrypt
 CRYPTLIB=

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ m4_include([acinclude/squid-util.m4])
 m4_include([acinclude/compiler-flags.m4])
 m4_include([acinclude/os-deps.m4])
 m4_include([acinclude/krb5.m4])
+m4_include([acinclude/nettle.m4])
 m4_include([acinclude/pam.m4])
 m4_include([acinclude/pkg.m4])
 m4_include([acinclude/tdb.m4])
@@ -1089,37 +1090,22 @@ AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 # Cryptograhic libraries
 SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
 AS_IF(test "x$with_nettle" != "xno"],[
-  SQUID_STATE_SAVE(nettle)
-  CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
-  AC_CHECK_LIB(nettle, nettle_md5_init,[
-    LIBNETTLE_LIBS="$LIBNETTLE_PATH -lnettle"
-    AC_CHECK_HEADERS(nettle/md5.h)
-  ],[with_nettle=no])
-  AS_IF([test "x$with_nettle" != "xno"],[
-    # Base64 uses the nettle 3.4 API
-    # which matters on 64-bit systems
-    AC_CHECK_HEADERS(nettle/base64.h)
-    AC_MSG_CHECKING([for Nettle 3.4 API compatibility])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#     include <cstddef>
-#     include <cstdint>
-#     include <nettle/base64.h>
-    ]],[[
-      char inData[10]; inData[0] = '\0';
-      size_t srcLen = 0;
-      struct base64_decode_ctx ctx;
-      base64_decode_init(&ctx);
-      uint8_t outData[10];
-      size_t dstLen = 0;
-      if (!base64_decode_update(&ctx, &dstLen, outData, srcLen, inData) ||
-              !base64_decode_final(&ctx)) {
-          return 1;
-      }
-    ]])],[AC_MSG_RESULT(yes)
-      AC_DEFINE(HAVE_NETTLE34_BASE64,1,[set to 1 if Nettle 3.4 API will link])
-    ],[AC_MSG_RESULT(no)])
+  SQUID_STATE_SAVE(squid_nettle_state)
+  PKG_CHECK_MODULES([LIBNETTLE],[nettle >= 3.4],[],[
+    CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
+    AC_CHECK_LIB(nettle,[nettle_md5_init],[LIBNETTLE_LIBS="-lnettle"])
   ])
-  SQUID_STATE_ROLLBACK(nettle)
+  AC_CHECK_HEADERS(nettle/base64.h nettle/md5.h)
+  SQUID_CHECK_NETTLE_BASE64
+  SQUID_STATE_ROLLBACK(squid_nettle_state)
+  AS_IF([test "x$LIBNETTLE_LIBS" != "x"],[
+    CXXFLAGS="$LIBNETTLE_CFLAGS $CXXFLAGS"
+    LIBNETTLE_LIBS="$LIBNETTLE_PATH $LIBNETTLE_LIBS"
+  ],[test "x$with_nettle" = "xyes"],[
+    AC_MSG_ERROR([Required library nettle not found])
+  ],[
+    AC_MSG_NOTICE([Library nettle not found.])
+  ])
 ])
 AC_MSG_NOTICE([Using Nettle cryptographic library: ${with_nettle:=yes}])
 AC_SUBST(LIBNETTLE_LIBS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -514,7 +514,6 @@ squid_LDADD = \
 	debug/libdebug.la \
 	$(XTRA_OBJS) \
 	$(REPL_OBJS) \
-	$(NETTLELIB) \
 	$(CRYPTLIB) \
 	$(REGEXLIB) \
 	$(ADAPTATION_LIBS) \
@@ -532,6 +531,7 @@ squid_LDADD = \
 	$(KRB5LIBS) \
 	$(SYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 
 if ENABLE_LOADABLE_MODULES
@@ -1151,11 +1151,11 @@ tests_testRock_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_testRock_LDFLAGS = $(AM_CPPFLAGS) $(LIBADD_DL)
 else
@@ -1331,11 +1331,11 @@ tests_testUfs_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_testUfs_LDFLAGS = $(LIBADD_DL)
 else
@@ -1496,12 +1496,12 @@ tests_testStore_LDADD= \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	CommCalls.o \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_testStore_LDFLAGS = $(LIBADD_DL)
 
@@ -1674,11 +1674,11 @@ tests_testDiskIO_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_testDiskIO_LDFLAGS = $(LIBADD_DL)
 
@@ -1957,13 +1957,13 @@ tests_test_http_range_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
 	$(LIBCPPUNIT_LIBS) \
 	$(SYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_test_http_range_LDFLAGS = $(LIBADD_DL)
 
@@ -2109,10 +2109,10 @@ tests_testHttpReply_LDADD=\
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(SSLLIB) \
 	$(LIBCPPUNIT_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_testHttpReply_LDFLAGS = $(LIBADD_DL)
 
@@ -2341,13 +2341,13 @@ tests_testHttpRequest_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
 	$(LIBCPPUNIT_LIBS) \
 	$(SYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_testHttpRequest_LDFLAGS = $(LIBADD_DL)
 
@@ -2639,13 +2639,13 @@ tests_testCacheManager_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
-	$(NETTLELIB) \
 	$(REGEXLIB) \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
 	$(LIBCPPUNIT_LIBS) \
 	$(SYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 tests_testCacheManager_LDFLAGS = $(LIBADD_DL)
 

--- a/src/auth/basic/NCSA/Makefile.am
+++ b/src/auth/basic/NCSA/Makefile.am
@@ -19,7 +19,7 @@ basic_ncsa_auth_LDADD= \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIB) \
 	$(CRYPTLIB) \
 	$(SSLLIB) \
 	$(XTRA_LIBS)

--- a/src/auth/basic/RADIUS/Makefile.am
+++ b/src/auth/basic/RADIUS/Makefile.am
@@ -21,6 +21,6 @@ basic_radius_auth_LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/src/base/libbase.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(SSLLIB) \
 	$(XTRA_LIBS)

--- a/src/auth/digest/LDAP/Makefile.am
+++ b/src/auth/digest/LDAP/Makefile.am
@@ -20,7 +20,7 @@ digest_ldap_auth_LDADD= \
 	$(COMPAT_LIB) \
 	$(LDAPLIB) \
 	$(LBERLIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(SSLLIB) \
 	$(XTRA_LIBS)

--- a/src/auth/digest/eDirectory/Makefile.am
+++ b/src/auth/digest/eDirectory/Makefile.am
@@ -22,7 +22,7 @@ digest_edirectory_auth_LDADD = \
 	$(COMPAT_LIB) \
 	$(LDAPLIB) \
 	$(LBERLIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(SSLLIB) \
 	$(XTRA_LIBS)

--- a/src/auth/digest/file/Makefile.am
+++ b/src/auth/digest/file/Makefile.am
@@ -20,7 +20,7 @@ digest_file_auth_LDADD = \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(SSLLIB) \
 	$(XTRA_LIBS)

--- a/src/auth/negotiate/kerberos/Makefile.am
+++ b/src/auth/negotiate/kerberos/Makefile.am
@@ -26,7 +26,7 @@ negotiate_kerberos_auth_LDFLAGS=
 negotiate_kerberos_auth_LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(KRB5LIBS) \
 	$(XTRA_LIBS)
 
@@ -36,7 +36,7 @@ negotiate_kerberos_auth_test_LDFLAGS=
 negotiate_kerberos_auth_test_LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(KRB5LIBS) \
 	$(XTRA_LIBS)
 

--- a/src/auth/negotiate/wrapper/Makefile.am
+++ b/src/auth/negotiate/wrapper/Makefile.am
@@ -16,5 +16,5 @@ negotiate_wrapper_auth_SOURCES = \
 negotiate_wrapper_auth_LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)

--- a/src/auth/ntlm/SMB_LM/Makefile.am
+++ b/src/auth/ntlm/SMB_LM/Makefile.am
@@ -16,7 +16,7 @@ ntlm_smb_lm_auth_LDADD = \
 	$(top_builddir)/lib/ntlmauth/libntlmauth.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(XTRA_LIBS)
 

--- a/src/auth/ntlm/fake/Makefile.am
+++ b/src/auth/ntlm/fake/Makefile.am
@@ -14,7 +14,7 @@ ntlm_fake_auth_LDADD= \
 	$(top_builddir)/lib/ntlmauth/libntlmauth.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(XTRA_LIBS)
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -22,7 +22,7 @@ LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(top_builddir)/lib/libmiscutil.la \
 	$(COMPAT_LIB) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(KRB5LIBS) \
 	$(XTRA_LIBS)
 

--- a/tools/squidclient/Makefile.am
+++ b/tools/squidclient/Makefile.am
@@ -21,7 +21,7 @@ LDADD = \
 	$(top_builddir)/lib/libmiscutil.la \
 	$(COMPAT_LIB) \
 	$(LIBGNUTLS_LIBS) \
-	$(NETTLELIB) \
+	$(LIBNETTLE_LIBS) \
 	$(KRB5LIBS) \
 	$(XTRA_LIBS)
 


### PR DESCRIPTION
... to use pkg-config compatible variable naming and break out
the code test to a dedicated macro per the style used by other
libraries.

Also, add support for pkg-config library auto-detection.

Also, our libcompat provides local replacement for Base64 on
builds with older libnettle. Fix the library link order to
ensure our functions get linked properly.