### PR TITLE
Do not check store_status when checking ENTRY_BAD_LENGTH

### DIFF
--- a/src/store.cc
+++ b/src/store.cc
@@ -915,7 +915,7 @@ StoreEntry::checkCachable()
         return 0; // avoid rerequesting release below
     }
 
-    if (store_status == STORE_OK && EBIT_TEST(flags, ENTRY_BAD_LENGTH)) {
+    if (EBIT_TEST(flags, ENTRY_BAD_LENGTH)) {
         debugs(20, 2, "StoreEntry::checkCachable: NO: wrong content-length");
         ++store_check_cachable_hist.no.wrong_content_length;
     } else if (!mem_obj) {

--- a/src/store_digest.cc
+++ b/src/store_digest.cc
@@ -248,7 +248,7 @@ storeDigestAddable(const StoreEntry * e)
         return 0;
     }
 
-    if (e->store_status == STORE_OK && EBIT_TEST(e->flags, ENTRY_BAD_LENGTH)) {
+    if (EBIT_TEST(e->flags, ENTRY_BAD_LENGTH)) {
         debugs(71, 6, "storeDigestAddable: NO: wrong content-length");
         return 0;
     }


### PR DESCRIPTION
Before 1997 commit b34ed72 (that introduced the current ENTRY_BAD_LENGTH
"cache"), checking store_status before calling storeEntryValidLength()
kind of made sense because storeEntryValidLength() did not support
STORE_PENDING entries with their unset object_len. Since that commit,
checking store_status does not cause any visible problems (i.e. the code
"works") because ENTRY_BAD_LENGTH implies STORE_OK. However, that
implication is not backed by some fundamental invariant and might
suddenly disappear. Checking two flags instead of one is also wasteful.

No Squid functionality changes are expected.
