### PR TITLE
Maintenance: Remove dead Multicast Miss Stream feature

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1013,14 +1013,6 @@ or obtained by writing to the Free Software Foundation, Inc.,
 
 ==============================================================================
 
-src/access_log.cc:
-
-mcast_encode() in src/access_log.c is derived from Mark Atkinson's
-(mark_a@cix.compulink.co.uk) "Tiny Encryption Algorithm".
-http://www.io.com/~paulhart/game/algorithms/tea.html
-
-==============================================================================
-
 src/acl/external/AD_group/:
 
  * (C)2008-2009 Guido Serassio - Acme Consulting S.r.l.

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -64,7 +64,21 @@ This section gives an account of those changes in three categories:
 <sect1>Removed directives<label id="removeddirectives">
 <p>
 <descrip>
-	<p>No removed directives in this version.
+	<tag>mcast_miss_addr</tag>
+	<p>The corresponding code has not built for many years, indicating that the
+	feature is unused.
+
+	<tag>mcast_miss_ttl</tag>
+	<p>The corresponding code has not built for many years, indicating that the
+	feature is unused.
+
+	<tag>mcast_miss_port</tag>
+	<p>The corresponding code has not built for many years, indicating that the
+	feature is unused.
+
+	<tag>mcast_miss_encode_key</tag>
+	<p>The corresponding code has not built for many years, indicating that the
+	feature is unused.
 
 </descrip>
 
@@ -98,6 +112,10 @@ This section gives an account of those changes in three categories:
 <p>
 <descrip>
 	<tag>CPPFLAGS=-DHEADERS_LOG</tag>
+	<p>The code enabled by this preprocessor macro has not built for many
+	   years, indicating that the feature is unused.
+
+	<tag>CPPFLAGS=-DMULTICAST_MISS_STREAM</tag>
 	<p>The code enabled by this preprocessor macro has not built for many
 	   years, indicating that the feature is unused.
 

--- a/squid.dox
+++ b/squid.dox
@@ -2068,7 +2068,6 @@ PREDEFINED             = __cplusplus \
                          FORW_VIA_DB \
                          ICAP_CLIENT \
                          LINUX_NETFILTER \
-                         MULTICAST_MISS_STREAM \
                          SQUID_SNMP \
                          USE_ADAPTATION \
                          USE_APPLE_KRB5 \

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -454,16 +454,6 @@ public:
     int max_open_disk_fds;
     int uri_whitespace;
     AclSizeLimit *rangeOffsetLimit;
-#if MULTICAST_MISS_STREAM
-
-    struct {
-
-        Ip::Address addr;
-        int ttl;
-        unsigned short port;
-        char *encode_key;
-    } mcast_miss;
-#endif
 
     /// request_header_access and request_header_replace
     HeaderManglers *request_header_access;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -8704,51 +8704,6 @@ DOC_START
 	By default, Squid doesn't listen on any multicast groups.
 DOC_END
 
-NAME: mcast_miss_addr
-IFDEF: MULTICAST_MISS_STREAM
-TYPE: address
-LOC: Config.mcast_miss.addr
-DEFAULT: no_addr
-DEFAULT_DOC: disabled.
-DOC_START
-	If you enable this option, every "cache miss" URL will
-	be sent out on the specified multicast address.
-
-	Do not enable this option unless you are are absolutely
-	certain you understand what you are doing.
-DOC_END
-
-NAME: mcast_miss_ttl
-IFDEF: MULTICAST_MISS_STREAM
-TYPE: u_short
-LOC: Config.mcast_miss.ttl
-DEFAULT: 16
-DOC_START
-	This is the time-to-live value for packets multicasted
-	when multicasting off cache miss URLs is enabled.  By
-	default this is set to 'site scope', i.e. 16.
-DOC_END
-
-NAME: mcast_miss_port
-IFDEF: MULTICAST_MISS_STREAM
-TYPE: u_short
-LOC: Config.mcast_miss.port
-DEFAULT: 3135
-DOC_START
-	This is the port number to be used in conjunction with
-	'mcast_miss_addr'.
-DOC_END
-
-NAME: mcast_miss_encode_key
-IFDEF: MULTICAST_MISS_STREAM
-TYPE: string
-LOC: Config.mcast_miss.encode_key
-DEFAULT: XXXXXXXXXXXXXXXX
-DOC_START
-	The URLs that are sent in the multicast miss stream are
-	encrypted.  This is the encryption key.
-DOC_END
-
 NAME: mcast_icp_query_timeout
 COMMENT: (msec)
 DEFAULT: 2000

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -43,13 +43,6 @@
 
 #include <unordered_map>
 
-#if MULTICAST_MISS_STREAM
-static int mcast_miss_fd = -1;
-
-static struct sockaddr_in mcast_miss_to;
-static void mcast_encode(unsigned int *, size_t, const unsigned int *);
-#endif
-
 #if USE_FORW_VIA_DB
 
 using HeaderValueCountsElement = std::pair<const SBuf, uint64_t>;
@@ -146,32 +139,6 @@ accessLogLog(const AccessLogEntryPointer &al, ACLChecklist *checklist)
         return;
 
     accessLogLogTo(Config.Log.accesslogs, al, checklist);
-#if MULTICAST_MISS_STREAM
-
-    if (al->cache.code != LOG_TCP_MISS)
-        (void) 0;
-    else if (al->http.method != METHOD_GET)
-        (void) 0;
-    else if (mcast_miss_fd < 0)
-        (void) 0;
-    else {
-        unsigned int ibuf[365];
-        size_t isize;
-        xstrncpy((char *) ibuf, al->url.c_str(), 364 * sizeof(int));
-        isize = ((al->url.length() + 8) / 8) * 2;
-
-        if (isize > 364)
-            isize = 364;
-
-        mcast_encode((unsigned int *) ibuf, isize,
-                     (const unsigned int *) Config.mcast_miss.encode_key);
-
-        comm_udp_sendto(mcast_miss_fd,
-                        &mcast_miss_to, sizeof(mcast_miss_to),
-                        ibuf, isize * sizeof(int));
-    }
-
-#endif
 }
 
 void
@@ -382,33 +349,6 @@ accessLogInit(void)
         }
 #endif
     }
-
-#if MULTICAST_MISS_STREAM
-
-    if (Config.mcast_miss.addr.s_addr != no_addr.s_addr) {
-        memset(&mcast_miss_to, '\0', sizeof(mcast_miss_to));
-        mcast_miss_to.sin_family = AF_INET;
-        mcast_miss_to.sin_port = htons(Config.mcast_miss.port);
-        mcast_miss_to.sin_addr.s_addr = Config.mcast_miss.addr.s_addr;
-        mcast_miss_fd = comm_open(SOCK_DGRAM,
-                                  IPPROTO_UDP,
-                                  Config.Addrs.udp_incoming,
-                                  Config.mcast_miss.port,
-                                  COMM_NONBLOCKING,
-                                  "Multicast Miss Stream");
-
-        if (mcast_miss_fd < 0)
-            fatal("Cannot open Multicast Miss Stream Socket");
-
-        debugs(46, DBG_IMPORTANT, "Multicast Miss Stream Socket opened on FD " << mcast_miss_fd);
-
-        mcastSetTtl(mcast_miss_fd, Config.mcast_miss.ttl);
-
-        if (strlen(Config.mcast_miss.encode_key) < 16)
-            fatal("mcast_encode_key is too short, must be 16 characters");
-    }
-
-#endif
 }
 
 #if USE_FORW_VIA_DB
@@ -460,47 +400,6 @@ fvdbClear(void)
 {
     TheViaCounts.clear();
     TheForwardedCounts.clear();
-}
-
-#endif
-
-#if MULTICAST_MISS_STREAM
-/*
- * From http://www.io.com/~paulhart/game/algorithms/tea.html
- *
- * size of 'ibuf' must be a multiple of 2.
- * size of 'key' must be 4.
- * 'ibuf' is modified in place, encrypted data is written in
- * network byte order.
- */
-static void
-mcast_encode(unsigned int *ibuf, size_t isize, const unsigned int *key)
-{
-    unsigned int y;
-    unsigned int z;
-    unsigned int sum;
-    const unsigned int delta = 0x9e3779b9;
-    unsigned int n = 32;
-    const unsigned int k0 = htonl(key[0]);
-    const unsigned int k1 = htonl(key[1]);
-    const unsigned int k2 = htonl(key[2]);
-    const unsigned int k3 = htonl(key[3]);
-    int i;
-
-    for (i = 0; i < isize; i += 2) {
-        y = htonl(ibuf[i]);
-        z = htonl(ibuf[i + 1]);
-        sum = 0;
-
-        for (n = 32; n; --n) {
-            sum += delta;
-            y += (z << 4) + (k0 ^ z) + (sum ^ (z >> 5)) + k1;
-            z += (y << 4) + (k2 ^ y) + (sum ^ (y >> 5)) + k3;
-        }
-
-        ibuf[i] = htonl(y);
-        ibuf[i + 1] = htonl(z);
-    }
 }
 
 #endif


### PR DESCRIPTION
This feature was added in 1998 commit e66d792 for special "you are
absolutely certain you understand what you are doing" experiments and
considered "largely undocumented and unsupported" by its primary
author[^1]. The corresponding MULTICAST_MISS_STREAM code in
access_log.cc has not built since 2007 commit cc192b5 (at least):

* 'class Ip::Address' has no member named 's_addr'
* 'comm_open' was not declared in this scope
* 'comm_udp_sendto' was not declared in this scope
* 'mcastSetTtl' was not declared in this scope
* 'METHOD_GET' was not declared in this scope
* 'no_addr' was not declared in this scope
* no match for 'operator!=' (operand types are LogTags and LogTags_ot)

[^1]: Duane Wessels. 2004. Squid: The Definitive Guide. O'Reilly &
Associates, Inc., USA. See mcast_miss_addr documentation on page 390.
