### PR TITLE
Do not send self-signed certificates from tls-cert=bundle

### DIFF
--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -50,11 +50,13 @@ Security::KeyData::loadCertificates()
         while (const auto bundledCert = Ssl::ReadOptionalCertificate(bio)) {
             assert(!wireCerts.empty()); // this->cert is there (at least)
 
-            // We cannot chain any certificate after a self-signed certificate. This
-            // check also protects the IssuedBy() check below from adding duplicated
-            // (i.e. listed multiple times in the bundle) self-signed certificates.
-            if (SelfSigned(*wireCerts.back())) {
-                debugs(83, DBG_PARSE_NOTE(2), "WARNING: Ignoring certificate after a self-signed one: " << *bundledCert);
+            // We ignore a self-signed certificate because it should not be
+            // sent: The recipients that do not already have it should not trust
+            // it. This check also protects the IssuedBy() check below from
+            // adding duplicated (i.e. listed multiple times in the bundle)
+            // self-signed signing certificates.
+            if (SelfSigned(*bundledCert)) {
+                debugs(83, DBG_PARSE_NOTE(2), "WARNING: Ignoring self-signed certificate: " << *bundledCert);
                 continue; // ... but keep going to report all ignored certificates
             }
 

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -970,8 +970,15 @@ void
 Ssl::chainCertificatesToSSLContext(Security::ContextPointer &ctx, Security::ServerOptions &options)
 {
     assert(ctx);
+
+    const auto signingCert = options.signingCa.cert.get();
+
+    if (Security::SelfSigned(*signingCert)) {
+        debugs(33, 3, "do not send self-signed certificates via SSL_CTX_add_extra_chain_cert(): " << *signingCert);
+        return;
+    }
+
     // Add signing certificate to the certificates chain
-    X509 *signingCert = options.signingCa.cert.get();
     if (SSL_CTX_add_extra_chain_cert(ctx.get(), signingCert)) {
         // increase the certificate lock
         X509_up_ref(signingCert);


### PR DESCRIPTION
... except the very first/signing certificate itself (if it is
self-signed), of course.

Sending such certificates is pointless: Recipients cannot trust a
received self-signed certificate unless they have already obtained it
from other (trusted) sources. Thus, this change is not expected to
affect any reasonable TLS client implementations (besides reducing noise
on the wire and associated overheads).

Co-authored-by: Christos Tsantilas <christos@chtsanti.net>

