### PR TITLE
Update Host, Via, and other headers in-place when possible

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -1029,10 +1029,7 @@ HttpHeader::addVia(const AnyP::ProtocolVersion &ver, const HttpHeader *from)
         if (!strVia.isEmpty())
             strVia.append(", ", 2);
         strVia.append(buf);
-        // XXX: putStr() still suffers from String size limits
-        Must(strVia.length() < String::SizeMaxXXX());
-        delById(Http::HdrType::VIA);
-        putStr(Http::HdrType::VIA, strVia.c_str());
+        updateOrAddStr(Http::HdrType::VIA, strVia);
     }
 }
 
@@ -1165,6 +1162,9 @@ HttpHeader::updateOrAddStr(const Http::HdrType id, const SBuf &newValue)
 {
     assert(any_registered_header(id));
     assert(Http::HeaderLookupTable.lookup(id).type == Http::HdrFieldType::ftStr);
+
+    // XXX: HttpHeaderEntry::value suffers from String size limits
+    Must(newValue.length() < String::SizeMaxXXX()); // TODO: Assure() in master/v6
 
     if (!CBIT_TEST(mask, id)) {
         auto newValueCopy = newValue; // until HttpHeaderEntry::value becomes SBuf

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -144,6 +144,11 @@ public:
     void putSc(HttpHdrSc *sc);
     void putWarning(const int code, const char *const text); ///< add a Warning header
     void putExt(const char *name, const char *value);
+
+    /// Ensures that the header has the given field, removing or replacing any
+    /// same-name fields with conflicting values as needed.
+    void updateOrAddStr(Http::HdrType, const SBuf &);
+
     int getInt(Http::HdrType id) const;
     int64_t getInt64(Http::HdrType id) const;
     time_t getTime(Http::HdrType id) const;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1323,8 +1323,8 @@ ErrorState::BuildHttpReply()
          */
         if (!Config.errorDirectory) {
             /* We 'negotiated' this ONLY from the Accept-Language. */
-            rep->header.delById(Http::HdrType::VARY);
-            rep->header.putStr(Http::HdrType::VARY, "Accept-Language");
+            static const SBuf acceptLanguage("Accept-Language");
+            rep->header.updateOrAddStr(Http::HdrType::VARY, acceptLanguage);
         }
 
         /* add the Content-Language header according to RFC section 14.12 */

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1644,10 +1644,10 @@ Ftp::Server::setDataCommand()
     HttpRequest *const request = http->request;
     assert(request != NULL);
     HttpHeader &header = request->header;
-    header.delById(Http::HdrType::FTP_COMMAND);
-    header.putStr(Http::HdrType::FTP_COMMAND, "PASV");
-    header.delById(Http::HdrType::FTP_ARGUMENTS);
-    header.putStr(Http::HdrType::FTP_ARGUMENTS, "");
+    static const SBuf pasvValue("PASV");
+    header.updateOrAddStr(Http::HdrType::FTP_COMMAND, pasvValue);
+    static const SBuf emptyValue("");
+    header.updateOrAddStr(Http::HdrType::FTP_ARGUMENTS, emptyValue);
     debugs(9, 5, "client data command converted to fake PASV");
 }
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -189,10 +189,13 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     // some code still uses Host directly so normalize it using the previously
     // sanitized URL authority value.
     // For now preserve the case where Host is completely absent. That matters.
-    if (const auto x = request->header.delById(Http::HOST)) {
-        debugs(33, 5, "normalize " << x << " Host header using " << request->url.authority());
-        SBuf tmp(request->url.authority());
-        request->header.putStr(Http::HOST, tmp.c_str());
+    if(request->header.findEntry(Http::HOST)){
+        SBuf domain(request->url.authority());
+        HttpHeaderEntry* host = new HttpHeaderEntry(Http::HOST, NULL, domain.c_str());
+        if(int x = request->header.delById(Http::HOST)){
+            debugs(33, 5, "normalize " << x << " Host header using " << request->url.authority());
+            request->header.insertEntry(host);
+        }
     }
 
     // TODO: We fill request notes here until we find a way to verify whether

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -189,12 +189,14 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     // some code still uses Host directly so normalize it using the previously
     // sanitized URL authority value.
     // For now preserve the case where Host is completely absent. That matters.
-    if(request->header.findEntry(Http::HOST)){
-        SBuf domain(request->url.authority());
-        HttpHeaderEntry* host = new HttpHeaderEntry(Http::HOST, NULL, domain.c_str());
-        if(int x = request->header.delById(Http::HOST)){
-            debugs(33, 5, "normalize " << x << " Host header using " << request->url.authority());
-            request->header.insertEntry(host);
+    if(request->header.has(Http::HOST)){
+        String host = request->header.getById(Http::HOST);
+        if(host.cmp(request->url.authority().c_str()) != 0){
+            if (const auto x = request->header.delById(Http::HOST)) {
+                debugs(33, 5, "normalize " << x << " Host header using " << request->url.authority());
+                SBuf tmp(request->url.authority());
+                request->header.putStr(Http::HOST, tmp.c_str());
+            }
         }
     }
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -189,16 +189,8 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     // some code still uses Host directly so normalize it using the previously
     // sanitized URL authority value.
     // For now preserve the case where Host is completely absent. That matters.
-    if(request->header.has(Http::HOST)){
-        String host = request->header.getById(Http::HOST);
-        if(host.cmp(request->url.authority().c_str()) != 0){
-            if (const auto x = request->header.delById(Http::HOST)) {
-                debugs(33, 5, "normalize " << x << " Host header using " << request->url.authority());
-                SBuf tmp(request->url.authority());
-                request->header.putStr(Http::HOST, tmp.c_str());
-            }
-        }
-    }
+    if (request->header.has(Http::HdrType::HOST))
+        request->header.updateOrAddStr(Http::HdrType::HOST, request->url.authority());
 
     // TODO: We fill request notes here until we find a way to verify whether
     // no ACL checking is performed before ClientHttpRequest::doCallouts().

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -65,6 +65,7 @@ void HttpHeader::putRange(const HttpHdrRange *) STUB
 void HttpHeader::putSc(HttpHdrSc *) STUB
 void HttpHeader::putWarning(const int, const char *const) STUB
 void HttpHeader::putExt(const char *, const char *) STUB
+void HttpHeader::updateOrAddStr(const Http::HdrType, const SBuf &) STUB
 int HttpHeader::getInt(Http::HdrType) const STUB_RETVAL(0)
 int64_t HttpHeader::getInt64(Http::HdrType) const STUB_RETVAL(0)
 time_t HttpHeader::getTime(Http::HdrType) const STUB_RETVAL(0)


### PR DESCRIPTION
This change optimizes Host header synchronization code that usually does
not need to change the Host header field but was always deleting the old
field and generating/appending a new one. Appending Host also violated
an RFC 9110 section 7.2 rule (on behalf of the user agent whose Host we
were rewriting): "A user agent that sends Host SHOULD send it as the
first field in the header section".

Also, removing old header fields and appending new ones introduced HTTP
header changes that broke otherwise working peers. For example, some
origins denied Squid-proxied messages exclusively due to an unusual
(from those origins point of view) Host header position. This change
reduces (but does not eliminate) such unnecessary and risky changes.
