### PR TITLE
Bug 5256: Intercepting port fails to accept

### DIFF
--- a/src/comm/Flag.h
+++ b/src/comm/Flag.h
@@ -15,7 +15,6 @@ namespace Comm
 typedef enum {
     OK = 0,
     COMM_ERROR = -1,
-    NOMESSAGE = -3,
     TIMEOUT = -4,
     SHUTDOWN = -5,
     IDLE = -6, /* there are no active fds and no pending callbacks. */

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -394,10 +394,13 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
         }
     } else if (conn->flags & COMM_INTERCEPTION) { // request the real client/dest IP address from NAT
         details->flags |= COMM_INTERCEPTION;
+        details->fd = sock; // XXX
         if (!Ip::Interceptor.LookupNat(*details)) {
+            details->fd = -1; // XXX
             debugs(50, DBG_IMPORTANT, "ERROR: NAT lookup failed to locate original IPs on " << details);
             return Comm::NOMESSAGE;
         }
+        details->fd = -1; // XXX
     }
 
 #if USE_SQUID_EUI

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -394,13 +394,10 @@ Comm::TcpAcceptor::oldAccept(Comm::ConnectionPointer &details)
         }
     } else if (conn->flags & COMM_INTERCEPTION) { // request the real client/dest IP address from NAT
         details->flags |= COMM_INTERCEPTION;
-        details->fd = sock; // XXX
         if (!Ip::Interceptor.LookupNat(*details)) {
-            details->fd = -1; // XXX
             debugs(50, DBG_IMPORTANT, "ERROR: NAT lookup failed to locate original IPs on " << details);
             return Comm::NOMESSAGE;
         }
-        details->fd = -1; // XXX
     }
 
 #if USE_SQUID_EUI

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -304,8 +304,9 @@ Comm::TcpAcceptor::acceptOne()
         notify(Comm::COMM_ERROR, newConnDetails);
     });
 
-    // TODO: Place under AsyncJob call protections and call mustStop() instead.
-    deleteThis("unrecoverable accept failure");
+    // XXX: Not under AsyncJob call protections but, if placed there, may cause
+    // problems like making the corresponding HttpSockets entry (if any) stale.
+    mustStop("unrecoverable accept failure");
 }
 
 void

--- a/src/comm/TcpAcceptor.h
+++ b/src/comm/TcpAcceptor.h
@@ -100,7 +100,7 @@ private:
     static void doAccept(int fd, void *data);
 
     void acceptOne();
-    Comm::Flag oldAccept(Comm::ConnectionPointer &details);
+    bool acceptInto(Comm::ConnectionPointer &);
     void setListen();
     void handleClosure(const CommCloseCbParams &io);
     /// whether we are listening on one of the squid.conf *ports

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -12,7 +12,6 @@
 #include "comm/Loops.h"
 #include "debug/Messages.h"
 #include "debug/Stream.h"
-#include "error/SysErrorDetail.h"
 #include "fatal.h"
 #include "fd.h"
 #include "fde.h"
@@ -318,23 +317,5 @@ fdAdjustReserved(void)
     debugs(51, DBG_CRITICAL, "Reserved FD adjusted from " << RESERVED_FD << " to " << newReserve <<
            " due to failures (" << (Squid_MaxFD - newReserve) << "/" << Squid_MaxFD << " file descriptors available)");
     RESERVED_FD = newReserve;
-}
-
-/* Comm::Descriptor */
-
-Comm::Descriptor::Descriptor(const int fd, const unsigned int type, const char * const description): fd_(fd)
-{
-    fd_open(fd_, type, description);
-}
-
-Comm::Descriptor::~Descriptor()
-{
-    if (fd_ >= 0) {
-        fd_close(fd_);
-        if (close(fd_) != 0) {
-            const auto savedErrno = errno;
-            debugs(51, 7, "failed to close FD " << fd_ << ReportSysError(savedErrno));
-        }
-    }
 }
 

--- a/src/fd.h
+++ b/src/fd.h
@@ -11,34 +11,6 @@
 #ifndef SQUID_FD_H_
 #define SQUID_FD_H_
 
-namespace Comm {
-
-/// An open Comm-registered file descriptor guard that, upon creation, registers
-/// the descriptor with Comm and, upon destruction, unregisters and closes the
-/// descriptor (unless the descriptor has been release()d by then).
-class Descriptor
-{
-public:
-    /// Starts owning the given FD of a given type, with a given description.
-    /// Assumes the given descriptor is open and calls legacy fd_open().
-    Descriptor(int fd, unsigned int type, const char *description);
-    Descriptor(Descriptor &&) = delete; // no copying (and, for now, moving) of any kind
-
-    /// Closes and calls legacy fd_close() unless release() was called earlier.
-    ~Descriptor();
-
-    /// A copy of the descriptor for use in system calls and such.
-    operator int() const { return fd_; }
-
-    /// Forgets the descriptor and prevents its automatic closure (by us).
-    int release() { const auto result = fd_; fd_ = -1; return result; }
-
-private:
-    int fd_;
-};
-
-} // namespace Comm
-
 void fd_close(int fd);
 void fd_open(int fd, unsigned int type, const char *);
 void fd_note(int fd, const char *);


### PR DESCRIPTION
    ERROR: NF getsockopt(ORIGINAL_DST) failed on ... Bad file descriptor
    ERROR: NAT lookup failed to locate original IPs on ...

Ip::Interceptor.LookupNat() needs an open Connection, but commit 7185c9e
supplied a half-baked details object, resulting in ERRORs (showing a
closed connection -- no FD... field) for every otherwise successful
accept(2) attempt on an intercepting port.

Refactored oldAccept() to use exceptions for error handling and false
return result for no-error-but-no-connection cases (Comm::NOMESSAGE).
This refactoring allows us to centralize connection closing code instead
of chasing individual COMM_ERROR and NOMESSAGE cases while still missing
connection closure (if a function called by oldAccept() throws). With
connection closure handled, we can now open the details Connection
earlier, as we have done before commit 7185c9e, meeting current
LookupNat() and other/future code expectations.

Positive side effects of this fix include elimination of the following
old error reporting problems that left admins puzzled why Squid is not
handling new connections with no error messages in non-debugging
cache.log (and with the socket listening queue growing).

* Silent lack of accept() after an ENFILE or EMFILE failure.
* Silent lack of accept() if some function used by oldAccept() throws.
* Silent at level-0 lack of accept() after logging a level-1 ERROR. This
  problem was specific to ALL,0 and similar (rare) configurations.

