### PR TITLE
ext_kerberos_ldap_group_acl: Support -b with -D

### DIFF
--- a/src/acl/external/kerberos_ldap_group/support_ldap.cc
+++ b/src/acl/external/kerberos_ldap_group/support_ldap.cc
@@ -1115,7 +1115,11 @@ get_memberof(struct main_args *margs, char *user, char *domain, char *group)
                   "%s| %s: DEBUG: Error during initialisation of ldap connection: %s\n",
                   LogTime(), PROGRAM, strerror(errno));
         }
-        bindp = convert_domain_to_bind_path(domain);
+        if (margs->lbind) {
+            bindp = xstrdup(margs->lbind);
+        } else {
+            bindp = convert_domain_to_bind_path(domain);
+        }
     }
     if ((!domain || !ld) && margs->lurl && strstr(margs->lurl, "://")) {
         char *hostname;


### PR DESCRIPTION
Authored-by: Alexander Bokovoy <abokovoy@redhat.com>

When both '-b' (i.e. bind DN) and '-D' (i.e. Kerberos domain) options
are specified, '-b' is ignored completely. This breaks the helper when a
search subtree has to be limited (e.g., when using FreeIPA).

Fix it to take '-b' into account if it was specified with '-D'.