### PR TITLE
bootstrap.sh: Polish output

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,7 +50,8 @@ find_variant()
   done
   if [ "x$found" = "xNOT_FOUND" ]; then
     echo "WARNING: Cannot find $tool version $versions" >&2
-    echo "Trying `$tool --version | head -1`" >&2
+    echo -n "Trying " >&2
+    ($tool --version | head -1) >&2
     found=""
   fi
   echo $found

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,7 +50,7 @@ find_variant()
   done
   if [ "x$found" = "xNOT_FOUND" ]; then
     echo "WARNING: Cannot find $tool version $versions" >&2
-    ($tool --version | head -1) >&2
+    echo "Trying `$tool --version 2>&1 | head -1`" >&2
     found=""
   fi
   echo $found

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -111,17 +111,21 @@ ltpath=`find_path ${LIBTOOL_BIN}${ltver}`
 # Set environment variable to tell automake which autoconf to use.
 AUTOCONF="autoconf${acver}" ; export AUTOCONF
 
-echo "automake ($amversion) : automake$amver"
-echo "autoconf ($acversion) : autoconf$acver"
-echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
-echo "libtool path : $ltpath"
+verbose=0
+if test "x$1" != "x--quiet" ; then
+    verbose=1
+    echo "automake ($amversion) : automake$amver"
+    echo "autoconf ($acversion) : autoconf$acver"
+    echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
+    echo "libtool path : $ltpath"
+fi
 
 for dir in \
 	""
 do
     if [ -z "$dir" ] || [ -d $dir ]; then
 	if (
-	echo "Bootstrapping $dir"
+	test $verbose -eq 1 && echo "Bootstrapping $dir"
 	cd ./$dir
 	if [ -n "$dir" ] && [ -f bootstrap.sh ]; then
 	    ./bootstrap.sh
@@ -158,7 +162,7 @@ fi
 # autoconf should inherit this option whe recursing into subdirectories
 # but it currently doesn't for some reason.
 if ! grep  "configure_args --quiet" configure >/dev/null; then
-echo "Fixing configure recursion"
+test $verbose -eq 1 && echo "Fixing configure recursion"
 ed -s configure <<'EOS' >/dev/null || true
 /ac_sub_configure_args=/
 +1
@@ -171,4 +175,4 @@ w
 EOS
 fi
 
-echo "Autotool bootstrapping complete."
+test $verbose -eq 1 && echo "Autotool bootstrapping complete."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,7 +50,6 @@ find_variant()
   done
   if [ "x$found" = "xNOT_FOUND" ]; then
     echo "WARNING: Cannot find $tool version $versions" >&2
-    echo -n "Trying " >&2
     ($tool --version | head -1) >&2
     found=""
   fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,7 +72,7 @@ bootstrap() {
   if "$@"; then
     true # Everything OK
   else
-    echo "$1 failed"
+    echo "$1 failed" >&2
     echo "Autotool bootstrapping failed. You will need to investigate and correct" ;
     echo "before you can develop on this source tree"
     exit 1
@@ -111,21 +111,17 @@ ltpath=`find_path ${LIBTOOL_BIN}${ltver}`
 # Set environment variable to tell automake which autoconf to use.
 AUTOCONF="autoconf${acver}" ; export AUTOCONF
 
-verbose=0
-if test "x$1" != "x--quiet" ; then
-    verbose=1
-    echo "automake ($amversion) : automake$amver"
-    echo "autoconf ($acversion) : autoconf$acver"
-    echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
-    echo "libtool path : $ltpath"
-fi
+echo "automake ($amversion) : automake$amver"
+echo "autoconf ($acversion) : autoconf$acver"
+echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
+echo "libtool path : $ltpath"
 
 for dir in \
 	""
 do
     if [ -z "$dir" ] || [ -d $dir ]; then
 	if (
-	test $verbose -eq 1 && echo "Bootstrapping $dir"
+	echo "Bootstrapping $dir"
 	cd ./$dir
 	if [ -n "$dir" ] && [ -f bootstrap.sh ]; then
 	    ./bootstrap.sh
@@ -162,7 +158,7 @@ fi
 # autoconf should inherit this option whe recursing into subdirectories
 # but it currently doesn't for some reason.
 if ! grep  "configure_args --quiet" configure >/dev/null; then
-test $verbose -eq 1 && echo "Fixing configure recursion"
+echo "Fixing configure recursion"
 ed -s configure <<'EOS' >/dev/null || true
 /ac_sub_configure_args=/
 +1
@@ -175,4 +171,4 @@ w
 EOS
 fi
 
-test $verbose -eq 1 && echo "Autotool bootstrapping complete."
+echo "Autotool bootstrapping complete."


### PR DESCRIPTION
We use bootstrap.sh a lot in maintenance scripts but do not
need to see its output on success.

 * Fix some incorrect uses of stderr and stdout such that
   all (and only) errors appear on stderr

 * Polish the message display when an error does occur
    detecting one of the tools.