### PR TITLE
basic_ncsa_auth: Fix missing libnettle dependency

### DIFF
--- a/src/auth/basic/NCSA/Makefile.am
+++ b/src/auth/basic/NCSA/Makefile.am
@@ -19,7 +19,7 @@ basic_ncsa_auth_LDADD= \
 	$(top_builddir)/lib/libmisccontainers.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
-	$(LIBNETTLE_LIB) \
+	$(LIBNETTLE_LIBS) \
 	$(CRYPTLIB) \
 	$(SSLLIB) \
 	$(XTRA_LIBS)


### PR DESCRIPTION
Broken since b12b66cdd75835c6fb92bf25c2f68272f55d21cd