### PR TITLE
Maintenance: Drop an unused, misleading condition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,9 +55,7 @@ AM_PROG_CC_C_O
 AC_PROG_CXX
 
 # AC_USE_SYSTEM_EXTENSIONS should be called before any macros that run the C compiler.
-AS_IF([test "x$squid_host_os" = "solaris" -a "x$GCC" = "xyes"],[
-  AC_USE_SYSTEM_EXTENSIONS
-])
+AC_USE_SYSTEM_EXTENSIONS
 
 AC_LANG([C++])
 


### PR DESCRIPTION
According to Autoconf NEWS, AC_USE_SYSTEM_EXTENSIONS is defined with
AC_DEFUN_ONCE since Autoconf v2.63b: "This means a subtle change in
semantics; previously, an AC_DEFUN macro could expand [this macro]
multiple times or surround the macro inside shell conditional text to
bypass [its] effects, but now the macro will expand exactly once, and
prior to the start of any enclosing AC_DEFUN macro".

In the generated ./configure script, the if statement no longer had any
code inside it, and AC_USE_SYSTEM_EXTENSIONS was unconditionally
expanded above the if statement.
