### PR TITLE
squid-conf-tests should test installed Squid

### DIFF
--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -43,8 +43,7 @@ TESTS += \
 	splay\
 	mem_node_test\
 	mem_hdr_test\
-	$(ESI_TESTS) \
-	squid-conf-tests
+	$(ESI_TESTS)
 
 ## Sort by alpha - any build failures are significant.
 check_PROGRAMS += \
@@ -136,10 +135,12 @@ VirtualDeleteOperator_SOURCES = \
 	VirtualDeleteOperator.cc \
 	stub_libmem.cc
 
+installcheck-local: squid-conf-tests
+
 squid-conf-tests: $(srcdir)/test-squid-conf.sh $(top_builddir)/src/squid.conf.default $(srcdir)/squidconf/*
 	@failed=0; cfglist="$(top_builddir)/src/squid.conf.default $(srcdir)/squidconf/*.conf"; rm -f $@ || $(TRUE); \
 	for cfg in $$cfglist ; do \
-		$(srcdir)/test-squid-conf.sh $(top_builddir) $$cfg || \
+		$(srcdir)/test-squid-conf.sh $(top_builddir) $(sbindir) $$cfg || \
 			{ echo "FAIL: squid.conf test: $$cfg" | \
 				sed s%$(top_builddir)/src/%% | \
 				sed s%$(srcdir)/squidconf/%% ; \

--- a/test-suite/test-squid-conf.sh
+++ b/test-suite/test-squid-conf.sh
@@ -9,10 +9,11 @@
 
 # Orchestrates a "squid -k parse ..." test of a single Squid configuration
 # file (with an optional .instructions file containing testing directions).
-# Usage: test-squid-conf.sh <top_builddir> <squid.conf>
+# Usage: test-squid-conf.sh <top_builddir> <sbindir> <squid.conf>
 
 top_builddir=$1
-configFile=$2
+sbindir=$2
+configFile=$3
 
 instructionsFile="$configFile.instructions"
 if test -e $instructionsFile
@@ -71,4 +72,4 @@ then
     # TODO: Add support for the "require-failure" instruction.
 fi
 
-exec $top_builddir/src/squid -k parse -f $configFile
+exec $sbindir/squid -k parse -f $configFile


### PR DESCRIPTION
    FATAL: ..._inst/etc/mime.conf: (2) No such file or directory
    FATAL: ..._inst/share/icons: (2) No such file or directory

Our squid-conf-tests are running "squid -k parse" that requires icons
and other supplementary files to be _installed_. Thus, squid-conf-tests
must run during "make installcheck" rather than during "make check".

With this change, "make distcheck" triggers squid-conf-tests at the
right time, after "all", "check", and "install" targets are built.
Also, we are now testing installed Squid binaries, as we should.
