### PR TITLE
Cleanup libsystemd variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1873,36 +1873,29 @@ AS_IF([test "$squid_host_os" = "mingw"],[
 AC_SUBST(LDAPLIB)
 AC_SUBST(LBERLIB)
 
-SQUID_AUTO_LIB(systemd,[systemd API for start-up notification],[SYSTEMD])
+SQUID_AUTO_LIB(systemd,[systemd API for start-up notification],[LIBSYSTEMD])
 AH_TEMPLATE(USE_SYSTEMD,[systemd support is available])
-AS_IF([test "x$with_systemd" != "xno" -a "x$squid_host_os" = "xlinux"],[
+AS_IF([test "x$with_systemd" != "xno"],[
   SQUID_STATE_SAVE(squid_systemd_state)
-
-  # User may have provided a custom location for systemd. Otherwise...
-  LIBS="$LIBS $SYSTEMD_PATH"
-
-  # auto-detect using pkg-config
-  PKG_CHECK_MODULES(SYSTEMD,[libsystemd],,[
+  LIBS="$LIBS $LIBSYSTEMD_PATH"
+  PKG_CHECK_MODULES(LIBSYSTEMD,[libsystemd],,[
     # systemd < 209
-    PKG_CHECK_MODULES(SYSTEMD,[libsystemd-daemon],,[:])
+    PKG_CHECK_MODULES(LIBSYSTEMD,[libsystemd-daemon],,[:])
   ])
-
   AC_CHECK_HEADERS(systemd/sd-daemon.h)
+  SQUID_STATE_ROLLBACK(squid_systemd_state)
 
-  SQUID_STATE_ROLLBACK(squid_systemd_state) #de-pollute LIBS
-
-  AS_IF([test "x$with_systemd" = "xyes" -a "x$SYSTEMD_LIBS" = "x"],[
-    AC_MSG_ERROR([Required systemd library not found])
-  ])
-  AS_IF([test "x$SYSTEMD_LIBS" != "x"],[
-    CXXFLAGS="$SYSTEMD_CFLAGS $CXXFLAGS"
-    LDFLAGS="$SYSTEMD_PATH $SYSTEMD_LIBS $LDFLAGS"
+  AS_IF([test "x$LIBSYSTEMD_LIBS" != "x"],[
+    CXXFLAGS="$LIBSYSTEMD_CFLAGS $CXXFLAGS"
+    LIBSYSTEMD_LIBS="$LIBSYSTEMD_PATH $LIBSYSTEMD_LIBS"
     AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
+  ],[test "x$with_systemd" = "xyes"],[
+    AC_MSG_ERROR([Required systemd library not found])
   ],[
-    with_systemd=no
+    AC_MSG_NOTICE([Library for systemd support not found])
   ])
 ])
-AC_MSG_NOTICE([systemd library support: ${with_systemd:=auto} ${SYSTEMD_PATH} ${SYSTEMD_LIBS}])
+AC_MSG_NOTICE([systemd library support: $with_systemd $LIBSYSTEMD_LIBS])
 
 AC_ARG_ENABLE(forw-via-db,
   AS_HELP_STRING([--enable-forw-via-db],[Enable Forw/Via database]), [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -530,7 +530,7 @@ squid_LDADD = \
 	$(EPOLL_LIBS) \
 	$(MINGW_LIBS) \
 	$(KRB5LIBS) \
-	$(SYSTEMD_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(XTRA_LIBS)
 
@@ -1962,7 +1962,7 @@ tests_test_http_range_LDADD = \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
 	$(LIBCPPUNIT_LIBS) \
-	$(SYSTEMD_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(XTRA_LIBS)
 tests_test_http_range_LDFLAGS = $(LIBADD_DL)
@@ -2346,7 +2346,7 @@ tests_testHttpRequest_LDADD = \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
 	$(LIBCPPUNIT_LIBS) \
-	$(SYSTEMD_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(XTRA_LIBS)
 tests_testHttpRequest_LDFLAGS = $(LIBADD_DL)
@@ -2644,7 +2644,7 @@ tests_testCacheManager_LDADD = \
 	$(SSLLIB) \
 	$(KRB5LIBS) \
 	$(LIBCPPUNIT_LIBS) \
-	$(SYSTEMD_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(XTRA_LIBS)
 tests_testCacheManager_LDFLAGS = $(LIBADD_DL)


### PR DESCRIPTION
Rename SYSTEMD_LIBS and related `*_CFLAGS` / `*_PATH` variables to
`LIBSYSTEMD_*` prefix in line with other libraries naming style.

Polish detection log outputs in line with other libraries.

Fix pollution of global LDFLAGS variable.

Also, expand possible -lsystemd builds beyond Linux. Some OS provide a
library for compatibility. Cross-builds can also need to link against
systemd.