### PR TITLE
Optimize RefCount comparison with raw pointers

### DIFF
--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -87,12 +87,16 @@ public:
         return p.p_ != p_;
     }
 
-    bool operator == (C const * p) const {
+    template <class Other>
+    bool operator ==(const Other * const p) const
+    {
         return p == p_;
     }
 
-    bool operator != (C const * p) const {
-        return p!= p_;
+    template <class Other>
+    bool operator !=(const Other * const p) const
+    {
+        return p != p_;
     }
 
 private:

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -87,6 +87,14 @@ public:
         return p.p_ != p_;
     }
 
+    bool operator == (C const * p) const {
+        return p == p_;
+    }
+
+    bool operator != (C const * p) const {
+        return p!= p_;
+    }
+
 private:
     void dereference(C const *newP = nullptr) {
         /* Setting p_ first is important:


### PR DESCRIPTION
GCC v12 and Clang v12 tests show that compilers cannot avoid creating
temporaries when comparing RefCount objects with arbitrary pointers.

Also fixes (not yet supported) C++20 build. C++20 automatically reverses
equality comparisons, triggering an ambiguity:

    src/esi/Esi.cc:1920:26: error: ambiguous overload for 'operator=='
        (operand types are 'ESISegment::Pointer' {aka
        'RefCount<ESISegment>'} and std::nullptr_t)
        assert (output->next == nullptr);

    src/esi/Esi.cc:77:6: note: candidate: 'bool operator==(const
        ESIElement*, const Pointer&)' (reversed)
 
    src/base/RefCount.h:82:10: note: candidate: 'bool
        RefCount<C>::operator==(const RefCount<C>&) const [with C =
        ESISegment]'
