### PR TITLE
Refactor HTTP Digest authentication Nonce handling

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -342,28 +342,21 @@ digest_nonce_h::stale()
     return false;
 }
 
-/**
- * \retval  0    the digest is not stale yet
- * \retval -1    the digest will be stale on the next request
- */
-int
-authDigestNonceLastRequest(digest_nonce_h * nonce)
+bool
+digest_nonce_h::lastRequest() const
 {
-    if (!nonce)
-        return -1;
-
-    if (nonce->nc == 99999997) {
+    if (nc == 99999997) {
         debugs(29, 4, "Nonce count about to overflow");
-        return -1;
+        return true;
     }
 
-    if (nonce->nc >= static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->noncemaxuses - 1) {
+    if (nc >= static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->noncemaxuses - 1) {
         debugs(29, 4, "Nonce count about to hit user limit");
-        return -1;
+        return true;
     }
 
     /* and other tests are possible. */
-    return 0;
+    return false;
 }
 
 void

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -257,15 +257,6 @@ authDigestNonceUnlink(digest_nonce_h * nonce)
         delete nonce;
 }
 
-const char *
-authenticateDigestNonceNonceHex(const digest_nonce_h * nonce)
-{
-    if (!nonce)
-        return nullptr;
-
-    return (char const *) nonce->key;
-}
-
 static digest_nonce_h *
 authenticateDigestNonceFindNonce(const char *noncehex)
 {
@@ -278,7 +269,7 @@ authenticateDigestNonceFindNonce(const char *noncehex)
 
     nonce = static_cast < digest_nonce_h * >(hash_lookup(digest_nonce_cache, noncehex));
 
-    if ((nonce == nullptr) || (strcmp(authenticateDigestNonceNonceHex(nonce), noncehex)))
+    if (!nonce || strcmp(nonce->hex(), noncehex) != 0)
         return nullptr;
 
     debugs(29, 9, "Found nonce '" << nonce << "'");
@@ -472,12 +463,12 @@ Auth::Digest::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Ht
 
     debugs(29, 9, "Sending type:" << hdrType <<
            " header: 'Digest realm=\"" << realm << "\", nonce=\"" <<
-           authenticateDigestNonceNonceHex(nonce) << "\", qop=\"" << QOP_AUTH <<
+           nonce->hex() << "\", qop=\"" << QOP_AUTH <<
            "\", stale=" << (stale ? "true" : "false"));
 
     /* in the future, for WWW auth we may want to support the domain entry */
     httpHeaderPutStrf(&rep->header, hdrType, "Digest realm=\"" SQUIDSBUFPH "\", nonce=\"%s\", qop=\"%s\", stale=%s",
-                      SQUIDSBUFPRINT(realm), authenticateDigestNonceNonceHex(nonce), QOP_AUTH, stale ? "true" : "false");
+                      SQUIDSBUFPRINT(realm), nonce->hex(), QOP_AUTH, stale ? "true" : "false");
 }
 
 /* Initialize helpers and the like for this auth scheme. Called AFTER parsing the

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -38,11 +38,6 @@
 #include "StrList.h"
 #include "wordlist.h"
 
-/* digest_nonce_h still uses explicit alloc()/freeOne() MemPool calls.
- * XXX: convert to MEMPROXY_CLASS() API
- */
-#include "mem/Pool.h"
-
 static AUTHSSTATS authenticateDigestStats;
 
 helper *digestauthenticators = nullptr;
@@ -50,7 +45,6 @@ helper *digestauthenticators = nullptr;
 static hash_table *digest_nonce_cache;
 
 static int authdigest_initialised = 0;
-static Mem::Allocator *digest_nonce_pool = nullptr;
 
 enum http_digest_attr_type {
     DIGEST_USERNAME,
@@ -90,7 +84,6 @@ DigestFieldsLookupTable(DIGEST_INVALID_ATTR, DigestAttrs);
 
 static void authenticateDigestNonceCacheCleanup(void *data);
 static digest_nonce_h *authenticateDigestNonceFindNonce(const char *noncehex);
-static void authenticateDigestNonceDelete(digest_nonce_h * nonce);
 static void authenticateDigestNonceSetup(void);
 static void authDigestNonceEncode(digest_nonce_h * nonce);
 static void authDigestNonceLink(digest_nonce_h * nonce);
@@ -118,8 +111,6 @@ authDigestNonceEncode(digest_nonce_h * nonce)
 digest_nonce_h *
 authenticateDigestNonceNew(void)
 {
-    digest_nonce_h *newnonce = static_cast < digest_nonce_h * >(digest_nonce_pool->alloc());
-
     /* NONCE CREATION - NOTES AND REASONING. RBC 20010108
      * === EXCERPT FROM RFC 2617 ===
      * The contents of the nonce are implementation dependent. The quality
@@ -161,8 +152,7 @@ authenticateDigestNonceNew(void)
     static xuniform_int_distribution<uint32_t> newRandomData;
 
     /* create a new nonce */
-    newnonce->nc = 0;
-    newnonce->flags.valid = true;
+    digest_nonce_h *newnonce = new digest_nonce_h;
     newnonce->noncedata.creationtime = current_time.tv_sec;
     newnonce->noncedata.randomdata = newRandomData(mt);
 
@@ -184,24 +174,8 @@ authenticateDigestNonceNew(void)
 }
 
 static void
-authenticateDigestNonceDelete(digest_nonce_h * nonce)
-{
-    if (nonce) {
-        assert(nonce->references == 0);
-        assert(!nonce->flags.incache);
-
-        safe_free(nonce->key);
-
-        digest_nonce_pool->freeOne(nonce);
-    }
-}
-
-static void
 authenticateDigestNonceSetup(void)
 {
-    if (!digest_nonce_pool)
-        digest_nonce_pool = memPoolCreate("Digest Scheme nonce's", sizeof(digest_nonce_h));
-
     if (!digest_nonce_cache) {
         digest_nonce_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
         assert(digest_nonce_cache);
@@ -288,7 +262,7 @@ authDigestNonceUnlink(digest_nonce_h * nonce)
     debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
 
     if (nonce->references == 0)
-        authenticateDigestNonceDelete(nonce);
+        delete nonce;
 }
 
 const char *

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -87,7 +87,6 @@ static digest_nonce_h *authenticateDigestNonceFindNonce(const char *noncehex);
 static void authenticateDigestNonceSetup(void);
 static void authDigestNonceEncode(digest_nonce_h * nonce);
 static void authDigestNonceLink(digest_nonce_h * nonce);
-static void authDigestNonceUserUnlink(digest_nonce_h * nonce);
 
 static void
 authDigestNonceEncode(digest_nonce_h * nonce)
@@ -228,7 +227,8 @@ authenticateDigestNonceCacheCleanup(void *)
             /* invalidate nonce so future requests fail */
             nonce->flags.valid = false;
             /* if it is tied to a auth_user, remove the tie */
-            authDigestNonceUserUnlink(nonce);
+            if (nonce->user)
+                nonce->user->unlink(nonce);
             authDigestNoncePurge(nonce);
         }
     }
@@ -425,7 +425,7 @@ Auth::Digest::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Ht
         return;
 
     bool stale = false;
-    digest_nonce_h *nonce = nullptr;
+    digest_nonce_h::Pointer nonce;
 
     /* on a 407 or 401 we always use a new nonce */
     if (auth_user_request != nullptr) {
@@ -542,79 +542,6 @@ authenticateDigestStats(StoreEntry * sentry)
 {
     if (digestauthenticators)
         digestauthenticators->packStatsInto(sentry, "Digest Authenticator Statistics");
-}
-
-/* NonceUserUnlink: remove the reference to auth_user and unlink the node from the list */
-
-static void
-authDigestNonceUserUnlink(digest_nonce_h * nonce)
-{
-    Auth::Digest::User *digest_user;
-    dlink_node *link, *tmplink;
-
-    if (!nonce)
-        return;
-
-    if (!nonce->user)
-        return;
-
-    digest_user = nonce->user;
-
-    /* unlink from the user list. Yes we're crossing structures but this is the only
-     * time this code is needed
-     */
-    link = digest_user->nonces.head;
-
-    while (link) {
-        tmplink = link;
-        link = link->next;
-
-        if (tmplink->data == nonce) {
-            dlinkDelete(tmplink, &digest_user->nonces);
-            authDigestNonceUnlink(static_cast < digest_nonce_h * >(tmplink->data));
-            delete tmplink;
-            link = nullptr;
-        }
-    }
-
-    /* this reference to user was not locked because freeeing the user frees
-     * the nonce too.
-     */
-    nonce->user = nullptr;
-}
-
-/* authDigesteserLinkNonce: add a nonce to a given user's struct */
-void
-authDigestUserLinkNonce(Auth::Digest::User * user, digest_nonce_h * nonce)
-{
-    dlink_node *node;
-
-    if (!user || !nonce || !nonce->user)
-        return;
-
-    Auth::Digest::User *digest_user = user;
-
-    node = digest_user->nonces.head;
-
-    while (node && (node->data != nonce))
-        node = node->next;
-
-    if (node)
-        return;
-
-    node = new dlink_node;
-
-    dlinkAddTail(nonce, node, &digest_user->nonces);
-
-    authDigestNonceLink(nonce);
-
-    /* ping this nonce to this auth user */
-    assert((nonce->user == nullptr) || (nonce->user == user));
-
-    /* we don't lock this reference because removing the user removes the
-     * hash too. Of course if that changes we're stuffed so read the code huh?
-     */
-    nonce->user = user;
 }
 
 /* setup the necessary info to log the username */
@@ -967,7 +894,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
          * or spoofing attack is taking place. We do this by assuming
          * the user agent won't change user name without warning.
          */
-        authDigestUserLinkNonce(digest_user, nonce);
+        digest_user->link(nonce);
 
         /* auth_user is now linked, we reset these values
          * after external auth occurs anyway */

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -928,7 +928,6 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
     }
 
     digest_request->nonce = nonce;
-    authDigestNonceLink(nonce);
 
     /* check that we're not being hacked / the username hasn't changed */
     if (nonce->user && strcmp(username, nonce->user->username())) {

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -239,29 +239,21 @@ authenticateDigestNonceCacheCleanup(void *)
         eventAdd("Digest nonce cache maintenance", authenticateDigestNonceCacheCleanup, nullptr, static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->nonceGCInterval, 1);
 }
 
+// XXX: replace raw-pointers using this with Pointer
 static void
 authDigestNonceLink(digest_nonce_h * nonce)
 {
     assert(nonce != nullptr);
-    ++nonce->references;
-    assert(nonce->references != 0); // no overflows
-    debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
+    nonce->lock();
 }
 
+// XXX: replace raw-pointers using this with Pointer
 void
 authDigestNonceUnlink(digest_nonce_h * nonce)
 {
     assert(nonce != nullptr);
-
-    if (nonce->references > 0) {
-        -- nonce->references;
-    } else {
-        debugs(29, DBG_IMPORTANT, "Attempt to lower nonce " << nonce << " refcount below 0!");
-    }
-
-    debugs(29, 9, "nonce '" << nonce << "' now at '" << nonce->references << "'.");
-
-    if (nonce->references == 0)
+    nonce->unlock();
+    if (nonce->LockCount() == 0)
         delete nonce;
 }
 

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -222,7 +222,7 @@ authenticateDigestNonceCacheCleanup(void *)
         debugs(29, 3, "nonce entry  : " << nonce << " '" << (char *) nonce->key << "'");
         debugs(29, 4, "Creation time: " << nonce->noncedata.creationtime);
 
-        if (authDigestNonceIsStale(nonce)) {
+        if (nonce->stale()) {
             debugs(29, 4, "Removing nonce " << (char *) nonce->key << " from cache due to timeout.");
             assert(nonce->flags.incache);
             /* invalidate nonce so future requests fail */
@@ -277,81 +277,69 @@ authenticateDigestNonceFindNonce(const char *noncehex)
     return nonce;
 }
 
-int
-authDigestNonceIsValid(digest_nonce_h * nonce, char nc[9])
+bool
+digest_nonce_h::valid(char aCount[9])
 {
-    unsigned long intnc;
-    /* do we have a nonce ? */
-
-    if (!nonce)
-        return 0;
-
-    intnc = strtol(nc, nullptr, 16);
+    unsigned long intnc = strtol(aCount, nullptr, 16);
 
     /* has it already been invalidated ? */
-    if (!nonce->flags.valid) {
+    if (!flags.valid) {
         debugs(29, 4, "Nonce already invalidated");
-        return 0;
+        return false;
     }
+
+    const auto cfg = static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"));
 
     /* is the nonce-count ok ? */
-    if (!static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->CheckNonceCount) {
+    if (!cfg->CheckNonceCount) {
         /* Ignore client supplied NC */
-        intnc = nonce->nc + 1;
+        intnc = nc + 1;
     }
 
-    if ((static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->NonceStrictness && intnc != nonce->nc + 1) ||
-            intnc < nonce->nc + 1) {
+    if ((cfg->NonceStrictness && intnc != nc + 1) || intnc < nc + 1) {
         debugs(29, 4, "Nonce count doesn't match");
-        nonce->flags.valid = false;
-        return 0;
+        flags.valid = false;
+        return false;
     }
 
     /* increment the nonce count - we've already checked that intnc is a
      *  valid representation for us, so we don't need the test here.
      */
-    nonce->nc = intnc;
+    nc = intnc;
 
-    return !authDigestNonceIsStale(nonce);
+    return !stale();
 }
 
-int
-authDigestNonceIsStale(digest_nonce_h * nonce)
+bool
+digest_nonce_h::stale()
 {
-    /* do we have a nonce ? */
-
-    if (!nonce)
-        return -1;
-
     /* Is it already invalidated? */
-    if (!nonce->flags.valid)
-        return -1;
+    if (!flags.valid)
+        return true;
+
+    const auto cfg = static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"));
 
     /* has it's max duration expired? */
-    if (nonce->noncedata.creationtime + static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->noncemaxduration < current_time.tv_sec) {
-        debugs(29, 4, "Nonce is too old. " <<
-               nonce->noncedata.creationtime << " " <<
-               static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->noncemaxduration << " " <<
-               current_time.tv_sec);
-
-        nonce->flags.valid = false;
-        return -1;
+    if (noncedata.creationtime + cfg->noncemaxduration < current_time.tv_sec) {
+        debugs(29, 4, "Nonce is too old. " << noncedata.creationtime << " " << cfg->noncemaxduration << " " << current_time.tv_sec);
+        flags.valid = false;
+        return true;
     }
 
-    if (nonce->nc > 99999998) {
+    if (nc > 99999998) {
         debugs(29, 4, "Nonce count overflow");
-        nonce->flags.valid = false;
-        return -1;
+        flags.valid = false;
+        return true;
     }
 
-    if (nonce->nc > static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->noncemaxuses) {
+    if (nc > cfg->noncemaxuses) {
         debugs(29, 4, "Nonce count over user limit");
-        nonce->flags.valid = false;
-        return -1;
+        flags.valid = false;
+        return true;
     }
 
     /* seems ok */
-    return 0;
+    return false;
 }
 
 /**

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -81,7 +81,6 @@ public:
 void authDigestNonceUnlink(digest_nonce_h * nonce);
 void authenticateDigestNonceShutdown(void);
 void authDigestNoncePurge(digest_nonce_h * nonce);
-void authDigestUserLinkNonce(Auth::Digest::User * user, digest_nonce_h * nonce);
 digest_nonce_h *authenticateDigestNonceNew(void);
 
 namespace Auth

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -47,6 +47,15 @@ public:
     /// \retval true if the nonce is stale.
     bool stale();
 
+    /**
+     * Try to predict what the nonce validity will be if used on the
+     * next HTTP Request.
+     *
+     * \retval false when the nonce is not stale yet
+     * \retval true if the nonce will be stale on the next request
+     */
+    bool lastRequest() const;
+
 public:
     /* data to be encoded into the nonce's hex representation */
     struct _digest_nonce_data {
@@ -68,7 +77,6 @@ public:
 };
 
 void authDigestNonceUnlink(digest_nonce_h * nonce);
-int authDigestNonceLastRequest(digest_nonce_h * nonce);
 void authenticateDigestNonceShutdown(void);
 void authDigestNoncePurge(digest_nonce_h * nonce);
 void authDigestUserLinkNonce(Auth::Digest::User * user, digest_nonce_h * nonce);

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -25,31 +25,35 @@ class User;
 }
 }
 
-/* Generic */
-typedef struct _digest_nonce_data digest_nonce_data;
-typedef struct _digest_nonce_h digest_nonce_h;
-
-/* data to be encoded into the nonce's hex representation */
-struct _digest_nonce_data {
-    time_t creationtime;
-    uint32_t randomdata;
-};
-
 /* the nonce structure we'll pass around */
+class digest_nonce_h : public hash_link
+{
+    MEMPROXY_CLASS(digest_nonce_h);
 
-struct _digest_nonce_h : public hash_link {
-    digest_nonce_data noncedata;
+public:
+    digest_nonce_h() = default;
+    digest_nonce_h(const digest_nonce_h &) = delete; // non-copyable
+    ~digest_nonce_h() { xfree(key); }
+
+    /* data to be encoded into the nonce's hex representation */
+    struct _digest_nonce_data {
+        time_t creationtime = 0;
+        uint32_t randomdata = 0;
+    } noncedata;
+
     /* number of uses we've seen of this nonce */
-    unsigned long nc;
-    /* reference count */
-    uint64_t references;
-    /* the auth_user this nonce has been tied to */
-    Auth::Digest::User *user;
-    /* has this nonce been invalidated ? */
+    unsigned long nc = 0;
 
+    /* reference count */
+    uint64_t references = 0;
+
+    /* the auth_user this nonce has been tied to */
+    Auth::Digest::User *user = nullptr;
+
+    /* has this nonce been invalidated ? */
     struct {
-        bool valid;
-        bool incache;
+        bool valid = true;
+        bool incache = false;
     } flags;
 };
 

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -32,6 +32,8 @@ class digest_nonce_h : public hash_link, public RefCountable
     MEMPROXY_CLASS(digest_nonce_h);
 
 public:
+    typedef RefCount<digest_nonce_h> Pointer;
+
     digest_nonce_h() = default;
     digest_nonce_h(const digest_nonce_h &) = delete; // non-copyable
     ~digest_nonce_h() { xfree(key); }

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -39,6 +39,14 @@ public:
     /// The HEX encoded unique identifier for this nonce
     const char *hex() const { return static_cast<const char *>(key); }
 
+    /// Check the nonce and invalidate if any tests fail.
+    /// \retval true if the nonce is valid.
+    bool valid(char clientCount[9]);
+
+    /// Check the freshness of this nonce and invalidate if stale.
+    /// \retval true if the nonce is stale.
+    bool stale();
+
 public:
     /* data to be encoded into the nonce's hex representation */
     struct _digest_nonce_data {
@@ -60,8 +68,6 @@ public:
 };
 
 void authDigestNonceUnlink(digest_nonce_h * nonce);
-int authDigestNonceIsValid(digest_nonce_h * nonce, char nc[9]);
-int authDigestNonceIsStale(digest_nonce_h * nonce);
 int authDigestNonceLastRequest(digest_nonce_h * nonce);
 void authenticateDigestNonceShutdown(void);
 void authDigestNoncePurge(digest_nonce_h * nonce);

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -14,6 +14,7 @@
 #include "auth/Gadgets.h"
 #include "auth/SchemeConfig.h"
 #include "auth/UserRequest.h"
+#include "base/RefCount.h"
 #include "helper/forward.h"
 #include "rfc2617.h"
 
@@ -26,7 +27,7 @@ class User;
 }
 
 /* the nonce structure we'll pass around */
-class digest_nonce_h : public hash_link
+class digest_nonce_h : public hash_link, public RefCountable
 {
     MEMPROXY_CLASS(digest_nonce_h);
 
@@ -43,9 +44,6 @@ public:
 
     /* number of uses we've seen of this nonce */
     unsigned long nc = 0;
-
-    /* reference count */
-    uint64_t references = 0;
 
     /* the auth_user this nonce has been tied to */
     Auth::Digest::User *user = nullptr;

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -36,6 +36,10 @@ public:
     digest_nonce_h(const digest_nonce_h &) = delete; // non-copyable
     ~digest_nonce_h() { xfree(key); }
 
+    /// The HEX encoded unique identifier for this nonce
+    const char *hex() const { return static_cast<const char *>(key); }
+
+public:
     /* data to be encoded into the nonce's hex representation */
     struct _digest_nonce_data {
         time_t creationtime = 0;
@@ -58,7 +62,6 @@ public:
 void authDigestNonceUnlink(digest_nonce_h * nonce);
 int authDigestNonceIsValid(digest_nonce_h * nonce, char nc[9]);
 int authDigestNonceIsStale(digest_nonce_h * nonce);
-const char *authenticateDigestNonceNonceHex(const digest_nonce_h * nonce);
 int authDigestNonceLastRequest(digest_nonce_h * nonce);
 void authenticateDigestNonceShutdown(void);
 void authDigestNoncePurge(digest_nonce_h * nonce);

--- a/src/auth/digest/User.cc
+++ b/src/auth/digest/User.cc
@@ -66,7 +66,7 @@ Auth::Digest::User::currentNonce()
     dlink_node *link = nonces.tail;
     if (link) {
         nonce = static_cast<digest_nonce_h *>(link->data);
-        if (authDigestNonceIsStale(nonce))
+        if (nonce->stale())
             nonce = nullptr;
     }
     return nonce;

--- a/src/auth/digest/User.cc
+++ b/src/auth/digest/User.cc
@@ -12,7 +12,6 @@
 #include "auth/digest/Config.h"
 #include "auth/digest/User.h"
 #include "debug/Stream.h"
-#include "dlink.h"
 
 Auth::Digest::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm) :
     Auth::User(aConfig, aRequestRealm),
@@ -23,16 +22,8 @@ Auth::Digest::User::User(Auth::SchemeConfig *aConfig, const char *aRequestRealm)
 
 Auth::Digest::User::~User()
 {
-    dlink_node *link, *tmplink;
-    link = nonces.head;
-
-    while (link) {
-        tmplink = link;
-        link = link->next;
-        dlinkDelete(tmplink, &nonces);
-        authDigestNoncePurge(static_cast < digest_nonce_h * >(tmplink->data));
-        authDigestNonceUnlink(static_cast < digest_nonce_h * >(tmplink->data));
-        delete tmplink;
+    for (const auto &nonce: nonces) {
+        authDigestNoncePurge(nonce.getRaw());
     }
 }
 
@@ -43,13 +34,10 @@ Auth::Digest::User::ttl() const
 
     /* find the longest lasting nonce. */
     int32_t latest_nonce = -1;
-    dlink_node *link = nonces.head;
-    while (link) {
-        digest_nonce_h *nonce = static_cast<digest_nonce_h *>(link->data);
+
+    for (const auto &nonce: nonces) {
         if (nonce->flags.valid && nonce->noncedata.creationtime > latest_nonce)
             latest_nonce = nonce->noncedata.creationtime;
-
-        link = link->next;
     }
     if (latest_nonce == -1)
         return min(-1, global_ttl);
@@ -59,17 +47,50 @@ Auth::Digest::User::ttl() const
     return min(nonce_ttl, global_ttl);
 }
 
-digest_nonce_h *
+void
+Auth::Digest::User::link(const digest_nonce_h::Pointer &nonce)
+{
+    if (!nonce)
+        return;
+
+    if (std::find_if(nonces.begin(), nonces.end(), [&nonce](const digest_nonce_h::Pointer &n){ return n == nonce; }) != nonces.end())
+        return;
+
+    nonces.push_back(nonce);
+
+    /* we don't lock this reference because removing the user removes the
+     * hash too. Of course if that changes we're stuffed so read the code huh?
+     */
+    nonce->user = this;
+}
+
+void
+Auth::Digest::User::unlink(const digest_nonce_h::Pointer &nonce)
+{
+    if (!nonce)
+        return;
+
+    if (!nonce->user)
+        return;
+
+    nonces.remove(nonce);
+
+    /* this reference to user was not locked because freeeing the user frees
+     * the nonce too.
+     */
+    nonce->user = nullptr;
+}
+
+digest_nonce_h::Pointer
 Auth::Digest::User::currentNonce()
 {
-    digest_nonce_h *nonce = nullptr;
-    dlink_node *link = nonces.tail;
-    if (link) {
-        nonce = static_cast<digest_nonce_h *>(link->data);
-        if (nonce->stale())
-            nonce = nullptr;
+    if (!nonces.empty()) {
+        if (const auto nonce = nonces.back()) {
+            if (!nonce->stale())
+                return nonce;
+        }
     }
-    return nonce;
+    return nullptr;
 }
 
 CbcPointer<Auth::CredentialsCache>

--- a/src/auth/digest/User.h
+++ b/src/auth/digest/User.h
@@ -31,17 +31,21 @@ public:
     int authenticated() const;
     virtual int32_t ttl() const override;
 
+    void link(const digest_nonce_h::Pointer &);
+    void unlink(const digest_nonce_h::Pointer &);
+
+    digest_nonce_h::Pointer currentNonce();
+
     /* Auth::User API */
     static CbcPointer<Auth::CredentialsCache> Cache();
     virtual void addToNameCache() override;
 
+public:
     HASH HA1;
     int HA1created;
 
     /* what nonces have been allocated to this user */
-    dlink_list nonces;
-
-    digest_nonce_h * currentNonce();
+    std::list<digest_nonce_h::Pointer> nonces;
 };
 
 } // namespace Digest

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -29,8 +29,7 @@ Auth::Digest::UserRequest::UserRequest() :
     pszMethod(nullptr),
     qop(nullptr),
     uri(nullptr),
-    response(nullptr),
-    nonce(nullptr)
+    response(nullptr)
 {
     memset(nc, 0, sizeof(nc));
     memset(&flags, 0, sizeof(flags));
@@ -53,9 +52,6 @@ Auth::Digest::UserRequest::~UserRequest()
     safe_free(qop);
     safe_free(uri);
     safe_free(response);
-
-    if (nonce)
-        authDigestNonceUnlink(nonce);
 }
 
 int
@@ -100,7 +96,7 @@ Auth::Digest::UserRequest::authenticate(HttpRequest * request, ConnStateData *, 
         return;
     }
 
-    if (digest_request->nonce == nullptr) {
+    if (!digest_request->nonce) {
         /* this isn't a nonce we issued */
         auth_user->credentials(Auth::Failed);
         return;
@@ -177,7 +173,7 @@ Auth::Digest::UserRequest::authenticate(HttpRequest * request, ConnStateData *, 
         debugs(29, 3, auth_user->username() << "' validated OK but nonce stale: " << digest_request->noncehex);
         /* Pending prevent banner and makes a ldap control */
         auth_user->credentials(Auth::Pending);
-        authDigestNoncePurge(nonce);
+        authDigestNoncePurge(nonce.getRaw());
         return;
     }
 

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -232,10 +232,10 @@ Auth::Digest::UserRequest::addAuthenticationInfoHeader(HttpReply * rep, int acce
         if (!digest_user)
             return;
 
-        digest_nonce_h *nextnonce = digest_user->currentNonce();
+        digest_nonce_h::Pointer nextnonce = digest_user->currentNonce();
         if (!nextnonce || nonce->lastRequest()) {
             nextnonce = authenticateDigestNonceNew();
-            authDigestUserLinkNonce(digest_user, nextnonce);
+            digest_user->link(nextnonce);
         }
         debugs(29, 9, "Sending type:" << type << " header: 'nextnonce=\"" << nextnonce->hex() << "\"");
         httpHeaderPutStrf(&rep->header, type, "nextnonce=\"%s\"", nextnonce->hex());
@@ -267,7 +267,7 @@ Auth::Digest::UserRequest::addAuthenticationInfoTrailer(HttpReply * rep, int acc
         nonce = digest_user->currentNonce();
         if (!nonce) {
             nonce = authenticateDigestNonceNew();
-            authDigestUserLinkNonce(digest_user, nonce);
+            digest_user->link(nonce);
         }
         debugs(29, 9, "Sending type:" << type << " header: 'nextnonce=\"" << nonce->hex() << "\"");
         httpTrailerPutStrf(&rep->header, type, "nextnonce=\"%s\"", nonce->hex());

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -230,14 +230,14 @@ Auth::Digest::UserRequest::addAuthenticationInfoHeader(HttpReply * rep, int acce
         return;
 #endif
 
-    if ((static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->authenticateProgram) && authDigestNonceLastRequest(nonce)) {
+    if ((static_cast<Auth::Digest::Config*>(Auth::SchemeConfig::Find("digest"))->authenticateProgram) && nonce->lastRequest()) {
         flags.authinfo_sent = true;
         Auth::Digest::User *digest_user = dynamic_cast<Auth::Digest::User *>(user().getRaw());
         if (!digest_user)
             return;
 
         digest_nonce_h *nextnonce = digest_user->currentNonce();
-        if (!nextnonce || authDigestNonceLastRequest(nonce)) {
+        if (!nextnonce || nonce->lastRequest()) {
             nextnonce = authenticateDigestNonceNew();
             authDigestUserLinkNonce(digest_user, nextnonce);
         }
@@ -266,7 +266,7 @@ Auth::Digest::UserRequest::addAuthenticationInfoTrailer(HttpReply * rep, int acc
 
     type = accel ? Http::HdrType::AUTHENTICATION_INFO : Http::HdrType::PROXY_AUTHENTICATION_INFO;
 
-    if ((static_cast<Auth::Digest::Config*>(digestScheme::GetInstance()->getConfig())->authenticate) && authDigestNonceLastRequest(nonce)) {
+    if ((static_cast<Auth::Digest::Config*>(digestScheme::GetInstance()->getConfig())->authenticate) && nonce->lastRequest()) {
         Auth::Digest::User *digest_user = dynamic_cast<Auth::Digest::User *>(auth_user_request->user().getRaw());
         nonce = digest_user->currentNonce();
         if (!nonce) {

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -173,11 +173,10 @@ Auth::Digest::UserRequest::authenticate(HttpRequest * request, ConnStateData *, 
     /* check for stale nonce */
     /* check Auth::Pending to avoid loop */
 
-    if (!authDigestNonceIsValid(digest_request->nonce, digest_request->nc) && user()->credentials() != Auth::Pending) {
+    if (!digest_request->nonce->valid(digest_request->nc) && user()->credentials() != Auth::Pending) {
         debugs(29, 3, auth_user->username() << "' validated OK but nonce stale: " << digest_request->noncehex);
         /* Pending prevent banner and makes a ldap control */
         auth_user->credentials(Auth::Pending);
-        nonce->flags.valid = false;
         authDigestNoncePurge(nonce);
         return;
     }

--- a/src/auth/digest/UserRequest.cc
+++ b/src/auth/digest/UserRequest.cc
@@ -107,11 +107,11 @@ Auth::Digest::UserRequest::authenticate(HttpRequest * request, ConnStateData *, 
     }
 
     DigestCalcHA1(digest_request->algorithm, nullptr, nullptr, nullptr,
-                  authenticateDigestNonceNonceHex(digest_request->nonce),
+                  digest_request->nonce->hex(),
                   digest_request->cnonce,
                   digest_user->HA1, SESSIONKEY);
     SBuf sTmp = request->method.image();
-    DigestCalcResponse(SESSIONKEY, authenticateDigestNonceNonceHex(digest_request->nonce),
+    DigestCalcResponse(SESSIONKEY, digest_request->nonce->hex(),
                        digest_request->nc, digest_request->cnonce, digest_request->qop,
                        sTmp.c_str(), digest_request->uri, HA2, Response);
 
@@ -133,7 +133,7 @@ Auth::Digest::UserRequest::authenticate(HttpRequest * request, ConnStateData *, 
              * used.
              */
             sTmp = HttpRequestMethod(Http::METHOD_GET).image();
-            DigestCalcResponse(SESSIONKEY, authenticateDigestNonceNonceHex(digest_request->nonce),
+            DigestCalcResponse(SESSIONKEY, digest_request->nonce->hex(),
                                digest_request->nc, digest_request->cnonce, digest_request->qop,
                                sTmp.c_str(), digest_request->uri, HA2, Response);
 
@@ -242,8 +242,8 @@ Auth::Digest::UserRequest::addAuthenticationInfoHeader(HttpReply * rep, int acce
             nextnonce = authenticateDigestNonceNew();
             authDigestUserLinkNonce(digest_user, nextnonce);
         }
-        debugs(29, 9, "Sending type:" << type << " header: 'nextnonce=\"" << authenticateDigestNonceNonceHex(nextnonce) << "\"");
-        httpHeaderPutStrf(&rep->header, type, "nextnonce=\"%s\"", authenticateDigestNonceNonceHex(nextnonce));
+        debugs(29, 9, "Sending type:" << type << " header: 'nextnonce=\"" << nextnonce->hex() << "\"");
+        httpHeaderPutStrf(&rep->header, type, "nextnonce=\"%s\"", nextnonce->hex());
     }
 }
 
@@ -274,8 +274,8 @@ Auth::Digest::UserRequest::addAuthenticationInfoTrailer(HttpReply * rep, int acc
             nonce = authenticateDigestNonceNew();
             authDigestUserLinkNonce(digest_user, nonce);
         }
-        debugs(29, 9, "Sending type:" << type << " header: 'nextnonce=\"" << authenticateDigestNonceNonceHex(nonce) << "\"");
-        httpTrailerPutStrf(&rep->header, type, "nextnonce=\"%s\"", authenticateDigestNonceNonceHex(nonce));
+        debugs(29, 9, "Sending type:" << type << " header: 'nextnonce=\"" << nonce->hex() << "\"");
+        httpTrailerPutStrf(&rep->header, type, "nextnonce=\"%s\"", nonce->hex());
     }
 }
 #endif

--- a/src/auth/digest/UserRequest.h
+++ b/src/auth/digest/UserRequest.h
@@ -60,7 +60,7 @@ public:
         bool invalid_password;
         bool helper_queried;
     } flags;
-    digest_nonce_h *nonce;
+    digest_nonce_h::Pointer nonce;
 
 private:
     static HLPCB HandleReply;


### PR DESCRIPTION
Convert the Nonce object to class with MEMPROXY memory
pooling, smart pointer reference counting, and most of the
old management functions converted to members.

While logic changes are implicit from refactoring, behaviour
change is avoided as much as possible.

However, one bug was identified which would prevent a new
nonce generated to replace a stale existing nonce being
associated to the username needing it. The if-condition
causing this ban has been dropped.