### PR TITLE
Drop CBDATA debugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,16 +352,6 @@ AC_ARG_ENABLE(optimizations,
   ])
 ])
 
-AC_ARG_ENABLE(debug-cbdata,
-  AS_HELP_STRING([--enable-debug-cbdata],
-      [Provide some debug information in cbdata]), [
-  SQUID_YESNO([$enableval],[--enable-debug-cbdata])
-])
-SQUID_DEFINE_BOOL(USE_CBDATA_DEBUG,${enable_debug_cbdata:=no},
-    [Enable support for cbdata debug information])
-AC_MSG_NOTICE([cbdata debugging enabled: $enable_debug_cbdata])
-
-
 dnl Nasty hack to get autoconf 2.64 on Linux to run.
 dnl all other uses of RUN_IFELSE are wrapped inside CACHE_CHECK which breaks on 2.64
 AC_RUN_IFELSE([AC_LANG_SOURCE([[ int main(int argc, char **argv) { return 0; } ]])],[],[],[:])

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -126,6 +126,10 @@ This section gives an account of those changes in three categories:
 	<p>This feature has been unreliable for many years. Other tools such as
 	   oprofile provide better tracking and should be used instead.
 
+	<tag>--enable-debug-cbdata</tag>
+	<p>This feature has been of limited use since AsyncCalls feature
+	   took over much of the CBDATA functionality.
+
 	<tag>--enable-kill-parent-hack</tag>
 	<p>This feature has been deprecated for years. Other features such as
 	   <em>--foreground</em> command line argument should be used instead.

--- a/src/base/CbcPointer.h
+++ b/src/base/CbcPointer.h
@@ -143,9 +143,6 @@ template<class Cbc>
 void
 CbcPointer<Cbc>::clear()
 {
-#if USE_CBDATA_DEBUG
-    debugs(45, 3, "cbc=" << (void*)cbc << ", lock=" << (void*)lock);
-#endif
     cbdataReferenceDone(lock); // lock may be nil before and will be nil after
     cbc = nullptr;
 }

--- a/src/cbdata.cc
+++ b/src/cbdata.cc
@@ -141,7 +141,7 @@ cbdataInternalAddType(cbdata_type type, const char *name, int size)
 }
 
 void *
-cbdataInternalAlloc(cbdata_type type, const char *file, int line)
+cbdataInternalAlloc(cbdata_type type)
 {
     cbdata *c;
     void *p;
@@ -164,8 +164,6 @@ cbdataInternalAlloc(cbdata_type type, const char *file, int line)
     c->locks = 0;
     c->cookie = (long) c ^ cbdata::Cookie;
     ++cbdataCount;
-    (void)file;
-    (void)line;
     debugs(45, 9, "Allocating " << p);
     return p;
 }

--- a/src/cbdata.h
+++ b/src/cbdata.h
@@ -196,12 +196,6 @@ typedef int cbdata_type;
 static const cbdata_type CBDATA_UNKNOWN = 0;
 
 /**
- * Create a run-time registration of CBDATA component with
- * the Squid cachemgr
- */
-void cbdataRegisterWithCacheManager(void);
-
-/**
  * Allocates a new entry of a registered CBDATA type.
  *
  * \note For internal CBDATA use only.
@@ -221,19 +215,8 @@ void *cbdataInternalAlloc(cbdata_type type, const char *, int);
  *
  * \note For internal CBDATA use only.
  */
-void *cbdataInternalFree(void *p, const char *, int);
+void *cbdataInternalFree(void *p);
 
-#if USE_CBDATA_DEBUG
-void cbdataInternalLockDbg(const void *p, const char *, int);
-#define cbdataInternalLock(a) cbdataInternalLockDbg(a,__FILE__,__LINE__)
-
-void cbdataInternalUnlockDbg(const void *p, const char *, int);
-#define cbdataInternalUnlock(a) cbdataInternalUnlockDbg(a,__FILE__,__LINE__)
-
-int cbdataInternalReferenceDoneValidDbg(void **p, void **tp, const char *, int);
-#define cbdataReferenceValidDone(var, ptr) cbdataInternalReferenceDoneValidDbg((void **)&(var), (ptr), __FILE__,__LINE__)
-
-#else
 void cbdataInternalLock(const void *p);
 void cbdataInternalUnlock(const void *p);
 
@@ -254,8 +237,6 @@ void cbdataInternalUnlock(const void *p);
  */
 int cbdataInternalReferenceDoneValid(void **p, void **tp);
 #define cbdataReferenceValidDone(var, ptr) cbdataInternalReferenceDoneValid((void **)&(var), (ptr))
-
-#endif /* !CBDATA_DEBUG */
 
 /**
  * \param p A cbdata entry reference pointer.
@@ -281,7 +262,7 @@ cbdata_type cbdataInternalAddType(cbdata_type type, const char *label, int size)
           return (type *)cbdataInternalAlloc(CBDATA_##type,__FILE__,__LINE__); \
         } \
         void operator delete (void *address) { \
-          if (address) cbdataInternalFree(address,__FILE__,__LINE__); \
+          if (address) cbdataInternalFree(address); \
         } \
         void *toCbdata() methodSpecifiers { return this; } \
     private: \

--- a/src/cbdata.h
+++ b/src/cbdata.h
@@ -200,7 +200,7 @@ static const cbdata_type CBDATA_UNKNOWN = 0;
  *
  * \note For internal CBDATA use only.
  */
-void *cbdataInternalAlloc(cbdata_type type, const char *, int);
+void *cbdataInternalAlloc(cbdata_type type);
 
 /**
  * Frees a entry allocated by cbdataInternalAlloc().
@@ -259,7 +259,7 @@ cbdata_type cbdataInternalAddType(cbdata_type type, const char *label, int size)
         void *operator new(size_t size) { \
           assert(size == sizeof(type)); \
           if (!CBDATA_##type) CBDATA_##type = cbdataInternalAddType(CBDATA_##type, #type, sizeof(type)); \
-          return (type *)cbdataInternalAlloc(CBDATA_##type,__FILE__,__LINE__); \
+          return (type *)cbdataInternalAlloc(CBDATA_##type); \
         } \
         void operator delete (void *address) { \
           if (address) cbdataInternalFree(address); \

--- a/src/main.cc
+++ b/src/main.cc
@@ -1201,9 +1201,6 @@ mainInitialize(void)
 #endif
 
     FwdState::initModule();
-    /* register the modules in the cache manager menus */
-
-    cbdataRegisterWithCacheManager();
     SBufStatsAction::RegisterWithCacheManager();
 
     /* These use separate calls so that the comm loops can eventually

--- a/src/tests/stub_cbdata.cc
+++ b/src/tests/stub_cbdata.cc
@@ -12,24 +12,16 @@
 #define STUB_API "cbdata.cc"
 #include "tests/STUB.h"
 
-void cbdataRegisterWithCacheManager(void) STUB
 void *cbdataInternalAlloc(cbdata_type, const char *, int sz) {
     return xcalloc(1, sz);
 }
-void *cbdataInternalFree(void *p, const char *, int) {
+void *cbdataInternalFree(void *p) {
     xfree(p);
     return nullptr;
 }
-#if USE_CBDATA_DEBUG
-void cbdataInternalLockDbg(const void *, const char *, int) STUB
-void cbdataInternalUnlockDbg(const void *, const char *, int) STUB
-int cbdataInternalReferenceDoneValidDbg(void **, void **, const char *, int) STUB_RETVAL(0)
-#else
 void cbdataInternalLock(const void *) STUB
 void cbdataInternalUnlock(const void *) STUB
 int cbdataInternalReferenceDoneValid(void **, void **) STUB_RETVAL(0)
-#endif
-
 int cbdataReferenceValid(const void *) STUB_RETVAL(0)
 cbdata_type cbdataInternalAddType(cbdata_type, const char *, int) STUB_RETVAL(CBDATA_UNKNOWN)
 

--- a/src/tests/stub_cbdata.cc
+++ b/src/tests/stub_cbdata.cc
@@ -7,18 +7,13 @@
  */
 
 #include "squid.h"
-#include "cbdata.h"
 
 #define STUB_API "cbdata.cc"
 #include "tests/STUB.h"
 
-void *cbdataInternalAlloc(cbdata_type, const char *, int sz) {
-    return xcalloc(1, sz);
-}
-void *cbdataInternalFree(void *p) {
-    xfree(p);
-    return nullptr;
-}
+#include "cbdata.h"
+void *cbdataInternalAlloc(cbdata_type) STUB_RETVAL(nullptr)
+void *cbdataInternalFree(void *) STUB_RETVAL(nullptr)
 void cbdataInternalLock(const void *) STUB
 void cbdataInternalUnlock(const void *) STUB
 int cbdataInternalReferenceDoneValid(void **, void **) STUB_RETVAL(0)

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -40,7 +40,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--disable-build-info \
 	--disable-shared \
 	--disable-gnuregex \
-	--disable-debug-cbdata \
 	--disable-xmalloc-statistics \
 	--disable-async-io \
 	--disable-storeio \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -60,7 +60,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--enable-shared \
 	--enable-gnuregex \
 	--enable-optimizations \
-	--enable-debug-cbdata \
 	--enable-xmalloc-statistics \
 	--enable-async-io \
 	--enable-storeio \

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -60,7 +60,6 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--enable-gnuregex \
 	--enable-optimizations \
 	--enable-inline \
-	--enable-debug-cbdata \
 	--enable-xmalloc-statistics \
 	--enable-async-io \
 	--enable-storeio \


### PR DESCRIPTION
This was occasionally (but still rare) useful when CBDATA was the
only method of passing callback parameters. Much of that has now
been replaced with AsyncJob/AsyncCall logic. Making this debug
much less useful.

Remove the --enable-debug-cbdata build option and two cache manager
reports only enabled when that option is built. Greatly reducing
the cbdata logic complexity and removing one of its five APIs
permutations entirely.