### PR TITLE
kerberos_ldap_group: fix unused variable warnings

### DIFF
--- a/src/acl/external/kerberos_ldap_group/kerberos_ldap_group.cc
+++ b/src/acl/external/kerberos_ldap_group/kerberos_ldap_group.cc
@@ -489,7 +489,7 @@ strup(char *s)
 #else
 #include <cstdlib>
 int
-main(int argc, char *const argv[])
+main(int , char *const [])
 {
     setbuf(stdout, nullptr);
     setbuf(stdin, nullptr);

--- a/src/acl/external/kerberos_ldap_group/kerberos_ldap_group.cc
+++ b/src/acl/external/kerberos_ldap_group/kerberos_ldap_group.cc
@@ -489,7 +489,7 @@ strup(char *s)
 #else
 #include <cstdlib>
 int
-main(int , char *const [])
+main()
 {
     setbuf(stdout, nullptr);
     setbuf(stdin, nullptr);

--- a/src/acl/external/kerberos_ldap_group/support_ldap.cc
+++ b/src/acl/external/kerberos_ldap_group/support_ldap.cc
@@ -644,6 +644,7 @@ ldap_set_ssl_defaults(struct main_args *margs)
         return rc;
     }
 #else
+    (void)margs;
     error((char *) "%s| %s: ERROR: SSL not supported by ldap library\n",
           LogTime(), PROGRAM);
 #endif


### PR DESCRIPTION
When built with disabled LDAP support.