### PR TITLE
 Fix build with clang v15.0.6 [-Wunused-but-set-variable]

### DIFF
--- a/src/icmp/net_db.cc
+++ b/src/icmp/net_db.cc
@@ -227,7 +227,6 @@ netdbPurgeLRU(void)
     netdbEntry **list;
     int k = 0;
     int list_count = 0;
-    int removed = 0;
     list = (netdbEntry **)xcalloc(netdbEntry::UseCount(), sizeof(netdbEntry *));
     hash_first(addr_table);
 
@@ -247,8 +246,6 @@ netdbPurgeLRU(void)
             break;
 
         netdbRelease(*(list + k));
-
-        ++removed;
     }
 
     xfree(list);


### PR DESCRIPTION
clang v15.0.6 distributed with Fedora Rawhide complains about a variable
that is updated but never used:

    net_db.cc:230:9: error: variable 'removed' set but not used
    [-Werror,-Wunused-but-set-variable]`
