### PR TITLE
Fix errorpage.cc build on MacOS

### DIFF
--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -39,6 +39,8 @@
 #include "ssl/ErrorDetailManager.h"
 #endif
 
+#include <array>
+
 /**
  \defgroup ErrorPageInternal Error Page Internals
  \ingroup ErrorPageAPI


### PR DESCRIPTION
    errorpage.cc:153:44: error: implicit instantiation of undefined
    template std::array<HardCodedError, 7> HardCodedErrors
