### PR TITLE
Remove dead "binary HTTP header logging" code (-DHEADERS_LOG)

### DIFF
--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -97,7 +97,9 @@ This section gives an account of those changes in three categories:
 <sect1>Removed options<label id="removedoptions">
 <p>
 <descrip>
-	<p>No removed options in this version.
+	<tag>CPPFLAGS=-DHEADERS_LOG</tag>
+	<p>The code enabled by this preprocessor macro has not built for many
+	   years, indicating that the feature is unused.
 
 </descrip>
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1838,10 +1838,6 @@ ClientHttpRequest::doCallouts()
     cbdataReferenceDone(calloutContext->http);
     delete calloutContext;
     calloutContext = nullptr;
-#if HEADERS_LOG
-
-    headersLog(0, 1, request->method, request);
-#endif
 
     debugs(83, 3, "calling processRequest()");
     processRequest();

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -97,11 +97,6 @@ esiBufferRecipient (clientStreamNode *node, ClientHttpRequest *http, HttpReply *
                 return;
             }
 
-#if HEADERS_LOG
-            /* should be done in the store rather than every recipient?  */
-            headersLog(0, 0, http->request->method, rep);
-
-#endif
             rep = nullptr;
         }
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -1057,11 +1057,6 @@ HttpStateData::haveParsedReplyHeaders()
         }
 #endif
     }
-
-#if HEADERS_LOG
-    headersLog(1, 0, request->method, rep);
-
-#endif
 }
 
 HttpStateData::ConnectionStatus

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -275,9 +275,6 @@ Http::Stream::sendStartOfMessage(HttpReply *rep, StoreIOBuffer bodyData)
 
     /* Save length of headers for persistent conn checks */
     http->out.headers_sz = mb->contentSize();
-#if HEADERS_LOG
-    headersLog(0, 0, http->request->method, rep);
-#endif
 
     if (bodyData.data && bodyData.length) {
         if (multipartRangeRequest())

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -43,10 +43,6 @@
 
 #include <unordered_map>
 
-#if HEADERS_LOG
-static Logfile *headerslog = NULL;
-#endif
-
 #if MULTICAST_MISS_STREAM
 static int mcast_miss_fd = -1;
 
@@ -190,12 +186,6 @@ accessLogRotate(void)
     for (log = Config.Log.accesslogs; log; log = log->next) {
         log->rotate();
     }
-
-#if HEADERS_LOG
-
-    logfileRotate(headerslog, Config.Log.rotateNumber);
-
-#endif
 }
 
 void
@@ -209,14 +199,6 @@ accessLogClose(void)
             log->logfile = nullptr;
         }
     }
-
-#if HEADERS_LOG
-
-    logfileClose(headerslog);
-
-    headerslog = NULL;
-
-#endif
 }
 
 HierarchyLogEntry::HierarchyLogEntry() :
@@ -401,13 +383,6 @@ accessLogInit(void)
 #endif
     }
 
-#if HEADERS_LOG
-
-    headerslog = logfileOpen("/usr/local/squid/logs/headers.log", 512);
-
-    assert(NULL != headerslog);
-
-#endif
 #if MULTICAST_MISS_STREAM
 
     if (Config.mcast_miss.addr.s_addr != no_addr.s_addr) {
@@ -526,61 +501,6 @@ mcast_encode(unsigned int *ibuf, size_t isize, const unsigned int *key)
         ibuf[i] = htonl(y);
         ibuf[i + 1] = htonl(z);
     }
-}
-
-#endif
-
-#if HEADERS_LOG
-void
-headersLog(int cs, int pq, const HttpRequestMethod& method, void *data)
-{
-    HttpReply *rep;
-    HttpRequest *req;
-    unsigned short magic = 0;
-    unsigned char M = (unsigned char) m;
-    char *hmask;
-    int ccmask = 0;
-
-    if (0 == pq) {
-        /* reply */
-        rep = data;
-        req = NULL;
-        magic = 0x0050;
-        hmask = rep->header.mask;
-
-        if (rep->cache_control)
-            ccmask = rep->cache_control->mask;
-    } else {
-        /* request */
-        req = data;
-        rep = NULL;
-        magic = 0x0051;
-        hmask = req->header.mask;
-
-        if (req->cache_control)
-            ccmask = req->cache_control->mask;
-    }
-
-    if (0 == cs) {
-        /* client */
-        magic |= 0x4300;
-    } else {
-        /* server */
-        magic |= 0x5300;
-    }
-
-    magic = htons(magic);
-    ccmask = htonl(ccmask);
-
-    unsigned short S = 0;
-    if (0 == pq)
-        S = static_cast<unsigned short>(rep->sline.status());
-
-    logfileWrite(headerslog, &magic, sizeof(magic));
-    logfileWrite(headerslog, &M, sizeof(M));
-    logfileWrite(headerslog, &S, sizeof(S));
-    logfileWrite(headerslog, hmask, sizeof(HttpHeaderMask));
-    logfileWrite(headerslog, &ccmask, sizeof(int));
 }
 
 #endif

--- a/src/log/access_log.h
+++ b/src/log/access_log.h
@@ -20,10 +20,5 @@ void fvdbCountVia(const SBuf &);
 /// count occurrences of the given X-Forwarded-For header value
 void fvdbCountForwarded(const SBuf &);
 
-#if HEADERS_LOG
-class HttpRequestMethod;
-void headersLog(int cs, int pq, const HttpRequestMethod& m, void *data);
-#endif
-
 #endif /* SQUID_LOG_ACCESS_LOG_H_ */
 

--- a/src/tests/stub_liblog.cc
+++ b/src/tests/stub_liblog.cc
@@ -32,9 +32,6 @@ const char *accessLogTime(time_t) STUB_RETVAL(nullptr)
 
 #include "log/access_log.h"
 void fvdbCountVia(const SBuf &) STUB
-#if HEADERS_LOG
-void headersLog(int, int, const HttpRequestMethod &, void *) STUB
-#endif
 
 #include "log/Config.h"
 namespace Log


### PR DESCRIPTION
The secret HEADERS_LOG hack was added in 2000 commit c360932 to collect
"better stats" than mgr:http_headers. The corresponding access_log.cc
code does not build since 2006 commit 985c86b (at least):

* 'm' was not declared in this scope
* cannot convert 'int*' to 'const char*'
* cannot convert 'short unsigned int*' to 'const char*'
* invalid conversion from 'unsigned char*' to 'const char*'
* invalid conversion from 'void*' to 'HttpReply*'
* invalid conversion from 'void*' to 'HttpRequest*'
* invalid use of incomplete type 'class HttpHdrCc'
* too few arguments to function 'logfileOpen(const char*, size_t, int)'

The removed hack is not to be confused with log_mime_hdrs directive.
