### PR TITLE
Maintenance: Remove a stale sponsor URL

### DIFF
--- a/SPONSORS.list
+++ b/SPONSORS.list
@@ -13,7 +13,7 @@ DigitalOcean - https://www.digitalocean.com/
 	DigitalOcean has donated droplets from their cloud infrastructure
 	to host most of Squid Project's continuous integration farm.
 
-SpinUp - https://SpinUp.com
+SpinUp
 
 	SpinUp has donated cloud resources to host our main website, wiki
 	and mailing lists.

--- a/SPONSORS.list
+++ b/SPONSORS.list
@@ -13,6 +13,11 @@ DigitalOcean - https://www.digitalocean.com/
 	DigitalOcean has donated droplets from their cloud infrastructure
 	to host most of Squid Project's continuous integration farm.
 
+SpinUp - https://SpinUp.com
+
+	SpinUp has donated cloud resources to host our main website, wiki
+	and mailing lists.
+
 The Measurement Factory - http://www.measurement-factory.com/
 
 	The Measurement Factory has contributed significant resources to

--- a/SPONSORS.list
+++ b/SPONSORS.list
@@ -13,11 +13,6 @@ DigitalOcean - https://www.digitalocean.com/
 	DigitalOcean has donated droplets from their cloud infrastructure
 	to host most of Squid Project's continuous integration farm.
 
-SpinUp - https://SpinUp.com
-
-	SpinUp has donated cloud resources to host our main website, wiki
-	and mailing lists.
-
 The Measurement Factory - http://www.measurement-factory.com/
 
 	The Measurement Factory has contributed significant resources to


### PR DESCRIPTION
SpinUp has ceased operations. Their URL is used by an unrelated entity.