### PR TITLE
Fix ./configure --enable-poll and --disable-poll

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1706,7 +1706,7 @@ AC_MSG_NOTICE([enabling select syscall for net I/O: ${enable_select:=auto}])
 AC_ARG_ENABLE(poll,
   AS_HELP_STRING([--disable-poll],[Disable poll(2) support.]),[
   SQUID_YESNO([$enableval],[--enable-poll])
-  AS_IF(["x$enableval" = "xyes"],[squid_opt_io_loop_engine="poll"])
+  AS_IF([test "x$enableval" = "xyes"],[squid_opt_io_loop_engine="poll"])
 ])
 AC_MSG_NOTICE([enabling poll syscall for net I/O: ${enable_poll:=auto}])
 


### PR DESCRIPTION
    ./configure: line 42685: xyes: command not found
    ./configure: line 42685: xno: command not found

Since commit a1c2236, these options triggered errors messages above, and
--enable-poll did not affect syscall selection for the I/O loop:

    ./configure --enable-poll
    configure: Using epoll for the IO loop.
