### PR TITLE
Runner to manage /etc/resolv.conf settings

### DIFF
--- a/src/dns/Makefile.am
+++ b/src/dns/Makefile.am
@@ -14,6 +14,8 @@ libdns_la_SOURCES = \
 	LookupDetails.cc \
 	LookupDetails.h \
 	forward.h \
+	ResolvConf.cc \
+	ResolvConf.h \
 	rfc1035.cc \
 	rfc1035.h \
 	rfc2671.cc \

--- a/src/dns/ResolvConf.cc
+++ b/src/dns/ResolvConf.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "base/PackableStream.h"
+#include "dns/ResolvConf.h"
+#include "tools.h"
+
+Dns::ResolvConf &
+Dns::ResolvConf::Current()
+{
+    static ResolvConf instance;
+    return instance;
+}
+
+void
+Dns::ResolvConf::dump(Packable *e)
+{
+    PackableStream out(*e);
+
+    out << "# DNS configuration from " << _PATH_RESCONF << ":" << std::endl;
+
+    if (options.ndots != 0)
+        out << "#    options ndots:" << options.ndots << std::endl;
+
+    if (!search.empty()) {
+        out << "#    search";
+        for (const auto &tld: search)
+            out << " " << tld;
+        out << std::endl;
+    }
+
+    if (!nameservers.empty()) {
+        for (const auto &ns: nameservers)
+            out << "#    nameserver " << ns << std::endl;
+    }
+    out << std::endl;
+}
+
+void
+Dns::ResolvConf::load()
+{
+#if !_SQUID_WINDOWS_
+    search.clear();
+    nameservers.clear();
+    options.clear();
+
+    // default specified for search list
+    if (auto *t = getMyHostname()) {
+        if ((t = strchr(t, '.')))
+            search.emplace_back(SBuf(t+1));
+    }
+
+    FILE *fp = fopen(_PATH_RESCONF, "r");
+    if (!fp) {
+        int xerrno = errno;
+        debugs(78, DBG_IMPORTANT, "" << _PATH_RESCONF << ": " << xstrerr(xerrno));
+        return;
+    }
+
+    char buf[8196]; // 8KB should be enough
+    while (fgets(buf, sizeof(buf)-1, fp)) {
+        auto *t = strtok(buf, w_space);
+
+        if (!t || *t == '#' || *t == ';')
+            continue; // skip empty or comment lines
+
+        if (strcmp(t, "nameserver") == 0) {
+            if ((t = strtok(nullptr, w_space)))
+                nameservers.emplace_back(SBuf(t));
+
+        } else if (strcmp(t, "domain") == 0) {
+            search.clear();
+            if ((t = strtok(nullptr, w_space)))
+                search.emplace_back(SBuf(t));
+
+        } else if (strcmp(t, "search") == 0) {
+            search.clear();
+            while (t) {
+                if ((t = strtok(nullptr, w_space))) {
+                    search.emplace_back(SBuf(t));
+                }
+            }
+
+        } else if (strcmp(t, "options") == 0) {
+            while (t) {
+                if (!(t = strtok(nullptr, w_space)))
+                    continue;
+
+                if (strncmp(t, "ndots:", 6) == 0) {
+                    options.ndots = atoi(t + 6);
+                    if (options.ndots < 1)
+                        options.ndots = 1;
+                }
+
+                // TODO: add support for timeout:N, attempts:N, edns0, rotate, no-check-names, single-request, use-vc, and no-reload
+
+            }
+        }
+    }
+
+    fclose(fp);
+#endif
+}

--- a/src/dns/ResolvConf.h
+++ b/src/dns/ResolvConf.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef _SQUID_SRC_DNS_RESOLVCONF_H
+#define _SQUID_SRC_DNS_RESOLVCONF_H
+
+#include "base/Packable.h"
+#include "base/RunnersRegistry.h"
+#include "sbuf/List.h"
+
+#if HAVE_RESOLV_H
+#include <resolv.h>
+#endif
+
+namespace Dns
+{
+
+/// system-wide DNS configuration from /etc/resolv.conf
+class ResolvConf : public IndependentRunner
+{
+public:
+    /// there can only be one resolv.conf configuration
+    static ResolvConf &Current();
+
+    /// (re)load settings from /etc/resolv.conf
+    void load();
+
+    void dump(Packable *);
+
+    /* RegisteredRunner API */
+    virtual void startReconfigure() override { load(); }
+
+public:
+    SBufList search;
+    SBufList nameservers;
+
+    class Options {
+    public:
+        /// restore resolv.conf default option values
+        void clear() { *this = Options(); }
+
+    public:
+        int ndots = 0;
+    } options;
+};
+
+} // namespace Dns
+
+#endif /* _SQUID_SRC_DNS_RESOLVCONF_H */

--- a/src/dns/forward.h
+++ b/src/dns/forward.h
@@ -20,6 +20,7 @@ namespace Dns
 {
 
 class LookupDetails;
+class ResolvConf;
 
 void Init(void);
 


### PR DESCRIPTION
Load settings from /etc/resolv.conf before parsing squid.conf.
This allows future use of DNS internal resolver using the OS
configuration before squid.conf directives are known and to
update DNS with "hot" changes of /etc/resolv.conf without a
full reload of squid.conf.

For now though do use use any settings until syncConfig()
merges squid.conf and /etc/resolv.conf settings.

Also, updates CacheManager "config" report to show
/etc/resolv.conf configured values (if any).