### PR TITLE
Sort CA certificates in tls-cert=bundle

### DIFF
--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -970,6 +970,12 @@ void
 Ssl::chainCertificatesToSSLContext(Security::ContextPointer &ctx, Security::ServerOptions &options)
 {
     assert(ctx);
+
+    if (Security::SelfSigned(*options.signingCa.cert)) {
+        debugs(33, 3, "do not send self-signed certificates via SSL_CTX_add_extra_chain_cert()");
+        return;
+    }
+
     // Add signing certificate to the certificates chain
     X509 *signingCert = options.signingCa.cert.get();
     if (SSL_CTX_add_extra_chain_cert(ctx.get(), signingCert)) {

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -971,11 +971,6 @@ Ssl::chainCertificatesToSSLContext(Security::ContextPointer &ctx, Security::Serv
 {
     assert(ctx);
 
-    if (Security::SelfSigned(*options.signingCa.cert)) {
-        debugs(33, 3, "do not send self-signed certificates via SSL_CTX_add_extra_chain_cert()");
-        return;
-    }
-
     // Add signing certificate to the certificates chain
     X509 *signingCert = options.signingCa.cert.get();
     if (SSL_CTX_add_extra_chain_cert(ctx.get(), signingCert)) {

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -970,7 +970,6 @@ void
 Ssl::chainCertificatesToSSLContext(Security::ContextPointer &ctx, Security::ServerOptions &options)
 {
     assert(ctx);
-
     // Add signing certificate to the certificates chain
     X509 *signingCert = options.signingCa.cert.get();
     if (SSL_CTX_add_extra_chain_cert(ctx.get(), signingCert)) {


### PR DESCRIPTION
... as opposed to requiring the bundle to contain CA certificates in the
correct on-the-wire/issuing order and warning about (and then ignoring)
out-of-order bundled certificates.

This enhancement makes it easier to configure Squid to send the right
intermediate certificates, especially during certificate upgrades when
intermediate certificates (which may be obtained from a source not
tightly coordinated with the signing certificate source) is likely to
contain a mix of old and new intermediate certificates.

Squid has to (and did) check the certificate issuing order anyway. The
new code uses very similar checks to sort intermediate certificates.

No on-the-wire changes expected for Squid configurations that have
correctly ordered certificate bundles. Other configurations may start
sending the previously missing intermediate certificates.
