### PR TITLE
Honor DNS RR TTLs larger than negative_dns_ttl

### DIFF
--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -136,7 +136,12 @@ public:
 
     hash_link hash;     /* must be first */
     time_t lastref;
-    time_t expires;
+
+    /// The earliest time this entry will be considered stale. Entries without
+    /// an expiration time (e.g., current "static" entries) are considered
+    /// fresh. \sa ipcacheExpiredEntry()
+    std::optional<time_t> expires;
+
     ipcache_addrs addrs;
     IpCacheLookupForwarder handler;
     char *error_message;
@@ -330,7 +335,8 @@ ipcache_get(const char *name)
 static int
 ipcacheExpiredEntry(ipcache_entry * i)
 {
-    /* all static entries are locked, so this takes care of them too */
+    if (!i->expires)
+        return 0; // presumably a current "static" entry
 
     if (i->locks != 0)
         return 0;
@@ -339,7 +345,7 @@ ipcacheExpiredEntry(ipcache_entry * i)
         if (0 == i->flags.negcached)
             return 1;
 
-    if (i->expires > squid_curtime)
+    if (*i->expires > squid_curtime)
         return 0;
 
     return 1;
@@ -405,13 +411,11 @@ purge_entries_fromhosts(void)
 
 ipcache_entry::ipcache_entry(const char *aName):
     lastref(0),
-    expires(0),
     error_message(nullptr),
     locks(0) // XXX: use Lock type ?
 {
     hash.key = xstrdup(aName);
     Tolower(static_cast<char*>(hash.key));
-    expires = squid_curtime + Config.negativeDnsTtl;
 }
 
 /// \ingroup IPCacheInternal
@@ -543,12 +547,14 @@ ipcache_entry::updateTtl(const unsigned int rrTtl)
                                 Config.positiveDnsTtl); // largest value allowed
 
     const time_t rrExpires = squid_curtime + ttl;
-    const auto firstRr = addrs.size() <= 1;
-    if (firstRr || rrExpires < expires) {
-        debugs(14, 5, "use " << ttl << " from RR TTL " << rrTtl << "; was: " << (expires - squid_curtime));
+    if (!expires) {
+        debugs(14, 5, "use " << ttl << " from RR TTL " << rrTtl);
+        expires = rrExpires;
+    } else if (rrExpires < *expires) {
+        debugs(14, 5, "use " << ttl << " from RR TTL " << rrTtl << "; was: " << (*expires - squid_curtime));
         expires = rrExpires;
     } else {
-        debugs(14, 7, "keep old " << (expires - squid_curtime) << " < " << ttl);
+        debugs(14, 7, "keep old " << (*expires - squid_curtime) << " < " << ttl);
     }
 }
 
@@ -782,7 +788,7 @@ ipcacheStatPrint(ipcache_entry * i, StoreEntry * sentry)
                       i->flags.fromhosts ? 'H' : ' ',
                       i->flags.negcached ? 'N' : ' ',
                       (int) (squid_curtime - i->lastref),
-                      (int) ((i->flags.fromhosts ? -1 : i->expires - squid_curtime)),
+                      static_cast<int>(!i->expires ? -1 : (*i->expires - squid_curtime)),
                       static_cast<int>(i->addrs.size()),
                       static_cast<int>(i->addrs.badCount()));
 
@@ -1139,6 +1145,8 @@ ipcacheAddEntryFromHosts(const char *name, const char *ipaddr)
 
     if ((i = ipcache_get(name))) {
         if (1 == i->flags.fromhosts) {
+            // improve ipcacheUnlockEntry() chances of reaching ipcacheRelease()
+            i->expires = squid_curtime;
             ipcacheUnlockEntry(i);
         } else if (i->locks > 0) {
             debugs(14, DBG_IMPORTANT, "ERROR: ipcacheAddEntryFromHosts: cannot add static entry for locked name '" << name << "'");

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -543,8 +543,13 @@ ipcache_entry::updateTtl(const unsigned int rrTtl)
                                 Config.positiveDnsTtl); // largest value allowed
 
     const time_t rrExpires = squid_curtime + ttl;
-    if (rrExpires < expires)
+    const auto firstRr = addrs.size() <= 1;
+    if (firstRr || rrExpires < expires) {
+        debugs(14, 5, "use " << ttl << " from RR TTL " << rrTtl << "; was: " << (expires - squid_curtime));
         expires = rrExpires;
+    } else {
+        debugs(14, 7, "keep old " << (expires - squid_curtime) << " < " << ttl);
+    }
 }
 
 /// \ingroup IPCacheInternal

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -543,12 +543,15 @@ ipcache_entry::updateTtl(const unsigned int rrTtl)
                                 Config.positiveDnsTtl); // largest value allowed
 
     const time_t rrExpires = squid_curtime + ttl;
-    const auto firstRr = addrs.size() <= 1;
-    if (firstRr || rrExpires < expires) {
-        debugs(14, 5, "use " << ttl << " from RR TTL " << rrTtl << "; was: " << (expires - squid_curtime));
+    const auto firstUpdate = addrs.size() <= 1;
+    if (firstUpdate) {
+        debugs(14, 5, "use first " << ttl << " from RR TTL " << rrTtl);
+        expires = rrExpires;
+    } else if (rrExpires < expires) {
+        debugs(14, 5, "use smaller " << ttl << " from RR TTL " << rrTtl << "; was: " << (expires - squid_curtime));
         expires = rrExpires;
     } else {
-        debugs(14, 7, "keep old " << (expires - squid_curtime) << " < " << ttl);
+        debugs(14, 7, "ignore " << ttl << " from RR TTL " << rrTtl << "; keep: " << (expires - squid_curtime));
     }
 }
 

--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -543,8 +543,7 @@ ipcache_entry::updateTtl(const unsigned int rrTtl)
                                 Config.positiveDnsTtl); // largest value allowed
 
     const time_t rrExpires = squid_curtime + ttl;
-    const auto firstUpdate = addrs.size() <= 1;
-    if (firstUpdate) {
+    if (addrs.size() <= 1) {
         debugs(14, 5, "use first " << ttl << " from RR TTL " << rrTtl);
         expires = rrExpires;
     } else if (rrExpires < expires) {


### PR DESCRIPTION
Since 2017 commit fd9c47d, Squid was effectively ignoring DNS RR TTLs
that exceeded negative_dns_ttl (i.e. 60 seconds by default) because the
"find the smallest TTL across the DNS records seen so far" code in
ipcache_entry::updateTtl() mistook the "default" ipcache_entry::expires
value as the one based on an earlier seen DNS record.

In most cases, this bug decreased IP cache hit ratio.

Existing fqdncache code does not suffer from the same bug because
fqdncacheParse() always resets fqdncache_entry::expires instead of
updating it incrementally. ipcacheParse() has to update incrementally
because it is called twice per entry, once with an A answer and once
with an AAAA answer.

Ideally, ipcache_entry::expires should be made optional to eliminate
awkward "first updateTtl() call" detection, but doing so well requires
significant code changes, so that entries without a known expiration
value are not cached forever _unless_ they were loaded from /etc/hosts.
And those changes should probably be propagated to fqdncache.cc.
