### PR TITLE
Maintenance: Consistent use of C++11 "override" specifier

### DIFF
--- a/lib/libTrie/TrieCharTransform.h
+++ b/lib/libTrie/TrieCharTransform.h
@@ -40,7 +40,7 @@ public:
 
 class TrieCaseless : public TrieCharTransform
 {
-    virtual char operator () (char const aChar) const {return tolower(aChar);}
+    char operator () (char const aChar) const override {return tolower(aChar);}
 };
 
 #endif /* __cplusplus */

--- a/src/AccessLogEntry.h
+++ b/src/AccessLogEntry.h
@@ -44,11 +44,11 @@ public:
     typedef RefCount<AccessLogEntry> Pointer;
 
     AccessLogEntry();
-    virtual ~AccessLogEntry();
+    ~AccessLogEntry() override;
 
     /* CodeContext API */
-    virtual std::ostream &detailCodeContext(std::ostream &os) const override;
-    virtual ScopedId codeContextGist() const override;
+    std::ostream &detailCodeContext(std::ostream &os) const override;
+    ScopedId codeContextGist() const override;
 
     /// Fetch the client IP log string into the given buffer.
     /// Knows about several alternate locations of the IP

--- a/src/BodyPipe.cc
+++ b/src/BodyPipe.cc
@@ -19,19 +19,19 @@ class BodySink: public BodyConsumer
 
 public:
     BodySink(const BodyPipe::Pointer &bp): AsyncJob("BodySink"), body_pipe(bp) {}
-    virtual ~BodySink() { assert(!body_pipe); }
+    ~BodySink() override { assert(!body_pipe); }
 
-    virtual void noteMoreBodyDataAvailable(BodyPipe::Pointer bp) {
+    void noteMoreBodyDataAvailable(BodyPipe::Pointer bp) override {
         size_t contentSize = bp->buf().contentSize();
         bp->consume(contentSize);
     }
-    virtual void noteBodyProductionEnded(BodyPipe::Pointer) {
+    void noteBodyProductionEnded(BodyPipe::Pointer) override {
         stopConsumingFrom(body_pipe);
     }
-    virtual void noteBodyProducerAborted(BodyPipe::Pointer) {
+    void noteBodyProducerAborted(BodyPipe::Pointer) override {
         stopConsumingFrom(body_pipe);
     }
-    bool doneAll() const {return !body_pipe && AsyncJob::doneAll();}
+    bool doneAll() const override {return !body_pipe && AsyncJob::doneAll();}
 
 private:
     BodyPipe::Pointer body_pipe; ///< the pipe we are consuming from
@@ -51,7 +51,7 @@ public:
                        Parent::Method aHandler, BodyPipe::Pointer bp):
         Parent(aProducer, aHandler, bp) {}
 
-    virtual bool canDial(AsyncCall &call);
+    bool canDial(AsyncCall &call) override;
 };
 
 // The BodyConsumerDialer is an AsyncCall class which used to schedule BodyConsumer calls.
@@ -66,7 +66,7 @@ public:
                        Parent::Method aHandler, BodyPipe::Pointer bp):
         Parent(aConsumer, aHandler, bp) {}
 
-    virtual bool canDial(AsyncCall &call);
+    bool canDial(AsyncCall &call) override;
 };
 
 bool

--- a/src/BodyPipe.cc
+++ b/src/BodyPipe.cc
@@ -15,7 +15,7 @@
 // data from a BodyPipe
 class BodySink: public BodyConsumer
 {
-    CBDATA_CLASS(BodySink);
+    CBDATA_CHILD(BodySink);
 
 public:
     BodySink(const BodyPipe::Pointer &bp): AsyncJob("BodySink"), body_pipe(bp) {}

--- a/src/BodyPipe.h
+++ b/src/BodyPipe.h
@@ -25,7 +25,7 @@ public:
     typedef CbcPointer<BodyProducer> Pointer;
 
     BodyProducer():AsyncJob("BodyProducer") {}
-    virtual ~BodyProducer() {}
+    ~BodyProducer() override {}
 
     virtual void noteMoreBodySpaceAvailable(RefCount<BodyPipe> bp) = 0;
     virtual void noteBodyConsumerAborted(RefCount<BodyPipe> bp) = 0;
@@ -45,7 +45,7 @@ public:
     typedef CbcPointer<BodyConsumer> Pointer;
 
     BodyConsumer():AsyncJob("BodyConsumer") {}
-    virtual ~BodyConsumer() {}
+    ~BodyConsumer() override {}
 
     virtual void noteMoreBodyDataAvailable(RefCount<BodyPipe> bp) = 0;
     virtual void noteBodyProductionEnded(RefCount<BodyPipe> bp) = 0;
@@ -103,7 +103,7 @@ public:
 
 public:
     BodyPipe(Producer *aProducer);
-    ~BodyPipe(); // asserts that producer and consumer are cleared
+    ~BodyPipe() override; // asserts that producer and consumer are cleared
 
     void setBodySize(uint64_t aSize); // set body size
     bool bodySizeKnown() const { return theBodySize >= 0; }

--- a/src/ClientDelayConfig.h
+++ b/src/ClientDelayConfig.h
@@ -27,7 +27,7 @@ public:
 
     ClientDelayPool()
         :   access(nullptr), rate(0), highwatermark(0) {}
-    ~ClientDelayPool();
+    ~ClientDelayPool() override;
     ClientDelayPool(const ClientDelayPool &) = delete;
     ClientDelayPool &operator=(const ClientDelayPool &) = delete;
 

--- a/src/ClientInfo.h
+++ b/src/ClientInfo.h
@@ -36,7 +36,11 @@ class ClientInfo : public hash_link
 
 public:
     explicit ClientInfo(const Ip::Address &);
+#if USE_DELAY_POOLS
     ~ClientInfo() override;
+#else
+    ~ClientInfo();
+#endif
 
     Ip::Address addr;
 

--- a/src/ClientInfo.h
+++ b/src/ClientInfo.h
@@ -36,7 +36,7 @@ class ClientInfo : public hash_link
 
 public:
     explicit ClientInfo(const Ip::Address &);
-    ~ClientInfo();
+    ~ClientInfo() override;
 
     Ip::Address addr;
 
@@ -82,11 +82,11 @@ public:
     void writeOrDequeue();
 
     /* BandwidthBucket API */
-    virtual int quota() override; ///< allocate quota for a just dequeued client
-    virtual bool applyQuota(int &nleft, Comm::IoCallback *state) override;
-    virtual void scheduleWrite(Comm::IoCallback *state) override;
-    virtual void onFdClosed() override;
-    virtual void reduceBucket(int len) override;
+    int quota() override; ///< allocate quota for a just dequeued client
+    bool applyQuota(int &nleft, Comm::IoCallback *state) override;
+    void scheduleWrite(Comm::IoCallback *state) override;
+    void onFdClosed() override;
+    void reduceBucket(int len) override;
 
     void quotaDumpQueue(); ///< dumps quota queue for debugging
 

--- a/src/ClientRequestContext.h
+++ b/src/ClientRequestContext.h
@@ -29,7 +29,7 @@ class ClientRequestContext : public RefCountable
 
 public:
     ClientRequestContext(ClientHttpRequest *);
-    ~ClientRequestContext();
+    ~ClientRequestContext() override;
 
     bool httpStateIsValid();
     void hostHeaderVerify();

--- a/src/CollapsedForwarding.cc
+++ b/src/CollapsedForwarding.cc
@@ -176,11 +176,11 @@ class CollapsedForwardingRr: public Ipc::Mem::RegisteredRunner
 public:
     /* RegisteredRunner API */
     CollapsedForwardingRr(): owner(nullptr) {}
-    virtual ~CollapsedForwardingRr();
+    ~CollapsedForwardingRr() override;
 
 protected:
-    virtual void create();
-    virtual void open();
+    void create() override;
+    void open() override;
 
 private:
     Ipc::MultiQueue::Owner *owner;

--- a/src/CommCalls.h
+++ b/src/CommCalls.h
@@ -172,12 +172,12 @@ public:
         CommDialerParamsT<Params_>(aJob->toCbdata()),
         method(aMeth) {}
 
-    virtual bool canDial(AsyncCall &c) {
+    bool canDial(AsyncCall &c) override {
         return JobDialer<C>::canDial(c) &&
                this->params.syncWithComm();
     }
 
-    virtual void print(std::ostream &os) const {
+    void print(std::ostream &os) const override {
         os << '(';
         this->params.print(os);
         os << ')';
@@ -187,7 +187,7 @@ public:
     Method method;
 
 protected:
-    virtual void doDial() { ((&(*this->job))->*method)(this->params); }
+    void doDial() override { ((&(*this->job))->*method)(this->params); }
 };
 
 // accept (IOACB) dialer
@@ -203,7 +203,7 @@ public:
 
     void dial();
 
-    virtual void print(std::ostream &os) const;
+    void print(std::ostream &os) const override;
 
 public:
     IOACB *handler;
@@ -219,7 +219,7 @@ public:
     CommConnectCbPtrFun(CNCB *aHandler, const Params &aParams);
     void dial();
 
-    virtual void print(std::ostream &os) const;
+    void print(std::ostream &os) const override;
 
 public:
     CNCB *handler;
@@ -235,7 +235,7 @@ public:
     CommIoCbPtrFun(IOCB *aHandler, const Params &aParams);
     void dial();
 
-    virtual void print(std::ostream &os) const;
+    void print(std::ostream &os) const override;
 
 public:
     IOCB *handler;
@@ -251,7 +251,7 @@ public:
     CommCloseCbPtrFun(CLCB *aHandler, const Params &aParams);
     void dial();
 
-    virtual void print(std::ostream &os) const;
+    void print(std::ostream &os) const override;
 
 public:
     CLCB *handler;
@@ -266,7 +266,7 @@ public:
     CommTimeoutCbPtrFun(CTCB *aHandler, const Params &aParams);
     void dial();
 
-    virtual void print(std::ostream &os) const;
+    void print(std::ostream &os) const override;
 
 public:
     CTCB *handler;
@@ -290,16 +290,16 @@ public:
         AsyncCall(o.debugSection, o.debugLevel, o.name),
         dialer(o.dialer) {}
 
-    ~CommCbFunPtrCallT() {}
+    ~CommCbFunPtrCallT() override {}
 
-    virtual CallDialer* getDialer() { return &dialer; }
+    CallDialer* getDialer() override { return &dialer; }
 
 public:
     Dialer dialer;
 
 protected:
-    inline virtual bool canFire();
-    inline virtual void fire();
+    inline bool canFire() override;
+    inline void fire() override;
 
 private:
     CommCbFunPtrCallT & operator=(const CommCbFunPtrCallT &); // not defined. not permitted.

--- a/src/CompositePoolNode.h
+++ b/src/CompositePoolNode.h
@@ -28,11 +28,11 @@ class CompositePoolNode : public RefCountable, public Updateable
 
 public:
     typedef RefCount<CompositePoolNode> Pointer;
-    virtual ~CompositePoolNode() {}
+    ~CompositePoolNode() override {}
 
     virtual void stats(StoreEntry * sentry) =0;
     virtual void dump(StoreEntry *entry) const =0;
-    virtual void update(int incr) =0;
+    void update(int incr) override =0;
     virtual void parse() = 0;
 
     class CompositeSelectionDetails;

--- a/src/ConfigOption.h
+++ b/src/ConfigOption.h
@@ -68,9 +68,9 @@ class ConfigOptionVector : public ConfigOption
 {
 
 public:
-    virtual ~ConfigOptionVector();
-    virtual bool parse(char const *option, const char *value, int reconfiguring);
-    virtual void dump(StoreEntry * e) const;
+    ~ConfigOptionVector() override;
+    bool parse(char const *option, const char *value, int reconfiguring) override;
+    void dump(StoreEntry * e) const override;
     std::vector<ConfigOption *>options;
 };
 
@@ -81,14 +81,14 @@ class ConfigOptionAdapter : public ConfigOption
 public:
     ConfigOptionAdapter(C& theObject, bool (C::*parseFP)(char const *option, const char *value, int reconfiguring), void (C::*dumpFP)(StoreEntry * e) const) : object(theObject), parser(parseFP), dumper(dumpFP) {}
 
-    bool parse(char const *option, const char *value, int isaReconf) {
+    bool parse(char const *option, const char *value, int isaReconf) override {
         if (parser)
             return (object.*parser)(option, value, isaReconf);
 
         return false;
     }
 
-    void dump(StoreEntry * e) const {
+    void dump(StoreEntry * e) const override {
         if (dumper)
             (object.*dumper)(e);
     }

--- a/src/DelayIdComposite.h
+++ b/src/DelayIdComposite.h
@@ -21,7 +21,7 @@ class DelayIdComposite : public RefCountable
 
 public:
     typedef RefCount<DelayIdComposite> Pointer;
-    virtual inline ~DelayIdComposite() {}
+    inline ~DelayIdComposite() override {}
 
     virtual int bytesWanted (int min, int max) const =0;
     virtual void bytesIn(int qty) = 0;

--- a/src/DelayTagged.h
+++ b/src/DelayTagged.h
@@ -31,7 +31,7 @@ public:
 
     void stats(StoreEntry *)const;
     DelayTaggedBucket(String &aTag);
-    ~DelayTaggedBucket();
+    ~DelayTaggedBucket() override;
     DelayBucket theBucket;
     String tag;
 };
@@ -45,13 +45,13 @@ public:
     typedef RefCount<DelayTagged> Pointer;
 
     DelayTagged();
-    virtual ~DelayTagged();
-    virtual void stats(StoreEntry * sentry);
-    virtual void dump(StoreEntry *entry) const;
-    virtual void update(int incr);
-    virtual void parse();
+    ~DelayTagged() override;
+    void stats(StoreEntry * sentry) override;
+    void dump(StoreEntry *entry) const override;
+    void update(int incr) override;
+    void parse() override;
 
-    virtual DelayIdComposite::Pointer id(CompositeSelectionDetails &);
+    DelayIdComposite::Pointer id(CompositeSelectionDetails &) override;
 
 private:
 
@@ -62,10 +62,10 @@ private:
 
     public:
         Id (RefCount<DelayTagged>, String &);
-        ~Id();
-        virtual int bytesWanted (int min, int max) const;
-        virtual void bytesIn(int qty);
-        virtual void delayRead(const AsyncCallPointer &);
+        ~Id() override;
+        int bytesWanted (int min, int max) const override;
+        void bytesIn(int qty) override;
+        void delayRead(const AsyncCallPointer &) override;
 
     private:
         RefCount<DelayTagged> theTagged;

--- a/src/DelayUser.h
+++ b/src/DelayUser.h
@@ -31,7 +31,7 @@ public:
 
     void stats(StoreEntry *)const;
     DelayUserBucket(Auth::User::Pointer);
-    ~DelayUserBucket();
+    ~DelayUserBucket() override;
     DelayBucket theBucket;
     Auth::User::Pointer authUser;
 };
@@ -44,13 +44,13 @@ class DelayUser : public CompositePoolNode
 public:
     typedef RefCount<DelayUser> Pointer;
     DelayUser();
-    virtual ~DelayUser();
-    virtual void stats(StoreEntry * sentry);
-    virtual void dump(StoreEntry *entry) const;
-    virtual void update(int incr);
-    virtual void parse();
+    ~DelayUser() override;
+    void stats(StoreEntry * sentry) override;
+    void dump(StoreEntry *entry) const override;
+    void update(int incr) override;
+    void parse() override;
 
-    virtual DelayIdComposite::Pointer id(CompositeSelectionDetails &);
+    DelayIdComposite::Pointer id(CompositeSelectionDetails &) override;
 
 private:
 
@@ -61,9 +61,9 @@ private:
 
     public:
         Id(RefCount<DelayUser>, Auth::User::Pointer);
-        ~Id();
-        virtual int bytesWanted (int min, int max) const;
-        virtual void bytesIn(int qty);
+        ~Id() override;
+        int bytesWanted (int min, int max) const override;
+        void bytesIn(int qty) override;
 
     private:
         RefCount<DelayUser> theUser;

--- a/src/DelayVector.h
+++ b/src/DelayVector.h
@@ -22,13 +22,13 @@ class DelayVector : public CompositePoolNode
 public:
     typedef RefCount<DelayVector> Pointer;
     DelayVector();
-    virtual ~DelayVector();
-    virtual void stats(StoreEntry * sentry);
-    virtual void dump(StoreEntry *entry) const;
-    virtual void update(int incr);
-    virtual void parse();
+    ~DelayVector() override;
+    void stats(StoreEntry * sentry) override;
+    void dump(StoreEntry *entry) const override;
+    void update(int incr) override;
+    void parse() override;
 
-    virtual DelayIdComposite::Pointer id(CompositeSelectionDetails &);
+    DelayIdComposite::Pointer id(CompositeSelectionDetails &) override;
     void push_back (CompositePoolNode::Pointer);
 
 private:
@@ -40,10 +40,10 @@ private:
 
     public:
         Id (RefCount<DelayVector>,CompositeSelectionDetails &);
-        ~Id();
-        virtual int bytesWanted (int min, int max) const;
-        virtual void bytesIn(int qty);
-        virtual void delayRead(const AsyncCallPointer &);
+        ~Id() override;
+        int bytesWanted (int min, int max) const override;
+        void bytesIn(int qty) override;
+        void delayRead(const AsyncCallPointer &) override;
 
     private:
         RefCount<DelayVector> theVector;

--- a/src/DiskIO/AIO/AIODiskFile.h
+++ b/src/DiskIO/AIO/AIODiskFile.h
@@ -26,25 +26,25 @@ public:
 
     friend class AIODiskIOStrategy;
     AIODiskFile (char const *path, AIODiskIOStrategy *);
-    ~AIODiskFile();
+    ~AIODiskFile() override;
 
     /// \bug the code has this as "IORequestor::Pointer callback"
-    virtual void open(int flags, mode_t mode, RefCount<IORequestor> callback);
+    void open(int flags, mode_t mode, RefCount<IORequestor> callback) override;
 
-    virtual void create (int, mode_t, RefCount<IORequestor>);
-    virtual void read(ReadRequest *);
-    virtual void write(WriteRequest *);
-    virtual void close ();
-    virtual bool canRead() const;
-    virtual bool canWrite() const;
+    void create (int, mode_t, RefCount<IORequestor>) override;
+    void read(ReadRequest *) override;
+    void write(WriteRequest *) override;
+    void close () override;
+    bool canRead() const override;
+    bool canWrite() const override;
 
     /* During migration only */
-    virtual int getFD() const;
+    int getFD() const override;
 
-    virtual bool error() const;
+    bool error() const override;
 
     /* Inform callers if there is IO in progress */
-    virtual bool ioInProgress() const;
+    bool ioInProgress() const override;
 
 private:
     void error(bool const &);

--- a/src/DiskIO/AIO/AIODiskIOModule.h
+++ b/src/DiskIO/AIO/AIODiskIOModule.h
@@ -19,10 +19,10 @@ class AIODiskIOModule : public DiskIOModule
 public:
     static AIODiskIOModule &GetInstance();
     AIODiskIOModule();
-    virtual void init();
-    virtual void gracefulShutdown();
-    virtual char const *type () const;
-    virtual DiskIOStrategy* createStrategy();
+    void init() override;
+    void gracefulShutdown() override;
+    char const *type () const override;
+    DiskIOStrategy* createStrategy() override;
 
 private:
     static AIODiskIOModule Instance;

--- a/src/DiskIO/AIO/AIODiskIOStrategy.h
+++ b/src/DiskIO/AIO/AIODiskIOStrategy.h
@@ -19,30 +19,30 @@ class AIODiskIOStrategy : public DiskIOStrategy
 
 public:
     AIODiskIOStrategy();
-    virtual ~AIODiskIOStrategy();
+    ~AIODiskIOStrategy() override;
 
-    virtual bool shedLoad();
+    bool shedLoad() override;
     /* What is the current load? 999 = 99.9% */
-    virtual int load();
+    int load() override;
     /* Return a handle for performing IO operations */
-    virtual RefCount<DiskFile> newFile (char const *path);
+    RefCount<DiskFile> newFile (char const *path) override;
     /* flush all IO operations  */
-    virtual void sync();
+    void sync() override;
     /** whether the IO Strategy can use unlinkd */
-    virtual bool unlinkdUseful() const;
+    bool unlinkdUseful() const override;
     /* unlink a file by path */
-    virtual void unlinkFile (char const *);
+    void unlinkFile (char const *) override;
 
     /* perform any pending callbacks */
-    virtual int callback();
+    int callback() override;
 
     /* Init per-instance logic */
-    virtual void init();
+    void init() override;
 
     /* cachemgr output on the IO instance stats */
-    virtual void statfs(StoreEntry & sentry)const;
+    void statfs(StoreEntry & sentry)const override;
     /* module specific options */
-    virtual ConfigOption *getOptionTree() const;
+    ConfigOption *getOptionTree() const override;
     /* a file descriptor */
     int fd;
     /* queue of requests */

--- a/src/DiskIO/Blocking/BlockingDiskIOModule.h
+++ b/src/DiskIO/Blocking/BlockingDiskIOModule.h
@@ -17,10 +17,10 @@ class BlockingDiskIOModule : public DiskIOModule
 public:
     static BlockingDiskIOModule &GetInstance();
     BlockingDiskIOModule();
-    virtual void init();
-    virtual void gracefulShutdown();
-    virtual char const *type () const;
-    virtual DiskIOStrategy* createStrategy();
+    void init() override;
+    void gracefulShutdown() override;
+    char const *type () const override;
+    DiskIOStrategy* createStrategy() override;
 
 private:
     static BlockingDiskIOModule Instance;

--- a/src/DiskIO/Blocking/BlockingFile.h
+++ b/src/DiskIO/Blocking/BlockingFile.h
@@ -22,17 +22,17 @@ class BlockingFile : public DiskFile
 
 public:
     BlockingFile(char const *path);
-    ~BlockingFile();
-    virtual void open(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void create(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void read(ReadRequest *);
-    virtual void write(WriteRequest *);
-    virtual void close();
-    virtual bool error() const;
-    virtual int getFD() const { return fd;}
+    ~BlockingFile() override;
+    void open(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void create(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void read(ReadRequest *) override;
+    void write(WriteRequest *) override;
+    void close() override;
+    bool error() const override;
+    int getFD() const override { return fd;}
 
-    virtual bool canRead() const;
-    virtual bool ioInProgress() const;
+    bool canRead() const override;
+    bool ioInProgress() const override;
 
 private:
     static DRCB ReadDone;

--- a/src/DiskIO/Blocking/BlockingIOStrategy.h
+++ b/src/DiskIO/Blocking/BlockingIOStrategy.h
@@ -16,11 +16,11 @@ class BlockingIOStrategy : public DiskIOStrategy
 {
 
 public:
-    virtual bool shedLoad();
-    virtual int load();
-    virtual RefCount<DiskFile> newFile(char const *path);
-    virtual bool unlinkdUseful() const;
-    virtual void unlinkFile (char const *);
+    bool shedLoad() override;
+    int load() override;
+    RefCount<DiskFile> newFile(char const *path) override;
+    bool unlinkdUseful() const override;
+    void unlinkFile (char const *) override;
 };
 
 #endif /* SQUID_BLOCKINGIOSTRATEGY_H */

--- a/src/DiskIO/DiskDaemon/DiskDaemonDiskIOModule.h
+++ b/src/DiskIO/DiskDaemon/DiskDaemonDiskIOModule.h
@@ -17,10 +17,10 @@ class DiskDaemonDiskIOModule : public DiskIOModule
 public:
     static DiskDaemonDiskIOModule &GetInstance();
     DiskDaemonDiskIOModule();
-    virtual void init();
-    virtual void gracefulShutdown();
-    virtual char const *type () const;
-    virtual DiskIOStrategy* createStrategy();
+    void init() override;
+    void gracefulShutdown() override;
+    char const *type () const override;
+    DiskIOStrategy* createStrategy() override;
 
 private:
     static DiskDaemonDiskIOModule Instance;

--- a/src/DiskIO/DiskDaemon/DiskdAction.h
+++ b/src/DiskIO/DiskDaemon/DiskdAction.h
@@ -58,14 +58,14 @@ protected:
 public:
     static Pointer Create(const Mgr::CommandPointer &aCmd);
     /* Action API */
-    virtual void add(const Mgr::Action& action);
-    virtual void pack(Ipc::TypedMsgHdr& hdrMsg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& hdrMsg);
+    void add(const Mgr::Action& action) override;
+    void pack(Ipc::TypedMsgHdr& hdrMsg) const override;
+    void unpack(const Ipc::TypedMsgHdr& hdrMsg) override;
 
 protected:
     /* Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     DiskdActionData data;

--- a/src/DiskIO/DiskDaemon/DiskdFile.h
+++ b/src/DiskIO/DiskDaemon/DiskdFile.h
@@ -27,15 +27,15 @@ class DiskdFile : public DiskFile
 
 public:
     DiskdFile(char const *path, DiskdIOStrategy *);
-    ~DiskdFile();
-    virtual void open(int flags, mode_t aMode, RefCount<IORequestor> callback);
-    virtual void create(int flags, mode_t aMode, RefCount<IORequestor> callback);
-    virtual void read(ReadRequest *);
-    virtual void write(WriteRequest *);
-    virtual void close();
-    virtual bool error() const;
-    virtual bool canRead() const;
-    virtual bool ioInProgress() const;
+    ~DiskdFile() override;
+    void open(int flags, mode_t aMode, RefCount<IORequestor> callback) override;
+    void create(int flags, mode_t aMode, RefCount<IORequestor> callback) override;
+    void read(ReadRequest *) override;
+    void write(WriteRequest *) override;
+    void close() override;
+    bool error() const override;
+    bool canRead() const override;
+    bool ioInProgress() const override;
 
     /* Temporary */
     int getID() const {return id;}

--- a/src/DiskIO/DiskDaemon/DiskdIOStrategy.h
+++ b/src/DiskIO/DiskDaemon/DiskdIOStrategy.h
@@ -44,16 +44,16 @@ class DiskdIOStrategy : public DiskIOStrategy
 
 public:
     DiskdIOStrategy();
-    virtual bool shedLoad();
-    virtual int load();
-    virtual RefCount<DiskFile> newFile(char const *path);
-    virtual bool unlinkdUseful() const;
-    virtual void unlinkFile (char const *);
-    virtual ConfigOption *getOptionTree() const;
-    virtual void init();
-    virtual void sync();
-    virtual int callback();
-    virtual void statfs(StoreEntry & sentry) const;
+    bool shedLoad() override;
+    int load() override;
+    RefCount<DiskFile> newFile(char const *path) override;
+    bool unlinkdUseful() const override;
+    void unlinkFile (char const *) override;
+    ConfigOption *getOptionTree() const override;
+    void init() override;
+    void sync() override;
+    int callback() override;
+    void statfs(StoreEntry & sentry) const override;
     int send(int mtype, int id, DiskdFile *theFile, size_t size, off_t offset, ssize_t shm_offset, Lock *requestor);
 
     /** public for accessing return address's */

--- a/src/DiskIO/DiskIOStrategy.h
+++ b/src/DiskIO/DiskIOStrategy.h
@@ -62,25 +62,25 @@ class SingletonIOStrategy : public DiskIOStrategy
 public:
     SingletonIOStrategy(DiskIOStrategy *anIO) : io(anIO) {}
 
-    virtual bool shedLoad() { return io->shedLoad(); }
+    bool shedLoad() override { return io->shedLoad(); }
 
-    virtual int load() { return io->load(); }
+    int load() override { return io->load(); }
 
-    virtual RefCount<DiskFile> newFile (char const *path) {return io->newFile(path); }
+    RefCount<DiskFile> newFile (char const *path) override {return io->newFile(path); }
 
-    virtual void sync() { io->sync(); }
+    void sync() override { io->sync(); }
 
-    virtual bool unlinkdUseful() const { return io->unlinkdUseful(); }
+    bool unlinkdUseful() const override { return io->unlinkdUseful(); }
 
-    virtual void unlinkFile(char const *path) { io->unlinkFile(path); }
+    void unlinkFile(char const *path) override { io->unlinkFile(path); }
 
-    virtual int callback() { return io->callback(); }
+    int callback() override { return io->callback(); }
 
-    virtual void init() { io->init(); }
+    void init() override { io->init(); }
 
-    virtual void statfs(StoreEntry & sentry) const { io->statfs(sentry); }
+    void statfs(StoreEntry & sentry) const override { io->statfs(sentry); }
 
-    virtual ConfigOption *getOptionTree() const { return io->getOptionTree(); }
+    ConfigOption *getOptionTree() const override { return io->getOptionTree(); }
 
 private:
     DiskIOStrategy *io;

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
@@ -22,18 +22,18 @@ class DiskThreadsDiskFile : public DiskFile
 
 public:
     DiskThreadsDiskFile(char const *path);
-    ~DiskThreadsDiskFile();
-    virtual void open(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void create(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void read(ReadRequest *);
-    virtual void write(WriteRequest *);
-    virtual void close();
-    virtual bool error() const;
-    virtual int getFD() const { return fd;}
+    ~DiskThreadsDiskFile() override;
+    void open(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void create(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void read(ReadRequest *) override;
+    void write(WriteRequest *) override;
+    void close() override;
+    bool error() const override;
+    int getFD() const override { return fd;}
 
-    virtual bool canRead() const;
-    virtual bool canWrite() const;
-    virtual bool ioInProgress() const;
+    bool canRead() const override;
+    bool canWrite() const override;
+    bool ioInProgress() const override;
 
 private:
 #if ASYNC_READ

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskIOModule.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskIOModule.h
@@ -17,11 +17,11 @@ class DiskThreadsDiskIOModule : public DiskIOModule
 public:
     static DiskThreadsDiskIOModule &GetInstance();
     DiskThreadsDiskIOModule();
-    virtual void init();
+    void init() override;
     //virtual void registerWithCacheManager(void);
-    virtual void gracefulShutdown();
-    virtual char const *type () const;
-    virtual DiskIOStrategy* createStrategy();
+    void gracefulShutdown() override;
+    char const *type () const override;
+    DiskIOStrategy* createStrategy() override;
 
 private:
     static DiskThreadsDiskIOModule Instance;

--- a/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsIOStrategy.h
@@ -25,14 +25,14 @@ class DiskThreadsIOStrategy : public DiskIOStrategy
 
 public:
     DiskThreadsIOStrategy();
-    virtual bool shedLoad();
-    virtual int load();
-    virtual RefCount<DiskFile> newFile(char const *path);
-    virtual bool unlinkdUseful() const;
-    virtual void unlinkFile (char const *);
-    virtual int callback();
-    virtual void sync();
-    virtual void init();
+    bool shedLoad() override;
+    int load() override;
+    RefCount<DiskFile> newFile(char const *path) override;
+    bool unlinkdUseful() const override;
+    void unlinkFile (char const *) override;
+    int callback() override;
+    void sync() override;
+    void init() override;
     void done();
     /* Todo: add access limitations */
     bool initialised;

--- a/src/DiskIO/IpcIo/IpcIoDiskIOModule.h
+++ b/src/DiskIO/IpcIo/IpcIoDiskIOModule.h
@@ -17,10 +17,10 @@ class IpcIoDiskIOModule : public DiskIOModule
 public:
     static IpcIoDiskIOModule &GetInstance();
     IpcIoDiskIOModule();
-    virtual void init();
-    virtual void gracefulShutdown();
-    virtual char const *type () const;
-    virtual DiskIOStrategy* createStrategy();
+    void init() override;
+    void gracefulShutdown() override;
+    char const *type () const override;
+    DiskIOStrategy* createStrategy() override;
 
 private:
     static IpcIoDiskIOModule Instance;

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -1015,12 +1015,12 @@ class IpcIoRr: public Ipc::Mem::RegisteredRunner
 public:
     /* RegisteredRunner API */
     IpcIoRr(): owner(nullptr) {}
-    virtual ~IpcIoRr();
-    virtual void claimMemoryNeeds();
+    ~IpcIoRr() override;
+    void claimMemoryNeeds() override;
 
 protected:
     /* Ipc::Mem::RegisteredRunner API */
-    virtual void create();
+    void create() override;
 
 private:
     Ipc::FewToFewBiQueue::Owner *owner;

--- a/src/DiskIO/IpcIo/IpcIoFile.h
+++ b/src/DiskIO/IpcIo/IpcIoFile.h
@@ -71,20 +71,20 @@ public:
     typedef RefCount<IpcIoFile> Pointer;
 
     IpcIoFile(char const *aDb);
-    virtual ~IpcIoFile();
+    ~IpcIoFile() override;
 
     /* DiskFile API */
-    virtual void configure(const Config &cfg);
-    virtual void open(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void create(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void read(ReadRequest *);
-    virtual void write(WriteRequest *);
-    virtual void close();
-    virtual bool error() const;
-    virtual int getFD() const;
-    virtual bool canRead() const;
-    virtual bool canWrite() const;
-    virtual bool ioInProgress() const;
+    void configure(const Config &cfg) override;
+    void open(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void create(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void read(ReadRequest *) override;
+    void write(WriteRequest *) override;
+    void close() override;
+    bool error() const override;
+    int getFD() const override;
+    bool canRead() const override;
+    bool canWrite() const override;
+    bool ioInProgress() const override;
 
     /// handle open response from coordinator
     static void HandleOpenResponse(const Ipc::StrandMessage &);

--- a/src/DiskIO/IpcIo/IpcIoIOStrategy.h
+++ b/src/DiskIO/IpcIo/IpcIoIOStrategy.h
@@ -14,11 +14,11 @@ class IpcIoIOStrategy : public DiskIOStrategy
 {
 
 public:
-    virtual bool shedLoad();
-    virtual int load();
-    virtual RefCount<DiskFile> newFile(char const *path);
-    virtual bool unlinkdUseful() const;
-    virtual void unlinkFile (char const *);
+    bool shedLoad() override;
+    int load() override;
+    RefCount<DiskFile> newFile(char const *path) override;
+    bool unlinkdUseful() const override;
+    void unlinkFile (char const *) override;
 };
 
 #endif /* SQUID_IPC_IOIOSTRATEGY_H */

--- a/src/DiskIO/Mmapped/MmappedDiskIOModule.h
+++ b/src/DiskIO/Mmapped/MmappedDiskIOModule.h
@@ -17,10 +17,10 @@ class MmappedDiskIOModule : public DiskIOModule
 public:
     static MmappedDiskIOModule &GetInstance();
     MmappedDiskIOModule();
-    virtual void init();
-    virtual void gracefulShutdown();
-    virtual char const *type () const;
-    virtual DiskIOStrategy* createStrategy();
+    void init() override;
+    void gracefulShutdown() override;
+    char const *type () const override;
+    DiskIOStrategy* createStrategy() override;
 
 private:
     static MmappedDiskIOModule Instance;

--- a/src/DiskIO/Mmapped/MmappedFile.h
+++ b/src/DiskIO/Mmapped/MmappedFile.h
@@ -19,18 +19,18 @@ class MmappedFile : public DiskFile
 
 public:
     MmappedFile(char const *path);
-    ~MmappedFile();
-    virtual void open(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void create(int flags, mode_t mode, RefCount<IORequestor> callback);
-    virtual void read(ReadRequest *);
-    virtual void write(WriteRequest *);
-    virtual void close();
-    virtual bool error() const;
-    virtual int getFD() const { return fd;}
+    ~MmappedFile() override;
+    void open(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void create(int flags, mode_t mode, RefCount<IORequestor> callback) override;
+    void read(ReadRequest *) override;
+    void write(WriteRequest *) override;
+    void close() override;
+    bool error() const override;
+    int getFD() const override { return fd;}
 
-    virtual bool canRead() const;
-    virtual bool canWrite() const;
-    virtual bool ioInProgress() const;
+    bool canRead() const override;
+    bool canWrite() const override;
+    bool ioInProgress() const override;
 
 private:
     char const *path_;

--- a/src/DiskIO/Mmapped/MmappedIOStrategy.h
+++ b/src/DiskIO/Mmapped/MmappedIOStrategy.h
@@ -14,11 +14,11 @@ class MmappedIOStrategy : public DiskIOStrategy
 {
 
 public:
-    virtual bool shedLoad();
-    virtual int load();
-    virtual RefCount<DiskFile> newFile(char const *path);
-    virtual bool unlinkdUseful() const;
-    virtual void unlinkFile (char const *);
+    bool shedLoad() override;
+    int load() override;
+    RefCount<DiskFile> newFile(char const *path) override;
+    bool unlinkdUseful() const override;
+    void unlinkFile (char const *) override;
 };
 
 #endif /* SQUID_MMAPPEDIOSTRATEGY_H */

--- a/src/DiskIO/ReadRequest.h
+++ b/src/DiskIO/ReadRequest.h
@@ -19,7 +19,7 @@ class ReadRequest : public RefCountable
 public:
     typedef RefCount<ReadRequest> Pointer;
     ReadRequest(char *buf, off_t offset, size_t len);
-    virtual ~ReadRequest() {}
+    ~ReadRequest() override {}
 
     char *buf;
     off_t offset;

--- a/src/DiskIO/WriteRequest.h
+++ b/src/DiskIO/WriteRequest.h
@@ -20,7 +20,7 @@ class WriteRequest : public RefCountable
 public:
     typedef RefCount<WriteRequest> Pointer;
     WriteRequest(char const *buf, off_t offset, size_t len, FREE *);
-    virtual ~WriteRequest() {}
+    ~WriteRequest() override {}
 
     char const *buf;
     off_t offset;

--- a/src/Downloader.cc
+++ b/src/Downloader.cc
@@ -29,7 +29,7 @@ public:
     typedef RefCount<DownloaderContext> Pointer;
 
     DownloaderContext(Downloader *dl, ClientHttpRequest *h);
-    ~DownloaderContext();
+    ~DownloaderContext() override;
     void finished();
 
     CbcPointer<Downloader> downloader;

--- a/src/Downloader.h
+++ b/src/Downloader.h
@@ -49,8 +49,8 @@ public:
     using Answer = DownloaderAnswer;
 
     Downloader(const SBuf &url, const AsyncCallback<Answer> &, const MasterXactionPointer &, unsigned int level = 0);
-    virtual ~Downloader();
-    virtual void swanSong();
+    ~Downloader() override;
+    void swanSong() override;
 
     /// delays destruction to protect doCallouts()
     void downloadFinished();
@@ -63,8 +63,8 @@ public:
 protected:
 
     /* AsyncJob API */
-    virtual bool doneAll() const;
-    virtual void start();
+    bool doneAll() const override;
+    void start() override;
 
 private:
 

--- a/src/Downloader.h
+++ b/src/Downloader.h
@@ -44,7 +44,7 @@ std::ostream &operator <<(std::ostream &, const DownloaderAnswer &);
 /// certificate chains.
 class Downloader: virtual public AsyncJob
 {
-    CBDATA_CLASS(Downloader);
+    CBDATA_CHILD(Downloader);
 public:
     using Answer = DownloaderAnswer;
 

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -21,7 +21,7 @@ class ExternalACLLookup : public ACLChecklist::AsyncState
 
 public:
     static ExternalACLLookup *Instance();
-    virtual void checkForAsync(ACLChecklist *)const;
+    void checkForAsync(ACLChecklist *)const override;
 
     // If possible, starts an asynchronous lookup of an external ACL.
     // Otherwise, asserts (or bails if background refresh is requested).
@@ -42,21 +42,21 @@ public:
     static void ExternalAclLookup(ACLChecklist * ch, ACLExternal *);
 
     ACLExternal(char const *);
-    ~ACLExternal();
+    ~ACLExternal() override;
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
     /* This really should be dynamic based on the external class defn */
-    virtual bool requiresAle() const {return true;}
-    virtual bool requiresRequest() const {return true;}
+    bool requiresAle() const override {return true;}
+    bool requiresRequest() const override {return true;}
 
     /* when requiresRequest is made dynamic, review this too */
     //    virtual bool requiresReply() const {return true;}
-    virtual bool isProxyAuth() const;
-    virtual SBufList dump() const;
-    virtual bool valid () const;
-    virtual bool empty () const;
+    bool isProxyAuth() const override;
+    SBufList dump() const override;
+    bool valid () const override;
+    bool empty () const override;
 
 protected:
     external_acl_data *data;

--- a/src/ExternalACLEntry.h
+++ b/src/ExternalACLEntry.h
@@ -57,7 +57,7 @@ class ExternalACLEntry: public hash_link, public RefCountable
 
 public:
     ExternalACLEntry();
-    ~ExternalACLEntry();
+    ~ExternalACLEntry() override;
 
     void update(ExternalACLEntryData const &);
     dlink_node lru;

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -55,7 +55,7 @@ class FwdState: public RefCountable, public PeerSelectionInitiator
 
 public:
     typedef RefCount<FwdState> Pointer;
-    virtual ~FwdState();
+    ~FwdState() override;
     static void initModule();
 
     /// Initiates request forwarding to a peer or origin server.
@@ -110,8 +110,8 @@ private:
     void stopAndDestroy(const char *reason);
 
     /* PeerSelectionInitiator API */
-    virtual void noteDestination(Comm::ConnectionPointer conn) override;
-    virtual void noteDestinationsEnd(ErrorState *selectionError) override;
+    void noteDestination(Comm::ConnectionPointer conn) override;
+    void noteDestinationsEnd(ErrorState *selectionError) override;
 
     bool transporting() const;
 

--- a/src/HappyConnOpener.cc
+++ b/src/HappyConnOpener.cc
@@ -101,11 +101,11 @@ public:
     PrimeChanceGiver(): HappyOrderEnforcer("happy_eyeballs_connect_timeout enforcement") {}
 
     /* HappyOrderEnforcer API */
-    virtual bool readyNow(const HappyConnOpener &job) const override;
+    bool readyNow(const HappyConnOpener &job) const override;
 
 private:
     /* HappyOrderEnforcer API */
-    virtual AsyncCall::Pointer notify(const CbcPointer<HappyConnOpener> &) override;
+    AsyncCall::Pointer notify(const CbcPointer<HappyConnOpener> &) override;
 };
 
 /// enforces happy_eyeballs_connect_gap and happy_eyeballs_connect_limit
@@ -115,7 +115,7 @@ public:
     SpareAllowanceGiver(): HappyOrderEnforcer("happy_eyeballs_connect_gap/happy_eyeballs_connect_limit enforcement") {}
 
     /* HappyOrderEnforcer API */
-    virtual bool readyNow(const HappyConnOpener &job) const override;
+    bool readyNow(const HappyConnOpener &job) const override;
 
     /// reacts to HappyConnOpener discovering readyNow() conditions for a spare path
     /// the caller must attempt to open a spare connection immediately
@@ -129,7 +129,7 @@ public:
 
 private:
     /* HappyOrderEnforcer API */
-    virtual AsyncCall::Pointer notify(const CbcPointer<HappyConnOpener> &) override;
+    AsyncCall::Pointer notify(const CbcPointer<HappyConnOpener> &) override;
 
     bool concurrencyLimitReached() const;
     void recordAllowance();

--- a/src/HappyConnOpener.h
+++ b/src/HappyConnOpener.h
@@ -107,7 +107,7 @@ public:
 
 public:
     HappyConnOpener(const ResolvedPeersPointer &, const AsyncCallback<Answer> &, const HttpRequestPointer &, time_t aFwdStart, int tries, const AccessLogEntryPointer &);
-    virtual ~HappyConnOpener() override;
+    ~HappyConnOpener() override;
 
     /// configures reuse of old connections
     void allowPersistent(bool permitted) { allowPconn_ = permitted; }
@@ -158,10 +158,10 @@ private:
     friend std::ostream &operator <<(std::ostream &, const Attempt &);
 
     /* AsyncJob API */
-    virtual void start() override;
-    virtual bool doneAll() const override;
-    virtual void swanSong() override;
-    virtual const char *status() const override;
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
+    const char *status() const override;
 
     void maybeOpenPrimeConnection();
     void maybeOpenSpareConnection();

--- a/src/HttpReply.h
+++ b/src/HttpReply.h
@@ -29,12 +29,12 @@ public:
     typedef RefCount<HttpReply> Pointer;
 
     HttpReply();
-    ~HttpReply();
+    ~HttpReply() override;
 
-    virtual void reset();
+    void reset() override;
 
     /* Http::Message API */
-    virtual bool sanityCheckStartLine(const char *buf, const size_t hdr_len, Http::StatusCode *error);
+    bool sanityCheckStartLine(const char *buf, const size_t hdr_len, Http::StatusCode *error) override;
 
     /** \par public, readable; never update these or their .hdr equivalents directly */
     time_t date;
@@ -62,11 +62,11 @@ public:
     bool do_clean;
 
 public:
-    virtual int httpMsgParseError();
+    int httpMsgParseError() override;
 
-    virtual bool expectingBody(const HttpRequestMethod&, int64_t&) const;
+    bool expectingBody(const HttpRequestMethod&, int64_t&) const override;
 
-    virtual bool inheritProperties(const Http::Message *);
+    bool inheritProperties(const Http::Message *) override;
 
     /// \returns nil (if no updates are necessary)
     /// \returns a new reply combining this reply with 304 updates (otherwise)
@@ -110,9 +110,9 @@ public:
     /** Clone this reply.
      *  Could be done as a copy-contructor but we do not want to accidentally copy a HttpReply..
      */
-    HttpReply *clone() const;
+    HttpReply *clone() const override;
 
-    virtual void hdrCacheInit();
+    void hdrCacheInit() override;
 
     /// whether our Date header value is smaller than theirs
     /// \returns false if any information is missing
@@ -121,7 +121,7 @@ public:
     /// Some response status codes prohibit sending Content-Length (RFC 7230 section 3.3.2).
     void removeIrrelevantContentLength();
 
-    virtual void configureContentLengthInterpreter(Http::ContentLengthInterpreter &);
+    void configureContentLengthInterpreter(Http::ContentLengthInterpreter &) override;
     /// parses reply header using Parser
     bool parseHeader(Http1::Parser &hp);
 
@@ -152,9 +152,9 @@ private:
     HttpHdrContRange *content_range; ///< parsed Content-Range; nil for non-206 responses!
 
 protected:
-    virtual void packFirstLineInto(Packable * p, bool) const { sline.packInto(p); }
+    void packFirstLineInto(Packable * p, bool) const override { sline.packInto(p); }
 
-    virtual bool parseFirstLine(const char *start, const char *end);
+    bool parseFirstLine(const char *start, const char *end) override;
 };
 
 #endif /* SQUID_HTTPREPLY_H */

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -54,12 +54,12 @@ public:
 
     HttpRequest(const MasterXaction::Pointer &);
     HttpRequest(const HttpRequestMethod& aMethod, AnyP::ProtocolType aProtocol, const char *schemeImage, const char *aUrlpath, const MasterXaction::Pointer &);
-    ~HttpRequest();
-    virtual void reset();
+    ~HttpRequest() override;
+    void reset() override;
 
     void initHTTP(const HttpRequestMethod& aMethod, AnyP::ProtocolType aProtocol, const char *schemeImage, const char *aUrlpath);
 
-    virtual HttpRequest *clone() const;
+    HttpRequest *clone() const override;
 
     /// Whether response to this request is potentially cachable
     /// \retval false  Not cacheable.
@@ -196,9 +196,9 @@ public:
 public:
     bool multipartRangeRequest() const;
 
-    bool parseFirstLine(const char *start, const char *end);
+    bool parseFirstLine(const char *start, const char *end) override;
 
-    virtual bool expectingBody(const HttpRequestMethod& unused, int64_t&) const;
+    bool expectingBody(const HttpRequestMethod& unused, int64_t&) const override;
 
     bool bodyNibbled() const; // the request has a [partially] consumed body
 
@@ -246,7 +246,7 @@ public:
     NotePairs::Pointer notes();
     bool hasNotes() const { return bool(theNotes) && !theNotes->empty(); }
 
-    virtual void configureContentLengthInterpreter(Http::ContentLengthInterpreter &) {}
+    void configureContentLengthInterpreter(Http::ContentLengthInterpreter &) override {}
 
     /// Check whether the message framing headers are valid.
     /// \returns Http::scNone or an HTTP error status
@@ -266,13 +266,13 @@ private:
     /// and(or) by annotate_transaction/annotate_client ACLs.
     NotePairs::Pointer theNotes;
 protected:
-    virtual void packFirstLineInto(Packable * p, bool full_uri) const;
+    void packFirstLineInto(Packable * p, bool full_uri) const override;
 
-    virtual bool sanityCheckStartLine(const char *buf, const size_t hdr_len, Http::StatusCode *error);
+    bool sanityCheckStartLine(const char *buf, const size_t hdr_len, Http::StatusCode *error) override;
 
-    virtual void hdrCacheInit();
+    void hdrCacheInit() override;
 
-    virtual bool inheritProperties(const Http::Message *);
+    bool inheritProperties(const Http::Message *) override;
 };
 
 class ConnStateData;

--- a/src/ICP.h
+++ b/src/ICP.h
@@ -63,7 +63,7 @@ class ICPState: public StoreClient
 
 public:
     ICPState(icp_common_t &aHeader, HttpRequest *aRequest);
-    virtual ~ICPState();
+    ~ICPState() override;
 
     /// whether the cache contains the requested entry
     bool isHit() const;
@@ -78,8 +78,8 @@ public:
 
 protected:
     /* StoreClient API */
-    virtual LogTags *loggingTags() const override;
-    virtual void fillChecklist(ACLFilledChecklist &) const override;
+    LogTags *loggingTags() const override;
+    void fillChecklist(ACLFilledChecklist &) const override;
 
     /// either confirms and starts processing a cache hit or returns false
     bool confirmAndPrepHit(const StoreEntry &) const;

--- a/src/MemBuf.h
+++ b/src/MemBuf.h
@@ -32,7 +32,7 @@ public:
         capacity(0),
         stolen(0)
     {}
-    virtual ~MemBuf() {
+    ~MemBuf() override {
         if (!stolen && buf)
             clean();
     }
@@ -109,8 +109,8 @@ public:
     FREE *freeFunc();
 
     /* Packable API */
-    virtual void append(const char *c, int sz);
-    virtual void vappendf(const char *fmt, va_list ap);
+    void append(const char *c, int sz) override;
+    void vappendf(const char *fmt, va_list ap) override;
 
 private:
     /**

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -38,8 +38,8 @@ public:
     ShmWriter(MemStore &aStore, StoreEntry *anEntry, const sfileno aFileNo, Ipc::StoreMapSliceId aFirstSlice = -1);
 
     /* Packable API */
-    virtual void append(const char *aBuf, int aSize) override;
-    virtual void vappendf(const char *fmt, va_list ap) override;
+    void append(const char *aBuf, int aSize) override;
+    void vappendf(const char *fmt, va_list ap) override;
 
 public:
     StoreEntry *entry; ///< the entry being updated
@@ -973,14 +973,14 @@ class MemStoreRr: public Ipc::Mem::RegisteredRunner
 public:
     /* RegisteredRunner API */
     MemStoreRr(): spaceOwner(nullptr), mapOwner(nullptr), extrasOwner(nullptr) {}
-    virtual void finalizeConfig();
-    virtual void claimMemoryNeeds();
-    virtual void useConfig();
-    virtual ~MemStoreRr();
+    void finalizeConfig() override;
+    void claimMemoryNeeds() override;
+    void useConfig() override;
+    ~MemStoreRr() override;
 
 protected:
     /* Ipc::Mem::RegisteredRunner API */
-    virtual void create();
+    void create() override;
 
 private:
     Ipc::Mem::Owner<Ipc::Mem::PageStack> *spaceOwner; ///< free slices Owner

--- a/src/MemStore.h
+++ b/src/MemStore.h
@@ -30,7 +30,7 @@ class MemStore: public Store::Controlled, public Ipc::StoreMapCleaner
 {
 public:
     MemStore();
-    virtual ~MemStore();
+    ~MemStore() override;
 
     /// whether e should be kept in local RAM for possible future caching
     bool keepInLocalMemory(const StoreEntry &e) const;
@@ -45,24 +45,24 @@ public:
     void disconnect(StoreEntry &e);
 
     /* Storage API */
-    virtual void create() override {}
-    virtual void init() override;
-    virtual StoreEntry *get(const cache_key *) override;
-    virtual uint64_t maxSize() const override;
-    virtual uint64_t minSize() const override;
-    virtual uint64_t currentSize() const override;
-    virtual uint64_t currentCount() const override;
-    virtual int64_t maxObjectSize() const override;
-    virtual void getStats(StoreInfoStats &stats) const override;
-    virtual void stat(StoreEntry &e) const override;
-    virtual void reference(StoreEntry &e) override;
-    virtual bool dereference(StoreEntry &e) override;
-    virtual void updateHeaders(StoreEntry *e) override;
-    virtual void maintain() override;
-    virtual bool anchorToCache(StoreEntry &) override;
-    virtual bool updateAnchored(StoreEntry &) override;
-    virtual void evictCached(StoreEntry &) override;
-    virtual void evictIfFound(const cache_key *) override;
+    void create() override {}
+    void init() override;
+    StoreEntry *get(const cache_key *) override;
+    uint64_t maxSize() const override;
+    uint64_t minSize() const override;
+    uint64_t currentSize() const override;
+    uint64_t currentCount() const override;
+    int64_t maxObjectSize() const override;
+    void getStats(StoreInfoStats &stats) const override;
+    void stat(StoreEntry &e) const override;
+    void reference(StoreEntry &e) override;
+    bool dereference(StoreEntry &e) override;
+    void updateHeaders(StoreEntry *e) override;
+    void maintain() override;
+    bool anchorToCache(StoreEntry &) override;
+    bool updateAnchored(StoreEntry &) override;
+    void evictCached(StoreEntry &) override;
+    void evictIfFound(const cache_key *) override;
 
     /// whether Squid is correctly configured to use a shared memory cache
     static bool Enabled() { return EntryLimit() > 0; }
@@ -92,7 +92,7 @@ protected:
     sfileno reserveSapForWriting(Ipc::Mem::PageId &page);
 
     // Ipc::StoreMapCleaner API
-    virtual void noteFreeMapSlice(const Ipc::StoreMapSliceId sliceId) override;
+    void noteFreeMapSlice(const Ipc::StoreMapSliceId sliceId) override;
 
 private:
     // TODO: move freeSlots into map

--- a/src/MessageBucket.h
+++ b/src/MessageBucket.h
@@ -27,9 +27,9 @@ public:
     MessageBucket(const int speed, const int initialLevelPercent, const double sizeLimit, MessageDelayPool::Pointer pool);
 
     /* BandwidthBucket API */
-    virtual int quota() override;
-    virtual void scheduleWrite(Comm::IoCallback *state) override;
-    virtual void reduceBucket(int len) override;
+    int quota() override;
+    void scheduleWrite(Comm::IoCallback *state) override;
+    void reduceBucket(int len) override;
 
 private:
     MessageDelayPool::Pointer theAggregate;

--- a/src/MessageDelayPools.h
+++ b/src/MessageDelayPools.h
@@ -30,7 +30,7 @@ public:
 
     MessageDelayPool(const SBuf &name, int64_t bucketSpeed, int64_t bucketSize,
                      int64_t aggregateSpeed, int64_t aggregateSize, uint16_t initialBucketPercent);
-    ~MessageDelayPool();
+    ~MessageDelayPool() override;
     MessageDelayPool(const MessageDelayPool &) = delete;
     MessageDelayPool &operator=(const MessageDelayPool &) = delete;
 

--- a/src/Notes.h
+++ b/src/Notes.h
@@ -47,7 +47,7 @@ public:
         enum Method { mhReplace, mhAppend };
 
         Value(const char *aVal, const bool quoted, const char *descr, const Method method = mhReplace);
-        ~Value();
+        ~Value() override;
         Value(const Value&) = delete;
         Value &operator=(const Value&) = delete;
 
@@ -116,7 +116,7 @@ public:
 
     explicit Notes(const char *aDescr, const Keys *extraReservedKeys = nullptr, bool allowFormatted = true);
     Notes() = default;
-    ~Notes() { notes.clear(); }
+    ~Notes() override { notes.clear(); }
     Notes(const Notes&) = delete;
     Notes &operator=(const Notes&) = delete;
 

--- a/src/NullDelayId.h
+++ b/src/NullDelayId.h
@@ -19,9 +19,9 @@ class NullDelayId : public DelayIdComposite
     MEMPROXY_CLASS(NullDelayId);
 
 public:
-    virtual int bytesWanted (int minimum, int maximum) const {return max(minimum,maximum);}
+    int bytesWanted (int minimum, int maximum) const override {return max(minimum,maximum);}
 
-    virtual void bytesIn(int) {}
+    void bytesIn(int) override {}
 };
 #endif
 #endif /* NULLDELAYID_H */

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -235,8 +235,8 @@ class PeerPoolMgrsRr: public RegisteredRunner
 {
 public:
     /* RegisteredRunner API */
-    virtual void useConfig() { syncConfig(); }
-    virtual void syncConfig();
+    void useConfig() override { syncConfig(); }
+    void syncConfig() override;
 };
 
 RunnerRegistrationEntry(PeerPoolMgrsRr);

--- a/src/PeerPoolMgr.h
+++ b/src/PeerPoolMgr.h
@@ -30,13 +30,13 @@ public:
     static void Checkpoint(const Pointer &mgr, const char *reason);
 
     explicit PeerPoolMgr(CachePeer *aPeer);
-    virtual ~PeerPoolMgr();
+    ~PeerPoolMgr() override;
 
 protected:
     /* AsyncJob API */
-    virtual void start();
-    virtual void swanSong();
-    virtual bool doneAll() const;
+    void start() override;
+    void swanSong() override;
+    bool doneAll() const override;
 
     /// whether the peer is still out there and in a valid state we can safely use
     bool validPeer() const;

--- a/src/PeerPoolMgr.h
+++ b/src/PeerPoolMgr.h
@@ -21,7 +21,7 @@ class CommConnectCbParams;
 /// Maintains an fixed-size "standby" PconnPool for a single CachePeer.
 class PeerPoolMgr: public AsyncJob
 {
-    CBDATA_CLASS(PeerPoolMgr);
+    CBDATA_CHILD(PeerPoolMgr);
 
 public:
     typedef CbcPointer<PeerPoolMgr> Pointer;

--- a/src/PeerSelectState.h
+++ b/src/PeerSelectState.h
@@ -32,7 +32,7 @@ void peerSelectInit(void);
 class PeerSelectionInitiator: public CbdataParent
 {
 public:
-    virtual ~PeerSelectionInitiator() = default;
+    ~PeerSelectionInitiator() override = default;
 
     /// called when a new unique destination has been found
     virtual void noteDestination(Comm::ConnectionPointer path) = 0;
@@ -62,12 +62,12 @@ class PeerSelector: public Dns::IpReceiver
 
 public:
     explicit PeerSelector(PeerSelectionInitiator*);
-    virtual ~PeerSelector() override;
+    ~PeerSelector() override;
 
     /* Dns::IpReceiver API */
-    virtual void noteIp(const Ip::Address &ip) override;
-    virtual void noteIps(const Dns::CachedIps *ips, const Dns::LookupDetails &details) override;
-    virtual void noteLookup(const Dns::LookupDetails &details) override;
+    void noteIp(const Ip::Address &ip) override;
+    void noteIps(const Dns::CachedIps *ips, const Dns::LookupDetails &details) override;
+    void noteLookup(const Dns::LookupDetails &details) override;
 
     // Produce a URL for display identifying the transaction we are
     // trying to locate a peer for.

--- a/src/SBufStatsAction.h
+++ b/src/SBufStatsAction.h
@@ -26,14 +26,14 @@ public:
 protected:
     explicit SBufStatsAction(const Mgr::CommandPointer &cmd);
     /* Mgr::Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     /* Mgr::Action API */
-    virtual void add(const Mgr::Action& action);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& msg);
+    void add(const Mgr::Action& action) override;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpack(const Ipc::TypedMsgHdr& msg) override;
 
     SBufStats sbdata;
     MemBlobStats mbdata;

--- a/src/Store.h
+++ b/src/Store.h
@@ -46,7 +46,7 @@ public:
 
     const char *getMD5Text() const;
     StoreEntry();
-    virtual ~StoreEntry();
+    ~StoreEntry() override;
 
     MemObject &mem() { assert(mem_obj); return *mem_obj; }
     const MemObject &mem() const { assert(mem_obj); return *mem_obj; }
@@ -297,10 +297,10 @@ public:
 #endif
 
     /* Packable API */
-    virtual void append(char const *, int);
-    virtual void vappendf(const char *, va_list);
-    virtual void buffer();
-    virtual void flush();
+    void append(char const *, int) override;
+    void vappendf(const char *, va_list) override;
+    void buffer() override;
+    void flush() override;
 
 protected:
     typedef Store::EntryGuard EntryGuard;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -27,7 +27,7 @@ class StoreClient: public Acl::ChecklistFiller
 {
 
 public:
-    virtual ~StoreClient () {}
+    ~StoreClient () override {}
 
     /// \return LogTags (if the class logs transactions) or nil (otherwise)
     virtual LogTags *loggingTags() const = 0;

--- a/src/StoreIOState.h
+++ b/src/StoreIOState.h
@@ -55,7 +55,7 @@ public:
     void operator delete (void *address);
 
     StoreIOState(StoreIOState::STFNCB *cbFile, StoreIOState::STIOCB *cbIo, void *data);
-    virtual ~StoreIOState();
+    ~StoreIOState() override;
 
     off_t offset() const {return offset_;}
 

--- a/src/StoreSearch.h
+++ b/src/StoreSearch.h
@@ -19,7 +19,7 @@ public:
     StoreSearch() {}
 
     StoreSearch(StoreSearch const &); /* no implementation - trigger link failures */
-    virtual ~StoreSearch() {}
+    ~StoreSearch() override {}
 
     /* not ready yet
     void asList(void (*) (CbDataList<StoreEntryPointer), void *cbdata);

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -399,11 +399,11 @@ class TransientsRr: public Ipc::Mem::RegisteredRunner
 {
 public:
     /* RegisteredRunner API */
-    virtual void useConfig();
-    virtual ~TransientsRr();
+    void useConfig() override;
+    ~TransientsRr() override;
 
 protected:
-    virtual void create();
+    void create() override;
 
 private:
     TransientsMap::Owner *mapOwner = nullptr;

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -36,7 +36,7 @@ public:
     };
 
     Transients();
-    virtual ~Transients();
+    ~Transients() override;
 
     /// return a local, previously collapsed entry
     StoreEntry *findCollapsed(const sfileno xitIndex);
@@ -58,21 +58,21 @@ public:
     void disconnect(StoreEntry &);
 
     /* Store API */
-    virtual StoreEntry *get(const cache_key *) override;
-    virtual void create() override {}
-    virtual void init() override;
-    virtual uint64_t maxSize() const override;
-    virtual uint64_t minSize() const override;
-    virtual uint64_t currentSize() const override;
-    virtual uint64_t currentCount() const override;
-    virtual int64_t maxObjectSize() const override;
-    virtual void getStats(StoreInfoStats &stats) const override;
-    virtual void stat(StoreEntry &e) const override;
-    virtual void reference(StoreEntry &e) override;
-    virtual bool dereference(StoreEntry &e) override;
-    virtual void evictCached(StoreEntry &) override;
-    virtual void evictIfFound(const cache_key *) override;
-    virtual void maintain() override;
+    StoreEntry *get(const cache_key *) override;
+    void create() override {}
+    void init() override;
+    uint64_t maxSize() const override;
+    uint64_t minSize() const override;
+    uint64_t currentSize() const override;
+    uint64_t currentCount() const override;
+    int64_t maxObjectSize() const override;
+    void getStats(StoreInfoStats &stats) const override;
+    void stat(StoreEntry &e) const override;
+    void reference(StoreEntry &e) override;
+    bool dereference(StoreEntry &e) override;
+    void evictCached(StoreEntry &) override;
+    void evictIfFound(const cache_key *) override;
+    void maintain() override;
 
     /// Whether an entry with the given public key exists and (but) was
     /// marked for removal some time ago; get(key) returns nil in such cases.
@@ -97,7 +97,7 @@ protected:
     void anchorEntry(StoreEntry &, const sfileno, const Ipc::StoreMapAnchor &);
 
     // Ipc::StoreMapCleaner API
-    virtual void noteFreeMapSlice(const Ipc::StoreMapSliceId sliceId) override;
+    void noteFreeMapSlice(const Ipc::StoreMapSliceId sliceId) override;
 
 private:
     /// shared packed info indexed by Store keys, for creating new StoreEntries

--- a/src/acl/AdaptationService.h
+++ b/src/acl/AdaptationService.h
@@ -16,7 +16,7 @@ class ACLAdaptationServiceStrategy : public ACLStrategy<const char *>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLADAPTATIONSERVICE_H */

--- a/src/acl/AdaptationServiceData.h
+++ b/src/acl/AdaptationServiceData.h
@@ -18,7 +18,7 @@ class ACLAdaptationServiceData : public ACLStringData
 {
 public:
     ACLAdaptationServiceData() : ACLStringData() {}
-    virtual void parse();
+    void parse() override;
 };
 
 #endif /* SQUID_ADAPTATIONSERVICEDATA_H */

--- a/src/acl/AllOf.h
+++ b/src/acl/AllOf.h
@@ -23,13 +23,13 @@ class AllOf: public Acl::InnerNode
 
 public:
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual SBufList dump() const;
+    char const *typeString() const override;
+    void parse() override;
+    SBufList dump() const override;
 
 private:
     /* Acl::InnerNode API */
-    virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const;
+    int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const override;
 };
 
 } // namespace Acl

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -16,8 +16,8 @@
 class ACLAnnotateClientStrategy : public Acl::AnnotationStrategy
 {
 public:
-    virtual bool requiresRequest() const { return true; }
-    virtual int match(ACLData<MatchType> * &, ACLFilledChecklist *);
+    bool requiresRequest() const override { return true; }
+    int match(ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLANNOTATECLIENT */

--- a/src/acl/AnnotateTransaction.h
+++ b/src/acl/AnnotateTransaction.h
@@ -16,8 +16,8 @@
 class ACLAnnotateTransactionStrategy: public Acl::AnnotationStrategy
 {
 public:
-    virtual int match(ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const { return true; }
+    int match(ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override { return true; }
 };
 
 #endif /* SQUID_ACLANNOTATETRANSACTION */

--- a/src/acl/AnnotationData.h
+++ b/src/acl/AnnotationData.h
@@ -22,10 +22,10 @@ public:
     ACLAnnotationData();
 
     /* ACLData<M> API */
-    virtual bool match(NotePairs::Entry *) { return true; }
-    virtual SBufList dump() const;
-    virtual void parse();
-    virtual bool empty() const { return notes->empty(); }
+    bool match(NotePairs::Entry *) override { return true; }
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override { return notes->empty(); }
 
     /// Stores annotations into pairs.
     void annotate(NotePairs::Pointer pairs, const CharacterSet *delimiters, const AccessLogEntry::Pointer &al);

--- a/src/acl/AnyOf.h
+++ b/src/acl/AnyOf.h
@@ -21,8 +21,8 @@ class AnyOf: public Acl::OrNode
 
 public:
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
+    char const *typeString() const override;
+    void parse() override;
 };
 
 } // namespace Acl

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -25,13 +25,13 @@ class ACLARP : public ACL
 
 public:
     ACLARP(char const *);
-    ~ACLARP() {}
+    ~ACLARP() override {}
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
 
 protected:
     char const *class_;

--- a/src/acl/Asn.h
+++ b/src/acl/Asn.h
@@ -28,13 +28,13 @@ class ACLASN : public ACLData<Ip::Address>
 
 public:
     ACLASN() : data(nullptr) {}
-    virtual ~ACLASN();
+    ~ACLASN() override;
 
-    virtual bool match(Ip::Address);
-    virtual SBufList dump() const;
-    virtual void parse();
-    bool empty() const;
-    virtual void prepareForUse();
+    bool match(Ip::Address) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
+    void prepareForUse() override;
 
 private:
     CbDataList<int> *data;

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -17,7 +17,7 @@ class ACLAtStepStrategy: public ACLStrategy<XactionStep>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLATSTEP_H */

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -20,11 +20,11 @@ class ACLAtStepData : public ACLData<XactionStep>
 
 public:
     ACLAtStepData();
-    virtual ~ACLAtStepData();
-    bool match(XactionStep);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const;
+    ~ACLAtStepData() override;
+    bool match(XactionStep) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
     std::list<XactionStep> values;
 };

--- a/src/acl/BoolOps.h
+++ b/src/acl/BoolOps.h
@@ -28,12 +28,12 @@ public:
 
 private:
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual SBufList dump() const;
+    char const *typeString() const override;
+    void parse() override;
+    SBufList dump() const override;
 
     /* Acl::InnerNode API */
-    virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const;
+    int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const override;
 };
 
 /// An inner ACL expression tree node representing a boolean conjunction (AND)
@@ -45,11 +45,11 @@ class AndNode: public InnerNode
 
 public:
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
+    char const *typeString() const override;
+    void parse() override;
 
 private:
-    virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const;
+    int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const override;
 };
 
 /// An inner ACL expression tree node representing a boolean disjuction (OR)
@@ -65,14 +65,14 @@ public:
     virtual bool bannedAction(ACLChecklist *, Nodes::const_iterator) const;
 
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
+    char const *typeString() const override;
+    void parse() override;
 
 protected:
     mutable Nodes::const_iterator lastMatch_;
 
 private:
-    virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const;
+    int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const override;
 };
 
 } // namespace Acl

--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -20,7 +20,7 @@ class ACLCertificateStrategy : public ACLStrategy<X509 *>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLCERTIFICATE_H */

--- a/src/acl/CertificateData.h
+++ b/src/acl/CertificateData.h
@@ -23,11 +23,11 @@ class ACLCertificateData : public ACLData<X509 *>
 
 public:
     ACLCertificateData(Ssl::GETX509ATTRIBUTE *, const char *attributes, bool optionalAttr = false);
-    virtual ~ACLCertificateData();
-    bool match(X509 *);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const;
+    ~ACLCertificateData() override;
+    bool match(X509 *) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
     /// A '|'-delimited list of valid ACL attributes.
     /// A "*" item means that any attribute is acceptable.

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -56,8 +56,8 @@ public:
 
     public:
         static NullState *Instance();
-        virtual void checkForAsync(ACLChecklist *) const;
-        virtual ~NullState() {}
+        void checkForAsync(ACLChecklist *) const override;
+        ~NullState() override {}
 
     private:
         static NullState _instance;

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -24,11 +24,11 @@ class ConnMark : public ACL
 
 public:
     /* ACL API */
-    virtual char const *typeString() const override;
-    virtual void parse() override;
-    virtual int match(ACLChecklist *checklist) override;
-    virtual SBufList dump() const override;
-    virtual bool empty() const override;
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty() const override;
 
 private:
     std::vector<Ip::NfMarkConfig> marks; ///< marks/masks in configured order

--- a/src/acl/ConnectionsEncrypted.h
+++ b/src/acl/ConnectionsEncrypted.h
@@ -21,13 +21,13 @@ class ConnectionsEncrypted : public ACL
 
 public:
     ConnectionsEncrypted(char const *);
-    virtual ~ConnectionsEncrypted();
+    ~ConnectionsEncrypted() override;
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
 
 protected:
     char const *class_;

--- a/src/acl/DestinationAsn.h
+++ b/src/acl/DestinationAsn.h
@@ -18,8 +18,8 @@ class ACLDestinationASNStrategy : public ACLStrategy<Ip::Address>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLDESTINATIONASN_H */

--- a/src/acl/DestinationDomain.h
+++ b/src/acl/DestinationDomain.h
@@ -21,9 +21,9 @@ class ACLDestinationDomainStrategy : public ACLStrategy<char const *>
 
 public:
     /* ACLStrategy API */
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
-    virtual const Acl::Options &options();
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
+    const Acl::Options &options() override;
 
 private:
     Acl::BooleanOptionValue lookupBanned; ///< Are DNS lookups allowed?
@@ -35,7 +35,7 @@ class DestinationDomainLookup : public ACLChecklist::AsyncState
 
 public:
     static DestinationDomainLookup *Instance();
-    virtual void checkForAsync(ACLChecklist *)const;
+    void checkForAsync(ACLChecklist *)const override;
 
 private:
     static DestinationDomainLookup instance_;

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -18,7 +18,7 @@ class DestinationIPLookup : public ACLChecklist::AsyncState
 
 public:
     static DestinationIPLookup *Instance();
-    virtual void checkForAsync(ACLChecklist *)const;
+    void checkForAsync(ACLChecklist *)const override;
 
 private:
     static DestinationIPLookup instance_;
@@ -30,9 +30,9 @@ class ACLDestinationIP : public ACLIP
     MEMPROXY_CLASS(ACLDestinationIP);
 
 public:
-    virtual char const *typeString() const;
-    virtual const Acl::Options &options();
-    virtual int match(ACLChecklist *checklist);
+    char const *typeString() const override;
+    const Acl::Options &options() override;
+    int match(ACLChecklist *checklist) override;
 
 private:
     Acl::BooleanOptionValue lookupBanned; ///< are DNS lookups allowed?

--- a/src/acl/DomainData.h
+++ b/src/acl/DomainData.h
@@ -19,11 +19,11 @@ class ACLDomainData : public ACLData<char const *>
 
 public:
     ACLDomainData() : domains(nullptr) {}
-    virtual ~ACLDomainData();
-    virtual bool match(char const *);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const;
+    ~ACLDomainData() override;
+    bool match(char const *) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
     Splay<char *> *domains;
 };

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -24,13 +24,13 @@ class ACLEui64 : public ACL
 
 public:
     ACLEui64(char const *);
-    ~ACLEui64() {}
+    ~ACLEui64() override {}
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
 
 protected:
     typedef std::set<Eui::Eui64> Eui64Data_t;

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -21,18 +21,18 @@ class ACLExtUser : public ACL
 
 public:
     ACLExtUser(ACLData<char const *> *newData, char const *);
-    ~ACLExtUser();
+    ~ACLExtUser() override;
 
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
 
 private:
     /* ACL API */
-    virtual const Acl::Options &lineOptions();
+    const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;
     char const *type_;

--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -36,7 +36,7 @@ class ACLFilledChecklist: public ACLChecklist
 public:
     ACLFilledChecklist();
     ACLFilledChecklist(const acl_access *, HttpRequest *, const char *ident = nullptr);
-    ~ACLFilledChecklist();
+    ~ACLFilledChecklist() override;
 
     /// configure client request-related fields for the first time
     void setRequest(HttpRequest *);
@@ -63,11 +63,11 @@ public:
     void markSourceDomainChecked();
 
     // ACLChecklist API
-    virtual bool hasRequest() const { return request != nullptr; }
-    virtual bool hasReply() const { return reply != nullptr; }
-    virtual bool hasAle() const { return al != nullptr; }
-    virtual void syncAle(HttpRequest *adaptedRequest, const char *logUri) const;
-    virtual void verifyAle() const;
+    bool hasRequest() const override { return request != nullptr; }
+    bool hasReply() const override { return reply != nullptr; }
+    bool hasAle() const override { return al != nullptr; }
+    void syncAle(HttpRequest *adaptedRequest, const char *logUri) const override;
+    void verifyAle() const override;
 
 public:
     Ip::Address src_addr;

--- a/src/acl/HasComponent.h
+++ b/src/acl/HasComponent.h
@@ -16,7 +16,7 @@
 class ACLHasComponentStrategy : public ACLStrategy<ACLChecklist *>
 {
 public:
-    virtual int match(ACLData<MatchType> * &, ACLFilledChecklist *);
+    int match(ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif

--- a/src/acl/HasComponentData.h
+++ b/src/acl/HasComponentData.h
@@ -21,10 +21,10 @@ public:
     ACLHasComponentData();
 
     /* ACLData<M> API */
-    virtual bool match(ACLChecklist *) override;
-    virtual SBufList dump() const override;
-    virtual void parse() override;
-    virtual bool empty() const override { return false; }
+    bool match(ACLChecklist *) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override { return false; }
 
 private:
     enum ComponentKind { coRequest = 0, coResponse, coAle, coEnd };

--- a/src/acl/HierCode.h
+++ b/src/acl/HierCode.h
@@ -17,8 +17,8 @@ class ACLHierCodeStrategy : public ACLStrategy<hier_code>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLHIERCODE_H */

--- a/src/acl/HierCodeData.h
+++ b/src/acl/HierCodeData.h
@@ -19,11 +19,11 @@ class ACLHierCodeData : public ACLData<hier_code>
 
 public:
     ACLHierCodeData();
-    virtual ~ACLHierCodeData();
-    bool match(hier_code);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const;
+    ~ACLHierCodeData() override;
+    bool match(hier_code) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
     /// mask of codes this ACL might match.
     bool values[HIER_MAX];

--- a/src/acl/HttpHeaderData.h
+++ b/src/acl/HttpHeaderData.h
@@ -20,15 +20,15 @@ class ACLHTTPHeaderData : public ACLData<HttpHeader*>
 
 public:
     ACLHTTPHeaderData();
-    virtual ~ACLHTTPHeaderData();
-    virtual bool match(HttpHeader* hdr);
-    virtual SBufList dump() const;
-    virtual void parse();
-    virtual bool empty() const;
+    ~ACLHTTPHeaderData() override;
+    bool match(HttpHeader* hdr) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
 private:
     /* ACLData API */
-    virtual const Acl::Options &lineOptions();
+    const Acl::Options &lineOptions() override;
 
     Http::HdrType hdrId;            /**< set if header is known */
     SBuf hdrName;                   /**< always set */

--- a/src/acl/HttpRepHeader.h
+++ b/src/acl/HttpRepHeader.h
@@ -18,8 +18,8 @@ class ACLHTTPRepHeaderStrategy : public ACLStrategy<HttpHeader*>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresReply() const { return true; }
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresReply() const override { return true; }
 };
 
 #endif /* SQUID_ACLHTTPREPHEADER_H */

--- a/src/acl/HttpReqHeader.h
+++ b/src/acl/HttpReqHeader.h
@@ -17,8 +17,8 @@ class ACLHTTPReqHeaderStrategy : public ACLStrategy<HttpHeader*>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const { return true; }
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override { return true; }
 };
 
 #endif /* SQUID_ACLHTTPREQHEADER_H */

--- a/src/acl/HttpStatus.h
+++ b/src/acl/HttpStatus.h
@@ -30,14 +30,14 @@ class ACLHTTPStatus : public ACL
 
 public:
     ACLHTTPStatus(char const *);
-    ~ACLHTTPStatus();
+    ~ACLHTTPStatus() override;
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
-    virtual bool requiresReply() const { return true; }
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
+    bool requiresReply() const override { return true; }
 
 protected:
     Splay<acl_httpstatus_data*> *data;

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -30,9 +30,9 @@ public:
     Nodes::size_type childrenCount() const { return nodes.size(); }
 
     /* ACL API */
-    virtual void prepareForUse();
-    virtual bool empty() const;
-    virtual SBufList dump() const;
+    void prepareForUse() override;
+    bool empty() const override;
+    SBufList dump() const override;
 
     /// parses a [ [!]acl1 [!]acl2... ] sequence, appending to nodes
     /// \returns the number of parsed ACL names
@@ -47,7 +47,7 @@ protected:
     virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const = 0;
 
     /* ACL API */
-    virtual int match(ACLChecklist *checklist);
+    int match(ACLChecklist *checklist) override;
 
     // XXX: use refcounting instead of raw pointers
     std::vector<ACL*> nodes; ///< children nodes of this intermediate node

--- a/src/acl/IntRange.h
+++ b/src/acl/IntRange.h
@@ -20,11 +20,11 @@ class ACLIntRange : public ACLData<int>
 public:
     ACLIntRange() {}
 
-    virtual ~ACLIntRange();
-    virtual bool match(int);
-    virtual SBufList dump() const;
-    virtual void parse();
-    virtual bool empty() const;
+    ~ACLIntRange() override;
+    bool match(int) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
 private:
     typedef Range<int> RangeType;

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -48,16 +48,16 @@ public:
     void operator delete(void *);
 
     ACLIP() : data(nullptr) {}
-    ~ACLIP();
+    ~ACLIP() override;
 
     typedef Splay<acl_ip_data *> IPSplay;
 
-    virtual char const *typeString() const = 0;
-    virtual void parse();
+    char const *typeString() const override = 0;
+    void parse() override;
     //    virtual bool isProxyAuth() const {return true;}
-    virtual int match(ACLChecklist *checklist) = 0;
-    virtual SBufList dump() const;
-    virtual bool empty () const;
+    int match(ACLChecklist *checklist) override = 0;
+    SBufList dump() const override;
+    bool empty () const override;
 
 protected:
 

--- a/src/acl/LocalIp.h
+++ b/src/acl/LocalIp.h
@@ -17,8 +17,8 @@ class ACLLocalIP : public ACLIP
     MEMPROXY_CLASS(ACLLocalIP);
 
 public:
-    virtual char const *typeString() const;
-    virtual int match(ACLChecklist *checklist);
+    char const *typeString() const override;
+    int match(ACLChecklist *checklist) override;
 };
 
 #endif /* SQUID_ACLLOCALIP_H */

--- a/src/acl/LocalPort.h
+++ b/src/acl/LocalPort.h
@@ -16,7 +16,7 @@ class ACLLocalPortStrategy : public ACLStrategy<int>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLLOCALPORT_H */

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -18,15 +18,15 @@ class ACLMaxConnection : public ACL
 
 public:
     ACLMaxConnection(char const *);
-    ~ACLMaxConnection();
+    ~ACLMaxConnection() override;
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
-    virtual bool valid () const;
-    virtual void prepareForUse();
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
+    bool valid () const override;
+    void prepareForUse() override;
 
 protected:
     char const *class_;

--- a/src/acl/Method.h
+++ b/src/acl/Method.h
@@ -17,8 +17,8 @@ class ACLMethodStrategy : public ACLStrategy<HttpRequestMethod>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLMETHOD_H */

--- a/src/acl/MethodData.h
+++ b/src/acl/MethodData.h
@@ -21,11 +21,11 @@ class ACLMethodData : public ACLData<HttpRequestMethod>
 
 public:
     ACLMethodData() {}
-    virtual ~ACLMethodData();
-    bool match(HttpRequestMethod);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const {return values.empty();}
+    ~ACLMethodData() override;
+    bool match(HttpRequestMethod) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override {return values.empty();}
 
     std::list<HttpRequestMethod> values;
 

--- a/src/acl/MyPortName.h
+++ b/src/acl/MyPortName.h
@@ -14,7 +14,7 @@ class ACLMyPortNameStrategy : public ACLStrategy<const char *>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLMYPORTNAME_H */

--- a/src/acl/Note.h
+++ b/src/acl/Note.h
@@ -22,7 +22,7 @@ class AnnotationStrategy: public ACLStrategy<NotePairs::Entry *>
 public:
     AnnotationStrategy(): delimiters(CharacterSet(__FILE__, ",")) {}
 
-    virtual const Acl::Options &options() override;
+    const Acl::Options &options() override;
 
     Acl::CharacterSetOptionValue delimiters; ///< annotation separators
 };
@@ -34,8 +34,8 @@ class ACLNoteStrategy: public Acl::AnnotationStrategy
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const { return true; }
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override { return true; }
 
 private:
     bool matchNotes(ACLData<MatchType> *, const NotePairs *) const;

--- a/src/acl/NoteData.h
+++ b/src/acl/NoteData.h
@@ -22,11 +22,11 @@ class ACLNoteData : public ACLData<NotePairs::Entry *>
 
 public:
     ACLNoteData();
-    virtual ~ACLNoteData();
-    virtual bool match(NotePairs::Entry *);
-    virtual SBufList dump() const;
-    virtual void parse();
-    virtual bool empty() const;
+    ~ACLNoteData() override;
+    bool match(NotePairs::Entry *) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
 private:
     SBuf name;                   ///< Note name to check. It is always set

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -142,16 +142,16 @@ public:
 
     /* Option API */
 
-    virtual bool configured() const override { return recipient_ && recipient_->configured; }
-    virtual bool disabled() const override { return recipient_ && recipient_->disabled && /* paranoid: */ offName; }
-    virtual bool valued() const override { return recipient_ && recipient_->valued; }
+    bool configured() const override { return recipient_ && recipient_->configured; }
+    bool disabled() const override { return recipient_ && recipient_->disabled && /* paranoid: */ offName; }
+    bool valued() const override { return recipient_ && recipient_->valued; }
 
-    virtual void unconfigure() const override {
+    void unconfigure() const override {
         assert(recipient_);
         recipient_->reset();
     }
 
-    virtual void enable() const override
+    void enable() const override
     {
         assert(recipient_);
         recipient_->configured = true;
@@ -160,7 +160,7 @@ public:
         // leave recipient_->value unchanged
     }
 
-    virtual void configureWith(const SBuf &rawValue) const override
+    void configureWith(const SBuf &rawValue) const override
     {
         assert(recipient_);
         recipient_->configured = true;
@@ -169,7 +169,7 @@ public:
         import(rawValue);
     }
 
-    virtual void disable() const override
+    void disable() const override
     {
         assert(recipient_);
         recipient_->configured = true;
@@ -178,7 +178,7 @@ public:
         // leave recipient_->value unchanged
     }
 
-    virtual void print(std::ostream &os) const override
+    void print(std::ostream &os) const override
     {
         if (configured()) {
             os << ' ' << (disabled() ? offName : onName);

--- a/src/acl/PeerName.h
+++ b/src/acl/PeerName.h
@@ -15,7 +15,7 @@ class ACLPeerNameStrategy : public ACLStrategy<const char *>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLPEERNAME_H */

--- a/src/acl/Protocol.h
+++ b/src/acl/Protocol.h
@@ -16,8 +16,8 @@ class ACLProtocolStrategy : public ACLStrategy<AnyP::ProtocolType>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLPROTOCOL_H */

--- a/src/acl/ProtocolData.h
+++ b/src/acl/ProtocolData.h
@@ -21,11 +21,11 @@ class ACLProtocolData : public ACLData<AnyP::ProtocolType>
 
 public:
     ACLProtocolData() {}
-    virtual ~ACLProtocolData();
-    bool match(AnyP::ProtocolType);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const {return values.empty();}
+    ~ACLProtocolData() override;
+    bool match(AnyP::ProtocolType) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override {return values.empty();}
 
     std::list<AnyP::ProtocolType> values;
 };

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -17,14 +17,14 @@ class ACLRandom : public ACL
 
 public:
     ACLRandom(char const *);
-    ~ACLRandom();
+    ~ACLRandom() override;
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
-    virtual bool valid() const;
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
+    bool valid() const override;
 
 protected:
     double data;        // value to be exceeded before this ACL will match

--- a/src/acl/RegexData.h
+++ b/src/acl/RegexData.h
@@ -20,18 +20,18 @@ class ACLRegexData : public ACLData<char const *>
     MEMPROXY_CLASS(ACLRegexData);
 
 public:
-    virtual ~ACLRegexData();
-    virtual bool match(char const *user);
-    virtual SBufList dump() const;
-    virtual void parse();
-    virtual bool empty() const;
+    ~ACLRegexData() override;
+    bool match(char const *user) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
 private:
     /// whether parse() is called in a case insensitive context
     static Acl::BooleanOptionValue CaseInsensitive_;
 
     /* ACLData API */
-    virtual const Acl::Options &lineOptions();
+    const Acl::Options &lineOptions() override;
 
     std::list<RegexPattern> data;
 };

--- a/src/acl/ReplyHeaderStrategy.h
+++ b/src/acl/ReplyHeaderStrategy.h
@@ -20,8 +20,8 @@ class ACLReplyHeaderStrategy : public ACLStrategy<char const *>
 {
 
 public:
-    virtual int match (ACLData<char const *> * &, ACLFilledChecklist *);
-    virtual bool requiresReply() const {return true;}
+    int match (ACLData<char const *> * &, ACLFilledChecklist *) override;
+    bool requiresReply() const override {return true;}
 };
 
 template <Http::HdrType header>

--- a/src/acl/RequestHeaderStrategy.h
+++ b/src/acl/RequestHeaderStrategy.h
@@ -19,8 +19,8 @@ class ACLRequestHeaderStrategy : public ACLStrategy<char const *>
 {
 
 public:
-    virtual int match (ACLData<char const *> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<char const *> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 template <Http::HdrType header>

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -19,7 +19,7 @@
 class ACLServerCertificateStrategy : public ACLStrategy<X509 *>
 {
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLSERVERCERTIFICATE_H */

--- a/src/acl/ServerName.h
+++ b/src/acl/ServerName.h
@@ -17,7 +17,7 @@ class ACLServerNameData : public ACLDomainData {
     MEMPROXY_CLASS(ACLServerNameData);
 public:
     ACLServerNameData() : ACLDomainData() {}
-    virtual bool match(const char *);
+    bool match(const char *) override;
 };
 
 class ACLServerNameStrategy : public ACLStrategy<char const *>
@@ -25,10 +25,10 @@ class ACLServerNameStrategy : public ACLStrategy<char const *>
 
 public:
     /* ACLStrategy API */
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
-    virtual const Acl::Options &options();
-    virtual bool valid() const;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
+    const Acl::Options &options() override;
+    bool valid() const override;
 
 private:
     Acl::BooleanOptionValue useClientRequested; ///< Ignore server-supplied names

--- a/src/acl/SourceAsn.h
+++ b/src/acl/SourceAsn.h
@@ -18,7 +18,7 @@ class ACLSourceASNStrategy : public ACLStrategy<Ip::Address>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACL_SOURCEASN_H */

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -18,7 +18,7 @@ class ACLSourceDomainStrategy : public ACLStrategy<char const *>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 class SourceDomainLookup : public ACLChecklist::AsyncState
@@ -26,7 +26,7 @@ class SourceDomainLookup : public ACLChecklist::AsyncState
 
 public:
     static SourceDomainLookup *Instance();
-    virtual void checkForAsync(ACLChecklist *)const;
+    void checkForAsync(ACLChecklist *)const override;
 
 private:
     static SourceDomainLookup instance_;

--- a/src/acl/SourceIp.h
+++ b/src/acl/SourceIp.h
@@ -16,8 +16,8 @@ class ACLSourceIP : public ACLIP
     MEMPROXY_CLASS(ACLSourceIP);
 
 public:
-    virtual char const *typeString() const;
-    virtual int match(ACLChecklist *checklist);
+    char const *typeString() const override;
+    int match(ACLChecklist *checklist) override;
 };
 
 #endif /* SQUID_ACLSOURCEIP_H */

--- a/src/acl/SquidError.h
+++ b/src/acl/SquidError.h
@@ -16,7 +16,7 @@ class ACLSquidErrorStrategy : public ACLStrategy<err_type>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLSQUIDERROR_H */

--- a/src/acl/SquidErrorData.h
+++ b/src/acl/SquidErrorData.h
@@ -20,11 +20,11 @@ class ACLSquidErrorData : public ACLData<err_type>
 public:
     ACLSquidErrorData(): ACLData<err_type>() {};
 
-    virtual ~ACLSquidErrorData() {}
-    virtual bool match(err_type err);
-    virtual SBufList dump() const;
-    virtual void parse();
-    virtual bool empty() const;
+    ~ACLSquidErrorData() override {}
+    bool match(err_type err) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
 private:
     CbDataListContainer <err_type> errors;

--- a/src/acl/SslError.h
+++ b/src/acl/SslError.h
@@ -16,7 +16,7 @@ class ACLSslErrorStrategy : public ACLStrategy<const Security::CertErrors *>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLSSL_ERROR_H */

--- a/src/acl/SslErrorData.h
+++ b/src/acl/SslErrorData.h
@@ -19,11 +19,11 @@ class ACLSslErrorData : public ACLData<const Security::CertErrors *>
 
 public:
     ACLSslErrorData() = default;
-    virtual ~ACLSslErrorData() {}
-    bool match(const Security::CertErrors *);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const { return values.empty(); }
+    ~ACLSslErrorData() override {}
+    bool match(const Security::CertErrors *) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override { return values.empty(); }
 
     Security::Errors values;
 };

--- a/src/acl/Strategised.h
+++ b/src/acl/Strategised.h
@@ -32,27 +32,27 @@ class ACLStrategised : public ACL
 public:
     typedef M MatchType;
 
-    ~ACLStrategised();
+    ~ACLStrategised() override;
     ACLStrategised(ACLData<MatchType> *, ACLStrategy<MatchType> *, char const *);
 
-    virtual char const *typeString() const;
+    char const *typeString() const override;
 
-    virtual bool requiresRequest() const {return matcher->requiresRequest();}
+    bool requiresRequest() const override {return matcher->requiresRequest();}
 
-    virtual bool requiresReply() const {return matcher->requiresReply();}
+    bool requiresReply() const override {return matcher->requiresReply();}
 
-    virtual void prepareForUse() { data->prepareForUse();}
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
+    void prepareForUse() override { data->prepareForUse();}
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
     virtual int match (M const &);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
-    virtual bool valid () const;
+    SBufList dump() const override;
+    bool empty () const override;
+    bool valid () const override;
 
 private:
     /* ACL API */
-    virtual const Acl::Options &options() { return matcher->options(); }
-    virtual const Acl::Options &lineOptions() { return data->lineOptions(); }
+    const Acl::Options &options() override { return matcher->options(); }
+    const Acl::Options &lineOptions() override { return data->lineOptions(); }
 
     ACLData<MatchType> *data;
     char const *type_;

--- a/src/acl/StringData.h
+++ b/src/acl/StringData.h
@@ -21,13 +21,13 @@ class ACLStringData : public ACLData<char const *>
 
 public:
     ACLStringData() {}
-    virtual ~ACLStringData() {}
+    ~ACLStringData() override {}
     /// \deprecated use match(SBuf&) instead.
-    bool match(char const *);
+    bool match(char const *) override;
     bool match(const SBuf &);
-    virtual SBufList dump() const;
-    virtual void parse();
-    bool empty() const;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
     /// Insert a string data value
     void insert(const char *);

--- a/src/acl/Tag.h
+++ b/src/acl/Tag.h
@@ -15,7 +15,7 @@ class ACLTagStrategy : public ACLStrategy<const char *>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLMYPORTNAME_H */

--- a/src/acl/Time.h
+++ b/src/acl/Time.h
@@ -15,7 +15,7 @@ class ACLTimeStrategy : public ACLStrategy<time_t>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
 #endif /* SQUID_ACLTIME_H */

--- a/src/acl/TimeData.h
+++ b/src/acl/TimeData.h
@@ -18,11 +18,11 @@ class ACLTimeData : public ACLData<time_t>
 
 public:
     ACLTimeData();
-    virtual ~ACLTimeData();
-    bool match(time_t);
-    virtual SBufList dump() const;
-    void parse();
-    bool empty() const;
+    ~ACLTimeData() override;
+    bool match(time_t) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
 private:
     int weekbits;

--- a/src/acl/TransactionInitiator.h
+++ b/src/acl/TransactionInitiator.h
@@ -24,12 +24,12 @@ class TransactionInitiator : public ACL
 public:
     TransactionInitiator(char const *);
 
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual int match(ACLChecklist *checklist);
-    virtual bool requiresRequest() const { return true; }
-    virtual SBufList dump() const;
-    virtual bool empty () const;
+    char const *typeString() const override;
+    void parse() override;
+    int match(ACLChecklist *checklist) override;
+    bool requiresRequest() const override { return true; }
+    SBufList dump() const override;
+    bool empty () const override;
 
 protected:
     char const *class_;

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -41,7 +41,7 @@ public:
 
 protected:
     /// Acl::OrNode API
-    virtual bool bannedAction(ACLChecklist *, Nodes::const_iterator) const override;
+    bool bannedAction(ACLChecklist *, Nodes::const_iterator) const override;
     Answer actionAt(const Nodes::size_type pos) const;
 
     /// if not empty, contains actions corresponding to InnerNode::nodes

--- a/src/acl/Url.h
+++ b/src/acl/Url.h
@@ -16,8 +16,8 @@ class ACLUrlStrategy : public ACLStrategy<char const *>
 {
 
 public:
-    virtual int match (ACLData<char const *> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<char const *> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLURL_H */

--- a/src/acl/UrlLogin.h
+++ b/src/acl/UrlLogin.h
@@ -17,8 +17,8 @@ class ACLUrlLoginStrategy : public ACLStrategy<char const *>
 {
 
 public:
-    virtual int match (ACLData<char const *> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<char const *> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLURLLOGIN_H */

--- a/src/acl/UrlPath.h
+++ b/src/acl/UrlPath.h
@@ -15,8 +15,8 @@ class ACLUrlPathStrategy : public ACLStrategy<char const *>
 {
 
 public:
-    virtual int match (ACLData<char const *> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<char const *> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLURLPATH_H */

--- a/src/acl/UrlPort.h
+++ b/src/acl/UrlPort.h
@@ -15,8 +15,8 @@ class ACLUrlPortStrategy : public ACLStrategy<int>
 {
 
 public:
-    virtual int match (ACLData<MatchType> * &, ACLFilledChecklist *);
-    virtual bool requiresRequest() const {return true;}
+    int match (ACLData<MatchType> * &, ACLFilledChecklist *) override;
+    bool requiresRequest() const override {return true;}
 };
 
 #endif /* SQUID_ACLURLPORT_H */

--- a/src/acl/UserData.h
+++ b/src/acl/UserData.h
@@ -20,19 +20,19 @@ class ACLUserData : public ACLData<char const *>
     MEMPROXY_CLASS(ACLUserData);
 
 public:
-    virtual ~ACLUserData() {}
+    ~ACLUserData() override {}
     ACLUserData();
-    bool match(char const *user);
-    virtual SBufList dump() const;
-    virtual void parse();
-    bool empty() const;
+    bool match(char const *user) override;
+    SBufList dump() const override;
+    void parse() override;
+    bool empty() const override;
 
 private:
     /// whether parse() is called in a case insensitive context
     static Acl::BooleanOptionValue CaseInsensitive_;
 
     /* ACLData API */
-    virtual const Acl::Options &lineOptions();
+    const Acl::Options &lineOptions() override;
 
     typedef std::set<SBuf,bool(*)(const SBuf&, const SBuf&)> UserDataNames_t;
     UserDataNames_t userDataNames;

--- a/src/adaptation/AccessCheck.h
+++ b/src/adaptation/AccessCheck.h
@@ -41,7 +41,7 @@ public:
 protected:
     // use Start to start adaptation checks
     AccessCheck(const ServiceFilter &aFilter, Adaptation::Initiator *);
-    ~AccessCheck();
+    ~AccessCheck() override;
 
 private:
     const ServiceFilter filter;
@@ -64,8 +64,8 @@ public:
 
 protected:
     // AsyncJob API
-    virtual void start();
-    virtual bool doneAll() const { return false; } /// not done until mustStop
+    void start() override;
+    bool doneAll() const override { return false; } /// not done until mustStop
 
     bool usedDynamicRules();
     void check();

--- a/src/adaptation/AccessCheck.h
+++ b/src/adaptation/AccessCheck.h
@@ -29,7 +29,7 @@ class AccessRule;
 // checks adaptation_access rules to find a matching adaptation service
 class AccessCheck: public virtual AsyncJob
 {
-    CBDATA_CLASS(AccessCheck);
+    CBDATA_CHILD(AccessCheck);
 
 public:
     typedef void AccessCheckCallback(ServiceGroupPointer group, void *data);

--- a/src/adaptation/Initiate.cc
+++ b/src/adaptation/Initiate.cc
@@ -25,11 +25,11 @@ class AnswerCall: public AsyncCallT<AnswerDialer>
 public:
     AnswerCall(const char *aName, const AnswerDialer &aDialer) :
         AsyncCallT<AnswerDialer>(93, 5, aName, aDialer), fired(false) {}
-    virtual void fire() {
+    void fire() override {
         fired = true;
         AsyncCallT<AnswerDialer>::fire();
     }
-    virtual ~AnswerCall() {
+    ~AnswerCall() override {
         if (!fired && dialer.arg1.message != nullptr && dialer.arg1.message->body_pipe != nullptr)
             dialer.arg1.message->body_pipe->expectNoConsumption();
     }

--- a/src/adaptation/Initiate.h
+++ b/src/adaptation/Initiate.h
@@ -32,7 +32,7 @@ class Initiate: virtual public AsyncJob
 
 public:
     Initiate(const char *aTypeName);
-    virtual ~Initiate();
+    ~Initiate() override;
 
     void initiator(const CbcPointer<Initiator> &i); ///< sets initiator
 
@@ -44,9 +44,9 @@ protected:
     void tellQueryAborted(bool final); // tell initiator
     void clearInitiator(); // used by noteInitiatorAborted; TODO: make private
 
-    virtual void swanSong(); // internal cleanup
+    void swanSong() override; // internal cleanup
 
-    virtual const char *status() const; // for debugging
+    const char *status() const override; // for debugging
 
     CbcPointer<Initiator> theInitiator;
 

--- a/src/adaptation/Initiator.h
+++ b/src/adaptation/Initiator.h
@@ -29,7 +29,7 @@ class Initiator: virtual public AsyncJob
 {
 public:
     Initiator(): AsyncJob("Initiator") {}
-    virtual ~Initiator() {}
+    ~Initiator() override {}
 
     /// AccessCheck calls this back with a possibly nil service group
     /// to signal whether adaptation is needed and where it should start.

--- a/src/adaptation/Iterator.h
+++ b/src/adaptation/Iterator.h
@@ -36,19 +36,19 @@ public:
     Iterator(Http::Message *virginHeader, HttpRequest *virginCause,
              const AccessLogEntryPointer &,
              const Adaptation::ServiceGroupPointer &aGroup);
-    virtual ~Iterator();
+    ~Iterator() override;
 
     // Adaptation::Initiate: asynchronous communication with the initiator
-    void noteInitiatorAborted();
+    void noteInitiatorAborted() override;
 
     // Adaptation::Initiator: asynchronous communication with the current launcher
-    virtual void noteAdaptationAnswer(const Answer &answer);
+    void noteAdaptationAnswer(const Answer &answer) override;
 
 protected:
     // Adaptation::Initiate API implementation
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
 
     /// launches adaptation for the service selected by the plan
     void step();

--- a/src/adaptation/Iterator.h
+++ b/src/adaptation/Iterator.h
@@ -30,7 +30,7 @@ namespace Adaptation
 /// iterates services in ServiceGroup, starting adaptation launchers
 class Iterator: public Initiate, public Initiator
 {
-    CBDATA_CLASS(Iterator);
+    CBDATA_CHILD(Iterator);
 
 public:
     Iterator(Http::Message *virginHeader, HttpRequest *virginCause,

--- a/src/adaptation/Service.h
+++ b/src/adaptation/Service.h
@@ -32,7 +32,7 @@ public:
 
 public:
     explicit Service(const ServiceConfigPointer &aConfig);
-    virtual ~Service();
+    ~Service() override;
 
     virtual bool probed() const = 0; // see comments above
     virtual bool broken() const;

--- a/src/adaptation/ServiceGroups.h
+++ b/src/adaptation/ServiceGroups.h
@@ -33,7 +33,7 @@ public:
 
 public:
     ServiceGroup(const String &aKind, bool areAllServicesSame);
-    virtual ~ServiceGroup();
+    ~ServiceGroup() override;
 
     virtual void parse();
     virtual void finalize(); // called after all are parsed

--- a/src/adaptation/ecap/Config.h
+++ b/src/adaptation/ecap/Config.h
@@ -26,7 +26,7 @@ class ServiceConfig: public Adaptation::ServiceConfig
 {
 public:
     // Adaptation::ServiceConfig API
-    virtual bool grokExtension(const char *name, const char *value);
+    bool grokExtension(const char *name, const char *value) override;
 
 public:
     typedef std::pair<std::string, std::string> Extension; // name=value in cfg
@@ -40,18 +40,18 @@ class Config: public Adaptation::Config
 
 public:
     Config();
-    ~Config();
+    ~Config() override;
 
-    virtual bool finalize();
+    bool finalize() override;
 
 protected:
-    virtual Adaptation::ServiceConfig *newServiceConfig() const;
+    Adaptation::ServiceConfig *newServiceConfig() const override;
 
 private:
     Config(const Config &); // not implemented
     Config &operator =(const Config &); // not implemented
 
-    virtual Adaptation::ServicePointer createService(const ServiceConfigPointer &cfg);
+    Adaptation::ServicePointer createService(const ServiceConfigPointer &cfg) override;
 };
 
 extern Config TheConfig;

--- a/src/adaptation/ecap/Host.h
+++ b/src/adaptation/ecap/Host.h
@@ -23,14 +23,14 @@ class Host : public libecap::host::Host
 {
 public:
     /* libecap::host::Host API */
-    virtual std::string uri() const; // unique across all vendors
-    virtual void describe(std::ostream &os) const; // free-format info
-    virtual void noteVersionedService(const char *libEcapVersion, const libecap::weak_ptr<libecap::adapter::Service> &s);
-    virtual std::ostream *openDebug(libecap::LogVerbosity lv);
-    virtual void closeDebug(std::ostream *debug);
+    std::string uri() const override; // unique across all vendors
+    void describe(std::ostream &os) const override; // free-format info
+    void noteVersionedService(const char *libEcapVersion, const libecap::weak_ptr<libecap::adapter::Service> &s) override;
+    std::ostream *openDebug(libecap::LogVerbosity lv) override;
+    void closeDebug(std::ostream *debug) override;
     typedef libecap::shared_ptr<libecap::Message> MessagePtr;
-    virtual MessagePtr newRequest() const;
-    virtual MessagePtr newResponse() const;
+    MessagePtr newRequest() const override;
+    MessagePtr newResponse() const override;
 
     static void Register(); ///< register adaptation host
 

--- a/src/adaptation/ecap/MessageRep.h
+++ b/src/adaptation/ecap/MessageRep.h
@@ -40,13 +40,13 @@ public:
     HeaderRep(Http::Message &aMessage);
 
     /* libecap::Header API */
-    virtual bool hasAny(const Name &name) const;
-    virtual Value value(const Name &name) const;
-    virtual void add(const Name &name, const Value &value);
-    virtual void removeAny(const Name &name);
-    virtual void visitEach(libecap::NamedValueVisitor &visitor) const;
-    virtual Area image() const;
-    virtual void parse(const Area &buf); // throws on failures
+    bool hasAny(const Name &name) const override;
+    Value value(const Name &name) const override;
+    void add(const Name &name, const Value &value) override;
+    void removeAny(const Name &name) override;
+    void visitEach(libecap::NamedValueVisitor &visitor) const override;
+    Area image() const override;
+    void parse(const Area &buf) override; // throws on failures
 
 protected:
     static Http::HdrType TranslateHeaderId(const Name &name);
@@ -88,14 +88,14 @@ public:
     RequestLineRep(HttpRequest &aMessage);
 
     /* libecap::RequestLine API */
-    virtual void uri(const Area &aUri);
-    virtual Area uri() const;
-    virtual void method(const Name &aMethod);
-    virtual Name method() const;
-    virtual libecap::Version version() const;
-    virtual void version(const libecap::Version &aVersion);
-    virtual Name protocol() const;
-    virtual void protocol(const Name &aProtocol);
+    void uri(const Area &aUri) override;
+    Area uri() const override;
+    void method(const Name &aMethod) override;
+    Name method() const override;
+    libecap::Version version() const override;
+    void version(const libecap::Version &aVersion) override;
+    Name protocol() const override;
+    void protocol(const Name &aProtocol) override;
 
 private:
     HttpRequest &theMessage; // the request header being translated to libecap
@@ -112,14 +112,14 @@ public:
     StatusLineRep(HttpReply &aMessage);
 
     /* libecap::StatusLine API */
-    virtual void statusCode(int code);
-    virtual int statusCode() const;
-    virtual void reasonPhrase(const Area &phrase);
-    virtual Area reasonPhrase() const;
-    virtual libecap::Version version() const;
-    virtual void version(const libecap::Version &aVersion);
-    virtual Name protocol() const;
-    virtual void protocol(const Name &aProtocol);
+    void statusCode(int code) override;
+    int statusCode() const override;
+    void reasonPhrase(const Area &phrase) override;
+    Area reasonPhrase() const override;
+    libecap::Version version() const override;
+    void version(const libecap::Version &aVersion) override;
+    Name protocol() const override;
+    void protocol(const Name &aProtocol) override;
 
 private:
     HttpReply &theMessage; // the request header being translated to libecap
@@ -137,7 +137,7 @@ public:
     void tie(const BodyPipe::Pointer &aBody); // late binding if !theBody;
 
     // libecap::Body API
-    virtual BodySize bodySize() const;
+    BodySize bodySize() const override;
 
 private:
     BodyPipe::Pointer theBody; // the body being translated to libecap
@@ -148,17 +148,17 @@ class MessageRep: public libecap::Message
 {
 public:
     explicit MessageRep(Http::Message *rawHeader);
-    virtual ~MessageRep();
+    ~MessageRep() override;
 
     /* libecap::Message API */
-    virtual libecap::shared_ptr<libecap::Message> clone() const;
-    virtual libecap::FirstLine &firstLine();
-    virtual const libecap::FirstLine &firstLine() const;
-    virtual libecap::Header &header();
-    virtual const libecap::Header &header() const;
-    virtual void addBody();
-    virtual libecap::Body *body();
-    virtual const libecap::Body *body() const;
+    libecap::shared_ptr<libecap::Message> clone() const override;
+    libecap::FirstLine &firstLine() override;
+    const libecap::FirstLine &firstLine() const override;
+    libecap::Header &header() override;
+    const libecap::Header &header() const override;
+    void addBody() override;
+    libecap::Body *body() override;
+    const libecap::Body *body() const override;
 
     void tieBody(Ecap::XactionRep *x); // to a specific transaction
 

--- a/src/adaptation/ecap/ServiceRep.cc
+++ b/src/adaptation/ecap/ServiceRep.cc
@@ -48,8 +48,8 @@ public:
     ConfigRep(const Master &aMaster);
 
     // libecap::Options API
-    virtual const libecap::Area option(const libecap::Name &name) const;
-    virtual void visitEachOption(libecap::NamedValueVisitor &visitor) const;
+    const libecap::Area option(const libecap::Name &name) const override;
+    void visitEachOption(libecap::NamedValueVisitor &visitor) const override;
 
     const Master &master; ///< the configuration being wrapped
 };
@@ -59,7 +59,7 @@ class Engine: public AsyncEngine
 {
 public:
     /* AsyncEngine API */
-    virtual int checkEvents(int timeout);
+    int checkEvents(int timeout) override;
 
 private:
     void kickAsyncServices(timeval &timeout);

--- a/src/adaptation/ecap/ServiceRep.h
+++ b/src/adaptation/ecap/ServiceRep.h
@@ -29,20 +29,20 @@ class ServiceRep : public Adaptation::Service
 {
 public:
     explicit ServiceRep(const ServiceConfigPointer &aConfig);
-    virtual ~ServiceRep();
+    ~ServiceRep() override;
 
     typedef libecap::shared_ptr<libecap::adapter::Service> AdapterService;
 
     /* Adaptation::Service API */
-    virtual void finalize();
-    virtual bool probed() const;
-    virtual bool up() const;
-    virtual Adaptation::Initiate *makeXactLauncher(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp);
-    virtual bool wantsUrl(const SBuf &urlPath) const;
-    virtual void noteFailure();
+    void finalize() override;
+    bool probed() const override;
+    bool up() const override;
+    Adaptation::Initiate *makeXactLauncher(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp) override;
+    bool wantsUrl(const SBuf &urlPath) const override;
+    void noteFailure() override;
     virtual const char *status() const;
-    virtual void detach();
-    virtual bool detached() const;
+    void detach() override;
+    bool detached() const override;
 
 protected:
     void tryConfigureAndStart();

--- a/src/adaptation/ecap/XactionRep.cc
+++ b/src/adaptation/ecap/XactionRep.cc
@@ -37,7 +37,7 @@ public:
     OptionsExtractor(HttpHeader &aMeta): meta(aMeta) {}
 
     // libecap::NamedValueVisitor API
-    virtual void visit(const Name &name, const Area &value) {
+    void visit(const Name &name, const Area &value) override {
         meta.putExt(name.image().c_str(), value.toString().c_str());
     }
 

--- a/src/adaptation/ecap/XactionRep.h
+++ b/src/adaptation/ecap/XactionRep.h
@@ -36,49 +36,49 @@ class XactionRep : public Adaptation::Initiate, public libecap::host::Xaction,
 
 public:
     XactionRep(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp, const Adaptation::ServicePointer &service);
-    virtual ~XactionRep();
+    ~XactionRep() override;
 
     typedef libecap::shared_ptr<libecap::adapter::Xaction> AdapterXaction;
     void master(const AdapterXaction &aMaster); // establish a link
 
     // libecap::host::Xaction API
-    virtual const libecap::Area option(const libecap::Name &name) const;
-    virtual void visitEachOption(libecap::NamedValueVisitor &visitor) const;
-    virtual libecap::Message &virgin();
-    virtual const libecap::Message &cause();
-    virtual libecap::Message &adapted();
-    virtual void useVirgin();
-    virtual void useAdapted(const libecap::shared_ptr<libecap::Message> &msg);
-    virtual void blockVirgin();
-    virtual void adaptationDelayed(const libecap::Delay &);
-    virtual void adaptationAborted();
-    virtual void resume();
-    virtual void vbDiscard();
-    virtual void vbMake();
-    virtual void vbStopMaking();
-    virtual void vbMakeMore();
-    virtual libecap::Area vbContent(libecap::size_type offset, libecap::size_type size);
-    virtual void vbContentShift(libecap::size_type size);
-    virtual void noteAbContentDone(bool atEnd);
-    virtual void noteAbContentAvailable();
+    const libecap::Area option(const libecap::Name &name) const override;
+    void visitEachOption(libecap::NamedValueVisitor &visitor) const override;
+    libecap::Message &virgin() override;
+    const libecap::Message &cause() override;
+    libecap::Message &adapted() override;
+    void useVirgin() override;
+    void useAdapted(const libecap::shared_ptr<libecap::Message> &msg) override;
+    void blockVirgin() override;
+    void adaptationDelayed(const libecap::Delay &) override;
+    void adaptationAborted() override;
+    void resume() override;
+    void vbDiscard() override;
+    void vbMake() override;
+    void vbStopMaking() override;
+    void vbMakeMore() override;
+    libecap::Area vbContent(libecap::size_type offset, libecap::size_type size) override;
+    void vbContentShift(libecap::size_type size) override;
+    void noteAbContentDone(bool atEnd) override;
+    void noteAbContentAvailable() override;
 
     // BodyProducer API
-    virtual void noteMoreBodySpaceAvailable(RefCount<BodyPipe> bp);
-    virtual void noteBodyConsumerAborted(RefCount<BodyPipe> bp);
+    void noteMoreBodySpaceAvailable(RefCount<BodyPipe> bp) override;
+    void noteBodyConsumerAborted(RefCount<BodyPipe> bp) override;
 
     // BodyConsumer API
-    virtual void noteMoreBodyDataAvailable(RefCount<BodyPipe> bp);
-    virtual void noteBodyProductionEnded(RefCount<BodyPipe> bp);
-    virtual void noteBodyProducerAborted(RefCount<BodyPipe> bp);
+    void noteMoreBodyDataAvailable(RefCount<BodyPipe> bp) override;
+    void noteBodyProductionEnded(RefCount<BodyPipe> bp) override;
+    void noteBodyProducerAborted(RefCount<BodyPipe> bp) override;
 
     // Initiate API
-    virtual void noteInitiatorAborted();
+    void noteInitiatorAborted() override;
 
     // AsyncJob API (via Initiate)
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
-    virtual const char *status() const;
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
+    const char *status() const override;
 
 protected:
     Service &service();

--- a/src/adaptation/ecap/XactionRep.h
+++ b/src/adaptation/ecap/XactionRep.h
@@ -32,7 +32,7 @@ namespace Ecap
 class XactionRep : public Adaptation::Initiate, public libecap::host::Xaction,
     public BodyConsumer, public BodyProducer
 {
-    CBDATA_CLASS(XactionRep);
+    CBDATA_CHILD(XactionRep);
 
 public:
     XactionRep(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp, const Adaptation::ServicePointer &service);

--- a/src/adaptation/icap/Config.h
+++ b/src/adaptation/icap/Config.h
@@ -39,7 +39,7 @@ public:
     int repeat_limit; ///< icap_retry_limit in squid.conf
 
     Config();
-    ~Config();
+    ~Config() override;
 
     time_t connect_timeout(bool bypassable) const;
     time_t io_timeout(bool bypassable) const;
@@ -48,7 +48,7 @@ private:
     Config(const Config &); // not implemented
     Config &operator =(const Config &); // not implemented
 
-    virtual Adaptation::ServicePointer createService(const ServiceConfigPointer &cfg);
+    Adaptation::ServicePointer createService(const ServiceConfigPointer &cfg) override;
 };
 
 extern Config TheConfig;

--- a/src/adaptation/icap/Launcher.h
+++ b/src/adaptation/icap/Launcher.h
@@ -48,13 +48,13 @@ class Launcher: public Adaptation::Initiate, public Adaptation::Initiator
 {
 public:
     Launcher(const char *aTypeName, Adaptation::ServicePointer &aService);
-    virtual ~Launcher();
+    ~Launcher() override;
 
     // Adaptation::Initiate: asynchronous communication with the initiator
-    void noteInitiatorAborted();
+    void noteInitiatorAborted() override;
 
     // Adaptation::Initiator: asynchronous communication with the current transaction
-    virtual void noteAdaptationAnswer(const Answer &answer);
+    void noteAdaptationAnswer(const Answer &answer) override;
     virtual void noteXactAbort(XactAbortInfo info);
 
 private:
@@ -63,9 +63,9 @@ private:
 
 protected:
     // Adaptation::Initiate API implementation
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
 
     // creates the right ICAP transaction using stored configuration params
     virtual Xaction *createXaction() = 0;

--- a/src/adaptation/icap/ModXact.h
+++ b/src/adaptation/icap/ModXact.h
@@ -140,7 +140,7 @@ private:
 
 class ModXact: public Xaction, public BodyProducer, public BodyConsumer
 {
-    CBDATA_CLASS(ModXact);
+    CBDATA_CHILD(ModXact);
 
 public:
     ModXact(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp, ServiceRep::Pointer &s);
@@ -377,7 +377,7 @@ private:
 // creates ModXact when needed
 class ModXactLauncher: public Launcher
 {
-    CBDATA_CLASS(ModXactLauncher);
+    CBDATA_CHILD(ModXactLauncher);
 
 public:
     ModXactLauncher(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp, Adaptation::ServicePointer s);

--- a/src/adaptation/icap/ModXact.h
+++ b/src/adaptation/icap/ModXact.h
@@ -126,7 +126,7 @@ class ChunkExtensionValueParser: public Http1::ChunkExtensionValueParser
 {
 public:
     /* Http1::ChunkExtensionValueParser API */
-    virtual void parse(Tokenizer &tok, const SBuf &extName) override;
+    void parse(Tokenizer &tok, const SBuf &extName) override;
 
     bool sawUseOriginalBody() const { return useOriginalBody_ >= 0; }
     uint64_t useOriginalBody() const { assert(sawUseOriginalBody()); return static_cast<uint64_t>(useOriginalBody_); }
@@ -144,21 +144,21 @@ class ModXact: public Xaction, public BodyProducer, public BodyConsumer
 
 public:
     ModXact(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp, ServiceRep::Pointer &s);
-    virtual ~ModXact();
+    ~ModXact() override;
 
     // BodyProducer methods
-    virtual void noteMoreBodySpaceAvailable(BodyPipe::Pointer);
-    virtual void noteBodyConsumerAborted(BodyPipe::Pointer);
+    void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;
+    void noteBodyConsumerAborted(BodyPipe::Pointer) override;
 
     // BodyConsumer methods
-    virtual void noteMoreBodyDataAvailable(BodyPipe::Pointer);
-    virtual void noteBodyProductionEnded(BodyPipe::Pointer);
-    virtual void noteBodyProducerAborted(BodyPipe::Pointer);
+    void noteMoreBodyDataAvailable(BodyPipe::Pointer) override;
+    void noteBodyProductionEnded(BodyPipe::Pointer) override;
+    void noteBodyProducerAborted(BodyPipe::Pointer) override;
 
     /* Xaction API */
-    virtual void startShoveling();
-    virtual void handleCommWrote(size_t size);
-    virtual void handleCommRead(size_t size);
+    void startShoveling() override;
+    void handleCommWrote(size_t size) override;
+    void handleCommRead(size_t size) override;
 
     void handleCommWroteHeaders();
     void handleCommWroteBody();
@@ -172,17 +172,17 @@ public:
     InOut adapted;
 
     // bypasses exceptions if needed and possible
-    virtual void callException(const std::exception &e);
+    void callException(const std::exception &e) override;
 
     /// record error detail in the virgin request if possible
-    virtual void detailError(const ErrorDetail::Pointer &errDetail);
+    void detailError(const ErrorDetail::Pointer &errDetail) override;
     // Icap::Xaction API
-    virtual void clearError();
+    void clearError() override;
     /// The master transaction log entry
-    virtual AccessLogEntry::Pointer masterLogEntry() { return alMaster; }
+    AccessLogEntry::Pointer masterLogEntry() override { return alMaster; }
 
 private:
-    virtual void start();
+    void start() override;
 
     /// locates the request, either as a cause or as a virgin message itself
     const HttpRequest &virginRequest() const; // Must always be available
@@ -204,8 +204,8 @@ private:
 
     void startReading();
     void readMore();
-    virtual bool doneReading() const { return commEof || state.doneParsing(); }
-    virtual bool doneWriting() const { return state.doneWriting(); }
+    bool doneReading() const override { return commEof || state.doneParsing(); }
+    bool doneWriting() const override { return state.doneWriting(); }
 
     size_t virginContentSize(const VirginBodyAct &act) const;
     const char *virginContentData(const VirginBodyAct &act) const;
@@ -260,8 +260,8 @@ private:
     void echoMore();
     void updateSources(); ///< Update the Http::Message sources
 
-    virtual bool doneAll() const;
-    virtual void swanSong();
+    bool doneAll() const override;
+    void swanSong() override;
 
     void stopReceiving();
     void stopSending(bool nicely);
@@ -269,9 +269,9 @@ private:
     void stopParsing(const bool checkUnparsedData = true);
     void stopBackup();
 
-    virtual void fillPendingStatus(MemBuf &buf) const;
-    virtual void fillDoneStatus(MemBuf &buf) const;
-    virtual bool fillVirginHttpHeader(MemBuf&) const;
+    void fillPendingStatus(MemBuf &buf) const override;
+    void fillDoneStatus(MemBuf &buf) const override;
+    bool fillVirginHttpHeader(MemBuf&) const override;
 
 private:
     /// parses a message header or trailer
@@ -292,7 +292,7 @@ private:
     bool expectIcapTrailers() const;
     void checkConsuming();
 
-    virtual void finalizeLogInfo();
+    void finalizeLogInfo() override;
 
     SizedEstimate virginBody;
     VirginBodyAct virginBodyWriting; // virgin body writing state
@@ -383,9 +383,9 @@ public:
     ModXactLauncher(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp, Adaptation::ServicePointer s);
 
 protected:
-    virtual Xaction *createXaction();
+    Xaction *createXaction() override;
 
-    virtual void swanSong();
+    void swanSong() override;
 
     /// starts or stops transaction accounting in ICAP history
     void updateHistory(bool start);

--- a/src/adaptation/icap/OptXact.h
+++ b/src/adaptation/icap/OptXact.h
@@ -24,7 +24,7 @@ namespace Icap
 
 class OptXact: public Xaction
 {
-    CBDATA_CLASS(OptXact);
+    CBDATA_CHILD(OptXact);
 
 public:
     OptXact(ServiceRep::Pointer &aService);
@@ -54,7 +54,7 @@ private:
 // creates OptXact when needed
 class OptXactLauncher: public Launcher
 {
-    CBDATA_CLASS(OptXactLauncher);
+    CBDATA_CHILD(OptXactLauncher);
 
 public:
     OptXactLauncher(Adaptation::ServicePointer aService);

--- a/src/adaptation/icap/OptXact.h
+++ b/src/adaptation/icap/OptXact.h
@@ -31,21 +31,21 @@ public:
 
 protected:
     /* Xaction API */
-    virtual void start();
-    virtual void startShoveling();
-    virtual void handleCommWrote(size_t size);
-    virtual void handleCommRead(size_t size);
+    void start() override;
+    void startShoveling() override;
+    void handleCommWrote(size_t size) override;
+    void handleCommRead(size_t size) override;
 
     void makeRequest(MemBuf &buf);
     bool parseResponse();
 
     void startReading();
-    virtual bool doneReading() const { return commEof || readAll; }
+    bool doneReading() const override { return commEof || readAll; }
 
-    virtual void swanSong();
+    void swanSong() override;
 
 private:
-    virtual void finalizeLogInfo();
+    void finalizeLogInfo() override;
 
     bool readAll; ///< read the entire OPTIONS response
 };
@@ -60,7 +60,7 @@ public:
     OptXactLauncher(Adaptation::ServicePointer aService);
 
 protected:
-    virtual Xaction *createXaction();
+    Xaction *createXaction() override;
 };
 
 } // namespace Icap

--- a/src/adaptation/icap/ServiceRep.h
+++ b/src/adaptation/icap/ServiceRep.h
@@ -59,7 +59,7 @@ class OptXact;
 class ServiceRep : public RefCountable, public Adaptation::Service,
     public Adaptation::Initiator
 {
-    CBDATA_CLASS(ServiceRep);
+    CBDATA_CHILD(ServiceRep);
 
 public:
     typedef RefCount<ServiceRep> Pointer;

--- a/src/adaptation/icap/ServiceRep.h
+++ b/src/adaptation/icap/ServiceRep.h
@@ -66,22 +66,22 @@ public:
 
 public:
     explicit ServiceRep(const ServiceConfigPointer &aConfig);
-    virtual ~ServiceRep();
+    ~ServiceRep() override;
 
-    virtual void finalize();
+    void finalize() override;
 
-    virtual bool probed() const; // see comments above
-    virtual bool up() const; // see comments above
+    bool probed() const override; // see comments above
+    bool up() const override; // see comments above
     bool availableForNew() const; ///< a new transaction may start communicating with the service
     bool availableForOld() const; ///< a transaction notified about connection slot availability may start communicating with the service
 
-    virtual Initiate *makeXactLauncher(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp);
+    Initiate *makeXactLauncher(Http::Message *virginHeader, HttpRequest *virginCause, AccessLogEntry::Pointer &alp) override;
 
     void callWhenAvailable(AsyncCall::Pointer &cb, bool priority = false);
     void callWhenReady(AsyncCall::Pointer &cb);
 
     // the methods below can only be called on an up() service
-    bool wantsUrl(const SBuf &urlPath) const;
+    bool wantsUrl(const SBuf &urlPath) const override;
     bool wantsPreview(const SBuf &urlPath, size_t &wantedSize) const;
     bool allows204() const;
     bool allows206() const;
@@ -91,25 +91,25 @@ public:
     void noteConnectionUse(const Comm::ConnectionPointer &conn);
     void noteConnectionFailed(const char *comment);
 
-    void noteFailure(); // called by transactions to report service failure
+    void noteFailure() override; // called by transactions to report service failure
 
     void noteNewWaiter() {theAllWaiters++;} ///< New xaction waiting for service to be up or available
     void noteGoneWaiter(); ///< An xaction is not waiting any more for service to be available
     bool existWaiters() const {return (theAllWaiters > 0);} ///< if there are xactions waiting for the service to be available
 
     //AsyncJob virtual methods
-    virtual bool doneAll() const { return Adaptation::Initiator::doneAll() && false;}
-    virtual void callException(const std::exception &e);
+    bool doneAll() const override { return Adaptation::Initiator::doneAll() && false;}
+    void callException(const std::exception &e) override;
 
-    virtual void detach();
-    virtual bool detached() const;
+    void detach() override;
+    bool detached() const override;
 
 public: // treat these as private, they are for callbacks only
     void noteTimeToUpdate();
     void noteTimeToNotify();
 
     // receive either an ICAP OPTIONS response header or an abort message
-    virtual void noteAdaptationAnswer(const Answer &answer);
+    void noteAdaptationAnswer(const Answer &answer) override;
 
     Security::ContextPointer sslContext;
     Security::SessionStatePointer sslSession;
@@ -183,7 +183,7 @@ private:
      */
     void busyCheckpoint();
 
-    const char *status() const;
+    const char *status() const override;
 
     mutable bool wasAnnouncedUp; // prevent sequential same-state announcements
     bool isDetached;
@@ -199,7 +199,7 @@ public:
     ServiceRep::Pointer theService;
     ConnWaiterDialer(const CbcPointer<Adaptation::Icap::ModXact> &xact, Adaptation::Icap::ConnWaiterDialer::Parent::Method aHandler);
     ConnWaiterDialer(const Adaptation::Icap::ConnWaiterDialer &aConnWaiter);
-    ~ConnWaiterDialer();
+    ~ConnWaiterDialer() override;
 };
 
 } // namespace Icap

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -52,15 +52,15 @@ public:
         Security::PeerConnector(aServerConn, aCallback, alp, timeout), icapService(service) {}
 
     /* Security::PeerConnector API */
-    virtual bool initialize(Security::SessionPointer &);
-    virtual void noteNegotiationDone(ErrorState *error);
-    virtual Security::ContextPointer getTlsContext() {
+    bool initialize(Security::SessionPointer &) override;
+    void noteNegotiationDone(ErrorState *error) override;
+    Security::ContextPointer getTlsContext() override {
         return icapService->sslContext;
     }
 
 private:
     /* Acl::ChecklistFiller API */
-    virtual void fillChecklist(ACLFilledChecklist &) const;
+    void fillChecklist(ACLFilledChecklist &) const override;
 
     Adaptation::Icap::ServiceRep::Pointer icapService;
 };

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -40,7 +40,7 @@ namespace Ssl
 {
 /// A simple PeerConnector for Secure ICAP services. No SslBump capabilities.
 class IcapPeerConnector: public Security::PeerConnector {
-    CBDATA_CLASS(IcapPeerConnector);
+    CBDATA_CHILD(IcapPeerConnector);
 public:
     IcapPeerConnector(
         Adaptation::Icap::ServiceRep::Pointer &service,

--- a/src/adaptation/icap/Xaction.h
+++ b/src/adaptation/icap/Xaction.h
@@ -45,7 +45,7 @@ class Xaction: public Adaptation::Initiate
 
 public:
     Xaction(const char *aTypeName, ServiceRep::Pointer &aService);
-    virtual ~Xaction();
+    ~Xaction() override;
 
     void disableRetries();
     void disableRepeats(const char *reason);
@@ -67,8 +67,8 @@ public:
     int attempts;
 
 protected:
-    virtual void start();
-    virtual void noteInitiatorAborted(); // TODO: move to Adaptation::Initiate
+    void start() override;
+    void noteInitiatorAborted() override; // TODO: move to Adaptation::Initiate
 
     /// starts sending/receiving ICAP messages
     virtual void startShoveling() = 0;
@@ -97,13 +97,13 @@ protected:
     virtual bool doneReading() const;
     virtual bool doneWriting() const;
     bool doneWithIo() const;
-    virtual bool doneAll() const;
+    bool doneAll() const override;
 
     // called just before the 'done' transaction is deleted
-    virtual void swanSong();
+    void swanSong() override;
 
     // returns a temporary string depicting transaction status, for debugging
-    virtual const char *status() const;
+    const char *status() const override;
     virtual void fillPendingStatus(MemBuf &buf) const;
     virtual void fillDoneStatus(MemBuf &buf) const;
 
@@ -112,8 +112,8 @@ protected:
 
 public:
     // custom exception handling and end-of-call checks
-    virtual void callException(const std::exception  &e);
-    virtual void callEnd();
+    void callException(const std::exception  &e) override;
+    void callEnd() override;
     /// clear stored error details, if any; used for retries/repeats
     virtual void clearError() {}
     virtual AccessLogEntry::Pointer masterLogEntry();

--- a/src/anyp/PortCfg.h
+++ b/src/anyp/PortCfg.h
@@ -27,14 +27,14 @@ public:
     PortCfg();
     // no public copying/moving but see ipV4clone()
     PortCfg(PortCfg &&) = delete;
-    ~PortCfg();
+    ~PortCfg() override;
 
     /// creates the same port configuration but listening on any IPv4 address
     PortCfg *ipV4clone() const;
 
     /* CodeContext API */
-    virtual ScopedId codeContextGist() const override;
-    virtual std::ostream &detailCodeContext(std::ostream &os) const override;
+    ScopedId codeContextGist() const override;
+    std::ostream &detailCodeContext(std::ostream &os) const override;
 
     PortCfgPointer next;
 

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -21,14 +21,14 @@ class ACLMaxUserIP : public ACL
 public:
     explicit ACLMaxUserIP(char const *theClass);
 
-    virtual char const *typeString() const;
-    virtual const Acl::Options &options();
-    virtual void parse();
-    virtual int match(ACLChecklist *cl);
-    virtual SBufList dump() const;
-    virtual bool empty() const;
-    virtual bool valid() const;
-    virtual bool requiresRequest() const {return true;}
+    char const *typeString() const override;
+    const Acl::Options &options() override;
+    void parse() override;
+    int match(ACLChecklist *cl) override;
+    SBufList dump() const override;
+    bool empty() const override;
+    bool valid() const override;
+    bool requiresRequest() const override {return true;}
 
     int getMaximum() const {return maximum;}
 

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -20,7 +20,7 @@ class ProxyAuthLookup : public ACLChecklist::AsyncState
 
 public:
     static ProxyAuthLookup *Instance();
-    virtual void checkForAsync(ACLChecklist *) const;
+    void checkForAsync(ACLChecklist *) const override;
 
 private:
     static ProxyAuthLookup instance_;
@@ -32,23 +32,23 @@ class ACLProxyAuth : public ACL
     MEMPROXY_CLASS(ACLProxyAuth);
 
 public:
-    ~ACLProxyAuth();
+    ~ACLProxyAuth() override;
     ACLProxyAuth(ACLData<char const *> *, char const *);
 
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual bool isProxyAuth() const {return true;}
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool valid() const;
-    virtual bool empty() const;
-    virtual bool requiresRequest() const {return true;}
-    virtual int matchForCache(ACLChecklist *checklist);
+    char const *typeString() const override;
+    void parse() override;
+    bool isProxyAuth() const override {return true;}
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool valid() const override;
+    bool empty() const override;
+    bool requiresRequest() const override {return true;}
+    int matchForCache(ACLChecklist *checklist) override;
 
 private:
     /* ACL API */
-    virtual const Acl::Options &lineOptions();
+    const Acl::Options &lineOptions() override;
 
     int matchProxyAuth(ACLChecklist *);
     ACLData<char const *> *data;

--- a/src/auth/CredentialsCache.cc
+++ b/src/auth/CredentialsCache.cc
@@ -26,19 +26,19 @@ public:
         whichCache(c)
     {}
 
-    virtual ~CredentialCacheRr() {
+    ~CredentialCacheRr() override {
         debugs(29, 5, "Terminating Auth credentials cache: " << name);
         // invalidate the CBDATA reference.
         // causes Auth::*::User::Cache() to produce nil / invalid pointer
         delete whichCache.get();
     }
 
-    virtual void endingShutdown() override {
+    void endingShutdown() override {
         debugs(29, 5, "Clearing Auth credentials cache: " << name);
         whichCache->reset();
     }
 
-    virtual void syncConfig() override {
+    void syncConfig() override {
         debugs(29, 5, "Reconfiguring Auth credentials cache: " << name);
         whichCache->doConfigChangeCleanup();
     }

--- a/src/auth/Scheme.h
+++ b/src/auth/Scheme.h
@@ -33,7 +33,7 @@ public:
 
 public:
     Scheme() : initialised (false) {};
-    virtual ~Scheme() {};
+    ~Scheme() override {};
 
     static void AddScheme(Scheme::Pointer);
 

--- a/src/auth/User.h
+++ b/src/auth/User.h
@@ -41,7 +41,7 @@ public:
 protected:
     User(Auth::SchemeConfig *, const char *requestRealm);
 public:
-    virtual ~User();
+    ~User() override;
 
     /* extra fields for proxy_auth */
     /** \deprecated this determines what scheme owns the user data. */

--- a/src/auth/UserRequest.h
+++ b/src/auth/UserRequest.h
@@ -80,7 +80,7 @@ public:
     typedef RefCount<Auth::UserRequest> Pointer;
 
     UserRequest();
-    virtual ~UserRequest();
+    ~UserRequest() override;
     void *operator new(size_t byteCount);
     void operator delete(void *address);
 

--- a/src/auth/basic/Config.h
+++ b/src/auth/basic/Config.h
@@ -26,18 +26,18 @@ class Config : public Auth::SchemeConfig
 {
 public:
     Config();
-    virtual bool active() const;
-    virtual bool configured() const;
-    virtual Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm);
-    virtual void done();
-    virtual void rotateHelpers();
-    virtual bool dump(StoreEntry *, const char *, Auth::SchemeConfig *) const;
-    virtual void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *);
-    virtual void init(Auth::SchemeConfig *);
-    virtual void parse(Auth::SchemeConfig *, int, char *);
+    bool active() const override;
+    bool configured() const override;
+    Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
+    void done() override;
+    void rotateHelpers() override;
+    bool dump(StoreEntry *, const char *, Auth::SchemeConfig *) const override;
+    void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *) override;
+    void init(Auth::SchemeConfig *) override;
+    void parse(Auth::SchemeConfig *, int, char *) override;
     void decode(char const *httpAuthHeader, Auth::UserRequest::Pointer);
-    virtual void registerWithCacheManager(void);
-    virtual const char * type() const;
+    void registerWithCacheManager(void) override;
+    const char * type() const override;
 
 public:
     time_t credentialsTTL;

--- a/src/auth/basic/Scheme.h
+++ b/src/auth/basic/Scheme.h
@@ -25,12 +25,12 @@ class Scheme : public Auth::Scheme
 public:
     static Auth::Scheme::Pointer GetInstance();
     Scheme() {};
-    virtual ~Scheme() {}
+    ~Scheme() override {}
 
     /* per scheme */
-    virtual char const *type() const;
-    virtual void shutdownCleanup();
-    virtual Auth::SchemeConfig *createConfig();
+    char const *type() const override;
+    void shutdownCleanup() override;
+    Auth::SchemeConfig *createConfig() override;
     /* Not implemented */
     Scheme(Scheme const &);
     Scheme &operator=(Scheme const &);

--- a/src/auth/basic/User.h
+++ b/src/auth/basic/User.h
@@ -30,17 +30,17 @@ class User : public Auth::User
 
 public:
     User(Auth::SchemeConfig *, const char *requestRealm);
-    virtual ~User();
+    ~User() override;
     bool authenticated() const;
     bool valid() const;
 
     /** Update the cached password for a username. */
     void updateCached(User *from);
-    virtual int32_t ttl() const override;
+    int32_t ttl() const override;
 
     /* Auth::User API */
     static CbcPointer<Auth::CredentialsCache> Cache();
-    virtual void addToNameCache() override;
+    void addToNameCache() override;
 
     char *passwd;
 

--- a/src/auth/basic/UserRequest.h
+++ b/src/auth/basic/UserRequest.h
@@ -30,13 +30,13 @@ class UserRequest : public Auth::UserRequest
 
 public:
     UserRequest() {}
-    virtual ~UserRequest() { assert(LockCount()==0); }
+    ~UserRequest() override { assert(LockCount()==0); }
 
-    virtual int authenticated() const;
-    virtual void authenticate(HttpRequest * request, ConnStateData *conn, Http::HdrType type);
-    virtual Auth::Direction module_direction();
-    virtual void startHelperLookup(HttpRequest * request, AccessLogEntry::Pointer &al, AUTHCB *, void *);
-    virtual const char *credentialsStr();
+    int authenticated() const override;
+    void authenticate(HttpRequest * request, ConnStateData *conn, Http::HdrType type) override;
+    Auth::Direction module_direction() override;
+    void startHelperLookup(HttpRequest * request, AccessLogEntry::Pointer &al, AUTHCB *, void *) override;
+    const char *credentialsStr() override;
 
 private:
     static HLPCB HandleReply;

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -73,17 +73,17 @@ class Config : public Auth::SchemeConfig
 {
 public:
     Config();
-    virtual bool active() const;
-    virtual bool configured() const;
-    virtual Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm);
-    virtual void done();
-    virtual void rotateHelpers();
-    virtual bool dump(StoreEntry *, const char *, Auth::SchemeConfig *) const;
-    virtual void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *);
-    virtual void init(Auth::SchemeConfig *);
-    virtual void parse(Auth::SchemeConfig *, int, char *);
-    virtual void registerWithCacheManager(void);
-    virtual const char * type() const;
+    bool active() const override;
+    bool configured() const override;
+    Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
+    void done() override;
+    void rotateHelpers() override;
+    bool dump(StoreEntry *, const char *, Auth::SchemeConfig *) const override;
+    void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *) override;
+    void init(Auth::SchemeConfig *) override;
+    void parse(Auth::SchemeConfig *, int, char *) override;
+    void registerWithCacheManager(void) override;
+    const char * type() const override;
 
 public:
     time_t nonceGCInterval;

--- a/src/auth/digest/Scheme.h
+++ b/src/auth/digest/Scheme.h
@@ -25,12 +25,12 @@ class Scheme : public Auth::Scheme
 public:
     static Auth::Scheme::Pointer GetInstance();
     Scheme() {};
-    virtual ~Scheme() {}
+    ~Scheme() override {}
 
     /* per scheme */
-    virtual char const *type () const;
-    virtual void shutdownCleanup();
-    virtual Auth::SchemeConfig *createConfig();
+    char const *type () const override;
+    void shutdownCleanup() override;
+    Auth::SchemeConfig *createConfig() override;
 
     /* Not implemented */
     Scheme(Scheme const &);

--- a/src/auth/digest/User.h
+++ b/src/auth/digest/User.h
@@ -27,13 +27,13 @@ class User : public Auth::User
 
 public:
     User(Auth::SchemeConfig *, const char *requestRealm);
-    virtual ~User();
+    ~User() override;
     int authenticated() const;
-    virtual int32_t ttl() const override;
+    int32_t ttl() const override;
 
     /* Auth::User API */
     static CbcPointer<Auth::CredentialsCache> Cache();
-    virtual void addToNameCache() override;
+    void addToNameCache() override;
 
     HASH HA1;
     int HA1created;

--- a/src/auth/digest/UserRequest.h
+++ b/src/auth/digest/UserRequest.h
@@ -31,18 +31,18 @@ class UserRequest : public Auth::UserRequest
 
 public:
     UserRequest();
-    virtual ~UserRequest();
+    ~UserRequest() override;
 
-    virtual int authenticated() const;
-    virtual void authenticate(HttpRequest * request, ConnStateData * conn, Http::HdrType type);
-    virtual Direction module_direction();
-    virtual void addAuthenticationInfoHeader(HttpReply * rep, int accel);
+    int authenticated() const override;
+    void authenticate(HttpRequest * request, ConnStateData * conn, Http::HdrType type) override;
+    Direction module_direction() override;
+    void addAuthenticationInfoHeader(HttpReply * rep, int accel) override;
 #if WAITING_FOR_TE
     virtual void addAuthenticationInfoTrailer(HttpReply * rep, int accel);
 #endif
 
-    virtual void startHelperLookup(HttpRequest *request, AccessLogEntry::Pointer &al, AUTHCB *, void *);
-    virtual const char *credentialsStr();
+    void startHelperLookup(HttpRequest *request, AccessLogEntry::Pointer &al, AUTHCB *, void *) override;
+    const char *credentialsStr() override;
 
     char *noncehex;             /* "dcd98b7102dd2f0e8b11d0f600bfb0c093" */
     char *cnonce;               /* "0a4f113b" */

--- a/src/auth/negotiate/Config.h
+++ b/src/auth/negotiate/Config.h
@@ -25,15 +25,15 @@ namespace Negotiate
 class Config : public Auth::SchemeConfig
 {
 public:
-    virtual bool active() const;
-    virtual bool configured() const;
-    virtual Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm);
-    virtual void done();
-    virtual void rotateHelpers();
-    virtual void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *);
-    virtual void init(Auth::SchemeConfig *);
-    virtual void registerWithCacheManager(void);
-    virtual const char * type() const;
+    bool active() const override;
+    bool configured() const override;
+    Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
+    void done() override;
+    void rotateHelpers() override;
+    void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *) override;
+    void init(Auth::SchemeConfig *) override;
+    void registerWithCacheManager(void) override;
+    const char * type() const override;
 };
 
 } // namespace Negotiate

--- a/src/auth/negotiate/Scheme.h
+++ b/src/auth/negotiate/Scheme.h
@@ -25,12 +25,12 @@ class Scheme : public Auth::Scheme
 public:
     static Auth::Scheme::Pointer GetInstance();
     Scheme() {};
-    virtual ~Scheme() {};
+    ~Scheme() override {};
 
     /* per scheme */
-    virtual char const *type() const;
-    virtual void shutdownCleanup();
-    virtual Auth::SchemeConfig *createConfig();
+    char const *type() const override;
+    void shutdownCleanup() override;
+    Auth::SchemeConfig *createConfig() override;
 
     /* Not implemented */
     Scheme (Scheme const &);

--- a/src/auth/negotiate/User.h
+++ b/src/auth/negotiate/User.h
@@ -28,12 +28,12 @@ class User : public Auth::User
 
 public:
     User(Auth::SchemeConfig *, const char *requestRealm);
-    virtual ~User();
-    virtual int32_t ttl() const override;
+    ~User() override;
+    int32_t ttl() const override;
 
     /* Auth::User API */
     static CbcPointer<Auth::CredentialsCache> Cache();
-    virtual void addToNameCache() override;
+    void addToNameCache() override;
 
     dlink_list proxy_auth_list;
 };

--- a/src/auth/negotiate/UserRequest.h
+++ b/src/auth/negotiate/UserRequest.h
@@ -30,16 +30,16 @@ class UserRequest : public Auth::UserRequest
 
 public:
     UserRequest();
-    virtual ~UserRequest();
-    virtual int authenticated() const;
-    virtual void authenticate(HttpRequest * request, ConnStateData * conn, Http::HdrType type);
-    virtual Direction module_direction();
-    virtual void startHelperLookup(HttpRequest *request, AccessLogEntry::Pointer &al, AUTHCB *, void *);
-    virtual const char *credentialsStr();
+    ~UserRequest() override;
+    int authenticated() const override;
+    void authenticate(HttpRequest * request, ConnStateData * conn, Http::HdrType type) override;
+    Direction module_direction() override;
+    void startHelperLookup(HttpRequest *request, AccessLogEntry::Pointer &al, AUTHCB *, void *) override;
+    const char *credentialsStr() override;
 
-    virtual const char * connLastHeader();
+    const char * connLastHeader() override;
 
-    void releaseAuthServer(void); ///< Release the authserver helper server properly.
+    void releaseAuthServer(void) override; ///< Release the authserver helper server properly.
 
     /* what connection is this associated with */
     /* ConnStateData * conn;*/

--- a/src/auth/ntlm/Config.h
+++ b/src/auth/ntlm/Config.h
@@ -28,15 +28,15 @@ namespace Ntlm
 class Config : public Auth::SchemeConfig
 {
 public:
-    virtual bool active() const;
-    virtual bool configured() const;
-    virtual Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm);
-    virtual void done();
-    virtual void rotateHelpers();
-    virtual void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *);
-    virtual void init(Auth::SchemeConfig *);
-    virtual void registerWithCacheManager(void);
-    virtual const char * type() const;
+    bool active() const override;
+    bool configured() const override;
+    Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
+    void done() override;
+    void rotateHelpers() override;
+    void fixHeader(Auth::UserRequest::Pointer, HttpReply *, Http::HdrType, HttpRequest *) override;
+    void init(Auth::SchemeConfig *) override;
+    void registerWithCacheManager(void) override;
+    const char * type() const override;
 };
 
 } // namespace Ntlm

--- a/src/auth/ntlm/Scheme.cc
+++ b/src/auth/ntlm/Scheme.cc
@@ -18,7 +18,7 @@ class NtlmAuthRr : public RegisteredRunner
 {
 public:
     /* RegisteredRunner API */
-    virtual void bootstrapConfig() override {
+    void bootstrapConfig() override {
         const char *type = Auth::Ntlm::Scheme::GetInstance()->type();
         debugs(29, 2, "Initialized Authentication Scheme '" << type << "'");
     }

--- a/src/auth/ntlm/Scheme.h
+++ b/src/auth/ntlm/Scheme.h
@@ -25,12 +25,12 @@ class Scheme : public Auth::Scheme
 public:
     static Auth::Scheme::Pointer GetInstance();
     Scheme() {};
-    virtual ~Scheme() {};
+    ~Scheme() override {};
 
     /* per scheme */
-    virtual char const *type() const;
-    virtual void shutdownCleanup();
-    virtual Auth::SchemeConfig *createConfig();
+    char const *type() const override;
+    void shutdownCleanup() override;
+    Auth::SchemeConfig *createConfig() override;
 
     /* Not implemented */
     Scheme (Scheme const &);

--- a/src/auth/ntlm/User.h
+++ b/src/auth/ntlm/User.h
@@ -26,12 +26,12 @@ class User : public Auth::User
 
 public:
     User(Auth::SchemeConfig *, const char *requestRealm);
-    virtual ~User();
-    virtual int32_t ttl() const override;
+    ~User() override;
+    int32_t ttl() const override;
 
     /* Auth::User API */
     static CbcPointer<Auth::CredentialsCache> Cache();
-    virtual void addToNameCache() override;
+    void addToNameCache() override;
 
     dlink_list proxy_auth_list;
 };

--- a/src/auth/ntlm/UserRequest.h
+++ b/src/auth/ntlm/UserRequest.h
@@ -30,16 +30,16 @@ class UserRequest : public Auth::UserRequest
 
 public:
     UserRequest();
-    virtual ~UserRequest();
-    virtual int authenticated() const;
-    virtual void authenticate(HttpRequest * request, ConnStateData * conn, Http::HdrType type);
-    virtual Auth::Direction module_direction();
-    virtual void startHelperLookup(HttpRequest *req, AccessLogEntry::Pointer &al, AUTHCB *, void *);
-    virtual const char *credentialsStr();
+    ~UserRequest() override;
+    int authenticated() const override;
+    void authenticate(HttpRequest * request, ConnStateData * conn, Http::HdrType type) override;
+    Auth::Direction module_direction() override;
+    void startHelperLookup(HttpRequest *req, AccessLogEntry::Pointer &al, AUTHCB *, void *) override;
+    const char *credentialsStr() override;
 
-    virtual const char * connLastHeader();
+    const char * connLastHeader() override;
 
-    virtual void releaseAuthServer(); ///< Release authserver NTLM helpers properly when finished or abandoning.
+    void releaseAuthServer() override; ///< Release authserver NTLM helpers properly when finished or abandoning.
 
     /* our current blob to pass to the client */
     char *server_blob;

--- a/src/base/AsyncCall.h
+++ b/src/base/AsyncCall.h
@@ -42,7 +42,7 @@ public:
     typedef RefCount <AsyncCall> Pointer;
 
     AsyncCall(int aDebugSection, int aDebugLevel, const char *aName);
-    virtual ~AsyncCall();
+    ~AsyncCall() override;
 
     void make(); // fire if we can; handles general call debugging
 
@@ -133,18 +133,18 @@ public:
         AsyncCall(o.debugSection, o.debugLevel, o.name),
         dialer(o.dialer) {}
 
-    ~AsyncCallT() {}
+    ~AsyncCallT() override {}
 
-    CallDialer *getDialer() { return &dialer; }
+    CallDialer *getDialer() override { return &dialer; }
 
     Dialer dialer;
 
 protected:
-    virtual bool canFire() {
+    bool canFire() override {
         return AsyncCall::canFire() &&
                dialer.canDial(*this);
     }
-    virtual void fire() { dialer.dial(*this); }
+    void fire() override { dialer.dial(*this); }
 
 private:
     AsyncCallT & operator=(const AsyncCallT &); // not defined. call assignments not permitted.

--- a/src/base/AsyncCallbacks.h
+++ b/src/base/AsyncCallbacks.h
@@ -85,15 +85,15 @@ public:
     using Handler = void (Argument1 &);
 
     explicit UnaryFunCallbackDialer(Handler * const aHandler): handler(aHandler) {}
-    virtual ~UnaryFunCallbackDialer() = default;
+    ~UnaryFunCallbackDialer() override = default;
 
     /* CallDialer API */
     bool canDial(AsyncCall &) { return bool(handler); }
     void dial(AsyncCall &) { handler(arg1); }
-    virtual void print(std::ostream &os) const final { os << '(' << arg1 << ')'; }
+    void print(std::ostream &os) const final { os << '(' << arg1 << ')'; }
 
     /* WithAnswer API */
-    virtual Argument1 &answer() final { return arg1; }
+    Argument1 &answer() final { return arg1; }
 
 private:
     Handler *handler; ///< the function to call
@@ -112,15 +112,15 @@ public:
     typedef void (Destination::*Method)(Argument1 &);
 
     UnaryCbcCallbackDialer(Method method, Destination *destination): destination_(destination), method_(method) {}
-    virtual ~UnaryCbcCallbackDialer() = default;
+    ~UnaryCbcCallbackDialer() override = default;
 
     /* CallDialer API */
     bool canDial(AsyncCall &) { return destination_.valid(); }
     void dial(AsyncCall &) {((*destination_).*method_)(arg1_); }
-    virtual void print(std::ostream &os) const final { os << '(' << arg1_ << ')'; }
+    void print(std::ostream &os) const final { os << '(' << arg1_ << ')'; }
 
     /* WithAnswer API */
-    virtual Argument1 &answer() final { return arg1_; }
+    Argument1 &answer() final { return arg1_; }
 
 private:
     CbcPointer<Destination> destination_; ///< object to deliver the answer to
@@ -142,7 +142,7 @@ public:
         Base(aJob, aMethod, {}) {}
 
     /* WithAnswer API */
-    virtual Argument1 &answer() final { return this->arg1; }
+    Argument1 &answer() final { return this->arg1; }
 };
 
 /// whether the given type is an AsyncJob

--- a/src/base/AsyncCbdataCalls.h
+++ b/src/base/AsyncCbdataCalls.h
@@ -27,7 +27,7 @@ public:
 
     virtual bool canDial(AsyncCall &) { return arg1.valid(); }
     void dial(AsyncCall &) { handler(arg1.get()); }
-    virtual void print(std::ostream &os) const {  os << '(' << arg1 << ')'; }
+    void print(std::ostream &os) const override {  os << '(' << arg1 << ')'; }
 
 public:
     CbcPointer<Argument1> arg1;

--- a/src/base/AsyncFunCalls.h
+++ b/src/base/AsyncFunCalls.h
@@ -24,7 +24,7 @@ public:
     /* CallDialer API */
     bool canDial(AsyncCall &) { return bool(handler); }
     void dial(AsyncCall &) { handler(); }
-    virtual void print(std::ostream &os) const override { os << "()"; }
+    void print(std::ostream &os) const override { os << "()"; }
 
 private:
     Handler *handler; ///< the function to call (or nil)
@@ -42,12 +42,12 @@ public:
         handler(aHandler),
         arg1(anArg1)
     {}
-    virtual ~UnaryFunDialer() = default;
+    ~UnaryFunDialer() override = default;
 
     /* CallDialer API */
     bool canDial(AsyncCall &) { return bool(handler); }
     void dial(AsyncCall &) { handler(std::move(arg1)); }
-    virtual void print(std::ostream &os) const final { os << '(' << arg1 << ')'; }
+    void print(std::ostream &os) const final { os << '(' << arg1 << ')'; }
 
 private:
     Handler *handler; ///< the function to call

--- a/src/base/AsyncJob.h
+++ b/src/base/AsyncJob.h
@@ -74,7 +74,7 @@ public:
 
 protected:
     // external destruction prohibited to ensure swanSong() is called
-    virtual ~AsyncJob();
+    ~AsyncJob() override;
 
     const char *stopReason; ///< reason for forcing done() to be true
     const char *typeName; ///< kid (leaf) class name, for debugging

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -94,13 +94,13 @@ public:
     explicit NullaryMemFunT(const CbcPointer<Job> &aJob, Method aMethod):
         JobDialer<Job>(aJob), method(aMethod) {}
 
-    virtual void print(std::ostream &os) const {  os << "()"; }
+    void print(std::ostream &os) const override {  os << "()"; }
 
 public:
     Method method;
 
 protected:
-    virtual void doDial() { ((&(*this->job))->*method)(); }
+    void doDial() override { ((&(*this->job))->*method)(); }
 };
 
 template <class Job, class Data, class Argument1 = Data>
@@ -112,14 +112,14 @@ public:
                           const Data &anArg1): JobDialer<Job>(aJob),
         method(aMethod), arg1(anArg1) {}
 
-    virtual void print(std::ostream &os) const {  os << '(' << arg1 << ')'; }
+    void print(std::ostream &os) const override {  os << '(' << arg1 << ')'; }
 
 public:
     Method method;
     Data arg1;
 
 protected:
-    virtual void doDial() { ((&(*this->job))->*method)(arg1); }
+    void doDial() override { ((&(*this->job))->*method)(arg1); }
 };
 
 // ... add more as needed

--- a/src/base/CodeContext.cc
+++ b/src/base/CodeContext.cc
@@ -15,8 +15,8 @@ class FadingCodeContext: public CodeContext
 {
 public:
     /* CodeContext API */
-    virtual ScopedId codeContextGist() const override { return gist; }
-    virtual std::ostream &detailCodeContext(std::ostream &os) const override { return os << gist; }
+    ScopedId codeContextGist() const override { return gist; }
+    std::ostream &detailCodeContext(std::ostream &os) const override { return os << gist; }
 
     ScopedId gist; ///< identifies the being-forgotten CodeContext
 };

--- a/src/base/CodeContext.h
+++ b/src/base/CodeContext.h
@@ -62,7 +62,7 @@ public:
     /// changes the current context; nil argument sets it to nil/unknown
     static void Reset(const Pointer);
 
-    virtual ~CodeContext() {}
+    ~CodeContext() override {}
 
     /// \returns a small, permanent ID of the current context
     /// gists persist forever and are suitable for passing to other SMP workers

--- a/src/base/PackableStream.h
+++ b/src/base/PackableStream.h
@@ -20,12 +20,12 @@ class AppendingStreamBuf : public std::streambuf
 {
 public:
     explicit AppendingStreamBuf(Buffer &p): buf_(p) { postInit(); }
-    virtual ~AppendingStreamBuf() = default;
+    ~AppendingStreamBuf() override = default;
 
 protected:
     /* std::streambuf API */
 
-    virtual int_type overflow(int_type aChar = traits_type::eof()) override {
+    int_type overflow(int_type aChar = traits_type::eof()) override {
         std::streamsize pending(pptr() - pbase());
 
         if (pending && sync())
@@ -40,14 +40,14 @@ protected:
         return aChar;
     }
 
-    virtual int sync() override {
+    int sync() override {
         std::streamsize pending(pptr() - pbase());
         lowAppend(pbase(), pending);
         postSync();
         return 0;
     }
 
-    virtual std::streamsize xsputn(const char * chars, std::streamsize number) override {
+    std::streamsize xsputn(const char * chars, std::streamsize number) override {
         lowAppend(chars, number);
         return number;
     }

--- a/src/base/RunnersRegistry.h
+++ b/src/base/RunnersRegistry.h
@@ -106,7 +106,7 @@ void RunRegistered(const RegisteredRunner::Method &m);
 class IndependentRunner: public RegisteredRunner
 {
 public:
-    virtual ~IndependentRunner() { unregisterRunner(); }
+    ~IndependentRunner() override { unregisterRunner(); }
 
 protected:
     void registerRunner();

--- a/src/base/Subscription.h
+++ b/src/base/Subscription.h
@@ -50,7 +50,7 @@ class CallSubscription: public Subscription
 public:
     /// Must be passed an object. nil pointers are not permitted.
     explicit CallSubscription(const RefCount<Call_> &aCall) : call(aCall) { assert(aCall != nullptr); }
-    virtual AsyncCall::Pointer callback() const
+    AsyncCall::Pointer callback() const override
     {
         const AsyncCall::Pointer cb = new Call_(*call);
         if (!cb->codeContext || CodeContext::Current())

--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -33,8 +33,8 @@ public:
     TextException& operator=(const TextException &) = default;
 
     /* std::runtime_error API */
-    virtual ~TextException() throw() override;
-    virtual const char *what() const throw() override;
+    ~TextException() throw() override;
+    const char *what() const throw() override;
 
     /// same-location exceptions have the same ID
     SourceLocationId id() const { return where.id(); }

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -4369,7 +4369,7 @@ class sslBumpCfgRr: public ::RegisteredRunner
 public:
     static Ssl::BumpMode lastDeprecatedRule;
     /* RegisteredRunner API */
-    virtual void finalizeConfig();
+    void finalizeConfig() override;
 };
 
 Ssl::BumpMode sslBumpCfgRr::lastDeprecatedRule = Ssl::bumpEnd;

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -51,7 +51,7 @@ public:
 public:
     ClassActionCreator(Handler *aHandler): handler(aHandler) {}
 
-    virtual Mgr::Action::Pointer create(const Mgr::Command::Pointer &cmd) const {
+    Mgr::Action::Pointer create(const Mgr::Command::Pointer &cmd) const override {
         return handler(cmd);
     }
 

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -100,7 +100,7 @@ class ClientDbRr: public RegisteredRunner
 {
 public:
     /* RegisteredRunner API */
-    virtual void useConfig();
+    void useConfig() override;
 };
 RunnerRegistrationEntry(ClientDbRr);
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -160,7 +160,7 @@ public:
         handler(aHandler), portCfg(aPortCfg), portTypeNote(note), sub(aSub) {}
 
     /* CallDialer API */
-    virtual void print(std::ostream &os) const {
+    void print(std::ostream &os) const override {
         os << '(' << answer_ << ", " << FdNote(portTypeNote) << " port=" << (void*)&portCfg << ')';
     }
 
@@ -168,7 +168,7 @@ public:
     virtual void dial(AsyncCall &) { (handler)(portCfg, portTypeNote, sub); }
 
     /* WithAnswer API */
-    virtual Ipc::StartListeningAnswer &answer() { return answer_; }
+    Ipc::StartListeningAnswer &answer() override { return answer_; }
 
 public:
     Handler handler;

--- a/src/client_side.h
+++ b/src/client_side.h
@@ -85,17 +85,17 @@ class ConnStateData:
 
 public:
     explicit ConnStateData(const MasterXactionPointer &xact);
-    virtual ~ConnStateData();
+    ~ConnStateData() override;
 
     /* ::Server API */
-    virtual void receivedFirstByte();
-    virtual bool handleReadData();
-    virtual void afterClientRead();
-    virtual void afterClientWrite(size_t);
+    void receivedFirstByte() override;
+    bool handleReadData() override;
+    void afterClientRead() override;
+    void afterClientWrite(size_t) override;
 
     /* HttpControlMsgSink API */
-    virtual void sendControlMsg(HttpControlMsg);
-    virtual void doneWithControlMsg();
+    void sendControlMsg(HttpControlMsg) override;
+    void doneWithControlMsg() override;
 
     /// Traffic parsing
     bool clientParseRequests();
@@ -174,8 +174,8 @@ public:
 
     /* BodyPipe API */
     BodyPipe::Pointer expectRequestBody(int64_t size);
-    virtual void noteMoreBodySpaceAvailable(BodyPipe::Pointer) = 0;
-    virtual void noteBodyConsumerAborted(BodyPipe::Pointer) = 0;
+    void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override = 0;
+    void noteBodyConsumerAborted(BodyPipe::Pointer) override = 0;
 
     bool handleRequestBodyData();
 
@@ -236,10 +236,10 @@ public:
     void lifetimeTimeout(const CommTimeoutCbParams &params);
 
     // AsyncJob API
-    virtual void start();
-    virtual bool doneAll() const { return BodyProducer::doneAll() && false;}
-    virtual void swanSong();
-    virtual void callException(const std::exception &);
+    void start() override;
+    bool doneAll() const override { return BodyProducer::doneAll() && false;}
+    void swanSong() override;
+    void callException(const std::exception &) override;
 
     /// Changes state so that we close the connection and quit after serving
     /// the client-side-detected error response instead of getting stuck.
@@ -350,8 +350,8 @@ public:
     SBuf preservedClientData;
 
     /* Registered Runner API */
-    virtual void startShutdown();
-    virtual void endingShutdown();
+    void startShutdown() override;
+    void endingShutdown() override;
 
     /// \returns existing non-empty connection annotations,
     /// creates and returns empty annotations otherwise
@@ -367,7 +367,7 @@ public:
     void updateError(const err_type c, const ErrorDetailPointer &d) { updateError(Error(c, d)); }
 
     /* Acl::ChecklistFiller API */
-    virtual void fillChecklist(ACLFilledChecklist &) const;
+    void fillChecklist(ACLFilledChecklist &) const override;
 
     /// fillChecklist() obligations not fulfilled by the front request
     /// TODO: This is a temporary ACLFilledChecklist::setConn() callback to
@@ -438,8 +438,8 @@ protected:
 
 private:
     /* ::Server API */
-    virtual void terminateAll(const Error &, const LogTagsErrors &);
-    virtual bool shouldCloseOnEof() const;
+    void terminateAll(const Error &, const LogTagsErrors &) override;
+    bool shouldCloseOnEof() const override;
 
     void checkLogging();
 

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -29,7 +29,7 @@ public:
     static STCB SendMoreData;
 
     clientReplyContext(ClientHttpRequest *);
-    ~clientReplyContext();
+    ~clientReplyContext() override;
 
     void saveState();
     void restoreState();
@@ -66,7 +66,7 @@ public:
     Http::StatusCode purgeStatus;
 
     /* StoreClient API */
-    virtual LogTags *loggingTags() const;
+    LogTags *loggingTags() const override;
 
     ClientHttpRequest *http;
     /// Base reply header bytes received from Store.
@@ -91,7 +91,7 @@ public:
 
 private:
     /* StoreClient API */
-    virtual void fillChecklist(ACLFilledChecklist &) const;
+    void fillChecklist(ACLFilledChecklist &) const override;
 
     clientStreamNode *getNextNode() const;
     void makeThisHead();

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -36,7 +36,11 @@ class ClientHttpRequest
       public BodyConsumer     // to receive reply bodies in request satisf. mode
 #endif
 {
+#if USE_ADAPTATION
+    CBDATA_CHILD(ClientHttpRequest);
+#else
     CBDATA_CLASS(ClientHttpRequest);
+#endif
 
 public:
     ClientHttpRequest(ConnStateData *);

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -41,7 +41,7 @@ class ClientHttpRequest
 public:
     ClientHttpRequest(ConnStateData *);
     ClientHttpRequest(ClientHttpRequest &&) = delete;
-    ~ClientHttpRequest();
+    ~ClientHttpRequest() override;
 
     String rangeBoundaryStr() const;
     void freeResources();
@@ -200,12 +200,12 @@ public:
     bool requestSatisfactionMode() const { return request_satisfaction_mode; }
 
     /* AsyncJob API */
-    virtual bool doneAll() const {
+    bool doneAll() const override {
         return Initiator::doneAll() &&
                BodyConsumer::doneAll() &&
                false; // TODO: Refactor into a proper AsyncJob
     }
-    virtual void callException(const std::exception &);
+    void callException(const std::exception &) override;
 
 private:
     /// Handles an adaptation client request failure.
@@ -216,13 +216,13 @@ private:
     void handleAdaptationBlock(const Adaptation::Answer &);
 
     /* Adaptation::Initiator API */
-    virtual void noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer);
-    virtual void noteAdaptationAnswer(const Adaptation::Answer &);
+    void noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer) override;
+    void noteAdaptationAnswer(const Adaptation::Answer &) override;
 
     /* BodyConsumer API */
-    virtual void noteMoreBodyDataAvailable(BodyPipe::Pointer);
-    virtual void noteBodyProductionEnded(BodyPipe::Pointer);
-    virtual void noteBodyProducerAborted(BodyPipe::Pointer);
+    void noteMoreBodyDataAvailable(BodyPipe::Pointer) override;
+    void noteBodyProductionEnded(BodyPipe::Pointer) override;
+    void noteBodyProducerAborted(BodyPipe::Pointer) override;
 
     void endRequestSatisfaction();
     /// called by StoreEntry when it has more buffer space available

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -41,7 +41,11 @@ class ClientHttpRequest
 public:
     ClientHttpRequest(ConnStateData *);
     ClientHttpRequest(ClientHttpRequest &&) = delete;
+#if USE_ADAPTATION
     ~ClientHttpRequest() override;
+#else
+    ~ClientHttpRequest();
+#endif
 
     String rangeBoundaryStr() const;
     void freeResources();

--- a/src/clients/Client.h
+++ b/src/clients/Client.h
@@ -36,7 +36,7 @@ class Client:
 
 public:
     Client(FwdState *);
-    virtual ~Client();
+    ~Client() override;
 
     /// \return primary or "request data connection"
     virtual const Comm::ConnectionPointer & dataConnection() const = 0;
@@ -44,9 +44,9 @@ public:
     // BodyConsumer: consume request body or adapted response body.
     // The implementation just calls the corresponding HTTP or ICAP handle*()
     // method, depending on the pipe.
-    virtual void noteMoreBodyDataAvailable(BodyPipe::Pointer);
-    virtual void noteBodyProductionEnded(BodyPipe::Pointer);
-    virtual void noteBodyProducerAborted(BodyPipe::Pointer);
+    void noteMoreBodyDataAvailable(BodyPipe::Pointer) override;
+    void noteBodyProductionEnded(BodyPipe::Pointer) override;
+    void noteBodyProducerAborted(BodyPipe::Pointer) override;
 
     /// read response data from the network
     virtual void maybeReadVirginBody() = 0;
@@ -64,19 +64,19 @@ public:
 
 #if USE_ADAPTATION
     // Adaptation::Initiator API: start an ICAP transaction and receive adapted headers.
-    virtual void noteAdaptationAnswer(const Adaptation::Answer &answer);
-    virtual void noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer group);
+    void noteAdaptationAnswer(const Adaptation::Answer &answer) override;
+    void noteAdaptationAclCheckDone(Adaptation::ServiceGroupPointer group) override;
 
     // BodyProducer: provide virgin response body to ICAP.
-    virtual void noteMoreBodySpaceAvailable(BodyPipe::Pointer );
-    virtual void noteBodyConsumerAborted(BodyPipe::Pointer );
+    void noteMoreBodySpaceAvailable(BodyPipe::Pointer ) override;
+    void noteBodyConsumerAborted(BodyPipe::Pointer ) override;
 #endif
     virtual bool getMoreRequestBody(MemBuf &buf);
     virtual void processReplyBody() = 0;
 
 //AsyncJob virtual methods
-    virtual void swanSong();
-    virtual bool doneAll() const;
+    void swanSong() override;
+    bool doneAll() const override;
 
 public: // should be protected
     void serverComplete();     /**< call when no server communication is expected */

--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -31,8 +31,8 @@ public:
     explicit ErrorDetail(const int code): completionCode(code) {}
 
     /* ErrorDetail API */
-    virtual SBuf brief() const override;
-    virtual SBuf verbose(const HttpRequestPointer &) const override;
+    SBuf brief() const override;
+    SBuf verbose(const HttpRequestPointer &) const override;
 
 private:
     int completionCode; ///< FTP reply completion code
@@ -113,7 +113,7 @@ class Client: public ::Client
 
 public:
     explicit Client(FwdState *fwdState);
-    virtual ~Client();
+    ~Client() override;
 
     /// handle a fatal transaction error, closing the control connection
     virtual void failed(err_type error = ERR_NONE, int xerrno = 0,
@@ -123,7 +123,7 @@ public:
     virtual void timeout(const CommTimeoutCbParams &io);
 
     /* Client API */
-    virtual void maybeReadVirginBody();
+    void maybeReadVirginBody() override;
 
     void writeCommand(const char *buf);
 
@@ -179,14 +179,14 @@ public:
 
 protected:
     /* AsyncJob API */
-    virtual void start();
+    void start() override;
 
     /* Client API */
-    virtual void closeServer();
-    virtual bool doneWithServer() const;
-    virtual const Comm::ConnectionPointer & dataConnection() const;
-    virtual void abortAll(const char *reason);
-    virtual void noteDelayAwareReadChance();
+    void closeServer() override;
+    bool doneWithServer() const override;
+    const Comm::ConnectionPointer & dataConnection() const override;
+    void abortAll(const char *reason) override;
+    void noteDelayAwareReadChance() override;
 
     virtual Http::StatusCode failedHttpStatus(err_type &error);
     void ctrlClosed(const CommCloseCbParams &io);
@@ -202,8 +202,8 @@ protected:
     void initReadBuf();
 
     // sending of the request body to the server
-    virtual void sentRequestBody(const CommIoCbParams &io);
-    virtual void doneSendingRequestBody();
+    void sentRequestBody(const CommIoCbParams &io) override;
+    void doneSendingRequestBody() override;
 
     /// Waits for an FTP data connection to the server to be established/opened.
     /// This wait only happens in FTP passive mode (via PASV or EPSV).

--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -109,8 +109,6 @@ public:
 /// FTP client functionality shared among FTP Gateway and Relay clients.
 class Client: public ::Client
 {
-    CBDATA_CLASS(Client);
-
 public:
     explicit Client(FwdState *fwdState);
     ~Client() override;

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -90,7 +90,7 @@ typedef void (StateMethod)(Ftp::Gateway *);
 /// converts one or more FTP responses into the final HTTP response.
 class Gateway : public Ftp::Client
 {
-    CBDATA_CLASS(Gateway);
+    CBDATA_CHILD(Gateway);
 
 public:
     Gateway(FwdState *);

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -94,7 +94,7 @@ class Gateway : public Ftp::Client
 
 public:
     Gateway(FwdState *);
-    virtual ~Gateway();
+    ~Gateway() override;
     char user[MAX_URL];
     char password[MAX_URL];
     int password_url;
@@ -122,8 +122,8 @@ public:
 
 public:
     // these should all be private
-    virtual void start();
-    virtual Http::StatusCode failedHttpStatus(err_type &error);
+    void start() override;
+    Http::StatusCode failedHttpStatus(err_type &error) override;
     int restartable();
     void appendSuccessHeader();
     void hackShortcut(StateMethod *nextState);
@@ -141,33 +141,33 @@ public:
     void buildTitleUrl();
     void writeReplyBody(const char *, size_t len);
     void printfReplyBody(const char *fmt, ...);
-    virtual void completeForwarding();
+    void completeForwarding() override;
     void processHeadResponse();
-    void processReplyBody();
+    void processReplyBody() override;
     void setCurrentOffset(int64_t offset) { currentOffset = offset; }
     int64_t getCurrentOffset() const { return currentOffset; }
 
-    virtual void dataChannelConnected(const CommConnectCbParams &io);
+    void dataChannelConnected(const CommConnectCbParams &io) override;
     static PF ftpDataWrite;
-    virtual void timeout(const CommTimeoutCbParams &io);
+    void timeout(const CommTimeoutCbParams &io) override;
     void ftpAcceptDataConnection(const CommAcceptCbParams &io);
 
     static HttpReply *ftpAuthRequired(HttpRequest * request, SBuf &realm, AccessLogEntry::Pointer &);
     SBuf ftpRealm();
     void loginFailed(void);
 
-    virtual void haveParsedReplyHeaders();
+    void haveParsedReplyHeaders() override;
 
     virtual bool haveControlChannel(const char *caller_name) const;
 
 protected:
-    virtual void handleControlReply();
-    virtual void dataClosed(const CommCloseCbParams &io);
+    void handleControlReply() override;
+    void dataClosed(const CommCloseCbParams &io) override;
 
 private:
-    virtual bool mayReadVirginReplyBody() const;
+    bool mayReadVirginReplyBody() const override;
     // BodyConsumer for HTTP: consume request body.
-    virtual void handleRequestBodyProducerAborted();
+    void handleRequestBodyProducerAborted() override;
 
     void loginParser(const SBuf &login, bool escaped);
 };

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -37,7 +37,7 @@ class Relay: public Ftp::Client
 
 public:
     explicit Relay(FwdState *const fwdState);
-    virtual ~Relay();
+    ~Relay() override;
 
 protected:
     const Ftp::MasterState &master() const;
@@ -46,21 +46,21 @@ protected:
     void serverState(const Ftp::ServerState newState);
 
     /* Ftp::Client API */
-    virtual void failed(err_type error = ERR_NONE, int xerrno = 0, ErrorState *ftperr = nullptr);
-    virtual void dataChannelConnected(const CommConnectCbParams &io);
+    void failed(err_type error = ERR_NONE, int xerrno = 0, ErrorState *ftperr = nullptr) override;
+    void dataChannelConnected(const CommConnectCbParams &io) override;
 
     /* Client API */
     virtual void serverComplete();
-    virtual void handleControlReply();
-    virtual void processReplyBody();
-    virtual void handleRequestBodyProducerAborted();
-    virtual bool mayReadVirginReplyBody() const;
-    virtual void completeForwarding();
-    virtual bool abortOnData(const char *reason);
+    void handleControlReply() override;
+    void processReplyBody() override;
+    void handleRequestBodyProducerAborted() override;
+    bool mayReadVirginReplyBody() const override;
+    void completeForwarding() override;
+    bool abortOnData(const char *reason) override;
 
     /* AsyncJob API */
-    virtual void start();
-    virtual void swanSong();
+    void start() override;
+    void swanSong() override;
 
     void forwardReply();
     void forwardError(err_type error = ERR_NONE, int xerrno = 0);

--- a/src/clients/FtpRelay.cc
+++ b/src/clients/FtpRelay.cc
@@ -33,7 +33,7 @@ namespace Ftp
 /// and then relaying FTP replies back to our FTP server.
 class Relay: public Ftp::Client
 {
-    CBDATA_CLASS(Relay);
+    CBDATA_CHILD(Relay);
 
 public:
     explicit Relay(FwdState *const fwdState);

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -49,11 +49,11 @@ public:
 
 protected:
     /* AsyncJob API */
-    virtual ~Tunneler();
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
-    virtual const char *status() const;
+    ~Tunneler() override;
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
+    const char *status() const override;
 
     void handleConnectionClosure(const CommCloseCbParams&);
     void watchForClosures();

--- a/src/clients/HttpTunneler.h
+++ b/src/clients/HttpTunneler.h
@@ -31,7 +31,7 @@ namespace Http
 /// connection during these negotiations. The caller receives TunnelerAnswer.
 class Tunneler: virtual public AsyncJob
 {
-    CBDATA_CLASS(Tunneler);
+    CBDATA_CHILD(Tunneler);
 
 public:
     using Answer = TunnelerAnswer;

--- a/src/comm.h
+++ b/src/comm.h
@@ -100,7 +100,7 @@ class CommSelectEngine : public AsyncEngine
 {
 
 public:
-    virtual int checkEvents(int timeout);
+    int checkEvents(int timeout) override;
 };
 
 #endif

--- a/src/comm/ConnOpener.h
+++ b/src/comm/ConnOpener.h
@@ -23,7 +23,7 @@ namespace Comm
 /// Comm::OK with an open connection or another Comm::Flag with a closed one.
 class ConnOpener : public AsyncJob
 {
-    CBDATA_CLASS(ConnOpener);
+    CBDATA_CHILD(ConnOpener);
 
 public:
     typedef CbcPointer<ConnOpener> Pointer;

--- a/src/comm/ConnOpener.h
+++ b/src/comm/ConnOpener.h
@@ -28,17 +28,17 @@ class ConnOpener : public AsyncJob
 public:
     typedef CbcPointer<ConnOpener> Pointer;
 
-    virtual bool doneAll() const;
+    bool doneAll() const override;
 
     ConnOpener(const Comm::ConnectionPointer &, const AsyncCall::Pointer &handler, time_t connect_timeout);
-    ~ConnOpener();
+    ~ConnOpener() override;
 
     void setHost(const char *);    ///< set the hostname note for this connection
     const char * getHost() const;  ///< get the hostname noted for this connection
 
 protected:
-    virtual void start();
-    virtual void swanSong();
+    void start() override;
+    void swanSong() override;
 
 private:
     // Undefined because two openers cannot share a connection

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -77,7 +77,7 @@ public:
     Connection();
 
     /** Clear the connection properties and close any open socket. */
-    virtual ~Connection();
+    ~Connection() override;
 
     /// To prevent accidental copying of Connection objects that we started to
     /// open or that are open, use cloneProfile() instead.
@@ -138,8 +138,8 @@ public:
     const Security::NegotiationHistory *hasTlsNegotiations() const {return tlsHistory;}
 
     /* CodeContext API */
-    virtual ScopedId codeContextGist() const override;
-    virtual std::ostream &detailCodeContext(std::ostream &os) const override;
+    ScopedId codeContextGist() const override;
+    std::ostream &detailCodeContext(std::ostream &os) const override;
 
 public:
     /** Address/Port for the Squid end of a TCP link. */

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -43,10 +43,10 @@ public:
     typedef CbcPointer<Comm::TcpAcceptor> Pointer;
 
 private:
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
-    virtual const char *status() const;
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
+    const char *status() const override;
 
     TcpAcceptor(const TcpAcceptor &); // not implemented.
 

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -37,7 +37,7 @@ class AcceptLimiter;
  */
 class TcpAcceptor : public AsyncJob
 {
-    CBDATA_CLASS(TcpAcceptor);
+    CBDATA_CHILD(TcpAcceptor);
 
 public:
     typedef CbcPointer<Comm::TcpAcceptor> Pointer;

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -241,8 +241,8 @@ public:
 
 protected:
     /* DebugChannel API */
-    virtual bool shouldWrite(const DebugMessageHeader &) const final;
-    virtual void write(const DebugMessageHeader &, const CompiledDebugMessageBody &) final;
+    bool shouldWrite(const DebugMessageHeader &) const final;
+    void write(const DebugMessageHeader &, const CompiledDebugMessageBody &) final;
 };
 
 /// DebugChannel managing messages destined for "standard error stream" (stderr)
@@ -262,8 +262,8 @@ public:
 
 protected:
     /* DebugChannel API */
-    virtual bool shouldWrite(const DebugMessageHeader &) const final;
-    virtual void write(const DebugMessageHeader &, const CompiledDebugMessageBody &) final;
+    bool shouldWrite(const DebugMessageHeader &) const final;
+    void write(const DebugMessageHeader &, const CompiledDebugMessageBody &) final;
 
 private:
     /// whether we are the last resort for logging debugs() messages
@@ -280,8 +280,8 @@ public:
 
 protected:
     /* DebugChannel API */
-    virtual bool shouldWrite(const DebugMessageHeader &) const final;
-    virtual void write(const DebugMessageHeader &, const CompiledDebugMessageBody &) final;
+    bool shouldWrite(const DebugMessageHeader &) const final;
+    void write(const DebugMessageHeader &, const CompiledDebugMessageBody &) final;
 
 private:
     bool opened = false; ///< whether openlog() was called

--- a/src/delay_pools.cc
+++ b/src/delay_pools.cc
@@ -47,17 +47,17 @@ class Aggregate : public CompositePoolNode
 public:
     typedef RefCount<Aggregate> Pointer;
     Aggregate();
-    ~Aggregate();
+    ~Aggregate() override;
     virtual DelaySpec *rate() {return &spec;}
 
     virtual DelaySpec const *rate() const {return &spec;}
 
-    virtual void stats(StoreEntry * sentry);
-    virtual void dump(StoreEntry *entry) const;
-    virtual void update(int incr);
-    virtual void parse();
+    void stats(StoreEntry * sentry) override;
+    void dump(StoreEntry *entry) const override;
+    void update(int incr) override;
+    void parse() override;
 
-    virtual DelayIdComposite::Pointer id(CompositeSelectionDetails &);
+    DelayIdComposite::Pointer id(CompositeSelectionDetails &) override;
 
 private:
 
@@ -68,9 +68,9 @@ private:
 
     public:
         AggregateId (RefCount<Aggregate>);
-        virtual int bytesWanted (int min, int max) const;
-        virtual void bytesIn(int qty);
-        virtual void delayRead(const AsyncCallPointer &);
+        int bytesWanted (int min, int max) const override;
+        void bytesIn(int qty) override;
+        void delayRead(const AsyncCallPointer &) override;
 
     private:
         RefCount<Aggregate> theAggregate;
@@ -110,15 +110,15 @@ class VectorPool : public CompositePoolNode
 
 public:
     typedef RefCount<VectorPool> Pointer;
-    virtual void dump(StoreEntry *entry) const;
-    virtual void parse();
-    virtual void update(int incr);
-    virtual void stats(StoreEntry * sentry);
+    void dump(StoreEntry *entry) const override;
+    void parse() override;
+    void update(int incr) override;
+    void stats(StoreEntry * sentry) override;
 
-    virtual DelayIdComposite::Pointer id(CompositeSelectionDetails &);
+    DelayIdComposite::Pointer id(CompositeSelectionDetails &) override;
     VectorMap<unsigned char, DelayBucket> buckets;
     VectorPool();
-    ~VectorPool();
+    ~VectorPool() override;
 
 protected:
     bool keyAllocated (unsigned char const key) const;
@@ -139,8 +139,8 @@ protected:
 
     public:
         Id (RefCount<VectorPool>, int);
-        virtual int bytesWanted (int min, int max) const;
-        virtual void bytesIn(int qty);
+        int bytesWanted (int min, int max) const override;
+        void bytesIn(int qty) override;
 
     private:
         RefCount<VectorPool> theVector;
@@ -154,8 +154,8 @@ class IndividualPool : public VectorPool
     MEMPROXY_CLASS(IndividualPool);
 
 protected:
-    virtual char const *label() const {return "Individual";}
-    virtual unsigned int makeKey(Ip::Address &src_addr) const;
+    char const *label() const override {return "Individual";}
+    unsigned int makeKey(Ip::Address &src_addr) const override;
 };
 
 /// \ingroup DelayPoolsInternal
@@ -164,8 +164,8 @@ class ClassCNetPool : public VectorPool
     MEMPROXY_CLASS(ClassCNetPool);
 
 protected:
-    virtual char const *label() const {return "Network";}
-    virtual unsigned int makeKey (Ip::Address &src_addr) const;
+    char const *label() const override {return "Network";}
+    unsigned int makeKey (Ip::Address &src_addr) const override;
 };
 
 /* don't use remote storage for these */
@@ -193,14 +193,14 @@ class ClassCHostPool : public CompositePoolNode
 
 public:
     typedef RefCount<ClassCHostPool> Pointer;
-    virtual void dump(StoreEntry *entry) const;
-    virtual void parse();
-    virtual void update(int incr);
-    virtual void stats(StoreEntry * sentry);
+    void dump(StoreEntry *entry) const override;
+    void parse() override;
+    void update(int incr) override;
+    void stats(StoreEntry * sentry) override;
 
-    virtual DelayIdComposite::Pointer id(CompositeSelectionDetails &);
+    DelayIdComposite::Pointer id(CompositeSelectionDetails &) override;
     ClassCHostPool();
-    ~ClassCHostPool();
+    ~ClassCHostPool() override;
 
 protected:
     bool keyAllocated (unsigned char const key) const;
@@ -228,8 +228,8 @@ protected:
 
     public:
         Id (RefCount<ClassCHostPool>, unsigned char, unsigned char);
-        virtual int bytesWanted (int min, int max) const;
-        virtual void bytesIn(int qty);
+        int bytesWanted (int min, int max) const override;
+        void bytesIn(int qty) override;
 
     private:
         RefCount<ClassCHostPool> theClassCHost;

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -206,8 +206,8 @@ class ConfigRr : public RegisteredRunner
 {
 public:
     /* RegisteredRunner API */
-    virtual void startReconfigure() override;
-    virtual void endingShutdown() override;
+    void startReconfigure() override;
+    void endingShutdown() override;
 };
 
 RunnerRegistrationEntry(ConfigRr);

--- a/src/error/Detail.cc
+++ b/src/error/Detail.cc
@@ -21,8 +21,8 @@ public:
     explicit NamedErrorDetail(const char *aName): name(aName) {}
 
     /* ErrorDetail API */
-    virtual SBuf brief() const override { return name; }
-    virtual SBuf verbose(const HttpRequestPointer &) const override { return name; }
+    SBuf brief() const override { return name; }
+    SBuf verbose(const HttpRequestPointer &) const override { return name; }
 
 private:
     /// distinguishes us from all other NamedErrorDetail objects

--- a/src/error/Detail.h
+++ b/src/error/Detail.h
@@ -22,7 +22,7 @@ class ErrorDetail: public RefCountable
 public:
     using Pointer = ErrorDetailPointer;
 
-    virtual ~ErrorDetail() {}
+    ~ErrorDetail() override {}
 
     /// \returns a single "token" summarizing available details
     /// suitable as an access.log field and similar output processed by programs

--- a/src/error/ExceptionErrorDetail.h
+++ b/src/error/ExceptionErrorDetail.h
@@ -26,11 +26,11 @@ public:
     explicit ExceptionErrorDetail(const SourceLocationId id): exceptionId(SQUID_EXCEPTION_START_BASE + id) {}
 
     /* ErrorDetail API */
-    virtual SBuf brief() const override {
+    SBuf brief() const override {
         return ToSBuf("exception=", std::hex, exceptionId);
     }
 
-    virtual SBuf verbose(const HttpRequestPointer &) const override {
+    SBuf verbose(const HttpRequestPointer &) const override {
         return ToSBuf("Exception (ID=", std::hex, exceptionId, ')');
     }
 

--- a/src/error/SysErrorDetail.h
+++ b/src/error/SysErrorDetail.h
@@ -29,8 +29,8 @@ public:
     static SBuf Brief(int errorNo);
 
     /* ErrorDetail API */
-    virtual SBuf brief() const override;
-    virtual SBuf verbose(const HttpRequestPointer &) const override;
+    SBuf brief() const override;
+    SBuf verbose(const HttpRequestPointer &) const override;
 
 private:
     // hidden by NewIfAny() to avoid creating SysErrorDetail from zero errno

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -218,7 +218,7 @@ public:
     const char *text() { return template_.c_str(); }
 
 protected:
-    virtual void setDefault() override {
+    void setDefault() override {
         template_ = "Internal Error: Missing Template ";
         template_.append(templateName.termedBuf());
     }

--- a/src/esi/Assign.h
+++ b/src/esi/Assign.h
@@ -19,9 +19,9 @@
 class ESIVariableExpression : public ESIVarState::Variable
 {
 public:
-    ~ESIVariableExpression();
+    ~ESIVariableExpression() override;
     ESIVariableExpression (String const &value);
-    virtual void eval (ESIVarState &state, char const *, char const *) const;
+    void eval (ESIVarState &state, char const *, char const *) const override;
 
 private:
     String expression;
@@ -37,14 +37,14 @@ public:
     ESIAssign (esiTreeParentPtr, int, const char **, ESIContext *);
     ESIAssign (ESIAssign const &);
     ESIAssign &operator=(ESIAssign const &);
-    ~ESIAssign();
-    esiProcessResult_t process (int dovars);
-    void render(ESISegment::Pointer);
-    bool addElement(ESIElement::Pointer);
-    void provideData (ESISegment::Pointer data, ESIElement * source);
-    Pointer makeCacheable() const;
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
-    void finish();
+    ~ESIAssign() override;
+    esiProcessResult_t process (int dovars) override;
+    void render(ESISegment::Pointer) override;
+    bool addElement(ESIElement::Pointer) override;
+    void provideData (ESISegment::Pointer data, ESIElement * source) override;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
+    void finish() override;
 
 private:
     void evaluateVariable();

--- a/src/esi/Context.h
+++ b/src/esi/Context.h
@@ -45,7 +45,7 @@ public:
         memset(&flags, 0, sizeof(flags));
     }
 
-    ~ESIContext();
+    ~ESIContext() override;
 
     enum esiKick_t {
         ESI_KICK_FAILED,
@@ -55,8 +55,8 @@ public:
     };
 
     /* when esi processing completes */
-    void provideData(ESISegment::Pointer, ESIElement *source);
-    void fail (ESIElement *source, char const*anError = nullptr);
+    void provideData(ESISegment::Pointer, ESIElement *source) override;
+    void fail (ESIElement *source, char const*anError = nullptr) override;
     void startRead();
     void finishRead();
     bool reading() const;
@@ -153,10 +153,10 @@ private:
     void updateCachedAST();
     bool hasCachedAST() const;
     void getCachedAST();
-    virtual void start(const char *el, const char **attr, size_t attrCount);
-    virtual void end(const char *el);
-    virtual void parserDefault (const char *s, int len);
-    virtual void parserComment (const char *s);
+    void start(const char *el, const char **attr, size_t attrCount) override;
+    void end(const char *el) override;
+    void parserDefault (const char *s, int len) override;
+    void parserComment (const char *s) override;
     bool processing;
 };
 

--- a/src/esi/Element.h
+++ b/src/esi/Element.h
@@ -32,7 +32,7 @@ struct esiTreeParent : public RefCountable {
 
     virtual void fail(ESIElement * /* source */, char const * /* reason */ = nullptr) {}
 
-    virtual ~esiTreeParent() {}
+    ~esiTreeParent() override {}
 };
 
 typedef RefCount<esiTreeParent> esiTreeParentPtr;

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -89,13 +89,13 @@ class esiComment : public ESIElement
     MEMPROXY_CLASS(esiComment);
 
 public:
-    ~esiComment();
+    ~esiComment() override;
     esiComment();
-    Pointer makeCacheable() const;
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
 
-    void render(ESISegment::Pointer);
-    void finish();
+    void render(ESISegment::Pointer) override;
+    void finish() override;
 };
 
 #include "esi/Literal.h"
@@ -112,13 +112,13 @@ class esiRemove : public ESIElement
 
 public:
     esiRemove() : ESIElement() {}
-    virtual ~esiRemove() {}
+    ~esiRemove() override {}
 
-    virtual void render(ESISegment::Pointer);
-    virtual bool addElement (ESIElement::Pointer);
-    virtual Pointer makeCacheable() const;
-    virtual Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
-    virtual void finish() {}
+    void render(ESISegment::Pointer) override;
+    bool addElement (ESIElement::Pointer) override;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
+    void finish() override {}
 };
 
 class esiTry : public ESIElement
@@ -127,15 +127,15 @@ class esiTry : public ESIElement
 
 public:
     esiTry(esiTreeParentPtr aParent);
-    ~esiTry();
+    ~esiTry() override;
 
-    void render(ESISegment::Pointer);
-    bool addElement (ESIElement::Pointer);
-    void fail(ESIElement *, char const * = nullptr);
-    esiProcessResult_t process (int dovars);
-    void provideData (ESISegment::Pointer data, ESIElement * source);
-    Pointer makeCacheable() const;
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
+    void render(ESISegment::Pointer) override;
+    bool addElement (ESIElement::Pointer) override;
+    void fail(ESIElement *, char const * = nullptr) override;
+    esiProcessResult_t process (int dovars) override;
+    void provideData (ESISegment::Pointer data, ESIElement * source) override;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
 
     ESIElement::Pointer attempt;
     ESIElement::Pointer except;
@@ -146,7 +146,7 @@ public:
         int attemptfailed:1; /* The attempt branch failed */
         int exceptfailed:1; /* the except branch failed */
     } flags;
-    void finish();
+    void finish() override;
 
 private:
     void notifyParent();
@@ -164,24 +164,24 @@ class esiChoose : public ESIElement
 
 public:
     esiChoose(esiTreeParentPtr);
-    ~esiChoose();
+    ~esiChoose() override;
 
-    void render(ESISegment::Pointer);
-    bool addElement (ESIElement::Pointer);
-    void fail(ESIElement *, char const * = nullptr);
-    esiProcessResult_t process (int dovars);
+    void render(ESISegment::Pointer) override;
+    bool addElement (ESIElement::Pointer) override;
+    void fail(ESIElement *, char const * = nullptr) override;
+    esiProcessResult_t process (int dovars) override;
 
-    void provideData (ESISegment::Pointer data, ESIElement *source);
+    void provideData (ESISegment::Pointer data, ESIElement *source) override;
     void makeCachableElements(esiChoose const &old);
     void makeUsableElements(esiChoose const &old, ESIVarState &);
-    Pointer makeCacheable() const;
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
     void NULLUnChosen();
 
     Esi::Elements elements;
     int chosenelement;
     ESIElement::Pointer otherwise;
-    void finish();
+    void finish() override;
 
 private:
     esiChoose(esiChoose const &);
@@ -196,9 +196,9 @@ class esiWhen : public esiSequence
 
 public:
     esiWhen(esiTreeParentPtr aParent, int attributes, const char **attr, ESIVarState *);
-    ~esiWhen();
-    Pointer makeCacheable() const;
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
+    ~esiWhen() override;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
 
     bool testsTrue() const { return testValue;}
 

--- a/src/esi/ExpatParser.cc
+++ b/src/esi/ExpatParser.cc
@@ -23,7 +23,7 @@ namespace Esi
 class ExpatRr : public RegisteredRunner
 {
 public:
-    void finalizeConfig()
+    void finalizeConfig() override
     {
         registration.reset(new ESIParser::Register("expat", &ESIExpatParser::NewParser));
     }

--- a/src/esi/ExpatParser.h
+++ b/src/esi/ExpatParser.h
@@ -22,13 +22,13 @@ class ESIExpatParser : public ESIParser
 
 public:
     ESIExpatParser(ESIParserClient *);
-    ~ESIExpatParser();
+    ~ESIExpatParser() override;
 
     /** \retval true    on success */
-    bool parse(char const *dataToParse, size_t const lengthOfData, bool const endOfStream);
+    bool parse(char const *dataToParse, size_t const lengthOfData, bool const endOfStream) override;
 
-    long int lineNumber() const;
-    char const * errorString() const;
+    long int lineNumber() const override;
+    char const * errorString() const override;
 
     EsiParserDeclaration;
 

--- a/src/esi/Include.h
+++ b/src/esi/Include.h
@@ -25,7 +25,7 @@ class ESIStreamContext : public RefCountable
 public:
     typedef RefCount<ESIStreamContext> Pointer;
     ESIStreamContext();
-    ~ESIStreamContext();
+    ~ESIStreamContext() override;
     void freeResources();
     int finished;
     ESIIncludePtr include;
@@ -39,11 +39,11 @@ class ESIInclude : public ESIElement
 
 public:
     ESIInclude(esiTreeParentPtr, int attributes, const char **attr, ESIContext *);
-    ~ESIInclude();
-    void render(ESISegment::Pointer);
-    esiProcessResult_t process (int dovars);
-    Pointer makeCacheable() const;
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
+    ~ESIInclude() override;
+    void render(ESISegment::Pointer) override;
+    esiProcessResult_t process (int dovars) override;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
     void subRequestDone (ESIStreamContext::Pointer, bool);
 
     struct {
@@ -58,7 +58,7 @@ public:
     ESIVarState *varState;
     char *srcurl, *alturl;
     void includeFail(ESIStreamContext::Pointer);
-    void finish();
+    void finish() override;
 
 private:
     void Start (ESIStreamContext::Pointer, char const *, ESIVarState *);

--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -27,7 +27,7 @@ namespace Esi
 class Libxml2Rr : public RegisteredRunner
 {
 public:
-    void finalizeConfig()
+    void finalizeConfig() override
     {
         registration.reset(new ESIParser::Register("libxml2", &ESILibxml2Parser::NewParser));
     }

--- a/src/esi/Libxml2Parser.h
+++ b/src/esi/Libxml2Parser.h
@@ -52,11 +52,11 @@ class ESILibxml2Parser : public ESIParser
 
 public:
     ESILibxml2Parser(ESIParserClient *);
-    ~ESILibxml2Parser();
+    ~ESILibxml2Parser() override;
     /* true on success */
-    bool parse(char const *dataToParse, size_t const lengthOfData, bool const endOfStream);
-    long int lineNumber() const;
-    char const * errorString() const;
+    bool parse(char const *dataToParse, size_t const lengthOfData, bool const endOfStream) override;
+    long int lineNumber() const override;
+    char const * errorString() const override;
 
     ESIParserClient *getClient() { return theClient; }
 

--- a/src/esi/Literal.h
+++ b/src/esi/Literal.h
@@ -22,12 +22,12 @@ class esiLiteral : public ESIElement
 public:
     esiLiteral(ESISegment::Pointer);
     esiLiteral(ESIContext *, const char *s, int len);
-    ~esiLiteral();
+    ~esiLiteral() override;
 
-    void render(ESISegment::Pointer);
-    esiProcessResult_t process (int dovars);
-    Pointer makeCacheable() const;
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
+    void render(ESISegment::Pointer) override;
+    esiProcessResult_t process (int dovars) override;
+    Pointer makeCacheable() const override;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
     /* optimise copies away later */
     ESISegment::Pointer buffer;
 
@@ -36,7 +36,7 @@ public:
     } flags;
 
     ESIVarState *varState;
-    void finish();
+    void finish() override;
 
 private:
     esiLiteral(esiLiteral const &);

--- a/src/esi/Segment.h
+++ b/src/esi/Segment.h
@@ -29,7 +29,7 @@ public:
 
     ESISegment() : len(0), next(nullptr) {*buf = 0;}
     ESISegment(ESISegment const &);
-    ~ESISegment() {}
+    ~ESISegment() override {}
 
     ESISegment::Pointer cloneList() const;
     char *listToChar() const;

--- a/src/esi/Sequence.h
+++ b/src/esi/Sequence.h
@@ -22,19 +22,19 @@ class esiSequence : public ESIElement
 
 public:
     esiSequence(esiTreeParentPtr, bool = false);
-    ~esiSequence();
+    ~esiSequence() override;
 
-    void render(ESISegment::Pointer);
-    bool addElement (ESIElement::Pointer);
-    esiProcessResult_t process (int dovars);
-    void provideData (ESISegment::Pointer, ESIElement*);
-    bool mayFail () const;
+    void render(ESISegment::Pointer) override;
+    bool addElement (ESIElement::Pointer) override;
+    esiProcessResult_t process (int dovars) override;
+    void provideData (ESISegment::Pointer, ESIElement*) override;
+    bool mayFail () const override;
     void wontFail();
-    void fail(ESIElement *, char const *anError = nullptr);
+    void fail(ESIElement *, char const *anError = nullptr) override;
     void makeCachableElements(esiSequence const &old);
-    Pointer makeCacheable() const;
+    Pointer makeCacheable() const override;
     void makeUsableElements(esiSequence const &old, ESIVarState &);
-    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const;
+    Pointer makeUsable(esiTreeParentPtr, ESIVarState &) const override;
 
     Esi::Elements elements; /* unprocessed or rendered nodes */
     size_t processedcount;
@@ -42,7 +42,7 @@ public:
     struct {
         int dovars:1; /* for esiVar */
     } flags;
-    void finish();
+    void finish() override;
 
 protected:
     esiSequence(esiSequence const &);

--- a/src/esi/VarState.h
+++ b/src/esi/VarState.h
@@ -101,21 +101,21 @@ class ESIVariableCookie : public ESIVarState::Variable
 {
 
 public:
-    virtual void eval (ESIVarState &state, char const *, char const *) const;
+    void eval (ESIVarState &state, char const *, char const *) const override;
 };
 
 class ESIVariableHost : public ESIVarState::Variable
 {
 
 public:
-    virtual void eval (ESIVarState &state, char const *, char const *) const;
+    void eval (ESIVarState &state, char const *, char const *) const override;
 };
 
 class ESIVariableLanguage : public ESIVarState::Variable
 {
 
 public:
-    virtual void eval (ESIVarState &state, char const *, char const *) const;
+    void eval (ESIVarState &state, char const *, char const *) const override;
 };
 
 class ESIVariableQuery : public ESIVarState::Variable
@@ -123,8 +123,8 @@ class ESIVariableQuery : public ESIVarState::Variable
 
 public:
     ESIVariableQuery(char const *uri);
-    ~ESIVariableQuery();
-    virtual void eval (ESIVarState &state, char const *, char const *) const;
+    ~ESIVariableQuery() override;
+    void eval (ESIVarState &state, char const *, char const *) const override;
     char const *queryString() const;
 
     struct _query_elem const *queryVector() const;
@@ -140,16 +140,16 @@ class ESIVariableReferer : public ESIVarState::Variable
 {
 
 public:
-    virtual void eval (ESIVarState &state, char const *, char const *) const;
+    void eval (ESIVarState &state, char const *, char const *) const override;
 };
 
 class ESIVariableUserAgent : public ESIVarState::Variable
 {
 
 public:
-    ~ESIVariableUserAgent();
+    ~ESIVariableUserAgent() override;
     ESIVariableUserAgent (ESIVarState &state);
-    virtual void eval (ESIVarState &state, char const *, char const *) const;
+    void eval (ESIVarState &state, char const *, char const *) const override;
 
 private:
     static char const * esiUserOs[];

--- a/src/event.cc
+++ b/src/event.cc
@@ -31,9 +31,9 @@ public:
 
     EventDialer(EVH *aHandler, void *anArg, bool lockedArg);
     EventDialer(const EventDialer &d);
-    virtual ~EventDialer();
+    ~EventDialer() override;
 
-    virtual void print(std::ostream &os) const;
+    void print(std::ostream &os) const override;
     virtual bool canDial(AsyncCall &call);
 
     void dial(AsyncCall &) { theHandler(theArg); }

--- a/src/event.h
+++ b/src/event.h
@@ -47,7 +47,7 @@ class EventScheduler : public AsyncEngine
 
 public:
     EventScheduler();
-    ~EventScheduler();
+    ~EventScheduler() override;
     /* cancel a scheduled but not dispatched event */
     void cancel(EVH * func, void * arg);
     /* clean up the used memory in the scheduler */
@@ -60,7 +60,7 @@ public:
     bool find(EVH * func, void * arg);
     /* schedule a callback function to run in when seconds */
     void schedule(const char *name, EVH * func, void *arg, double when, int weight, bool cbdata=true);
-    int checkEvents(int timeout);
+    int checkEvents(int timeout) override;
     static EventScheduler *GetInstance();
 
 private:

--- a/src/fs/rock/RockHeaderUpdater.h
+++ b/src/fs/rock/RockHeaderUpdater.h
@@ -35,13 +35,13 @@ public:
         ssize_t size;
     };
     HeaderUpdater(const Rock::SwapDir::Pointer &aStore, const Ipc::StoreMapUpdate &update);
-    virtual ~HeaderUpdater() override = default;
+    ~HeaderUpdater() override = default;
 
 protected:
     /* AsyncJob API */
-    virtual void start() override;
-    virtual bool doneAll() const override;
-    virtual void swanSong() override;
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
 
 private:
     static StoreIOState::STRCB NoteRead;

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -433,7 +433,7 @@ public:
         callback_data = cbdataReference(cb.callback_data);
     }
 
-    virtual ~StoreIOStateCb() {
+    ~StoreIOStateCb() override {
         cbdataReferenceDone(callback_data); // may be nil already
     }
 
@@ -447,7 +447,7 @@ public:
         return cbdataReferenceValid(callback_data) && callback;
     }
 
-    virtual void print(std::ostream &os) const {
+    void print(std::ostream &os) const override {
         os << '(' << callback_data << ", err=" << errflag << ')';
     }
 

--- a/src/fs/rock/RockIoState.h
+++ b/src/fs/rock/RockIoState.h
@@ -30,14 +30,14 @@ public:
     typedef RefCount<IoState> Pointer;
 
     IoState(Rock::SwapDir::Pointer &aDir, StoreEntry *e, StoreIOState::STFNCB *cbFile, StoreIOState::STIOCB *cbIo, void *data);
-    virtual ~IoState();
+    ~IoState() override;
 
     void file(const RefCount<DiskFile> &aFile);
 
     // ::StoreIOState API
-    virtual void read_(char *buf, size_t size, off_t offset, STRCB * callback, void *callback_data);
-    virtual bool write(char const *buf, size_t size, off_t offset, FREE * free_func);
-    virtual void close(int how);
+    void read_(char *buf, size_t size, off_t offset, STRCB * callback, void *callback_data) override;
+    bool write(char const *buf, size_t size, off_t offset, FREE * free_func) override;
+    void close(int how) override;
 
     /// whether we are still waiting for the I/O results (i.e., not closed)
     bool stillWaiting() const { return theFile != nullptr; }

--- a/src/fs/rock/RockRebuild.h
+++ b/src/fs/rock/RockRebuild.h
@@ -57,15 +57,15 @@ protected:
     static bool IsResponsible(const SwapDir &);
 
     Rebuild(SwapDir *dir, const Ipc::Mem::Pointer<Stats> &);
-    virtual ~Rebuild() override;
+    ~Rebuild() override;
 
     /* Registered Runner API */
-    virtual void startShutdown() override;
+    void startShutdown() override;
 
     /* AsyncJob API */
-    virtual void start() override;
-    virtual bool doneAll() const override;
-    virtual void swanSong() override;
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
 
     bool doneLoading() const;
     bool doneValidating() const;

--- a/src/fs/rock/RockStoreFileSystem.h
+++ b/src/fs/rock/RockStoreFileSystem.h
@@ -23,11 +23,11 @@ public:
     static void Stats(StoreEntry * sentry);
 
     StoreFileSystem();
-    virtual ~StoreFileSystem();
+    ~StoreFileSystem() override;
 
     /* StoreFileSystem API */
-    virtual char const *type() const override;
-    virtual SwapDir *createSwapDir() override;
+    char const *type() const override;
+    SwapDir *createSwapDir() override;
 
 private:
     //static Stats Stats_;

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -36,23 +36,23 @@ public:
     typedef Ipc::StoreMap DirMap;
 
     SwapDir();
-    virtual ~SwapDir();
+    ~SwapDir() override;
 
     /* public ::SwapDir API */
-    virtual void reconfigure();
-    virtual StoreEntry *get(const cache_key *key);
-    virtual void evictCached(StoreEntry &);
-    virtual void evictIfFound(const cache_key *);
-    virtual void disconnect(StoreEntry &e);
-    virtual uint64_t currentSize() const;
-    virtual uint64_t currentCount() const;
-    virtual bool doReportStat() const;
-    virtual void finalizeSwapoutSuccess(const StoreEntry &);
-    virtual void finalizeSwapoutFailure(StoreEntry &);
-    virtual void create();
-    virtual void parse(int index, char *path);
-    virtual bool smpAware() const { return true; }
-    virtual bool hasReadableEntry(const StoreEntry &) const;
+    void reconfigure() override;
+    StoreEntry *get(const cache_key *key) override;
+    void evictCached(StoreEntry &) override;
+    void evictIfFound(const cache_key *) override;
+    void disconnect(StoreEntry &e) override;
+    uint64_t currentSize() const override;
+    uint64_t currentCount() const override;
+    bool doReportStat() const override;
+    void finalizeSwapoutSuccess(const StoreEntry &) override;
+    void finalizeSwapoutFailure(StoreEntry &) override;
+    void create() override;
+    void parse(int index, char *path) override;
+    bool smpAware() const override { return true; }
+    bool hasReadableEntry(const StoreEntry &) const override;
 
     // temporary path to the shared memory map of first slots of cached entries
     SBuf inodeMapPath() const;
@@ -78,36 +78,36 @@ public:
     void writeError(StoreIOState &sio);
 
     /* StoreMapCleaner API */
-    virtual void noteFreeMapSlice(const Ipc::StoreMapSliceId fileno);
+    void noteFreeMapSlice(const Ipc::StoreMapSliceId fileno) override;
 
     uint64_t slotSize; ///< all db slots are of this size
 
 protected:
     /* Store API */
-    virtual bool anchorToCache(StoreEntry &);
-    virtual bool updateAnchored(StoreEntry &);
+    bool anchorToCache(StoreEntry &) override;
+    bool updateAnchored(StoreEntry &) override;
 
     /* protected ::SwapDir API */
-    virtual bool needsDiskStrand() const;
-    virtual void init();
-    virtual ConfigOption *getOptionTree() const;
-    virtual bool allowOptionReconfigure(const char *const option) const;
-    virtual bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const;
-    virtual StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *);
-    virtual StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *);
-    virtual void maintain();
-    virtual void diskFull();
-    virtual void reference(StoreEntry &e);
-    virtual bool dereference(StoreEntry &e);
-    virtual void updateHeaders(StoreEntry *e);
-    virtual bool unlinkdUseful() const;
-    virtual void statfs(StoreEntry &e) const;
+    bool needsDiskStrand() const override;
+    void init() override;
+    ConfigOption *getOptionTree() const override;
+    bool allowOptionReconfigure(const char *const option) const override;
+    bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
+    StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
+    StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
+    void maintain() override;
+    void diskFull() override;
+    void reference(StoreEntry &e) override;
+    bool dereference(StoreEntry &e) override;
+    void updateHeaders(StoreEntry *e) override;
+    bool unlinkdUseful() const override;
+    void statfs(StoreEntry &e) const override;
 
     /* IORequestor API */
-    virtual void ioCompletedNotification();
-    virtual void closeCompleted();
-    virtual void readCompleted(const char *buf, int len, int errflag, RefCount< ::ReadRequest>);
-    virtual void writeCompleted(int errflag, size_t len, RefCount< ::WriteRequest>);
+    void ioCompletedNotification() override;
+    void closeCompleted() override;
+    void readCompleted(const char *buf, int len, int errflag, RefCount< ::ReadRequest>) override;
+    void writeCompleted(int errflag, size_t len, RefCount< ::WriteRequest>) override;
 
     void parseSize(const bool reconfiguring); ///< parses anonymous cache_dir size option
     void validateOptions(); ///< warns of configuration problems; may quit
@@ -156,11 +156,11 @@ class SwapDirRr: public Ipc::Mem::RegisteredRunner
 {
 public:
     /* ::RegisteredRunner API */
-    virtual ~SwapDirRr();
+    ~SwapDirRr() override;
 
 protected:
     /* Ipc::Mem::RegisteredRunner API */
-    virtual void create();
+    void create() override;
 
 private:
     std::vector<Ipc::Mem::Owner<Rebuild::Stats> *> rebuildStatsOwners;

--- a/src/fs/ufs/StoreFSufs.h
+++ b/src/fs/ufs/StoreFSufs.h
@@ -36,11 +36,11 @@ class StoreFSufs : public StoreFileSystem
 public:
     static StoreFileSystem &GetInstance();
     StoreFSufs(char const *DefaultModuleType, char const *label);
-    virtual ~StoreFSufs() {}
+    ~StoreFSufs() override {}
 
     /* StoreFileSystem API */
-    virtual const char *type() const override;
-    virtual SwapDir *createSwapDir() override;
+    const char *type() const override;
+    SwapDir *createSwapDir() override;
 
 protected:
     DiskIOModule *IO;

--- a/src/fs/ufs/StoreSearchUFS.h
+++ b/src/fs/ufs/StoreSearchUFS.h
@@ -23,24 +23,24 @@ class StoreSearchUFS : public StoreSearch
 
 public:
     StoreSearchUFS(RefCount<UFSSwapDir> sd);
-    virtual ~StoreSearchUFS();
+    ~StoreSearchUFS() override;
 
     // TODO: misplaced Iterator API
     /**
      * callback the client when a new StoreEntry is available
      * or an error occurs
      */
-    virtual void next(void (callback)(void *cbdata), void *cbdata);
+    void next(void (callback)(void *cbdata), void *cbdata) override;
 
     /**
      \retval true if a new StoreEntry is immediately available
      \retval false if a new StoreEntry is NOT immediately available
      */
-    virtual bool next();
+    bool next() override;
 
-    virtual bool error() const;
-    virtual bool isDone() const;
-    virtual StoreEntry *currentItem();
+    bool error() const override;
+    bool isDone() const override;
+    StoreEntry *currentItem() override;
 
     RefCount<UFSSwapDir> sd;
     RemovalPolicyWalker *walker;

--- a/src/fs/ufs/UFSStoreState.h
+++ b/src/fs/ufs/UFSStoreState.h
@@ -25,13 +25,13 @@ class UFSStoreState : public StoreIOState, public IORequestor
 
 public:
     UFSStoreState(SwapDir * SD, StoreEntry * anEntry, STIOCB * callback_, void *callback_data_);
-    ~UFSStoreState();
-    virtual void close(int how);
-    virtual void closeCompleted();
+    ~UFSStoreState() override;
+    void close(int how) override;
+    void closeCompleted() override;
     // protected:
-    virtual void ioCompletedNotification();
-    virtual void readCompleted(const char *buf, int len, int errflag, RefCount<ReadRequest>);
-    virtual void writeCompleted(int errflag, size_t len, RefCount<WriteRequest>);
+    void ioCompletedNotification() override;
+    void readCompleted(const char *buf, int len, int errflag, RefCount<ReadRequest>) override;
+    void writeCompleted(int errflag, size_t len, RefCount<WriteRequest>) override;
     RefCount<DiskFile> theFile;
     bool opening;
     bool creating;
@@ -39,8 +39,8 @@ public:
     bool reading;
     bool writing;
     /* StoreIOState API */
-    void read_(char *buf, size_t size, off_t offset, STRCB * callback, void *callback_data);
-    virtual bool write(char const *buf, size_t size, off_t offset, FREE * free_func);
+    void read_(char *buf, size_t size, off_t offset, STRCB * callback, void *callback_data) override;
+    bool write(char const *buf, size_t size, off_t offset, FREE * free_func) override;
 
 protected:
     virtual void doCloseCallback (int errflag);

--- a/src/fs/ufs/UFSSwapDir.cc
+++ b/src/fs/ufs/UFSSwapDir.cc
@@ -47,10 +47,10 @@ public:
     UFSCleanLog(SwapDir *aSwapDir) : sd(aSwapDir) {}
 
     /// Get the next entry that is a candidate for clean log writing
-    virtual const StoreEntry *nextEntry();
+    const StoreEntry *nextEntry() override;
 
     /// "write" an entry to the clean log file.
-    virtual void write(StoreEntry const &);
+    void write(StoreEntry const &) override;
 
     SBuf cur;
     SBuf newLog;

--- a/src/fs/ufs/UFSSwapDir.h
+++ b/src/fs/ufs/UFSSwapDir.h
@@ -41,41 +41,41 @@ public:
     static bool FilenoBelongsHere(int fn, int cachedir, int level1dir, int level2dir);
 
     UFSSwapDir(char const *aType, const char *aModuleType);
-    virtual ~UFSSwapDir();
+    ~UFSSwapDir() override;
 
     /* Store::Disk API */
-    virtual void create() override;
-    virtual void init() override;
-    virtual void dump(StoreEntry &) const override;
-    virtual bool doubleCheck(StoreEntry &) override;
-    virtual bool unlinkdUseful() const override;
-    virtual void statfs(StoreEntry &) const override;
-    virtual void maintain() override;
-    virtual void evictCached(StoreEntry &) override;
-    virtual void evictIfFound(const cache_key *) override;
-    virtual bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
-    virtual void reference(StoreEntry &) override;
-    virtual bool dereference(StoreEntry &) override;
-    virtual StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
-    virtual StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
-    virtual void openLog() override;
-    virtual void closeLog() override;
-    virtual int writeCleanStart() override;
-    virtual void writeCleanDone() override;
-    virtual void logEntry(const StoreEntry & e, int op) const override;
-    virtual void parse(int index, char *path) override;
-    virtual void reconfigure() override;
-    virtual int callback() override;
-    virtual void sync() override;
-    virtual void finalizeSwapoutSuccess(const StoreEntry &) override;
-    virtual void finalizeSwapoutFailure(StoreEntry &) override;
-    virtual uint64_t currentSize() const override { return cur_size; }
-    virtual uint64_t currentCount() const override { return n_disk_objects; }
-    virtual ConfigOption *getOptionTree() const override;
-    virtual bool smpAware() const override { return false; }
+    void create() override;
+    void init() override;
+    void dump(StoreEntry &) const override;
+    bool doubleCheck(StoreEntry &) override;
+    bool unlinkdUseful() const override;
+    void statfs(StoreEntry &) const override;
+    void maintain() override;
+    void evictCached(StoreEntry &) override;
+    void evictIfFound(const cache_key *) override;
+    bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
+    void reference(StoreEntry &) override;
+    bool dereference(StoreEntry &) override;
+    StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
+    StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
+    void openLog() override;
+    void closeLog() override;
+    int writeCleanStart() override;
+    void writeCleanDone() override;
+    void logEntry(const StoreEntry & e, int op) const override;
+    void parse(int index, char *path) override;
+    void reconfigure() override;
+    int callback() override;
+    void sync() override;
+    void finalizeSwapoutSuccess(const StoreEntry &) override;
+    void finalizeSwapoutFailure(StoreEntry &) override;
+    uint64_t currentSize() const override { return cur_size; }
+    uint64_t currentCount() const override { return n_disk_objects; }
+    ConfigOption *getOptionTree() const override;
+    bool smpAware() const override { return false; }
     /// as long as ufs relies on the global store_table to index entries,
     /// it is wrong to ask individual ufs cache_dirs whether they have an entry
-    virtual bool hasReadableEntry(const StoreEntry &) const override { return false; }
+    bool hasReadableEntry(const StoreEntry &) const override { return false; }
 
     void unlinkFile(sfileno f);
     // move down when unlink is a virtual method

--- a/src/fs/ufs/UFSSwapLogParser.cc
+++ b/src/fs/ufs/UFSSwapLogParser.cc
@@ -41,7 +41,7 @@ public:
         record_size = sizeof(UFSSwapLogParser_v1_32bs::StoreSwapLogDataOld);
     }
     /// Convert the on-disk 32-bit format to our current format while reading
-    bool ReadRecord(StoreSwapLogData &swapData) {
+    bool ReadRecord(StoreSwapLogData &swapData) override {
         UFSSwapLogParser_v1_32bs::StoreSwapLogDataOld readData;
         int bytes = sizeof(UFSSwapLogParser_v1_32bs::StoreSwapLogDataOld);
 
@@ -71,7 +71,7 @@ public:
     UFSSwapLogParser_v2(FILE *fp): Fs::Ufs::UFSSwapLogParser(fp) {
         record_size = sizeof(StoreSwapLogData);
     }
-    bool ReadRecord(StoreSwapLogData &swapData) {
+    bool ReadRecord(StoreSwapLogData &swapData) override {
         assert(log);
         return fread(&swapData, sizeof(StoreSwapLogData), 1, log) == 1;
     }

--- a/src/helper.h
+++ b/src/helper.h
@@ -172,7 +172,7 @@ private:
 class HelperServerBase: public CbdataParent
 {
 public:
-    virtual ~HelperServerBase();
+    ~HelperServerBase() override;
     /** Closes pipes to the helper safely.
      * Handles the case where the read and write pipes are the same FD.
      *
@@ -266,7 +266,7 @@ public:
     typedef std::map<uint64_t, Requests::iterator> RequestIndex;
     RequestIndex requestsIndex; ///< maps request IDs to requests
 
-    virtual ~helper_server();
+    ~helper_server() override;
     /// Search in queue for the request with requestId, return the related
     /// Xaction object and remove it from queue.
     /// If concurrency is disabled then the requestId is ignored and the
@@ -278,9 +278,9 @@ public:
     void checkForTimedOutRequests(bool const retry);
 
     /*HelperServerBase API*/
-    virtual bool reserved() override {return false;}
-    virtual void dropQueued() override;
-    virtual helper *getParent() const override {return parent;}
+    bool reserved() override {return false;}
+    void dropQueued() override;
+    helper *getParent() const override {return parent;}
 
     /// Read timeout handler
     static void requestTimeout(const CommTimeoutCbParams &io);
@@ -296,13 +296,13 @@ class helper_stateful_server : public HelperServerBase
     CBDATA_CHILD(helper_stateful_server);
 
 public:
-    virtual ~helper_stateful_server();
+    ~helper_stateful_server() override;
     void reserve();
     void clearReservation();
 
     /* HelperServerBase API */
-    virtual bool reserved() override {return reservationId.reserved();}
-    virtual helper *getParent() const override {return parent;}
+    bool reserved() override {return reservationId.reserved();}
+    helper *getParent() const override {return parent;}
 
     /// close handler to handle exited server processes
     static void HelperServerClosed(helper_stateful_server *srv);

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -136,12 +136,12 @@ public:
     }
 
     /* CodeContext API */
-    virtual ScopedId codeContextGist() const; // override
-    virtual std::ostream &detailCodeContext(std::ostream &os) const; // override
+    ScopedId codeContextGist() const override; // override
+    std::ostream &detailCodeContext(std::ostream &os) const override; // override
 
     /* StoreClient API */
-    virtual LogTags *loggingTags() const;
-    virtual void fillChecklist(ACLFilledChecklist &) const;
+    LogTags *loggingTags() const override;
+    void fillChecklist(ACLFilledChecklist &) const override;
 
 public:
     const char *method = nullptr;

--- a/src/http.h
+++ b/src/http.h
@@ -21,7 +21,7 @@ class String;
 
 class HttpStateData : public Client
 {
-    CBDATA_CLASS(HttpStateData);
+    CBDATA_CHILD(HttpStateData);
 
 public:
 

--- a/src/http.h
+++ b/src/http.h
@@ -42,7 +42,7 @@ public:
     };
 
     HttpStateData(FwdState *);
-    ~HttpStateData();
+    ~HttpStateData() override;
 
     static void httpBuildRequestHeader(HttpRequest * request,
                                        StoreEntry * entry,
@@ -50,13 +50,13 @@ public:
                                        HttpHeader * hdr_out,
                                        const Http::StateFlags &flags);
 
-    virtual const Comm::ConnectionPointer & dataConnection() const;
+    const Comm::ConnectionPointer & dataConnection() const override;
     /* should be private */
     bool sendRequest();
     void processReplyHeader();
-    void processReplyBody();
+    void processReplyBody() override;
     void readReply(const CommIoCbParams &io);
-    virtual void maybeReadVirginBody(); // read response data from the network
+    void maybeReadVirginBody() override; // read response data from the network
 
     // Checks whether the response is cacheable/shareable.
     ReuseDecision::Answers reusableReply(ReuseDecision &decision);
@@ -76,7 +76,7 @@ public:
 
 protected:
     /* Client API */
-    virtual void noteDelayAwareReadChance();
+    void noteDelayAwareReadChance() override;
 
     void processReply();
     void proceedAfter1xx();
@@ -104,13 +104,13 @@ private:
     bool continueAfterParsingHeader();
     void truncateVirginBody();
 
-    virtual void start();
-    virtual void haveParsedReplyHeaders();
-    virtual bool getMoreRequestBody(MemBuf &buf);
-    virtual void closeServer(); // end communication with the server
-    virtual bool doneWithServer() const; // did we end communication?
-    virtual void abortAll(const char *reason); // abnormal termination
-    virtual bool mayReadVirginReplyBody() const;
+    void start() override;
+    void haveParsedReplyHeaders() override;
+    bool getMoreRequestBody(MemBuf &buf) override;
+    void closeServer() override; // end communication with the server
+    bool doneWithServer() const override; // did we end communication?
+    void abortAll(const char *reason) override; // abnormal termination
+    bool mayReadVirginReplyBody() const override;
 
     void abortTransaction(const char *reason) { abortAll(reason); } // abnormal termination
 
@@ -127,15 +127,15 @@ private:
 
     // consuming request body
     virtual void handleMoreRequestBodyAvailable();
-    virtual void handleRequestBodyProducerAborted();
+    void handleRequestBodyProducerAborted() override;
 
     void writeReplyBody();
     bool decodeAndWriteReplyBody();
     bool finishingBrokenPost();
     bool finishingChunkedRequest();
-    void doneSendingRequestBody();
+    void doneSendingRequestBody() override;
     void requestBodyHandler(MemBuf &);
-    virtual void sentRequestBody(const CommIoCbParams &io);
+    void sentRequestBody(const CommIoCbParams &io) override;
     void wroteLast(const CommIoCbParams &io);
     void sendComplete();
     void httpStateConnClosed(const CommCloseCbParams &params);

--- a/src/http/Message.h
+++ b/src/http/Message.h
@@ -46,7 +46,7 @@ public:
     };
 
     Message(http_hdr_owner_type);
-    virtual ~Message();
+    ~Message() override;
 
     virtual void reset() = 0; // will have body when http*Clean()s are gone
 

--- a/src/http/Stream.h
+++ b/src/http/Stream.h
@@ -73,7 +73,7 @@ class Stream : public RefCountable
 public:
     /// construct with HTTP/1.x details
     Stream(const Comm::ConnectionPointer &aConn, ClientHttpRequest *aReq);
-    ~Stream();
+    ~Stream() override;
 
     /// register this stream with the Server
     void registerWithConn();

--- a/src/http/one/Parser.h
+++ b/src/http/one/Parser.h
@@ -48,7 +48,7 @@ public:
     Parser &operator =(const Parser &) = default;
     Parser(Parser &&) = default;
     Parser &operator =(Parser &&) = default;
-    virtual ~Parser() {}
+    ~Parser() override {}
 
     /// Set this parser back to a default state.
     /// Will DROP any reference to a buffer (does not free).

--- a/src/http/one/RequestParser.h
+++ b/src/http/one/RequestParser.h
@@ -36,12 +36,12 @@ public:
     RequestParser &operator =(const RequestParser &) = default;
     RequestParser(RequestParser &&) = default;
     RequestParser &operator =(RequestParser &&) = default;
-    virtual ~RequestParser() {}
+    ~RequestParser() override {}
 
     /* Http::One::Parser API */
-    virtual void clear() {*this = RequestParser();}
-    virtual Http1::Parser::size_type firstLineSize() const;
-    virtual bool parse(const SBuf &aBuf);
+    void clear() override {*this = RequestParser();}
+    Http1::Parser::size_type firstLineSize() const override;
+    bool parse(const SBuf &aBuf) override;
 
     /// the HTTP method if this is a request message
     const HttpRequestMethod & method() const {return method_;}

--- a/src/http/one/ResponseParser.h
+++ b/src/http/one/ResponseParser.h
@@ -34,12 +34,12 @@ public:
     ResponseParser &operator =(const ResponseParser &) = default;
     ResponseParser(ResponseParser &&) = default;
     ResponseParser &operator =(ResponseParser &&) = default;
-    virtual ~ResponseParser() {}
+    ~ResponseParser() override {}
 
     /* Http::One::Parser API */
-    virtual void clear() {*this=ResponseParser();}
-    virtual Http1::Parser::size_type firstLineSize() const;
-    virtual bool parse(const SBuf &aBuf);
+    void clear() override {*this=ResponseParser();}
+    Http1::Parser::size_type firstLineSize() const override;
+    bool parse(const SBuf &aBuf) override;
 
     /* respone specific fields, read-only */
     Http::StatusCode messageStatus() const { return statusCode_;}

--- a/src/http/one/TeChunkedParser.h
+++ b/src/http/one/TeChunkedParser.h
@@ -52,7 +52,7 @@ class TeChunkedParser : public Http1::Parser
 {
 public:
     TeChunkedParser();
-    virtual ~TeChunkedParser() { theOut=nullptr; /* we do not own this object */ }
+    ~TeChunkedParser() override { theOut=nullptr; /* we do not own this object */ }
 
     /// set the buffer to be used to store decoded chunk data
     void setPayloadBuffer(MemBuf *parsedContent) {theOut = parsedContent;}
@@ -64,9 +64,9 @@ public:
     bool needsMoreSpace() const;
 
     /* Http1::Parser API */
-    virtual void clear();
-    virtual bool parse(const SBuf &);
-    virtual Parser::size_type firstLineSize() const {return 0;} // has no meaning with multiple chunks
+    void clear() override;
+    bool parse(const SBuf &) override;
+    Parser::size_type firstLineSize() const override {return 0;} // has no meaning with multiple chunks
 
 private:
     bool parseChunkSize(Tokenizer &tok);

--- a/src/icmp/Icmp4.h
+++ b/src/icmp/Icmp4.h
@@ -134,13 +134,13 @@ class Icmp4 : public Icmp
 {
 public:
     Icmp4();
-    virtual ~Icmp4();
+    ~Icmp4() override;
 
-    virtual int Open();
+    int Open() override;
 
 #if USE_ICMP
-    virtual void SendEcho(Ip::Address &, int, const char*, int);
-    virtual void Recv(void);
+    void SendEcho(Ip::Address &, int, const char*, int) override;
+    void Recv(void) override;
 #endif
 };
 

--- a/src/icmp/Icmp6.h
+++ b/src/icmp/Icmp6.h
@@ -46,13 +46,13 @@ class Icmp6 : public Icmp
 {
 public:
     Icmp6();
-    virtual ~Icmp6();
+    ~Icmp6() override;
 
-    virtual int Open();
+    int Open() override;
 
 #if USE_ICMP
-    virtual void SendEcho(Ip::Address &, int, const char*, int);
-    virtual void Recv(void);
+    void SendEcho(Ip::Address &, int, const char*, int) override;
+    void Recv(void) override;
 #endif
 };
 

--- a/src/icmp/IcmpPinger.h
+++ b/src/icmp/IcmpPinger.h
@@ -19,13 +19,13 @@ class IcmpPinger : public Icmp
 {
 public:
     IcmpPinger();
-    virtual ~IcmpPinger();
+    ~IcmpPinger() override;
 
     /// Start and initiate control channel to squid
-    virtual int Open();
+    int Open() override;
 
     /// Shutdown pinger helper and control channel
-    virtual void Close();
+    void Close() override;
 
 #if USE_ICMP
 
@@ -33,11 +33,11 @@ public:
     void SendResult(pingerReplyData &preply, int len);
 
     /// Handle ICMP requests from squid, passing to helpers.
-    virtual void Recv(void);
+    void Recv(void) override;
 
 private:
     // unused in IcmpPinger
-    virtual void SendEcho(Ip::Address &, int, const char *, int) {}
+    void SendEcho(Ip::Address &, int, const char *, int) override {}
 
     /**
      * Control channel(s) to squid.

--- a/src/icmp/IcmpSquid.h
+++ b/src/icmp/IcmpSquid.h
@@ -25,16 +25,16 @@ class IcmpSquid : public Icmp
 {
 public:
     IcmpSquid();
-    virtual ~IcmpSquid();
+    ~IcmpSquid() override;
 
-    virtual int Open();
-    virtual void Close();
+    int Open() override;
+    void Close() override;
 
     void DomainPing(Ip::Address &to, const char *domain);
 
 #if USE_ICMP
-    virtual void SendEcho(Ip::Address &to, int opcode, const char* payload=nullptr, int len=0);
-    virtual void Recv(void);
+    void SendEcho(Ip::Address &to, int opcode, const char* payload=nullptr, int len=0) override;
+    void Recv(void) override;
 #endif
 };
 

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -208,7 +208,7 @@ public:
     ICP2State(icp_common_t & aHeader, HttpRequest *aRequest):
         ICPState(aHeader, aRequest),rtt(0),src_rtt(0),flags(0) {}
 
-    ~ICP2State();
+    ~ICP2State() override;
 
     int rtt;
     int src_rtt;

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -27,7 +27,7 @@ public:
     ICP3State(icp_common_t &aHeader, HttpRequest *aRequest) :
         ICPState(aHeader, aRequest) {}
 
-    ~ICP3State() = default;
+    ~ICP3State() override = default;
 };
 
 /// \ingroup ServerProtocolICPInternal3

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -19,7 +19,7 @@ class IdentLookup : public ACLChecklist::AsyncState
 
 public:
     static IdentLookup *Instance();
-    virtual void checkForAsync(ACLChecklist *)const;
+    void checkForAsync(ACLChecklist *)const override;
 
 private:
     static IdentLookup instance_;
@@ -36,19 +36,19 @@ class ACLIdent : public ACL
 
 public:
     ACLIdent(ACLData<char const *> *newData, char const *);
-    ~ACLIdent();
+    ~ACLIdent() override;
 
     /* ACL API */
-    virtual char const *typeString() const;
-    virtual void parse();
-    virtual bool isProxyAuth() const {return true;}
-    virtual int match(ACLChecklist *checklist);
-    virtual SBufList dump() const;
-    virtual bool empty () const;
+    char const *typeString() const override;
+    void parse() override;
+    bool isProxyAuth() const override {return true;}
+    int match(ACLChecklist *checklist) override;
+    SBufList dump() const override;
+    bool empty () const override;
 
 private:
     /* ACL API */
-    virtual const Acl::Options &lineOptions();
+    const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;
     char const *type_;

--- a/src/ipc/Coordinator.h
+++ b/src/ipc/Coordinator.h
@@ -29,7 +29,7 @@ namespace Ipc
 ///  Coordinates shared activities of Strands (Squid processes or threads)
 class Coordinator: public Port
 {
-    CBDATA_CLASS(Coordinator);
+    CBDATA_CHILD(Coordinator);
 
 public:
     static Coordinator* Instance();

--- a/src/ipc/Coordinator.h
+++ b/src/ipc/Coordinator.h
@@ -42,8 +42,8 @@ public:
     const StrandCoords &strands() const; ///< currently registered strands
 
 protected:
-    virtual void start(); // Port (AsyncJob) API
-    virtual void receive(const TypedMsgHdr& message); // Port API
+    void start() override; // Port (AsyncJob) API
+    void receive(const TypedMsgHdr& message) override; // Port API
 
     StrandCoord* findStrand(int kidId); ///< registered strand or NULL
     void registerStrand(const StrandCoord &); ///< adds or updates existing

--- a/src/ipc/Forwarder.cc
+++ b/src/ipc/Forwarder.cc
@@ -19,8 +19,6 @@
 #include "ipc/RequestId.h"
 #include "ipc/TypedMsgHdr.h"
 
-CBDATA_NAMESPACED_CLASS_INIT(Ipc, Forwarder);
-
 Ipc::Forwarder::RequestsMap Ipc::Forwarder::TheRequestsMap;
 Ipc::RequestId::Index Ipc::Forwarder::LastRequestId = 0;
 

--- a/src/ipc/Forwarder.h
+++ b/src/ipc/Forwarder.h
@@ -28,6 +28,8 @@ namespace Ipc
  */
 class Forwarder: public AsyncJob
 {
+    CBDATA_INTERMEDIATE();
+
 public:
     Forwarder(Request::Pointer aRequest, double aTimeout);
     ~Forwarder() override;
@@ -47,8 +49,8 @@ protected:
     bool doneAll() const override;
 
     virtual void handleError();
-    virtual void handleTimeout() = 0;
-    virtual void handleException(const std::exception& e) = 0;
+    virtual void handleTimeout();
+    virtual void handleException(const std::exception& e);
 
 private:
     static void RequestTimedOut(void* param);

--- a/src/ipc/Forwarder.h
+++ b/src/ipc/Forwarder.h
@@ -28,8 +28,6 @@ namespace Ipc
  */
 class Forwarder: public AsyncJob
 {
-    CBDATA_CLASS(Forwarder);
-
 public:
     Forwarder(Request::Pointer aRequest, double aTimeout);
     ~Forwarder() override;
@@ -49,8 +47,8 @@ protected:
     bool doneAll() const override;
 
     virtual void handleError();
-    virtual void handleTimeout();
-    virtual void handleException(const std::exception& e);
+    virtual void handleTimeout() = 0;
+    virtual void handleException(const std::exception& e) = 0;
 
 private:
     static void RequestTimedOut(void* param);

--- a/src/ipc/Forwarder.h
+++ b/src/ipc/Forwarder.h
@@ -32,21 +32,21 @@ class Forwarder: public AsyncJob
 
 public:
     Forwarder(Request::Pointer aRequest, double aTimeout);
-    virtual ~Forwarder();
+    ~Forwarder() override;
 
     /// finds and calls the right Forwarder upon Coordinator's response
     static void HandleRemoteAck(RequestId);
 
     /* has-to-be-public AsyncJob API */
-    virtual void callException(const std::exception& e);
+    void callException(const std::exception& e) override;
 
     CodeContextPointer codeContext;
 
 protected:
     /* AsyncJob API */
-    virtual void start();
-    virtual void swanSong();
-    virtual bool doneAll() const;
+    void start() override;
+    void swanSong() override;
+    bool doneAll() const override;
 
     virtual void handleError();
     virtual void handleTimeout();

--- a/src/ipc/Inquirer.cc
+++ b/src/ipc/Inquirer.cc
@@ -21,8 +21,6 @@
 #include <algorithm>
 #include <unordered_map>
 
-CBDATA_NAMESPACED_CLASS_INIT(Ipc, Inquirer);
-
 Ipc::RequestId::Index Ipc::Inquirer::LastRequestId = 0;
 
 namespace Ipc {

--- a/src/ipc/Inquirer.h
+++ b/src/ipc/Inquirer.h
@@ -26,6 +26,8 @@ namespace Ipc
 /// aggregating individual strand responses and dumping the result if needed
 class Inquirer: public AsyncJob
 {
+    CBDATA_INTERMEDIATE();
+
 public:
     Inquirer(Request::Pointer aRequest, const Ipc::StrandCoords& coords, double aTimeout);
     ~Inquirer() override;

--- a/src/ipc/Inquirer.h
+++ b/src/ipc/Inquirer.h
@@ -30,22 +30,22 @@ class Inquirer: public AsyncJob
 
 public:
     Inquirer(Request::Pointer aRequest, const Ipc::StrandCoords& coords, double aTimeout);
-    virtual ~Inquirer();
+    ~Inquirer() override;
 
     /// finds and calls the right Inquirer upon strand's response
     static void HandleRemoteAck(const Response& response);
 
     /* has-to-be-public AsyncJob API */
-    virtual void callException(const std::exception& e);
+    void callException(const std::exception& e) override;
 
     CodeContextPointer codeContext;
 
 protected:
     /* AsyncJob API */
-    virtual void start();
-    virtual void swanSong();
-    virtual bool doneAll() const;
-    virtual const char *status() const;
+    void start() override;
+    void swanSong() override;
+    bool doneAll() const override;
+    const char *status() const override;
 
     /// inquire the next strand
     virtual void inquire();

--- a/src/ipc/Inquirer.h
+++ b/src/ipc/Inquirer.h
@@ -26,8 +26,6 @@ namespace Ipc
 /// aggregating individual strand responses and dumping the result if needed
 class Inquirer: public AsyncJob
 {
-    CBDATA_CLASS(Inquirer);
-
 public:
     Inquirer(Request::Pointer aRequest, const Ipc::StrandCoords& coords, double aTimeout);
     ~Inquirer() override;

--- a/src/ipc/Port.h
+++ b/src/ipc/Port.h
@@ -29,8 +29,8 @@ public:
     static String CoordinatorAddr();
 
 protected:
-    virtual void start() = 0; // UdsOp (AsyncJob) API; has body
-    virtual bool doneAll() const; // UdsOp (AsyncJob) API
+    void start() override = 0; // UdsOp (AsyncJob) API; has body
+    bool doneAll() const override; // UdsOp (AsyncJob) API
 
     /// read the next incoming message
     void doListen();

--- a/src/ipc/Queue.h
+++ b/src/ipc/Queue.h
@@ -284,12 +284,12 @@ public:
     template<class Value> bool findOldest(const int remoteProcessId, Value &value) const;
 
 protected:
-    virtual const OneToOneUniQueue &inQueue(const int remoteProcessId) const;
-    virtual const OneToOneUniQueue &outQueue(const int remoteProcessId) const;
-    virtual const QueueReader &localReader() const;
-    virtual const QueueReader &remoteReader(const int processId) const;
-    virtual int remotesCount() const;
-    virtual int remotesIdOffset() const;
+    const OneToOneUniQueue &inQueue(const int remoteProcessId) const override;
+    const OneToOneUniQueue &outQueue(const int remoteProcessId) const override;
+    const QueueReader &localReader() const override;
+    const QueueReader &remoteReader(const int processId) const override;
+    int remotesCount() const override;
+    int remotesIdOffset() const override;
 
 private:
     bool validProcessId(const Group group, const int processId) const;
@@ -348,12 +348,12 @@ public:
     MultiQueue(const String &id, const int localProcessId);
 
 protected:
-    virtual const OneToOneUniQueue &inQueue(const int remoteProcessId) const;
-    virtual const OneToOneUniQueue &outQueue(const int remoteProcessId) const;
-    virtual const QueueReader &localReader() const;
-    virtual const QueueReader &remoteReader(const int remoteProcessId) const;
-    virtual int remotesCount() const;
-    virtual int remotesIdOffset() const;
+    const OneToOneUniQueue &inQueue(const int remoteProcessId) const override;
+    const OneToOneUniQueue &outQueue(const int remoteProcessId) const override;
+    const QueueReader &localReader() const override;
+    const QueueReader &remoteReader(const int remoteProcessId) const override;
+    int remotesCount() const override;
+    int remotesIdOffset() const override;
 
 private:
     bool validProcessId(const int processId) const;

--- a/src/ipc/Strand.h
+++ b/src/ipc/Strand.h
@@ -26,7 +26,7 @@ class StrandCoord;
 /// Receives coordination messages on behalf of its process or thread
 class Strand: public Port
 {
-    CBDATA_CLASS(Strand);
+    CBDATA_CHILD(Strand);
 
 public:
     Strand();

--- a/src/ipc/Strand.h
+++ b/src/ipc/Strand.h
@@ -31,11 +31,11 @@ class Strand: public Port
 public:
     Strand();
 
-    virtual void start(); // Port (AsyncJob) API
+    void start() override; // Port (AsyncJob) API
 
 protected:
-    virtual void timedout(); // Port (UsdOp) API
-    virtual void receive(const TypedMsgHdr &message); // Port API
+    void timedout() override; // Port (UsdOp) API
+    void receive(const TypedMsgHdr &message) override; // Port API
 
 private:
     void registerSelf(); /// let Coordinator know this strand exists

--- a/src/ipc/UdsOp.h
+++ b/src/ipc/UdsOp.h
@@ -67,7 +67,7 @@ struct sockaddr_un PathToAddress(const String &pathAddr);
 /// attempts to send an IPC message a few times, with a timeout
 class UdsSender: public UdsOp
 {
-    CBDATA_CLASS(UdsSender);
+    CBDATA_CHILD(UdsSender);
 
 public:
     UdsSender(const String& pathAddr, const TypedMsgHdr& aMessage);

--- a/src/ipc/UdsOp.h
+++ b/src/ipc/UdsOp.h
@@ -31,7 +31,7 @@ class UdsOp: public AsyncJob
 {
 public:
     UdsOp(const String &pathAddr);
-    virtual ~UdsOp();
+    ~UdsOp() override;
 
 public:
     struct sockaddr_un address; ///< UDS address from path; treat as read-only
@@ -75,10 +75,10 @@ public:
     CodeContextPointer codeContext;
 
 protected:
-    virtual void swanSong(); // UdsOp (AsyncJob) API
-    virtual void start(); // UdsOp (AsyncJob) API
-    virtual bool doneAll() const; // UdsOp (AsyncJob) API
-    virtual void timedout(); // UdsOp API
+    void swanSong() override; // UdsOp (AsyncJob) API
+    void start() override; // UdsOp (AsyncJob) API
+    bool doneAll() const override; // UdsOp (AsyncJob) API
+    void timedout() override; // UdsOp API
 
 private:
     void startSleep();

--- a/src/ipc/mem/Pages.cc
+++ b/src/ipc/mem/Pages.cc
@@ -94,10 +94,10 @@ class SharedMemPagesRr: public Ipc::Mem::RegisteredRunner
 public:
     /* RegisteredRunner API */
     SharedMemPagesRr(): owner(nullptr) {}
-    virtual void useConfig();
-    virtual void create();
-    virtual void open();
-    virtual ~SharedMemPagesRr();
+    void useConfig() override;
+    void create() override;
+    void open() override;
+    ~SharedMemPagesRr() override;
 
 private:
     Ipc::Mem::PagePool::Owner *owner;

--- a/src/ipc/mem/Segment.h
+++ b/src/ipc/mem/Segment.h
@@ -85,7 +85,7 @@ class RegisteredRunner: public ::RegisteredRunner
 {
 public:
     /* RegisteredRunner API */
-    virtual void useConfig();
+    void useConfig() override;
 
 protected:
     /// called when the runner should create a new memory segment

--- a/src/ipcache.h
+++ b/src/ipcache.h
@@ -194,7 +194,7 @@ private:
 class IpReceiver: public virtual CbdataParent
 {
 public:
-    virtual ~IpReceiver() {}
+    ~IpReceiver() override {}
 
     /// Called when nbgethostbyname() fully resolves the name.
     /// The `ips` may contain both bad and good IP addresses, but each good IP

--- a/src/log/TcpLogger.h
+++ b/src/log/TcpLogger.h
@@ -38,7 +38,7 @@ public:
 
 protected:
     TcpLogger(size_t, bool, Ip::Address);
-    virtual ~TcpLogger();
+    ~TcpLogger() override;
 
     /// Called when Squid is reconfiguring (or exiting) to give us a chance to
     /// flush remaining buffers and end this job w/o loss of data. No new log
@@ -53,9 +53,9 @@ protected:
     void flush();
 
     /* AsyncJob API */
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
 
 private:
     /* Logfile API. Map c-style Logfile calls to TcpLogger method calls. */

--- a/src/log/TcpLogger.h
+++ b/src/log/TcpLogger.h
@@ -28,7 +28,7 @@ namespace Log
  */
 class TcpLogger : public AsyncJob
 {
-    CBDATA_CLASS(TcpLogger);
+    CBDATA_CHILD(TcpLogger);
 
 public:
     typedef CbcPointer<TcpLogger> Pointer;

--- a/src/main.cc
+++ b/src/main.cc
@@ -187,7 +187,7 @@ class StoreRootEngine : public AsyncEngine
 {
 
 public:
-    int checkEvents(int) {
+    int checkEvents(int) override {
         Store::Root().callback();
         return EVENT_IDLE;
     };
@@ -197,7 +197,7 @@ class SignalEngine: public AsyncEngine
 {
 
 public:
-    virtual int checkEvents(int timeout);
+    int checkEvents(int timeout) override;
 
 private:
     static void StopEventLoop(void *) {

--- a/src/mem/Pool.h
+++ b/src/mem/Pool.h
@@ -143,11 +143,11 @@ public:
     virtual void clean(time_t maxage) = 0;
 
     /* Mem::Allocator API */
-    virtual PoolMeter const &getMeter() const;
-    virtual void *alloc();
-    virtual void freeOne(void *);
-    virtual size_t objectSize() const;
-    virtual int getInUseCount() = 0;
+    PoolMeter const &getMeter() const override;
+    void *alloc() override;
+    void freeOne(void *) override;
+    size_t objectSize() const override;
+    int getInUseCount() override = 0;
 
 protected:
     virtual void *allocate() = 0;

--- a/src/mem/PoolChunked.h
+++ b/src/mem/PoolChunked.h
@@ -23,23 +23,23 @@ class MemPoolChunked : public MemImplementingAllocator
 public:
     friend class MemChunk;
     MemPoolChunked(const char *label, size_t obj_size);
-    ~MemPoolChunked();
+    ~MemPoolChunked() override;
     void convertFreeCacheToChunkFreeCache();
-    virtual void clean(time_t maxage);
+    void clean(time_t maxage) override;
     void createChunk();
     void *get();
     void push(void *obj);
 
     /* Mem::Allocator API */
-    virtual size_t getStats(Mem::PoolStats &);
-    virtual int getInUseCount();
-    virtual void setChunkSize(size_t);
+    size_t getStats(Mem::PoolStats &) override;
+    int getInUseCount() override;
+    void setChunkSize(size_t) override;
 
 protected:
-    virtual void *allocate();
-    virtual void deallocate(void *, bool aggressive);
+    void *allocate() override;
+    void deallocate(void *, bool aggressive) override;
 public:
-    virtual bool idleTrigger(int shift) const;
+    bool idleTrigger(int shift) const override;
 
     size_t chunk_size;
     int chunk_capacity;

--- a/src/mem/PoolMalloc.h
+++ b/src/mem/PoolMalloc.h
@@ -37,17 +37,17 @@ class MemPoolMalloc : public MemImplementingAllocator
 {
 public:
     MemPoolMalloc(char const *label, size_t aSize);
-    ~MemPoolMalloc();
-    virtual bool idleTrigger(int shift) const;
-    virtual void clean(time_t maxage);
+    ~MemPoolMalloc() override;
+    bool idleTrigger(int shift) const override;
+    void clean(time_t maxage) override;
 
     /* Mem::Allocator API */
-    virtual size_t getStats(Mem::PoolStats &);
-    virtual int getInUseCount();
+    size_t getStats(Mem::PoolStats &) override;
+    int getInUseCount() override;
 
 protected:
-    virtual void *allocate();
-    virtual void deallocate(void *, bool aggressive);
+    void *allocate() override;
+    void deallocate(void *, bool aggressive) override;
 private:
     std::stack<void *> freelist;
 };

--- a/src/mgr/Action.h
+++ b/src/mgr/Action.h
@@ -28,7 +28,7 @@ public:
 
 public:
     Action(const CommandPointer &aCmd);
-    virtual ~Action();
+    ~Action() override;
 
     /* for local Cache Manager use */
 

--- a/src/mgr/ActionCreator.h
+++ b/src/mgr/ActionCreator.h
@@ -25,7 +25,7 @@ class ActionCreator: public RefCountable
 public:
     typedef RefCount<ActionCreator> Pointer;
 
-    virtual ~ActionCreator() {}
+    ~ActionCreator() override {}
 
     /// returns a pointer to the new Action object for cmd; never nil
     virtual ActionPointer create(const CommandPointer &cmd) const = 0;

--- a/src/mgr/ActionWriter.h
+++ b/src/mgr/ActionWriter.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     /* AsyncJob API */
-    virtual void start();
+    void start() override;
 
 private:
     Action::Pointer action; ///< action that fills the entry

--- a/src/mgr/ActionWriter.h
+++ b/src/mgr/ActionWriter.h
@@ -21,7 +21,7 @@ namespace Mgr
 /// Comm-writes it using parent StoreToCommWriter.
 class ActionWriter: public StoreToCommWriter
 {
-    CBDATA_CLASS(ActionWriter);
+    CBDATA_CHILD(ActionWriter);
 
 public:
     ActionWriter(const Action::Pointer &anAction, const Comm::ConnectionPointer &conn);

--- a/src/mgr/BasicActions.h
+++ b/src/mgr/BasicActions.h
@@ -27,7 +27,7 @@ class IndexAction: public Action
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void dump(StoreEntry *entry);
+    void dump(StoreEntry *entry) override;
 
 protected:
     IndexAction(const CommandPointer &cmd);
@@ -39,7 +39,7 @@ class MenuAction: public Action
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void dump(StoreEntry *entry);
+    void dump(StoreEntry *entry) override;
 
 protected:
     MenuAction(const CommandPointer &cmd);
@@ -51,7 +51,7 @@ class ShutdownAction: public Action
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void dump(StoreEntry *entry);
+    void dump(StoreEntry *entry) override;
 
 protected:
     ShutdownAction(const CommandPointer &cmd);
@@ -63,7 +63,7 @@ class ReconfigureAction: public Action
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void dump(StoreEntry *entry);
+    void dump(StoreEntry *entry) override;
 
 protected:
     ReconfigureAction(const CommandPointer &cmd);
@@ -75,7 +75,7 @@ class RotateAction: public Action
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void dump(StoreEntry *entry);
+    void dump(StoreEntry *entry) override;
 
 protected:
     RotateAction(const CommandPointer &cmd);
@@ -87,7 +87,7 @@ class OfflineToggleAction: public Action
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void dump(StoreEntry *entry);
+    void dump(StoreEntry *entry) override;
 
 protected:
     OfflineToggleAction(const CommandPointer &cmd);

--- a/src/mgr/CountersAction.h
+++ b/src/mgr/CountersAction.h
@@ -96,14 +96,14 @@ protected:
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void add(const Action& action);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& msg);
+    void add(const Action& action) override;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpack(const Ipc::TypedMsgHdr& msg) override;
 
 protected:
     /* Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     CountersActionData data;

--- a/src/mgr/Filler.h
+++ b/src/mgr/Filler.h
@@ -22,7 +22,7 @@ namespace Mgr
 /// provides Coordinator with a local cache manager response
 class Filler: public StoreToCommWriter
 {
-    CBDATA_CLASS(Filler);
+    CBDATA_CHILD(Filler);
 
 public:
     Filler(const Action::Pointer &, const Comm::ConnectionPointer &, Ipc::RequestId);

--- a/src/mgr/Filler.h
+++ b/src/mgr/Filler.h
@@ -29,8 +29,8 @@ public:
 
 protected:
     /* AsyncJob API */
-    virtual void start();
-    virtual void swanSong();
+    void start() override;
+    void swanSong() override;
 
 private:
     Action::Pointer action; ///< action that will run() and sendResponse()

--- a/src/mgr/Forwarder.h
+++ b/src/mgr/Forwarder.h
@@ -30,7 +30,7 @@ namespace Mgr
  */
 class Forwarder: public Ipc::Forwarder
 {
-    CBDATA_CLASS(Forwarder);
+    CBDATA_CHILD(Forwarder);
 
 public:
     Forwarder(const Comm::ConnectionPointer &aConn, const ActionParams &aParams, HttpRequest* aRequest,

--- a/src/mgr/Forwarder.h
+++ b/src/mgr/Forwarder.h
@@ -35,14 +35,14 @@ class Forwarder: public Ipc::Forwarder
 public:
     Forwarder(const Comm::ConnectionPointer &aConn, const ActionParams &aParams, HttpRequest* aRequest,
               StoreEntry* anEntry, const AccessLogEntryPointer &anAle);
-    virtual ~Forwarder();
+    ~Forwarder() override;
 
 protected:
     /* Ipc::Forwarder API */
-    virtual void swanSong();
-    virtual void handleError();
-    virtual void handleTimeout();
-    virtual void handleException(const std::exception& e);
+    void swanSong() override;
+    void handleError() override;
+    void handleTimeout() override;
+    void handleException(const std::exception& e) override;
 
 private:
     void noteCommClosed(const CommCloseCbParams& params);

--- a/src/mgr/FunAction.h
+++ b/src/mgr/FunAction.h
@@ -28,13 +28,13 @@ public:
     static Pointer Create(const CommandPointer &cmd, OBJH *aHandler);
 
     /* Action API */
-    virtual void respond(const Request& request);
+    void respond(const Request& request) override;
     // we cannot aggregate because we do not even know what the handler does
-    virtual bool aggregatable() const { return false; }
+    bool aggregatable() const override { return false; }
 
 protected:
     /* Action API */
-    virtual void dump(StoreEntry *entry);
+    void dump(StoreEntry *entry) override;
 
 private:
     OBJH *handler; ///< legacy function that collects and dumps info
@@ -47,7 +47,7 @@ public:
     explicit FunActionCreator(OBJH *aHandler): handler(aHandler) {}
 
     /* ActionCreator API */
-    virtual Action::Pointer create(const CommandPointer &cmd) const {
+    Action::Pointer create(const CommandPointer &cmd) const override {
         return FunAction::Create(cmd, handler);
     }
 

--- a/src/mgr/InfoAction.h
+++ b/src/mgr/InfoAction.h
@@ -99,15 +99,15 @@ protected:
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void add(const Action& action);
-    virtual void respond(const Request& request);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& msg);
+    void add(const Action& action) override;
+    void respond(const Request& request) override;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpack(const Ipc::TypedMsgHdr& msg) override;
 
 protected:
     /* Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     InfoActionData data;

--- a/src/mgr/Inquirer.h
+++ b/src/mgr/Inquirer.h
@@ -33,13 +33,13 @@ public:
 
 protected:
     /* AsyncJob API */
-    virtual void start();
-    virtual bool doneAll() const;
+    void start() override;
+    bool doneAll() const override;
 
     /* Ipc::Inquirer API */
-    virtual void cleanup();
-    virtual void sendResponse();
-    virtual bool aggregate(Ipc::Response::Pointer aResponse);
+    void cleanup() override;
+    void sendResponse() override;
+    bool aggregate(Ipc::Response::Pointer aResponse) override;
 
 private:
     void noteWroteHeader(const CommIoCbParams& params);

--- a/src/mgr/Inquirer.h
+++ b/src/mgr/Inquirer.h
@@ -25,7 +25,7 @@ namespace Mgr
 /// aggregating individual strand responses and dumping the result if needed
 class Inquirer: public Ipc::Inquirer
 {
-    CBDATA_CLASS(Inquirer);
+    CBDATA_CHILD(Inquirer);
 
 public:
     Inquirer(Action::Pointer anAction, const Request &aCause,

--- a/src/mgr/IntParam.h
+++ b/src/mgr/IntParam.h
@@ -24,8 +24,8 @@ class IntParam: public QueryParam
 public:
     IntParam();
     IntParam(const std::vector<int>& anArray);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpackValue(const Ipc::TypedMsgHdr& msg);
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpackValue(const Ipc::TypedMsgHdr& msg) override;
     const std::vector<int>& value() const;
 
 private:

--- a/src/mgr/IntervalAction.h
+++ b/src/mgr/IntervalAction.h
@@ -116,14 +116,14 @@ public:
     static Pointer Create5min(const CommandPointer &cmd);
     static Pointer Create60min(const CommandPointer &cmd);
     /* Action API */
-    virtual void add(const Action& action);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& msg);
+    void add(const Action& action) override;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpack(const Ipc::TypedMsgHdr& msg) override;
 
 protected:
     /* Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     int minutes;

--- a/src/mgr/IoAction.h
+++ b/src/mgr/IoAction.h
@@ -40,14 +40,14 @@ protected:
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void add(const Action& action);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& msg);
+    void add(const Action& action) override;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpack(const Ipc::TypedMsgHdr& msg) override;
 
 protected:
     /* Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     IoActionData data;

--- a/src/mgr/QueryParam.h
+++ b/src/mgr/QueryParam.h
@@ -25,7 +25,7 @@ public:
 
 public:
     QueryParam(Type aType): type(aType) {}
-    virtual ~QueryParam() {}
+    ~QueryParam() override {}
     virtual void pack(Ipc::TypedMsgHdr& msg) const = 0; ///< store parameter into msg
     virtual void unpackValue(const Ipc::TypedMsgHdr& msg) = 0; ///< load parameter value from msg
 

--- a/src/mgr/Request.h
+++ b/src/mgr/Request.h
@@ -27,8 +27,8 @@ public:
 
     explicit Request(const Ipc::TypedMsgHdr& msg); ///< from recvmsg()
     /* Ipc::Request API */
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual Pointer clone() const;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    Pointer clone() const override;
 
 public:
     Comm::ConnectionPointer conn; ///< HTTP client connection descriptor

--- a/src/mgr/Response.h
+++ b/src/mgr/Response.h
@@ -29,8 +29,8 @@ public:
     explicit Response(const Ipc::TypedMsgHdr& msg); ///< from recvmsg()
 
     /* Ipc::Response API */
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual Ipc::Response::Pointer clone() const;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    Ipc::Response::Pointer clone() const override;
 
     bool hasAction() const; ///< whether response contain action object
     const Action& getAction() const; ///< returns action object

--- a/src/mgr/ServiceTimesAction.h
+++ b/src/mgr/ServiceTimesAction.h
@@ -53,14 +53,14 @@ protected:
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void add(const Action& action);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& msg);
+    void add(const Action& action) override;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpack(const Ipc::TypedMsgHdr& msg) override;
 
 protected:
     /* Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     ServiceTimesActionData data;

--- a/src/mgr/StoreIoAction.h
+++ b/src/mgr/StoreIoAction.h
@@ -39,14 +39,14 @@ protected:
 public:
     static Pointer Create(const CommandPointer &cmd);
     /* Action API */
-    virtual void add(const Action& action);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpack(const Ipc::TypedMsgHdr& msg);
+    void add(const Action& action) override;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpack(const Ipc::TypedMsgHdr& msg) override;
 
 protected:
     /* Action API */
-    virtual void collect();
-    virtual void dump(StoreEntry* entry);
+    void collect() override;
+    void dump(StoreEntry* entry) override;
 
 private:
     StoreIoActionData data;

--- a/src/mgr/StoreToCommWriter.cc
+++ b/src/mgr/StoreToCommWriter.cc
@@ -20,8 +20,6 @@
 #include "Store.h"
 #include "StoreClient.h"
 
-CBDATA_NAMESPACED_CLASS_INIT(Mgr, StoreToCommWriter);
-
 Mgr::StoreToCommWriter::StoreToCommWriter(const Comm::ConnectionPointer &conn, StoreEntry* anEntry):
     AsyncJob("Mgr::StoreToCommWriter"),
     clientConnection(conn), entry(anEntry), sc(nullptr), writeOffset(0), closer(nullptr)

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -28,15 +28,13 @@ namespace Mgr
 /// for the given StoreEntry and client FD
 class StoreToCommWriter: public AsyncJob
 {
-    CBDATA_CLASS(StoreToCommWriter);
-
 public:
     StoreToCommWriter(const Comm::ConnectionPointer &conn, StoreEntry *anEntry);
     ~StoreToCommWriter() override;
 
 protected:
     /* AsyncJob API */
-    void start() override;
+    void start() override = 0;
     void swanSong() override;
     bool doneAll() const override;
 

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -32,13 +32,13 @@ class StoreToCommWriter: public AsyncJob
 
 public:
     StoreToCommWriter(const Comm::ConnectionPointer &conn, StoreEntry *anEntry);
-    virtual ~StoreToCommWriter();
+    ~StoreToCommWriter() override;
 
 protected:
     /* AsyncJob API */
-    virtual void start();
-    virtual void swanSong();
-    virtual bool doneAll() const;
+    void start() override;
+    void swanSong() override;
+    bool doneAll() const override;
 
     /// request more action results from the store
     void scheduleStoreCopy();

--- a/src/mgr/StoreToCommWriter.h
+++ b/src/mgr/StoreToCommWriter.h
@@ -28,13 +28,15 @@ namespace Mgr
 /// for the given StoreEntry and client FD
 class StoreToCommWriter: public AsyncJob
 {
+    CBDATA_INTERMEDIATE();
+
 public:
     StoreToCommWriter(const Comm::ConnectionPointer &conn, StoreEntry *anEntry);
     ~StoreToCommWriter() override;
 
 protected:
     /* AsyncJob API */
-    void start() override = 0;
+    void start() override;
     void swanSong() override;
     bool doneAll() const override;
 

--- a/src/mgr/StringParam.h
+++ b/src/mgr/StringParam.h
@@ -24,8 +24,8 @@ class StringParam: public QueryParam
 public:
     StringParam();
     StringParam(const String& aString);
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual void unpackValue(const Ipc::TypedMsgHdr& msg);
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    void unpackValue(const Ipc::TypedMsgHdr& msg) override;
     const String& value() const;
 
 private:

--- a/src/mime.cc
+++ b/src/mime.cc
@@ -40,14 +40,14 @@ class MimeIcon : public StoreClient
 
 public:
     explicit MimeIcon(const char *aName);
-    ~MimeIcon();
+    ~MimeIcon() override;
     void setName(char const *);
     SBuf getName() const;
     void load();
 
     /* StoreClient API */
-    virtual LogTags *loggingTags() const { return nullptr; } // no access logging/ACLs
-    virtual void fillChecklist(ACLFilledChecklist &) const;
+    LogTags *loggingTags() const override { return nullptr; } // no access logging/ACLs
+    void fillChecklist(ACLFilledChecklist &) const override;
 
 private:
     SBuf icon_;

--- a/src/pconn.h
+++ b/src/pconn.h
@@ -40,7 +40,7 @@ class IdleConnList: public hash_link, private IndependentRunner
 
 public:
     IdleConnList(const char *key, PconnPool *parent);
-    ~IdleConnList();
+    ~IdleConnList() override;
 
     /// Pass control of the connection to the idle list.
     void push(const Comm::ConnectionPointer &conn);
@@ -62,7 +62,7 @@ public:
     void closeN(size_t count);
 
     // IndependentRunner API
-    virtual void endingShutdown();
+    void endingShutdown() override;
 private:
     bool isAvailable(int i) const;
     bool removeAt(int index);

--- a/src/sbuf/MemBlob.h
+++ b/src/sbuf/MemBlob.h
@@ -59,7 +59,7 @@ public:
     /// create a MemBlob containing a copy of the buffer of a given size
     MemBlob(const char *buffer, const size_type bufferSize);
 
-    virtual ~MemBlob();
+    ~MemBlob() override;
 
     /// the number unused bytes at the end of the allocated blob
     size_type spaceSize() const { return capacity - size; }

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -18,7 +18,7 @@ namespace Security
 
 /// A simple PeerConnector for SSL/TLS cache_peers. No SslBump capabilities.
 class BlindPeerConnector: public Security::PeerConnector {
-    CBDATA_CLASS(BlindPeerConnector);
+    CBDATA_CHILD(BlindPeerConnector);
 public:
     BlindPeerConnector(HttpRequestPointer &aRequest,
                        const Comm::ConnectionPointer &aServerConn,

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -37,14 +37,14 @@ public:
     /// to try and reuse a TLS session and sets the hostname to use for
     /// certificate validation
     /// \returns true on successful initialization
-    virtual bool initialize(Security::SessionPointer &);
+    bool initialize(Security::SessionPointer &) override;
 
     /// Return the configured TLS context object
-    virtual Security::ContextPointer getTlsContext();
+    Security::ContextPointer getTlsContext() override;
 
     /// On success, stores the used TLS session for later use.
     /// On error, informs the peer.
-    virtual void noteNegotiationDone(ErrorState *);
+    void noteNegotiationDone(ErrorState *) override;
 };
 
 } // namespace Security

--- a/src/security/ErrorDetail.h
+++ b/src/security/ErrorDetail.h
@@ -56,8 +56,8 @@ public:
 #endif
 
     /* ErrorDetail API */
-    virtual SBuf brief() const;
-    virtual SBuf verbose(const HttpRequestPointer &) const;
+    SBuf brief() const override;
+    SBuf verbose(const HttpRequestPointer &) const override;
 
     /// \returns error category; \see ErrorCode
     ErrorCode errorNo() const { return error_no; }

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -35,8 +35,6 @@
 #include "ssl/helper.h"
 #endif
 
-CBDATA_NAMESPACED_CLASS_INIT(Security, PeerConnector);
-
 Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerConn, const AsyncCallback<EncryptorAnswer> &aCallback, const AccessLogEntryPointer &alp, const time_t timeout):
     AsyncJob("Security::PeerConnector"),
     noteFwdPconnUse(false),

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -47,6 +47,8 @@ typedef RefCount<IoResult> IoResultPointer;
  */
 class PeerConnector: virtual public AsyncJob, public Acl::ChecklistFiller
 {
+    CBDATA_INTERMEDIATE();
+
 public:
     typedef CbcPointer<PeerConnector> Pointer;
 

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -56,20 +56,20 @@ public:
                   const AsyncCallback<EncryptorAnswer> &,
                   const AccessLogEntryPointer &alp,
                   const time_t timeout = 0);
-    virtual ~PeerConnector();
+    ~PeerConnector() override;
 
     /// hack: whether the connection requires fwdPconnPool->noteUses()
     bool noteFwdPconnUse;
 
 protected:
     // AsyncJob API
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
-    virtual const char *status() const;
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
+    const char *status() const override;
 
     /* Acl::ChecklistFiller API */
-    virtual void fillChecklist(ACLFilledChecklist &) const;
+    void fillChecklist(ACLFilledChecklist &) const override;
 
     /// The connection read timeout callback handler.
     void commTimeoutHandler(const CommTimeoutCbParams &);

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -47,8 +47,6 @@ typedef RefCount<IoResult> IoResultPointer;
  */
 class PeerConnector: virtual public AsyncJob, public Acl::ChecklistFiller
 {
-    CBDATA_CLASS(PeerConnector);
-
 public:
     typedef CbcPointer<PeerConnector> Pointer;
 

--- a/src/security/ServerOptions.h
+++ b/src/security/ServerOptions.h
@@ -39,13 +39,13 @@ public:
     ServerOptions &operator =(const ServerOptions &);
     ServerOptions(ServerOptions &&o) { this->operator =(o); }
     ServerOptions &operator =(ServerOptions &&o) { this->operator =(o); return *this; }
-    virtual ~ServerOptions() = default;
+    ~ServerOptions() override = default;
 
     /* Security::PeerOptions API */
-    virtual void parse(const char *);
-    virtual void clear() {*this = ServerOptions();}
-    virtual Security::ContextPointer createBlankContext() const;
-    virtual void dumpCfg(Packable *, const char *pfx) const;
+    void parse(const char *) override;
+    void clear() override {*this = ServerOptions();}
+    Security::ContextPointer createBlankContext() const override;
+    void dumpCfg(Packable *, const char *pfx) const override;
 
     /// initialize all server contexts as-needed and load PEM files.
     /// if none can be created this may do nothing.

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -413,11 +413,11 @@ class SharedSessionCacheRr: public Ipc::Mem::RegisteredRunner
 public:
     /* RegisteredRunner API */
     SharedSessionCacheRr(): owner(nullptr) {}
-    virtual void useConfig();
-    virtual ~SharedSessionCacheRr();
+    void useConfig() override;
+    ~SharedSessionCacheRr() override;
 
 protected:
-    virtual void create();
+    void create() override;
 
 private:
     Ipc::MemMap::Owner *owner;

--- a/src/servers/FtpServer.h
+++ b/src/servers/FtpServer.h
@@ -60,10 +60,10 @@ class Server: public ConnStateData
 
 public:
     explicit Server(const MasterXaction::Pointer &xact);
-    virtual ~Server() override;
+    ~Server() override;
 
     /* AsyncJob API */
-    virtual void callException(const std::exception &e) override;
+    void callException(const std::exception &e) override;
 
     /// Called by Ftp::Client class when it is start receiving or
     /// sending data.
@@ -93,21 +93,21 @@ protected:
     };
 
     /* ConnStateData API */
-    virtual Http::Stream *parseOneRequest() override;
-    virtual void processParsedRequest(Http::StreamPointer &context) override;
-    virtual void notePeerConnection(Comm::ConnectionPointer conn) override;
-    virtual void clientPinnedConnectionClosed(const CommCloseCbParams &io) override;
-    virtual void handleReply(HttpReply *header, StoreIOBuffer receivedData) override;
-    virtual int pipelinePrefetchMax() const override;
-    virtual bool writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &call) override;
-    virtual time_t idleTimeout() const override;
+    Http::Stream *parseOneRequest() override;
+    void processParsedRequest(Http::StreamPointer &context) override;
+    void notePeerConnection(Comm::ConnectionPointer conn) override;
+    void clientPinnedConnectionClosed(const CommCloseCbParams &io) override;
+    void handleReply(HttpReply *header, StoreIOBuffer receivedData) override;
+    int pipelinePrefetchMax() const override;
+    bool writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &call) override;
+    time_t idleTimeout() const override;
 
     /* BodyPipe API */
-    virtual void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;
-    virtual void noteBodyConsumerAborted(BodyPipe::Pointer ptr) override;
+    void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;
+    void noteBodyConsumerAborted(BodyPipe::Pointer ptr) override;
 
     /* AsyncJob API */
-    virtual void start() override;
+    void start() override;
 
     /* Comm callbacks */
     static void AcceptCtrlConnection(const CommAcceptCbParams &params);

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -19,7 +19,7 @@ namespace One
 /// Manages a connection from an HTTP/1 or HTTP/0.9 client.
 class Server: public ConnStateData
 {
-    CBDATA_CLASS(Server);
+    CBDATA_CHILD(Server);
 
 public:
     Server(const MasterXaction::Pointer &xact, const bool beHttpsServer);

--- a/src/servers/Http1Server.h
+++ b/src/servers/Http1Server.h
@@ -23,26 +23,26 @@ class Server: public ConnStateData
 
 public:
     Server(const MasterXaction::Pointer &xact, const bool beHttpsServer);
-    virtual ~Server() {}
+    ~Server() override {}
 
     void readSomeHttpData();
 
 protected:
     /* ConnStateData API */
-    virtual Http::Stream *parseOneRequest();
-    virtual void processParsedRequest(Http::StreamPointer &context);
-    virtual void handleReply(HttpReply *rep, StoreIOBuffer receivedData);
-    virtual bool writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &call);
-    virtual int pipelinePrefetchMax() const;
-    virtual time_t idleTimeout() const;
-    virtual void noteTakeServerConnectionControl(ServerConnectionContext);
+    Http::Stream *parseOneRequest() override;
+    void processParsedRequest(Http::StreamPointer &context) override;
+    void handleReply(HttpReply *rep, StoreIOBuffer receivedData) override;
+    bool writeControlMsgAndCall(HttpReply *rep, AsyncCall::Pointer &call) override;
+    int pipelinePrefetchMax() const override;
+    time_t idleTimeout() const override;
+    void noteTakeServerConnectionControl(ServerConnectionContext) override;
 
     /* BodyPipe API */
-    virtual void noteMoreBodySpaceAvailable(BodyPipe::Pointer);
-    virtual void noteBodyConsumerAborted(BodyPipe::Pointer);
+    void noteMoreBodySpaceAvailable(BodyPipe::Pointer) override;
+    void noteBodyConsumerAborted(BodyPipe::Pointer) override;
 
     /* AsyncJob API */
-    virtual void start();
+    void start() override;
 
     void proceedAfterBodyContinuation(Http::StreamPointer context);
 

--- a/src/servers/Server.h
+++ b/src/servers/Server.h
@@ -30,12 +30,12 @@ class Server : virtual public AsyncJob, public BodyProducer
 {
 public:
     Server(const MasterXactionPointer &xact);
-    virtual ~Server() {}
+    ~Server() override {}
 
     /* AsyncJob API */
-    virtual void start();
-    virtual bool doneAll() const;
-    virtual void swanSong();
+    void start() override;
+    bool doneAll() const override;
+    void swanSong() override;
 
     /// whether to stop serving our client after reading EOF on its connection
     virtual bool shouldCloseOnEof() const = 0;

--- a/src/snmp/Forwarder.h
+++ b/src/snmp/Forwarder.h
@@ -26,7 +26,7 @@ namespace Snmp
  */
 class Forwarder: public Ipc::Forwarder
 {
-    CBDATA_CLASS(Forwarder);
+    CBDATA_CHILD(Forwarder);
 
 public:
     Forwarder(const Pdu& aPdu, const Session& aSession, int aFd,

--- a/src/snmp/Forwarder.h
+++ b/src/snmp/Forwarder.h
@@ -34,9 +34,9 @@ public:
 
 protected:
     /* Ipc::Forwarder API */
-    virtual void swanSong();
-    virtual void handleTimeout();
-    virtual void handleException(const std::exception& e);
+    void swanSong() override;
+    void handleTimeout() override;
+    void handleException(const std::exception& e) override;
 
 private:
     void noteCommClosed(const CommCloseCbParams& params);

--- a/src/snmp/Inquirer.h
+++ b/src/snmp/Inquirer.h
@@ -25,7 +25,7 @@ namespace Snmp
 /// aggregates strand responses and send back the result to client
 class Inquirer: public Ipc::Inquirer
 {
-    CBDATA_CLASS(Inquirer);
+    CBDATA_CHILD(Inquirer);
 
 public:
     Inquirer(const Request& aRequest, const Ipc::StrandCoords& coords);

--- a/src/snmp/Inquirer.h
+++ b/src/snmp/Inquirer.h
@@ -32,14 +32,14 @@ public:
 
 protected:
     /* AsyncJob API */
-    virtual void start();
-    virtual bool doneAll() const;
+    void start() override;
+    bool doneAll() const override;
 
     /* Ipc::Inquirer API */
-    virtual void cleanup();
-    virtual void handleException(const std::exception& e);
-    virtual void sendResponse();
-    virtual bool aggregate(Ipc::Response::Pointer aResponse);
+    void cleanup() override;
+    void handleException(const std::exception& e) override;
+    void sendResponse() override;
+    bool aggregate(Ipc::Response::Pointer aResponse) override;
 
 private:
     void noteCommClosed(const CommCloseCbParams& params);

--- a/src/snmp/Request.h
+++ b/src/snmp/Request.h
@@ -29,8 +29,8 @@ public:
 
     explicit Request(const Ipc::TypedMsgHdr& msg); ///< from recvmsg()
     /* Ipc::Request API */
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual Pointer clone() const;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    Pointer clone() const override;
 
 public:
     Pdu pdu; ///< SNMP protocol data unit

--- a/src/snmp/Response.h
+++ b/src/snmp/Response.h
@@ -26,8 +26,8 @@ public:
     explicit Response(Ipc::RequestId); ///< sender's constructor
     explicit Response(const Ipc::TypedMsgHdr& msg); ///< from recvmsg()
     /* Ipc::Response API */
-    virtual void pack(Ipc::TypedMsgHdr& msg) const;
-    virtual Ipc::Response::Pointer clone() const;
+    void pack(Ipc::TypedMsgHdr& msg) const override;
+    Ipc::Response::Pointer clone() const override;
 
 public:
     Pdu pdu; ///< SNMP protocol data unit

--- a/src/snmp_core.h
+++ b/src/snmp_core.h
@@ -55,7 +55,7 @@ void oid2addr(oid *Dest, Ip::Address &addr, u_int code);
 class ACLSNMPCommunityStrategy: public ACLStrategy<char const *>
 {
 public:
-    virtual int match (ACLData<MatchType> *&data, ACLFilledChecklist *checklist) override;
+    int match (ACLData<MatchType> *&data, ACLFilledChecklist *checklist) override;
 };
 
 #endif /* SQUID_SNMP_CORE_H */

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -37,7 +37,7 @@ public:
 
 private:
     ErrorDetailsList::Pointer  theDetails;
-    virtual bool parse() override;
+    bool parse() override;
 };
 }// namespace Ssl
 

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -28,11 +28,11 @@ public:
                          time_t timeout = 0);
 
     /* Security::PeerConnector API */
-    virtual bool initialize(Security::SessionPointer &);
-    virtual Security::ContextPointer getTlsContext();
-    virtual void noteWantWrite();
-    virtual void noteNegotiationError(const Security::ErrorDetailPointer &);
-    virtual void noteNegotiationDone(ErrorState *error);
+    bool initialize(Security::SessionPointer &) override;
+    Security::ContextPointer getTlsContext() override;
+    void noteWantWrite() override;
+    void noteNegotiationError(const Security::ErrorDetailPointer &) override;
+    void noteNegotiationDone(ErrorState *error) override;
 
     /// Updates associated client connection manager members
     /// if the server certificate was received from the server.

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -18,7 +18,7 @@ namespace Ssl
 
 /// A PeerConnector for HTTP origin servers. Capable of SslBumping.
 class PeekingPeerConnector: public Security::PeerConnector {
-    CBDATA_CLASS(PeekingPeerConnector);
+    CBDATA_CHILD(PeekingPeerConnector);
 public:
     PeekingPeerConnector(HttpRequestPointer &aRequest,
                          const Comm::ConnectionPointer &aServerConn,

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -75,13 +75,13 @@ public:
     /// The ClientBio version of the Ssl::Bio::stateChanged method
     /// When the client hello message retrieved, fill the
     /// "features" member with the client provided information.
-    virtual void stateChanged(const SSL *ssl, int where, int ret);
+    void stateChanged(const SSL *ssl, int where, int ret) override;
     /// The ClientBio version of the Ssl::Bio::write method
-    virtual int write(const char *buf, int size, BIO *table);
+    int write(const char *buf, int size, BIO *table) override;
     /// The ClientBio version of the Ssl::Bio::read method
     /// If the holdRead flag is true then it does not write any data
     /// to socket and sets the "read retry" flag of the BIO to true
-    virtual int read(char *buf, int size, BIO *table);
+    int read(char *buf, int size, BIO *table) override;
     /// Prevents or allow writing on socket.
     void hold(bool h) {holdRead_ = holdWrite_ = h;}
 
@@ -125,18 +125,18 @@ public:
     explicit ServerBio(const int anFd);
 
     /// The ServerBio version of the Ssl::Bio::stateChanged method
-    virtual void stateChanged(const SSL *ssl, int where, int ret);
+    void stateChanged(const SSL *ssl, int where, int ret) override;
     /// The ServerBio version of the Ssl::Bio::write method
     /// If a clientRandom number is set then rewrites the raw hello message
     /// "client random" field with the provided random number.
     /// It may buffer the output packets.
-    virtual int write(const char *buf, int size, BIO *table);
+    int write(const char *buf, int size, BIO *table) override;
     /// The ServerBio version of the Ssl::Bio::read method
     /// If the record flag is set then append the data to the rbuf member
-    virtual int read(char *buf, int size, BIO *table);
+    int read(char *buf, int size, BIO *table) override;
     /// The ServerBio version of the Ssl::Bio::flush method.
     /// Flushes any buffered data
-    virtual void flush(BIO *table);
+    void flush(BIO *table) override;
     /// Sets the random number to use in client SSL HELLO message
     void setClientFeatures(Security::TlsDetails::Pointer const &details, SBuf const &hello);
 

--- a/src/ssl/context_storage.h
+++ b/src/ssl/context_storage.h
@@ -37,12 +37,12 @@ class CertificateStorageAction : public Mgr::Action
 public:
     CertificateStorageAction(const Mgr::Command::Pointer &cmd);
     static Pointer Create(const Mgr::Command::Pointer &cmd);
-    virtual void dump (StoreEntry *sentry);
+    void dump (StoreEntry *sentry) override;
     /**
      * We do not support aggregation of information across workers
      * TODO: aggregate these stats
      */
-    virtual bool aggregatable() const { return false; }
+    bool aggregatable() const override { return false; }
 };
 
 inline uint64_t MemoryUsedByContext(const Security::ContextPointer &) {

--- a/src/store/Controller.h
+++ b/src/store/Controller.h
@@ -23,23 +23,23 @@ class Controller: public Storage
 {
 public:
     Controller();
-    virtual ~Controller() override;
+    ~Controller() override;
 
     /* Storage API */
-    virtual void create() override;
-    virtual void init() override;
-    virtual uint64_t maxSize() const override;
-    virtual uint64_t minSize() const override;
-    virtual uint64_t currentSize() const override;
-    virtual uint64_t currentCount() const override;
-    virtual int64_t maxObjectSize() const override;
-    virtual void getStats(StoreInfoStats &stats) const override;
-    virtual void stat(StoreEntry &) const override;
-    virtual void sync() override;
-    virtual void maintain() override;
-    virtual void evictCached(StoreEntry &) override;
-    virtual void evictIfFound(const cache_key *) override;
-    virtual int callback() override;
+    void create() override;
+    void init() override;
+    uint64_t maxSize() const override;
+    uint64_t minSize() const override;
+    uint64_t currentSize() const override;
+    uint64_t currentCount() const override;
+    int64_t maxObjectSize() const override;
+    void getStats(StoreInfoStats &stats) const override;
+    void stat(StoreEntry &) const override;
+    void sync() override;
+    void maintain() override;
+    void evictCached(StoreEntry &) override;
+    void evictIfFound(const cache_key *) override;
+    int callback() override;
 
     /// \returns a locally indexed and SMP-tracked matching StoreEntry (or nil)
     /// Slower than peek() but does not restrict StoreEntry use and storage.

--- a/src/store/Disk.h
+++ b/src/store/Disk.h
@@ -25,7 +25,7 @@ public:
     typedef RefCount<Disk> Pointer;
 
     explicit Disk(char const *aType);
-    virtual ~Disk();
+    ~Disk() override;
     virtual void reconfigure() = 0;
     char const *type() const;
 
@@ -43,16 +43,16 @@ public:
     virtual void diskFull();
 
     /* Controlled API */
-    virtual void create() override;
-    virtual StoreEntry *get(const cache_key *) override;
-    virtual uint64_t maxSize() const override { return max_size; }
-    virtual uint64_t minSize() const override;
-    virtual int64_t maxObjectSize() const override;
-    virtual void getStats(StoreInfoStats &stats) const override;
-    virtual void stat(StoreEntry &) const override;
-    virtual void reference(StoreEntry &e) override;
-    virtual bool dereference(StoreEntry &e) override;
-    virtual void maintain() override;
+    void create() override;
+    StoreEntry *get(const cache_key *) override;
+    uint64_t maxSize() const override { return max_size; }
+    uint64_t minSize() const override;
+    int64_t maxObjectSize() const override;
+    void getStats(StoreInfoStats &stats) const override;
+    void stat(StoreEntry &) const override;
+    void reference(StoreEntry &e) override;
+    bool dereference(StoreEntry &e) override;
+    void maintain() override;
     /// whether this disk storage is capable of serving multiple workers
     virtual bool smpAware() const = 0;
 

--- a/src/store/Disks.h
+++ b/src/store/Disks.h
@@ -21,26 +21,26 @@ public:
     Disks();
 
     /* Storage API */
-    virtual void create() override;
-    virtual void init() override;
-    virtual StoreEntry *get(const cache_key *) override;
-    virtual uint64_t maxSize() const override;
-    virtual uint64_t minSize() const override;
-    virtual uint64_t currentSize() const override;
-    virtual uint64_t currentCount() const override;
-    virtual int64_t maxObjectSize() const override;
-    virtual void getStats(StoreInfoStats &stats) const override;
-    virtual void stat(StoreEntry &) const override;
-    virtual void sync() override;
-    virtual void reference(StoreEntry &) override;
-    virtual bool dereference(StoreEntry &e) override;
-    virtual void updateHeaders(StoreEntry *) override;
-    virtual void maintain() override;
-    virtual bool anchorToCache(StoreEntry &) override;
-    virtual bool updateAnchored(StoreEntry &) override;
-    virtual void evictCached(StoreEntry &) override;
-    virtual void evictIfFound(const cache_key *) override;
-    virtual int callback() override;
+    void create() override;
+    void init() override;
+    StoreEntry *get(const cache_key *) override;
+    uint64_t maxSize() const override;
+    uint64_t minSize() const override;
+    uint64_t currentSize() const override;
+    uint64_t currentCount() const override;
+    int64_t maxObjectSize() const override;
+    void getStats(StoreInfoStats &stats) const override;
+    void stat(StoreEntry &) const override;
+    void sync() override;
+    void reference(StoreEntry &) override;
+    bool dereference(StoreEntry &e) override;
+    void updateHeaders(StoreEntry *) override;
+    void maintain() override;
+    bool anchorToCache(StoreEntry &) override;
+    bool updateAnchored(StoreEntry &) override;
+    void evictCached(StoreEntry &) override;
+    void evictIfFound(const cache_key *) override;
+    int callback() override;
 
     /// update configuration, including limits (re)calculation
     void configure();

--- a/src/store/LocalSearch.cc
+++ b/src/store/LocalSearch.cc
@@ -23,11 +23,11 @@ class LocalSearch : public StoreSearch
 
 public:
     /* StoreSearch API */
-    virtual void next(void (callback)(void *cbdata), void *cbdata) override;
-    virtual bool next() override;
-    virtual bool error() const override;
-    virtual bool isDone() const override;
-    virtual StoreEntry *currentItem() override;
+    void next(void (callback)(void *cbdata), void *cbdata) override;
+    bool next() override;
+    bool error() const override;
+    bool isDone() const override;
+    StoreEntry *currentItem() override;
 
 private:
     void copyBucket();

--- a/src/store/Storage.h
+++ b/src/store/Storage.h
@@ -23,7 +23,7 @@ namespace Store {
 class Storage: public RefCountable
 {
 public:
-    virtual ~Storage() {}
+    ~Storage() override {}
 
     /// create system resources needed for this store to operate in the future
     virtual void create() = 0;

--- a/src/tests/CapturingStoreEntry.h
+++ b/src/tests/CapturingStoreEntry.h
@@ -24,15 +24,15 @@ public:
     int _buffer_calls;
     int _flush_calls;
 
-    virtual void buffer() {
+    void buffer() override {
         _buffer_calls += 1;
     }
 
-    virtual void flush() {
+    void flush() override {
         _flush_calls += 1;
     }
 
-    virtual void append(char const * buf, int len) {
+    void append(char const * buf, int len) override {
         if (!buf || len < 0) // old 'String' can't handle these cases
             return;
         _appended_text.append(buf, len);

--- a/src/tests/TestSwapDir.h
+++ b/src/tests/TestSwapDir.h
@@ -20,23 +20,23 @@ public:
     bool statsCalled;
 
     /* Store::Disk API */
-    virtual uint64_t maxSize() const override;
-    virtual uint64_t currentSize() const override;
-    virtual uint64_t currentCount() const override;
-    virtual void stat(StoreEntry &) const override;
-    virtual void finalizeSwapoutSuccess(const StoreEntry &) override {}
-    virtual void finalizeSwapoutFailure(StoreEntry &) override {}
-    virtual void reconfigure() override;
-    virtual void init() override;
-    virtual bool unlinkdUseful() const override;
-    virtual bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
-    virtual StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
-    virtual StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
-    virtual void parse(int, char*) override;
-    virtual void evictCached(StoreEntry &) override {}
-    virtual void evictIfFound(const cache_key *) override {}
-    virtual bool hasReadableEntry(const StoreEntry &) const override { return false; }
-    virtual bool smpAware() const override { return false; }
+    uint64_t maxSize() const override;
+    uint64_t currentSize() const override;
+    uint64_t currentCount() const override;
+    void stat(StoreEntry &) const override;
+    void finalizeSwapoutSuccess(const StoreEntry &) override {}
+    void finalizeSwapoutFailure(StoreEntry &) override {}
+    void reconfigure() override;
+    void init() override;
+    bool unlinkdUseful() const override;
+    bool canStore(const StoreEntry &e, int64_t diskSpaceNeeded, int &load) const override;
+    StoreIOState::Pointer createStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
+    StoreIOState::Pointer openStoreIO(StoreEntry &, StoreIOState::STFNCB *, StoreIOState::STIOCB *, void *) override;
+    void parse(int, char*) override;
+    void evictCached(StoreEntry &) override {}
+    void evictIfFound(const cache_key *) override {}
+    bool hasReadableEntry(const StoreEntry &) const override { return false; }
+    bool smpAware() const override { return false; }
 };
 
 typedef RefCount<TestSwapDir> TestSwapDirPointer;

--- a/src/tests/stub_ipc_Forwarder.cc
+++ b/src/tests/stub_ipc_Forwarder.cc
@@ -7,12 +7,18 @@
  */
 
 #include "squid.h"
-#include "ipc/Forwarder.h"
 
-//Avoid linker errors about Ipc::Forwarder
-void foo_stub_ipc_forwarder();
-void foo_stub_ipc_forwarder()
-{
-    Ipc::Forwarder foo(nullptr,1.0);
-}
+#define STUB_API "ipc/Forwarder.cc"
+#include "tests/STUB.h"
+
+#include "ipc/Forwarder.h"
+Ipc::Forwarder::Forwarder(Request::Pointer, double): AsyncJob("Ipc::Forwarder"), timeout(0) STUB
+Ipc::Forwarder::~Forwarder() STUB
+void Ipc::Forwarder::start() STUB
+bool Ipc::Forwarder::doneAll() const STUB_RETVAL(false)
+void Ipc::Forwarder::swanSong() STUB
+void Ipc::Forwarder::callException(const std::exception &) STUB
+void Ipc::Forwarder::handleError() STUB
+void Ipc::Forwarder::handleTimeout() STUB
+void Ipc::Forwarder::handleException(const std::exception &) STUB
 

--- a/src/tests/stub_ipc_Forwarder.cc
+++ b/src/tests/stub_ipc_Forwarder.cc
@@ -12,7 +12,7 @@
 #include "tests/STUB.h"
 
 #include "ipc/Forwarder.h"
-Ipc::Forwarder::Forwarder(Request::Pointer, double): AsyncJob("Ipc::Forwarder"), timeout(0) STUB
+Ipc::Forwarder::Forwarder(Request::Pointer, double): AsyncJob("Ipc::Forwarder"), timeout(0) {STUB}
 Ipc::Forwarder::~Forwarder() STUB
 void Ipc::Forwarder::start() STUB
 bool Ipc::Forwarder::doneAll() const STUB_RETVAL(false)

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -73,7 +73,6 @@ const char *Security::NegotiationHistory::printTlsVersion(AnyP::ProtocolVersion 
 
 #include "security/PeerConnector.h"
 class TlsNegotiationDetails: public RefCountable {};
-CBDATA_NAMESPACED_CLASS_INIT(Security, PeerConnector);
 namespace Security
 {
 PeerConnector::PeerConnector(const Comm::ConnectionPointer &, const AsyncCallback<EncryptorAnswer> &, const AccessLogEntryPointer &, const time_t):

--- a/src/tests/testACLMaxUserIP.h
+++ b/src/tests/testACLMaxUserIP.h
@@ -27,7 +27,7 @@ class testACLMaxUserIP : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    virtual void setUp() override;
+    void setUp() override;
 
 protected:
     void testDefaults();

--- a/src/tests/testCacheManager.h
+++ b/src/tests/testCacheManager.h
@@ -24,7 +24,7 @@ class testCacheManager : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testCreate();

--- a/src/tests/testConfigParser.h
+++ b/src/tests/testConfigParser.h
@@ -22,7 +22,7 @@ class testConfigParser : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     bool doParseQuotedTest(const char *, const char *);

--- a/src/tests/testDiskIO.h
+++ b/src/tests/testDiskIO.h
@@ -22,7 +22,7 @@ class testDiskIO : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testFindDefault();

--- a/src/tests/testEvent.h
+++ b/src/tests/testEvent.h
@@ -27,7 +27,7 @@ class testEvent : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testCreate();

--- a/src/tests/testEventLoop.cc
+++ b/src/tests/testEventLoop.cc
@@ -28,7 +28,7 @@ class RecordingEngine : public AsyncEngine
 public:
     RecordingEngine(int aTimeout = 0) : return_timeout(aTimeout) {}
 
-    virtual int checkEvents(int timeout) {
+    int checkEvents(int timeout) override {
         ++calls;
         lasttimeout = timeout;
         return return_timeout;
@@ -131,7 +131,7 @@ public:
     StubTime() : calls(0) {}
 
     int calls;
-    void tick() {
+    void tick() override {
         ++calls;
     }
 };

--- a/src/tests/testHttpReply.h
+++ b/src/tests/testHttpReply.h
@@ -22,7 +22,7 @@ class testHttpReply : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testSanityCheckFirstLine();

--- a/src/tests/testHttpRequest.h
+++ b/src/tests/testHttpRequest.h
@@ -24,7 +24,7 @@ class testHttpRequest : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testCreateFromUrl();

--- a/src/tests/testIcmp.h
+++ b/src/tests/testIcmp.h
@@ -19,15 +19,15 @@ class stubIcmp : public Icmp
 {
 public:
     stubIcmp() {};
-    virtual ~stubIcmp() {};
-    virtual int Open() { return 0; };
-    virtual void Close() {};
+    ~stubIcmp() override {};
+    int Open() override { return 0; };
+    void Close() override {};
 
     /// Construct ECHO request
-    virtual void SendEcho(Ip::Address &, int, const char *, int) {}
+    void SendEcho(Ip::Address &, int, const char *, int) override {}
 
     /// Handle ICMP responses.
-    virtual void Recv(void) {};
+    void Recv(void) override {};
 
     /* methods to relay test data from tester to private methods being tested */
     int testChecksum(unsigned short *ptr, int size) { return CheckSum(ptr,size); };

--- a/src/tests/testPackableStream.h
+++ b/src/tests/testPackableStream.h
@@ -22,7 +22,7 @@ class testPackableStream : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testGetStream();

--- a/src/tests/testRefCount.cc
+++ b/src/tests/testRefCount.cc
@@ -19,7 +19,7 @@ class _ToRefCount : public RefCountable
 {
 public:
     _ToRefCount () {++Instances;}
-    ~_ToRefCount() {--Instances;}
+    ~_ToRefCount() override {--Instances;}
 
     int someMethod() {
         if (!Instances)

--- a/src/tests/testRock.h
+++ b/src/tests/testRock.h
@@ -24,8 +24,8 @@ class testRock : public CPPUNIT_NS::TestFixture
 
 public:
     testRock() : rr(nullptr) {}
-    virtual void setUp();
-    virtual void tearDown();
+    void setUp() override;
+    void tearDown() override;
 
     typedef RefCount<Rock::SwapDir> SwapDirPointer;
 

--- a/src/tests/testStore.h
+++ b/src/tests/testStore.h
@@ -47,29 +47,29 @@ public:
 
     bool statsCalled;
 
-    virtual int callback();
+    int callback() override;
 
     virtual StoreEntry* get(const cache_key*);
 
     virtual void get(String, void (*)(StoreEntry*, void*), void*);
 
-    virtual void init();
+    void init() override;
 
-    virtual void maintain() {};
+    void maintain() override {};
 
-    virtual uint64_t maxSize() const;
+    uint64_t maxSize() const override;
 
-    virtual uint64_t minSize() const;
+    uint64_t minSize() const override;
 
-    virtual uint64_t currentSize() const;
+    uint64_t currentSize() const override;
 
-    virtual uint64_t currentCount() const;
+    uint64_t currentCount() const override;
 
-    virtual int64_t maxObjectSize() const;
+    int64_t maxObjectSize() const override;
 
-    virtual void getStats(StoreInfoStats &) const;
+    void getStats(StoreInfoStats &) const override;
 
-    virtual void stat(StoreEntry &) const; /* output stats to the provided store entry */
+    void stat(StoreEntry &) const override; /* output stats to the provided store entry */
 
     virtual void reference(StoreEntry &) {} /* Reference this object */
 

--- a/src/tests/testString.h
+++ b/src/tests/testString.h
@@ -26,7 +26,7 @@ class testString : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testCmpDefault();

--- a/src/tests/testURL.h
+++ b/src/tests/testURL.h
@@ -23,7 +23,7 @@ class testURL : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
 

--- a/src/tests/testUriScheme.h
+++ b/src/tests/testUriScheme.h
@@ -29,7 +29,7 @@ class testUriScheme : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp();
+    void setUp() override;
 
 protected:
     void testAssignFromprotocol_t();

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -77,7 +77,7 @@ class TunnelStateData: public PeerSelectionInitiator
 
 public:
     TunnelStateData(ClientHttpRequest *);
-    virtual ~TunnelStateData();
+    ~TunnelStateData() override;
     TunnelStateData(const TunnelStateData &); // do not implement
     TunnelStateData &operator =(const TunnelStateData &); // do not implement
 
@@ -218,8 +218,8 @@ public:
     void secureConnectionToPeer(const Comm::ConnectionPointer &);
 
     /* PeerSelectionInitiator API */
-    virtual void noteDestination(Comm::ConnectionPointer conn) override;
-    virtual void noteDestinationsEnd(ErrorState *selectionError) override;
+    void noteDestination(Comm::ConnectionPointer conn) override;
+    void noteDestinationsEnd(ErrorState *selectionError) override;
 
     void syncHierNote(const Comm::ConnectionPointer &server, const char *origin);
 

--- a/src/urn.cc
+++ b/src/urn.cc
@@ -39,7 +39,7 @@ public:
     void start (HttpRequest *, StoreEntry *);
     void setUriResFromRequest(HttpRequest *);
 
-    virtual ~UrnState();
+    ~UrnState() override;
 
     StoreEntry *entry = nullptr;
     store_client *sc = nullptr;
@@ -53,8 +53,8 @@ public:
 
 private:
     /* StoreClient API */
-    virtual LogTags *loggingTags() const { return ale ? &ale->cache.code : nullptr; }
-    virtual void fillChecklist(ACLFilledChecklist &) const;
+    LogTags *loggingTags() const override { return ale ? &ale->cache.code : nullptr; }
+    void fillChecklist(ACLFilledChecklist &) const override;
 
     char *urlres = nullptr;
 };

--- a/test-suite/VirtualDeleteOperator.cc
+++ b/test-suite/VirtualDeleteOperator.cc
@@ -68,7 +68,7 @@ class ChildVirtual : public BaseVirtual
 public:
     void *operator new (size_t);
     void operator delete (void *);
-    virtual ~ChildVirtual();
+    ~ChildVirtual() override;
     static CallCounter Calls;
 };
 


### PR DESCRIPTION
Start following CppCoreGuidelines recommendation C.128: Virtual
functions should specify exactly one of virtual, override, or final.

Used clang-tidy modernize-use-override check to mark overridden methods.
Clang-tidy uses clang AST, so we can only modernize code that clang can
see, but we can enable enough ./configure options for clang to reach
most (possibly all) relevant classes in a single build.

Manual gradual conversion of modified (for other reasons) method
declarations is impractical because some compilers complain when a class
uses an inconsistent _mix_ of virtual and override declarations:

    warning: 'toCbdata' overrides a member function but is not marked
    'override' [-Winconsistent-missing-override]

### cbdata changes

The following manual changes avoid -Winconsistent-missing-override
warnings. Doing these separately, either before or after applying
modernize-use-override, would trigger those warnings.

* Replaced CbdataParent-CBDATA_CLASS with CbdataParent-CBDATA_CHILD
  class inheritance sequences. This fix does not really change anything
  except for making toCbdata() specifiers consistent.

* Replaced CbdataParent-CBDATA_CLASS-CBDATA_CHILD with
  CbdataParent-CBDATA_INTERMEDIATE-CBDATA_CHILD class inheritance
  sequences. This fix removes unused new/delete operators in
  intermediate classes (and associated unused static memory pools) and
  makes toCbdata() specifiers consistent. This fix was difficult to get
  right because of the old design problem discussed below.

While working on the second bullet changes, we first tried to simply
drop the intermediate CBDATA_CLASS sequence element because it should
never be needed/used in class hierarchies ending with CBDATA_CHILD.
Fortunately, CI tests discovered that dropping CBDATA_CLASS converts an
old design problem into runtime bugs: Those intermediate class
constructors (e.g., Mgr::StoreToCommWriter) actually call toCbdata()
when creating connection closure callbacks and such!

During intermediate constructor execution, the class virtual table does
not yet point to toCbdata() defined by CBDATA_CHILD. If we simply remove
CBDATA_CLASS, then, during that intermediate constructor execution, the
virtual table would still point to pure CbdataParent::toCbdata(). Those
intermediate constructors would then crash Squid:

    FATAL: Dying from an exception handling failure;
    exception: [no active exception]

    in OnTerminate () at main.cc:1310
    in std::terminate() () from libstdc++.so.6
    in __cxa_pure_virtual () from libstdc++.so.6
    in CbcPointer<Mgr::StoreToCommWriter>::CbcPointer at CbcPointer.h:94
    in Mgr::StoreToCommWriter::StoreToCommWriter at ...oCommWriter.cc:29
    
We now use lighter CBDATA_INTERMEDIATE() instead of intermediate
CBDATA_CLASS. The resulting code is as risky as it used to be, but at
least we are marking this (old) design problem (in some cases).

We rejected the idea of defining CbdataParent::toCbdata() instead. It
would work fine for linear class inheritance where "this" does not
change -- in those simple class hierarchies, we do not need toCbdata()!
However, such a change would make any constructor-time bugs in multiple
inheritance hierarchies much more difficult to find because the faulty
constructor will work instead of triggering the above FATAL error. The
crashes would happen later, when wrong cbdata pointer is used. While
CBDATA_INTERMEDIATE() cannot fix this design problem, it does not make
it _worse_, so we prefer that solution.
