### PR TITLE
Fix GCC v13 build [-Warray-bounds]

### DIFF
--- a/src/ipc/mem/FlexibleArray.h
+++ b/src/ipc/mem/FlexibleArray.h
@@ -31,7 +31,6 @@ public:
     }
 
     Item &operator [](const int idx) { return *(raw() + idx); }
-    const Item &operator [](const int idx) const { return *(raw() + idx); }
 
     Item *raw() { return reinterpret_cast<Item*>(&raw_); }
 

--- a/src/ipc/mem/FlexibleArray.h
+++ b/src/ipc/mem/FlexibleArray.h
@@ -32,10 +32,10 @@ public:
 
     Item &operator [](const int idx) { return *(raw() + idx); }
 
-    Item *raw() { return reinterpret_cast<Item*>(&raw_); }
+    Item *raw() { return reinterpret_cast<Item*>(&start_); }
 
 private:
-    alignas(Item) std::byte raw_; // ensures proper alignment of array elements
+    alignas(Item) std::byte start_; ///< the first byte of the first array item
 };
 
 } // namespace Mem

--- a/src/ipc/mem/FlexibleArray.h
+++ b/src/ipc/mem/FlexibleArray.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_IPC_MEM_FLEXIBLE_ARRAY_H
 #define SQUID_IPC_MEM_FLEXIBLE_ARRAY_H
 
-// sometimes required for placement-new operator to be declared
+#include <cstddef>
 #include <new>
 
 namespace Ipc
@@ -27,20 +27,16 @@ class FlexibleArray
 {
 public:
     explicit FlexibleArray(const int capacity) {
-        if (capacity > 1) // the first item is initialized automatically
-            new (raw()+1) Item[capacity-1];
+        new (raw()) Item[capacity];
     }
 
-    Item &operator [](const int idx) { return items[idx]; }
-    const Item &operator [](const int idx) const { return items[idx]; }
+    Item &operator [](const int idx) { return *(raw() + idx); }
+    const Item &operator [](const int idx) const { return *(raw() + idx); }
 
-    //const Item *operator ()() const { return items; }
-    //Item *operator ()() { return items; }
-
-    Item *raw() { return items; }
+    Item *raw() { return reinterpret_cast<Item*>(&raw_); }
 
 private:
-    Item items[1]; // ensures proper alignment of array elements
+    alignas(Item) std::byte raw_; // ensures proper alignment of array elements
 };
 
 } // namespace Mem


### PR DESCRIPTION
    src/ipc/mem/FlexibleArray.h:34:52: error: array subscript -1 is
    below array bounds of 'int [1]' [-Werror=array-bounds]

We suspect this warning is a GCC v13 regression bug because the callers
marked as problematic by GCC (e.g., Rock::LoadingEntry::LoadingEntry) do
not use "array subscript -1", and the Ipc::StoreMapItems::at() operator
they use even asserts that the subscript is not negative. It might be
GCC bug 107699: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107699

This change replaces the fake one-item array hack with a properly
aligned byte (still used as the "start of the real array" marker).

Also removed some unused and problematic code (instead of polishing it).

