### PR TITLE
Add SQUID_CHECK_LIB_WORKS macro

### DIFF
--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -218,7 +218,7 @@ dnl Check that a library is actually available, useable,
 dnl and where its pieces are (eg headers and hack macros)
 dnl Parameters for this macro are:
 dnl 1) library name (without 'lib' prefix)
-dnl 2) logic to run checks
+dnl 2) necessary library checks (to be executed by this macro unless the use of the library is disabled)
 AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
 AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
   $2

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -236,6 +236,7 @@ AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
     AC_MSG_NOTICE([Library '$1' support: no (auto)])
   ])
 ])
+AC_SUBST(m4_toupper(m4_translit([LIB$1_LIBS], [-+.], [___])))
 ])
 
 dnl check the build parameters for a library to auto-enable

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -217,7 +217,7 @@ AC_DEFUN([SQUID_YESNO],[
 dnl Check that a library is actually available, useable,
 dnl and where its pieces are (eg headers and hack macros)
 dnl Parameters for this macro are:
-dnl 1) binary library name (without 'lib' prefix)
+dnl 1) library name (without 'lib' prefix)
 dnl 2) logic to run checks
 AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
 AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -219,8 +219,8 @@ dnl and where its pieces are (eg headers and hack macros)
 dnl Parameters for this macro are:
 dnl 1) library name (without 'lib' prefix)
 dnl 2) necessary library checks (to be executed by this macro unless the use of the library is disabled)
-dnl   These checks should set LIBFOO_LIBS variable for automake
-dnl   and ensure that it is empty on detection/validation failures.
+dnl   These checks should set LIBFOO_LIBS automake variable (on success)
+dnl   and ensure that it is empty or unset (on failures).
 AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
 AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
   $2

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -219,6 +219,8 @@ dnl and where its pieces are (eg headers and hack macros)
 dnl Parameters for this macro are:
 dnl 1) library name (without 'lib' prefix)
 dnl 2) necessary library checks (to be executed by this macro unless the use of the library is disabled)
+dnl   These checks should set LIBFOO_LIBS variable for automake
+dnl   and ensure that it is empty on detection/validation failures.
 AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
 AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
   $2

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -227,7 +227,7 @@ AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
   AS_IF([! test -z m4_toupper(m4_translit(["$LIB$1_LIBS"], [-+.], [___]))],[
     m4_toupper(m4_translit([CXXFLAGS="$LIB$1_CFLAGS $CXXFLAGS"], [-+.], [___]))
     m4_toupper(m4_translit([LIB$1_LIBS="$LIB$1_PATH $LIB$1_LIBS"], [-+.], [___]))
-    AC_MSG_NOTICE([Library '$1' support: ${with_$1:=yes (auto)} m4_toupper($LIB$1_LIBS)])
+    AC_MSG_NOTICE([Library '$1' support: m4_translit([${with_$1:=yes (auto)} m4_toupper($LIB$1_LIBS)], [-+.], [___])])
     m4_translit([with_$1], [-+.], [___])=yes
   ],[m4_translit([test "x$with_$1" = "xyes"], [-+.], [___])],[
     AC_MSG_ERROR([Required library '$1' not found])

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -222,6 +222,15 @@ dnl 2) logic to run checks
 AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
 AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
   $2
+  AS_IF([! test -z m4_toupper(m4_translit(["$LIB$1_LIBS"], [-+.], [___]))],[
+    m4_translit([with_$1], [-+.], [___])=yes
+    m4_toupper(m4_translit([CXXFLAGS="$LIB$1_CFLAGS $CXXFLAGS"], [-+.], [___]))
+    m4_toupper(m4_translit([LIB$1_LIBS="$LIB$1_PATH $LIB$1_LIBS"], [-+.], [___]))
+  ],[m4_translit([test "x$with_$1" = "xyes"], [-+.], [___])],[
+    AC_MSG_ERROR([Required library '$1' not found])
+  ],[
+    m4_translit([with_$1], [-+.], [___])=no
+  ])
 ])
 ])
 

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -225,7 +225,7 @@ AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
 AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
   $2
   AS_IF([! test -z m4_toupper(m4_translit(["$LIB$1_LIBS"], [-+.], [___]))],[
-    m4_toupper(m4_translit([CXXFLAGS="$LIB$1_CFLAGS $CXXFLAGS"], [-+.], [___]))
+    m4_toupper(m4_translit([CPPFLAGS="$LIB$1_CFLAGS $CPPFLAGS"], [-+.], [___]))
     m4_toupper(m4_translit([LIB$1_LIBS="$LIB$1_PATH $LIB$1_LIBS"], [-+.], [___]))
     AC_MSG_NOTICE([Library '$1' support: m4_translit([${with_$1:=yes (auto)} m4_toupper($LIB$1_LIBS)], [-+.], [___])])
     m4_translit([with_$1], [-+.], [___])=yes

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -214,6 +214,17 @@ AC_DEFUN([SQUID_YESNO],[
   AS_IF([test "$1" != "yes" -a "$1" != "no"],[AC_MSG_ERROR([Bad argument for $2: "$1". Expecting "yes", "no", or no argument.])])
 ])
 
+dnl Check that a library is actually available, useable,
+dnl and where its pieces are (eg headers and hack macros)
+dnl Parameters for this macro are:
+dnl 1) binary library name (without 'lib' prefix)
+dnl 2) logic to run checks
+AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
+AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
+  $2
+])
+])
+
 dnl check the build parameters for a library to auto-enable
 dnl Parameters for this macro are:
 dnl 1) binary library name (without 'lib' prefix)

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -223,13 +223,15 @@ AC_DEFUN([SQUID_CHECK_LIB_WORKS],[
 AS_IF([m4_translit([test "x$with_$1" != "xno"], [-+.], [___])],[
   $2
   AS_IF([! test -z m4_toupper(m4_translit(["$LIB$1_LIBS"], [-+.], [___]))],[
-    m4_translit([with_$1], [-+.], [___])=yes
     m4_toupper(m4_translit([CXXFLAGS="$LIB$1_CFLAGS $CXXFLAGS"], [-+.], [___]))
     m4_toupper(m4_translit([LIB$1_LIBS="$LIB$1_PATH $LIB$1_LIBS"], [-+.], [___]))
+    AC_MSG_NOTICE([Library '$1' support: ${with_$1:=yes (auto)} m4_toupper($LIB$1_LIBS)])
+    m4_translit([with_$1], [-+.], [___])=yes
   ],[m4_translit([test "x$with_$1" = "xyes"], [-+.], [___])],[
     AC_MSG_ERROR([Required library '$1' not found])
   ],[
     m4_translit([with_$1], [-+.], [___])=no
+    AC_MSG_NOTICE([Library '$1' support: no (auto)])
   ])
 ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -1858,7 +1858,6 @@ AC_MSG_NOTICE([Linux Netfilter support requested: ${enable_linux_netfilter:=auto
 
 dnl Look for libnetfilter_conntrack options (needed for QOS netfilter marking)
 SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[LIBNETFILTER_CONNTRACK])
-AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_conntrack:=auto}])
 SQUID_CHECK_LIB_WORKS(netfilter-conntrack,[
   LDFLAGS="$LIBNETFILTER_CONNTRACK_PATH $LDFLAGS"
   CPPFLAGS="$LIBNETFILTER_CONNTRACK_CFLAGS $CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -391,7 +391,7 @@ AS_IF([test "x$squid_opt_aufs_threads" != "x"],[
 
 ## TODO check if this is necessary, LT_INIT does these checks
 SQUID_AUTO_LIB(dl,[dynamic linking],[LIBDL])
-AS_IF([test "x$with_dl" != "xno"],[
+SQUID_CHECK_LIB_WORKS(dl,[
   CXXFLAGS="$LIBDL_CFLAGS $CXXFLAGS"
   LDFLAGS="$LIBDL_PATH $LDFLAGS"
   AC_CHECK_LIB(dl, dlopen)
@@ -1073,7 +1073,7 @@ AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 
 # Cryptograhic libraries
 SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
-AS_IF(test "x$with_nettle" != "xno"],[
+SQUID_CHECK_LIB_WORKS(nettle,[
   SQUID_STATE_SAVE(squid_nettle_state)
   PKG_CHECK_MODULES([LIBNETTLE],[nettle >= 3.4],[],[
     CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
@@ -1107,7 +1107,7 @@ SSLLIB=""
 
 SQUID_AUTO_LIB(gnutls,[GnuTLS crypto],[LIBGNUTLS])
 AH_TEMPLATE(USE_GNUTLS,[GnuTLS support is available])
-AS_IF([test "x$with_gnutls" != "xno"],[
+SQUID_CHECK_LIB_WORKS(gnutls,[
   SQUID_STATE_SAVE(squid_gnutls_state)
 
   # User may have provided a custom location for GnuTLS. Otherwise...
@@ -1640,7 +1640,7 @@ AC_SUBST(KRB5INCS)
 AC_SUBST(KRB5LIBS)
 
 SQUID_AUTO_LIB(ldap,[LDAP],[LIBLDAP])
-AS_IF([test "x$with_ldap" != "xno"],[
+SQUID_CHECK_LIB_WORKS(ldap,[
   dnl On MinGW OpenLDAP is not available, so LDAP helpers can be linked
   dnl only with Windows LDAP libraries using -lwldap32
   AS_IF([test "$squid_host_os" = "mingw"],[
@@ -1681,7 +1681,7 @@ AC_SUBST(LIBLDAP_LIBS)
 
 SQUID_AUTO_LIB(systemd,[systemd API for start-up notification],[LIBSYSTEMD])
 AH_TEMPLATE(USE_SYSTEMD,[systemd support is available])
-AS_IF([test "x$with_systemd" != "xno"],[
+SQUID_CHECK_LIB_WORKS(systemd,[
   SQUID_STATE_SAVE(squid_systemd_state)
   LIBS="$LIBS $LIBSYSTEMD_PATH"
   PKG_CHECK_MODULES(LIBSYSTEMD,[libsystemd],,[
@@ -1893,7 +1893,7 @@ AC_MSG_NOTICE([Linux Netfilter support requested: ${enable_linux_netfilter:=auto
 dnl Look for libnetfilter_conntrack options (needed for QOS netfilter marking)
 SQUID_AUTO_LIB(netfilter-conntrack,[Netfilter conntrack],[LIBNETFILTER_CONNTRACK])
 AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_conntrack:=auto}])
-AS_IF([test "x$with_netfilter_conntrack" != "xno"],[
+SQUID_CHECK_LIB_WORKS(netfilter-conntrack,[
   LDFLAGS="$LIBNETFILTER_CONNTRACK_PATH $LDFLAGS"
   CPPFLAGS="$LIBNETFILTER_CONNTRACK_CFLAGS $CPPFLAGS"
   AC_SEARCH_LIBS([nfct_query], [netfilter_conntrack],,[
@@ -2241,7 +2241,7 @@ SQUID_DEFINE_BOOL(X_ACCELERATOR_VARY,${enable_x_accelerator_vary:=no},
 AC_MSG_NOTICE([X-Accelerator-Vary support enabled: $enable_x_accelerator_vary])
 
 SQUID_AUTO_LIB(cppunit,[cppunit test framework],[LIBCPPUNIT])
-AS_IF([test "x$with_cppunit" != "xno"],[
+SQUID_CHECK_LIB_WORKS(cppunit,[
   LIBCPPUNIT_LIBS="$LIBCPPUNIT_PATH -lcppunit"
   PKG_CHECK_MODULES([LIBCPPUNIT],[cppunit],[
     squid_cv_cppunit_version="`pkg-config --modversion cppunit`"
@@ -2466,7 +2466,7 @@ dnl Check for special functions
 AC_FUNC_ALLOCA
 
 SQUID_AUTO_LIB(cap,[Linux capabilities],[LIBCAP])
-AS_IF([test "x$with_cap" != "xno"],[
+SQUID_CHECK_LIB_WORKS(cap,[
   SQUID_STATE_SAVE(squid_libcap_state)
   CXXFLAGS="$LIBCAP_CFLAGS $CXXFLAGS"
   LDFLAGS="$LIBCAP_PATH $LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -1083,7 +1083,6 @@ SQUID_CHECK_LIB_WORKS(nettle,[
   SQUID_CHECK_NETTLE_BASE64
   SQUID_STATE_ROLLBACK(squid_nettle_state)
 ])
-AC_MSG_NOTICE([Using Nettle cryptographic library: ${with_nettle:=yes}])
 AC_SUBST(LIBNETTLE_LIBS)
 
 dnl Check for libcrypt
@@ -1125,7 +1124,6 @@ SQUID_CHECK_LIB_WORKS(gnutls,[
     AC_DEFINE(USE_GNUTLS,1,[GnuTLS support is available])
   ])
 ])
-AC_MSG_NOTICE([GnuTLS library support: ${with_gnutls:=auto} ${LIBGNUTLS_PATH} ${LIBGNUTLS_LIBS}])
 
 dnl User may specify OpenSSL is needed from a non-standard location
 SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[LIBOPENSSL])
@@ -1672,7 +1670,6 @@ SQUID_CHECK_LIB_WORKS(systemd,[
     AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
   ])
 ])
-AC_MSG_NOTICE([systemd library support: $with_systemd $LIBSYSTEMD_LIBS])
 
 AC_ARG_ENABLE(forw-via-db,
   AS_HELP_STRING([--enable-forw-via-db],[Enable Forw/Via database]), [
@@ -2443,7 +2440,6 @@ SQUID_CHECK_LIB_WORKS(cap,[
     AC_DEFINE(USE_LIBCAP,1,[Linux capabilities library support])
   ])
 ])
-AC_MSG_NOTICE([Linux capabilities support enabled: ${with_cap} ${LIBCAP_LIBS}])
 
 dnl Check for needed libraries
 AC_SEARCH_LIBS([gethostbyname],[nsl resolv bind])

--- a/configure.ac
+++ b/configure.ac
@@ -1083,7 +1083,6 @@ SQUID_CHECK_LIB_WORKS(nettle,[
   SQUID_CHECK_NETTLE_BASE64
   SQUID_STATE_ROLLBACK(squid_nettle_state)
 ])
-AC_SUBST(LIBNETTLE_LIBS)
 
 dnl Check for libcrypt
 CRYPTLIB=
@@ -1652,7 +1651,6 @@ SQUID_CHECK_LIB_WORKS(ldap,[
     SQUID_CHECK_LDAP_API
   ])
 ])
-AC_SUBST(LIBLDAP_LIBS)
 
 SQUID_AUTO_LIB(systemd,[systemd API for start-up notification],[LIBSYSTEMD])
 AH_TEMPLATE(USE_SYSTEMD,[systemd support is available])

--- a/configure.ac
+++ b/configure.ac
@@ -392,9 +392,9 @@ AS_IF([test "x$squid_opt_aufs_threads" != "x"],[
 ## TODO check if this is necessary, LT_INIT does these checks
 SQUID_AUTO_LIB(dl,[dynamic linking],[LIBDL])
 SQUID_CHECK_LIB_WORKS(dl,[
-  CXXFLAGS="$LIBDL_CFLAGS $CXXFLAGS"
   LDFLAGS="$LIBDL_PATH $LDFLAGS"
-  AC_CHECK_LIB(dl, dlopen)
+  AC_CHECK_LIB(dl, dlopen,[LIBDL_LIBS="-ldl"])
+  LIBS="$LIBDL_LIBS $LIBS"
 ])
 
 AC_DEFUN([LIBATOMIC_CHECKER],[
@@ -1082,14 +1082,6 @@ SQUID_CHECK_LIB_WORKS(nettle,[
   AC_CHECK_HEADERS(nettle/base64.h nettle/md5.h)
   SQUID_CHECK_NETTLE_BASE64
   SQUID_STATE_ROLLBACK(squid_nettle_state)
-  AS_IF([test "x$LIBNETTLE_LIBS" != "x"],[
-    CXXFLAGS="$LIBNETTLE_CFLAGS $CXXFLAGS"
-    LIBNETTLE_LIBS="$LIBNETTLE_PATH $LIBNETTLE_LIBS"
-  ],[test "x$with_nettle" = "xyes"],[
-    AC_MSG_ERROR([Required library nettle not found])
-  ],[
-    AC_MSG_NOTICE([Library nettle not found.])
-  ])
 ])
 AC_MSG_NOTICE([Using Nettle cryptographic library: ${with_nettle:=yes}])
 AC_SUBST(LIBNETTLE_LIBS)
@@ -1128,15 +1120,9 @@ SQUID_CHECK_LIB_WORKS(gnutls,[
 
   SQUID_STATE_ROLLBACK(squid_gnutls_state) #de-pollute LIBS
 
-  AS_IF([test "x$with_gnutls" = "xyes" -a "x$LIBGNUTLS_LIBS" = "x"],[
-    AC_MSG_ERROR([Required GnuTLS library not found])
-  ])
   AS_IF([test "x$LIBGNUTLS_LIBS" != "x"],[
-    CXXFLAGS="$LIBGNUTLS_CFLAGS $CXXFLAGS"
     SSLLIB="$LIBGNUTLS_PATH $LIBGNUTLS_LIBS $SSLLIB"
     AC_DEFINE(USE_GNUTLS,1,[GnuTLS support is available])
-  ],[
-    with_gnutls=no
   ])
 ])
 AC_MSG_NOTICE([GnuTLS library support: ${with_gnutls:=auto} ${LIBGNUTLS_PATH} ${LIBGNUTLS_LIBS}])
@@ -1667,15 +1653,6 @@ SQUID_CHECK_LIB_WORKS(ldap,[
     AC_CHECK_HEADERS(mozldap/ldap.h)
     SQUID_CHECK_LDAP_API
   ])
-
-  AS_IF([test "x$LIBLDAP_LIBS" != "x"],[
-    CPPFLAGS="$LIBLDAP_CFLAGS $CPPFLAGS"
-    LIBLDAP_LIBS="$LIBLDAP_PATH $LIBLDAP_LIBS"
-  ],[test "x$with_ldap" = "xyes"],[
-    AC_MSG_ERROR([Required library ldap not found])
-  ],[
-    AC_MSG_NOTICE([Library ldap not found.])
-  ])
 ])
 AC_SUBST(LIBLDAP_LIBS)
 
@@ -1692,13 +1669,7 @@ SQUID_CHECK_LIB_WORKS(systemd,[
   SQUID_STATE_ROLLBACK(squid_systemd_state)
 
   AS_IF([test "x$LIBSYSTEMD_LIBS" != "x"],[
-    CXXFLAGS="$LIBSYSTEMD_CFLAGS $CXXFLAGS"
-    LIBSYSTEMD_LIBS="$LIBSYSTEMD_PATH $LIBSYSTEMD_LIBS"
     AC_DEFINE(USE_SYSTEMD,1,[systemd support is available])
-  ],[test "x$with_systemd" = "xyes"],[
-    AC_MSG_ERROR([Required systemd library not found])
-  ],[
-    AC_MSG_NOTICE([Library for systemd support not found])
   ])
 ])
 AC_MSG_NOTICE([systemd library support: $with_systemd $LIBSYSTEMD_LIBS])
@@ -1896,22 +1867,11 @@ AC_MSG_NOTICE([Linux Netfilter Conntrack support requested: ${with_netfilter_con
 SQUID_CHECK_LIB_WORKS(netfilter-conntrack,[
   LDFLAGS="$LIBNETFILTER_CONNTRACK_PATH $LDFLAGS"
   CPPFLAGS="$LIBNETFILTER_CONNTRACK_CFLAGS $CPPFLAGS"
-  AC_SEARCH_LIBS([nfct_query], [netfilter_conntrack],,[
-    AS_IF([test "x$with_netfilter_conntrack" = "xyes"],[
-      AC_MSG_ERROR([--with-netfilter-conntrack specified but libnetfilter-conntrack library not found])
-    ])
-    with_netfilter_conntrack=no
-  ])
+  AC_SEARCH_LIBS([nfct_query],[netfilter_conntrack],[LIBNETFILTER_CONNTRACK_LIBS="-lnetfilter_conntrack"])
   AC_CHECK_HEADERS([ \
     libnetfilter_conntrack/libnetfilter_conntrack.h \
     libnetfilter_conntrack/libnetfilter_conntrack_tcp.h
-  ],,[
-    AS_IF([test "x$with_netfilter_conntrack" = "xyes"],[
-      AC_MSG_ERROR([--with-netfilter-conntrack specified but libnetfilter-conntrack headers not found])
-    ])
-    with_netfilter_conntrack=no
-  ])
-  AS_IF([test "x$with_netfilter_conntrack" != "xno"],[with_netfilter_conntrack=yes])
+  ],,[LIBNETFILTER_CONNTRACK_LIBS=""])
 ])
 
 dnl Enable Large file support
@@ -2480,15 +2440,7 @@ SQUID_CHECK_LIB_WORKS(cap,[
   SQUID_STATE_ROLLBACK(squid_libcap_state)
 
   AS_IF([test "x$LIBCAP_LIBS" != "x"],[
-    with_cap=yes
-    CPPFLAGS="$LIBCAP_CFLAGS $CPPFLAGS"
-    LIBCAP_LIBS="$LIBCAP_PATH $LIBCAP_LIBS"
     AC_DEFINE(USE_LIBCAP,1,[Linux capabilities library support])
-  ],[test "x$with_cap" = "xyes"],[
-    AC_MSG_ERROR([Required library libcap not found])
-  ],[
-    AC_MSG_NOTICE([Library libcap not found])
-    with_cap=no
   ])
 ])
 AC_MSG_NOTICE([Linux capabilities support enabled: ${with_cap} ${LIBCAP_LIBS}])


### PR DESCRIPTION
... to run validation for a library after SQUID_AUTO_LIB detection.

A typical use of this macro could be:
```
  SQUID_AUTO_LIB(foo,[Foo],[LIBFOO])
  SQUID_CHECK_LIB_WORKS(foo,[
    PKG_CHECK_MODULES([LIBFOO],[foo >= 1.0],[],[
      LIBFOO_LIBS=""
    ])
    AC_CHECK_HEADERS([foo.h],[],[LIBFOO_LIBS=""])
  ])
```

Update of configure.ac to use this macro uncovered and
fixed a bug which may have broken libnettle detection on
some systems.