### PR TITLE
Fix escaping leading regex dashes in ./configure sources

### DIFF
--- a/acinclude/krb5.m4
+++ b/acinclude/krb5.m4
@@ -192,7 +192,7 @@ main(void)
         return 0;
 }
   ]])],  [ squid_cv_working_gssapi=yes ], [ squid_cv_working_gssapi=no ], [:])])
-  AS_IF([test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "[-]L"` -gt 0],[
+  AS_IF([test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "@<:@-@:>@L"` -gt 0],[
     AC_MSG_NOTICE([Check Runtime library path !])
   ])
 ])
@@ -284,7 +284,7 @@ main(void)
         return 0;
 }
   ]])], [ squid_cv_working_krb5=yes ], [ squid_cv_working_krb5=no ],[:])])
-  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "[-]L"` -gt 0],[
+  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "@<:@-@:>@L"` -gt 0],[
     AC_MSG_NOTICE([Check Runtime library path !])
   ])
 ])

--- a/acinclude/krb5.m4
+++ b/acinclude/krb5.m4
@@ -192,7 +192,7 @@ main(void)
         return 0;
 }
   ]])],  [ squid_cv_working_gssapi=yes ], [ squid_cv_working_gssapi=no ], [:])])
-  AS_IF([test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "@<:@-@:>@L"` -gt 0],[
+  AS_IF([test "x$squid_cv_working_gssapi" = "xno" -a `echo $LIBS | grep -i -c "(-)L"` -gt 0],[
     AC_MSG_NOTICE([Check Runtime library path !])
   ])
 ])
@@ -284,7 +284,7 @@ main(void)
         return 0;
 }
   ]])], [ squid_cv_working_krb5=yes ], [ squid_cv_working_krb5=no ],[:])])
-  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "@<:@-@:>@L"` -gt 0],[
+  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "(-)L"` -gt 0],[
     AC_MSG_NOTICE([Check Runtime library path !])
   ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AS_IF([test "x$BUILDCXX" = "x"],[
 AC_SUBST(BUILDCXX)
 
 # If the user did not specify a C++ version.
-user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "[-]std="`
+user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "@<:@-@:>@std="`
 AS_IF([test "x$user_cxx" = "x"],[
   # Check for C++11 compiler support
   AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AS_IF([test "x$BUILDCXX" = "x"],[
 AC_SUBST(BUILDCXX)
 
 # If the user did not specify a C++ version.
-user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "@<:@-@:>@std="`
+user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "(-)std="`
 AS_IF([test "x$user_cxx" = "x"],[
   # Check for C++11 compiler support
   AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])


### PR DESCRIPTION
    grep: invalid option -- 't'
    Usage: grep [OPTION]... PATTERNS [FILE]...
    Try 'grep --help' for more information.

    Usage: grep [OPTION]... PATTERNS [FILE]...
    Try 'grep --help' for more information.
    ./configure: line 27524: test: too many arguments

    Usage: grep [OPTION]... PATTERNS [FILE]...
    Try 'grep --help' for more information.
    ./configure: line 27698: test: too many arguments

Configure scripts are written in m4, not shell. M4 treats [square
brackets] specially. We could use quadrigraphs instead (as documented in
autoconf manual) but `(-)` looks a lot simpler than `@<:@-@:>@`!