### PR TITLE
Bug 5241: Block to-localhost, to-link-local requests by default

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1071,9 +1071,9 @@ DEFAULT: all src all
 DEFAULT: manager url_regex -i ^cache_object:// +i ^[^:]+://[^/]+/squid-internal-mgr/
 DEFAULT: localhost src 127.0.0.1/32 ::1
 DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1/128 ::/128
-DEFAULT: to_APIPA dst 169.254.0.0/16
+DEFAULT: to_linklocal dst 169.254.0.0/16
 DEFAULT: CONNECT method CONNECT
-DEFAULT_DOC: ACLs all, manager, localhost, to_localhost, to_APIPA, and CONNECT are predefined.
+DEFAULT_DOC: ACLs all, manager, localhost, to_localhost, to_linklocal, and CONNECT are predefined.
 DOC_START
 	Defining an Access List
 
@@ -1897,9 +1897,9 @@ http_access deny manager
 # assume that only local users can access them at "localhost" ports.
 http_access deny to_localhost
 
-# Protect cloud servers that often provide local users with sensitive info
-# about their server via certain well-known APIPA link-local addresses.
-http_access deny to_APIPA
+# Protect cloud servers that provide local users with sensitive info about
+# their server via certain well-known link-local (a.k.a. APIPA) addresses.
+http_access deny to_linklocal
 
 #
 # INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1071,8 +1071,9 @@ DEFAULT: all src all
 DEFAULT: manager url_regex -i ^cache_object:// +i ^[^:]+://[^/]+/squid-internal-mgr/
 DEFAULT: localhost src 127.0.0.1/32 ::1
 DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1/128 ::/128
+DEFAULT: to_APIPA dst 169.254.0.0/16
 DEFAULT: CONNECT method CONNECT
-DEFAULT_DOC: ACLs all, manager, localhost, to_localhost, and CONNECT are predefined.
+DEFAULT_DOC: ACLs all, manager, localhost, to_localhost, to_APIPA, and CONNECT are predefined.
 DOC_START
 	Defining an Access List
 
@@ -1892,10 +1893,13 @@ http_access deny CONNECT !SSL_ports
 http_access allow localhost manager
 http_access deny manager
 
-# We strongly recommend the following be uncommented to protect innocent
-# web applications running on the proxy server who think the only
-# one who can access services on "localhost" is a local user
-#http_access deny to_localhost
+# Protect web applications running on the same server as Squid. They often
+# assume that only local users can access them at "localhost" ports.
+http_access deny to_localhost
+
+# Protect cloud servers that often provide local users with sensitive info
+# about their server via certain well-known APIPA link-local addresses.
+http_access deny to_APIPA
 
 #
 # INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1071,7 +1071,7 @@ DEFAULT: all src all
 DEFAULT: manager url_regex -i ^cache_object:// +i ^[^:]+://[^/]+/squid-internal-mgr/
 DEFAULT: localhost src 127.0.0.1/32 ::1
 DEFAULT: to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1/128 ::/128
-DEFAULT: to_linklocal dst 169.254.0.0/16
+DEFAULT: to_linklocal dst 169.254.0.0/16 fe80::/10
 DEFAULT: CONNECT method CONNECT
 DEFAULT_DOC: ACLs all, manager, localhost, to_localhost, to_linklocal, and CONNECT are predefined.
 DOC_START


### PR DESCRIPTION
Squid suggested blocking to-localhost access since 2001 commit 4cc6eb1.
At that time, the default was not adjusted because some use cases were
known to require to-localhost access. However, the existence of special
cases should not affect defaults! The _default_ configuration should
either block all traffic or only allow traffic that is unlikely to
introduce new attack vectors into the network.

Also block to-link-local traffic (by default), for very similar reasons:
Popular cloud services use well-known IPv4 link-local (i.e. RFC 3927)
addresses (a.k.a. APIPA), to provide sensitive instance metadata
information, via HTTP, to instance users and scripts. Given cloud
popularity, those special addresses become nearly as ubiquitous as
127.0.0.1. Cloud provider networks shield metadata services from
external accesses, but proxies like Squid that forward external HTTP
requests may circumvent that protection.
