### PR TITLE
Do not populate StoreEntry basics from Transients

### DIFF
--- a/src/MemObject.h
+++ b/src/MemObject.h
@@ -169,6 +169,20 @@ public:
     class XitTable
     {
     public:
+        /// associate our StoreEntry with a Transients entry at the given index
+        void open(const int32_t anIndex, const Io anIo)
+        {
+            index = anIndex;
+            io = anIo;
+        }
+
+        /// stop associating our StoreEntry with a Transients entry
+        void close()
+        {
+            index = -1;
+            io = Store::ioDone;
+        }
+
         int32_t index = -1; ///< entry position inside the in-transit table
         Io io = ioUndecided; ///< current I/O state
     };

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -238,7 +238,7 @@ Transients::addWriterEntry(StoreEntry &e, const cache_key *key)
     xitTable.index = index;
     xitTable.io = Store::ioWriting;
 
-    anchor->set(e, key);
+    anchor->setKey(key);
     // allow reading and receive remote DELETE events, but do not switch to
     // the reading lock because transientReaders() callers want true readers
     map->startAppending(index);
@@ -260,15 +260,13 @@ Transients::addReaderEntry(StoreEntry &e, const cache_key *key)
 
 /// fills (recently created) StoreEntry with information currently in Transients
 void
-Transients::anchorEntry(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnchor &anchor)
+Transients::anchorEntry(StoreEntry &e, const sfileno index, const Ipc::StoreMapAnchor & /* XXX: remove */)
 {
     // set ASAP in hope to unlock the slot if something throws
     // and to provide index to such methods as hasWriter()
     auto &xitTable = e.mem_obj->xitTable;
     xitTable.index = index;
     xitTable.io = Store::ioReading;
-
-    anchor.exportInto(e);
 }
 
 bool

--- a/src/Transients.h
+++ b/src/Transients.h
@@ -94,7 +94,6 @@ protected:
     void addEntry(StoreEntry*, const cache_key *, const Store::IoStatus);
     void addWriterEntry(StoreEntry &, const cache_key *);
     void addReaderEntry(StoreEntry &, const cache_key *);
-    void anchorEntry(StoreEntry &, const sfileno, const Ipc::StoreMapAnchor &);
 
     // Ipc::StoreMapCleaner API
     void noteFreeMapSlice(const Ipc::StoreMapSliceId sliceId) override;

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -100,7 +100,7 @@ Ipc::StoreMap::forgetWritingEntry(sfileno fileno)
 }
 
 const Ipc::StoreMap::Anchor *
-Ipc::StoreMap::openOrCreateForReading(const cache_key *const key, sfileno &fileno, const StoreEntry &entry)
+Ipc::StoreMap::openOrCreateForReading(const cache_key *const key, sfileno &fileno, const StoreEntry & /* XXX: remove */)
 {
     debugs(54, 5, "opening/creating entry with key " << storeKeyText(key)
            << " for reading " << path);
@@ -115,7 +115,7 @@ Ipc::StoreMap::openOrCreateForReading(const cache_key *const key, sfileno &filen
     // the competing openOrCreateForReading() workers race to create a new entry
     idx = fileNoByKey(key);
     if (auto anchor = openForWritingAt(idx)) {
-        anchor->set(entry, key);
+        anchor->setKey(key);
         anchor->lock.switchExclusiveToShared();
         // race ended
         assert(anchor->complete());

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -100,7 +100,7 @@ Ipc::StoreMap::forgetWritingEntry(sfileno fileno)
 }
 
 const Ipc::StoreMap::Anchor *
-Ipc::StoreMap::openOrCreateForReading(const cache_key *const key, sfileno &fileno, const StoreEntry & /* XXX: remove */)
+Ipc::StoreMap::openOrCreateForReading(const cache_key *const key, sfileno &fileno)
 {
     debugs(54, 5, "opening/creating entry with key " << storeKeyText(key)
            << " for reading " << path);

--- a/src/ipc/StoreMap.h
+++ b/src/ipc/StoreMap.h
@@ -314,7 +314,7 @@ public:
     void closeForReadingAndFreeIdle(const sfileno fileno);
 
     /// openForReading() but creates a new entry if there is no old one
-    const Anchor *openOrCreateForReading(const cache_key *, sfileno &, const StoreEntry &);
+    const Anchor *openOrCreateForReading(const cache_key *, sfileno &);
 
     /// writeable slice within an entry chain created by openForWriting()
     Slice &writeableSlice(const AnchorId anchorId, const SliceId sliceId);


### PR DESCRIPTION
    client_side_reply.cc:1078: "http->storeEntry()->objectLen() >= 0"
    inside clientReplyContext::storeOKTransferDone()

Since commit 24c9378, Transients are not supposed to maintain "basic"
cache entry information (i.e. StoreMapAnchor::Basics a.k.a. StoreEntry
STORE_META_STD fields). Using often-at-their-defaults Transient basics
may unexpectedly erase valuable StoreEntry information obtained from one
of the caches (e.g., swap_file_sz) and lead to assertions.

Consequently, do not populate unused Transients entry basics either.

Eventually, we may find a good way to parameterize StoreMapAnchor to
avoid keeping those unused fields in Transients StoreMap.

