### PR TITLE
pinger: improve timer accuracy and resolution

### DIFF
--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -89,7 +89,7 @@ Win32__WSAFDIsSet(int fd, fd_set FAR * set)
 #endif  /* _SQUID_WINDOWS_ */
 
 using namespace std::literals::chrono_literals;
-static const std::chrono::seconds PingerTimeout = 10s;
+static const auto PingerTimeout = 10s;
 
 // ICMP Engines are declared global here so they can call each other easily.
 IcmpPinger control;
@@ -197,7 +197,7 @@ main(int, char **)
 
     for (;;) {
         struct timeval tv;
-        tv.tv_sec = PingerTimeout.count();
+        tv.tv_sec = std::chrono::seconds(PingerTimeout).count();
         tv.tv_usec = 0;
         FD_ZERO(&R);
         if (icmp4_worker >= 0) {
@@ -232,7 +232,7 @@ main(int, char **)
         }
 
         const auto delay = std::chrono::duration_cast<std::chrono::seconds>(timer.total());
-        if (delay.count() >= PingerTimeout.count()) {
+        if (delay >= PingerTimeout) {
             if (send(LINK_TO_SQUID, &tv, 0, 0) < 0) {
                 debugs(42, DBG_CRITICAL, "Closing. No requests in last " << delay.count() << " seconds.");
                 control.Close();

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -210,6 +210,7 @@ main(int, char **)
 
         FD_SET(squid_link, &R);
         Stopwatch timer;
+        timer.resume();
         x = select(max_fd+1, &R, nullptr, nullptr, &tv);
         getCurrentTime();
 

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -49,6 +49,7 @@
 #include "Icmp6.h"
 #include "IcmpPinger.h"
 #include "ip/tools.h"
+#include "time/gadgets.h"
 
 #if HAVE_SYS_CAPABILITY_H
 #include <sys/capability.h>
@@ -118,6 +119,8 @@ main(int, char **)
     int squid_link = -1;
 
     Debug::NameThisHelper("pinger");
+
+    getCurrentTime();
 
     // determine IPv4 or IPv6 capabilities before using sockets.
     Ip::ProbeTransport();
@@ -208,6 +211,7 @@ main(int, char **)
         FD_SET(squid_link, &R);
         Stopwatch timer;
         x = select(max_fd+1, &R, nullptr, nullptr, &tv);
+        getCurrentTime();
 
         if (x < 0) {
             int xerrno = errno;

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -231,9 +231,10 @@ main(int, char **)
             icmp4.Recv();
         }
 
-        if (PINGER_TIMEOUT <= timer.total().count()) {
+        const auto waited = std::chrono::duration_cast<std::chrono::seconds>(timer.total()).count();
+        if (waited >= PINGER_TIMEOUT) {
             if (send(LINK_TO_SQUID, &tv, 0, 0) < 0) {
-                debugs(42, DBG_CRITICAL, "Closing. No requests in last " << timer.total().count() << " seconds.");
+                debugs(42, DBG_CRITICAL, "Closing. No requests in last " << waited << " seconds.");
                 control.Close();
                 exit(EXIT_FAILURE);
             }

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -66,8 +66,6 @@
 
 #include "fde.h"
 
-#define PINGER_TIMEOUT 5
-
 /* windows uses the control socket for feedback to squid */
 #define LINK_TO_SQUID squid_link
 
@@ -85,12 +83,13 @@ Win32__WSAFDIsSet(int fd, fd_set FAR * set)
 
 #else
 
-#define PINGER_TIMEOUT 10
-
 /* non-windows use STDOUT for feedback to squid */
 #define LINK_TO_SQUID   1
 
 #endif  /* _SQUID_WINDOWS_ */
+
+using namespace std::literals::chrono_literals;
+static const std::chrono::seconds PingerTimeout = 10s;
 
 // ICMP Engines are declared global here so they can call each other easily.
 IcmpPinger control;
@@ -198,7 +197,7 @@ main(int, char **)
 
     for (;;) {
         struct timeval tv;
-        tv.tv_sec = PINGER_TIMEOUT;
+        tv.tv_sec = PingerTimeout.count();
         tv.tv_usec = 0;
         FD_ZERO(&R);
         if (icmp4_worker >= 0) {
@@ -233,7 +232,7 @@ main(int, char **)
         }
 
         const auto delay = std::chrono::duration_cast<std::chrono::seconds>(timer.total());
-        if (delay.count() >= PINGER_TIMEOUT) {
+        if (delay.count() >= PingerTimeout.count()) {
             if (send(LINK_TO_SQUID, &tv, 0, 0) < 0) {
                 debugs(42, DBG_CRITICAL, "Closing. No requests in last " << delay.count() << " seconds.");
                 control.Close();

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -194,7 +194,9 @@ main(int, char **)
 #endif
 
     for (;;) {
-        struct timeval tv = { .tv_sec = PINGER_TIMEOUT, .tv_usec = 0 };
+        struct timeval tv;
+        tv.tv_sec = PINGER_TIMEOUT;
+        tv.tv_usec = 0;
         FD_ZERO(&R);
         if (icmp4_worker >= 0) {
             FD_SET(icmp4_worker, &R);

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -232,10 +232,10 @@ main(int, char **)
             icmp4.Recv();
         }
 
-        const auto waited = std::chrono::duration_cast<std::chrono::seconds>(timer.total()).count();
-        if (waited >= PINGER_TIMEOUT) {
+        const auto delay = std::chrono::duration_cast<std::chrono::seconds>(timer.total());
+        if (delay.count() >= PINGER_TIMEOUT) {
             if (send(LINK_TO_SQUID, &tv, 0, 0) < 0) {
-                debugs(42, DBG_CRITICAL, "Closing. No requests in last " << waited << " seconds.");
+                debugs(42, DBG_CRITICAL, "Closing. No requests in last " << delay.count() << " seconds.");
                 control.Close();
                 exit(EXIT_FAILURE);
             }


### PR DESCRIPTION
For consistency across platforms, we also increase the ICMP request
timeout on Windows systems from 5 to 10 seconds.