### PR TITLE
GCC 12 build error no match for 'operator<<'

### DIFF
--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -11,6 +11,7 @@
 
 #include "base/AsyncJob.h"
 #include "base/CbcPointer.h"
+#include "base/IoManip.h"
 #include "debug/Stream.h"
 
 /**

--- a/src/base/PackableStream.h
+++ b/src/base/PackableStream.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_SRC_BASE_PACKABLESTREAM_H
 #define SQUID_SRC_BASE_PACKABLESTREAM_H
 
+#include "base/IoManip.h"
 #include "base/Packable.h"
 
 #include <ostream>

--- a/src/store/SwapMetaView.cc
+++ b/src/store/SwapMetaView.cc
@@ -84,7 +84,7 @@ Store::SwapMetaView::checkExpectedLength(const size_t expectedLength) const
 {
     if (rawLength != expectedLength)
         throw TextException(ToSBuf("Bad value length in a Store entry meta field expecting a ",
-                                   expectedLength, "-byte value: ", *this), Here());
+                                   expectedLength, "-byte value: ", this), Here());
 }
 
 std::ostream &


### PR DESCRIPTION
C++17 fold expression and std::optional printing hits these
errors expanding ostream other than debugs().