### PR TITLE
Support "negative" squid-conf-tests

### DIFF
--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -154,4 +154,4 @@ squid-conf-tests: $(srcdir)/test-squid-conf.sh $(top_builddir)/src/squid.conf.de
 	done; \
 	if test "$$failed" -eq 0; then cp $(TRUE) $@ ; fi
 
-CLEANFILES += squid-conf-tests
+CLEANFILES += squid-conf-tests squid-stderr.log

--- a/test-suite/squidconf/bad-regex.conf
+++ b/test-suite/squidconf/bad-regex.conf
@@ -1,0 +1,8 @@
+## Copyright (C) 1996-2022 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+acl foo browser *

--- a/test-suite/squidconf/bad-regex.conf.instructions
+++ b/test-suite/squidconf/bad-regex.conf.instructions
@@ -1,0 +1,2 @@
+expect-failure (ERROR|FATAL):.*POSIX.regcomp.*failure
+

--- a/test-suite/squidconf/bad-regex.conf.instructions
+++ b/test-suite/squidconf/bad-regex.conf.instructions
@@ -1,2 +1,2 @@
-expect-failure (ERROR|FATAL):.*POSIX.regcomp.*failure
+expect-failure ERROR:.configuration.failure:.POSIX.regcomp.*failure
 

--- a/test-suite/squidconf/regex.conf
+++ b/test-suite/squidconf/regex.conf
@@ -18,6 +18,3 @@ acl G dstdom_regex \.g...le\.com$
 
 acl B browser ^Mozilla
 acl B browser ^Java/[0-9]+(\.[0-9]+)?
-
-# TODO: Support testing invalid configurations, like this one:
-# acl foo browser *

--- a/test-suite/test-squid-conf.sh
+++ b/test-suite/test-squid-conf.sh
@@ -92,7 +92,7 @@ then
     done < $instructionsFile
 fi
 
-errorLog="$top_builddir/squid-stderr.log"
+errorLog="squid-stderr.log"
 
 $sbindir/squid -k parse -f $configFile 2> $errorLog
 result=$?


### PR DESCRIPTION
The test suite can now check that Squid rejects a given malformed
configuration file and that the rejection reason matches the expected
one. The latter reduces the probability that a successful "negative"
test outcome would hide a bug (because Squid has rejected a malformed
file but for a reason unrelated to what the test was trying to verify).

For now, enable just one acl regex test case, addressing an old TODO.

To improve "negative" test coverage, we would need to generate test
configurations using a configuration template and a list of problematic
expressions (with corresponding failure messages), but this hard-coded
approach is already better than nothing.

