### PR TITLE
Replaced clientReplyContext::tempBuffer with old_reqofs

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -66,7 +66,6 @@ clientReplyContext::~clientReplyContext()
     /* old_entry might still be set if we didn't yet get the reply
      * code in HandleIMSReply() */
     removeStoreReference(&old_sc, &old_entry);
-    safe_free(tempBuffer.data);
     cbdataReferenceDone(http);
     HTTPMSGUNLOCK(reply);
 }
@@ -76,7 +75,6 @@ clientReplyContext::clientReplyContext(ClientHttpRequest *clientContext) :
     http(cbdataReference(clientContext)),
     headers_sz(0),
     sc(nullptr),
-    old_reqsize(0),
     reqsize(0),
     reqofs(0),
     ourNode(nullptr),
@@ -84,6 +82,8 @@ clientReplyContext::clientReplyContext(ClientHttpRequest *clientContext) :
     old_entry(nullptr),
     old_sc(nullptr),
     old_lastmod(-1),
+    old_reqofs(0),
+    old_reqsize(0),
     deleting(false),
     collapsedRevalidation(crNone)
 {
@@ -202,7 +202,7 @@ clientReplyContext::saveState()
     old_lastmod = http->request->lastmod;
     old_etag = http->request->etag;
     old_reqsize = reqsize;
-    tempBuffer.offset = reqofs;
+    old_reqofs = reqofs;
     /* Prevent accessing the now saved entries */
     http->storeEntry(nullptr);
     sc = nullptr;
@@ -219,7 +219,7 @@ clientReplyContext::restoreState()
     http->storeEntry(old_entry);
     sc = old_sc;
     reqsize = old_reqsize;
-    reqofs = tempBuffer.offset;
+    reqofs = old_reqofs;
     http->request->lastmod = old_lastmod;
     http->request->etag = old_etag;
     /* Prevent accessed the old saved entries */
@@ -228,7 +228,7 @@ clientReplyContext::restoreState()
     old_lastmod = -1;
     old_etag.clean();
     old_reqsize = 0;
-    tempBuffer.offset = 0;
+    old_reqofs = 0;
 }
 
 void
@@ -377,7 +377,7 @@ clientReplyContext::sendClientUpstreamResponse()
         http->storeEntry()->clearPublicKeyScope();
 
     /* here the data to send is the data we just received */
-    tempBuffer.offset = 0;
+    old_reqofs = 0;
     old_reqsize = 0;
     /* sendMoreData tracks the offset as well.
      * Force it back to zero */

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -74,8 +74,6 @@ public:
     /// Not to be confused with ClientHttpRequest::Out::headers_sz.
     int headers_sz;
     store_client *sc;       /* The store_client we're using */
-    StoreIOBuffer tempBuffer;   /* For use in validating requests via IMS */
-    int old_reqsize;        /* ... again, for the buffer */
     size_t reqsize;
     size_t reqofs;
     char tempbuf[HTTP_REQBUF_SZ];   ///< a temporary buffer if we need working storage
@@ -135,11 +133,13 @@ private:
     /// TODO: Exclude internal Store match bans from the "mismatch" category.
     const char *firstStoreLookup_ = nullptr;
 
+    /* (stale) cache hit information preserved during IMS revalidation */
     StoreEntry *old_entry;
-    /* ... for entry to be validated */
     store_client *old_sc;
     time_t old_lastmod;
     String old_etag;
+    size_t old_reqofs;
+    size_t old_reqsize;
 
     bool deleting;
 


### PR DESCRIPTION
The tempBuffer data member was not actually used as a buffer. We only
used its offset field, and only for saving reqofs (which has a different
type than tempBuffer.offset!). Replaced the buffer with old_reqofs,
consistent with the rest of the "saved stale entry state" code.

Also fixed old_reqsize type to match reqsize and grouped that member
with the other private "saved stale entry state" fields.

Bad old types probably did not trigger runtime failures because the
associated saved numbers are saved at the very beginning of fetching the
entry, when all these accumulation-related counters are still small.

The remaining reqofs and reqsize types are wrong for platforms where
size_t is not uint64_t, but fixing that deserves a dedicated change. For
now, we just made the types of "old_" and "current" members consistent.
