### PR TITLE
Fix fatalf() undefined for environments without syslog

### DIFF
--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "base/TextException.h"
 #include "debug/Stream.h"
+#include "fatal.h"
 #include "fd.h"
 #include "ipc/Kids.h"
 #include "time/gadgets.h"


### PR DESCRIPTION
src/debug/debug.cc:1087
error: 'fatalf' was not declared in this scope