### PR TITLE
Destroy an idle PeerDigest after its CachePeer disappears

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -13,6 +13,7 @@
 #include "neighbors.h"
 #include "NeighborTypeDomainList.h"
 #include "pconn.h"
+#include "PeerDigest.h"
 #include "PeerPoolMgr.h"
 #include "SquidConfig.h"
 #include "util.h"
@@ -40,7 +41,9 @@ CachePeer::~CachePeer()
     aclDestroyAccessList(&access);
 
 #if USE_CACHE_DIGESTS
-    cbdataReferenceDone(digest);
+    void *digestTmp = nullptr;
+    if (cbdataReferenceValidDone(digest, &digestTmp))
+        peerDigestNotePeerGone(static_cast<PeerDigest *>(digestTmp));
     xfree(digest_url);
 #endif
 

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -167,6 +167,8 @@ peerDigestDestroy(PeerDigest * pd)
 
 PeerDigest::~PeerDigest()
 {
+    if (times.next_check && eventFind(peerDigestCheck, this))
+        eventDelete(peerDigestCheck, this);
     delete cd;
     // req_result pointer is not owned by us
 }


### PR DESCRIPTION
Delaying this destruction until the next peerDigestCheck() event results
in accumulation of PeerDigests (and related objects) during frequent
reconfigurations.