### PR TITLE
add refresh_pattern option 'ignore-must-revalidate' back in

### DIFF
--- a/src/RefreshPattern.h
+++ b/src/RefreshPattern.h
@@ -63,6 +63,7 @@ public:
         bool reload_into_ims;
         bool ignore_reload;
         bool ignore_no_store;
+        bool ignore_must_revalidate;
         bool ignore_private;
 #endif
     } flags;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -6445,6 +6445,7 @@ DOC_START
 		 reload-into-ims
 		 ignore-reload
 		 ignore-no-store
+		 ignore-must-revalidate
 		 ignore-private
 		 max-stale=NN
 		 refresh-ims
@@ -6477,6 +6478,11 @@ DOC_START
 		it causes.
 
 		ignore-no-store ignores any ``Cache-control: no-store''
+		headers received from a server. Doing this VIOLATES
+		the HTTP standard. Enabling this feature could make you
+		liable for problems which it causes.
+
+		ignore-must-revalidate ignores any ``Cache-Control: must-revalidate``
 		headers received from a server. Doing this VIOLATES
 		the HTTP standard. Enabling this feature could make you
 		liable for problems which it causes.

--- a/src/http.cc
+++ b/src/http.cc
@@ -395,7 +395,7 @@ HttpStateData::reusableReply(HttpStateData::ReuseDecision &decision)
             mayStore = true;
 
             // HTTPbis pt6 section 3.2: a response CC:must-revalidate is present
-        } else if (rep->cache_control->hasMustRevalidate()) {
+        } else if (rep->cache_control->hasMustRevalidate() && !REFRESH_OVERRIDE(ignore_must_revalidate)) {
             debugs(22, 3, "Authenticated but server reply Cache-Control:must-revalidate");
             mayStore = true;
 
@@ -404,7 +404,7 @@ HttpStateData::reusableReply(HttpStateData::ReuseDecision &decision)
             // HTTPbis WG verdict on this is that it is omitted from the spec due to being 'unexpected' by
             // some. The caching+revalidate is not exactly unsafe though with Squids interpretation of no-cache
             // (without parameters) as equivalent to must-revalidate in the reply.
-        } else if (rep->cache_control->hasNoCacheWithoutParameters()) {
+        } else if (rep->cache_control->hasNoCacheWithoutParameters() && !REFRESH_OVERRIDE(ignore_must_revalidate)) {
             debugs(22, 3, "Authenticated but server reply Cache-Control:no-cache (equivalent to must-revalidate)");
             mayStore = true;
 #endif

--- a/src/refresh.cc
+++ b/src/refresh.cc
@@ -336,6 +336,9 @@ refreshCheck(const StoreEntry * entry, HttpRequest * request, time_t delta)
      */
     const bool revalidateAlways = EBIT_TEST(entry->flags, ENTRY_REVALIDATE_ALWAYS);
     if (revalidateAlways || (staleness > -1 &&
+#if USE_HTTP_VIOLATIONS
+                             !R->flags.ignore_must_revalidate &&
+#endif
                              EBIT_TEST(entry->flags, ENTRY_REVALIDATE_STALE))) {
         debugs(22, 3, "YES: Must revalidate stale object (origin set " <<
                (revalidateAlways ? "no-cache or private" :


### PR DESCRIPTION
This is a partial revert of commit 064679ea374d2f58ae4660d9a2af213b9be24bba, which removed the "ignore-must-revalidate" option.  The option was not actually broken, but it is not about the storage of objects - it is about whether they need to be retrieved again for new requests.

For example, I encountered a university download service that has set both "Expires: 0" and "Cache-Control: must-revalidate" for unchanging content.  The refresh_pattern "override-expires" option will allow you to store a cache of this content, but due to the "Cache-Control: must-revalidate" header the proxy server will always re-fetch the content because the server has effectively indicated (incorrectly) that it is a live data feed.  By re-enabling the "ignore-must-revalidate" refresh_pattern option it is possible to override the behavior for the download service's specific URL, such that the proxy can properly cache the content and not have to constantly re-fetch a bunch of multi-gigabyte files.