### PR TITLE
Do not erase aborted StoreMap entries that are still being read

### DIFF
--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -127,6 +127,28 @@ Ipc::ReadWriteLock::startAppending()
     appending = true;
 }
 
+bool
+Ipc::ReadWriteLock::stopAppendingAndRestoreExclusive()
+{
+    assert(writing);
+
+    // avoid more expensive and less readable compare_exchange_strong() because
+    // only the writer (i.e. us) can change appending
+    if (!appending) {
+        assert(!readers);
+        return true; // we are not appending and have exclusive access already
+    }
+    appending = false;
+
+    // Checking `readers` here would mishandle a lockShared() call that started
+    // before we banned appending above, saw still true `appending`, got on a
+    // "success" code path, but had not incremented the `readers` counter yet.
+    // Checking `readLevel` mishandles lockShared() that saw false `appending`,
+    // got on a "failure" code path, but had not decremented `readLevel` yet.
+    // Our callers prefer the wrong "false" to the wrong "true" result.
+    return !readLevel;
+}
+
 void
 Ipc::ReadWriteLock::updateStats(ReadWriteLockStats &stats) const
 {

--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -131,12 +131,9 @@ bool
 Ipc::ReadWriteLock::stopAppendingAndRestoreExclusive()
 {
     assert(writing);
+    assert(appending);
 
-    // We could immediately return true if appending is already false, but that
-    // would require ensuring that this method is never called twice in a row
-    // for the same lock, and we have no good way to ensure that. Instead, we
-    // accept a few wrong "false" results below.
-    appending = false; // might already be false
+    appending = false;
 
     // Checking `readers` here would mishandle a lockShared() call that started
     // before we banned appending above, saw still true `appending`, got on a

--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -160,17 +160,6 @@ Ipc::ReadWriteLock::updateStats(ReadWriteLockStats &stats) const
     ++stats.count;
 }
 
-void
-Ipc::ReadWriteLock::print(std::ostream &os) const
-{
-    os << readers << 'R';
-    if (writing)
-        os << 'W';
-    if (appending)
-        os << 'A';
-    // impossible to report updating without setting/clearing that flag
-}
-
 /* Ipc::ReadWriteLockStats */
 
 Ipc::ReadWriteLockStats::ReadWriteLockStats()
@@ -203,3 +192,13 @@ Ipc::ReadWriteLockStats::dump(StoreEntry &e) const
                           appenders, appPerc);
     }
 }
+
+std::ostream &
+Ipc::operator <<(std::ostream &os, const Ipc::ReadWriteLock &lock)
+{
+    return os << lock.readers << 'R' <<
+           (lock.writing ? "W" : "") <<
+           (lock.appending ? "A" : "");
+    // impossible to report lock.updating without setting/clearing that flag
+}
+

--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -165,6 +165,17 @@ Ipc::ReadWriteLock::updateStats(ReadWriteLockStats &stats) const
     ++stats.count;
 }
 
+void
+Ipc::ReadWriteLock::print(std::ostream &os) const
+{
+    os << readers << 'R';
+    if (writing)
+        os << 'W';
+    if (appending)
+        os << 'A';
+    // impossible to report updating without setting/clearing that flag
+}
+
 /* Ipc::ReadWriteLockStats */
 
 Ipc::ReadWriteLockStats::ReadWriteLockStats()
@@ -197,13 +208,3 @@ Ipc::ReadWriteLockStats::dump(StoreEntry &e) const
                           appenders, appPerc);
     }
 }
-
-std::ostream &
-Ipc::operator <<(std::ostream &os, const Ipc::ReadWriteLock &lock)
-{
-    return os << lock.readers << 'R' <<
-           (lock.writing ? "W" : "") <<
-           (lock.appending ? "A" : "");
-    // impossible to report lock.updating without setting/clearing that flag
-}
-

--- a/src/ipc/ReadWriteLock.cc
+++ b/src/ipc/ReadWriteLock.cc
@@ -132,13 +132,11 @@ Ipc::ReadWriteLock::stopAppendingAndRestoreExclusive()
 {
     assert(writing);
 
-    // avoid more expensive and less readable compare_exchange_strong() because
-    // only the writer (i.e. us) can change appending
-    if (!appending) {
-        assert(!readers);
-        return true; // we are not appending and have exclusive access already
-    }
-    appending = false;
+    // We could immediately return true if appending is already false, but that
+    // would require ensuring that this method is never called twice in a row
+    // for the same lock, and we have no good way to ensure that. Instead, we
+    // accept a few wrong "false" results below.
+    appending = false; // might already be false
 
     // Checking `readers` here would mishandle a lockShared() call that started
     // before we banned appending above, saw still true `appending`, got on a

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -50,29 +50,21 @@ public:
     /// adds approximate current stats to the supplied ones
     void updateStats(ReadWriteLockStats &stats) const;
 
-    /// dumps approximate lock state (for debugging)
-    void print(std::ostream &) const;
-
 public:
     mutable std::atomic<uint32_t> readers; ///< number of reading users
     std::atomic<bool> writing; ///< there is a writing user (there can be at most 1)
+    std::atomic<bool> appending; ///< the writer has promised to only append
     std::atomic_flag updating; ///< a reader is updating metadata/headers
 
 private:
     bool finalizeExclusive();
 
-    std::atomic<bool> appending; ///< the writer has promised to only append
     mutable std::atomic<uint32_t> readLevel; ///< number of users reading (or trying to)
     std::atomic<uint32_t> writeLevel; ///< number of users writing (or trying to write)
 };
 
-/// \copydoc ReadWriteLock::print()
-inline std::ostream &
-operator <<(std::ostream &os, const ReadWriteLock &lock)
-{
-    lock.print(os);
-    return os;
-}
+/// dumps approximate lock state (for debugging)
+std::ostream &operator <<(std::ostream &, const ReadWriteLock &);
 
 /// approximate stats of a set of ReadWriteLocks
 class ReadWriteLockStats

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -43,7 +43,8 @@ public:
     void startAppending(); ///< writer keeps its lock but also allows reading
 
     /// writer keeps its lock and disallows future readers
-    /// \returns whether access became exclusive (i.e. no concurrent readers)
+    /// \returns whether access became exclusive (i.e. no readers)
+    /// \prec appending is true
     bool stopAppendingAndRestoreExclusive();
 
     /// adds approximate current stats to the supplied ones

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -42,6 +42,10 @@ public:
 
     void startAppending(); ///< writer keeps its lock but also allows reading
 
+    /// writer keeps its lock and disallows future readers
+    /// \returns whether access became exclusive (i.e. no concurrent readers)
+    bool stopAppendingAndRestoreExclusive();
+
     /// adds approximate current stats to the supplied ones
     void updateStats(ReadWriteLockStats &stats) const;
 

--- a/src/ipc/ReadWriteLock.h
+++ b/src/ipc/ReadWriteLock.h
@@ -49,21 +49,29 @@ public:
     /// adds approximate current stats to the supplied ones
     void updateStats(ReadWriteLockStats &stats) const;
 
+    /// dumps approximate lock state (for debugging)
+    void print(std::ostream &) const;
+
 public:
     mutable std::atomic<uint32_t> readers; ///< number of reading users
     std::atomic<bool> writing; ///< there is a writing user (there can be at most 1)
-    std::atomic<bool> appending; ///< the writer has promised to only append
     std::atomic_flag updating; ///< a reader is updating metadata/headers
 
 private:
     bool finalizeExclusive();
 
+    std::atomic<bool> appending; ///< the writer has promised to only append
     mutable std::atomic<uint32_t> readLevel; ///< number of users reading (or trying to)
     std::atomic<uint32_t> writeLevel; ///< number of users writing (or trying to write)
 };
 
-/// dumps approximate lock state (for debugging)
-std::ostream &operator <<(std::ostream &, const ReadWriteLock &);
+/// \copydoc ReadWriteLock::print()
+inline std::ostream &
+operator <<(std::ostream &os, const ReadWriteLock &lock)
+{
+    lock.print(os);
+    return os;
+}
 
 /// approximate stats of a set of ReadWriteLocks
 class ReadWriteLockStats

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -253,15 +253,14 @@ Ipc::StoreMap::abortWriting(const sfileno fileno)
     debugs(54, 5, "aborting entry " << fileno << " for writing " << path);
     Anchor &s = anchorAt(fileno);
     assert(s.writing());
-    s.lock.appending = false; // locks out any new readers
-    if (!s.lock.readers) {
+    if (s.lock.stopAppendingAndRestoreExclusive()) {
         freeChain(fileno, s, false);
-        debugs(54, 5, "closed clean entry " << fileno << " for writing " << path);
+        debugs(54, 5, "closed idle entry " << fileno << " for writing " << path);
     } else {
         s.waitingToBeFreed = true;
         s.writerHalted = true;
         s.lock.unlockExclusive();
-        debugs(54, 5, "closed dirty entry " << fileno << " for writing " << path);
+        debugs(54, 5, "closed busy entry " << fileno << " for writing " << path);
     }
 }
 

--- a/src/ipc/StoreMap.cc
+++ b/src/ipc/StoreMap.cc
@@ -253,7 +253,7 @@ Ipc::StoreMap::abortWriting(const sfileno fileno)
     debugs(54, 5, "aborting entry " << fileno << " for writing " << path);
     Anchor &s = anchorAt(fileno);
     assert(s.writing());
-    if (s.lock.stopAppendingAndRestoreExclusive()) {
+    if (!s.lock.appending || s.lock.stopAppendingAndRestoreExclusive()) {
         freeChain(fileno, s, false);
         debugs(54, 5, "closed idle entry " << fileno << " for writing " << path);
     } else {


### PR DESCRIPTION
The old `!s.lock.readers` precondition for calling freeChain() in
StoreMap::abortWriting() was not broad enough: It covered "old" readers
that have incremented ReadWriteLock::readers already while missing those
lockShared() callers that have fully qualified for becoming a reader but
have not incremented the `readers` counter yet. A correct test is now
implemented by ReadWriteLock::stopAppendingAndRestoreExclusive().

This code was broken since appending mode was introduced in 2013 commit
ce49546. Evidently, the mishandled race condition is short-lived enough
and abortWriting() calls are rare enough, that there are no (known)
relevant bug reports. This bug was accidentally discovered while reading
the code to explain another SMP bug.

Controller::markedForDeletionAndAbandoned() similarly misjudges
readers(), but that bug does not lead to serious problems, and we would
like to find a fix that identifies such entries without false positives
(that looking at ReadWriteLock::readLevel instead of readers creates).

Also polished Ipc::StoreMap::abortWriting() debugging a little.

