### PR TITLE
squidclient: Drop cache_object protocol support

### DIFF
--- a/tools/squidclient/squidclient.cc
+++ b/tools/squidclient/squidclient.cc
@@ -417,11 +417,11 @@ main(int argc, char *argv[])
             }
         }
         if (ProxyAuthorization.password && !ProxyAuthorization.user) {
-            std::cerr << "ERROR: Proxy authentication username is missing\n";
+            std::cerr << "ERROR: Proxy authentication password (-w) is given, but username (-u) is missing\n";
             exit(EXIT_FAILURE);
         }
         if (OriginAuthorization.password && !OriginAuthorization.user) {
-            std::cerr << "ERROR: WWW authentication username is missing\n";
+            std::cerr << "ERROR: WWW authentication password (-W) is given, but username (-U) is missing\n";
             exit(EXIT_FAILURE);
         }
     }


### PR DESCRIPTION
Use `http` URL scheme for `mgr:command` cache manager requests instead.

Also fixed a bug: When `mgr:command` was used together with a `-w X`
command-line option, squidclient sent that proxy authentication password
`X` in the `cache_object` URL instead of sending the `Y` password from
the `-W Y` option (or no password at all if no `-W` option was given).
If no Authorization header had been sent, Squid's cachemgr_passwd
honored the `-w X` password sent in the cache_object URL.  If
Authorization header had been sent, Squid's cachemgr_passwd honored the
corresponding `-W Y` password, ignoring any password sent in the
cache_object URL.

Now, squidclient uses Authorization HTTP header for sending cache
manager authentication credentials with `mgr:command` requests. Those
credentials are taken either from the `-U` and `-W` command-line options
(if `mgr:command` parameter lacks an embedded password) or from the `-U`
command line option and from the `mgr:command@password` parameter
(otherwise).

squidclient now sends Proxy authentication credentials if and only if
`-u` and `-w` command line options are given. These credentials may be
required to authenticate with the proxy, but they do not affect cache
manager authentication driven by the cachemgr_passwd directive.

Also prohibit specifying a command-line option with a password (`-w` or
`-W`) without specifying the corresponding user name (`-u` or `-U`).
Prior to this change, squidclient did not send the Proxy-Authorization
or Authorization header if the corresponding user name was missing but
did not complain about the problem.
