### PR TITLE
negotiate_kerberos_auth: Fix build [-Wunused-but-set-variable]

### DIFF
--- a/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_auth.cc
@@ -95,7 +95,7 @@ gethost_name(void)
      */
     char hostname[1024];
     struct addrinfo *hres = nullptr, *hres_list;
-    int rc, count;
+    int rc;
 
     rc = gethostname(hostname, sizeof(hostname)-1);
     if (rc) {
@@ -114,9 +114,7 @@ gethost_name(void)
         return nullptr;
     }
     hres_list = hres;
-    count = 0;
     while (hres_list) {
-        ++count;
         hres_list = hres_list->ai_next;
     }
     rc = getnameinfo(hres->ai_addr, hres->ai_addrlen, hostname,


### PR DESCRIPTION
Unused variable discovered by clang v15.