### PR TITLE
Update Host, Via, and other headers in-place when possible

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -153,6 +153,7 @@ Thank you!
     Eray Aslan <eray.aslan@caf.com.tr>
     Eray Aslan <eraya@a21an.org>
     Eric Stern <estern@logisense.com>
+    Eric Walters <walters.w.eric@gmail.com>
     Erik Hofman <erik.hofman@a1.nl>
     Eugene Gladchenko <eugene@donpac.ru>
     Evan Jones <ejones@uwaterloo.ca>

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -133,11 +133,11 @@ dnl Or, a shell script (config.test) which returns 0 exit status if
 dnl the helper is to be built.
 AC_DEFUN([SQUID_CHECK_HELPER],[
   AS_IF([test "x$helper" = "x$1"],[
-    AS_IF([test -d "$ac_top_srcdir/src/$2/$1"],[
+    AS_IF([test -d "$srcdir/src/$2/$1"],[
       dnl find helpers providing autoconf M4 requirement checks
       m4_include(m4_echo([src/$2/$1/required.m4]))
       dnl find helpers not yet converted to autoconf (or third party drop-in's)
-      AS_IF([test -f "$ac_top_srcdir/src/$2/$1/config.test" && sh "$ac_top_srcdir/src/$2/$1/config.test" "$squid_host_os"],[
+      AS_IF([test -f "$srcdir/src/$2/$1/config.test" && sh "$srcdir/src/$2/$1/config.test" "$squid_host_os"],[
         BUILD_HELPER="$1"
       ])
       AS_IF(
@@ -164,13 +164,13 @@ AC_DEFUN([SQUID_HELPER_FEATURE_CHECK],[
   AS_IF([test "x$enable_$1" = "x"],[enable_$1=$2],
     [test "x$enable_$1" = "xnone"],[enable_$1=""])
   AS_IF([test "x$enable_$1" = "xyes"],[
-    SQUID_LOOK_FOR_MODULES([$$ac_top_srcdir/src/$3], enable_$1)
+    SQUID_LOOK_FOR_MODULES([$srcdir/src/$3], enable_$1)
     auto_helpers=yes
   ])
   SQUID_CLEANUP_MODULES_LIST([enable_$1])
   AC_MSG_NOTICE([checking $3 helpers: $enable_$1])
   AS_IF([test "x$enable_$1" != "xno" -a "x$enable_$1" != "x"],[
-    SQUID_CHECK_EXISTING_MODULES([$$ac_top_srcdir/src/$3],[enable_$1])
+    SQUID_CHECK_EXISTING_MODULES([$srcdir/src/$3],[enable_$1])
     for helper in $enable_$1 ; do
       $4
     done

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -133,11 +133,11 @@ dnl Or, a shell script (config.test) which returns 0 exit status if
 dnl the helper is to be built.
 AC_DEFUN([SQUID_CHECK_HELPER],[
   AS_IF([test "x$helper" = "x$1"],[
-    AS_IF([test -d "$srcdir/src/$2/$1"],[
+    AS_IF([test -d "$ac_top_srcdir/src/$2/$1"],[
       dnl find helpers providing autoconf M4 requirement checks
       m4_include(m4_echo([src/$2/$1/required.m4]))
       dnl find helpers not yet converted to autoconf (or third party drop-in's)
-      AS_IF([test -f "$srcdir/src/$2/$1/config.test" && sh "$srcdir/src/$2/$1/config.test" "$squid_host_os"],[
+      AS_IF([test -f "$ac_top_srcdir/src/$2/$1/config.test" && sh "$ac_top_srcdir/src/$2/$1/config.test" "$squid_host_os"],[
         BUILD_HELPER="$1"
       ])
       AS_IF(
@@ -164,13 +164,13 @@ AC_DEFUN([SQUID_HELPER_FEATURE_CHECK],[
   AS_IF([test "x$enable_$1" = "x"],[enable_$1=$2],
     [test "x$enable_$1" = "xnone"],[enable_$1=""])
   AS_IF([test "x$enable_$1" = "xyes"],[
-    SQUID_LOOK_FOR_MODULES([$srcdir/src/$3], enable_$1)
+    SQUID_LOOK_FOR_MODULES([$$ac_top_srcdir/src/$3], enable_$1)
     auto_helpers=yes
   ])
   SQUID_CLEANUP_MODULES_LIST([enable_$1])
   AC_MSG_NOTICE([checking $3 helpers: $enable_$1])
   AS_IF([test "x$enable_$1" != "xno" -a "x$enable_$1" != "x"],[
-    SQUID_CHECK_EXISTING_MODULES([$srcdir/src/$3],[enable_$1])
+    SQUID_CHECK_EXISTING_MODULES([$$ac_top_srcdir/src/$3],[enable_$1])
     for helper in $enable_$1 ; do
       $4
     done

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 55    HTTP Header */
 
 #include "squid.h"
+#include "base/Assure.h"
 #include "base/CharacterSet.h"
 #include "base/EnumIterator.h"
 #include "base/Raw.h"
@@ -1118,7 +1119,7 @@ HttpHeader::updateOrAddStr(const Http::HdrType id, const SBuf &newValue)
     assert(Http::HeaderLookupTable.lookup(id).type == Http::HdrFieldType::ftStr);
 
     // XXX: HttpHeaderEntry::value suffers from String size limits
-    Must(newValue.length() < String::SizeMaxXXX()); // TODO: Assure() in master/v6
+    Assure(newValue.length() < String::SizeMaxXXX());
 
     if (!CBIT_TEST(mask, id)) {
         auto newValueCopy = newValue; // until HttpHeaderEntry::value becomes SBuf

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -991,10 +991,7 @@ HttpHeader::addVia(const AnyP::ProtocolVersion &ver, const HttpHeader *from)
         if (!strVia.isEmpty())
             strVia.append(", ", 2);
         strVia.append(buf);
-        // XXX: putStr() still suffers from String size limits
-        Must(strVia.length() < String::SizeMaxXXX());
-        delById(Http::HdrType::VIA);
-        putStr(Http::HdrType::VIA, strVia.c_str());
+        updateOrAddStr(Http::HdrType::VIA, strVia);
     }
 }
 
@@ -1112,6 +1109,43 @@ HttpHeader::putExt(const char *name, const char *value)
     assert(name && value);
     debugs(55, 8, this << " adds ext entry " << name << " : " << value);
     addEntry(new HttpHeaderEntry(Http::HdrType::OTHER, SBuf(name), value));
+}
+
+void
+HttpHeader::updateOrAddStr(const Http::HdrType id, const SBuf &newValue)
+{
+    assert(any_registered_header(id));
+    assert(Http::HeaderLookupTable.lookup(id).type == Http::HdrFieldType::ftStr);
+
+    // XXX: HttpHeaderEntry::value suffers from String size limits
+    Must(newValue.length() < String::SizeMaxXXX()); // TODO: Assure() in master/v6
+
+    if (!CBIT_TEST(mask, id)) {
+        auto newValueCopy = newValue; // until HttpHeaderEntry::value becomes SBuf
+        addEntry(new HttpHeaderEntry(id, SBuf(), newValueCopy.c_str()));
+        return;
+    }
+
+    auto foundSameName = false;
+    for (auto &e: entries) {
+        if (!e || e->id != id)
+            continue;
+
+        if (foundSameName) {
+            // get rid of this repeated same-name entry
+            delete e;
+            e = nullptr;
+            continue;
+        }
+
+        if (newValue.cmp(e->value.termedBuf()) != 0)
+            e->value.assign(newValue.rawContent(), newValue.plength());
+
+        foundSameName = true;
+        // continue to delete any repeated same-name entries
+    }
+    assert(foundSameName);
+    debugs(55, 5, "synced: " << Http::HeaderLookupTable.lookup(id).name << ": " << newValue);
 }
 
 int

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -142,6 +142,9 @@ public:
     void putRange(const HttpHdrRange * range);
     void putSc(HttpHdrSc *sc);
     void putExt(const char *name, const char *value);
+     /// Ensures that the header has the given field, removing or replacing any
+    /// same-name fields with conflicting values as needed.
+    void updateOrAddStr(Http::HdrType, const SBuf &);
     int getInt(Http::HdrType id) const;
     int64_t getInt64(Http::HdrType id) const;
     time_t getTime(Http::HdrType id) const;

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -146,7 +146,7 @@ public:
     /// Ensures that the header has the given field, removing or replacing any
     /// same-name fields with conflicting values as needed.
     void updateOrAddStr(Http::HdrType, const SBuf &);
-    
+
     int getInt(Http::HdrType id) const;
     int64_t getInt64(Http::HdrType id) const;
     time_t getTime(Http::HdrType id) const;

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -142,9 +142,11 @@ public:
     void putRange(const HttpHdrRange * range);
     void putSc(HttpHdrSc *sc);
     void putExt(const char *name, const char *value);
-     /// Ensures that the header has the given field, removing or replacing any
+
+    /// Ensures that the header has the given field, removing or replacing any
     /// same-name fields with conflicting values as needed.
     void updateOrAddStr(Http::HdrType, const SBuf &);
+    
     int getInt(Http::HdrType id) const;
     int64_t getInt64(Http::HdrType id) const;
     time_t getTime(Http::HdrType id) const;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1324,8 +1324,8 @@ ErrorState::BuildHttpReply()
          */
         if (!Config.errorDirectory) {
             /* We 'negotiated' this ONLY from the Accept-Language. */
-            rep->header.delById(Http::HdrType::VARY);
-            rep->header.putStr(Http::HdrType::VARY, "Accept-Language");
+            static const SBuf acceptLanguage("Accept-Language");
+            rep->header.updateOrAddStr(Http::HdrType::VARY, acceptLanguage);
         }
 
         /* add the Content-Language header according to RFC section 14.12 */

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1649,10 +1649,10 @@ Ftp::Server::setDataCommand()
     HttpRequest *const request = http->request;
     assert(request != nullptr);
     HttpHeader &header = request->header;
-    header.delById(Http::HdrType::FTP_COMMAND);
-    header.putStr(Http::HdrType::FTP_COMMAND, "PASV");
-    header.delById(Http::HdrType::FTP_ARGUMENTS);
-    header.putStr(Http::HdrType::FTP_ARGUMENTS, "");
+    static const SBuf pasvValue("PASV");
+    header.updateOrAddStr(Http::HdrType::FTP_COMMAND, pasvValue);
+    static const SBuf emptyValue("");
+    header.updateOrAddStr(Http::HdrType::FTP_ARGUMENTS, emptyValue);
     debugs(9, 5, "client data command converted to fake PASV");
 }
 

--- a/src/servers/Http1Server.cc
+++ b/src/servers/Http1Server.cc
@@ -185,11 +185,8 @@ Http::One::Server::buildHttpRequest(Http::StreamPointer &context)
     // some code still uses Host directly so normalize it using the previously
     // sanitized URL authority value.
     // For now preserve the case where Host is completely absent. That matters.
-    if (const auto x = request->header.delById(Http::HOST)) {
-        debugs(33, 5, "normalize " << x << " Host header using " << request->url.authority());
-        SBuf tmp(request->url.authority());
-        request->header.putStr(Http::HOST, tmp.c_str());
-    }
+    if (request->header.has(Http::HdrType::HOST))
+        request->header.updateOrAddStr(Http::HdrType::HOST, request->url.authority());
 
     // TODO: We fill request notes here until we find a way to verify whether
     // no ACL checking is performed before ClientHttpRequest::doCallouts().

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -64,6 +64,7 @@ void HttpHeader::putContRange(const HttpHdrContRange *) STUB
 void HttpHeader::putRange(const HttpHdrRange *) STUB
 void HttpHeader::putSc(HttpHdrSc *) STUB
 void HttpHeader::putExt(const char *, const char *) STUB
+void HttpHeader::updateOrAddStr(const Http::HdrType, const SBuf &) STUB
 int HttpHeader::getInt(Http::HdrType) const STUB_RETVAL(0)
 int64_t HttpHeader::getInt64(Http::HdrType) const STUB_RETVAL(0)
 time_t HttpHeader::getTime(Http::HdrType) const STUB_RETVAL(0)

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -64,7 +64,7 @@ void HttpHeader::putContRange(const HttpHdrContRange *) STUB
 void HttpHeader::putRange(const HttpHdrRange *) STUB
 void HttpHeader::putSc(HttpHdrSc *) STUB
 void HttpHeader::putExt(const char *, const char *) STUB
-void HttpHeader::updateOrAddStr(const Http::HdrType, const SBuf &) STUB
+void HttpHeader::updateOrAddStr(Http::HdrType, const SBuf &) STUB
 int HttpHeader::getInt(Http::HdrType) const STUB_RETVAL(0)
 int64_t HttpHeader::getInt64(Http::HdrType) const STUB_RETVAL(0)
 time_t HttpHeader::getTime(Http::HdrType) const STUB_RETVAL(0)


### PR DESCRIPTION
This change optimizes Host header synchronization code that usually does
not need to change the Host header field but was always deleting the old
field and generating/appending a new one. Appending Host also violated
an RFC 9110 section 7.2 rule (on behalf of the user agent whose Host we
were rewriting): "A user agent that sends Host SHOULD send it as the
first field in the header section".

Also, removing old header fields and appending new ones introduced HTTP
header changes that broke otherwise working peers. For example, some
origins denied Squid-proxied messages exclusively due to an unusual
(from those origins point of view) Host header position. This change
reduces (but does not eliminate) such unnecessary and risky changes.