### PR TITLE
Fix ./configure detection of various LDAP functions

### DIFF
--- a/acinclude/ldap.m4
+++ b/acinclude/ldap.m4
@@ -85,13 +85,13 @@ AC_DEFUN([SQUID_CHECK_LDAP_API],[
   AC_CHECK_LIB(ldap,[ldapssl_client_init],[
     AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
   ])
-  AC_CHECK_LIB($LIBLDAP_LIBS,[ldap_url_desc2str],[
+  AC_CHECK_LIB(ldap,[ldap_url_desc2str],[
     AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
   ])
-  AC_CHECK_LIB($LIBLDAP_LIBS,[ldap_url_parse],[
+  AC_CHECK_LIB(ldap,[ldap_url_parse],[
     AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
   ])
-  AC_CHECK_LIB($LIBLDAP_LIBS,[ldap_start_tls_s],[
+  AC_CHECK_LIB(ldap,[ldap_start_tls_s],[
     AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
   ])
   SQUID_STATE_ROLLBACK(squid_ldap_state)

--- a/acinclude/ldap.m4
+++ b/acinclude/ldap.m4
@@ -85,6 +85,8 @@ AC_DEFUN([SQUID_CHECK_LDAP_API],[
   AC_CHECK_LIB(ldap,[ldapssl_client_init],[
     AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
   ])
+  dnl Extract library names for AC_SEARCH_LIBS() to iterate.
+  LIBLDAP_NAMES="`echo "$LIBLDAP_LIBS" | sed -e 's/-l//g'`"
   dnl If a AC_SEARCH_LIBS() finds a required library X then subsequent calls
   dnl may produce a misleading "none required" result for the same library X
   dnl because the first successful search adds -lX to LIBS.

--- a/acinclude/ldap.m4
+++ b/acinclude/ldap.m4
@@ -88,13 +88,13 @@ AC_DEFUN([SQUID_CHECK_LDAP_API],[
   dnl If a AC_SEARCH_LIBS() finds a required library X then subsequent calls
   dnl may produce a misleading "none required" result for the same library X
   dnl because the first successful search adds -lX to LIBS.
-  AC_SEARCH_LIBS([ldap_url_desc2str],[$LIBLBER_NAME ldap],[
+  AC_SEARCH_LIBS([ldap_url_desc2str],[$LIBLDAP_NAMES],[
     AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
   ])
-  AC_SEARCH_LIBS([ldap_url_parse],[$LIBLBER_NAME ldap],[
+  AC_SEARCH_LIBS([ldap_url_parse],[$LIBLDAP_NAMES],[
     AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
   ])
-  AC_SEARCH_LIBS([ldap_start_tls_s],[$LIBLBER_NAME ldap],[
+  AC_SEARCH_LIBS([ldap_start_tls_s],[$LIBLDAP_NAMES],[
     AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
   ])
   SQUID_STATE_ROLLBACK(squid_ldap_state)

--- a/acinclude/ldap.m4
+++ b/acinclude/ldap.m4
@@ -85,13 +85,16 @@ AC_DEFUN([SQUID_CHECK_LDAP_API],[
   AC_CHECK_LIB(ldap,[ldapssl_client_init],[
     AC_DEFINE(HAVE_LDAPSSL_CLIENT_INIT,1,[Define to 1 if you have ldapssl_client_init])
   ])
-  AC_CHECK_LIB(ldap,[ldap_url_desc2str],[
+  dnl If a AC_SEARCH_LIBS() finds a required library X then subsequent calls
+  dnl may produce a misleading "none required" result for the same library X
+  dnl because the first successful search adds -lX to LIBS.
+  AC_SEARCH_LIBS([ldap_url_desc2str],[$LIBLBER_NAME ldap],[
     AC_DEFINE(HAVE_LDAP_URL_DESC2STR,1,[Define to 1 if you have ldap_url_desc2str])
   ])
-  AC_CHECK_LIB(ldap,[ldap_url_parse],[
+  AC_SEARCH_LIBS([ldap_url_parse],[$LIBLBER_NAME ldap],[
     AC_DEFINE(HAVE_LDAP_URL_PARSE,1,[Define to 1 if you have ldap_url_parse])
   ])
-  AC_CHECK_LIB(ldap,[ldap_start_tls_s],[
+  AC_SEARCH_LIBS([ldap_start_tls_s],[$LIBLBER_NAME ldap],[
     AC_DEFINE(HAVE_LDAP_START_TLS_S,1,[Define to 1 if you have ldap_start_tls_s])
   ])
   SQUID_STATE_ROLLBACK(squid_ldap_state)

--- a/configure.ac
+++ b/configure.ac
@@ -1634,37 +1634,21 @@ AS_IF([test "x$with_ldap" != "xno"],[
   dnl only with Windows LDAP libraries using -lwldap32
   AS_IF([test "$squid_host_os" = "mingw"],[
     LIBLDAP_LIBS="-lwldap32"
-    LIBLDAP_NAMES="wldap32"
   ],[
     SQUID_STATE_SAVE(squid_ldap_state)
     LIBS="$LIBLDAP_PATH $LIBPTHREADS $LIBS"
     PKG_CHECK_MODULES([LIBLDAP],[ldap],[],[
-      AC_CHECK_LIB(lber, ber_init, [
-        LIBLBER_NAMES="lber";
-        LIBLBER_LIBS="-llber"
-      ])
-      AC_CHECK_LIB(ldap, ldap_init, [
-        LIBLDAP_LIBS="-lldap $LIBLBER_LIBS"
-        LIBLDAP_NAMES="ldap $LIBLBER_NAMES"
-      ])
+      AC_CHECK_LIB(lber, ber_init, [LIBLBER="-llber"])
+      AC_CHECK_LIB(ldap, ldap_init, [LIBLDAP_LIBS="-lldap $LIBLBER"])
       dnl if no ldap lib found check for mozilla version
       AS_IF([test "x$ac_cv_lib_ldap_ldap_init" != "xyes"],[
         SQUID_STATE_SAVE(squid_ldap_mozilla)
         LIBS="$LIBLDAP_PATH $LIBPTHREADS"
-        AC_CHECK_LIB(ldap60, ldap_init, [
-          LIBLDAP_LIBS="-lldap60 $LIBLBER_LIBS"
-          LIBLDAP_NAMES="ldap60 $LIBLBER_NAMES"
-        ])
+        AC_CHECK_LIB(ldap60, ldap_init, [LIBLDAP_LIBS="-lldap60 $LIBLBER"])
         LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
-        AC_CHECK_LIB(prldap60, prldap_init, [
-          LIBLDAP_LIBS="-lprldap60 $LIBLDAP_LIBS"
-          LIBLDAP_NAMES="prldap60 $LIBLDAP_NAMES"
-        ])
+        AC_CHECK_LIB(prldap60, prldap_init, [LIBLDAP_LIBS="-lprldap60 $LIBLDAP_LIBS"])
         LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
-        AC_CHECK_LIB(ssldap60, ldapssl_init, [
-          LIBLDAP_LIBS="-lssldap60 $LIBLDAP_LIBS"
-          LIBLDAP_NAMES="ssldap60 $LIBLDAP_NAMES"
-        ])
+        AC_CHECK_LIB(ssldap60, ldapssl_init, [LIBLDAP_LIBS="-lssldap60 $LIBLDAP_LIBS"])
         SQUID_STATE_ROLLBACK(squid_ldap_mozilla)
       ])
     ])

--- a/configure.ac
+++ b/configure.ac
@@ -1634,21 +1634,37 @@ AS_IF([test "x$with_ldap" != "xno"],[
   dnl only with Windows LDAP libraries using -lwldap32
   AS_IF([test "$squid_host_os" = "mingw"],[
     LIBLDAP_LIBS="-lwldap32"
+    LIBLDAP_NAMES="wldap32"
   ],[
     SQUID_STATE_SAVE(squid_ldap_state)
     LIBS="$LIBLDAP_PATH $LIBPTHREADS $LIBS"
     PKG_CHECK_MODULES([LIBLDAP],[ldap],[],[
-      AC_CHECK_LIB(lber, ber_init, [LIBLBER_NAME="lber"; LIBLBER_LIBS="-l$LIBLBER_NAME"])
-      AC_CHECK_LIB(ldap, ldap_init, [LIBLDAP_LIBS="-lldap $LIBLBER_LIBS"])
+      AC_CHECK_LIB(lber, ber_init, [
+        LIBLBER_NAMES="lber";
+        LIBLBER_LIBS="-llber"
+      ])
+      AC_CHECK_LIB(ldap, ldap_init, [
+        LIBLDAP_LIBS="-lldap $LIBLBER_LIBS"
+        LIBLDAP_NAMES="ldap $LIBLBER_NAMES"
+      ])
       dnl if no ldap lib found check for mozilla version
       AS_IF([test "x$ac_cv_lib_ldap_ldap_init" != "xyes"],[
         SQUID_STATE_SAVE(squid_ldap_mozilla)
         LIBS="$LIBLDAP_PATH $LIBPTHREADS"
-        AC_CHECK_LIB(ldap60, ldap_init, [LIBLDAP_LIBS="-lldap60 $LIBLBER_LIBS"])
+        AC_CHECK_LIB(ldap60, ldap_init, [
+          LIBLDAP_LIBS="-lldap60 $LIBLBER_LIBS"
+          LIBLDAP_NAMES="ldap60 $LIBLBER_NAMES"
+        ])
         LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
-        AC_CHECK_LIB(prldap60, prldap_init, [LIBLDAP_LIBS="-lprldap60 $LIBLDAP_LIBS"])
+        AC_CHECK_LIB(prldap60, prldap_init, [
+          LIBLDAP_LIBS="-lprldap60 $LIBLDAP_LIBS"
+          LIBLDAP_NAMES="prldap60 $LIBLDAP_NAMES"
+        ])
         LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
-        AC_CHECK_LIB(ssldap60, ldapssl_init, [LIBLDAP_LIBS="-lssldap60 $LIBLDAP_LIBS"])
+        AC_CHECK_LIB(ssldap60, ldapssl_init, [
+          LIBLDAP_LIBS="-lssldap60 $LIBLDAP_LIBS"
+          LIBLDAP_NAMES="ssldap60 $LIBLDAP_NAMES"
+        ])
         SQUID_STATE_ROLLBACK(squid_ldap_mozilla)
       ])
     ])

--- a/configure.ac
+++ b/configure.ac
@@ -1638,13 +1638,13 @@ AS_IF([test "x$with_ldap" != "xno"],[
     SQUID_STATE_SAVE(squid_ldap_state)
     LIBS="$LIBLDAP_PATH $LIBPTHREADS $LIBS"
     PKG_CHECK_MODULES([LIBLDAP],[ldap],[],[
-      AC_CHECK_LIB(lber, ber_init, [LIBLBER="-llber"])
-      AC_CHECK_LIB(ldap, ldap_init, [LIBLDAP_LIBS="-lldap $LIBLBER"])
+      AC_CHECK_LIB(lber, ber_init, [LIBLBER_NAME="lber"; LIBLBER_LIBS="-l$LIBLBER_NAME"])
+      AC_CHECK_LIB(ldap, ldap_init, [LIBLDAP_LIBS="-lldap $LIBLBER_LIBS"])
       dnl if no ldap lib found check for mozilla version
       AS_IF([test "x$ac_cv_lib_ldap_ldap_init" != "xyes"],[
         SQUID_STATE_SAVE(squid_ldap_mozilla)
         LIBS="$LIBLDAP_PATH $LIBPTHREADS"
-        AC_CHECK_LIB(ldap60, ldap_init, [LIBLDAP_LIBS="-lldap60 $LIBLBER"])
+        AC_CHECK_LIB(ldap60, ldap_init, [LIBLDAP_LIBS="-lldap60 $LIBLBER_LIBS"])
         LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"
         AC_CHECK_LIB(prldap60, prldap_init, [LIBLDAP_LIBS="-lprldap60 $LIBLDAP_LIBS"])
         LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS $LIBPTHREADS"


### PR DESCRIPTION
Commit 0d57ed2 started using $LIBLDAP_LIBS as AC_CHECK_LIB() argument,
but that does not work because AC_CHECK_LIB() expects a library name (X)
rather than a linker option (-lX). The macro adds a "-l" prefix itself:

    checking for ldap_url_desc2str in -l-lldap -llber... no
    checking for ldap_url_parse in -l-lldap -llber... no
    checking for ldap_start_tls_s in -l-lldap -llber... no
