### PR TITLE
Remove broken -sha1 option from server_cert_fingerprint

### DIFF
--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -63,7 +63,9 @@ This section gives an account of those changes in three categories:
 <sect1>Changes to existing directives<label id="modifieddirectives">
 <p>
 <descrip>
-	<p>There have been no directives changed.
+	<tag>server_cert_fingerprint</tag>
+	<p>The <em>-sha</em> argument has been removed.
+	<p>The support for this parameter has been broken for years. It has a single-dash syntax that violates the double-dash pattern used for other long <em>ACL</em> options. After removal, Squid behavior will remain the same because <em>SHA1</em> is the default (and the only supported) fingerprinting algorithm.
 </descrip>
 
 <sect1>Removed directives<label id="removeddirectives">

--- a/doc/release-notes/release-6.sgml
+++ b/doc/release-notes/release-6.sgml
@@ -64,8 +64,7 @@ This section gives an account of those changes in three categories:
 <p>
 <descrip>
 	<tag>server_cert_fingerprint</tag>
-	<p>The <em>-sha</em> argument has been removed.
-	<p>The support for this parameter has been broken for years. It has a single-dash syntax that violates the double-dash pattern used for other long <em>ACL</em> options. After removal, Squid behavior will remain the same because <em>SHA1</em> is the default (and the only supported) fingerprinting algorithm.
+	<p>Removed the broken <em>-sha</em> option. <em>SHA1</em> remains the default and only supported fingerprinting algorithm. Configuring it is unnecessary.
 </descrip>
 
 <sect1>Removed directives<label id="removeddirectives">

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -170,7 +170,7 @@ Acl::Init()
     RegisterMaker("ssl_error", [](TypeName name)->ACL* { return new ACLStrategised<const Security::CertErrors *>(new ACLSslErrorData, new ACLSslErrorStrategy, name); });
     RegisterMaker("user_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509UserAttribute, "*"), new ACLCertificateStrategy, name); });
     RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509CAAttribute, "*"), new ACLCertificateStrategy, name); });
-    RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509Fingerprint, "-sha1", true), new ACLServerCertificateStrategy, name); });
+    RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new ACLStrategised<X509*>(new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true), new ACLServerCertificateStrategy, name); });
     RegisterMaker("at_step", [](TypeName name)->ACL* { return new ACLStrategised<XactionStep>(new ACLAtStepData, new ACLAtStepStrategy, name); });
     RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLServerNameData, new ACLServerNameStrategy, name); });
     RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new ACLStrategised<char const *>(new ACLRegexData, new ACLServerNameStrategy, name); });

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1533,14 +1533,13 @@ IF USE_OPENSSL
 	  # ssl::certUntrusted, and ssl::certSelfSigned can also be used as
 	  # predefined ACLs, just like the 'all' ACL.
 
-	acl aclname server_cert_fingerprint [-sha1] fingerprint
+	acl aclname server_cert_fingerprint fingerprint
 	  # match against server SSL certificate fingerprint [fast]
 	  #
 	  # The fingerprint is the digest of the DER encoded version
 	  # of the whole certificate. The user should use the form: XX:XX:...
-	  # Optional argument specifies the digest algorithm to use.
 	  # The SHA1 digest algorithm is the default and is currently
-	  # the only algorithm supported (-sha1).
+	  # the only algorithm supported.
 
 	acl aclname ssl::server_name [option] .foo.com ...
 	  # matches server name obtained from various sources [fast]


### PR DESCRIPTION
server_cert_fingerprint support for the sha1 parameter has been broken
for years, probably since its inception (2012 commit 42d3334). The bug
was known since at least 2018 when it was mentioned in Bug 4847
discussion.  The single-dash syntax violates the double-dash pattern
used for other --long ACL options. If fixed, using the option would not
change Squid behavior because SHA1 is the default (and the only
supported) fingerprinting algorithm.

The option was meant to allow admins to be explicit about that default
in case it changes in the future, but implementation bugs derailed that
plan. The fix is not straightforward, and we should be focusing on more
important things.