### PR TITLE
Avoid negative test-builds.sh results due to lack of LDAP

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -105,7 +105,6 @@ jobs:
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 install libtool-bin
           sudo apt-get --quiet=2 install libcppunit-dev
-          sudo apt-get --quiet=2 install libldap2-dev
           # TODO: Add some deb-src URI to sources.list and do build-dep
           # instead of the above installs?
           # sudo apt-get --quiet=2 build-dep squid

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -48,6 +48,7 @@ MAKETEST="distcheck"
 #   --with-gnugss \
 #   --with-heimdal-krb5 \
 #   --with-mit-krb5 \
+#   --with-ldap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
 #
@@ -111,7 +112,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-gnu-ld \
 	--with-ipv6-split-stack \
 	--with-large-files \
-	--with-ldap \
 	--with-pic \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -37,6 +37,7 @@ MAKETEST="distcheck"
 #   --with-gnugss \
 #   --with-heimdal-krb5 \
 #   --with-mit-krb5 \
+#   --with-ldap \
 #
 #	Following features require special support from other optional packages.
 #	We can't test them automatically everywhere without detecting those
@@ -113,7 +114,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-gnu-ld \
 	--with-ipv6-split-stack \
 	--with-large-files \
-	--with-ldap \
 	--with-pic \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -37,7 +37,6 @@ MAKETEST="distcheck"
 #   --with-gnugss \
 #   --with-heimdal-krb5 \
 #   --with-mit-krb5 \
-#   --with-ldap \
 #
 #	Following features require special support from other optional packages.
 #	We can't test them automatically everywhere without detecting those
@@ -48,6 +47,7 @@ MAKETEST="distcheck"
 #   --enable-kqueue \
 #   --enable-win32-service \
 #   --with-valgrind-debug \
+#   --with-ldap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
 #


### PR DESCRIPTION
    TESTING: layer-02-maximus
    BUILD: test-suite/buildtests/layer-02-maximus.opts
    configure: error: Required library ldap not found

Broken by commit 0d57ed2.
