### PR TITLE
Simplify use of DIST_SUBDIRS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,12 +6,14 @@
 ##
 
 AUTOMAKE_OPTIONS = dist-bzip2 1.5 foreign
-DIST_SUBDIRS	= compat lib libltdl scripts icons errors contrib doc src test-suite tools
-SUBDIRS		= compat lib
+
+SUBDIRS = compat contrib doc errors icons
+
 if ENABLE_LOADABLE_MODULES
 SUBDIRS += libltdl
 endif
-SUBDIRS += scripts icons errors doc src tools test-suite
+
+SUBDIRS += lib scripts src tools test-suite
 
 DISTCLEANFILES = include/stamp-h include/stamp-h[0-9]*
 DEFAULT_PINGER = $(libexecdir)/`echo pinger | sed '$(transform);s/$$/$(EXEEXT)/'`

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -22,7 +22,7 @@ EXTRA_DIST = \
 
 all:
 
-install: install-@host_os@
+#install: install-@host_os@
 
 install-hpux10.10 install-hpux10.20:
 	$(INSTALL_BIN) $(SQUID_RC) /sbin/init.d/squid

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -22,8 +22,6 @@ EXTRA_DIST = \
 
 all:
 
-#install: install-@host_os@
-
 install-hpux10.10 install-hpux10.20:
 	$(INSTALL_BIN) $(SQUID_RC) /sbin/init.d/squid
 	$(INSTALL_FILE) $(SQUID_OPTIONS) /etc/rc.config.d/squid

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -7,7 +7,6 @@
 
 include $(top_srcdir)/src/Common.am
 
-DIST_SUBDIRS = ntlmauth rfcnb smblib libTrie snmplib
 SUBDIRS=
 EXTRA_DIST=
 

--- a/lib/libTrie/Makefile.am
+++ b/lib/libTrie/Makefile.am
@@ -8,7 +8,6 @@
 include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/src/TestHeaders.am
 
-DIST_SUBDIRS = . test
 SUBDIRS = . test
 
 noinst_LIBRARIES = libTrie.a

--- a/src/DiskIO/Makefile.am
+++ b/src/DiskIO/Makefile.am
@@ -9,7 +9,6 @@ include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/src/TestHeaders.am
 
 SUBDIRS=
-DIST_SUBDIRS= AIO Blocking DiskDaemon DiskThreads IpcIo Mmapped
 
 noinst_LTLIBRARIES = libdiskio.la
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,17 +17,14 @@ LOADABLE_MODULES_SOURCES = \
 	LoadableModules.h
 
 SUBDIRS = mem time debug base anyp helper dns ftp parser comm error eui acl format clients sbuf servers fs repl store DiskIO proxyp
-DIST_SUBDIRS = mem time debug base anyp helper dns ftp parser comm error eui acl format clients sbuf servers fs repl store DiskIO proxyp
 
 if ENABLE_AUTH
 SUBDIRS += auth
 AUTH_LIBS= auth/libauth.la
 AUTH_ACL_LIBS= auth/libacls.la
 endif
-DIST_SUBDIRS += auth
 
 SUBDIRS	+= http ip icmp ident log ipc mgr
-DIST_SUBDIRS += http ip icmp ident log ipc mgr
 
 SSL_LIBS=
 if ENABLE_SSL
@@ -36,7 +33,6 @@ SSL_LIBS += \
 	ssl/libsslsquid.la \
 	ssl/libsslutil.la
 endif
-DIST_SUBDIRS += ssl security
 SUBDIRS += security
 
 SNMP_ALL_SOURCE = \
@@ -52,12 +48,10 @@ SNMP_LIBS = snmp/libsnmp.la $(SNMPLIB)
 else
 SNMP_SOURCE =
 endif
-DIST_SUBDIRS += snmp
 
 if ENABLE_ADAPTATION
 SUBDIRS += adaptation
 endif
-DIST_SUBDIRS += adaptation
 
 if ENABLE_ESI
 SUBDIRS += esi
@@ -69,7 +63,6 @@ ESI_LIBS = \
 else
 ESI_LIBS =
 endif
-DIST_SUBDIRS += esi
 
 DELAY_POOL_ALL_SOURCE = \
 	BandwidthBucket.cc \

--- a/src/adaptation/Makefile.am
+++ b/src/adaptation/Makefile.am
@@ -8,7 +8,6 @@
 include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/src/TestHeaders.am
 
-DIST_SUBDIRS= ecap icap
 SUBDIRS =
 
 noinst_LTLIBRARIES = libadaptation.la

--- a/src/http/Makefile.am
+++ b/src/http/Makefile.am
@@ -9,7 +9,6 @@ include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/src/TestHeaders.am
 
 SUBDIRS = one url_rewriters
-DIST_SUBDIRS = one url_rewriters
 
 noinst_LTLIBRARIES = libhttp.la
 


### PR DESCRIPTION
automake only needs the DIST_SUBDIRS list to be set 'manually' when
the SUBDIRS list is built using AC_SUBST variables.

For Makefile.am which exclusively use AC_CONDITIONAL we can leave
the DIST_SUBDIRS construction to automake.