### PR TITLE
Report (problems with) DEAD-at-start cache_peers

### DIFF
--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -143,7 +143,11 @@ public:
     char *digest_url = nullptr;
 #endif
 
-    int tcp_up = 0;         /* 0 if a connect() fails */
+    /// The number of failures sufficient to stop selecting this cache_peer. All
+    /// peer selection algorithms skip peers with zero tcp_up values. The
+    /// initial zero value prevents unprobed cache_peers from being selected.
+    int tcp_up = 0;
+
     /// whether to do another TCP probe after current TCP probes
     bool reprobe = false;
 

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -144,8 +144,8 @@ public:
 #endif
 
     /// The number of failures sufficient to stop selecting this cache_peer. All
-    /// peer selection algorithms skip peers with zero tcp_up values. The
-    /// initial zero value prevents unprobed cache_peers from being selected.
+    /// cache_peer selection algorithms skip cache_peers with 0 tcp_up values.
+    /// The initial 0 value prevents unprobed cache_peers from being selected.
     int tcp_up = 0;
 
     /// whether to do another TCP probe after current TCP probes


### PR DESCRIPTION
When a cache_peer is (re)configured, Squid probes its address using a
throw-away TCP connection. If and only if that TCP probe succeeds, peer
selection algorithms may pick the peer. Until then, the cache_peer is
treated as if it was DEAD.

This change preserves the logic summarized above but starts _reporting_
the initial probe failure and the fact that it marks the cache_peer
DEAD. Without these reports, admins often naturally assume that the
cache_peer is alive, especially if traffic can be served without it.