### PR TITLE
Move Namespace::Foo printing operators to Namespace

### DIFF
--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -74,16 +74,16 @@ operator <<(std::ostream &os, const SipcIo &sio)
 /* IpcIo::Command */
 
 std::ostream &
-operator <<(std::ostream &os, const IpcIo::Command command)
+IpcIo::operator <<(std::ostream &os, const Command command)
 {
     switch (command) {
-    case IpcIo::cmdNone:
+    case cmdNone:
         return os << '-';
-    case IpcIo::cmdOpen:
+    case cmdOpen:
         return os << 'o';
-    case IpcIo::cmdRead:
+    case cmdRead:
         return os << 'r';
-    case IpcIo::cmdWrite:
+    case cmdWrite:
         return os << 'w';
     }
     // unreachable code

--- a/src/DiskIO/IpcIo/IpcIoFile.h
+++ b/src/DiskIO/IpcIo/IpcIoFile.h
@@ -32,9 +32,10 @@ namespace IpcIo
 /// what kind of I/O the disker needs to do or have done
 typedef enum { cmdNone, cmdOpen, cmdRead, cmdWrite } Command;
 
+std::ostream &operator <<(std::ostream &, Command);
+
 } // namespace IpcIo
 
-std::ostream &operator <<(std::ostream &, IpcIo::Command);
 
 /// converts DiskIO requests to IPC queue messages
 class IpcIoMsg

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -167,10 +167,8 @@ public:
     bool implicit = false;
 };
 
-} // namespace Acl
-
 inline std::ostream &
-operator <<(std::ostream &o, const Acl::Answer a)
+operator <<(std::ostream &o, const Answer a)
 {
     switch (a) {
     case ACCESS_DENIED:
@@ -188,6 +186,8 @@ operator <<(std::ostream &o, const Acl::Answer a)
     }
     return o;
 }
+
+} // namespace Acl
 
 /// \ingroup ACLAPI
 class acl_proxy_auth_match_cache

--- a/src/acl/Options.cc
+++ b/src/acl/Options.cc
@@ -245,14 +245,14 @@ Acl::CaseSensitivityOption()
 }
 
 std::ostream &
-operator <<(std::ostream &os, const Acl::Option &option)
+Acl::operator <<(std::ostream &os, const Option &option)
 {
     option.print(os);
     return os;
 }
 
 std::ostream &
-operator <<(std::ostream &os, const Acl::Options &options)
+Acl::operator <<(std::ostream &os, const Options &options)
 {
     for (const auto option: options)
         os << *option;

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -225,10 +225,10 @@ const Options &NoOptions(); ///< \returns an empty Options container
 /// A disabled (+i) and default states are "case sensitive".
 const BooleanOption &CaseSensitivityOption();
 
-} // namespace Acl
+std::ostream &operator <<(std::ostream &, const Option &);
+std::ostream &operator <<(std::ostream &, const Options &);
 
-std::ostream &operator <<(std::ostream &os, const Acl::Option &option);
-std::ostream &operator <<(std::ostream &os, const Acl::Options &options);
+} // namespace Acl
 
 #endif /* SQUID_ACL_OPTIONS_H */
 

--- a/src/anyp/ProtocolVersion.h
+++ b/src/anyp/ProtocolVersion.h
@@ -92,7 +92,7 @@ public:
 };
 
 inline std::ostream &
-operator << (std::ostream &os, const AnyP::ProtocolVersion &v)
+operator << (std::ostream &os, const ProtocolVersion &v)
 {
     return (os << AnyP::ProtocolType_str[v.protocol] << '/' << v.major << '.' << v.minor);
 }

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -186,24 +186,24 @@ private:
     mutable SBuf absolute_;          ///< RFC 7230 section 5.3.2 absolute-URI
 };
 
-} // namespace AnyP
-
 inline std::ostream &
-operator <<(std::ostream &os, const AnyP::Uri &url)
+operator <<(std::ostream &os, const Uri &url)
 {
     // none means explicit empty string for scheme.
-    if (url.getScheme() != AnyP::PROTO_NONE)
+    if (url.getScheme() != PROTO_NONE)
         os << url.getScheme().image();
     os << ":";
 
     // no authority section on URN
-    if (url.getScheme() != AnyP::PROTO_URN)
+    if (url.getScheme() != PROTO_URN)
         os << "//" << url.authority();
 
     // path is what it is - including absent
     os << url.path();
     return os;
 }
+
+} // namespace AnyP
 
 /* Deprecated functions for Legacy code handling URLs */
 

--- a/src/anyp/UriScheme.h
+++ b/src/anyp/UriScheme.h
@@ -69,14 +69,14 @@ private:
     SBuf image_;
 };
 
-} // namespace AnyP
-
 inline std::ostream &
-operator << (std::ostream &os, AnyP::UriScheme const &scheme)
+operator <<(std::ostream &os, const UriScheme &scheme)
 {
     os << scheme.image();
     return os;
 }
+
+} // namespace AnyP
 
 #endif /* SQUID_ANYP_URISCHEME_H */
 

--- a/src/clients/HttpTunnelerAnswer.h
+++ b/src/clients/HttpTunnelerAnswer.h
@@ -47,7 +47,7 @@ public:
     Comm::ConnectionPointer conn;
 };
 
-std::ostream &operator <<(std::ostream &, const Http::TunnelerAnswer &);
+std::ostream &operator <<(std::ostream &, const TunnelerAnswer &);
 
 } // namespace Http
 

--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -192,7 +192,7 @@ Comm::Connection::detailCodeContext(std::ostream &os) const
 }
 
 std::ostream &
-operator << (std::ostream &os, const Comm::Connection &conn)
+Comm::operator << (std::ostream &os, const Connection &conn)
 {
     os << conn.id;
     if (!conn.local.isNoAddr() || conn.local.port())

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -193,17 +193,17 @@ private:
     Security::NegotiationHistory *tlsHistory;
 };
 
-}; // namespace Comm
-
-std::ostream &operator << (std::ostream &os, const Comm::Connection &conn);
+std::ostream &operator <<(std::ostream &, const Connection &);
 
 inline std::ostream &
-operator << (std::ostream &os, const Comm::ConnectionPointer &conn)
+operator <<(std::ostream &os, const ConnectionPointer &conn)
 {
     if (conn != nullptr)
         os << *conn;
     return os;
 }
+
+} // namespace Comm
 
 #endif
 

--- a/src/dns/LookupDetails.h
+++ b/src/dns/LookupDetails.h
@@ -30,13 +30,13 @@ public:
     int wait; ///< msecs spent waiting for the lookup (if any) or -1 (if none)
 };
 
-} // namespace Dns
-
 inline std::ostream &
-operator <<(std::ostream &os, const Dns::LookupDetails &dns)
+operator <<(std::ostream &os, const LookupDetails &dns)
 {
     return dns.print(os);
 }
+
+} // namespace Dns
 
 #endif /* SQUID_DNS_LOOKUPDETAILS_H */
 

--- a/src/helper/Reply.cc
+++ b/src/helper/Reply.cc
@@ -193,26 +193,26 @@ Helper::Reply::emptyBuf() const
 }
 
 std::ostream &
-operator <<(std::ostream &os, const Helper::Reply &r)
+Helper::operator <<(std::ostream &os, const Reply &r)
 {
     os << "{result=";
     switch (r.result) {
-    case Helper::Okay:
+    case Okay:
         os << "OK";
         break;
-    case Helper::Error:
+    case Error:
         os << "ERR";
         break;
-    case Helper::BrokenHelper:
+    case BrokenHelper:
         os << "BH";
         break;
-    case Helper::TT:
+    case TT:
         os << "TT";
         break;
-    case Helper::TimedOut:
+    case TimedOut:
         os << "Timeout";
         break;
-    case Helper::Unknown:
+    case Unknown:
         os << "Unknown";
         break;
     }

--- a/src/helper/Reply.h
+++ b/src/helper/Reply.h
@@ -73,9 +73,10 @@ private:
     MemBuf other_;
 };
 
+std::ostream &operator <<(std::ostream &, const Reply &);
+
 } // namespace Helper
 
-std::ostream &operator <<(std::ostream &os, const Helper::Reply &r);
 
 #endif /* _SQUID_SRC_HELPER_REPLY_H */
 

--- a/src/helper/ReservationId.h
+++ b/src/helper/ReservationId.h
@@ -36,13 +36,13 @@ private:
     uint64_t id = 0; ///< uniquely identifies this reservation
 };
 
-}; // namespace Helper
-
 inline std::ostream &
-operator <<(std::ostream &os, const Helper::ReservationId &id)
+operator <<(std::ostream &os, const ReservationId &id)
 {
     return id.print(os);
 }
+
+}; // namespace Helper
 
 namespace std {
 /// default hash functor to support std::unordered_map<HelperReservationId, *>

--- a/src/http/RegisteredHeaders.cc
+++ b/src/http/RegisteredHeaders.cc
@@ -62,10 +62,10 @@ const HeaderLookupTable_t HeaderLookupTable;
 }; /* namespace Http */
 
 std::ostream&
-operator<< (std::ostream &s, Http::HdrType id)
+Http::operator<< (std::ostream &s, const HdrType id)
 {
-    if (Http::any_HdrType_enum_value(id))
-        s << Http::HeaderLookupTable.lookup(id).name << '[' << static_cast<int>(id) << ']';
+    if (any_HdrType_enum_value(id))
+        s << HeaderLookupTable.lookup(id).name << '[' << static_cast<int>(id) << ']';
     else
         s << "Invalid-Header[" << static_cast<int>(id) << ']';
     return s;

--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -222,11 +222,10 @@ any_registered_header (const Http::HdrType id)
     return (id >= Http::HdrType::ACCEPT && id < Http::HdrType::OTHER);
 }
 
+std::ostream &operator <<(std::ostream &, HdrType);
+
 }; /* namespace Http */
 
-/* ostream output for Http::HdrType */
-std::ostream &
-operator<< (std::ostream&, Http::HdrType);
 
 #endif /* SQUID_HTTP_REGISTEREDHEADERS_H */
 

--- a/src/ip/NfMarkConfig.cc
+++ b/src/ip/NfMarkConfig.cc
@@ -49,7 +49,7 @@ Ip::NfMarkConfig::applyToMark(nfmark_t m) const
 }
 
 std::ostream &
-operator <<(std::ostream &os, const Ip::NfMarkConfig c)
+Ip::operator <<(std::ostream &os, const NfMarkConfig c)
 {
     os << asHex(c.mark);
 

--- a/src/ip/NfMarkConfig.h
+++ b/src/ip/NfMarkConfig.h
@@ -42,9 +42,10 @@ public:
     nfmark_t mask = 0xffffffff;
 };
 
+std::ostream &operator <<(std::ostream &, NfMarkConfig);
+
 } // namespace Ip
 
-std::ostream &operator <<(std::ostream &os, const Ip::NfMarkConfig connmark);
 
 #endif // SQUID_NFMARKCONFIG_H
 

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -59,7 +59,7 @@ private:
 };
 
 /// dumps approximate lock state (for debugging)
-std::ostream &operator <<(std::ostream &os, const Ipc::ReadWriteLock &);
+std::ostream &operator <<(std::ostream &, const ReadWriteLock &);
 
 /// approximate stats of a set of ReadWriteLocks
 class ReadWriteLockStats

--- a/src/ipcache.h
+++ b/src/ipcache.h
@@ -212,6 +212,13 @@ public:
 /// initiate an (often) asynchronous DNS lookup; the `receiver` gets the results
 void nbgethostbyname(const char *name, const CbcPointer<IpReceiver> &receiver);
 
+inline std::ostream &
+operator <<(std::ostream &os, const CachedIps &ips)
+{
+    ips.reportCurrent(os);
+    return os;
+}
+
 } // namespace Dns
 
 typedef Dns::CachedIps ipcache_addrs; ///< deprecated alias
@@ -228,13 +235,6 @@ void ipcacheMarkBadAddr(const char *name, const Ip::Address &);
 void ipcacheMarkGoodAddr(const char *name, const Ip::Address &);
 void ipcache_restart(void);
 int ipcacheAddEntryFromHosts(const char *name, const char *ipaddr);
-
-inline std::ostream &
-operator <<(std::ostream &os, const Dns::CachedIps &ips)
-{
-    ips.reportCurrent(os);
-    return os;
-}
 
 /* inlined implementations */
 

--- a/src/mgr/ActionParams.h
+++ b/src/mgr/ActionParams.h
@@ -44,7 +44,5 @@ public:
 
 } // namespace Mgr
 
-std::ostream &operator <<(std::ostream &os, const Mgr::ActionParams &params);
-
 #endif /* SQUID_MGR_ACTION_PARAMS_H */
 

--- a/src/mgr/ActionProfile.h
+++ b/src/mgr/ActionProfile.h
@@ -38,13 +38,13 @@ public:
     ActionCreatorPointer creator; ///< creates Action objects with this profile
 };
 
-} // namespace Mgr
-
 inline std::ostream &
-operator <<(std::ostream &os, const Mgr::ActionProfile &profile)
+operator <<(std::ostream &os, const ActionProfile &profile)
 {
     return os << profile.name;
 }
+
+} // namespace Mgr
 
 #endif /* SQUID_MGR_ACTION_PROFILE_H */
 

--- a/src/mgr/Command.cc
+++ b/src/mgr/Command.cc
@@ -13,7 +13,7 @@
 #include "mgr/Command.h"
 
 std::ostream &
-operator <<(std::ostream &os, const Mgr::Command &cmd)
+Mgr::operator <<(std::ostream &os, const Command &cmd)
 {
     if (cmd.profile != nullptr)
         return os << *cmd.profile;

--- a/src/mgr/Command.h
+++ b/src/mgr/Command.h
@@ -28,9 +28,9 @@ public:
     ActionParams params; ///< user-supplied action arguments
 };
 
-} // namespace Mgr
+std::ostream &operator <<(std::ostream &, const Command &);
 
-std::ostream &operator <<(std::ostream &os, const Mgr::Command &cmd);
+} // namespace Mgr
 
 #endif /* SQUID_MGR_COMMAND_H */
 

--- a/src/security/EncryptorAnswer.h
+++ b/src/security/EncryptorAnswer.h
@@ -33,7 +33,7 @@ public:
     bool tunneled;
 };
 
-std::ostream &operator <<(std::ostream &, const Security::EncryptorAnswer &);
+std::ostream &operator <<(std::ostream &, const EncryptorAnswer &);
 
 } // namespace Security
 

--- a/src/security/ErrorDetail.h
+++ b/src/security/ErrorDetail.h
@@ -126,17 +126,17 @@ ErrorCode ErrorCodeFromName(const char *name);
 /// \param prefixRawCode whether to prefix raw codes with "SSL_ERR="
 const char *ErrorNameFromCode(ErrorCode err, bool prefixRawCode = false);
 
-} // namespace Security
-
 /// Dump the given Security::ErrorDetail via a possibly nil pointer (for
 /// debugging). Unfortunately, without this, compilers pick generic RefCount<T>
 /// operator "<<" overload (with T=Security::ErrorDetail) instead of the
 /// overload provided by the parent ErrorDetail class (that we call here).
 inline std::ostream &
-operator <<(std::ostream &os, const Security::ErrorDetail::Pointer &p)
+operator <<(std::ostream &os, const ErrorDetail::Pointer &p)
 {
     return operator <<(os, ::ErrorDetail::Pointer(p));
 }
+
+} // namespace Security
 
 #endif
 

--- a/src/security/Handshake.h
+++ b/src/security/Handshake.h
@@ -50,8 +50,8 @@ public:
     Ciphers ciphers;
 };
 
-inline
-std::ostream &operator <<(std::ostream &os, Security::TlsDetails const &details)
+inline std::ostream &
+operator <<(std::ostream &os, const TlsDetails &details)
 {
     return details.print(os);
 }

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -85,5 +85,5 @@ void Comm::Write(const Comm::ConnectionPointer &, MemBuf *, AsyncCall::Pointer &
 void Comm::WriteCancel(const Comm::ConnectionPointer &, const char *) STUB
 /*PF*/ void Comm::HandleWrite(int, void*) STUB
 
-std::ostream &operator << (std::ostream &os, const Comm::Connection &) STUB_RETVAL(os << "[Connection object]")
+std::ostream &Comm::operator <<(std::ostream &os, const Connection &) STUB_RETVAL(os << "[Connection object]")
 

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -67,7 +67,7 @@ HeaderLookupTable_t::HeaderLookupTable_t() {STUB_NOP}
 const HeaderTableRecord& HeaderLookupTable_t::lookup(const char *, const std::size_t) const STUB_RETVAL(BadHdr)
 const HeaderLookupTable_t HeaderLookupTable;
 }
-std::ostream &operator<< (std::ostream&os, Http::HdrType) STUB_RETVAL(os)
+std::ostream &Http::operator <<(std::ostream &os, HdrType) STUB_RETVAL(os)
 
 #include "http/RequestMethod.h"
 HttpRequestMethod::HttpRequestMethod(const SBuf &) {STUB}

--- a/src/tests/stub_libmgr.cc
+++ b/src/tests/stub_libmgr.cc
@@ -19,7 +19,7 @@
 
 // NP: used by Action.h instantiations
 #include "mgr/Command.h"
-std::ostream &operator <<(std::ostream &os, const Mgr::Command &) STUB_RETVAL(os)
+std::ostream &Mgr::operator <<(std::ostream &os, const Command &) STUB_RETVAL(os)
 
 #include "mgr/Action.h"
 Mgr::Action::Action(const CommandPointer &) STUB
@@ -40,7 +40,6 @@ static Mgr::Action::Pointer dummyAction;
 Mgr::ActionParams::ActionParams() STUB_NOP
 Mgr::ActionParams::ActionParams(const Ipc::TypedMsgHdr &) STUB_NOP
 void Mgr::ActionParams::pack(Ipc::TypedMsgHdr &) const STUB
-std::ostream &operator <<(std::ostream &os, const Mgr::ActionParams &) STUB_RETVAL(os)
 
 #include "mgr/ActionWriter.h"
 //Mgr::ActionWriter::ActionWriter(const Action::Pointer &, int) STUB


### PR DESCRIPTION
... where C++ Argument-Dependent Lookup (ADL) can find them.

These specific printing operators did not encounter build problems yet,
but they were misplaced. See commit XXX for rationale and details.

Also removed unimplemented Mgr::ActionParams printing operator.

Also removed excessive "Namespace::" prefixes inside Namespace in
several printing operators declarations that were already properly
placed in their argument's namespaces (e.g., Ipc::ReadWriteLock).

No functionality changes expected.
