### PR TITLE
Bug 5241: Block all non-localhost requests by default

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1893,6 +1893,15 @@ http_access deny CONNECT !SSL_ports
 http_access allow localhost manager
 http_access deny manager
 
+# This default configuration only allows localhost requests because a more
+# permissive Squid installation could introduce new attack vectors into the
+# network by proxying external TCP connections to unprotected services.
+http_access allow localhost
+
+# The two deny rules below are unnecessary in this default configuration
+# because they are followed by a "deny all" rule. However, they may become
+# critically important when you start allowing external requests below them.
+
 # Protect web applications running on the same server as Squid. They often
 # assume that only local users can access them at "localhost" ports.
 http_access deny to_localhost
@@ -1904,12 +1913,6 @@ http_access deny to_linklocal
 #
 # INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
 #
-
-# Example rule allowing access from your local networks.
-# Adapt localnet in the ACL section to list your (internal) IP networks
-# from where browsing should be allowed
-http_access allow localnet
-http_access allow localhost
 
 # And finally deny all other access to this proxy
 http_access deny all


### PR DESCRIPTION
This change goes one step further than commit 6d2f8ed in satisfying the
same "by default, introduce no new attack vectors" principle.

Commit 6d2f8ed blocked access to localhost and to-link-local services
but still allowed access to potentially vulnerable popular cloud
instance metadata services running on site-local IPv6 addresses. It also
still allowed external access to localnet services that could be
completely unprepared for such dangers! This change closes those holes.

This default configuration has two extra deny rules. These rules become
necessary only when the admin adds an "http_access allow" rule below
them. We enabled these rules despite their overheads, including more DNS
queries in some environments, so that the admin does not have to
remember to enable them when following our "INSERT...HERE" instructions.
