### PR TITLE
Rename class ACL to Acl::Node

### DIFF
--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -196,101 +196,101 @@ Acl::Init()
     // of the return expression inside lambda is not ACL* but AclFoo* while
     // Acl::Maker is defined to return ACL*.
 
-    RegisterMaker("all-of", [](TypeName)->ACL* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("any-of", [](TypeName)->ACL* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("random", [](TypeName name)->ACL* { return new ACLRandom(name); });
-    RegisterMaker("time", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
-    RegisterMaker("src_as", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
-    RegisterMaker("dst_as", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
-    RegisterMaker("browser", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
+    RegisterMaker("all-of", [](TypeName)->Node* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("any-of", [](TypeName)->Node* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("random", [](TypeName name)->Node* { return new ACLRandom(name); });
+    RegisterMaker("time", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
+    RegisterMaker("src_as", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
+    RegisterMaker("dst_as", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
+    RegisterMaker("browser", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
 
-    RegisterMaker("dstdomain", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("dstdom_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("dstdomain", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("dstdom_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>::PreferAllocatorLabelPrefix("dstdomain+");
 
-    RegisterMaker("dst", [](TypeName)->ACL* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("hier_code", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
-    RegisterMaker("rep_header", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("req_header", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("http_status", [](TypeName name)->ACL* { return new ACLHTTPStatus(name); });
-    RegisterMaker("maxconn", [](TypeName name)->ACL* { return new ACLMaxConnection(name); });
-    RegisterMaker("method", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
-    RegisterMaker("localip", [](TypeName)->ACL* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("localport", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("myportname", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
+    RegisterMaker("dst", [](TypeName)->Node* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("hier_code", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
+    RegisterMaker("rep_header", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("req_header", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("http_status", [](TypeName name)->Node* { return new ACLHTTPStatus(name); });
+    RegisterMaker("maxconn", [](TypeName name)->Node* { return new ACLMaxConnection(name); });
+    RegisterMaker("method", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
+    RegisterMaker("localip", [](TypeName)->Node* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("localport", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("myportname", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
 
-    RegisterMaker("peername", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
-    RegisterMaker("peername_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("peername", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
+    RegisterMaker("peername_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>::PreferAllocatorLabelPrefix("peername+");
 
-    RegisterMaker("proto", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
-    RegisterMaker("referer_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
-    RegisterMaker("rep_mime_type", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
-    RegisterMaker("req_mime_type", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("proto", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
+    RegisterMaker("referer_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
+    RegisterMaker("rep_mime_type", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("req_mime_type", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
 
-    RegisterMaker("srcdomain", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("srcdom_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("srcdomain", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("srcdom_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>::PreferAllocatorLabelPrefix("srcdomain+");
 
-    RegisterMaker("src", [](TypeName)->ACL* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("url_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
-    RegisterMaker("urllogin", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
-    RegisterMaker("urlpath_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
-    RegisterMaker("port", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("external", [](TypeName name)->ACL* { return new ACLExternal(name); });
-    RegisterMaker("squid_error", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
-    RegisterMaker("connections_encrypted", [](TypeName name)->ACL* { return new Acl::ConnectionsEncrypted(name); });
-    RegisterMaker("tag", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
-    RegisterMaker("note", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
-    RegisterMaker("annotate_client", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("annotate_transaction", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("has", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
-    RegisterMaker("transaction_initiator", [](TypeName name)->ACL* {return new TransactionInitiator(name);});
+    RegisterMaker("src", [](TypeName)->Node* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("url_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
+    RegisterMaker("urllogin", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
+    RegisterMaker("urlpath_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
+    RegisterMaker("port", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("external", [](TypeName name)->Node* { return new ACLExternal(name); });
+    RegisterMaker("squid_error", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
+    RegisterMaker("connections_encrypted", [](TypeName name)->Node* { return new Acl::ConnectionsEncrypted(name); });
+    RegisterMaker("tag", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
+    RegisterMaker("note", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
+    RegisterMaker("annotate_client", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("annotate_transaction", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("has", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
+    RegisterMaker("transaction_initiator", [](TypeName name)->Node* {return new TransactionInitiator(name);});
 
 #if USE_LIBNETFILTERCONNTRACK
-    RegisterMaker("clientside_mark", [](TypeName)->ACL* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
-    RegisterMaker("client_connection_mark", [](TypeName)->ACL* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("clientside_mark", [](TypeName)->Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("client_connection_mark", [](TypeName)->Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
 #endif
 
 #if USE_OPENSSL
-    RegisterMaker("ssl_error", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
+    RegisterMaker("ssl_error", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
 
-    RegisterMaker("user_cert", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
-    RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
+    RegisterMaker("user_cert", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
+    RegisterMaker("ca_cert", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
     Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>::PreferAllocatorLabelPrefix("user_cert+");
 
-    RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
-    RegisterMaker("at_step", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
+    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
+    RegisterMaker("at_step", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
 
-    RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
-    RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("ssl::server_name", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
+    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
 #endif
 
 #if USE_SQUID_EUI
-    RegisterMaker("arp", [](TypeName name)->ACL* { return new ACLARP(name); });
-    RegisterMaker("eui64", [](TypeName name)->ACL* { return new ACLEui64(name); });
+    RegisterMaker("arp", [](TypeName name)->Node* { return new ACLARP(name); });
+    RegisterMaker("eui64", [](TypeName name)->Node* { return new ACLEui64(name); });
 #endif
 
 #if USE_IDENT
-    RegisterMaker("ident", [](TypeName name)->ACL* { return new ACLIdent(new ACLUserData, name); });
-    RegisterMaker("ident_regex", [](TypeName name)->ACL* { return new ACLIdent(new ACLRegexData, name); });
+    RegisterMaker("ident", [](TypeName name)->Node* { return new ACLIdent(new ACLUserData, name); });
+    RegisterMaker("ident_regex", [](TypeName name)->Node* { return new ACLIdent(new ACLRegexData, name); });
 #endif
 
 #if USE_AUTH
-    RegisterMaker("ext_user", [](TypeName name)->ACL* { return new ACLExtUser(new ACLUserData, name); });
-    RegisterMaker("ext_user_regex", [](TypeName name)->ACL* { return new ACLExtUser(new ACLRegexData, name); });
-    RegisterMaker("proxy_auth", [](TypeName name)->ACL* { return new ACLProxyAuth(new ACLUserData, name); });
-    RegisterMaker("proxy_auth_regex", [](TypeName name)->ACL* { return new ACLProxyAuth(new ACLRegexData, name); });
-    RegisterMaker("max_user_ip", [](TypeName name)->ACL* { return new ACLMaxUserIP(name); });
+    RegisterMaker("ext_user", [](TypeName name)->Node* { return new ACLExtUser(new ACLUserData, name); });
+    RegisterMaker("ext_user_regex", [](TypeName name)->Node* { return new ACLExtUser(new ACLRegexData, name); });
+    RegisterMaker("proxy_auth", [](TypeName name)->Node* { return new ACLProxyAuth(new ACLUserData, name); });
+    RegisterMaker("proxy_auth_regex", [](TypeName name)->Node* { return new ACLProxyAuth(new ACLRegexData, name); });
+    RegisterMaker("max_user_ip", [](TypeName name)->Node* { return new ACLMaxUserIP(name); });
 #endif
 
 #if USE_ADAPTATION
-    RegisterMaker("adaptation_service", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
+    RegisterMaker("adaptation_service", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
 #endif
 
 #if SQUID_SNMP
-    RegisterMaker("snmp_community", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
+    RegisterMaker("snmp_community", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
 #endif
 }
 

--- a/src/ClientDelayConfig.cc
+++ b/src/ClientDelayConfig.cc
@@ -7,8 +7,8 @@
  */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/Gadgets.h"
+#include "acl/Node.h"
 #include "ClientDelayConfig.h"
 #include "ConfigParser.h"
 #include "Parsing.h"

--- a/src/DelayConfig.cc
+++ b/src/DelayConfig.cc
@@ -11,8 +11,8 @@
 #include "squid.h"
 
 #if USE_DELAY_POOLS
-#include "acl/Acl.h"
 #include "acl/Gadgets.h"
+#include "acl/Node.h"
 #include "ConfigParser.h"
 #include "DelayConfig.h"
 #include "DelayPool.h"

--- a/src/DelayPool.cc
+++ b/src/DelayPool.cc
@@ -11,8 +11,8 @@
 #include "squid.h"
 
 #if USE_DELAY_POOLS
-#include "acl/Acl.h"
 #include "acl/Gadgets.h"
+#include "acl/Node.h"
 #include "CommonPool.h"
 #include "DelayPool.h"
 #include "Store.h"

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -32,9 +32,7 @@ private:
     static void LookupDone(void *data, const ExternalACLEntryPointer &result);
 };
 
-#include "acl/Acl.h"
-
-class ACLExternal : public ACL
+class ACLExternal : public Acl::Node
 {
     MEMPROXY_CLASS(ACLExternal);
 

--- a/src/ExternalACLEntry.h
+++ b/src/ExternalACLEntry.h
@@ -11,8 +11,7 @@
 #ifndef SQUID_EXTERNALACLENTRY_H
 #define SQUID_EXTERNALACLENTRY_H
 
-#include "acl/Acl.h"
-#include "acl/forward.h"
+#include "acl/Node.h"
 #include "hash.h"
 #include "Notes.h"
 #include "SquidString.h"

--- a/src/HttpUpgradeProtocolAccess.cc
+++ b/src/HttpUpgradeProtocolAccess.cc
@@ -7,7 +7,6 @@
  */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/Gadgets.h"
 #include "cache_cf.h"
 #include "ConfigParser.h"

--- a/src/MessageDelayPools.h
+++ b/src/MessageDelayPools.h
@@ -10,8 +10,7 @@
 #define MESSAGEDELAYPOOLS_H
 
 #if USE_DELAY_POOLS
-
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "base/RefCount.h"
 #include "DelayBucket.h"
 #include "DelayPools.h"

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -352,7 +352,7 @@ public:
 
     std::chrono::nanoseconds paranoid_hit_validation;
 
-    class ACL *aclList;
+    class Acl::Node *aclList;
 
     struct {
         acl_access *http;

--- a/src/acl/AdaptationServiceData.h
+++ b/src/acl/AdaptationServiceData.h
@@ -9,8 +9,6 @@
 #ifndef SQUID_ADAPTATIONSERVICEDATA_H
 #define SQUID_ADAPTATIONSERVICEDATA_H
 
-#include "acl/Acl.h"
-#include "acl/Data.h"
 #include "acl/StringData.h"
 
 /// \ingroup ACLAPI

--- a/src/acl/Address.h
+++ b/src/acl/Address.h
@@ -9,7 +9,7 @@
 #ifndef _SQUID_SRC_ACL_ADDRESS_H
 #define _SQUID_SRC_ACL_ADDRESS_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "ip/Address.h"
 
 namespace Acl
@@ -24,7 +24,7 @@ public:
     Address() : next(nullptr), aclList(nullptr) {}
     ~Address();
 
-    Acl::Address *next;
+    Address *next;
     ACLList *aclList;
 
     Ip::Address addr;

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -46,11 +46,11 @@ Acl::AllOf::doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const
 void
 Acl::AllOf::parse()
 {
-    Acl::InnerNode *whole = nullptr;
-    ACL *oldNode = empty() ? nullptr : nodes.front();
+    InnerNode *whole = nullptr;
+    Node *oldNode = empty() ? nullptr : nodes.front();
 
     // optimization: this logic reduces subtree hight (number of tree levels)
-    if (Acl::OrNode *oldWhole = dynamic_cast<Acl::OrNode*>(oldNode)) {
+    if (auto *oldWhole = dynamic_cast<OrNode*>(oldNode)) {
         // this acl saw multiple lines before; add another one to the old node
         whole = oldWhole;
     } else if (oldNode) {
@@ -61,7 +61,7 @@ Acl::AllOf::parse()
         wholeCtx.appendf("(%s lines)", name);
         wholeCtx.terminate();
 
-        Acl::OrNode *newWhole = new Acl::OrNode;
+        auto *newWhole = new OrNode;
         newWhole->context(wholeCtx.content(), oldNode->cfgline);
         newWhole->add(oldNode); // old (i.e. first) line
         nodes.front() = whole = newWhole;
@@ -79,7 +79,7 @@ Acl::AllOf::parse()
     lineCtx.appendf("(%s line #%d)", name, lineId);
     lineCtx.terminate();
 
-    Acl::AndNode *line = new AndNode;
+    auto *line = new AndNode;
     line->context(lineCtx.content(), config_input_line);
     line->lineParse();
 

--- a/src/acl/AllOf.h
+++ b/src/acl/AllOf.h
@@ -17,12 +17,12 @@ namespace Acl
 /// Configurable all-of ACL. Each ACL line is a conjunction of ACLs.
 /// Uses AndNode and OrNode to handle squid.conf configuration where multiple
 /// acl all-of lines are always ORed together.
-class AllOf: public Acl::InnerNode
+class AllOf: public InnerNode
 {
     MEMPROXY_CLASS(AllOf);
 
 public:
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;

--- a/src/acl/AnnotationData.cc
+++ b/src/acl/AnnotationData.cc
@@ -7,9 +7,9 @@
  */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/AnnotationData.h"
 #include "acl/Checklist.h"
+#include "acl/Node.h"
 #include "cache_cf.h"
 #include "ConfigParser.h"
 #include "debug/Stream.h"

--- a/src/acl/AnyOf.h
+++ b/src/acl/AnyOf.h
@@ -15,7 +15,7 @@ namespace Acl
 {
 
 /// Configurable any-of ACL. Each ACL line is a disjuction of ACLs.
-class AnyOf: public Acl::OrNode
+class AnyOf: public OrNode
 {
     MEMPROXY_CLASS(AnyOf);
 

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACLARP_H
 #define SQUID_ACLARP_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 
 #include <set>
 
@@ -19,7 +19,7 @@ class Eui48;
 };
 
 /// \ingroup ACLAPI
-class ACLARP : public ACL
+class ACLARP : public Acl::Node
 {
     MEMPROXY_CLASS(ACLARP);
 

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -9,7 +9,6 @@
 /* DEBUG: section 53    AS Number handling */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/Asn.h"
 #include "acl/DestinationAsn.h"
 #include "acl/DestinationIp.h"
@@ -116,7 +115,7 @@ static int printRadixNode(struct squid_radix_node *rn, void *sentry);
 }
 #endif
 
-void asnAclInitialize(ACL * acls);
+void asnAclInitialize(Acl::Node *);
 
 static void destroyRadixNodeInfo(as_info *);
 

--- a/src/acl/AtStepData.h
+++ b/src/acl/AtStepData.h
@@ -9,9 +9,9 @@
 #ifndef SQUID_ACLATSTEPDATA_H
 #define SQUID_ACLATSTEPDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "XactionStep.h"
+
 #include <list>
 
 class ACLAtStepData : public ACLData<XactionStep>

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -14,7 +14,7 @@
 
 /* Acl::NotNode */
 
-Acl::NotNode::NotNode(ACL *acl)
+Acl::NotNode::NotNode(Node *acl)
 {
     assert(acl);
     Must(strlen(acl->name) <= sizeof(name)-2);

--- a/src/acl/BoolOps.h
+++ b/src/acl/BoolOps.h
@@ -24,10 +24,10 @@ class NotNode: public InnerNode
     MEMPROXY_CLASS(NotNode);
 
 public:
-    explicit NotNode(ACL *acl);
+    explicit NotNode(Node *);
 
 private:
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;
@@ -44,7 +44,7 @@ class AndNode: public InnerNode
     MEMPROXY_CLASS(AndNode);
 
 public:
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
 
@@ -64,7 +64,7 @@ public:
     /// on its action
     virtual bool bannedAction(ACLChecklist *, Nodes::const_iterator) const;
 
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
 

--- a/src/acl/CertificateData.h
+++ b/src/acl/CertificateData.h
@@ -9,10 +9,9 @@
 #ifndef SQUID_ACLCERTIFICATEDATA_H
 #define SQUID_ACLCERTIFICATEDATA_H
 
-#include "acl/Acl.h"
-#include "acl/Data.h"
 #include "acl/StringData.h"
 #include "ssl/support.h"
+
 #include <string>
 #include <list>
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -78,7 +78,7 @@ ACLChecklist::preCheck(const char *what)
 }
 
 bool
-ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const ACL *child)
+ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const Acl::Node *child)
 {
     assert(current && child);
 

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -140,7 +140,7 @@ public:
 
     /// Matches (or resumes matching of) a child node while maintaning
     /// resumption breadcrumbs if a [grand]child node goes async.
-    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const ACL *child);
+    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const Acl::Node *child);
 
     /// Whether we should continue to match tree nodes or stop/pause.
     bool keepMatching() const { return !finished() && !asyncInProgress(); }

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACLCONNMARK_H
 #define SQUID_ACLCONNMARK_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "ip/forward.h"
 #include "ip/NfMarkConfig.h"
 #include "parser/Tokenizer.h"
@@ -18,12 +18,12 @@
 
 namespace Acl {
 
-class ConnMark : public ACL
+class ConnMark : public Node
 {
     MEMPROXY_CLASS(ConnMark);
 
 public:
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;

--- a/src/acl/ConnectionsEncrypted.h
+++ b/src/acl/ConnectionsEncrypted.h
@@ -9,13 +9,13 @@
 #ifndef SQUID_ACL_CONNECTIONS_ENCRYPTED_H
 #define SQUID_ACL_CONNECTIONS_ENCRYPTED_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "acl/Checklist.h"
 
 namespace Acl
 {
 
-class ConnectionsEncrypted : public ACL
+class ConnectionsEncrypted : public Node
 {
     MEMPROXY_CLASS(ConnectionsEncrypted);
 

--- a/src/acl/DomainData.h
+++ b/src/acl/DomainData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLDOMAINDATA_H
 #define SQUID_ACLDOMAINDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "splay.h"
 

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACLEUI64_H
 #define SQUID_ACLEUI64_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 
 #include <set>
 
@@ -18,7 +18,7 @@ namespace Eui
 class Eui64;
 };
 
-class ACLEui64 : public ACL
+class ACLEui64 : public Acl::Node
 {
     MEMPROXY_CLASS(ACLEui64);
 

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -11,11 +11,10 @@
 
 #if USE_AUTH
 
-#include "acl/Acl.h"
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ACLExtUser : public ACL
+class ACLExtUser : public Acl::Node
 {
     MEMPROXY_CLASS(ACLExtUser);
 
@@ -23,7 +22,7 @@ public:
     ACLExtUser(ACLData<char const *> *newData, char const *);
     ~ACLExtUser() override;
 
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;
@@ -31,7 +30,7 @@ public:
     bool empty () const override;
 
 private:
-    /* ACL API */
+    /* Acl::Node API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -11,7 +11,6 @@
 
 #include "AccessLogEntry.h"
 #include "acl/Checklist.h"
-#include "acl/forward.h"
 #include "base/CbcPointer.h"
 #include "error/forward.h"
 #include "ip/Address.h"

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -30,7 +30,7 @@
 #include <set>
 #include <algorithm>
 
-typedef std::set<ACL*> AclSet;
+using AclSet = std::set<Acl::Node *>;
 /// Accumulates all ACLs to facilitate their clean deletion despite reuse.
 static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
@@ -76,9 +76,7 @@ aclIsProxyAuth(const char *name)
 
     debugs(28, 5, "aclIsProxyAuth: called for " << name);
 
-    ACL *a;
-
-    if ((a = ACL::FindByName(name))) {
+    if (const auto a = Acl::Node::FindByName(name)) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }
@@ -218,7 +216,7 @@ aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 }
 
 void
-aclRegister(ACL *acl)
+aclRegister(Acl::Node *acl)
 {
     if (!acl->registered) {
         if (!RegisteredAcls)
@@ -231,7 +229,7 @@ aclRegister(ACL *acl)
 /// remove registered acl from the centralized deletion set
 static
 void
-aclDeregister(ACL *acl)
+aclDeregister(Acl::Node *acl)
 {
     if (acl->registered) {
         if (RegisteredAcls)
@@ -246,13 +244,13 @@ aclDeregister(ACL *acl)
 
 /// called to delete ALL Acls.
 void
-aclDestroyAcls(ACL ** head)
+aclDestroyAcls(Acl::Node ** head)
 {
     *head = nullptr; // Config.aclList
     if (AclSet *acls = RegisteredAcls) {
         debugs(28, 8, "deleting all " << acls->size() << " ACLs");
         while (!acls->empty()) {
-            ACL *acl = *acls->begin();
+            const auto acl = *acls->begin();
             // We use centralized deletion (this function) so ~ACL should not
             // delete other ACLs, but we still deregister first to prevent any
             // accesses to the being-deleted ACL via RegisteredAcls.

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -21,11 +21,11 @@ class wordlist;
 
 /// Register an ACL object for future deletion. Repeated registrations are OK.
 /// \ingroup ACLAPI
-void aclRegister(ACL *acl);
+void aclRegister(Acl::Node *);
 /// \ingroup ACLAPI
 void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
-void aclDestroyAcls(ACL **);
+void aclDestroyAcls(Acl::Node **);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 /// Parses a single line of a "action followed by acls" directive (e.g., http_access).
@@ -54,7 +54,7 @@ void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI
 void aclDestroyDenyInfoList(AclDenyInfoList **);
 /// \ingroup ACLAPI
-wordlist *aclDumpGeneric(const ACL *);
+wordlist *aclDumpGeneric(const Acl::Node *);
 /// \ingroup ACLAPI
 void aclCacheMatchFlush(dlink_list * cache);
 /// \ingroup ACLAPI

--- a/src/acl/HierCodeData.h
+++ b/src/acl/HierCodeData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLHIERCODEDATA_H
 #define SQUID_ACLHIERCODEDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "hier_code.h"
 

--- a/src/acl/HttpHeaderData.cc
+++ b/src/acl/HttpHeaderData.cc
@@ -9,9 +9,9 @@
 /* DEBUG: section 28    Access Control */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/Checklist.h"
 #include "acl/HttpHeaderData.h"
+#include "acl/Node.h"
 #include "acl/RegexData.h"
 #include "base/RegexPattern.h"
 #include "cache_cf.h"

--- a/src/acl/HttpStatus.h
+++ b/src/acl/HttpStatus.h
@@ -9,8 +9,8 @@
 #ifndef SQUID_ACLHTTPSTATUS_H
 #define SQUID_ACLHTTPSTATUS_H
 
-#include "acl/Acl.h"
 #include "acl/Checklist.h"
+#include "acl/Node.h"
 #include "splay.h"
 
 /// \ingroup ACLAPI
@@ -24,7 +24,7 @@ struct acl_httpstatus_data {
 };
 
 /// \ingroup ACLAPI
-class ACLHTTPStatus : public ACL
+class ACLHTTPStatus : public Acl::Node
 {
     MEMPROXY_CLASS(ACLHTTPStatus);
 

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -7,7 +7,6 @@
  */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/BoolOps.h"
 #include "acl/Checklist.h"
 #include "acl/Gadgets.h"
@@ -32,7 +31,7 @@ Acl::InnerNode::empty() const
 }
 
 void
-Acl::InnerNode::add(ACL *node)
+Acl::InnerNode::add(Node *node)
 {
     assert(node != nullptr);
     nodes.push_back(node);
@@ -56,9 +55,8 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        ACL *a = ACL::FindByName(t);
-
-        if (a == nullptr) {
+        auto *a = FindByName(t);
+        if (!a) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);
             self_destruct();
             return count; // not reached

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -9,16 +9,19 @@
 #ifndef SQUID_ACL_INNER_NODE_H
 #define SQUID_ACL_INNER_NODE_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
+
 #include <vector>
 
 namespace Acl
 {
 
-typedef std::vector<ACL*> Nodes; ///< a collection of nodes
+// XXX: use refcounting instead of raw pointers
+/// a collection of nodes
+using Nodes = std::vector<Node *>;
 
 /// An intermediate ACL tree node. Manages a collection of child tree nodes.
-class InnerNode: public ACL
+class InnerNode: public Node
 {
 public:
     // No ~InnerNode() to delete children. They are aclRegister()ed instead.
@@ -29,7 +32,7 @@ public:
     /// the number of children nodes
     Nodes::size_type childrenCount() const { return nodes.size(); }
 
-    /* ACL API */
+    /* Acl::Node API */
     void prepareForUse() override;
     bool empty() const override;
     SBufList dump() const override;
@@ -39,7 +42,7 @@ public:
     size_t lineParse();
 
     /// appends the node to the collection and takes control over it
-    void add(ACL *node);
+    void add(Node *);
 
 protected:
     /// checks whether the nodes match, starting with the given one
@@ -49,8 +52,7 @@ protected:
     /* ACL API */
     int match(ACLChecklist *checklist) override;
 
-    // XXX: use refcounting instead of raw pointers
-    std::vector<ACL*> nodes; ///< children nodes of this intermediate node
+    Nodes nodes; ///< children nodes of this intermediate node
 };
 
 } // namespace Acl

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -9,8 +9,7 @@
 #ifndef SQUID_ACLIP_H
 #define SQUID_ACLIP_H
 
-#include "acl/Acl.h"
-#include "acl/Data.h"
+#include "acl/Node.h"
 #include "ip/Address.h"
 #include "splay.h"
 
@@ -41,7 +40,7 @@ private:
     static bool DecodeMask(const char *asc, Ip::Address &mask, int string_format_type);
 };
 
-class ACLIP : public ACL
+class ACLIP : public Acl::Node
 {
 public:
     void *operator new(size_t);

--- a/src/acl/Makefile.am
+++ b/src/acl/Makefile.am
@@ -14,8 +14,6 @@ noinst_LTLIBRARIES = libapi.la libstate.la libacls.la
 
 ## General data-independent ACL API
 libapi_la_SOURCES = \
-	Acl.cc \
-	Acl.h \
 	BoolOps.cc \
 	BoolOps.h \
 	Checklist.cc \
@@ -23,6 +21,8 @@ libapi_la_SOURCES = \
 	ChecklistFiller.h \
 	InnerNode.cc \
 	InnerNode.h \
+	Node.cc \
+	Node.h \
 	Options.cc \
 	Options.h \
 	Tree.cc \

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -9,10 +9,10 @@
 #ifndef SQUID_ACLMAXCONNECTION_H
 #define SQUID_ACLMAXCONNECTION_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 
 /// \ingroup ACLAPI
-class ACLMaxConnection : public ACL
+class ACLMaxConnection : public Acl::Node
 {
     MEMPROXY_CLASS(ACLMaxConnection);
 

--- a/src/acl/MethodData.h
+++ b/src/acl/MethodData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLMETHODDATA_H
 #define SQUID_ACLMETHODDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "http/RequestMethod.h"
 

--- a/src/acl/Node.cc
+++ b/src/acl/Node.cc
@@ -123,7 +123,7 @@ Acl::Node::FindByName(const char *name)
         if (!strcasecmp(a->name, name))
             return a;
 
-    debugs(28, 9, "found no match");
+    debugs(28, 5, "found no match");
     return nullptr;
 }
 

--- a/src/acl/NoteData.cc
+++ b/src/acl/NoteData.cc
@@ -7,8 +7,8 @@
  */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/Checklist.h"
+#include "acl/Node.h"
 #include "acl/NoteData.h"
 #include "acl/StringData.h"
 #include "ConfigParser.h"

--- a/src/acl/ParameterizedNode.h
+++ b/src/acl/ParameterizedNode.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_SRC_ACL_PARAMETERIZEDNODE_H
 #define SQUID_SRC_ACL_PARAMETERIZEDNODE_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "base/Assure.h"
 
 #include <memory>
@@ -20,7 +20,7 @@ namespace Acl
 /// An ACL that manages squid.conf-configured ACL parameters using a given class
 /// P. That P class must support the ACLData<> or equivalent API.
 template <class P>
-class ParameterizedNode: public ACL
+class ParameterizedNode: public Node
 {
 public:
     using Parameters = P;
@@ -31,7 +31,7 @@ public:
     ~ParameterizedNode() override = default;
 
 protected:
-    /* ACL API */
+    /* Acl::Node API */
     void parse() override { Assure(data); data->parse(); }
     void prepareForUse() override { data->prepareForUse(); }
     SBufList dump() const override { return data->dump(); }

--- a/src/acl/ProtocolData.h
+++ b/src/acl/ProtocolData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLPROTOCOLDATA_H
 #define SQUID_ACLPROTOCOLDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "anyp/ProtocolType.h"
 

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -9,9 +9,9 @@
 #ifndef SQUID_ACL_RANDOM_H
 #define SQUID_ACL_RANDOM_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 
-class ACLRandom : public ACL
+class ACLRandom : public Acl::Node
 {
     MEMPROXY_CLASS(ACLRandom);
 

--- a/src/acl/RegexData.cc
+++ b/src/acl/RegexData.cc
@@ -15,7 +15,7 @@
 /* DEBUG: section 28    Access Control */
 
 #include "squid.h"
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "acl/Checklist.h"
 #include "acl/RegexData.h"
 #include "base/RegexPattern.h"

--- a/src/acl/RequestMimeType.h
+++ b/src/acl/RequestMimeType.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLREQUESTMIMETYPE_H
 #define SQUID_ACLREQUESTMIMETYPE_H
 
-#include "acl/Data.h"
 #include "acl/FilledChecklist.h"
 #include "acl/RequestHeaderStrategy.h"
 

--- a/src/acl/SslErrorData.h
+++ b/src/acl/SslErrorData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLSSL_ERRORDATA_H
 #define SQUID_ACLSSL_ERRORDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "security/forward.h"
 

--- a/src/acl/StringData.h
+++ b/src/acl/StringData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLSTRINGDATA_H
 #define SQUID_ACLSTRINGDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "sbuf/SBuf.h"
 

--- a/src/acl/TimeData.h
+++ b/src/acl/TimeData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLTIMEDATA_H
 #define SQUID_ACLTIMEDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 
 class ACLTimeData : public ACLData<time_t>

--- a/src/acl/TransactionInitiator.h
+++ b/src/acl/TransactionInitiator.h
@@ -9,15 +9,15 @@
 #ifndef SQUID_ACL_TRANSACTION_INITIATOR_H
 #define SQUID_ACL_TRANSACTION_INITIATOR_H
 
-#include "acl/Acl.h"
 #include "acl/Checklist.h"
+#include "acl/Node.h"
 #include "XactionInitiator.h"
 
 namespace Acl
 {
 
 /// transaction_initiator ACL
-class TransactionInitiator : public ACL
+class TransactionInitiator : public Node
 {
     MEMPROXY_CLASS(TransactionInitiator);
 

--- a/src/acl/Tree.cc
+++ b/src/acl/Tree.cc
@@ -41,7 +41,7 @@ Acl::Tree::actionAt(const Nodes::size_type pos) const
 }
 
 void
-Acl::Tree::add(ACL *rule, const Acl::Answer &action)
+Acl::Tree::add(Node *rule, const Acl::Answer &action)
 {
     // either all rules have actions or none
     assert(nodes.size() == actions.size());
@@ -50,7 +50,7 @@ Acl::Tree::add(ACL *rule, const Acl::Answer &action)
 }
 
 void
-Acl::Tree::add(ACL *rule)
+Acl::Tree::add(Node *rule)
 {
     // either all rules have actions or none
     assert(actions.empty());

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -36,8 +36,8 @@ public:
     Answer lastAction() const;
 
     /// appends and takes control over the rule with a given action
-    void add(ACL *rule, const Answer &action);
-    void add(ACL *rule); ///< same as InnerNode::add()
+    void add(Node *rule, const Answer &action);
+    void add(Node *rule); ///< same as InnerNode::add()
 
 protected:
     /// Acl::OrNode API

--- a/src/acl/UserData.h
+++ b/src/acl/UserData.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_ACLUSERDATA_H
 #define SQUID_ACLUSERDATA_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
 #include "sbuf/SBuf.h"
 

--- a/src/acl/forward.h
+++ b/src/acl/forward.h
@@ -11,7 +11,6 @@
 
 #include "base/RefCount.h"
 
-class ACL;
 class ACLChecklist;
 class ACLFilledChecklist;
 class ACLList;
@@ -27,6 +26,7 @@ class AndNode;
 class Answer;
 class ChecklistFiller;
 class InnerNode;
+class Node;
 class NotNode;
 class OrNode;
 class Tree;

--- a/src/adaptation/AccessCheck.h
+++ b/src/adaptation/AccessCheck.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ADAPTATION__ACCESS_CHECK_H
 #define SQUID_ADAPTATION__ACCESS_CHECK_H
 
-#include "acl/Acl.h"
+#include "acl/forward.h"
 #include "adaptation/Elements.h"
 #include "adaptation/forward.h"
 #include "adaptation/Initiator.h"

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -7,7 +7,6 @@
  */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/FilledChecklist.h"
 #include "auth/Acl.h"
 #include "auth/AclProxyAuth.h"

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -11,7 +11,7 @@
 
 #if USE_AUTH
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 
 // ACL-related code used by authentication-related code. This code is not in
 // auth/Gadgets to avoid making auth/libauth dependent on acl/libstate because

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -11,10 +11,10 @@
 
 #if USE_AUTH
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "auth/UserRequest.h"
 
-class ACLMaxUserIP : public ACL
+class ACLMaxUserIP : public Acl::Node
 {
     MEMPROXY_CLASS(ACLMaxUserIP);
 

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -11,7 +11,6 @@
 
 #if USE_AUTH
 
-#include "acl/Acl.h"
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
@@ -27,7 +26,7 @@ private:
     static void LookupDone(void *data);
 };
 
-class ACLProxyAuth : public ACL
+class ACLProxyAuth : public Acl::Node
 {
     MEMPROXY_CLASS(ACLProxyAuth);
 
@@ -35,7 +34,7 @@ public:
     ~ACLProxyAuth() override;
     ACLProxyAuth(ACLData<char const *> *, char const *);
 
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -47,7 +46,7 @@ public:
     int matchForCache(ACLChecklist *checklist) override;
 
 private:
-    /* ACL API */
+    /* Acl::Node API */
     const Acl::Options &lineOptions() override;
 
     int matchProxyAuth(ACLChecklist *);

--- a/src/auth/Gadgets.cc
+++ b/src/auth/Gadgets.cc
@@ -13,8 +13,8 @@
  * See acl.c for access control and client_side.c for auditing */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/FilledChecklist.h"
+#include "acl/Node.h"
 #include "auth/AclProxyAuth.h"
 #include "auth/basic/User.h"
 #include "auth/Config.h"

--- a/src/auth/User.cc
+++ b/src/auth/User.cc
@@ -9,8 +9,8 @@
 /* DEBUG: section 29    Authenticator */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/Gadgets.h"
+#include "acl/Node.h"
 #include "auth/Config.h"
 #include "auth/CredentialsCache.h"
 #include "auth/Gadgets.h"

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -9,7 +9,6 @@
 /* DEBUG: section 03    Configuration File Parsing */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/AclDenyInfoList.h"
 #include "acl/AclSizeLimit.h"
 #include "acl/Address.h"
@@ -255,7 +254,7 @@ static void free_configuration_includes_quoted_values(bool *recognizeQuotedValue
 static void parse_on_unsupported_protocol(acl_access **access);
 static void dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *access);
 static void free_on_unsupported_protocol(acl_access **access);
-static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, ACL *acl = nullptr);
+static void ParseAclWithAction(acl_access **, const Acl::Answer &, const char *desc, Acl::Node * = nullptr);
 static void parse_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
 static void dump_http_upgrade_request_protocols(StoreEntry *entry, const char *name, HttpUpgradeProtocolAccess *protoGuards);
 static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
@@ -1476,7 +1475,7 @@ free_SBufList(SBufList *list)
 }
 
 static void
-dump_acl(StoreEntry * entry, const char *name, ACL * ae)
+dump_acl(StoreEntry *entry, const char *name, Acl::Node *ae)
 {
     while (ae != nullptr) {
         debugs(3, 3, "dump_acl: " << name << " " << ae->name);
@@ -1493,13 +1492,13 @@ dump_acl(StoreEntry * entry, const char *name, ACL * ae)
 }
 
 static void
-parse_acl(ACL ** ae)
+parse_acl(Acl::Node **ae)
 {
-    ACL::ParseAclLine(LegacyParser, ae);
+    Acl::Node::ParseAclLine(LegacyParser, ae);
 }
 
 static void
-free_acl(ACL ** ae)
+free_acl(Acl::Node **ae)
 {
     aclDestroyAcls(ae);
 }
@@ -2015,7 +2014,7 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 #endif /* USE_AUTH */
 
 static void
-ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, ACL *acl)
+ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::Node *acl)
 {
     assert(access);
     SBuf name;
@@ -4711,7 +4710,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         *ftp_epsv = nullptr;
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
-            if (ACL *a = ACL::FindByName("all"))
+            if (const auto a = Acl::Node::FindByName("all"))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -9,7 +9,6 @@
 /* DEBUG: section 82    External ACL */
 
 #include "squid.h"
-#include "acl/Acl.h"
 #include "acl/FilledChecklist.h"
 #include "cache_cf.h"
 #include "client_side.h"
@@ -1151,7 +1150,7 @@ ExternalACLLookup::checkForAsync(ACLChecklist *checklist)const
 {
     /* TODO: optimise this - we probably have a pointer to this
      * around somewhere */
-    ACL *acl = ACL::FindByName(AclMatchedName);
+    const auto acl = Acl::Node::FindByName(AclMatchedName);
     assert(acl);
     ACLExternal *me = dynamic_cast<ACLExternal *> (acl);
     assert (me);

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -10,7 +10,6 @@
 
 #include "squid.h"
 #include "AccessLogEntry.h"
-#include "acl/Acl.h"
 #include "acl/FilledChecklist.h"
 #include "base/AsyncCallbacks.h"
 #include "CachePeer.h"

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -15,7 +15,6 @@
 
 #include "squid.h"
 #include "AccessLogEntry.h"
-#include "acl/Acl.h"
 #include "acl/FilledChecklist.h"
 #include "base/AsyncCallbacks.h"
 #include "client_db.h"

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -12,6 +12,7 @@
 #if USE_IDENT
 
 #include "acl/Checklist.h"
+#include "acl/Data.h"
 
 /// \ingroup ACLAPI
 class IdentLookup : public ACLChecklist::AsyncState
@@ -26,11 +27,8 @@ private:
     static void LookupDone(const char *ident, void *data);
 };
 
-#include "acl/Acl.h"
-#include "acl/Data.h"
-
 /// \ingroup ACLAPI
-class ACLIdent : public ACL
+class ACLIdent : public Acl::Node
 {
     MEMPROXY_CLASS(ACLIdent);
 
@@ -38,7 +36,7 @@ public:
     ACLIdent(ACLData<char const *> *newData, char const *);
     ~ACLIdent() override;
 
-    /* ACL API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -47,7 +45,7 @@ public:
     bool empty () const override;
 
 private:
-    /* ACL API */
+    /* Acl::Node API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/ident/Config.h
+++ b/src/ident/Config.h
@@ -11,7 +11,7 @@
 
 #if USE_IDENT
 
-#include "acl/Acl.h"
+#include "acl/forward.h"
 
 namespace Ident
 {

--- a/src/main.cc
+++ b/src/main.cc
@@ -10,9 +10,7 @@
 
 #include "squid.h"
 #include "AccessLogEntry.h"
-//#include "acl/Acl.h"
 #include "acl/Asn.h"
-#include "acl/forward.h"
 #include "anyp/UriScheme.h"
 #include "auth/Config.h"
 #include "auth/Gadgets.h"
@@ -806,7 +804,7 @@ serverConnectionsOpen(void)
         icmpEngine.Open();
         netdbInit();
         asnInit();
-        ACL::Initialize();
+        Acl::Node::Initialize();
         peerSelectInit();
 
         carpInit();

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -9,7 +9,6 @@
 #ifndef SQUID_SRC_SECURITY_PEERCONNECTOR_H
 #define SQUID_SRC_SECURITY_PEERCONNECTOR_H
 
-#include "acl/Acl.h"
 #include "acl/ChecklistFiller.h"
 #include "base/AsyncCallbacks.h"
 #include "base/AsyncJob.h"

--- a/src/tests/stub_acl.cc
+++ b/src/tests/stub_acl.cc
@@ -13,7 +13,7 @@
 #define STUB_API "acl/"
 #include "tests/STUB.h"
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 const char *AclMatchedName = nullptr;
 
 #include "acl/Gadgets.h"

--- a/src/tests/stub_cache_cf.cc
+++ b/src/tests/stub_cache_cf.cc
@@ -9,7 +9,7 @@
 /* DEBUG: section 03    Configuration File Parsing */
 
 #include "squid.h"
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "acl/Gadgets.h"
 #include "ConfigParser.h"
 #include "wordlist.h"

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -12,8 +12,6 @@
 #include "tests/STUB.h"
 
 #if USE_AUTH
-#include "acl/Acl.h" /* for Acl::Answer */
-
 #include "auth/Acl.h"
 Acl::Answer AuthenticateAcl(ACLChecklist *) STUB_RETVAL(ACCESS_DENIED)
 

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -9,8 +9,6 @@
 #include "squid.h"
 
 #if USE_AUTH
-
-#include "acl/Acl.h"
 #include "auth/AclMaxUserIp.h"
 #include "auth/UserRequest.h"
 #include "compat/cppunit.h"
@@ -64,7 +62,7 @@ public:
 void
 MyTestProgram::startup()
 {
-    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->ACL* { return new ACLMaxUserIP(name); });
+    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->Acl::Node* { return new ACLMaxUserIP(name); });
 }
 
 void
@@ -74,9 +72,9 @@ TestACLMaxUserIP::testParseLine()
     char * line = xstrdup("test max_user_ip -s 1");
     /* seed the parser */
     ConfigParser::SetCfgLine(line);
-    ACL *anACL = nullptr;
+    Acl::Node *anACL = nullptr;
     ConfigParser LegacyParser;
-    ACL::ParseAclLine(LegacyParser, &anACL);
+    Acl::Node::ParseAclLine(LegacyParser, &anACL);
     ACLMaxUserIP *maxUserIpACL = dynamic_cast<ACLMaxUserIP *>(anACL);
     CPPUNIT_ASSERT(maxUserIpACL);
     if (maxUserIpACL) {


### PR DESCRIPTION
Also a lot of style cleanup on touched code
and lines documenting class ACL