### PR TITLE
Fix milliseconds in certain cache.log messages

### DIFF
--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -49,7 +49,7 @@ Debug::LogMessage(const Context &context)
         return;
 
     fprintf(stderr, "%s| %s\n",
-            "stub time", // debugLogTime(squid_curtime),
+            "stub time", // debugLogTime(current_time),
             context.buf.str().c_str());
 }
 


### PR DESCRIPTION
This change fixes two bugs:

1. The milliseconds part of an early message time was wrong because
   debugLogTime() got it from the current_time global instead of the
   saved message timestamp. This problem probably affected only early
   saved messages in rare situations where current_time was updated
   between message creation and message writing. This fix adjusts
   DebugMessageHeader::timestamp to store message time with microsecond
   precision.

2. Level-0/1 messages that followed same-second level-2+ messages were
   logged with an unwanted (and stale) milliseconds value. This fix
   forces a reset of the message line format buffer in relevant cases.
