### PR TITLE
Fix ./configure detection of libxml2 headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -847,13 +847,13 @@ AS_IF([test "x$squid_opt_use_esi" != "xno" -a "x$with_xml2" != "xno"],[
   PKG_CHECK_MODULES([LIBXML2],[libxml-2.0],[],[
     AC_CHECK_LIB([xml2],[main],[LIBXML2_LIBS="$LIBXML2_PATH -lxml2"])
   ])
-  CXXFLAGS="$LIBXML2_CFLAGS $CXXFLAGS"
+  CPPFLAGS="$LIBXML2_CFLAGS $CPPFLAGS"
   AC_CHECK_HEADERS(libxml/parser.h libxml/HTMLparser.h libxml/HTMLtree.h)
   SQUID_STATE_ROLLBACK([squid_libxml2_save])
 
   AS_IF([test "x$LIBXML2_LIBS" != "x"],[
     squid_opt_use_esi=yes
-    CXXFLAGS="$LIBXML2_CFLAGS $CXXFLAGS"
+    CPPFLAGS="$LIBXML2_CFLAGS $CPPFLAGS"
     LIBXML2_LIBS="$LIBXML2_PATH $LIBXML2_LIBS"
     AC_DEFINE(HAVE_LIBXML2,1,[Define to 1 if you have the xml2 library])
   ],[test "x$with_xml2" = "xyes"],[


### PR DESCRIPTION
    checking for LIBXML2... yes
    checking libxml/parser.h usability... yes
    checking libxml/parser.h presence... no
    configure: WARNING: libxml/parser.h: accepted by the compiler,
               rejected by the preprocessor!
    configure: WARNING: libxml/parser.h: proceeding with the compiler's
               result

PKG_CHECK_MODULES() documentation warns that it uses a "misleading" name
for the foo_CFLAGS variable it sets: "the variable provides the flags to
pass to the preprocessor, rather than the compiler". Lots of Squid code
has been mislead by that macro, but this fix is specific to a recent
regression introduced in commit 866a092. TODO: Fix all others.