### PR TITLE
Build SPONSORS only when needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,6 @@ EXTRA_DIST = \
 	INSTALL \
 	QUICKSTART \
 	README \
-	SPONSORS \
 	bootstrap.sh \
 	po4a.conf
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -149,11 +149,6 @@ do
     fi
 done
 
-# Make a copy of SPONSORS we can package
-if test -f SPONSORS.list; then
-  sed -e 's/@Squid-[0-9\.]*://' <SPONSORS.list > SPONSORS || (rm -f SPONSORS && exit 1)
-fi
-
 # Fixup autoconf recursion using --silent/--quiet option
 # autoconf should inherit this option whe recursing into subdirectories
 # but it currently doesn't for some reason.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -13,4 +13,11 @@ DEFAULT_ERROR_DIR       = $(datadir)/errors
 
 EXTRA_DIST = \
 	debug-messages.dox \
-	debug-sections.txt
+	debug-sections.txt \
+	SPONSORS.in
+
+data_DATA = SPONSORS
+CLEANFILES = $(data_DATA)
+
+SPONSORS: SPONSORS.in
+	sed -e 's/@Squid-[0-9\.]*://' <$< >$@

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST = \
 	debug-sections.txt \
 	SPONSORS.in
 
-data_DATA = SPONSORS
+noinst_data_DATA = SPONSORS
 CLEANFILES = $(data_DATA)
 
 SPONSORS: SPONSORS.in

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -15,9 +15,9 @@ EXTRA_DIST = \
 	debug-messages.dox \
 	debug-sections.txt \
 	SPONSORS.in
+CLEANFILES = SPONSORS
 
-noinst_data_DATA = SPONSORS
-CLEANFILES = $(data_DATA)
+all: SPONSORS
 
 SPONSORS: SPONSORS.in
 	sed -e 's/@Squid-[0-9\.]*://' <$< >$@

--- a/doc/SPONSORS.in
+++ b/doc/SPONSORS.in
@@ -8,10 +8,16 @@ The Squid Software Foundation - http://foundation.squid-cache.org/
 	developers and users.
 
 @Squid-7:
+DigitalOcean - https://www.digitalocean.com/
+
+	DigitalOcean has donated droplets from their cloud infrastructure
+	to host most of Squid Project's continuous integration farm.
+
 GitHub - https://github.com/
 
 	GitHub provide git repository mirroring services for the
-	Squid-3+ development code.
+	Squid-3+ development code, hosting services for the wiki,
+	and support tools for code review and content integration.
 
 The Measurement Factory - http://www.measurement-factory.com/
 
@@ -25,11 +31,6 @@ Treehouse Networks, NZ - http://treenet.co.nz/
 	gateways and CDN.
 
 @Squid-6:
-DigitalOcean - https://www.digitalocean.com/
-
-	DigitalOcean has donated droplets from their cloud infrastructure
-	to host most of Squid Project's continuous integration farm.
-
 SpinUp - https://SpinUp.com
 
 	SpinUp has donated cloud resources to host our main website, wiki

--- a/doc/SPONSORS.in
+++ b/doc/SPONSORS.in
@@ -7,16 +7,11 @@ The Squid Software Foundation - http://foundation.squid-cache.org/
 	providing the infrastructure and support framework for Squid
 	developers and users.
 
-@Squid-6:
-DigitalOcean - https://www.digitalocean.com/
+@Squid-7:
+GitHub - https://github.com/
 
-	DigitalOcean has donated droplets from their cloud infrastructure
-	to host most of Squid Project's continuous integration farm.
-
-SpinUp - https://SpinUp.com
-
-	SpinUp has donated cloud resources to host our main website, wiki
-	and mailing lists.
+	GitHub provide git repository mirroring services for the
+	Squid-3+ development code.
 
 The Measurement Factory - http://www.measurement-factory.com/
 
@@ -28,6 +23,17 @@ Treehouse Networks, NZ - http://treenet.co.nz/
 	Treehouse Networks has contributed significant resources
 	toward Squid-3+ development and maintenance for their customer
 	gateways and CDN.
+
+@Squid-6:
+DigitalOcean - https://www.digitalocean.com/
+
+	DigitalOcean has donated droplets from their cloud infrastructure
+	to host most of Squid Project's continuous integration farm.
+
+SpinUp - https://SpinUp.com
+
+	SpinUp has donated cloud resources to host our main website, wiki
+	and mailing lists.
 
 @Squid-5:
 RackSpace - https://www.rackspace.com/


### PR DESCRIPTION
The SPONSORS file is no longer distributed in the Squid tarball.

If needed it can be generated using:
  make -C doc SPONSORS