### PR TITLE
Fix build with clang v15.0.6 [-Wdeprecated-non-prototype]

### DIFF
--- a/lib/snmplib/mib.c
+++ b/lib/snmplib/mib.c
@@ -226,10 +226,7 @@ found:
 }
 
 int
-read_objid(input, output, out_len)
-char *input;
-oid *output;
-int *out_len;       /* number of subid's in "output" */
+read_objid(char *input, oid *output, int *out_len)
 {
     struct snmp_mib_tree *root = Mib;
     oid *op = output;
@@ -260,10 +257,7 @@ int *out_len;       /* number of subid's in "output" */
     return (1);
 }
 
-void
-print_objid(objid, objidlen)
-oid *objid;
-int objidlen;       /* number of subidentifiers */
+void print_objid(oid *objid, int objidlen)
 {
     char buf[256];
     struct snmp_mib_tree *subtree = Mib;
@@ -274,11 +268,7 @@ int objidlen;       /* number of subidentifiers */
 
 }
 
-void
-sprint_objid(buf, objid, objidlen)
-char *buf;
-oid *objid;
-int objidlen;       /* number of subidentifiers */
+void sprint_objid(char *buf, oid *objid, int objidlen)
 {
     struct snmp_mib_tree *subtree = Mib;
 
@@ -287,11 +277,7 @@ int objidlen;       /* number of subidentifiers */
 }
 
 static struct snmp_mib_tree *
-get_symbol(objid, objidlen, subtree, buf)
-oid *objid;
-int objidlen;
-struct snmp_mib_tree *subtree;
-char *buf;
+get_symbol(oid *objid, int objidlen, struct snmp_mib_tree *subtree, char *buf)
 {
     struct snmp_mib_tree *return_tree = NULL;
 

--- a/lib/snmplib/mib.c
+++ b/lib/snmplib/mib.c
@@ -225,6 +225,7 @@ found:
     return (++*out_len);
 }
 
+/// \param out_len number of subid's in "output"
 int
 read_objid(char *input, oid *output, int *out_len)
 {
@@ -257,7 +258,9 @@ read_objid(char *input, oid *output, int *out_len)
     return (1);
 }
 
-void print_objid(oid *objid, int objidlen)
+/// \param objidlen number of subidentifiers
+void
+print_objid(oid *objid, int objidlen)
 {
     char buf[256];
     struct snmp_mib_tree *subtree = Mib;
@@ -268,7 +271,9 @@ void print_objid(oid *objid, int objidlen)
 
 }
 
-void sprint_objid(char *buf, oid *objid, int objidlen)
+/// \param objidlen number of subidentifiers
+void
+sprint_objid(char *buf, oid *objid, int objidlen)
 {
     struct snmp_mib_tree *subtree = Mib;
 

--- a/lib/snmplib/snmp_api.c
+++ b/lib/snmplib/snmp_api.c
@@ -102,12 +102,8 @@
  * Returns the length of the encoded packet in out_length.  If an error
  * occurs, -1 is returned.  If all goes well, 0 is returned.
  */
-int
-snmp_build(session, pdu, packet, out_length)
-struct snmp_session *session;
-struct snmp_pdu *pdu;
-u_char *packet;
-int *out_length;
+int snmp_build(struct snmp_session *session,
+    struct snmp_pdu *pdu, u_char *packet, int *out_length)
 {
     u_char *bufp;
 

--- a/lib/snmplib/snmp_api.c
+++ b/lib/snmplib/snmp_api.c
@@ -102,8 +102,8 @@
  * Returns the length of the encoded packet in out_length.  If an error
  * occurs, -1 is returned.  If all goes well, 0 is returned.
  */
-int snmp_build(struct snmp_session *session,
-    struct snmp_pdu *pdu, u_char *packet, int *out_length)
+int
+snmp_build(struct snmp_session *session, struct snmp_pdu *pdu, u_char *packet, int *out_length)
 {
     u_char *bufp;
 


### PR DESCRIPTION
clang v15.0.6 distributed with Fedora Rawhide complains about function
definitions using K&R style:

    lib/snmplib/mib.c:229:1: error: a function definition without a
    prototype is deprecated in all versions of C and is not supported in
    C2x [-Werror,-Wdeprecated-non-prototype]
