### PR TITLE
Remove --enable-kill-parent-hack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -960,16 +960,6 @@ SQUID_DEFINE_BOOL(USE_WCCPv2,${enable_wccpv2:=yes},
             [Define to enable WCCP V2])
 AC_MSG_NOTICE([Web Cache Coordination V2 Protocol enabled: $enable_wccpv2])
 
-AC_ARG_ENABLE(kill-parent-hack,
-  AS_HELP_STRING([--enable-kill-parent-hack],[Kill parent on shutdown]), [
-  SQUID_YESNO([$enableval],[--enable-kill-parent-hack])
-])
-SQUID_DEFINE_BOOL(KILL_PARENT_OPT,${enable_kill_parent_hack:=no},
-                   [A dangerous feature which causes Squid to kill its parent
-                    process (presumably the RunCache script) upon receipt
-                    of SIGTERM or SIGINT. Deprecated, Use with caution.])
-AC_MSG_NOTICE([Kill parent on shutdown hack enabled: $enable_kill_parent_hack])
-
 AC_ARG_ENABLE(snmp,
   AS_HELP_STRING([--disable-snmp],[Disable SNMP monitoring support]), [
   SQUID_YESNO([$enableval],[--enable-snmp])

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -126,6 +126,10 @@ This section gives an account of those changes in three categories:
 	<p>This feature has been unreliable for many years. Other tools such as
 	   oprofile provide better tracking and should be used instead.
 
+	<tag>--enable-kill-parent-hack</tag>
+	<p>This feature has been deprecated for years. Other features such as
+	   <em>--foreground</em> command line argument should be used instead.
+
 	<tag>--disable-loadable-modules</tag>
 	<p>This option was performing the same duties as <em>--disable-shared</em>.
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -197,12 +197,6 @@ class SignalEngine: public AsyncEngine
 {
 
 public:
-#if KILL_PARENT_OPT
-    SignalEngine(): parentKillNotified(false) {
-        parentPid = getppid();
-    }
-#endif
-
     virtual int checkEvents(int timeout);
 
 private:
@@ -225,11 +219,6 @@ private:
 
     void doShutdown(time_t wait);
     void handleStoppedChild();
-
-#if KILL_PARENT_OPT
-    bool parentKillNotified;
-    pid_t parentPid;
-#endif
 };
 
 int
@@ -286,23 +275,10 @@ SignalEngine::doShutdown(time_t wait)
     debugs(1, Important(2), "Preparing for shutdown after " << statCounter.client_http.requests << " requests");
     debugs(1, Important(3), "Waiting " << wait << " seconds for active connections to finish");
 
-#if KILL_PARENT_OPT
-    if (!IamMasterProcess() && !parentKillNotified && ShutdownSignal > 0 && parentPid > 1) {
-        debugs(1, DBG_IMPORTANT, "Killing master process, pid " << parentPid);
-        if (kill(parentPid, ShutdownSignal) < 0) {
-            int xerrno = errno;
-            debugs(1, DBG_IMPORTANT, "kill " << parentPid << ": " << xstrerr(xerrno));
-        }
-        parentKillNotified = true;
-    }
-#endif
-
     if (shutting_down) {
-#if !KILL_PARENT_OPT
         // Already a shutdown signal has received and shutdown is in progress.
         // Shutdown as soon as possible.
         wait = 0;
-#endif
     } else {
         shutting_down = 1;
 

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -55,7 +55,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--disable-referer-log \
 	--disable-wccp \
 	--disable-wccpv2 \
-	--disable-kill-parent-hack \
 	--disable-snmp \
 	--disable-cachemgr-hostname \
 	--disable-eui \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -73,7 +73,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--enable-referer-log \
 	--enable-wccp \
 	--enable-wccpv2 \
-	--enable-kill-parent-hack \
 	--enable-snmp \
 	--enable-cachemgr-hostname \
 	--enable-eui \

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -73,7 +73,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--enable-referer-log \
 	--enable-wccp \
 	--enable-wccpv2 \
-	--enable-kill-parent-hack \
 	--enable-snmp \
 	--enable-cachemgr-hostname \
 	--enable-eui \


### PR DESCRIPTION
This feature has been deprecated for some time.

The useful functionality can more safely be implemented in the parent
script by using the --foreground command line option and waiting for
the Squid process to exit.

It has always been labeled dangerous as the parent process can be
PID 1 or some other vital system process than the intended
RunCache script. Currently it breaks SMP support for manually
killing a single worker or disker process.