### PR TITLE
Fix logging of responses truncated by premature EOF

### DIFF
--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -114,7 +114,17 @@ This section gives an account of those changes in three categories:
 <sect1>Changes to existing options<label id="modifiedoptions">
 <p>
 <descrip>
-	<p>There have been no options changed.
+	<tag>logformat</tag>
+	<p>More logged <em>Ss</em> code values may contain an <em>_ABORTED</em>
+	suffix because Squid now adds that suffix in more cases where a TCP
+	Squid-to-server connection was closed prematurely (e.g., an EOF in the
+	middle of a chunked HTTP response body transfer). In general, tools
+	processing <em>Ss</em> code values should treat each value as an
+	underscore-delimited list of tags rather than an enumeration of a few
+	hard-coded values.
+
+	<p>This change affects all <em>Ss</em> code uses, not just those specific to
+	the <em>logformat</em> directive.
 
 </descrip>
 </p>

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -291,19 +291,12 @@ FwdState::completed()
                 // no flags.dont_retry: completed() is a post-reforward() act
             }
 #endif
-        } else if (!storedWholeReply_) {
-            if (!err) { // message ended prematurely (due to EOF) before an error
-                const auto errorState = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, request, al);
-                static const auto d = MakeNamedErrorDetail("SRV_PREMATURE_EOF");
-                errorState->detailError(d);
-                fail(errorState);
-            }
-            assert(err);
-            updateAleWithFinalError();
-            entry->completeTruncated("FwdState default");
         } else {
             updateAleWithFinalError(); // if any
-            entry->completeSuccessfully(storedWholeReply_);
+            if (storedWholeReply_)
+                entry->completeSuccessfully(storedWholeReply_);
+            else
+                entry->completeTruncated("FwdState default");
         }
     }
 

--- a/src/http.cc
+++ b/src/http.cc
@@ -1395,8 +1395,9 @@ HttpStateData::truncateVirginBody()
     }
 }
 
-static void
-FailOnPrematureEof(const FwdState::Pointer fwd)
+/// called when an incomplete reply body preliminary ends with unexpected EOF
+void
+HttpStateData::failOnPrematureReplyBodyEof()
 {
     const auto err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request, fwd->al);
     static const auto d = MakeNamedErrorDetail("SRV_PREMATURE_EOF");
@@ -1431,7 +1432,7 @@ HttpStateData::writeReplyBody()
     if (parsedWhole)
         markParsedVirginReplyAsWhole(parsedWhole);
     else if (eof)
-        FailOnPrematureEof(fwd);
+        failOnPrematureReplyBodyEof();
 }
 
 bool
@@ -1451,7 +1452,7 @@ HttpStateData::decodeAndWriteReplyBody()
             flags.do_next_read = false;
             markParsedVirginReplyAsWhole("http parsed last-chunk");
         } else if (eof) {
-            FailOnPrematureEof(fwd);
+            failOnPrematureReplyBodyEof();
         }
         return true;
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -1255,6 +1255,8 @@ HttpStateData::readReply(const CommIoCbParams &io)
         debugs(11, 2, io.conn << ": read failure: " << xstrerr(rd.xerrno));
         const auto err = new ErrorState(ERR_READ_ERROR, Http::scBadGateway, fwd->request, fwd->al);
         err->xerrno = rd.xerrno;
+        static const auto d = MakeNamedErrorDetail("SRV_READ_FAILURE");
+        err->detailError(d);
         fwd->fail(err);
         flags.do_next_read = false;
         closeServer();

--- a/src/http.h
+++ b/src/http.h
@@ -140,6 +140,7 @@ private:
     void sendComplete();
     void httpStateConnClosed(const CommCloseCbParams &params);
     void httpTimeout(const CommTimeoutCbParams &params);
+    void failOnPrematureReplyBodyEof();
 
     mb_size_t buildRequestPrefix(MemBuf * mb);
     void forwardUpgrade(HttpHeader&);

--- a/src/http.h
+++ b/src/http.h
@@ -140,7 +140,7 @@ private:
     void sendComplete();
     void httpStateConnClosed(const CommCloseCbParams &params);
     void httpTimeout(const CommTimeoutCbParams &params);
-    void failOnPrematureReplyBodyEof();
+    void markPrematureReplyBodyEofFailure();
 
     mb_size_t buildRequestPrefix(MemBuf * mb);
     void forwardUpgrade(HttpHeader&);

--- a/src/whois.cc
+++ b/src/whois.cc
@@ -172,6 +172,8 @@ WhoisState::readReply(const Comm::ConnectionPointer &conn, char *aBuffer, size_t
 
     if (dataWritten) // treat zero-length responses as incomplete
         fwd->markStoredReplyAsWhole("whois received/stored the entire response");
+    else
+        fwd->fail(new ErrorState(ERR_ZERO_SIZE_OBJECT, Http::scBadGateway, fwd->request, fwd->al));
 
     fwd->complete();
     debugs(75, 3, "whoisReadReply: Done: " << entry->url());


### PR DESCRIPTION
When a transaction failed due to a premature EOF while receiving an HTTP
response, %Ss logformat code was missing the ABORTED suffix (e.g.,
logging TCP_MISS instead of TCP_MISS_ABORTED). When premature EOF
truncated the header, the default "squid" access log format contained a
502 sent status code (%>Hs), hinting at the problem. When the body was
truncated, even that weak hint was usually absent because the actual
status code returned by the server (usually 200) was usually logged.

Similarly, %err_code/%err_detail logformat codes for HTTP responses with
truncated by a premature EOF bodies carried no information. Now they
expand to ERR_READ_ERROR/SRV_PREMATURE_EOF in those cases.

No changes to requests truncated by Squid-server read timeouts. They
were and are still logged with TIMEDOUT %Ss suffix and
ERR_READ_TIMEOUT/WITH_SERVER %err_code/%err_detail.

Also adjusted WHOIS to mark zero-length responses with
ERR_ZERO_SIZE_OBJECT instead of default ERR_READ_ERROR. This affects
forwarded WHOIS transactions and AS number queries generated during
(re)configuration.