### PR TITLE
Move MemPoolMeter into Mem namespace

### DIFF
--- a/src/mem/AllocatorProxy.cc
+++ b/src/mem/AllocatorProxy.cc
@@ -8,6 +8,7 @@
 
 #include "squid.h"
 #include "mem/AllocatorProxy.h"
+#include "mem/Meter.h"
 #include "mem/Pool.h"
 
 void *

--- a/src/mem/AllocatorProxy.cc
+++ b/src/mem/AllocatorProxy.cc
@@ -50,7 +50,7 @@ Mem::AllocatorProxy::zeroBlocks(bool doIt)
     getAllocator()->zeroBlocks(doIt);
 }
 
-MemPoolMeter const &
+Mem::PoolMeter const &
 Mem::AllocatorProxy::getMeter() const
 {
     return getAllocator()->getMeter();

--- a/src/mem/AllocatorProxy.h
+++ b/src/mem/AllocatorProxy.h
@@ -9,8 +9,6 @@
 #ifndef _SQUID_SRC_MEM_ALLOCATORPROXY_H
 #define _SQUID_SRC_MEM_ALLOCATORPROXY_H
 
-#include "mem/Meter.h"
-
 class MemAllocator;
 class MemPoolStats;
 
@@ -45,6 +43,8 @@ class MemPoolStats;
 
 namespace Mem
 {
+
+class PoolMeter;
 
 /**
  * Support late binding of pool type for allocator agnostic classes

--- a/src/mem/AllocatorProxy.h
+++ b/src/mem/AllocatorProxy.h
@@ -9,9 +9,10 @@
 #ifndef _SQUID_SRC_MEM_ALLOCATORPROXY_H
 #define _SQUID_SRC_MEM_ALLOCATORPROXY_H
 
+#include "mem/Meter.h"
+
 class MemAllocator;
 class MemPoolStats;
-class MemPoolMeter;
 
 /**
  * \hideinitializer
@@ -68,7 +69,7 @@ public:
     size_t objectSize() const {return size;}
     char const * objectType() const {return label;}
 
-    MemPoolMeter const &getMeter() const;
+    PoolMeter const &getMeter() const;
 
     /**
      * \param stats Object to be filled with statistical data about pool.

--- a/src/mem/Meter.h
+++ b/src/mem/Meter.h
@@ -48,6 +48,44 @@ private:
     time_t hwater_stamp = 0; ///< timestamp of last high water mark change
 };
 
+/**
+ * Object to track per-pool memory usage (alloc = inuse+idle)
+ */
+class PoolMeter
+{
+public:
+    /// Object to track per-pool cumulative counters
+    struct mgb_t {
+        double count = 0.0;
+        double bytes = 0.0;
+    };
+
+    /// flush counters back to 0, but leave historic peak records
+    void flush() {
+        alloc.flush();
+        inuse.flush();
+        idle.flush();
+        gb_allocated = mgb_t();
+        gb_oallocated = mgb_t();
+        gb_saved = mgb_t();
+        gb_freed = mgb_t();
+    }
+
+    Mem::Meter alloc;
+    Mem::Meter inuse;
+    Mem::Meter idle;
+
+    /** history Allocations */
+    mgb_t gb_allocated;
+    mgb_t gb_oallocated;
+
+    /** account Saved Allocations */
+    mgb_t gb_saved;
+
+    /** account Free calls */
+    mgb_t gb_freed;
+};
+
 } // namespace Mem
 
 #endif /* SQUID_SRC_MEM_METER_H */

--- a/src/mem/Meter.h
+++ b/src/mem/Meter.h
@@ -71,9 +71,9 @@ public:
         gb_freed = mgb_t();
     }
 
-    Mem::Meter alloc;
-    Mem::Meter inuse;
-    Mem::Meter idle;
+    Meter alloc;
+    Meter inuse;
+    Meter idle;
 
     /** history Allocations */
     mgb_t gb_allocated;

--- a/src/mem/Meter.h
+++ b/src/mem/Meter.h
@@ -20,8 +20,6 @@ namespace Mem
 class Meter
 {
 public:
-    Meter() : level(0), hwater_level(0), hwater_stamp(0) {}
-
     /// flush the meter level back to 0, but leave peak records
     void flush() {level=0;}
 
@@ -45,9 +43,9 @@ private:
         }
     }
 
-    ssize_t level;          ///< current level (count or volume)
-    ssize_t hwater_level;   ///< high water mark
-    time_t hwater_stamp;    ///< timestamp of last high water mark change
+    ssize_t level = 0; ///< current level (count or volume)
+    ssize_t hwater_level = 0; ///< high water mark
+    time_t hwater_stamp = 0; ///< timestamp of last high water mark change
 };
 
 } // namespace Mem

--- a/src/mem/Pool.cc
+++ b/src/mem/Pool.cc
@@ -21,7 +21,7 @@
 
 extern time_t squid_curtime;
 
-static MemPoolMeter TheMeter;
+static Mem::PoolMeter TheMeter;
 static MemPoolIterator Iterator;
 static int Pool_id_counter = 0;
 
@@ -131,27 +131,6 @@ MemImplementingAllocator::flushMetersFull()
     getMeter().gb_allocated.bytes = getMeter().gb_allocated.count * obj_size;
     getMeter().gb_saved.bytes = getMeter().gb_saved.count * obj_size;
     getMeter().gb_freed.bytes = getMeter().gb_freed.count * obj_size;
-}
-
-void
-MemPoolMeter::flush()
-{
-    alloc.flush();
-    inuse.flush();
-    idle.flush();
-    gb_allocated.count = 0;
-    gb_allocated.bytes = 0;
-    gb_oallocated.count = 0;
-    gb_oallocated.bytes = 0;
-    gb_saved.count = 0;
-    gb_saved.bytes = 0;
-    gb_freed.count = 0;
-    gb_freed.bytes = 0;
-}
-
-MemPoolMeter::MemPoolMeter()
-{
-    flush();
 }
 
 /*
@@ -332,13 +311,13 @@ MemImplementingAllocator::~MemImplementingAllocator()
     --MemPools::GetInstance().poolCount;
 }
 
-MemPoolMeter const &
+Mem::PoolMeter const &
 MemImplementingAllocator::getMeter() const
 {
     return meter;
 }
 
-MemPoolMeter &
+Mem::PoolMeter &
 MemImplementingAllocator::getMeter()
 {
     return meter;

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -73,43 +73,6 @@ public:
     MemPoolIterator * next;
 };
 
-/**
- \ingroup MemPoolsAPI
- * Object to track per-pool cumulative counters
- */
-class mgb_t
-{
-public:
-    mgb_t() : count(0), bytes(0) {}
-    double count;
-    double bytes;
-};
-
-/**
- \ingroup MemPoolsAPI
- * Object to track per-pool memory usage (alloc = inuse+idle)
- */
-class MemPoolMeter
-{
-public:
-    MemPoolMeter();
-    void flush();
-
-    Mem::Meter alloc;
-    Mem::Meter inuse;
-    Mem::Meter idle;
-
-    /** history Allocations */
-    mgb_t gb_allocated;
-    mgb_t gb_oallocated;
-
-    /** account Saved Allocations */
-    mgb_t gb_saved;
-
-    /** account Free calls */
-    mgb_t gb_freed;
-};
-
 class MemImplementingAllocator;
 
 /// \ingroup MemPoolsAPI
@@ -192,7 +155,7 @@ public:
      */
     virtual int getStats(MemPoolStats * stats, int accumulate = 0) = 0;
 
-    virtual MemPoolMeter const &getMeter() const = 0;
+    virtual Mem::PoolMeter const &getMeter() const = 0;
 
     /**
      * Allocate one element from the pool
@@ -247,8 +210,8 @@ class MemImplementingAllocator : public MemAllocator
 public:
     MemImplementingAllocator(char const *aLabel, size_t aSize);
     virtual ~MemImplementingAllocator();
-    virtual MemPoolMeter const &getMeter() const;
-    virtual MemPoolMeter &getMeter();
+    virtual Mem::PoolMeter const &getMeter() const;
+    virtual Mem::PoolMeter &getMeter();
     virtual void flushMetersFull();
     virtual void flushMeters();
 
@@ -269,7 +232,7 @@ public:
 protected:
     virtual void *allocate() = 0;
     virtual void deallocate(void *, bool aggressive) = 0;
-    MemPoolMeter meter;
+    Mem::PoolMeter meter;
     int memPID;
 public:
     MemImplementingAllocator *next;
@@ -286,7 +249,7 @@ class MemPoolStats
 public:
     MemAllocator *pool;
     const char *label;
-    MemPoolMeter *meter;
+    Mem::PoolMeter *meter;
     int obj_size;
     int chunk_capacity;
     int chunk_size;
@@ -306,7 +269,7 @@ public:
 /// \ingroup MemPoolsAPI
 /// TODO: Classify and add constructor/destructor to initialize properly.
 struct _MemPoolGlobalStats {
-    MemPoolMeter *TheMeter;
+    Mem::PoolMeter *TheMeter;
 
     int tot_pools_alloc;
     int tot_pools_inuse;

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -146,6 +146,8 @@ private:
 class MemAllocator
 {
 public:
+    typedef Mem::PoolMeter PoolMeter; // TODO remove
+
     MemAllocator (char const *aLabel);
     virtual ~MemAllocator() {}
 
@@ -155,7 +157,7 @@ public:
      */
     virtual int getStats(MemPoolStats * stats, int accumulate = 0) = 0;
 
-    virtual Mem::PoolMeter const &getMeter() const = 0;
+    virtual PoolMeter const &getMeter() const = 0;
 
     /**
      * Allocate one element from the pool
@@ -208,10 +210,12 @@ private:
 class MemImplementingAllocator : public MemAllocator
 {
 public:
+    typedef Mem::PoolMeter PoolMeter; // TODO remove
+
     MemImplementingAllocator(char const *aLabel, size_t aSize);
     virtual ~MemImplementingAllocator();
-    virtual Mem::PoolMeter const &getMeter() const;
-    virtual Mem::PoolMeter &getMeter();
+    virtual PoolMeter const &getMeter() const;
+    virtual PoolMeter &getMeter();
     virtual void flushMetersFull();
     virtual void flushMeters();
 
@@ -232,7 +236,7 @@ public:
 protected:
     virtual void *allocate() = 0;
     virtual void deallocate(void *, bool aggressive) = 0;
-    Mem::PoolMeter meter;
+    PoolMeter meter;
     int memPID;
 public:
     MemImplementingAllocator *next;
@@ -247,9 +251,11 @@ public:
 class MemPoolStats
 {
 public:
+    typedef Mem::PoolMeter PoolMeter; // TODO remove
+
     MemAllocator *pool;
     const char *label;
-    Mem::PoolMeter *meter;
+    PoolMeter *meter;
     int obj_size;
     int chunk_capacity;
     int chunk_size;
@@ -269,7 +275,9 @@ public:
 /// \ingroup MemPoolsAPI
 /// TODO: Classify and add constructor/destructor to initialize properly.
 struct _MemPoolGlobalStats {
-    Mem::PoolMeter *TheMeter;
+    typedef Mem::PoolMeter PoolMeter; // TODO remove
+
+    PoolMeter *TheMeter;
 
     int tot_pools_alloc;
     int tot_pools_inuse;

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -17,16 +17,18 @@
 
 class StoreEntry;
 class MemPoolStats;
-class MemPoolMeter;
 
 /// Memory Management
 namespace Mem
 {
+class Meter;
+class PoolMeter;
+
 void Init();
 void Stats(StoreEntry *);
 void CleanIdlePools(void *unused);
 void Report(std::ostream &);
-void PoolReport(const MemPoolStats * mp_st, const MemPoolMeter * AllMeter, std::ostream &);
+void PoolReport(const MemPoolStats *, const PoolMeter *, std::ostream &);
 };
 
 extern const size_t squidSystemPageSize;

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -576,14 +576,12 @@ memFreeBufFunc(size_t size)
     }
 }
 
-/* MemPoolMeter */
-
 void
-Mem::PoolReport(const MemPoolStats * mp_st, const MemPoolMeter * AllMeter, std::ostream &stream)
+Mem::PoolReport(const MemPoolStats * mp_st, const Mem::PoolMeter * AllMeter, std::ostream &stream)
 {
     int excess = 0;
     int needed = 0;
-    MemPoolMeter *pm = mp_st->meter;
+    Mem::PoolMeter *pm = mp_st->meter;
     const char *delim = "\t ";
 
     stream.setf(std::ios_base::fixed);

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -577,11 +577,11 @@ memFreeBufFunc(size_t size)
 }
 
 void
-Mem::PoolReport(const MemPoolStats * mp_st, const Mem::PoolMeter * AllMeter, std::ostream &stream)
+Mem::PoolReport(const MemPoolStats * mp_st, const PoolMeter * AllMeter, std::ostream &stream)
 {
     int excess = 0;
     int needed = 0;
-    Mem::PoolMeter *pm = mp_st->meter;
+    PoolMeter *pm = mp_st->meter;
     const char *delim = "\t ";
 
     stream.setf(std::ios_base::fixed);

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -17,7 +17,7 @@
 void *Mem::AllocatorProxy::alloc() {return xmalloc(64*1024);}
 void Mem::AllocatorProxy::freeOne(void *address) {xfree(address);}
 int Mem::AllocatorProxy::inUseCount() const {return 0;}
-//Mem::PoolMeter const &Mem::AllocatorProxy::getMeter() const STUB_RETSTATREF(Mem::PoolMeter)
+//Mem::PoolMeter const &Mem::AllocatorProxy::getMeter() const STUB_RETSTATREF(PoolMeter)
 int Mem::AllocatorProxy::getStats(MemPoolStats *) STUB_RETVAL(0)
 
 #include "mem/forward.h"
@@ -91,8 +91,8 @@ size_t MemAllocator::RoundedSize(size_t minSize) STUB_RETVAL(minSize)
 
 //MemImplementingAllocator::MemImplementingAllocator(char const *, size_t) STUB_NOP
 //MemImplementingAllocator::~MemImplementingAllocator();
-Mem::PoolMeter const &MemImplementingAllocator::getMeter() const STUB_RETSTATREF(Mem::PoolMeter)
-Mem::PoolMeter &MemImplementingAllocator::getMeter() STUB_RETSTATREF(Mem::PoolMeter)
+Mem::PoolMeter const &MemImplementingAllocator::getMeter() const STUB_RETSTATREF(PoolMeter)
+Mem::PoolMeter &MemImplementingAllocator::getMeter() STUB_RETSTATREF(PoolMeter)
 void MemImplementingAllocator::flushMetersFull() STUB
 void MemImplementingAllocator::flushMeters() STUB
 void *MemImplementingAllocator::alloc() STUB_RETVAL(nullptr)

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -25,7 +25,7 @@ void Mem::Init() STUB_NOP
 void Mem::Stats(StoreEntry *) STUB_NOP
 void Mem::CleanIdlePools(void *) STUB_NOP
 void Mem::Report(std::ostream &) STUB_NOP
-void Mem::PoolReport(const MemPoolStats *, const Mem::PoolMeter *, std::ostream &) STUB_NOP
+void Mem::PoolReport(const MemPoolStats *, const PoolMeter *, std::ostream &) STUB_NOP
 //const size_t squidSystemPageSize = 4096;
 void memClean(void) STUB
 void memInitModule(void) STUB

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -17,8 +17,7 @@
 void *Mem::AllocatorProxy::alloc() {return xmalloc(64*1024);}
 void Mem::AllocatorProxy::freeOne(void *address) {xfree(address);}
 int Mem::AllocatorProxy::inUseCount() const {return 0;}
-//static MemPoolMeter tmpMemPoolMeter;
-//MemPoolMeter const &Mem::AllocatorProxy::getMeter() const STUB_RETVAL(tmpMemPoolMeter)
+//Mem::PoolMeter const &Mem::AllocatorProxy::getMeter() const STUB_RETSTATREF(Mem::PoolMeter)
 int Mem::AllocatorProxy::getStats(MemPoolStats *) STUB_RETVAL(0)
 
 #include "mem/forward.h"
@@ -26,7 +25,7 @@ void Mem::Init() STUB_NOP
 void Mem::Stats(StoreEntry *) STUB_NOP
 void Mem::CleanIdlePools(void *) STUB_NOP
 void Mem::Report(std::ostream &) STUB_NOP
-void Mem::PoolReport(const MemPoolStats *, const MemPoolMeter *, std::ostream &) STUB_NOP
+void Mem::PoolReport(const MemPoolStats *, const Mem::PoolMeter *, std::ostream &) STUB_NOP
 //const size_t squidSystemPageSize = 4096;
 void memClean(void) STUB
 void memInitModule(void) STUB
@@ -77,8 +76,6 @@ void memDataInit(mem_type, const char *, size_t, int, bool) STUB_NOP
 void memCheckInit(void) STUB_NOP
 
 #include "mem/Pool.h"
-MemPoolMeter::MemPoolMeter() STUB_NOP
-void MemPoolMeter::flush() STUB
 static MemPools tmpMemPools;
 MemPools &MemPools::GetInstance() {return tmpMemPools;}
 MemPools::MemPools() STUB_NOP
@@ -94,8 +91,8 @@ size_t MemAllocator::RoundedSize(size_t minSize) STUB_RETVAL(minSize)
 
 //MemImplementingAllocator::MemImplementingAllocator(char const *, size_t) STUB_NOP
 //MemImplementingAllocator::~MemImplementingAllocator();
-MemPoolMeter const &MemImplementingAllocator::getMeter() const STUB_RETSTATREF(MemPoolMeter)
-MemPoolMeter &MemImplementingAllocator::getMeter() STUB_RETSTATREF(MemPoolMeter)
+Mem::PoolMeter const &MemImplementingAllocator::getMeter() const STUB_RETSTATREF(Mem::PoolMeter)
+Mem::PoolMeter &MemImplementingAllocator::getMeter() STUB_RETSTATREF(Mem::PoolMeter)
 void MemImplementingAllocator::flushMetersFull() STUB
 void MemImplementingAllocator::flushMeters() STUB
 void *MemImplementingAllocator::alloc() STUB_RETVAL(nullptr)


### PR DESCRIPTION
Simplified PoolMeter::flush() implementation
and inlined it for performance.

Convert mgb_t type to a sub-struct and inline
C++11 initialization for performance.

Also update Mem::Meter initialization.