### PR TITLE
Fix default build with libgnutls but absent GnuTLS headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1093,7 +1093,8 @@ AS_IF([test "x$with_gnutls" != "xno"],[
     ## by testing for a 3.4.0+ function which we use
     AC_CHECK_LIB(gnutls,gnutls_pcert_export_x509,[LIBGNUTLS_LIBS="-lgnutls"])
   ])
-  AC_CHECK_HEADERS(gnutls/gnutls.h gnutls/x509.h gnutls/abstract.h)
+  # if any of the required headers is not found, signal we can't support gnutls
+  AC_CHECK_HEADERS(gnutls/gnutls.h gnutls/x509.h gnutls/abstract.h, [], [LIBGNUTLS_LIBS=""])
 
   SQUID_STATE_ROLLBACK(squid_gnutls_state) #de-pollute LIBS
 

--- a/configure.ac
+++ b/configure.ac
@@ -1094,7 +1094,7 @@ AS_IF([test "x$with_gnutls" != "xno"],[
     AC_CHECK_LIB(gnutls,gnutls_pcert_export_x509,[LIBGNUTLS_LIBS="-lgnutls"])
   ])
   # if any of the required headers is not found, signal we can't support gnutls
-  AC_CHECK_HEADERS(gnutls/gnutls.h gnutls/x509.h gnutls/abstract.h, [], [LIBGNUTLS_LIBS=""])
+  AC_CHECK_HEADERS([gnutls/gnutls.h gnutls/x509.h gnutls/abstract.h], [], [LIBGNUTLS_LIBS=""])
 
   SQUID_STATE_ROLLBACK(squid_gnutls_state) #de-pollute LIBS
 


### PR DESCRIPTION
Ensure that when libgnutls is found but any of the required GnuTLS
headers cannot be used, GnuTLS support is not enabled by default and an
explicit request for GnuTLS support is fatally rejected during
./configure. Otherwise, the build fails later anyway, during "make".

The problem was exposed by a mingw-cross build.
