### PR TITLE
CI: Remove irrelevant branch from v6 GitHub Actions config

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,12 +1,13 @@
-# Test the default branch, supported release branches, and their PRs
 name: GitHub CI
 
 on:
   push:
-    branches: [ "master", "v5", "auto" ]
+    # test this branch and staged PRs based on this branch code
+    branches: [ "v6", "auto" ]
 
   pull_request:
-    branches: [ "master", "v5" ]
+    # test PRs targeting this branch code
+    branches: [ "v6" ]
 
 env:
   # empty except for pull_request events


### PR DESCRIPTION
The original GitHub Actions configuration (see commit 2ed8cc4)
incorrectly assumed that GitHub will use that configuration (stored in
the master branch) for testing _all_ repository branches. In reality,
GitHub uses configuration from the being-tested branch. Thus, we do not
need to (and, hence, should not) list any branches in the X branch
configuration, with the exception of the X branch itself and the "auto"
branch where all PRs (including all X-targeting PRs) are staged for the
final "as if merged" testing.

----

Cherry-picked master/v7 commit 58ecf6052ef258aaafd6d4c810a0757299113e9b
and then replaced "master" with "v6" because "this branch" is v6.
