### PR TITLE
MinGW-w64: update libcompat structure

### DIFF
--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -50,6 +50,7 @@ libcompatsquid_la_SOURCES = \
 	os/hpux.h \
 	os/linux.h \
 	os/macosx.h \
+	os/mingw.h \
 	os/mswindows.h \
 	os/netbsd.h \
 	os/openbsd.h \

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -68,6 +68,7 @@
 #include "compat/os/hpux.h"
 #include "compat/os/linux.h"
 #include "compat/os/macosx.h"
+#include "compat/os/mingw.h"
 #include "compat/os/mswindows.h"
 #include "compat/os/netbsd.h"
 #include "compat/os/openbsd.h"

--- a/compat/mswindows.cc
+++ b/compat/mswindows.cc
@@ -12,7 +12,7 @@
 #include "squid.h"
 
 // The following code section is part of an EXPERIMENTAL native Windows NT/2000 Squid port.
-// Compiles only on MS Visual C++ or MinGW
+// Compiles only on MS Visual C++
 // CygWin appears not to need any of these
 #if _SQUID_WINDOWS_ && !_SQUID_CYGWIN_
 
@@ -123,7 +123,6 @@ gettimeofday(struct timeval *pcur_time, void *tzp)
 }
 #endif /* !HAVE_GETTIMEOFDAY */
 
-#if !_SQUID_MINGW_
 int
 WIN32_ftruncate(int fd, off_t size)
 {
@@ -171,7 +170,6 @@ WIN32_truncate(const char *pathname, off_t length)
 
     return res;
 }
-#endif /* !_SQUID_MINGW_ */
 
 struct passwd *
 getpwnam(char *unused) {
@@ -184,34 +182,6 @@ getgrnam(char *unused) {
     static struct group grp = {nullptr, nullptr, 100, nullptr};
     return &grp;
 }
-
-#if _SQUID_MINGW_
-int
-_free_osfhnd(int filehandle)
-{
-    if (((unsigned) filehandle < SQUID_MAXFD) &&
-            (_osfile(filehandle) & FOPEN) &&
-            (_osfhnd(filehandle) != (long) INVALID_HANDLE_VALUE)) {
-        switch (filehandle) {
-        case 0:
-            SetStdHandle(STD_INPUT_HANDLE, nullptr);
-            break;
-        case 1:
-            SetStdHandle(STD_OUTPUT_HANDLE, nullptr);
-            break;
-        case 2:
-            SetStdHandle(STD_ERROR_HANDLE, nullptr);
-            break;
-        }
-        _osfhnd(filehandle) = (long) INVALID_HANDLE_VALUE;
-        return (0);
-    } else {
-        errno = EBADF;      /* bad handle */
-        _doserrno = 0L;     /* not an OS error */
-        return -1;
-    }
-}
-#endif /* _SQUID_MINGW_ */
 
 struct errorentry {
     unsigned long WIN32_code;

--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_OS_MINGW_H
+#define SQUID_OS_MINGW_H
+
+#if _SQUID_MINGW_
+
+/****************************************************************************
+ *--------------------------------------------------------------------------*
+ * DO *NOT* MAKE ANY CHANGES below here unless you know what you're doing...*
+ *--------------------------------------------------------------------------*
+ ****************************************************************************/
+
+// all windows native code requires windows.h
+#if HAVE_WINDOWS_H
+#include <windows.h>
+#endif
+
+#endif /* _SQUID_MINGW_*/
+#endif /* SQUID_OS_MINGW_H */

--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -17,6 +17,16 @@
  *--------------------------------------------------------------------------*
  ****************************************************************************/
 
+// include this header before winsock2.h
+#if HAVE_WS2TCPIP_H
+#include <ws2tcpip.h>
+#endif
+
+// error: #warning Please include winsock2.h before windows.h
+#if HAVE_WINSOCK2_H
+#include <winsock2.h>
+#endif
+
 // all windows native code requires windows.h
 #if HAVE_WINDOWS_H
 #include <windows.h>

--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -22,16 +22,6 @@
  *--------------------------------------------------------------------------*
  ****************************************************************************/
 
-/* we target Windows XP and later - some API are missing otherwise */
-#if _SQUID_MINGW_
-#if WINVER < 0x0501
-#undef WINVER
-#define WINVER 0x0501
-#undef _WIN32_WINNT
-#define _WIN32_WINNT WINVER
-#endif
-#endif /* _SQUID_MINGW_ */
-
 #include "compat/initgroups.h"
 
 #if HAVE_DIRECT_H
@@ -54,19 +44,6 @@
 #pragma warning( disable : 4290 )
 #pragma warning( disable : 4996 )
 #endif
-#endif
-
-/* Some MinGW version defines min() and max() as macros
-   causing the fail of the build process. The following
-   #define will disable that definition
- */
-#if defined(__GNUC__) && !NOMINMAX
-#define NOMINMAX
-#endif
-
-/// some builds of MinGW do not define IPV6_V6ONLY socket option
-#if !defined(IPV6_V6ONLY)
-#define IPV6_V6ONLY 27
 #endif
 
 #if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
@@ -112,7 +89,7 @@ typedef unsigned long ino_t;
 #define vsnprintf _vsnprintf
 #endif
 
-/*  Microsoft C Compiler and CygWin need these. MinGW does not */
+/*  Microsoft C Compiler and CygWin need these. */
 #if defined(_MSC_VER) || _SQUID_CYGWIN_
 SQUIDCEXTERN int WIN32_ftruncate(int fd, off_t size);
 #define ftruncate WIN32_ftruncate
@@ -236,12 +213,6 @@ SQUIDCEXTERN int WIN32_truncate(const char *pathname, off_t length);
 #define SIGCHLD 20  /* to parent on child stop or exit */
 #define SIGUSR1 30  /* user defined signal 1 */
 #define SIGUSR2 31  /* user defined signal 2 */
-
-#if _SQUID_MINGW_
-typedef unsigned char boolean;
-typedef unsigned char u_char;
-typedef unsigned int u_int;
-#endif
 
 #if defined(_MSC_VER)
 typedef int uid_t;
@@ -420,11 +391,6 @@ typedef struct {
 #if defined(_MSC_VER)
 SQUIDCEXTERN _CRTIMP ioinfo * __pioinfo[];
 SQUIDCEXTERN int __cdecl _free_osfhnd(int);
-#endif
-
-#if _SQUID_MINGW_
-__MINGW_IMPORT ioinfo * __pioinfo[];
-SQUIDCEXTERN int _free_osfhnd(int);
 #endif
 
 SQUIDCEXTERN THREADLOCAL int ws32_result;
@@ -935,11 +901,6 @@ setgid (gid_t gid)
     return 0;
 }
 
-/* for some reason autoconf misdetects getpagesize.. */
-#if HAVE_GETPAGESIZE && _SQUID_MINGW_
-#undef HAVE_GETPAGESIZE
-#endif
-
 #if !HAVE_GETPAGESIZE
 /* And now we define a compatibility layer */
 size_t getpagesize();
@@ -990,24 +951,6 @@ SQUIDCEXTERN DWORD WIN32_IpAddrChangeMonitorInit();
 
 void openlog(const char *ident, int logopt, int facility);
 void syslog(int priority, const char *fmt, ...);
-#endif
-
-#if _SQUID_MINGW_
-/* MinGW missing bits from sys/wait.h */
-/* A status looks like:
- *  <2 bytes info> <2 bytes code>
- *
- *  <code> == 0, child has exited, info is the exit value
- *  <code> == 1..7e, child has exited, info is the signal number.
- *  <code> == 7f, child has stopped, info was the signal number.
- *  <code> == 80, there was a core dump.
- */
-#define WIFEXITED(w)    (((w) & 0xff) == 0)
-#define WIFSIGNALED(w)  (((w) & 0x7f) > 0 && (((w) & 0x7f) < 0x7f))
-#define WIFSTOPPED(w)   (((w) & 0xff) == 0x7f)
-#define WEXITSTATUS(w)  (((w) >> 8) & 0xff)
-#define WTERMSIG(w) ((w) & 0x7f)
-#define WSTOPSIG    WEXITSTATUS
 #endif
 
 /* prototypes */

--- a/compat/osdetect.h
+++ b/compat/osdetect.h
@@ -66,7 +66,6 @@
 
 #elif defined(__MINGW32__) || defined(__MINGW__)
 #define _SQUID_MINGW_ 1
-#define _SQUID_WINDOWS_ 1
 
 #elif defined(WIN32) || defined(WINNT) || defined(__WIN32__) || defined(__WIN32)
 #define _SQUID_WINDOWS_ 1

--- a/compat/statvfs.cc
+++ b/compat/statvfs.cc
@@ -21,7 +21,7 @@
 int
 xstatvfs(const char *path, struct statvfs *sfs)
 {
-#if !HAVE_STATFS && _SQUID_WINDOWS_
+#if !HAVE_STATFS && (_SQUID_MINGW_ || _SQUID_WINDOWS_)
     char drive[4];
     DWORD spc, bps, freec, totalc;
     DWORD vsn, maxlen, flags;


### PR DESCRIPTION
Separate the Squid for Windows portability fixes for MinGW and
MSVC builds. Beginning a new MinGW-w64 specific port with
a clean starting base.

With these changes the libcompat portability library builds.
The rest of Squid remains mostly non-building.