### PR TITLE
Remove Mem::Report() and polish memory_pools_limit storage

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2084,6 +2084,7 @@ tests_testHttpReply_SOURCES = \
 	tests/stub_libcomm.cc \
 	tests/stub_liberror.cc \
 	tests/stub_libformat.cc \
+	tests/stub_libmem.cc \
 	tests/stub_libmgr.cc \
 	tests/stub_libsecurity.cc \
 	tests/stub_libsslsquid.cc \
@@ -2113,7 +2114,6 @@ tests_testHttpReply_LDADD=\
 	ip/libip.la \
 	base/libbase.la \
 	ipc/libipc.la \
-	mem/libmem.la \
 	sbuf/libsbuf.la \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \

--- a/src/main.cc
+++ b/src/main.cc
@@ -924,7 +924,6 @@ mainReconfigureFinish(void *)
     CpuAffinityReconfigure();
 
     setUmask(Config.umask);
-    Mem::Report();
     setEffectiveUser();
     Debug::UseCacheLog();
     ipcache_restart();      /* clear stuck entries */
@@ -1558,8 +1557,6 @@ SquidMain(int argc, char **argv)
                    (opt_parse_cfg_only ? " Run squid -k parse and check for errors." : ""));
             parse_err = 1;
         }
-
-        Mem::Report();
 
         if (opt_parse_cfg_only || parse_err > 0)
             return parse_err;

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -131,9 +131,9 @@ public:
      * not strict upper limit, but a hint. When MemPools are over this limit,
      * deallocate attempts to release memory to the system instead of pooling.
      */
-    void setIdleLimit(ssize_t newLimit) {poolIdleLimit = newLimit;}
-    /// \see void setIdleLimit(ssize_t)
-    ssize_t idleLimit() const {return poolIdleLimit;}
+    void setIdleLimit(const ssize_t newLimit) { idleLimit_ = newLimit; }
+    /// \copydoc idleLimit_
+    ssize_t idleLimit() const { return idleLimit_; }
 
     /**
      \par
@@ -170,10 +170,10 @@ public:
     bool defaultIsChunked = false;
 
 private:
-    /// Limit for allocated (but unused) memory in memory pools.
+    /// Limits the cumulative size of allocated (but unused) memory in all pools.
     /// Initial value is 2MB until first configuration,
-    /// \see squid.conf memory_pools_limit directive.
-    ssize_t poolIdleLimit = (2 << 20);
+    /// See squid.conf memory_pools_limit directive.
+    ssize_t idleLimit_ = (2 << 20);
 };
 
 /**

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -129,11 +129,11 @@ public:
     /**
      * Sets upper limit in bytes to amount of free ram kept in pools. This is
      * not strict upper limit, but a hint. When MemPools are over this limit,
-     * totally free chunks are immediately considered for release. Otherwise
-     * only chunks that have not been referenced for a long time are checked.
+     * deallocate attempts to release memory to the system instead of pooling.
      */
-    void setIdleLimit(ssize_t new_idle_limit);
-    ssize_t idleLimit() const;
+    void setIdleLimit(ssize_t newLimit) {poolIdleLimit = newLimit;}
+    /// \see void setIdleLimit(ssize_t)
+    ssize_t idleLimit() const {return poolIdleLimit;}
 
     /**
      \par
@@ -166,9 +166,14 @@ public:
     void setDefaultPoolChunking(bool const &);
 
     MemImplementingAllocator *pools = nullptr;
-    ssize_t mem_idle_limit = (2 << 20) /* 2MB */;
     int poolCount = 0;
     bool defaultIsChunked = false;
+
+private:
+    /// Limit for allocated (but unused) memory in memory pools.
+    /// Initial value is 2MB until first configuration,
+    /// \see squid.conf memory_pools_limit directive.
+    ssize_t poolIdleLimit = (2 << 20);
 };
 
 /**

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -23,7 +23,6 @@ class MemPoolMeter;
 namespace Mem
 {
 void Init();
-void Report();
 void Stats(StoreEntry *);
 void CleanIdlePools(void *unused);
 void Report(std::ostream &);

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -10,7 +10,6 @@
 
 #include "squid.h"
 #include "base/PackableStream.h"
-#include "base/RunnersRegistry.h"
 #include "ClientInfo.h"
 #include "dlink.h"
 #include "event.h"
@@ -456,29 +455,6 @@ Mem::Init(void)
     // finally register with the cache manager
     Mgr::RegisterAction("mem", "Memory Utilization", Mem::Stats, 0, 1);
 }
-
-namespace Mem
-{
-
-static void
-LogPoolSummary()
-{
-    debugs(13, 3, "Memory pools are '" <<
-           (Config.onoff.mem_pools ? "on" : "off")  << "'; limit: " <<
-           std::setprecision(3) << toMB(MemPools::GetInstance().idleLimit()) <<
-           " MB");
-}
-
-class ConfigRr : public RegisteredRunner
-{
-public:
-    /* RegisteredRunner API */
-    virtual void finalizeConfig() override {LogPoolSummary();}
-    virtual void syncConfig() override {LogPoolSummary();}
-};
-RunnerRegistrationEntry(ConfigRr);
-
-} // namespace Mem
 
 static mem_type &
 operator++(mem_type &aMem)

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -23,7 +23,6 @@ int Mem::AllocatorProxy::getStats(MemPoolStats *) STUB_RETVAL(0)
 
 #include "mem/forward.h"
 void Mem::Init() STUB_NOP
-void Mem::Report() STUB_NOP
 void Mem::Stats(StoreEntry *) STUB_NOP
 void Mem::CleanIdlePools(void *) STUB_NOP
 void Mem::Report(std::ostream &) STUB_NOP

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -81,16 +81,9 @@ MemPoolMeter::MemPoolMeter() STUB_NOP
 void MemPoolMeter::flush() STUB
 static MemPools tmpMemPools;
 MemPools &MemPools::GetInstance() {return tmpMemPools;}
-MemPools::MemPools() :
-    pools(nullptr),
-    mem_idle_limit(0),
-    poolCount(0),
-    defaultIsChunked(false)
-{}
+MemPools::MemPools() STUB_NOP
 void MemPools::flushMeters() STUB
 MemImplementingAllocator * MemPools::create(const char *, size_t) STUB_RETVAL(nullptr);
-void MemPools::setIdleLimit(ssize_t) STUB
-ssize_t MemPools::idleLimit() const STUB_RETVAL(0)
 void MemPools::clean(time_t) STUB
 void MemPools::setDefaultPoolChunking(bool const &) STUB
 


### PR DESCRIPTION
The official code should not call Mem::Report(). There is no
justification for main.cc treating memory module in such a
special way. The reporting code itself has problems.
Removing all this code is better than leaving or polishing it.