### PR TITLE
WIP: Polish checks for working Kerberos library

### DIFF
--- a/acinclude/krb5.m4
+++ b/acinclude/krb5.m4
@@ -8,60 +8,74 @@
 dnl these checks must be performed in the same order as here defined,
 dnl and have mostly been lifted out of an inlined configure.ac.
 
-dnl checks for a broken solaris header file, and sets squid_cv_broken_krb5_h
-dnl to yes if that's the case
-AC_DEFUN([SQUID_CHECK_KRB5_SOLARIS_BROKEN_KRB5_H], [
+dnl checks for a broken solaris header file
+AC_DEFUN([SQUID_CHECK_KRB5_SOLARIS_BROKEN_KRB5_H],[
   AC_CACHE_CHECK([for broken Solaris krb5.h],squid_cv_broken_krb5_h, [
     SQUID_STATE_SAVE(squid_krb5_solaris_test)
     CPPFLAGS="-I${srcdir:-.} $CPPFLAGS"
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <krb5.h>
-int i;
-]])], [ squid_cv_broken_krb5_h=no ], [
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[#include <krb5.h>]],[[int i;]])
+    ],[squid_cv_broken_krb5_h=no],[
+      AC_COMPILE_IFELSE([
+        AC_LANG_PROGRAM([[
 #define HAVE_BROKEN_SOLARIS_KRB5_H  1
 #include "compat/krb5.h"
-int i;
-]])], [ squid_cv_broken_krb5_h=yes ], [ squid_cv_broken_krb5_h=no ])
+        ]],[[int i;]])
+      ],[
+        squid_cv_broken_krb5_h=yes
+        AC_MSG_WARN([You have a broken Solaris <krb5.h> system include.])
+        AC_MSG_WARN([Please see http://bugs.opensolaris.org/bugdatabase/view_bug.do?bug_id=6837512])
+        AC_MSG_WARN([If you need Kerberos support you will have to patch])
+        AC_MSG_WARN([your system. See contrib/solaris/solaris-krb5-include.patch])
+      ],[squid_cv_broken_krb5_h=no])
     ])
     SQUID_STATE_ROLLBACK(squid_krb5_solaris_test)
   ])
-]) dnl SQUID_CHECK_KRB5_SOLARIS_BROKEN_KRB5_H
+  AS_IF([test "x$squid_cv_broken_krb5_h" = "xyes"],[
+    AC_DEFINE(HAVE_BROKEN_SOLARIS_KRB5_H,1,[Define to 1 if Solaris krb5.h is broken for C++])
+  ])
+])
 
-
-AC_DEFUN([SQUID_CHECK_KRB5_HEIMDAL_BROKEN_KRB5_H], [
+AC_DEFUN([SQUID_CHECK_KRB5_HEIMDAL_BROKEN_KRB5_H],[
   AC_CACHE_CHECK([for broken Heimdal krb5.h],squid_cv_broken_heimdal_krb5_h, [
     SQUID_STATE_SAVE(squid_krb5_heimdal_test)
     CPPFLAGS="-I${srcdir:-.} $CPPFLAGS"
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <krb5.h>
-int
-main(void)
-{
-        krb5_context context;
-
-        krb5_init_context(&context);
-
-        return 0;
-}
-]])], [ squid_cv_broken_heimdal_krb5_h=no ], [
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    AC_RUN_IFELSE([
+      AC_LANG_PROGRAM([[#include <krb5.h>]],[[krb5_context c; krb5_init_context(&c);]])
+    ],[squid_cv_broken_heimdal_krb5_h=no],[
+      AC_RUN_IFELSE([
+        AC_LANG_PROGRAM([[
 #define HAVE_BROKEN_HEIMDAL_KRB5_H  1
 #include "compat/krb5.h"
-int
-main(void)
-{
-        krb5_context context;
-
-        krb5_init_context(&context);
-
-        return 0;
-}
-]])], [ squid_cv_broken_heimdal_krb5_h=yes ], [ squid_cv_broken_heimdal_krb5_h=no ])
+        ]],[[krb5_context c; krb5_init_context(&c);]])
+      ],[squid_cv_broken_heimdal_krb5_h=yes],[squid_cv_broken_heimdal_krb5_h=no])
     ])
     SQUID_STATE_ROLLBACK(squid_krb5_heimdal_test)
   ])
-]) dnl SQUID_CHECK_KRB5_HEIMDAL_BROKEN_KRB5_H
+  AS_IF([test "x$squid_cv_broken_heimdal_krb5_h" = "xyes"],[
+    AC_DEFINE(HAVE_BROKEN_HEIMDAL_KRB5_H,1,[Define to 1 if Heimdal krb5.h is broken for C++])
+  ])
+])
+
+dnl checks that krb5 is functional. Sets squid_cv_working_krb5
+AC_DEFUN([SQUID_CHECK_WORKING_KRB5],[
+  AS_CASE("$1",
+    ["Heimdal"],[SQUID_CHECK_KRB5_HEIMDAL_BROKEN_KRB5_H],
+    ["Solaris"],[SQUID_CHECK_KRB5_SOLARIS_BROKEN_KRB5_H]
+  )
+  AC_CACHE_CHECK([for working krb5],squid_cv_working_krb5,[
+    SQUID_STATE_SAVE(squid_krb5_test)
+    CPPFLAGS="-I${srcdir:-.} $CPPFLAGS"
+    AC_RUN_IFELSE([
+      AC_LANG_PROGRAM([[#include "compat/krb5.h"]],[[krb5_context c; krb5_init_context(&c);]])
+    ],[squid_cv_working_krb5=yes],[squid_cv_working_krb5=no],[:])])
+  SQUID_STATE_ROLLBACK(squid_krb5_test)
+  AS_IF([test "x$squid_cv_working_krb5" = "xyes"],[
+    AC_DEFINE(HAVE_KRB5,1,[KRB5 support])
+  ],[test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "(-)L"` -gt 0],[
+    AC_MSG_NOTICE([Check Runtime library path !])
+  ])
+])
 
 dnl check the max skew in the krb5 context, and sets squid_cv_max_skew_context
 AC_DEFUN([SQUID_CHECK_MAX_SKEW_IN_KRB5_CONTEXT],[
@@ -226,30 +240,6 @@ gss_OID gss_mech_spnego = &_gss_mech_spnego;
   [ squid_cv_have_spnego=yes ], [ squid_cv_have_spnego=no ],[:])])
 ])
 
-dnl checks that krb5 is functional. Sets squid_cv_working_krb5
-AC_DEFUN([SQUID_CHECK_WORKING_KRB5],[
-  AC_CACHE_CHECK([for working krb5], squid_cv_working_krb5, [
-    SQUID_STATE_SAVE(squid_krb5_test)
-    CPPFLAGS="-I${srcdir:-.} $CPPFLAGS"
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include "compat/krb5.h"
-int
-main(void)
-{
-        krb5_context context;
-
-        krb5_init_context(&context);
-
-        return 0;
-}
-  ]])], [ squid_cv_working_krb5=yes ], [ squid_cv_working_krb5=no ],[:])])
-  SQUID_STATE_ROLLBACK(squid_krb5_test)
-  AS_IF([test "x$squid_cv_working_krb5" = "xno" -a `echo $LIBS | grep -i -c "(-)L"` -gt 0],[
-    AC_MSG_NOTICE([Check Runtime library path !])
-  ])
-])
-
-
 dnl checks for existence of krb5 functions
 AC_DEFUN([SQUID_CHECK_KRB5_FUNCS],[
 
@@ -346,8 +336,5 @@ AC_DEFUN([SQUID_CHECK_KRB5_FUNCS],[
 
   SQUID_CHECK_SPNEGO_SUPPORT
   SQUID_DEFINE_BOOL(HAVE_SPNEGO,$squid_cv_have_spnego,[SPNEGO support])
-
-  SQUID_CHECK_WORKING_KRB5
-  SQUID_DEFINE_BOOL(HAVE_KRB5,$squid_cv_working_krb5,[KRB5 support])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1331,6 +1331,7 @@ AS_IF([test "x$with_mit_krb5" != "xno" -a "x$with_solaris_krb5" != "xyes"],[
     AC_CHECK_HEADERS(krb5.h com_err.h et/com_err.h)
     AC_CHECK_HEADERS(profile.h)
 
+    SQUID_CHECK_WORKING_KRB5($KRB5_FLAVOUR)
     SQUID_CHECK_KRB5_FUNCS
   ])
   AS_IF([test "x$with_mit_krb5" = "xyes" -a "x$KRB5LIBS" = "x"],[
@@ -1404,14 +1405,7 @@ AS_IF([test "x$with_solaris_krb5" = "xyes" -a "x$KRB5LIBS" = "x"],[
     AC_CHECK_HEADERS(gssapi/gssapi.h gssapi/gssapi_ext.h)
     AC_CHECK_HEADERS(krb5.h com_err.h)
 
-    SQUID_CHECK_KRB5_SOLARIS_BROKEN_KRB5_H
-    AS_IF([test "x$squid_cv_broken_krb5_h" = "xyes"],[
-      AC_DEFINE(HAVE_BROKEN_SOLARIS_KRB5_H, 1, [Define to 1 if Solaris krb5.h is broken for C++])
-      AC_MSG_WARN([You have a broken Solaris <krb5.h> system include.])
-      AC_MSG_WARN([Please see http://bugs.opensolaris.org/bugdatabase/view_bug.do?bug_id=6837512])
-      AC_MSG_WARN([If you need Kerberos support you will have to patch])
-      AC_MSG_WARN([your system. See contrib/solaris/solaris-krb5-include.patch])
-    ])
+    SQUID_CHECK_WORKING_KRB5($KRB5_FLAVOUR)
     SQUID_CHECK_KRB5_FUNCS
   ])
   AS_IF([test "x$with_mit_krb5" = "xyes" -a "x$KRB5LIBS" = "x"],[
@@ -1555,10 +1549,7 @@ AS_IF([test "x$with_heimdal_krb5" != "xno" -a "x$KRB5LIBS" = "x"],[
     AC_CHECK_HEADERS(gssapi.h gssapi/gssapi.h gssapi/gssapi_krb5.h)
     AC_CHECK_HEADERS(krb5.h com_err.h et/com_err.h)
 
-    SQUID_CHECK_KRB5_HEIMDAL_BROKEN_KRB5_H
-    AS_IF([test "x$squid_cv_broken_heimdal_krb5_h" = "xyes"],[
-      AC_DEFINE(HAVE_BROKEN_HEIMDAL_KRB5_H, 1, [Define to 1 if Heimdal krb5.h is broken for C++])
-    ])
+    SQUID_CHECK_WORKING_KRB5($KRB5_FLAVOUR)
     SQUID_CHECK_KRB5_FUNCS
   ])
   AS_IF([test "x$KRB5LIBS" = "x"],[
@@ -1610,7 +1601,7 @@ AS_IF([test "x$with_gnugss" != "xno" -a "x$KRB5LIBS" = "x"],[
     SQUID_CHECK_SPNEGO_SUPPORT
     SQUID_DEFINE_BOOL(HAVE_SPNEGO,$squid_cv_have_spnego,[SPNEGO support])
 
-    SQUID_CHECK_WORKING_KRB5
+    SQUID_CHECK_WORKING_KRB5($KRB5_FLAVOUR)
     SQUID_DEFINE_BOOL(HAVE_KRB5,$squid_cv_working_krb5,[KRB5 support])
   ])
   AS_IF([test "x$KRB5LIBS" = "x"],[


### PR DESCRIPTION
These checks test whether the library chosen is able to be used
without any specific features Squid may have workarounds for.

Take advantage of AC_CACHE better to enable reentrant macros
instead of requiring order-specific calls and update to use the
simpler AC_LANG_PROGRAM macro.

Now that they are reentrant shuffle library-specific brokenness
checks inside SQUID_CHECK_WORKING_KRB5 macro and set the
relevant AC_DEFINE as-needed instead of in callers.