### PR TITLE
Do not report DNS answers without A/AAAA records by default

### DIFF
--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -164,7 +164,7 @@ public:
     void addGood(const rfc1035_rr &rr, Specs &specs);
 
     /// remembers the last error seen, overwriting any previous errors
-    void latestError(const char *text, const int debugLevel = 3);
+    void latestError(const char *text);
 
 protected:
     void updateTtl(const unsigned int rrTtl);
@@ -452,9 +452,9 @@ ipcacheCallback(ipcache_entry *i, const bool hit, const int wait)
 }
 
 void
-ipcache_entry::latestError(const char *text, const int debugLevel)
+ipcache_entry::latestError(const char *text)
 {
-    debugs(14, debugLevel, "ERROR: DNS failure while resolving " << name() << ": " << text);
+    debugs(14, 3, "ERROR: DNS failure while resolving " << name() << ": " << text);
     safe_free(error_message);
     error_message = xstrdup(text);
 }
@@ -568,7 +568,7 @@ ipcacheHandleReply(void *data, const rfc1035_rr * answers, int na, const char *e
         i->expires = squid_curtime + Config.negativeDnsTtl;
 
         if (!i->error_message) {
-            i->latestError("No valid address records", DBG_IMPORTANT);
+            i->latestError("No valid address records");
             if (i->sawCname)
                 ++IpcacheStats.cname_only;
         }


### PR DESCRIPTION
Default (i.e. level-0/1) cache.log error reports should focus on
problems that may affect Squid components or transaction security rather
than on individual transaction failures due to external agents (that
most Squid admins cannot prevent or fix). The latter should be detailed
in access.log, where individual transactions are reported.

We were already using this principle for ipcache_entry::latestError()
calls except for one call devoted to DNS responses that have no A/AAAA
records in the answer section _but_ have other records in that section.
Removing that exceptional treatment simplifies Squid code and addresses
admin complaints about cache.log pollution with minor error messages
that they often cannot prevent or stop.
