### PR TITLE
Fix --disable-optimizations build: Undefined RetryGapUsec

### DIFF
--- a/src/base/File.cc
+++ b/src/base/File.cc
@@ -332,7 +332,7 @@ File::lock(const FileOpeningConfig &cfg)
                    " more time(s) after a failure: " << ex.what());
         }
         Must(attemptsLeft); // the catch statement handles the last attempt
-        std::this_thread::sleep_for(std::chrono::microseconds(cfg.RetryGapUsec));
+        std::this_thread::sleep_for(std::chrono::microseconds(cfg.retryGapUsec));
     }
     debugs(54, 9, "disabled");
 }

--- a/src/base/File.h
+++ b/src/base/File.h
@@ -57,7 +57,7 @@ private:
 #else
     int flockMode = LOCK_UN; ///< 2nd flock(2) parameter
 #endif
-    const unsigned int RetryGapUsec = 500000; ///< pause before each lock retry
+    const unsigned int retryGapUsec = 500000; ///< pause before each lock retry
     unsigned int lockAttempts = 0; ///< how many times to try locking
     bool openByRoot = false;
 };

--- a/src/base/File.h
+++ b/src/base/File.h
@@ -57,7 +57,7 @@ private:
 #else
     int flockMode = LOCK_UN; ///< 2nd flock(2) parameter
 #endif
-    const unsigned int RetryGapUsec = 500000; /// pause before each lock retry
+    const unsigned int RetryGapUsec = 500000; ///< pause before each lock retry
     unsigned int lockAttempts = 0; ///< how many times to try locking
     bool openByRoot = false;
 };

--- a/src/base/File.h
+++ b/src/base/File.h
@@ -57,7 +57,7 @@ private:
 #else
     int flockMode = LOCK_UN; ///< 2nd flock(2) parameter
 #endif
-    static const unsigned int RetryGapUsec = 500000; /// pause before each lock retry
+    const unsigned int RetryGapUsec = 500000; /// pause before each lock retry
     unsigned int lockAttempts = 0; ///< how many times to try locking
     bool openByRoot = false;
 };


### PR DESCRIPTION
Since inception (2017 commit e99fa72), FileOpeningConfig::RetryGapUsec
was declared but not defined in any translation unit (a bug). The build
probably "worked" because compilers simply inlined the value of the
constant data member when calling xusleep(). Commit 5eee0e4 removed code
that passed RetryGapUsec to that external "C" function. Now, the same
member is passed to a heavily-inlined and convoluted STL code, and at
least some compilers (e.g., GCC v10-v12 on Ubuntu 22.04) stopped
inlining RetryGapUsec unless optimization is enabled. Our CI tests
passed because we do not test --disable-optimizations builds (yet).

We do not need FileOpeningConfig::RetryGapUsec to be static, breaking
builds, requiring extra code, and triggering questions. We do not even
need it to be constant, but removing "const" is an arguably out-of-scope
change, as is improving its type.

File::InvalidHandle is missing a definition as well, except on Windows,
but we are leaving that code "as is" for now, until we can test whether
Windows is OK with removing that "static" keyword.

