### PR TITLE
Fix time_t type conflicts in libdebug

### DIFF
--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -1226,10 +1226,11 @@ debugLogTime(const timeval &t)
     static time_t last_t = 0;
 
     if (Debug::Level() > 1) {
+        last_t = t.tv_sec;
         // 4 bytes smaller than buf to ensure .NNN catenation by snprintf()
         // is safe and works even if strftime() fills its buffer.
         char buf2[sizeof(buf)-4];
-        const auto tm = localtime(&t.tv_sec);
+        const auto tm = localtime(&last_t);
         strftime(buf2, sizeof(buf2), "%Y/%m/%d %H:%M:%S", tm);
         buf2[sizeof(buf2)-1] = '\0';
         const auto sz = snprintf(buf, sizeof(buf), "%s.%03d", buf2, static_cast<int>(t.tv_usec / 1000));
@@ -1237,10 +1238,10 @@ debugLogTime(const timeval &t)
         // force buf reset for subsequent level-0/1 messages that should have no milliseconds
         last_t = 0;
     } else if (t.tv_sec != last_t) {
-        const auto tm = localtime(&t.tv_sec);
+        last_t = t.tv_sec;
+        const auto tm = localtime(&last_t);
         const int sz = strftime(buf, sizeof(buf), "%Y/%m/%d %H:%M:%S", tm);
         assert(0 < sz && sz <= static_cast<int>(sizeof(buf)));
-        last_t = t.tv_sec;
     }
 
     buf[sizeof(buf)-1] = '\0';


### PR DESCRIPTION
    error: cannot convert 'const long int*' to 'const time_t*'

On Windows, time_t is 64-bit, and long is not.