### PR TITLE
Improve detection of lonely StoreEntry clients

### DIFF
--- a/src/store.cc
+++ b/src/store.cc
@@ -290,7 +290,7 @@ StoreEntry::storeClientType() const
     /*
      * If this is the first client, let it be the mem client
      */
-    if (mem_obj->nclients == 1)
+    if (mem_obj->nclients == 0)
         return STORE_MEM_CLIENT;
 
     /*


### PR DESCRIPTION
The first storeClientType() call still sees zero nclients because
storeClientListAdd() creates a store_client object (which triggers
storeClientType()) first and only then adds it to the list of clients
(which increases nclients). This off-by-one bug was introduced in commit
528b2c6 that reordered nclients increase and the storeClientType() call.

The bug could lead to excessive disk I/O in some environments because
Squid could see more STORE_DISK_CLIENT store_client objects, and those
may trigger startSwapin() in store_client::doCopy(). However, the exact
effects of this bug/fix are difficult to predict because startSwapin()
may be separated by async calls and is guarded by additional conditions.

A full fix requires refactoring the caller, but there are so many
problems associated with storeClientType() and startSwapin() calls that
such refactoring deserves a dedicated effort.

Technically, this "first" client may be 10th client this StoreEntry has
seen, but it is the first one among the _current_ entry clients.
