### PR TITLE
CI: Remove irrelevant branch from master GitHub Actions config

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -3,10 +3,10 @@ name: GitHub CI
 
 on:
   push:
-    branches: [ "master", "v5", "auto" ]
+    branches: [ "master", "auto" ]
 
   pull_request:
-    branches: [ "master", "v5" ]
+    branches: [ "master" ]
 
 env:
   # empty except for pull_request events

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,11 +1,12 @@
-# Test the default branch, supported release branches, and their PRs
 name: GitHub CI
 
 on:
   push:
+    # test this branch and staged PRs based on this branch code
     branches: [ "master", "auto" ]
 
   pull_request:
+    # test PRs targeting this branch code
     branches: [ "master" ]
 
 env:


### PR DESCRIPTION
The original GitHub Actions configuration (see commit 2ed8cc4)
incorrectly assumed that GitHub will use that configuration (stored in
the master branch) for testing _all_ repository branches. In reality,
GitHub uses configuration from the being-tested branch. Thus, we do not
need to (and, hence, should not) list any branches in the X branch
configuration, with the exception of the X branch itself and the "auto"
branch where all PRs (including all X-targeting PRs) are staged for the
final "as if merged" testing.

