### PR TITLE
Maintenance: Missing squid.h include

### DIFF
--- a/src/base/Random.cc
+++ b/src/base/Random.cc
@@ -6,6 +6,7 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
+#include "squid.h"
 #include "base/Random.h"
 
 std::mt19937::result_type


### PR DESCRIPTION
Broken since inception (i.e. master/v6 commit 4a28fc5).
Detected by scripts/source-maintenance.sh.