### PR TITLE
Add buffered_logs OFF support to UDP logger

### DIFF
--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -58,7 +58,7 @@ This section gives an account of those changes in three categories:
 <p>
 <descrip>
 	<tag>buffered_logs</tag>
-	<p>Support <em>off</em> to disable UDP log buffering..
+	<p>Support <em>off</em> to disable UDP log buffering.
 
 </descrip>
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -58,7 +58,7 @@ This section gives an account of those changes in three categories:
 <p>
 <descrip>
 	<tag>buffered_logs</tag>
-	<p>Support <em>off</em> to disable UDP log buffering.
+	<p>Support <em>off</em> to disable UDP log buffering..
 
 </descrip>
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -57,7 +57,8 @@ This section gives an account of those changes in three categories:
 <sect1>Changes to existing directives<label id="modifieddirectives">
 <p>
 <descrip>
-	<p>No changed directives in this version.
+	<tag>buffered_logs</tag>
+	<p>Support <em>off</em> to disable UDP log buffering.
 
 </descrip>
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -58,7 +58,7 @@ This section gives an account of those changes in three categories:
 <p>
 <descrip>
 	<tag>buffered_logs</tag>
-	<p>Support <em>off</em> to disable UDP log buffering.
+	<p>Honor the <em>off</em> setting in 'udp' access_log module.
 
 </descrip>
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -5554,7 +5554,7 @@ DOC_START
 	records if it cannot write/send them immediately due to pending I/Os
 	(e.g., the I/O writing the previous log record) or connectivity loss.
 
-	Currently honored by 'daemon' and 'tcp' access_log modules only.
+	Currently honored by 'daemon', 'tcp' and 'udp' access_log modules only.
 DOC_END
 
 NAME: netdb_filename

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -101,8 +101,10 @@ logfile_mod_udp_linestart(Logfile *)
 }
 
 static void
-logfile_mod_udp_lineend(Logfile *)
+logfile_mod_udp_lineend(Logfile *lf)
 {
+    if (!Config.onoff.buffered_logs)
+        lf->f_flush(lf);
 }
 
 static void


### PR DESCRIPTION
UDP log module always buffers log entries with a limit of
1400 bytes. Enable the "buffered_logs off" squid.conf
setting to disable this behaviour.