### PR TITLE
Update StoreEntry to emulate MEMPROXY_CLASS

### DIFF
--- a/src/Store.h
+++ b/src/Store.h
@@ -59,7 +59,7 @@ class StoreEntry : public hash_link, public Packable
         if (address)
             Pool().freeOne(address);
     }
-    static size_t UseCount() { return Pool().inUseCount(); }
+    static int UseCount() { return Pool().inUseCount(); }
 
 public:
     bool checkDeferRead(int fd) const;

--- a/src/Store.h
+++ b/src/Store.h
@@ -43,10 +43,10 @@ class StoreEntry : public hash_link, public Packable
 
     // XXX: new/delete operators need to be replaced with MEMPROXY_CLASS
     // definitions but doing so exposes bug 4370, and maybe 4354 and 4355
-    // for now emulate MEMPROXY_CLASS(StoreEntry), but leave pool zero'ing memory
+    // for now, emulate MEMPROXY_CLASS(StoreEntry), but do zero allocated memory
     private:
     static inline Mem::AllocatorProxy &Pool() {
-        static Mem::AllocatorProxy thePool("StoreEntry", sizeof(StoreEntry) /*, false*/);
+        static Mem::AllocatorProxy thePool("StoreEntry", sizeof(StoreEntry), true /* for now; see XXX above */);
         return thePool;
     }
     public:

--- a/src/snmp_agent.cc
+++ b/src/snmp_agent.cc
@@ -410,7 +410,7 @@ snmp_prfSysFn(variable_list * Var, snint * ErrP)
 
     case PERF_SYS_NUMOBJCNT:
         Answer = snmp_var_new_integer(Var->name, Var->name_length,
-                                      (snint) StoreEntry::inUseCount(),
+                                      (snint) StoreEntry::UseCount(),
                                       SMI_GAUGE32);
         break;
 

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -137,7 +137,7 @@ void
 Store::Controller::stat(StoreEntry &output) const
 {
     storeAppendPrintf(&output, "Store Directory Statistics:\n");
-    storeAppendPrintf(&output, "Store Entries          : %" PRIuSIZE "\n",
+    storeAppendPrintf(&output, "Store Entries          : %d\n",
                       StoreEntry::UseCount());
     storeAppendPrintf(&output, "Maximum Swap Size      : %" PRIu64 " KB\n",
                       maxSize() >> 10);

--- a/src/store/Controller.cc
+++ b/src/store/Controller.cc
@@ -129,7 +129,7 @@ Store::Controller::getStats(StoreInfoStats &stats) const
     swapDir->getStats(stats);
 
     // low-level info not specific to memory or disk cache
-    stats.store_entry_count = StoreEntry::inUseCount();
+    stats.store_entry_count = StoreEntry::UseCount();
     stats.mem_object_count = MemObject::inUseCount();
 }
 
@@ -137,8 +137,8 @@ void
 Store::Controller::stat(StoreEntry &output) const
 {
     storeAppendPrintf(&output, "Store Directory Statistics:\n");
-    storeAppendPrintf(&output, "Store Entries          : %lu\n",
-                      (unsigned long int)StoreEntry::inUseCount());
+    storeAppendPrintf(&output, "Store Entries          : %" PRIuSIZE "\n",
+                      StoreEntry::UseCount());
     storeAppendPrintf(&output, "Maximum Swap Size      : %" PRIu64 " KB\n",
                       maxSize() >> 10);
     storeAppendPrintf(&output, "Current Store Swap Size: %.2f KB\n",

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -91,7 +91,7 @@ storeDigestCalcCap()
      */
     const uint64_t hi_cap = Store::Root().maxSize() / Config.Store.avgObjectSize;
     const uint64_t lo_cap = 1 + Store::Root().currentSize() / Config.Store.avgObjectSize;
-    const uint64_t e_count = StoreEntry::inUseCount();
+    const uint64_t e_count = StoreEntry::UseCount();
     uint64_t cap = e_count ? e_count : hi_cap;
     debugs(71, 2, "have: " << e_count << ", want " << cap <<
            " entries; limits: [" << lo_cap << ", " << hi_cap << "]");

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -69,13 +69,6 @@ bool StoreEntry::modifiedSince(const time_t, const int) const STUB_RETVAL(false)
 bool StoreEntry::hasIfMatchEtag(const HttpRequest &) const STUB_RETVAL(false)
 bool StoreEntry::hasIfNoneMatchEtag(const HttpRequest &) const STUB_RETVAL(false)
 Store::Disk &StoreEntry::disk() const STUB_RETREF(Store::Disk)
-size_t StoreEntry::inUseCount() STUB_RETVAL(0)
-void *StoreEntry::operator new(size_t)
-{
-    STUB
-    return new StoreEntry();
-}
-void StoreEntry::operator delete(void *) STUB
 //#if USE_SQUID_ESI
 //ESIElement::Pointer StoreEntry::cachedESITree STUB_RETVAL(nullptr)
 //#endif


### PR DESCRIPTION
Prepare the StoreEntry class for future switch to MEMPROXY_CLASS
without actually going all the way. There are several bugs which still
have to be solved before the actual switch can happen.

For now though we can use the modern Pool() API and same method
types provided by MEMPROXY_CLASS macro.