### PR TITLE
Ignore changes in "note" ACL key; inform admins

### DIFF
--- a/src/acl/NoteData.cc
+++ b/src/acl/NoteData.cc
@@ -49,6 +49,18 @@ ACLNoteData::parse()
 {
     char* t = ConfigParser::strtokFile();
     assert (t != nullptr);
+
+    if (!name.isEmpty() && name.cmp(t) != 0) {
+        debugs(28, DBG_CRITICAL, "ERROR: Ignoring conflicting 'note' ACL configuration:" <<
+               Debug::Extra << "honored annotation name: " << name <<
+               Debug::Extra << "ignored annotation name: " << t <<
+               Debug::Extra << "configuration location: " << ConfigParser::CurrentLocation() <<
+               Debug::Extra << "advice: To match annotations with different names, " <<
+               "use note ACLs with different names " <<
+               "(that may be ORed using an 'any-of' ACL.");
+        return;
+    }
+
     name = t;
     values->parse();
 }

--- a/src/acl/NoteData.cc
+++ b/src/acl/NoteData.cc
@@ -57,7 +57,7 @@ ACLNoteData::parse()
                Debug::Extra << "configuration location: " << ConfigParser::CurrentLocation() <<
                Debug::Extra << "advice: To match annotations with different names, " <<
                "use note ACLs with different names " <<
-               "(that may be ORed using an 'any-of' ACL.");
+               "(that may be ORed using an 'any-of' ACL).");
         return;
     }
 


### PR DESCRIPTION
    acl banned note color green   # never matches before this change
    acl banned note weight heavy  # never matches after this change
    http_access deny banned

Admins expect the above configuration to deny both green transactions
and heavy transactions, but that is not what actually happens.

Before this change, Squid was denying only heavy transactions,
effectively (and silently!) ignoring the first "acl banned..." line.
Now, Squid denies only green transactions (with a configuration-time
ERROR) and otherwise ignores the second and any subsequent "acl
banned..." lines.

We now honor the first instead of the last "acl" line (for the same-name
note ACL) because:

* req_header/rep_header ACLs are doing that since 2016 commit a0b240c;
* it is easier to implement while still reporting the ignored location
  (which we do not need to remember or pass around in this case);
* we should just reject these configurations as invalid instead.
