### PR TITLE
WCCP: fix inverted range check

### DIFF
--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -1452,7 +1452,7 @@ wccp2HandleUdp(int sock, void *)
         ptr += sizeof(*routerCountRaw);
         const auto ipCount = ntohl(*routerCountRaw);
         const auto ipsSize = ipCount * sizeof(struct in_addr); // we check for unsigned overflow below
-        Must3(ipsSize / sizeof(struct in_addr) != ipCount, "huge IP address count", Here());
+        Must3(ipsSize / sizeof(struct in_addr) == ipCount, "huge IP address count", Here());
         CheckSectionLength(ptr, ipsSize, router_view_header, router_view_size, "invalid IP address count");
         ptr += ipsSize;
 


### PR DESCRIPTION
Correct a typo in 464223c147a568169e940fb466947bdb556d87af