### PR TITLE
Improve LDAP library detection

### DIFF
--- a/acinclude/ldap.m4
+++ b/acinclude/ldap.m4
@@ -9,8 +9,8 @@ dnl checks for LDAP functionality
 AC_DEFUN([SQUID_LDAP_TEST],[
   AC_CACHE_CHECK([for $1],[squid_cv_$1],[
     SQUID_STATE_SAVE(squid_ldap_test_state)
-    LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
-    CXXFLAGS="-DLDAP_DEPRECATED=1 -DLDAP_REFERRALS $CXXFLAGS"
+    LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
+    CPPFLAGS="-DLDAP_DEPRECATED=1 -DLDAP_REFERRALS $CPPFLAGS"
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #       if HAVE_LDAP_H
 #       include <ldap.h>
@@ -18,7 +18,6 @@ AC_DEFUN([SQUID_LDAP_TEST],[
 #       include <mozldap/ldap.h>
 #       endif
       ]],[[$2]])
-      SQUID_STATE_ROLLBACK(squid_ldap_test_state)
     ],[
       squid_cv_$1=1
     ],[
@@ -26,16 +25,17 @@ AC_DEFUN([SQUID_LDAP_TEST],[
     ],[
       squid_cv_$1=0
     ])
+    SQUID_STATE_ROLLBACK(squid_ldap_test_state)
   ])
-  AC_DEFINE([HAVE_$1],[${squid_cv_$1}],[Define to 1 if you have $1])
+  AC_DEFINE_UNQUOTED([HAVE_$1],${squid_cv_$1},[Define to 1 if you have $1])
 ])
 
 dnl similar to SQUID_LDAP_TEST but runs the test program
 AC_DEFUN([SQUID_LDAP_TEST_RUN],[
   AC_CACHE_CHECK([for $1],[m4_translit([squid_cv_$1],[-+. ],[____])],[
     SQUID_STATE_SAVE(squid_ldap_test_state)
-    LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
-    CXXFLAGS="-DLDAP_DEPRECATED=1 -DLDAP_REFERRALS $CXXFLAGS"
+    LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
+    CPPFLAGS="-DLDAP_DEPRECATED=1 -DLDAP_REFERRALS $CPPFLAGS"
     AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #       if HAVE_LDAP_H
 #       include <ldap.h>
@@ -44,7 +44,6 @@ AC_DEFUN([SQUID_LDAP_TEST_RUN],[
 #       endif
 #       include <string.h>
       ]],[[$2]])
-      SQUID_STATE_ROLLBACK(squid_ldap_test_state)
     ],[
       m4_translit([squid_cv_$1],[-+. ],[____])=1
     ],[
@@ -52,14 +51,48 @@ AC_DEFUN([SQUID_LDAP_TEST_RUN],[
     ],[
       m4_translit([squid_cv_$1],[-+. ],[____])=0
     ])
+    SQUID_STATE_ROLLBACK(squid_ldap_test_state)
   ])
-  AC_DEFINE([m4_translit([m4_translit([HAVE_$1],[-+. abcdefghijklmnopqrstuvwxyz],[____ABCDEFGHIJKLMNOPQRSTUVWXYZ])],[-+. ],[____])],
-    [${m4_translit([squid_cv_$1],[-+. ],[____])}],[Define to 1 if you have $1])
+  AC_DEFINE_UNQUOTED([m4_translit([m4_translit([HAVE_$1],[-+. abcdefghijklmnopqrstuvwxyz],[____ABCDEFGHIJKLMNOPQRSTUVWXYZ])],[-+. ],[____])],
+    ${m4_translit([squid_cv_$1],[-+. ],[____])},[Define to 1 if you have $1])
 ])
 
+dnl find the LDAP library vendor and define relevant HAVE_(vendor name) macro
 AC_DEFUN([SQUID_LDAP_CHECK_VENDOR],[
   SQUID_LDAP_TEST_RUN([OpenLDAP],[return strcmp(LDAP_VENDOR_NAME,"OpenLDAP")])
   SQUID_LDAP_TEST_RUN([Sun LDAP SDK],[return strcmp(LDAP_VENDOR_NAME,"Sun Microsystems Inc.")])
   SQUID_LDAP_TEST_RUN([Mozilla LDAP SDK],[return strcmp(LDAP_VENDOR_NAME,"mozilla.org")])
 ])
 
+dnl check whether the LDAP library(s) provide the needed API and types
+dnl define HAVE_DAP_* macros for each checked item
+AC_DEFUN([SQUID_CHECK_LDAP_API],[
+  SQUID_LDAP_TEST([LDAP],[
+    char host[]="";
+    int port;
+    ldap_init((const char *)&host, port);
+  ])
+  SQUID_LDAP_CHECK_VENDOR
+  SQUID_LDAP_TEST([LDAP_OPT_DEBUG_LEVEL],[auto i=LDAP_OPT_DEBUG_LEVEL])
+  SQUID_LDAP_TEST([LDAP_SCOPE_DEFAULT],[auto i=LDAP_SCOPE_DEFAULT])
+  SQUID_LDAP_TEST([LDAP_REBIND_PROC],[LDAP_REBIND_PROC ldap_rebind])
+  SQUID_LDAP_TEST([LDAP_REBINDPROC_CALLBACK],[LDAP_REBINDPROC_CALLBACK ldap_rebind])
+  SQUID_LDAP_TEST([LDAP_REBIND_FUNCTION],[LDAP_REBIND_FUNCTION ldap_rebind])
+
+  dnl TODO check this test's code actually works, it looks broken
+  SQUID_LDAP_TEST([LDAP_URL_LUD_SCHEME],[struct ldap_url_desc.lud_scheme])
+
+  AC_CHECK_LIB(ldap,[ldapssl_client_init],[
+    AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
+  ])
+  AC_CHECK_LIB($LIBLDAP_LIBS,[ldap_url_desc2str],[
+    AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
+  ])
+  AC_CHECK_LIB($LIBLDAP_LIBS,[ldap_url_parse],[
+    AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
+  ])
+  AC_CHECK_LIB($LIBLDAP_LIBS,[ldap_start_tls_s],[
+    AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
+  ])
+  SQUID_STATE_ROLLBACK(squid_ldap_state)
+])

--- a/acinclude/ldap.m4
+++ b/acinclude/ldap.m4
@@ -1,0 +1,65 @@
+# Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+dnl checks for LDAP functionality
+AC_DEFUN([SQUID_LDAP_TEST],[
+  AC_CACHE_CHECK([for $1],[squid_cv_$1],[
+    SQUID_STATE_SAVE(squid_ldap_test_state)
+    LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
+    CXXFLAGS="-DLDAP_DEPRECATED=1 -DLDAP_REFERRALS $CXXFLAGS"
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#       if HAVE_LDAP_H
+#       include <ldap.h>
+#       elif HAVE_MOZLDAP_LDAP_H
+#       include <mozldap/ldap.h>
+#       endif
+      ]],[[$2]])
+      SQUID_STATE_ROLLBACK(squid_ldap_test_state)
+    ],[
+      squid_cv_$1=1
+    ],[
+      squid_cv_$1=0
+    ],[
+      squid_cv_$1=0
+    ])
+  ])
+  AC_DEFINE([HAVE_$1],[${squid_cv_$1}],[Define to 1 if you have $1])
+])
+
+dnl similar to SQUID_LDAP_TEST but runs the test program
+AC_DEFUN([SQUID_LDAP_TEST_RUN],[
+  AC_CACHE_CHECK([for $1],[m4_translit([squid_cv_$1],[-+. ],[____])],[
+    SQUID_STATE_SAVE(squid_ldap_test_state)
+    LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
+    CXXFLAGS="-DLDAP_DEPRECATED=1 -DLDAP_REFERRALS $CXXFLAGS"
+    AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+#       if HAVE_LDAP_H
+#       include <ldap.h>
+#       elif HAVE_MOZLDAP_LDAP_H
+#       include <mozldap/ldap.h>
+#       endif
+#       include <string.h>
+      ]],[[$2]])
+      SQUID_STATE_ROLLBACK(squid_ldap_test_state)
+    ],[
+      m4_translit([squid_cv_$1],[-+. ],[____])=1
+    ],[
+      m4_translit([squid_cv_$1],[-+. ],[____])=0
+    ],[
+      m4_translit([squid_cv_$1],[-+. ],[____])=0
+    ])
+  ])
+  AC_DEFINE([m4_translit([m4_translit([HAVE_$1],[-+. abcdefghijklmnopqrstuvwxyz],[____ABCDEFGHIJKLMNOPQRSTUVWXYZ])],[-+. ],[____])],
+    [${m4_translit([squid_cv_$1],[-+. ],[____])}],[Define to 1 if you have $1])
+])
+
+AC_DEFUN([SQUID_LDAP_CHECK_VENDOR],[
+  SQUID_LDAP_TEST_RUN([OpenLDAP],[return strcmp(LDAP_VENDOR_NAME,"OpenLDAP")])
+  SQUID_LDAP_TEST_RUN([Sun LDAP SDK],[return strcmp(LDAP_VENDOR_NAME,"Sun Microsystems Inc.")])
+  SQUID_LDAP_TEST_RUN([Mozilla LDAP SDK],[return strcmp(LDAP_VENDOR_NAME,"mozilla.org")])
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -1628,65 +1628,45 @@ AC_MSG_NOTICE([$KRB5_FLAVOUR Kerberos library support: ${with_krb5:=no} ${LIB_KR
 AC_SUBST(KRB5INCS)
 AC_SUBST(KRB5LIBS)
 
-dnl On MinGW OpenLDAP is not available, so LDAP helpers can be linked
-dnl only with Windows LDAP libraries using -lwldap32
-AS_IF([test "$squid_host_os" = "mingw"],[
-  LDAPLIB="-lwldap32"
-  LBERLIB=""
-],[
-  AC_CHECK_LIB(ldap, ldap_init, [LDAPLIB="-lldap"])
-  AC_CHECK_LIB(lber, ber_init, [LBERLIB="-llber"])
-  dnl if no ldap lib found check for mozilla version
-  AS_IF([test "x$ac_cv_lib_ldap_ldap_init" != "xyes"],[
-    SQUID_STATE_SAVE(squid_ldap_mozilla)
-    LIBS="$LIBPTHREADS"
-    AC_CHECK_LIB(ldap60, ldap_init, [LDAPLIB="-lldap60"])
-    LIBS="$LDAPLIB $LIBPTHREADS"
-    AC_CHECK_LIB(prldap60, prldap_init, [LDAPLIB="-lprldap60 $LDAPLIB"])
-    LIBS="$LDAPLIB $LIBPTHREADS"
-    AC_CHECK_LIB(ssldap60, ldapssl_init, [LDAPLIB="-lssldap60 $LDAPLIB"])
-    SQUID_STATE_ROLLBACK(squid_ldap_mozilla)
+SQUID_AUTO_LIB(ldap,[LDAP],[LIBLDAP])
+AS_IF([test "x$with_ldap" != "xno"],[
+  dnl On MinGW OpenLDAP is not available, so LDAP helpers can be linked
+  dnl only with Windows LDAP libraries using -lwldap32
+  AS_IF([test "$squid_host_os" = "mingw"],[
+    LIBLDAP_LIBS="-lwldap32"
+  ],[
+    SQUID_STATE_SAVE(squid_ldap_state)
+    LIBS="$LIBLDAP_PATH $LIBPTHREADS $LIBS"
+    PKG_CHECK_MODULES([LIBLDAP],[ldap],[],[
+      AC_CHECK_LIB(lber, ber_init, [LIBLBER="-llber"])
+      AC_CHECK_LIB(ldap, ldap_init, [LIBLDAP_LIBS="-lldap $LIBLBER"])
+      dnl if no ldap lib found check for mozilla version
+      AS_IF([test "x$ac_cv_lib_ldap_ldap_init" != "xyes"],[
+        SQUID_STATE_SAVE(squid_ldap_mozilla)
+        LIBS="$LIBLDAP_PATH $LIBPTHREADS"
+        AC_CHECK_LIB(ldap60, ldap_init, [LIBLDAP_LIBS="-lldap60 $LIBLBER"])
+        LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
+        AC_CHECK_LIB(prldap60, prldap_init, [LIBLDAP_LIBS="-lprldap60 $LIBLDAP_LIBS"])
+        LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
+        AC_CHECK_LIB(ssldap60, ldapssl_init, [LIBLDAP_LIBS="-lssldap60 $LIBLDAP_LIBS"])
+        SQUID_STATE_ROLLBACK(squid_ldap_mozilla)
+      ])
+    ])
+    AC_CHECK_HEADERS(ldap.h lber.h)
+    AC_CHECK_HEADERS(mozldap/ldap.h)
+    SQUID_CHECK_LDAP_API
   ])
 
-  AC_CHECK_HEADERS(ldap.h lber.h)
-  AC_CHECK_HEADERS(mozldap/ldap.h)
-
-  SQUID_LDAP_TEST([LDAP],[
-    char host[]="";
-    int port;
-    ldap_init((const char *)&host, port);
-  ])
-
-  SQUID_LDAP_CHECK_VENDOR
-
-  SQUID_LDAP_TEST([LDAP_OPT_DEBUG_LEVEL],[auto i=LDAP_OPT_DEBUG_LEVEL])
-  SQUID_LDAP_TEST([LDAP_SCOPE_DEFAULT],[auto i=LDAP_SCOPE_DEFAULT;])
-
-  SQUID_LDAP_TEST([LDAP_REBIND_PROC],[LDAP_REBIND_PROC ldap_rebind;])
-  SQUID_LDAP_TEST([LDAP_REBINDPROC_CALLBACK],[LDAP_REBINDPROC_CALLBACK ldap_rebind;])
-  SQUID_LDAP_TEST([LDAP_REBIND_FUNCTION],[LDAP_REBIND_FUNCTION ldap_rebind;])
-
-  SQUID_LDAP_TEST([LDAP_URL_LUD_SCHEME],[struct ldap_url_desc.lud_scheme v;])
-
-  AC_CHECK_LIB(ldap,ldapssl_client_init,[
-    AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
-  ])
-
-  AC_CHECK_LIB(ldap,ldap_url_desc2str,[
-    AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
-  ])
-
-  AC_CHECK_LIB(ldap,ldap_url_parse,[
-    AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
-  ])
-
-  AC_CHECK_LIB(ldap,ldap_start_tls_s,[
-    AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
+  AS_IF([test "x$LIBLDAP_LIBS" != "x"],[
+    CPPFLAGS="$LIBLDAP_CFLAGS $CPPFLAGS"
+    LIBLDAP_LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS"
+  ],[test "x$with_ldap" = "xyes"],[
+    AC_MSG_ERROR([Required library ldap not found])
+  ],[
+    AC_MSG_NOTICE([Library ldap not found.])
   ])
 ])
-
-AC_SUBST(LDAPLIB)
-AC_SUBST(LBERLIB)
+AC_SUBST(LIBLDAP_LIBS)
 
 SQUID_AUTO_LIB(systemd,[systemd API for start-up notification],[LIBSYSTEMD])
 AH_TEMPLATE(USE_SYSTEMD,[systemd support is available])
@@ -2284,8 +2264,6 @@ AC_CHECK_HEADERS( \
   gnumalloc.h \
   grp.h \
   ipl.h \
-  lber.h \
-  ldap.h \
   libc.h \
   limits.h \
   linux/posix_types.h \

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ m4_include([acinclude/squid-util.m4])
 m4_include([acinclude/compiler-flags.m4])
 m4_include([acinclude/os-deps.m4])
 m4_include([acinclude/krb5.m4])
+m4_include([acinclude/ldap.m4])
 m4_include([acinclude/nettle.m4])
 m4_include([acinclude/pam.m4])
 m4_include([acinclude/pkg.m4])
@@ -1637,206 +1638,51 @@ AS_IF([test "$squid_host_os" = "mingw"],[
   AC_CHECK_LIB(lber, ber_init, [LBERLIB="-llber"])
   dnl if no ldap lib found check for mozilla version
   AS_IF([test "x$ac_cv_lib_ldap_ldap_init" != "xyes"],[
-    oLIBS=$LIBS
+    SQUID_STATE_SAVE(squid_ldap_mozilla)
     LIBS="$LIBPTHREADS"
     AC_CHECK_LIB(ldap60, ldap_init, [LDAPLIB="-lldap60"])
     LIBS="$LDAPLIB $LIBPTHREADS"
     AC_CHECK_LIB(prldap60, prldap_init, [LDAPLIB="-lprldap60 $LDAPLIB"])
     LIBS="$LDAPLIB $LIBPTHREADS"
     AC_CHECK_LIB(ssldap60, ldapssl_init, [LDAPLIB="-lssldap60 $LDAPLIB"])
-    LIBS=$oLIBS
+    SQUID_STATE_ROLLBACK(squid_ldap_mozilla)
   ])
 
   AC_CHECK_HEADERS(ldap.h lber.h)
   AC_CHECK_HEADERS(mozldap/ldap.h)
 
-  AC_MSG_CHECKING([for LDAP_OPT_DEBUG_LEVEL])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <ldap.h>
-  ]],[[
-    int i=LDAP_OPT_DEBUG_LEVEL
-  ]])],[
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
+  SQUID_LDAP_TEST([LDAP],[
+    char host[]="";
+    int port;
+    ldap_init((const char *)&host, port);
   ])
 
-  AC_MSG_CHECKING([for working ldap])
-  oLIBS=$LIBS
-  LIBS="$LDAPLIB $LBERLIB $LIBPTHREADS"
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#   define  LDAP_DEPRECATED 1
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   elif HAVE_MOZLDAP_LDAP_H
-#   include <mozldap/ldap.h>
-#   endif
-    int
-    main(void)
-    {
-        char host[]="";
-        int port;
-        ldap_init((const char *)&host, port);
-        return 0;
-    }
-  ]])],[
-    AC_DEFINE(HAVE_LDAP, 1, [LDAP support])
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-  ],[
-     AC_MSG_RESULT(cross-compiler cant tell)
-  ])
-  LIBS=$oLIBS
+  SQUID_LDAP_CHECK_VENDOR
 
-  AC_MSG_CHECKING([for OpenLDAP])
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   endif
-#   include <string.h>
-    int
-    main(void)
-    {
-        return strcmp(LDAP_VENDOR_NAME,"OpenLDAP");
-    }
-  ]])],[
-    AC_DEFINE(HAVE_OPENLDAP, 1, [OpenLDAP support])
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-  ],[
-    AC_MSG_RESULT(cross-compiler cant tell)
-  ])
+  SQUID_LDAP_TEST([LDAP_OPT_DEBUG_LEVEL],[auto i=LDAP_OPT_DEBUG_LEVEL])
+  SQUID_LDAP_TEST([LDAP_SCOPE_DEFAULT],[auto i=LDAP_SCOPE_DEFAULT;])
 
-  AC_MSG_CHECKING([for Sun LDAP SDK])
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   endif
-#   include <string.h>
-    int
-    main(void)
-    {
-        return strcmp(LDAP_VENDOR_NAME,"Sun Microsystems Inc.");
-    }
-  ]])],[
-    AC_DEFINE(HAVE_SUN_LDAP_SDK, 1, [Sun LDAP SDK support])
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-  ],[
-    AC_MSG_RESULT(cross-compiler cant tell)
-  ])
+  SQUID_LDAP_TEST([LDAP_REBIND_PROC],[LDAP_REBIND_PROC ldap_rebind;])
+  SQUID_LDAP_TEST([LDAP_REBINDPROC_CALLBACK],[LDAP_REBINDPROC_CALLBACK ldap_rebind;])
+  SQUID_LDAP_TEST([LDAP_REBIND_FUNCTION],[LDAP_REBIND_FUNCTION ldap_rebind;])
 
-  AC_MSG_CHECKING([for Mozilla LDAP SDK])
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   elif HAVE_MOZLDAP_LDAP_H
-#   include <mozldap/ldap.h>
-#   endif
-#   include <string.h>
-    int
-    main(void)
-    {
-        return strcmp(LDAP_VENDOR_NAME,"mozilla.org");
-    }
-  ]])],[
-    AC_DEFINE(HAVE_MOZILLA_LDAP_SDK, 1, [Mozilla LDAP SDK support])
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-  ],[
-    AC_MSG_RESULT(cross-compiler cant tell)
-  ])
-
-  AC_MSG_CHECKING([for LDAP_REBINDPROC_CALLBACK])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   elif HAVE_MOZLDAP_LDAP_H
-#   include <mozldap/ldap.h>
-#   endif
-  ]],[[
-    LDAP_REBINDPROC_CALLBACK ldap_rebind;
-  ]])],[
-    AC_DEFINE(HAVE_LDAP_REBINDPROC_CALLBACK,1,[Define to 1 if you have LDAP_REBINDPROC_CALLBACK])
-    AC_MSG_RESULT(yes)
-  ],[
-     AC_MSG_RESULT(no)
-  ])
-
-  AC_MSG_CHECKING([for LDAP_REBIND_PROC])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   elif HAVE_MOZLDAP_LDAP_H
-#   include <mozldap/ldap.h>
-#   endif
-  ]],[[
-    LDAP_REBIND_PROC ldap_rebind;
-  ]])],[
-    AC_DEFINE(HAVE_LDAP_REBIND_PROC,1,[Define to 1 if you have LDAP_REBIND_PROC])
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-  ])
-
-  AC_MSG_CHECKING([for LDAP_REBIND_FUNCTION])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#   define LDAP_REFERRALS
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   elif HAVE_MOZLDAP_LDAP_H
-#   include <mozldap/ldap.h>
-#   endif
-  ]],[[
-    LDAP_REBIND_FUNCTION ldap_rebind;
-  ]])],[
-    AC_DEFINE(HAVE_LDAP_REBIND_FUNCTION,1,[Define to 1 if you have LDAP_REBIND_FUNCTION])
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-  ])
-
-  AC_MSG_CHECKING([for LDAP_SCOPE_DEFAULT])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#   if HAVE_LDAP_H
-#   include <ldap.h>
-#   elif HAVE_MOZLDAP_LDAP_H
-#   include <mozldap/ldap.h>
-#   endif
-  ]],[[
-    int i=LDAP_SCOPE_DEFAULT;
-  ]])],[
-    AC_DEFINE(HAVE_LDAP_SCOPE_DEFAULT,1,[Define to 1 if you have LDAP_SCOPE_DEFAULT])
-    AC_MSG_RESULT(yes)
-  ],[
-    AC_MSG_RESULT(no)
-  ])
-
-  AC_CHECK_MEMBER([struct ldap_url_desc.lud_scheme],[
-    AC_DEFINE(HAVE_LDAP_URL_LUD_SCHEME,1,[Define to 1 if you have LDAPURLDesc.lud_scheme])
-  ],,[
-#include <ldap.h>
-  ])
+  SQUID_LDAP_TEST([LDAP_URL_LUD_SCHEME],[struct ldap_url_desc.lud_scheme v;])
 
   AC_CHECK_LIB(ldap,ldapssl_client_init,[
     AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
-  ],)
+  ])
 
   AC_CHECK_LIB(ldap,ldap_url_desc2str,[
     AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
-  ],)
+  ])
 
   AC_CHECK_LIB(ldap,ldap_url_parse,[
     AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
-  ],)
+  ])
 
   AC_CHECK_LIB(ldap,ldap_start_tls_s,[
     AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
-  ],)
+  ])
 ])
 
 AC_SUBST(LDAPLIB)

--- a/doc/release-notes/release-5.sgml
+++ b/doc/release-notes/release-5.sgml
@@ -342,6 +342,12 @@ This section gives an account of those changes in three categories:
 <sect1>New options<label id="newoptions">
 <p>
 <descrip>
+	<tag>--without-ldap</tag>
+	<p>New option to determine whether LDAP support is used, and
+	   build against local custom installs.
+	<p>This will prevent all helper binaries depending on LDAP
+	   from being auto-built.
+
 	<tag>--without-tdb</tag>
 	<p>New option to determine whether TrivialDB support is used, and
 	   build against local custom installs.

--- a/src/acl/external/LDAP_group/Makefile.am
+++ b/src/acl/external/LDAP_group/Makefile.am
@@ -15,8 +15,7 @@ ext_ldap_group_acl_SOURCES = \
 ext_ldap_group_acl_LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(LDAPLIB) \
-	$(LBERLIB) \
+	$(LIBLDAP_LIBS) \
 	$(XTRA_LIBS)
 
 EXTRA_DIST= \

--- a/src/acl/external/eDirectory_userip/Makefile.am
+++ b/src/acl/external/eDirectory_userip/Makefile.am
@@ -14,8 +14,7 @@ ext_edirectory_userip_acl_SOURCES = \
 
 ext_edirectory_userip_acl_LDADD = \
 	$(COMPAT_LIB) \
-	$(LDAPLIB) \
-	$(LBERLIB) \
+	$(LIBLDAP_LIBS) \
 	$(XTRA_LIBS)
 
 man_MANS = ext_edirectory_userip_acl.8

--- a/src/acl/external/kerberos_ldap_group/Makefile.am
+++ b/src/acl/external/kerberos_ldap_group/Makefile.am
@@ -36,8 +36,7 @@ ext_kerberos_ldap_group_acl_LDFLAGS =
 ext_kerberos_ldap_group_acl_LDADD = \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(LDAPLIB) \
-	$(LBERLIB) \
+	$(LIBLDAP_LIBS) \
 	$(LIBSASL) \
 	$(KRB5LIBS) \
 	$(XTRA_LIBS)

--- a/src/auth/basic/LDAP/Makefile.am
+++ b/src/auth/basic/LDAP/Makefile.am
@@ -15,5 +15,4 @@ basic_ldap_auth_SOURCES = basic_ldap_auth.cc
 basic_ldap_auth_LDADD = \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(LDAPLIB) \
-	$(LBERLIB)
+	$(LIBLDAP_LIBS)

--- a/src/auth/digest/LDAP/Makefile.am
+++ b/src/auth/digest/LDAP/Makefile.am
@@ -18,8 +18,7 @@ digest_ldap_auth_SOURCES = \
 digest_ldap_auth_LDADD= \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(LDAPLIB) \
-	$(LBERLIB) \
+	$(LIBLDAP_LIBS) \
 	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(SSLLIB) \

--- a/src/auth/digest/eDirectory/Makefile.am
+++ b/src/auth/digest/eDirectory/Makefile.am
@@ -20,8 +20,7 @@ digest_edirectory_auth_SOURCES = \
 digest_edirectory_auth_LDADD = \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(LDAPLIB) \
-	$(LBERLIB) \
+	$(LIBLDAP_LIBS) \
 	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(SSLLIB) \

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -100,6 +100,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--without-cap \
 	--without-dl \
 	--without-large-files \
+	--without-ldap \
 	--without-nettle \
 	--without-valgrind-debug \
 	--without-ipv6-split-stack \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -108,6 +108,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-gnu-ld \
 	--with-ipv6-split-stack \
 	--with-large-files \
+	--with-ldap \
 	--with-pic \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -110,6 +110,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-gnu-ld \
 	--with-ipv6-split-stack \
 	--with-large-files \
+	--with-ldap \
 	--with-pic \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \


### PR DESCRIPTION
Add --with-ldap and pkg-config support to speed up Squid builds
where LDAP is not to be used. This also adds support for custom
LDAP library locations like other --with-foo options.

'pkg-config --libs ldap' finds both -lldap and -llber. Stop using
different variables for them in Makefile.am.

Extract LDAP API tests into simpler dedicated macros and stop
polluting LIBS when running LDAP tests.