### PR TITLE
Maintenance: Fix "make installcheck" with --enable-gnuregex

### DIFF
--- a/test-suite/squidconf/bad-regex.conf
+++ b/test-suite/squidconf/bad-regex.conf
@@ -5,4 +5,5 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-acl foo browser *
+# REG_EPAREN: Unmatched parenthesis group operator.
+acl foo browser x(y


### PR DESCRIPTION
... and, hypothetically, old system regex libraries (e.g., 1999 glibc).

    ERROR: Squid successfully parsed malformed
        ...test-suite/squidconf/bad-regex.conf instead of rejecting it

We compile regexes using regcomp(3) with a REG_EXTENDED flag. Under the
hood, that flag gets converted into the RE_SYNTAX_POSIX_EXTENDED syntax
bit set. Glibc changed the definition of that set on 2000-01-18 by
adding a RE_CONTEXT_INVALID_OPS bit. Prior to that, a `*` regex was a
valid expression -- a leading `*` itself matched[^1] an empty string!
Squid copied glibc's bit set macro in 1996 (i.e. without the new bit).

Thus, Squid built with --enable-gnuregex would accept `*` regex, while
Squid linked against a modern regex library would reject it. When 2015
commit 6d2a427 added the `*` test, --enable-gnuregex support was broken,
so the "unstable" test result could not have been noticed. When a recent
commit 12cac45 re-enabled that test, the failures were again missed (due
to another old test-suite bug that ignored failures; to be fixed next).

We now use an invalid regex rejected by system and built-in regex code.

[^1]: https://web.mit.edu/gnu/doc/html/regex_3.html#SEC12
