### PR TITLE
Cleanup IPC queue classes

### DIFF
--- a/src/ipc/Queue.cc
+++ b/src/ipc/Queue.cc
@@ -68,10 +68,9 @@ Ipc::OneToOneUniQueue::OneToOneUniQueue(const unsigned int aMaxItemSize, const i
     Must(theCapacity > 0);
 }
 
-int
-Ipc::OneToOneUniQueue::Items2Bytes(const unsigned int maxItemSize, const int size)
+size_t
+Ipc::OneToOneUniQueue::Items2Bytes(const size_t maxItemSize, const size_t size)
 {
-    assert(size >= 0);
     return sizeof(OneToOneUniQueue) + maxItemSize * size;
 }
 
@@ -112,7 +111,7 @@ Ipc::OneToOneUniQueues::sharedMemorySize() const
 size_t
 Ipc::OneToOneUniQueues::SharedMemorySize(const int capacity, const unsigned int maxItemSize, const int queueCapacity)
 {
-    const int queueSize =
+    const auto queueSize =
         OneToOneUniQueue::Items2Bytes(maxItemSize, queueCapacity);
     return sizeof(OneToOneUniQueues) + queueSize * capacity;
 }

--- a/src/ipc/Queue.cc
+++ b/src/ipc/Queue.cc
@@ -69,14 +69,6 @@ Ipc::OneToOneUniQueue::OneToOneUniQueue(const unsigned int aMaxItemSize, const i
 }
 
 int
-Ipc::OneToOneUniQueue::Bytes2Items(const unsigned int maxItemSize, int size)
-{
-    assert(maxItemSize > 0);
-    size -= sizeof(OneToOneUniQueue);
-    return size >= 0 ? size / maxItemSize : 0;
-}
-
-int
 Ipc::OneToOneUniQueue::Items2Bytes(const unsigned int maxItemSize, const int size)
 {
     assert(size >= 0);

--- a/src/ipc/Queue.cc
+++ b/src/ipc/Queue.cc
@@ -52,20 +52,8 @@ Ipc::QueueReader::QueueReader(): popBlocked(false), popSignal(false),
 
 /* QueueReaders */
 
-Ipc::QueueReaders::QueueReaders(const int aCapacity): theCapacity(aCapacity),
-    theReaders(theCapacity)
-{
-    Must(theCapacity > 0);
-}
-
 size_t
-Ipc::QueueReaders::sharedMemorySize() const
-{
-    return SharedMemorySize(theCapacity);
-}
-
-size_t
-Ipc::QueueReaders::SharedMemorySize(const int capacity)
+Ipc::QueueReaders::SharedMemorySize(const size_t capacity)
 {
     return sizeof(QueueReaders) + sizeof(QueueReader) * capacity;
 }
@@ -238,7 +226,7 @@ Ipc::FewToFewBiQueue::FewToFewBiQueue(const String &id, const Group aLocalGroup,
     theLocalGroup(aLocalGroup)
 {
     Must(queues->theCapacity == metadata->theGroupASize * metadata->theGroupBSize * 2);
-    Must(readers->theCapacity == metadata->theGroupASize + metadata->theGroupBSize);
+    Must(readers->theCapacity == size_t(metadata->theGroupASize) + size_t(metadata->theGroupBSize));
 
     debugs(54, 7, "queue " << id << " reader: " << localReader().id);
 }
@@ -377,7 +365,7 @@ Ipc::MultiQueue::MultiQueue(const String &id, const int localProcessId):
     readers(shm_old(QueueReaders)(ReadersId(id).termedBuf()))
 {
     Must(queues->theCapacity == metadata->theProcessCount * metadata->theProcessCount);
-    Must(readers->theCapacity == metadata->theProcessCount);
+    Must(readers->theCapacity == size_t(metadata->theProcessCount));
 
     debugs(54, 7, "queue " << id << " reader: " << localReader().id);
 }

--- a/src/ipc/Queue.cc
+++ b/src/ipc/Queue.cc
@@ -60,8 +60,8 @@ Ipc::QueueReaders::SharedMemorySize(const size_t capacity)
 
 // OneToOneUniQueue
 
-Ipc::OneToOneUniQueue::OneToOneUniQueue(const unsigned int aMaxItemSize, const int aCapacity):
-    theIn(0), theOut(0), theSize(0), theMaxItemSize(aMaxItemSize),
+Ipc::OneToOneUniQueue::OneToOneUniQueue(const size_t aMaxItemSize, const size_t aCapacity):
+    theSize(0), theMaxItemSize(aMaxItemSize),
     theCapacity(aCapacity)
 {
     Must(theMaxItemSize > 0);

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -98,17 +98,17 @@ public:
     class Full {};
     class ItemTooLarge {};
 
-    OneToOneUniQueue(const unsigned int aMaxItemSize, const int aCapacity);
+    OneToOneUniQueue(const size_t aMaxItemSize, const size_t aCapacity);
 
-    unsigned int maxItemSize() const { return theMaxItemSize; }
-    int size() const { return theSize; }
-    int capacity() const { return theCapacity; }
-    int sharedMemorySize() const { return Items2Bytes(theMaxItemSize, theCapacity); }
+    static size_t Items2Bytes(const size_t maxItemSize, const size_t size);
+
+    size_t maxItemSize() const { return theMaxItemSize; }
+    uint32_t size() const { return theSize; }
+    uint32_t capacity() const { return theCapacity; }
+    size_t sharedMemorySize() const { return Items2Bytes(theMaxItemSize, theCapacity); }
 
     bool empty() const { return !theSize; }
     bool full() const { return theSize == theCapacity; }
-
-    static size_t Items2Bytes(const size_t maxItemSize, const size_t size);
 
     /// returns true iff the value was set; [un]blocks the reader as needed
     template<class Value> bool pop(Value &value, QueueReader *const reader = nullptr);
@@ -132,11 +132,11 @@ private:
 
     // optimization: these non-std::atomic data members are in shared memory,
     // but each is used only by one process (aside from obscured reporting)
-    unsigned int theIn; ///< current push() position; reporting aside, used only in push()
-    unsigned int theOut; ///< current pop() position; reporting aside, used only in pop()/peek()
+    unsigned int theIn = 0; ///< current push() position; reporting aside, used only in push()
+    unsigned int theOut = 0; ///< current pop() position; reporting aside, used only in pop()/peek()
 
     std::atomic<uint32_t> theSize; ///< number of items in the queue
-    const unsigned int theMaxItemSize; ///< maximum item size
+    const size_t theMaxItemSize; ///< maximum item size
     const uint32_t theCapacity; ///< maximum number of items, i.e. theBuffer size
 
     char theBuffer[];

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -108,7 +108,7 @@ public:
     bool empty() const { return !theSize; }
     bool full() const { return theSize == theCapacity; }
 
-    static int Items2Bytes(const unsigned int maxItemSize, const int size);
+    static size_t Items2Bytes(const size_t maxItemSize, const size_t size);
 
     /// returns true iff the value was set; [un]blocks the reader as needed
     template<class Value> bool pop(Value &value, QueueReader *const reader = nullptr);

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -71,11 +71,13 @@ public:
 class QueueReaders
 {
 public:
-    QueueReaders(const int aCapacity);
-    size_t sharedMemorySize() const;
-    static size_t SharedMemorySize(const int capacity);
+    QueueReaders(const size_t n) : theCapacity(n), theReaders(n) {}
 
-    const int theCapacity; /// number of readers
+    static size_t SharedMemorySize(const size_t capacity);
+    size_t sharedMemorySize() const { return SharedMemorySize(theCapacity); }
+
+public:
+    const size_t theCapacity; /// number of readers
     Ipc::Mem::FlexibleArray<QueueReader> theReaders; /// readers
 };
 

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -108,7 +108,6 @@ public:
     bool empty() const { return !theSize; }
     bool full() const { return theSize == theCapacity; }
 
-    static int Bytes2Items(const unsigned int maxItemSize, int size);
     static int Items2Bytes(const unsigned int maxItemSize, const int size);
 
     /// returns true iff the value was set; [un]blocks the reader as needed


### PR DESCRIPTION
sizes should use size_t instead of int or unsigned int.
This should resolve several integer overflow issues
identified by CodeQL static analysis.

Also, small shuffle of declarations to meet squid coding
style guide.