### PR TITLE
Fix stub for ip/libip.la

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1095,6 +1095,7 @@ tests_testRock_SOURCES = \
 	tests/stub_libeui.cc \
 	tests/stub_libformat.cc \
 	tests/stub_libicmp.cc \
+	tests/stub_libip.cc \
 	tests/stub_liblog.cc \
 	tests/stub_libmgr.cc \
 	tests/stub_libsecurity.cc \
@@ -1131,7 +1132,6 @@ tests_testRock_LDADD = \
 	parser/libparser.la \
 	libsquid.la \
 	comm/libcomm.la \
-	ip/libip.la \
 	fs/libfs.la \
 	$(COMMON_LIBS) \
 	$(REPL_OBJS) \
@@ -1269,6 +1269,7 @@ tests_testUfs_SOURCES = \
 	tests/stub_libeui.cc \
 	tests/stub_libformat.cc \
 	tests/stub_libicmp.cc \
+	tests/stub_libip.cc \
 	tests/stub_liblog.cc \
 	tests/stub_libsecurity.cc \
 	log/access_log.h \
@@ -1310,7 +1311,6 @@ tests_testUfs_LDADD = \
 	acl/libstate.la \
 	acl/libapi.la \
 	libsquid.la \
-	ip/libip.la \
 	fs/libfs.la \
 	mgr/libmgr.la \
 	$(REPL_OBJS) \
@@ -1323,7 +1323,6 @@ tests_testUfs_LDADD = \
 	comm/libcomm.la \
 	dns/libdns.la \
 	base/libbase.la \
-	ip/libip.la \
 	mem/libmem.la \
 	store/libstore.la \
 	$(ADAPTATION_LIBS) \
@@ -1615,6 +1614,7 @@ tests_testDiskIO_SOURCES = \
 	tests/stub_libeui.cc \
 	tests/stub_libformat.cc \
 	tests/stub_libicmp.cc \
+	tests/stub_libip.cc \
 	tests/stub_liblog.cc \
 	tests/stub_libsecurity.cc \
 	tests/stub_libstore.cc \
@@ -1659,7 +1659,6 @@ tests_testDiskIO_LDADD = \
 	acl/libacls.la \
 	acl/libstate.la \
 	comm/libcomm.la \
-	ip/libip.la \
 	fs/libfs.la \
 	ipc/libipc.la \
 	$(REPL_OBJS) \

--- a/src/tests/stub_libip.cc
+++ b/src/tests/stub_libip.cc
@@ -13,65 +13,62 @@
 #include "tests/STUB.h"
 
 #include "ip/Address.h"
-namespace Ip
-{
-Address::Address(const struct in_addr &) STUB
-Address::Address(const struct sockaddr_in &) STUB
-Address::Address(const struct in6_addr &) STUB
-Address::Address(const struct sockaddr_in6 &) STUB
-Address::Address(const struct hostent &) STUB
-Address::Address(const struct addrinfo &) STUB
-Address::Address(const char*) STUB
-Address& Address::operator =(struct sockaddr_in const &) STUB_RETVAL(*this)
-Address& Address::operator =(struct sockaddr_storage const &) STUB_RETVAL(*this)
-Address& Address::operator =(struct in_addr const &) STUB_RETVAL(*this)
-Address& Address::operator =(struct in6_addr const &) STUB_RETVAL(*this)
-Address& Address::operator =(struct sockaddr_in6 const &) STUB_RETVAL(*this)
-bool Address::operator =(const struct hostent &) STUB_RETVAL(false)
-bool Address::operator =(const struct addrinfo &) STUB_RETVAL(false)
-bool Address::operator =(const char *) STUB_RETVAL(false)
-bool Address::operator ==(Address const &) const STUB_RETVAL(false)
-bool Address::operator !=(Address const &) const STUB_RETVAL(false)
-bool Address::operator >=(Address const &) const STUB_RETVAL(false)
-bool Address::operator <=(Address const &) const STUB_RETVAL(false)
-bool Address::operator >(Address const &) const STUB_RETVAL(false)
-bool Address::operator <(Address const &) const STUB_RETVAL(false)
-bool Address::isIPv4() const STUB_RETVAL(false)
-bool Address::isIPv6() const STUB_RETVAL(false)
-bool Address::isSockAddr() const STUB_RETVAL(false)
-bool Address::isAnyAddr() const STUB_RETVAL(false)
-bool Address::isNoAddr() const STUB_RETVAL(false)
-bool Address::isLocalhost() const STUB_RETVAL(false)
-bool Address::isSiteLocal6() const STUB_RETVAL(false)
-bool Address::isSiteLocalAuto() const STUB_RETVAL(false)
-unsigned short Address::port() const STUB
-unsigned short Address::port(unsigned short) STUB
-void Address::setAnyAddr() STUB
-void Address::setNoAddr() STUB
-void Address::setLocalhost() STUB
-void Address::setEmpty() STUB_NOP // NOP for default constructor
-bool Address::setIPv4() STUB_RETVAL(false)
-int Address::cidr() const STUB_RETVAL(0)
-int Address::applyMask(const Address &) STUB_RETVAL(0)
-bool Address::applyMask(const unsigned int, int) STUB_RETVAL(false)
-void Address::applyClientMask(const Address &) STUB
-char* Address::toStr(char *, const unsigned int, int) const STUB_RETVAL(nullptr)
-char* Address::toUrl(char *, unsigned int) const STUB_RETVAL(nullptr)
-unsigned int Address::toHostStr(char *, const unsigned int) const STUB_RETVAL(0)
-bool Address::fromHost(const char *) STUB_RETVAL(false)
-bool Address::getReverseString(char [], int) const STUB_RETVAL(false)
-int Address::matchIPAddr(const Address &) const STUB_RETVAL(0)
-int Address::compareWhole(const Ip::Address &) const STUB_RETVAL(0)
-void Address::getAddrInfo(struct addrinfo *&, int) const STUB
-void Address::FreeAddr(struct addrinfo *&) STUB
-void Address::InitAddr(struct addrinfo *&) STUB
-bool Address::GetHostByName(const char *) STUB_RETVAL(false)
-void Address::getSockAddr(struct sockaddr_storage &, const int) const STUB
-void Address::getSockAddr(struct sockaddr_in &) const STUB
-bool Address::getInAddr(struct in_addr &) const STUB_RETVAL(false)
-void Address::getSockAddr(struct sockaddr_in6 &) const STUB
-void Address::getInAddr(struct in6_addr &) const STUB
-} // namespace Ip
+Ip::Address::Address(const struct in_addr &) STUB
+Ip::Address::Address(const struct sockaddr_in &) STUB
+Ip::Address::Address(const struct in6_addr &) STUB
+Ip::Address::Address(const struct sockaddr_in6 &) STUB
+Ip::Address::Address(const struct hostent &) STUB
+Ip::Address::Address(const struct addrinfo &) STUB
+Ip::Address::Address(const char*) STUB
+Ip::Address& Ip::Address::operator =(struct sockaddr_in const &) STUB_RETVAL(*this)
+Ip::Address& Ip::Address::operator =(struct sockaddr_storage const &) STUB_RETVAL(*this)
+Ip::Address& Ip::Address::operator =(struct in_addr const &) STUB_RETVAL(*this)
+Ip::Address& Ip::Address::operator =(struct in6_addr const &) STUB_RETVAL(*this)
+Ip::Address& Ip::Address::operator =(struct sockaddr_in6 const &) STUB_RETVAL(*this)
+bool Ip::Address::operator =(const struct hostent &) STUB_RETVAL(false)
+bool Ip::Address::operator =(const struct addrinfo &) STUB_RETVAL(false)
+bool Ip::Address::operator =(const char *) STUB_RETVAL(false)
+bool Ip::Address::operator ==(Ip::Address const &) const STUB_RETVAL(false)
+bool Ip::Address::operator !=(Ip::Address const &) const STUB_RETVAL(false)
+bool Ip::Address::operator >=(Ip::Address const &) const STUB_RETVAL(false)
+bool Ip::Address::operator <=(Ip::Address const &) const STUB_RETVAL(false)
+bool Ip::Address::operator >(Ip::Address const &) const STUB_RETVAL(false)
+bool Ip::Address::operator <(Ip::Address const &) const STUB_RETVAL(false)
+bool Ip::Address::isIPv4() const STUB_RETVAL(false)
+bool Ip::Address::isIPv6() const STUB_RETVAL(false)
+bool Ip::Address::isSockAddr() const STUB_RETVAL(false)
+bool Ip::Address::isAnyAddr() const STUB_RETVAL(false)
+bool Ip::Address::isNoAddr() const STUB_RETVAL(false)
+bool Ip::Address::isLocalhost() const STUB_RETVAL(false)
+bool Ip::Address::isSiteLocal6() const STUB_RETVAL(false)
+bool Ip::Address::isSiteLocalAuto() const STUB_RETVAL(false)
+unsigned short Ip::Address::port() const STUB
+unsigned short Ip::Address::port(unsigned short) STUB
+void Ip::Address::setAnyAddr() STUB
+void Ip::Address::setNoAddr() STUB
+void Ip::Address::setLocalhost() STUB
+void Ip::Address::setEmpty() STUB_NOP // NOP for default constructor
+bool Ip::Address::setIPv4() STUB_RETVAL(false)
+int Ip::Address::cidr() const STUB_RETVAL(0)
+int Ip::Address::applyMask(const Ip::Address &) STUB_RETVAL(0)
+bool Ip::Address::applyMask(const unsigned int, int) STUB_RETVAL(false)
+void Ip::Address::applyClientMask(const Ip::Address &) STUB
+char* Ip::Address::toStr(char *, const unsigned int, int) const STUB_RETVAL(nullptr)
+char* Ip::Address::toUrl(char *, unsigned int) const STUB_RETVAL(nullptr)
+unsigned int Ip::Address::toHostStr(char *, const unsigned int) const STUB_RETVAL(0)
+bool Ip::Address::fromHost(const char *) STUB_RETVAL(false)
+bool Ip::Address::getReverseString(char [], int) const STUB_RETVAL(false)
+int Ip::Address::matchIPAddr(const Ip::Address &) const STUB_RETVAL(0)
+int Ip::Address::compareWhole(const Ip::Address &) const STUB_RETVAL(0)
+void Ip::Address::getAddrInfo(struct addrinfo *&, int) const STUB
+void Ip::Address::FreeAddr(struct addrinfo *&) STUB
+void Ip::Address::InitAddr(struct addrinfo *&) STUB
+bool Ip::Address::GetHostByName(const char *) STUB_RETVAL(false)
+void Ip::Address::getSockAddr(struct sockaddr_storage &, const int) const STUB
+void Ip::Address::getSockAddr(struct sockaddr_in &) const STUB
+bool Ip::Address::getInAddr(struct in_addr &) const STUB_RETVAL(false)
+void Ip::Address::getSockAddr(struct sockaddr_in6 &) const STUB
+void Ip::Address::getInAddr(struct in6_addr &) const STUB
 void parse_IpAddress_list_token(Ip::Address_list **, char *) STUB
 
 //#include "ip/forward.h"
@@ -81,53 +78,38 @@ CBDATA_CLASS_INIT(acl_tos);
 acl_tos::~acl_tos() STUB
 CBDATA_CLASS_INIT(acl_nfmark);
 acl_nfmark::~acl_nfmark() STUB
-namespace Ip
-{
-namespace Qos
-{
-void getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB
-nfmark_t getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1)
-bool setNfConnmark(Comm::ConnectionPointer &, const ConnectionDirection, const NfMarkConfig &) STUB_RETVAL(false)
-int doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
-int doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
-int doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
-int doNfmarkLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
-int setSockTos(const Comm::ConnectionPointer &, tos_t) STUB_RETVAL(-1)
-int setSockTos(const int, tos_t, int) STUB_RETVAL(-1)
-int setSockNfmark(const Comm::ConnectionPointer &, nfmark_t) STUB_RETVAL(-1)
-int setSockNfmark(const int, nfmark_t) STUB_RETVAL(-1)
-Config::Config() STUB_NOP
-void Config::parseConfigLine() STUB
-void Config::dumpConfigLine(char *, const char *) const STUB
-bool Config::isAclNfmarkActive() const STUB_RETVAL(false)
-bool Config::isAclTosActive() const STUB_RETVAL(false)
-Config TheConfig;
-} // namespace Qos
-} // namespace Ip
+void Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB
+nfmark_t Ip::Qos::getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1)
+bool Ip::Qos::setNfConnmark(Comm::ConnectionPointer &, const ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false)
+int Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
+int Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
+int Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
+int Ip::Qos::doNfmarkLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
+int Ip::Qos::setSockTos(const Comm::ConnectionPointer &, tos_t) STUB_RETVAL(-1)
+int Ip::Qos::setSockTos(const int, tos_t, int) STUB_RETVAL(-1)
+int Ip::Qos::setSockNfmark(const Comm::ConnectionPointer &, nfmark_t) STUB_RETVAL(-1)
+int Ip::Qos::setSockNfmark(const int, nfmark_t) STUB_RETVAL(-1)
+Ip::Qos::Config::Config() STUB_NOP
+void Ip::Qos::Config::parseConfigLine() STUB
+void Ip::Qos::Config::dumpConfigLine(char *, const char *) const STUB
+bool Ip::Qos::Config::isAclNfmarkActive() const STUB_RETVAL(false)
+bool Ip::Qos::Config::isAclTosActive() const STUB_RETVAL(false)
+Ip::Qos::Config Ip::Qos::TheConfig;
 
 #include "ip/Intercept.h"
-namespace Ip
-{
-bool Intercept::LookupNat(const Comm::Connection &) STUB_RETVAL(false)
-bool Intercept::ProbeForTproxy(Address &) STUB_RETVAL(false)
-void Intercept::StartTransparency() STUB
-void Intercept::StopTransparency(const char *) STUB
-void Intercept::StartInterception() STUB
-Intercept Interceptor;
-} // namespace Ip
+bool Ip::Intercept::LookupNat(const Comm::Connection &) STUB_RETVAL(false)
+bool Ip::Intercept::ProbeForTproxy(Ip::Address &) STUB_RETVAL(false)
+void Ip::Intercept::StartTransparency() STUB
+void Ip::Intercept::StopTransparency(const char *) STUB
+void Ip::Intercept::StartInterception() STUB
+Ip::Intercept Ip::Interceptor;
 
 #include "ip/NfMarkConfig.h"
-namespace Ip
-{
-NfMarkConfig NfMarkConfig::Parse(const SBuf &) STUB_RETSTATREF(NfMarkConfig)
-nfmark_t NfMarkConfig::applyToMark(nfmark_t) const STUB_RETVAL(0)
-std::ostream &operator <<(std::ostream &os, NfMarkConfig) STUB_RETVAL(os)
-} // namespace Ip
+Ip::NfMarkConfig Ip::NfMarkConfig::Parse(const SBuf &) STUB_RETSTATREF(Ip::NfMarkConfig)
+nfmark_t Ip::NfMarkConfig::applyToMark(nfmark_t) const STUB_RETVAL(0)
+std::ostream &Ip::operator <<(std::ostream &os, Ip::NfMarkConfig) STUB_RETVAL(os)
 
 #include "ip/tools.h"
-namespace Ip
-{
-void ProbeTransport() STUB
-int EnableIpv6 = 0;
-} // namespace Ip
+void Ip::ProbeTransport() STUB
+int Ip::EnableIpv6 = 0;
 

--- a/src/tests/stub_libip.cc
+++ b/src/tests/stub_libip.cc
@@ -12,34 +12,122 @@
 #define STUB_API "ip/libip.la"
 #include "tests/STUB.h"
 
+#include "ip/Address.h"
+namespace Ip
+{
+Address::Address(const struct in_addr &) STUB
+Address::Address(const struct sockaddr_in &) STUB
+Address::Address(const struct in6_addr &) STUB
+Address::Address(const struct sockaddr_in6 &) STUB
+Address::Address(const struct hostent &) STUB
+Address::Address(const struct addrinfo &) STUB
+Address::Address(const char*) STUB
+Address& Address::operator =(struct sockaddr_in const &) STUB_RETVAL(*this)
+Address& Address::operator =(struct sockaddr_storage const &) STUB_RETVAL(*this)
+Address& Address::operator =(struct in_addr const &) STUB_RETVAL(*this)
+Address& Address::operator =(struct in6_addr const &) STUB_RETVAL(*this)
+Address& Address::operator =(struct sockaddr_in6 const &) STUB_RETVAL(*this)
+bool Address::operator =(const struct hostent &) STUB_RETVAL(false)
+bool Address::operator =(const struct addrinfo &) STUB_RETVAL(false)
+bool Address::operator =(const char *) STUB_RETVAL(false)
+bool Address::operator ==(Address const &) const STUB_RETVAL(false)
+bool Address::operator !=(Address const &) const STUB_RETVAL(false)
+bool Address::operator >=(Address const &) const STUB_RETVAL(false)
+bool Address::operator <=(Address const &) const STUB_RETVAL(false)
+bool Address::operator >(Address const &) const STUB_RETVAL(false)
+bool Address::operator <(Address const &) const STUB_RETVAL(false)
+bool Address::isIPv4() const STUB_RETVAL(false)
+bool Address::isIPv6() const STUB_RETVAL(false)
+bool Address::isSockAddr() const STUB_RETVAL(false)
+bool Address::isAnyAddr() const STUB_RETVAL(false)
+bool Address::isNoAddr() const STUB_RETVAL(false)
+bool Address::isLocalhost() const STUB_RETVAL(false)
+bool Address::isSiteLocal6() const STUB_RETVAL(false)
+bool Address::isSiteLocalAuto() const STUB_RETVAL(false)
+unsigned short Address::port() const STUB
+unsigned short Address::port(unsigned short) STUB
+void Address::setAnyAddr() STUB
+void Address::setNoAddr() STUB
+void Address::setLocalhost() STUB
+void Address::setEmpty() STUB_NOP // NOP for default constructor
+bool Address::setIPv4() STUB_RETVAL(false)
+int Address::cidr() const STUB_RETVAL(0)
+int Address::applyMask(const Address &) STUB_RETVAL(0)
+bool Address::applyMask(const unsigned int, int) STUB_RETVAL(false)
+void Address::applyClientMask(const Address &) STUB
+char* Address::toStr(char *, const unsigned int, int) const STUB_RETVAL(nullptr)
+char* Address::toUrl(char *, unsigned int) const STUB_RETVAL(nullptr)
+unsigned int Address::toHostStr(char *, const unsigned int) const STUB_RETVAL(0)
+bool Address::fromHost(const char *) STUB_RETVAL(false)
+bool Address::getReverseString(char [], int) const STUB_RETVAL(false)
+int Address::matchIPAddr(const Address &) const STUB_RETVAL(0)
+int Address::compareWhole(const Ip::Address &) const STUB_RETVAL(0)
+void Address::getAddrInfo(struct addrinfo *&, int) const STUB
+void Address::FreeAddr(struct addrinfo *&) STUB
+void Address::InitAddr(struct addrinfo *&) STUB
+bool Address::GetHostByName(const char *) STUB_RETVAL(false)
+void Address::getSockAddr(struct sockaddr_storage &, const int) const STUB
+void Address::getSockAddr(struct sockaddr_in &) const STUB
+bool Address::getInAddr(struct in_addr &) const STUB_RETVAL(false)
+void Address::getSockAddr(struct sockaddr_in6 &) const STUB
+void Address::getInAddr(struct in6_addr &) const STUB
+} // namespace Ip
+void parse_IpAddress_list_token(Ip::Address_list **, char *) STUB
+
+//#include "ip/forward.h"
+
 #include "ip/QosConfig.h"
+CBDATA_CLASS_INIT(acl_tos);
+acl_tos::~acl_tos() STUB
+CBDATA_CLASS_INIT(acl_nfmark);
+acl_nfmark::~acl_nfmark() STUB
 namespace Ip
 {
 namespace Qos
 {
-void getTosFromServer(fde *, const int) {
-#if USE_QOS_TOS
-    STUB
-#endif
-}
-void getNfmarkFromServer(const fde *, const fde *, const int) {
-#if USE_QOS_NFMARK
-    STUB
-#endif
-}
-#if USE_QOS_NFMARK
-int GetNfMarkCallback(enum nf_conntrack_msg_type, struct nf_conntrack *, void *) STUB_RETVAL(-1)
-#endif
-tos_t doTosLocalMiss(const int, const hier_code) STUB_RETVAL(-1)
-int doNfmarkLocalMiss(const int, const hier_code) STUB_RETVAL(-1)
-int doTosLocalHit(const int) STUB_RETVAL(-1)
-int doNfmarkLocalHit(const int) STUB_RETVAL(-1)
-void parseConfigLine() STUB
-void dumpConfigLine(char *, const char *) STUB
-
-Config::Config() {STUB}
+void getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB
+nfmark_t getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1)
+bool setNfConnmark(Comm::ConnectionPointer &, const ConnectionDirection, const NfMarkConfig &) STUB_RETVAL(false)
+int doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
+int doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
+int doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
+int doNfmarkLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
+int setSockTos(const Comm::ConnectionPointer &, tos_t) STUB_RETVAL(-1)
+int setSockTos(const int, tos_t, int) STUB_RETVAL(-1)
+int setSockNfmark(const Comm::ConnectionPointer &, nfmark_t) STUB_RETVAL(-1)
+int setSockNfmark(const int, nfmark_t) STUB_RETVAL(-1)
+Config::Config() STUB_NOP
+void Config::parseConfigLine() STUB
+void Config::dumpConfigLine(char *, const char *) const STUB
 bool Config::isAclNfmarkActive() const STUB_RETVAL(false)
 bool Config::isAclTosActive() const STUB_RETVAL(false)
-}
-}
+Config TheConfig;
+} // namespace Qos
+} // namespace Ip
+
+#include "ip/Intercept.h"
+namespace Ip
+{
+bool Intercept::LookupNat(const Comm::Connection &) STUB_RETVAL(false)
+bool Intercept::ProbeForTproxy(Address &) STUB_RETVAL(false)
+void Intercept::StartTransparency() STUB
+void Intercept::StopTransparency(const char *) STUB
+void Intercept::StartInterception() STUB
+Intercept Interceptor;
+} // namespace Ip
+
+#include "ip/NfMarkConfig.h"
+namespace Ip
+{
+NfMarkConfig NfMarkConfig::Parse(const SBuf &) STUB_RETSTATREF(NfMarkConfig)
+nfmark_t NfMarkConfig::applyToMark(nfmark_t) const STUB_RETVAL(0)
+std::ostream &operator <<(std::ostream &os, NfMarkConfig) STUB_RETVAL(os)
+} // namespace Ip
+
+#include "ip/tools.h"
+namespace Ip
+{
+void ProbeTransport() STUB
+int EnableIpv6 = 0;
+} // namespace Ip
 


### PR DESCRIPTION
Use to build disk I/O tests which do not need IP address
operations. This also ensures bitrot does not reappear.