### PR TITLE
Fix build with clang v15 [-Wunused-but-set-variable]

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -605,7 +605,6 @@ neighborsUdpPing(HttpRequest * request,
     int i;
     int reqnum = 0;
     int flags;
-    int queries_sent = 0;
     int peers_pinged = 0;
     int parent_timeout = 0, parent_exprep = 0;
     int sibling_timeout = 0, sibling_exprep = 0;
@@ -680,8 +679,6 @@ neighborsUdpPing(HttpRequest * request,
                 }
             }
         }
-
-        ++queries_sent;
 
         ++ p->stats.pings_sent;
 


### PR DESCRIPTION
Remove unused variable in neigbours.cc:neighborsUdpPing