### PR TITLE
CI: Disable optimizations in "minimal" build tests

### DIFF
--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -30,9 +30,6 @@ MAKETEST="distcheck"
 #   --without-filedescriptors \
 #   --without-build-environment \
 #
-#  GCC-9 cannot (yet) test this due to segmentation faults in std::string template optimizations (via cppunit)
-#	--disable-optimizations \
-#
 # NP: DISTCHECK_CONFIGURE_FLAGS is a magic automake macro for the
 #     distcheck target recursive tests beteen scripted runs.
 #     we use it to perform the same duty between our nested scripts.
@@ -91,6 +88,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--disable-zph-qos \
 	--disable-auto-locale \
 	--disable-translation \
+	--disable-optimizations \
  \
 	--without-pthreads \
 	--without-aio \


### PR DESCRIPTION
Our "minimal" layer tests had to stop disabling optimizations in 2019
commit 4f3c41b due to problems specific to GCC v9 (v9.1 or earlier). GCC
v9.4 (and later) appear to work OK (at least on Ubuntu 22.04), so let's
try to resume testing --disable-optimizations ./configure option.

