### PR TITLE
Improve reply_body_max_size matching accuracy

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1198,8 +1198,7 @@ clientReplyContext::replyStatus()
     }
 
     // XXX: Should this be checked earlier? We could return above w/o checking.
-    if (reply->receivedBodyTooLarge(*http->request, http->out.offset - 4096)) {
-        /* 4096 is a margin for the HTTP headers included in out.offset */
+    if (reply->receivedBodyTooLarge(*http->request, http->out.offset)) {
         debugs(88, 5, "clientReplyStatus: client reply body is too large");
         return STREAM_FAILED;
     }


### PR DESCRIPTION
    HttpReply.cc(553) receivedBodyTooLarge: -4096 >? -1

ClientHttpRequest::out.offset is documented to only count body bytes,
and that is what receivedBodyTooLarge() needs. We should not subtract
the guessed header size, occasionally violating reply_body_max_size
configuration and often leading to a confusing negative body size in
receivedBodyTooLarge() debugging.

Possibly broken since 2003 commit b51aec6: out.offset was not documented
back then, but, AFAICT, it was already used just for the body bytes.
