### PR TITLE
MinGW: fix winsock dependency issues

### DIFF
--- a/acinclude/lib-checks.m4
+++ b/acinclude/lib-checks.m4
@@ -10,8 +10,8 @@ AC_DEFUN([SQUID_CHECK_LIBIPHLPAPI],[
     SQUID_STATE_SAVE(iphlpapi)
     LIBS="$LIBS -liphlpapi"
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #include <iphlpapi.h>
 ]], [[
   MIB_IPNETTABLE i;

--- a/configure.ac
+++ b/configure.ac
@@ -189,6 +189,19 @@ AS_CASE(["$squid_host_os"],
   [mingw],[
     CFLAGS="$CFLAGS -mthreads"
     CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
+    dnl Check for Winsock only on MinGW
+    SQUID_CHECK_WINSOCK_LIB
+    AC_CHECK_HEADERS([winsock2.h windows.h ws2tcpip.h],,,[
+#if HAVE_WINSOCK2_H
+#include <winsock2.h>
+#endif
+#if HAVE_WINDOWS_H
+#include <windows.h>
+#endif
+#if HAVE_WS2TCPIP_H
+#include <ws2tcpip.h>
+#endif
+    ])
     MINGW_LIBS="-lmingwex"
     AC_SUBST(MINGW_LIBS)
   ],
@@ -2487,24 +2500,6 @@ AC_SEARCH_LIBS([__res_search],[resolv])
 AC_SEARCH_LIBS([bind],[socket])
 AC_SEARCH_LIBS([opcom_stack_trace],[opcom_stack])
 AC_SEARCH_LIBS([yp_match], [nsl nss_nis nss_nisplus])
-dnl Check for Winsock only on MinGW, on Cygwin we must use emulated BSD socket API
-AS_IF([test "x$squid_host_os" = "xmingw"],[
-  SQUID_CHECK_WINSOCK_LIB
-  AC_CHECK_HEADERS( \
-    windows.h \
-    ws2tcpip.h \
-    iphlpapi.h ,,,[
-#if HAVE_WINSOCK2_H
-#include <winsock2.h>
-#endif
-#if HAVE_WINDOWS_H
-#include <windows.h>
-#endif
-#if HAVE_WS2TCPIP_H
-#include <ws2tcpip.h>
-#endif
-  ])
-])
 
 # check that we have unix sockets
 SQUID_CHECK_UNIX_SOCKET

--- a/configure.ac
+++ b/configure.ac
@@ -191,15 +191,15 @@ AS_CASE(["$squid_host_os"],
     CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
     dnl Check for Winsock only on MinGW
     SQUID_CHECK_WINSOCK_LIB
-    AC_CHECK_HEADERS([winsock2.h windows.h ws2tcpip.h],,,[
+    AC_CHECK_HEADERS([ws2tcpip.h winsock2.h windows.h],,,[
+#if HAVE_WS2TCPIP_H
+#include <ws2tcpip.h>
+#endif
 #if HAVE_WINSOCK2_H
 #include <winsock2.h>
 #endif
 #if HAVE_WINDOWS_H
 #include <windows.h>
-#endif
-#if HAVE_WS2TCPIP_H
-#include <ws2tcpip.h>
 #endif
     ])
     MINGW_LIBS="-lmingwex"

--- a/src/icmp/Icmp4.h
+++ b/src/icmp/Icmp4.h
@@ -63,12 +63,7 @@
 #include "fde.h"
 
 #if _SQUID_WINDOWS_
-
-#if HAVE_WINSOCK2_H
-#include <winsock2.h>
-#endif
 #include <process.h>
-
 #endif
 
 /* IP Header */

--- a/src/icmp/pinger.cc
+++ b/src/icmp/pinger.cc
@@ -57,9 +57,6 @@
 
 #if _SQUID_WINDOWS_
 
-#if HAVE_WINSOCK2_H
-#include <winsock2.h>
-#endif
 #include <process.h>
 
 #include "fde.h"


### PR DESCRIPTION
  error: warning: Please include winsock2.h before windows.h

Cleanup these header includes across all Squid code built for
Windows.

Also, detect these headers early to fix autoconf tests relying
on them.