### PR TITLE
Bug 5148: Log %Ss of failed tunnels as TCP_TUNNEL

### DIFF
--- a/doc/release-notes/release-6.sgml.in
+++ b/doc/release-notes/release-6.sgml.in
@@ -234,6 +234,8 @@ This section gives an account of those changes in three categories:
 	   made for this request.
 	<p>Squid now adds <em>ABORTED</em> to values printed by the <em>Ss</em> code in more
 	   cases where a TCP Squid-to-server connection was closed prematurely.
+	<p>Squid now logs <em>TCP_TUNNEL</em> with the <em>Ss</em> code when a CONNECT tunnel
+	   is attempted, not just on successful tunnel setup.
 
 	<tag>server_cert_fingerprint</tag>
 	<p>Removed the broken <em>-sha</em> option. <em>SHA1</em> remains the default and

--- a/src/LogTags.h
+++ b/src/LogTags.h
@@ -53,7 +53,7 @@ typedef enum {
     LOG_TCP_DENIED_REPLY,
     LOG_TCP_OFFLINE_HIT,
     LOG_TCP_REDIRECT,
-    LOG_TCP_TUNNEL, // an attempt to establish a bidirectional TCP tunnel
+    LOG_TCP_TUNNEL, ///< an attempt to establish a bidirectional TCP tunnel
     LOG_UDP_HIT,
     LOG_UDP_MISS,
     LOG_UDP_DENIED,

--- a/src/LogTags.h
+++ b/src/LogTags.h
@@ -53,7 +53,7 @@ typedef enum {
     LOG_TCP_DENIED_REPLY,
     LOG_TCP_OFFLINE_HIT,
     LOG_TCP_REDIRECT,
-    LOG_TCP_TUNNEL,             // a binary tunnel was established for this transaction
+    LOG_TCP_TUNNEL, // an attempt to establish a bidirectional TCP tunnel
     LOG_UDP_HIT,
     LOG_UDP_MISS,
     LOG_UDP_DENIED,


### PR DESCRIPTION
    ERR_CONNECT_FAIL/errno=111 NONE_NONE/503 CONNECT

    TAG_NONE/503 0 CONNECT example.com:443 - HIER_NONE/- -

When Squid failed to open a TCP connection to an origin server (or
through a cache peer) while handling a CONNECT request, Squid logged %Ss
as NONE_NONE because TunnelStateData waited for a successful TCP
connection to update the log tag. That unnecessary wait (modeled after
the necessary HTTP status code wait) complicated code. Squid now logs
TCP_TUNNEL to indicate the request handling path chosen by Squid.

We already use the same "handling path" approach for most other request
status codes. For example, TCP_MISS does not mean the miss transaction
was successful. It only means that Squid satisfied the request using the
cache miss forwarding logic. Even the LOG_TCP_REFRESH_FAIL_ERR status
code does not imply that the error response was successfully forwarded
to the client; only that the request was satisfied on a particular
(albeit very detailed in this case!) handling path.

Apply the same logic to tunneling attempts blocked by miss_access. They
were also logged as NONE_NONE and are now logged as TCP_TUNNEL.

The actual outcome of a tunneling attempt can usually be determined
using %err_code/%err_detail and %>Hs logformat codes.
