### PR TITLE
Mimic GET reforwarding decisions when our CONNECT fails

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1339,7 +1339,7 @@ FwdState::reforward()
 
     const auto s = entry->mem().baseReply().sline.status();
     debugs(17, 3, "status " << s);
-    return reforwardableStatus(s);
+    return Http::IsReforwardableStatus(s);
 }
 
 static void
@@ -1370,32 +1370,6 @@ fwdStats(StoreEntry * s)
 }
 
 /**** STATIC MEMBER FUNCTIONS *************************************************/
-
-bool
-FwdState::reforwardableStatus(const Http::StatusCode s) const
-{
-    switch (s) {
-
-    case Http::scBadGateway:
-
-    case Http::scGatewayTimeout:
-        return true;
-
-    case Http::scForbidden:
-
-    case Http::scInternalServerError:
-
-    case Http::scNotImplemented:
-
-    case Http::scServiceUnavailable:
-        return Config.retry.onerror;
-
-    default:
-        return false;
-    }
-
-    /* NOTREACHED */
-}
 
 void
 FwdState::initModule()

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -85,7 +85,6 @@ public:
 
     void handleUnregisteredServerEnd();
     int reforward();
-    bool reforwardableStatus(const Http::StatusCode s) const;
     void serverClosed();
     void connectStart();
     void connectDone(const Comm::ConnectionPointer & conn, Comm::Flag status, int xerrno);

--- a/src/http.cc
+++ b/src/http.cc
@@ -33,6 +33,7 @@
 #include "http.h"
 #include "http/one/ResponseParser.h"
 #include "http/one/TeChunkedParser.h"
+#include "http/StatusCode.h"
 #include "http/Stream.h"
 #include "HttpControlMsg.h"
 #include "HttpHdrCc.h"
@@ -967,7 +968,7 @@ HttpStateData::haveParsedReplyHeaders()
             // TODO: check whether such responses are shareable.
             // Do not share for now.
             entry->makePrivate(false);
-            if (fwd->reforwardableStatus(rep->sline.status()))
+            if (Http::IsReforwardableStatus(rep->sline.status()))
                 EBIT_SET(entry->flags, ENTRY_FWD_HDR_WAIT);
             varyFailure = true;
         } else {
@@ -986,7 +987,7 @@ HttpStateData::haveParsedReplyHeaders()
          * If its not a reply that we will re-forward, then
          * allow the client to get it.
          */
-        if (fwd->reforwardableStatus(rep->sline.status()))
+        if (Http::IsReforwardableStatus(rep->sline.status()))
             EBIT_SET(entry->flags, ENTRY_FWD_HDR_WAIT);
 
         ReuseDecision decision(entry, statusCode);

--- a/src/http/StatusCode.cc
+++ b/src/http/StatusCode.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "debug/Stream.h"
 #include "http/StatusCode.h"
+#include "SquidConfig.h"
 
 const char *
 Http::StatusCodeString(const Http::StatusCode status)
@@ -276,3 +277,28 @@ Http::StatusCodeString(const Http::StatusCode status)
     return "Unassigned";
 }
 
+bool
+Http::IsReforwardableStatus(const Http::StatusCode s)
+{
+    switch (s) {
+
+    case Http::scBadGateway:
+
+    case Http::scGatewayTimeout:
+        return true;
+
+    case Http::scForbidden:
+
+    case Http::scInternalServerError:
+
+    case Http::scNotImplemented:
+
+    case Http::scServiceUnavailable:
+        return Config.retry.onerror;
+
+    default:
+        return false;
+    }
+
+    /* NOTREACHED */
+}

--- a/src/http/StatusCode.cc
+++ b/src/http/StatusCode.cc
@@ -278,22 +278,18 @@ Http::StatusCodeString(const Http::StatusCode status)
 }
 
 bool
-Http::IsReforwardableStatus(const Http::StatusCode s)
+Http::IsReforwardableStatus(const StatusCode s)
 {
     switch (s) {
 
-    case Http::scBadGateway:
-
-    case Http::scGatewayTimeout:
+    case scBadGateway:
+    case scGatewayTimeout:
         return true;
 
-    case Http::scForbidden:
-
-    case Http::scInternalServerError:
-
-    case Http::scNotImplemented:
-
-    case Http::scServiceUnavailable:
+    case scForbidden:
+    case scInternalServerError:
+    case scNotImplemented:
+    case scServiceUnavailable:
         return Config.retry.onerror;
 
     default:
@@ -302,3 +298,4 @@ Http::IsReforwardableStatus(const Http::StatusCode s)
 
     /* NOTREACHED */
 }
+

--- a/src/http/StatusCode.h
+++ b/src/http/StatusCode.h
@@ -92,8 +92,8 @@ const char *StatusCodeString(const Http::StatusCode status);
 inline bool Is1xx(const int sc) { return scContinue <= sc && sc < scOkay; }
 /// whether this response status code prohibits sending Content-Length
 inline bool ProhibitsContentLength(const StatusCode sc) { return sc == scNoContent || Is1xx(sc); }
-
-bool IsReforwardableStatus(const Http::StatusCode);
+/// whether the response with this status can be retried
+bool IsReforwardableStatus(Http::StatusCode);
 
 } // namespace Http
 

--- a/src/http/StatusCode.h
+++ b/src/http/StatusCode.h
@@ -93,7 +93,7 @@ inline bool Is1xx(const int sc) { return scContinue <= sc && sc < scOkay; }
 /// whether this response status code prohibits sending Content-Length
 inline bool ProhibitsContentLength(const StatusCode sc) { return sc == scNoContent || Is1xx(sc); }
 /// whether the response with this status can be retried
-bool IsReforwardableStatus(Http::StatusCode);
+bool IsReforwardableStatus(StatusCode);
 
 } // namespace Http
 

--- a/src/http/StatusCode.h
+++ b/src/http/StatusCode.h
@@ -92,7 +92,7 @@ const char *StatusCodeString(const Http::StatusCode status);
 inline bool Is1xx(const int sc) { return scContinue <= sc && sc < scOkay; }
 /// whether this response status code prohibits sending Content-Length
 inline bool ProhibitsContentLength(const StatusCode sc) { return sc == scNoContent || Is1xx(sc); }
-/// whether the response with this status can be retried
+/// whether to send the request to another peer based on the current response status code
 bool IsReforwardableStatus(StatusCode);
 
 } // namespace Http

--- a/src/http/StatusCode.h
+++ b/src/http/StatusCode.h
@@ -93,6 +93,8 @@ inline bool Is1xx(const int sc) { return scContinue <= sc && sc < scOkay; }
 /// whether this response status code prohibits sending Content-Length
 inline bool ProhibitsContentLength(const StatusCode sc) { return sc == scNoContent || Is1xx(sc); }
 
+bool IsReforwardableStatus(const Http::StatusCode);
+
 } // namespace Http
 
 #endif /* _SQUID_SRC_HTTP_STATUSCODE_H */

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1407,6 +1407,8 @@ TunnelStateData::usePinned()
         const auto serverConn = ConnStateData::BorrowPinnedConnection(request.getRaw(), al);
         debugs(26, 7, "pinned peer connection: " << serverConn);
 
+        ++n_tries;
+
         // Set HttpRequest pinned related flags for consistency even if
         // they are not really used by tunnel.cc code.
         request->flags.pinned = true;
@@ -1423,7 +1425,7 @@ TunnelStateData::usePinned()
         sendError(error, "pinned path failure");
         return;
     }
-    ++n_tries;
+
 }
 
 CBDATA_CLASS_INIT(TunnelStateData);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1044,7 +1044,7 @@ TunnelStateData::noteConnection(HappyConnOpener::Answer &answer)
 {
     transportWait.finish();
 
-    Must(n_tries <= answer.n_tries); // n_tries cannot decrease
+    Assure(n_tries <= answer.n_tries); // n_tries cannot decrease
     n_tries = answer.n_tries;
 
     ErrorState *error = nullptr;

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -31,6 +31,7 @@
 #include "globals.h"
 #include "HappyConnOpener.h"
 #include "http.h"
+#include "http/StatusCode.h"
 #include "http/Stream.h"
 #include "HttpRequest.h"
 #include "icmp/net_db.h"
@@ -187,6 +188,7 @@ public:
     SBuf preReadServerData;
     time_t startTime; ///< object creation time, before any peer selection/connection attempts
     ResolvedPeersPointer destinations; ///< paths for forwarding the request
+    int n_tries; ///< the number of forwarding attempts so far
     bool destinationsFound; ///< At least one candidate path found
     /// whether another destination may be still attempted if the TCP connection
     /// was unexpectedly closed
@@ -231,6 +233,7 @@ public:
 
     void saveError(ErrorState *finalError);
     void sendError(ErrorState *finalError, const char *reason);
+    void forgetError();
 
 private:
     void usePinned();
@@ -259,6 +262,9 @@ private:
     void deleteThis();
 
     void cancelStep(const char *reason);
+
+    /// whether we have used up all permitted forwarding attempts
+    bool exhaustedTries() const;
 
 public:
     bool keepGoingAfterRead(size_t len, Comm::Flag errcode, int xerrno, Connection &from, Connection &to);
@@ -391,12 +397,18 @@ TunnelStateData::checkRetry()
 {
     if (shutting_down)
         return "shutting down";
+    if (exhaustedTries())
+        return "exhausted tries";
     if (!FwdState::EnoughTimeToReForward(startTime))
         return "forwarding timeout";
     if (!retriable)
         return "not retriable";
     if (noConnections())
         return "no connections";
+    if (destinations->empty() && !PeerSelectionInitiator::subscribed)
+        return "no alternative forwarding paths left";
+    if (!Http::IsReforwardableStatus(Http::StatusCode(al->http.code)))
+        return "status code is not reforwardable";
     return nullptr;
 }
 
@@ -407,15 +419,14 @@ TunnelStateData::retryOrBail(const char *context)
 
     const auto *bailDescription = checkRetry();
     if (!bailDescription) {
-        if (!destinations->empty())
-            return startConnecting(); // try connecting to another destination
-
-        if (subscribed) {
+        if (destinations->empty()) {
+            Assure(subscribed);
             debugs(26, 4, "wait for more destinations to try");
-            return; // expect a noteDestination*() call
+            // expect a noteDestination*() call
+        } else {
+            startConnecting(); // try connecting to another destination
         }
-
-        // fall through to bail
+        return;
     }
 
     /* bail */
@@ -1034,6 +1045,9 @@ TunnelStateData::noteConnection(HappyConnOpener::Answer &answer)
 {
     transportWait.finish();
 
+    Must(n_tries <= answer.n_tries); // n_tries cannot decrease
+    n_tries = answer.n_tries;
+
     ErrorState *error = nullptr;
     if ((error = answer.error.get())) {
         Must(!Comm::IsConnOpen(answer.conn));
@@ -1088,6 +1102,12 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
     else {
         notePeerReadyToShovel(conn);
     }
+}
+
+bool
+TunnelStateData::exhaustedTries() const
+{
+    return n_tries >= Config.forward_max_tries;
 }
 
 void
@@ -1310,6 +1330,13 @@ TunnelStateData::saveError(ErrorState *error)
     savedError = error;
 }
 
+void
+TunnelStateData::forgetError()
+{
+    delete savedError; // may be nil
+    savedError = nullptr;
+}
+
 /// Starts sending the given error message to the client, leading to the
 /// eventual transaction termination. Call with savedError to send savedError.
 void
@@ -1357,8 +1384,10 @@ TunnelStateData::startConnecting()
 
     assert(!destinations->empty());
     assert(!transporting());
+    forgetError();
+    al->http.code = Http::scNone;
     const auto callback = asyncCallback(17, 5, TunnelStateData::noteConnection, this);
-    const auto cs = new HappyConnOpener(destinations, callback, request, startTime, 0, al);
+    const auto cs = new HappyConnOpener(destinations, callback, request, startTime, n_tries, al);
     cs->setHost(request->url.host());
     cs->setRetriable(false);
     cs->allowPersistent(false);
@@ -1392,7 +1421,7 @@ TunnelStateData::usePinned()
         sendError(error, "pinned path failure");
         return;
     }
-
+    ++n_tries;
 }
 
 CBDATA_CLASS_INIT(TunnelStateData);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -263,7 +263,6 @@ private:
 
     void cancelStep(const char *reason);
 
-    /// whether we have used up all permitted forwarding attempts
     bool exhaustedTries() const;
 
 public:
@@ -409,7 +408,7 @@ TunnelStateData::checkRetry()
         return "no alternative forwarding paths left";
     if (!Http::IsReforwardableStatus(Http::StatusCode(al->http.code)))
         return "status code is not reforwardable";
-    // TODO: check whether a pinned connection can be retried
+    // TODO: check pinned connections; see FwdState::pinnedCanRetry()
     return nullptr;
 }
 
@@ -1107,6 +1106,7 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
     }
 }
 
+/// whether we have used up all permitted forwarding attempts
 bool
 TunnelStateData::exhaustedTries() const
 {
@@ -1380,7 +1380,7 @@ TunnelStateData::startConnecting()
 
     assert(!destinations->empty());
     assert(!transporting());
-    delete savedError; // may be nil
+    delete savedError; // may still be nil
     savedError = nullptr;
     al->http.code = Http::scNone;
     const auto callback = asyncCallback(17, 5, TunnelStateData::noteConnection, this);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -406,8 +406,11 @@ TunnelStateData::checkRetry()
         return banRetries;
     if (noConnections())
         return "no connections";
-    if (!Http::IsReforwardableStatus(Http::StatusCode(al->http.code)))
+
+    // TODO: Use Optional for http.code to avoid treating zero code specially.
+    if (al->http.code && !Http::IsReforwardableStatus(Http::StatusCode(al->http.code)))
         return "status code is not reforwardable";
+
     // TODO: check pinned connections; see FwdState::pinnedCanRetry()
     return nullptr;
 }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -188,14 +188,15 @@ public:
     SBuf preReadServerData;
     time_t startTime; ///< object creation time, before any peer selection/connection attempts
     ResolvedPeersPointer destinations; ///< paths for forwarding the request
-    int n_tries; ///< the number of forwarding attempts so far
     bool destinationsFound; ///< At least one candidate path found
-
-    /// a reason to ban reforwarding attempts (or nil)
-    const char *banRetries;
 
     /// whether the decision to tunnel to a particular destination was final
     bool committedToServer;
+
+    int n_tries; ///< the number of forwarding attempts so far
+
+    /// a reason to ban reforwarding attempts (or nil)
+    const char *banRetries;
 
     // TODO: remove after fixing deferred reads in TunnelStateData::copyRead()
     CodeContext::Pointer codeContext; ///< our creator context
@@ -349,8 +350,9 @@ TunnelStateData::TunnelStateData(ClientHttpRequest *clientRequest) :
     startTime(squid_curtime),
     destinations(new ResolvedPeers()),
     destinationsFound(false),
-    banRetries(nullptr),
     committedToServer(false),
+    n_tries(0),
+    banRetries(nullptr),
     codeContext(CodeContext::Current())
 {
     debugs(26, 3, "TunnelStateData constructed this=" << this);

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -966,7 +966,7 @@ TunnelStateData::tunnelEstablishmentDone(Http::TunnelerAnswer &answer)
 
     al->cache.code.update(LOG_TCP_TUNNEL);
 
-    // XXX: al->hier.peer_reply_status (i.e. *status_ptr) should not be (re)set
+    // XXX: al->http.code (i.e. *status_ptr) should not be (re)set
     // until we actually start responding to the client. Right here/now, we only
     // know how this cache_peer has responded to us.
     if (answer.peerResponseStatus != Http::scNone)


### PR DESCRIPTION
Authored-by: Eduard Bagdasaryan <eduard.bagdasaryan@measurement-factory.com>

Use FwdState::reforwardableStatus() logic when deciding whether to
reforward our CONNECT request after a failed tunneling attempt.

Also honor forward_max_tries limit when retrying tunneling attempts.

These TunnelStateData fixes deal with ordinary CONNECT traffic (no
SslBump). FwdState also handles CONNECT requests (with SslBump). We make
that CONNECT handling more consistent across these classes (in addition
to making it more consistent across CONNECT and GET/etc. methods).

Co-authored-by: Alex Rousskov <rousskov@measurement-factory.com>