### PR TITLE
release cache.log fd at logrotate for version 5.7

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "Debug.h"
+#include "comm.h"
 #include "fd.h"
 #include "ipc/Kids.h"
 #include "SquidTime.h"
@@ -103,8 +104,10 @@ DebugFile::reset(FILE *newFile, const char *newName)
     }
     file_ = newFile; // may be nil
 
-    if (file_)
-        fd_open(fileno(file_), FD_LOG, Debug::cache_log);
+    if (file_) {
+        commSetCloseOnExec(fileno(file_));
+	fd_open(fileno(file_), FD_LOG, Debug::cache_log);
+    }
 
     xfree(name);
     name = newName ? xstrdup(newName) : nullptr;


### PR DESCRIPTION
A port of PR #1223 for v5. Cache.log has to be rotated externally, but at least it won't leak space in filesystem upon deletion.