### PR TITLE
Add transparent_outgoing_ip option

### DIFF
--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1489,6 +1489,12 @@ getOutgoingAddress(HttpRequest * request, const Comm::ConnectionPointer &conn)
         // else no tproxy today ...
     }
 
+    if(Config.onoff.transparent_outgoing_ip) {
+        conn->local = request->clientConnectionManager->clientConnection->local;
+        conn->local.port(0);
+        return;
+    }
+
     if (!Config.accessList.outgoing_address) {
         return; // anything will do.
     }

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -333,6 +333,7 @@ public:
         int memory_cache_first;
         int memory_cache_disk;
         int hostStrictVerify;
+        int transparent_outgoing_ip;
         int client_dst_passthru;
         int dns_mdns;
 #if USE_OPENSSL

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2953,6 +2953,15 @@ DOC_START
 
 DOC_END
 
+NAME: transparent_outgoing_ip
+TYPE: onoff
+LOC: Config.onoff.transparent_outgoing_ip
+DEFAULT: off
+DOC_START
+	If this is enabled, the outgoing IP address will match the
+	local IP address that the request came in through.
+DOC_END
+
 NAME: client_dst_passthru
 TYPE: onoff
 DEFAULT: on


### PR DESCRIPTION
Let's say you have a squid proxy listening on IPs 1.2.3.4 and 1.2.3.5, and it's not used as a load-balancer or cache. With this option enabled, a request coming in on the .5 IP will use the system's .5 IP as outbound, whereas .4 will go through .4.

This allows the proxy user to decide what their outbound IP will be - allowing an entirely new use case for Squid. In order to do this without this option, your squid config would have to look like:

`acl ip1 myip 1.2.3.4
tcp_outgoing_address 1.2.3.4 ip1
acl ip2 myip 1.2.3.5
tcp_outgoing_address 1.2.3.5 ip2`

And so on for each outbound IP you want...

This is not practical for large subnets, and especially not for IPv6.