### PR TITLE
Fix regression test configuration

### DIFF
--- a/test-suite/squidconf/regressions-3.4.0.1.conf
+++ b/test-suite/squidconf/regressions-3.4.0.1.conf
@@ -24,7 +24,7 @@ concurrency=0 ttl=600 negative_ttl=10 grace=0 protocol=2.5 %SRC \
   /bin/true -v 3 -h 127.0.0.1 -b "o=A,c=INVALID" -B "org=borken?,ou=People,o=A,c=INVALID" \
   -f "(&(cn=%g)(memberUid=%u))" -F "(&(objectClass=account)(uid=%s))" -s sub 
 
-acl Mark dstdomain "empty"
+acl Mark dstdomain "empty.conf"
 
 refresh_pattern "foo 0 80% 20160
 refresh_pattern "foo\" 0 80% 20160


### PR DESCRIPTION
The regressions-3.4.0.1 configuration produces an error message:

    ERROR: Can not open file empty for reading

Broken since commit 6c9a5e8 that renamed "empty" to "empty.conf".