### PR TITLE
ESI: Fix build [-Wdeprecated-declarations]

### DIFF
--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -108,7 +108,7 @@ esi_getEntitySAXFunc(void * /* ctx */, const xmlChar *name)
 ESILibxml2Parser::ESILibxml2Parser(ESIParserClient *aClient) : theClient (aClient)
 {
     xmlSAXHandler sax;
-    htmlDefaultSAXHandlerInit();
+    xmlInitParser();
     memset(&sax, 0, sizeof(sax));
     sax.startElement = esi_startElementSAXFunc;
     sax.endElement = esi_endElementSAXFunc;


### PR DESCRIPTION
Replaced deprecated htmlDefaultSAXHandlerInit() libxml2 initialization
call with xmlInitParser().
