### PR TITLE
Maintenance: source maintenance script improvements

### DIFF
--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -441,30 +441,30 @@ git grep "ifn?def .*_SQUID_" |
 # Scan for file-specific actions
 #
 
-# The two git commands below will also list any files modified during the
-# current run (e.g., src/http/RegisteredHeadersHash.cci or icons/icon.am).
-FilesToOperateOn=""
-if test "x$OnlyChangedSince" != "x" ; then
-    FilesToOperateOn=`git diff --name-only $OnlyChangedSince`
-    gitResult=$?
-    if test $gitResult -ne 0 ; then
-        echo "ERROR: Cannot use --only-changed-since reference point: $OnlyChangedSince"
-        echo "Consider using a git commit SHA (from git log) instead"
-        return $gitResult
+    # The two git commands below will also list any files modified during the
+    # current run (e.g., src/http/RegisteredHeadersHash.cci or icons/icon.am).
+    FilesToOperateOn=""
+    if test "x$OnlyChangedSince" != "x" ; then
+        FilesToOperateOn=`git diff --name-only $OnlyChangedSince`
+        gitResult=$?
+        if test $gitResult -ne 0 ; then
+            echo "ERROR: Cannot use --only-changed-since reference point: $OnlyChangedSince"
+            echo "Consider using a git commit SHA (from git log) instead"
+            return $gitResult
+        fi
+    else
+        FilesToOperateOn=`git ls-files`
+        gitResult=$?
+        # a bit paranoid but protects the empty $FilesToOperateOn check below
+        if test $gitResult -ne 0 ; then
+            echo "ERROR: Cannot find source code file names"
+            return $gitResult
+        fi
     fi
-else
-    FilesToOperateOn=`git ls-files`
-    gitResult=$?
-    # a bit paranoid but protects the empty $FilesToOperateOn check below
-    if test $gitResult -ne 0 ; then
-        echo "ERROR: Cannot find source code file names"
-        return $gitResult
+    if test "x$FilesToOperateOn" = "x"; then
+        echo "WARNING: No files to scan and format"
+        return 0
     fi
-fi
-if test "x$FilesToOperateOn" = "x"; then
-    echo "WARNING: No files to scan and format"
-    return 0
-fi
 
 for FILENAME in $FilesToOperateOn; do
     skip_copyright_check=""

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -410,11 +410,12 @@ processDebugSections ()
 {
     destination="doc/debug-sections.txt"
 
-    LC_ALL=C sort -u < doc/debug-sections.tmp > doc/debug-sections.tmp2
     if test "x$OnlyChangedSince" != "x"; then
         echo "WARNING: Skipping update of $destination due to --only-changed-since"
         return 0
     fi
+
+    LC_ALL=C sort -u < doc/debug-sections.tmp > doc/debug-sections.tmp2
 
     cat scripts/boilerplate.h > $destination
     echo "" >> $destination

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -163,18 +163,6 @@ fi
 made="generated" # a hack: prevents $GeneratedByMe searches matching this file
 GeneratedByMe="This file is $made by scripts/source-maintenance.sh."
 
-for Checksum in md5sum md5 shasum sha1sum false
-do
-    if "$Checksum" </dev/null >/dev/null 2>/dev/null ; then
-        break
-    fi
-done
-if [ "$Checksum" = "false" ]; then
-    "Could not find any program to calculate a checksum such as md5sum"
-    exit 1
-fi
-echo "detected checksum program $Checksum"
-
 if [ "x$ASTYLE" != "x" ] ; then
     if ! ${ASTYLE} --version > /dev/null 2> /dev/null ; then
         echo "ERROR: Cannot run user-supplied astyle: ${ASTYLE}"

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -189,7 +189,7 @@ made="generated" # a hack: prevents $GeneratedByMe searches matching this file
 GeneratedByMe="This file is $made by scripts/source-maintenance.sh."
 
 if [ "x$ASTYLE" != "x" ] ; then
-    if ! ${ASTYLE} --version > /dev/null 2> /dev/null ; then
+    if ! "${ASTYLE}" --version > /dev/null 2> /dev/null ; then
         echo "ERROR: Cannot run user-supplied astyle: ${ASTYLE}"
         exit 1
     fi
@@ -198,7 +198,7 @@ else
     ASTYLE=$FoundProgram
 fi
 
-ASVER=`${ASTYLE} --version 2>&1 | grep -o -E "[0-9.]+"`
+ASVER=`"${ASTYLE}" --version 2>&1 | grep -o -E "[0-9.]+"`
 if test "${ASVER}" != "${TargetAstyleVersion}" ; then
 	if test "${ASTYLE}" = "astyle" ; then
 		echo "Astyle version problem. You have ${ASVER} instead of ${TargetAstyleVersion}"

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -160,6 +160,31 @@ if ! git diff --quiet; then
 	exit 1
 fi
 
+# usage: <well-known program name> <program argument(s)> <candidate name>...
+# Finds the first working program among the given candidate program names.
+# The found program name is returned via the $FoundProgram global:
+FoundProgram=""
+findProgram() {
+    wellKnown="$1"
+    shift
+        options="$1"
+    shift
+
+    for candidate in $*
+    do
+        if "$candidate" $options < /dev/null > /dev/null 2> /dev/null
+        then
+            echo "Found ${wellKnown}-like program: $candidate"
+            FoundProgram="$candidate"
+            return 0
+        fi
+    done
+
+    echo "ERROR: Failed to find a ${wellKnown}-like program; tried: $*"
+    FoundProgram=""
+    return 1
+}
+
 made="generated" # a hack: prevents $GeneratedByMe searches matching this file
 GeneratedByMe="This file is $made by scripts/source-maintenance.sh."
 

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -164,10 +164,11 @@ fi
 # Finds the first working program among the given candidate program names.
 # The found program name is returned via the $FoundProgram global:
 FoundProgram=""
-findProgram() {
+findProgram ()
+{
     wellKnown="$1"
     shift
-        options="$1"
+    options="$1"
     shift
 
     for candidate in $*

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -116,7 +116,7 @@ while [ $# -ge 1 ]; do
         then
             printUsage
             echo "Error: Option $1 expects a yes or no argument but got $2"
-            exit 1;
+            exit 1
         fi
         CheckAndUpdateCopyright=$2
         shift 2
@@ -126,14 +126,14 @@ while [ $# -ge 1 ]; do
         then
             printUsage
             echo "Error: Option $1 expects an argument."
-            exit 1;
+            exit 1
         fi
         UpdateContributorsSince="$2"
-        shift 2;
+        shift 2
         ;;
     --help|-h)
         printHelp
-        exit 0;
+        exit 0
         ;;
     --with-astyle)
         ASTYLE=$2
@@ -146,7 +146,7 @@ while [ $# -ge 1 ]; do
     *)
         printUsage
         echo "Unsupported command-line option: $1"
-        exit 1;
+        exit 1
         ;;
     esac
 done

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -236,7 +236,7 @@ fi
 # in KeepGoing mode, remembers errors and hides them from callers
 run_ ()
 {
-        "$@" && return; # return on success
+        "$@" && return 0 # return on success
         error=$?
 
         if test $KeepGoing = no; then
@@ -318,7 +318,7 @@ collectDebugMessagesFrom ()
     if test "x$OnlyChangedSince" != "x"; then
         # Skipping collection due to --only-changed-since.
         # processDebugMessages() will warn.
-        return 0;
+        return 0
     fi
 
     # Merge multi-line debugs() into one-liners and remove '//...' comments.
@@ -368,12 +368,12 @@ processDebugMessages ()
 
     if test "x$OnlyChangedSince" != "x"; then
         echo "WARNING: Skipping update of $destination due to --only-changed-since"
-        return 0;
+        return 0
     fi
 
     if test '!' -s "$source"; then
         echo "ERROR: Failed to find debugs() message IDs"
-        return 1;
+        return 1
     fi
 
     repeatedIds=`awk '{print $1}' $source | sort -n | uniq -d`
@@ -381,7 +381,7 @@ processDebugMessages ()
         echo "ERROR: Repeated debugs() message IDs:"
         echo "$repeatedIds"
         echo ""
-        return 1;
+        return 1
     fi
 
     repeatedGists=`awk '{$1=""; print substr($0,2)}' $source | sort | uniq -d`
@@ -389,7 +389,7 @@ processDebugMessages ()
         echo "ERROR: Repeated debugs() message gists:"
         echo "$repeatedGists"
         echo ""
-        return 1;
+        return 1
     fi
 
     cat scripts/boilerplate.h > $destination
@@ -413,7 +413,7 @@ processDebugSections ()
     LC_ALL=C sort -u < doc/debug-sections.tmp > doc/debug-sections.tmp2
     if test "x$OnlyChangedSince" != "x"; then
         echo "WARNING: Skipping update of $destination due to --only-changed-since"
-        return 0;
+        return 0
     fi
 
     cat scripts/boilerplate.h > $destination
@@ -463,7 +463,7 @@ else
 fi
 if test "x$FilesToOperateOn" = "x"; then
     echo "WARNING: No files to scan and format"
-    return 0;
+    return 0
 fi
 
 for FILENAME in $FilesToOperateOn; do
@@ -671,7 +671,7 @@ generateGperfFile ()
     cciFile=`echo $gperfFile | sed 's/[.]gperf$/.cci/'`
 
     if test $gperfFile -ot $cciFile; then
-        return 0;
+        return 0
     fi
 
     generateRawGperfFile $gperfFile > $cciFile.unformatted || return
@@ -710,7 +710,7 @@ collectAuthors ()
 {
     if test "x$UpdateContributorsSince" = xnever
     then
-        return 0; # successfully did nothing, as requested
+        return 0 # successfully did nothing, as requested
     fi
 
     vettedCommitPhraseRegex='[Rr]eference point for automated CONTRIBUTORS updates'
@@ -725,7 +725,7 @@ collectAuthors ()
         if test "x$humanSha" = x && test "x$botSha" = x
         then
             echo "ERROR: Unable to determine the commit to start contributors extraction from"
-            return 1;
+            return 1
         fi
 
         # find the latest commit among the above one or two commits


### PR DESCRIPTION
- Allow passing astyle program name via ASTYLE environment variable.
- By default, use "astyle-3.1" if present or "astyle" otherwise.
- Add an option to format changed source files only.

No changes to the default behavior except for environments where a
program named "astyle-3.1" is present but a program named "astyle" was
previously used.