### PR TITLE
Forget non-peer access details

### DIFF
--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -30,11 +30,23 @@ The Squid-@SQUID_RELEASE@ change history can be <url url="https://github.com/squ
 
 <p>The most important of these new features are:
 <itemize>
-	<item>cache manager non_peers report removal
+	<item>Cache Manager changes
 </itemize>
 
-Most user-facing changes are reflected in squid.conf (see below).
+<p>Most user-facing changes are reflected in squid.conf (see further below).
 
+<sect1>Cache Manager changes<label id="mgr">
+<p>For more information about the Cache Manager feature, see <url url="https://wiki.squid-cache.org/Features/CacheManager/Index" name="wiki">.
+
+<p>
+<descrip>
+	<tag>non_peers</tag>
+	<p>Removed the <em>mgr:non_peers</em> report. Squid still ignores
+	unexpected ICP responses but no longer remembers the details that comprised
+	the removed report. The senders of these ICP messages are still reported to
+	cache.log at debugging level 1 (with an exponential backoff).
+
+</descrip>
 
 <sect>Changes to squid.conf since Squid-@SQUID_RELEASE_OLD@
 <p>
@@ -105,17 +117,6 @@ This section gives an account of those changes in three categories:
 	<tag>CPPFLAGS=-DHEADERS_LOG</tag>
 	<p>The code enabled by this preprocessor macro has not built for many
 	   years, indicating that the feature is unused.
-
-</descrip>
-
-<sect>Cache Manager changes since Squid-@SQUID_RELEASE_OLD@<label id="mgr">
-<p>
-<descrip>
-	<tag>non_peers</tag>
-	<p>Removed the <em>mgr:non_peers</em> report. Squid still ignores
-	unexpected ICP responses but no longer remembers the details that comprised
-	the removed report. The senders of these ICP messages are still reported to
-	cache.log at debugging level 1 (with an exponential backoff).
 
 </descrip>
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -30,7 +30,7 @@ The Squid-@SQUID_RELEASE@ change history can be <url url="https://github.com/squ
 
 <p>The most important of these new features are:
 <itemize>
-	<item>
+	<item> cache manager non_peers report removal
 </itemize>
 
 Most user-facing changes are reflected in squid.conf (see below).
@@ -60,6 +60,8 @@ This section gives an account of those changes in three categories:
 	<tag>buffered_logs</tag>
 	<p>Honor the <em>off</em> setting in 'udp' access_log module.
 
+	<tag>cachemgr_passwd</tag>
+	<p>Removed the <em>non_peers</em> action.
 </descrip>
 
 <sect1>Removed directives<label id="removeddirectives">

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -30,7 +30,7 @@ The Squid-@SQUID_RELEASE@ change history can be <url url="https://github.com/squ
 
 <p>The most important of these new features are:
 <itemize>
-	<item> cache manager non_peers report removal
+	<item>
 </itemize>
 
 Most user-facing changes are reflected in squid.conf (see below).

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -61,7 +61,8 @@ This section gives an account of those changes in three categories:
 	<p>Honor the <em>off</em> setting in 'udp' access_log module.
 
 	<tag>cachemgr_passwd</tag>
-	<p>Removed the <em>non_peers</em> action.
+	<p>Removed the <em>non_peers</em> action. See the Cache Manager
+	<ref id="mgr" name="section"> for details.
 
 </descrip>
 
@@ -104,6 +105,17 @@ This section gives an account of those changes in three categories:
 	<tag>CPPFLAGS=-DHEADERS_LOG</tag>
 	<p>The code enabled by this preprocessor macro has not built for many
 	   years, indicating that the feature is unused.
+
+</descrip>
+
+<sect>Cache Manager changes since Squid-@SQUID_RELEASE_OLD@<label id="mgr">
+<p>
+<descrip>
+	<tag>non_peers</tag>
+	<p>Removed the <em>mgr:non_peers</em> report. Squid still ignores
+	unexpected ICP responses but no longer remembers the details that comprised
+	the removed report. The senders of these ICP messages are still reported to
+	cache.log at debugging level 1 (with an exponential backoff).
 
 </descrip>
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -30,7 +30,7 @@ The Squid-@SQUID_RELEASE@ change history can be <url url="https://github.com/squ
 
 <p>The most important of these new features are:
 <itemize>
-	<item>
+	<item> cache manager non_peers report removal
 </itemize>
 
 Most user-facing changes are reflected in squid.conf (see below).

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -30,7 +30,7 @@ The Squid-@SQUID_RELEASE@ change history can be <url url="https://github.com/squ
 
 <p>The most important of these new features are:
 <itemize>
-	<item> cache manager non_peers report removal
+	<item>cache manager non_peers report removal
 </itemize>
 
 Most user-facing changes are reflected in squid.conf (see below).

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -62,6 +62,7 @@ This section gives an account of those changes in three categories:
 
 	<tag>cachemgr_passwd</tag>
 	<p>Removed the <em>non_peers</em> action.
+
 </descrip>
 
 <sect1>Removed directives<label id="removeddirectives">

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -52,16 +52,14 @@ public:
 
     /// cache_peer name (if explicitly configured) or hostname (otherwise).
     /// Unique across already configured cache_peers in the current configuration.
-    /// Not necessarily unique across discovered non-peers (see mgr:non_peers).
     /// The value may change during CachePeer configuration.
     /// The value affects various peer selection hashes (e.g., carp.hash).
     /// Preserves configured spelling (i.e. does not lower letters case).
     /// Never nil.
     char *name = nullptr;
 
-    /// The lowercase version of the configured cache_peer hostname or
-    /// the IP address of a non-peer (see mgr:non_peers).
-    /// May not be unique among cache_peers and non-peers.
+    /// The lowercase version of the configured cache_peer hostname.
+    /// May not be unique among cache_peers.
     /// Never nil.
     char *host = nullptr;
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -10354,7 +10354,6 @@ DOC_START
 		mem
 		menu
 		netdb
-		non_peers
 		objects
 		offline_toggle *
 		pconn


### PR DESCRIPTION
We were using the CachePeer class to record the address of each non-peer
sending us certain unwanted ICP responses, along with the number of such
responses and a histogram of associated ICP opcodes. Since 1997 commit
e102ebd, these historical records were accumulated without a limit and
linearly searched, endangering a Squid instance that used ICP. Using
CachePeer to store this non-cache_peer information also complicated
cache_peer code.

This change removes these records and the corresponding mgr:non_peers
report, leaving just the cache.log warning about unexpected messages.
The warning is useful because these ICP messages from non-peers indicate
a cache hierarchy misconfiguration or a fairly sophisticated attack.

This is the simplest fix that minimizes Squid and developer resources
spent on handling these errors.