### PR TITLE
Fixed comm.cc:644: "address.port() != 0" assertion

### DIFF
--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -95,7 +95,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     } else void(0)
 
     if (type == IPC_TCP_SOCKET) {
-        crfd = cwfd = comm_open(SOCK_STREAM,
+        crfd = cwfd = comm_open_listener(SOCK_STREAM,
                                 0,
                                 local_addr,
                                 COMM_NOCLOEXEC,

--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -127,7 +127,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     }
 
     if (type == IPC_TCP_SOCKET) {
-        crfd = cwfd = comm_open(SOCK_STREAM,
+        crfd = cwfd = comm_open_listener(SOCK_STREAM,
                                 IPPROTO_TCP,
                                 local_addr,
                                 COMM_NOCLOEXEC,


### PR DESCRIPTION
IPC code creating a TCP socket pair for communication with helpers used
comm_open() to create a _listening_ socket, misleading Comm into
applying IP_BIND_ADDRESS_NO_PORT optimization that delays port
assignment until connect(2) (which is never called for listening
sockets). Listening sockets must be opened using comm_open_listener(),
but the IPC use case was missed in 2009 commit 31be869 that introduced
comm_open_listener(). IP_BIND_ADDRESS_NO_PORT changes in recent commit
74d7d19 hit that bug.

Disclaimer: Windows-specific code adjusted without testing.