### PR TITLE
Do not use raw pointers to index CARP CachePeers

### DIFF
--- a/src/CachePeers.h
+++ b/src/CachePeers.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_CACHEPEERS_H
+#define SQUID_CACHEPEERS_H
+
+#include "base/forward.h"
+#include "CachePeer.h"
+#include "mem/PoolingAllocator.h"
+
+#include <vector>
+
+/// Weak pointers to zero or more Config.peers.
+/// Users must specify the selection algorithm and the order of entries.
+using SelectedCachePeers = std::vector< CbcPointer<CachePeer>, PoolingAllocator< CbcPointer<CachePeer> > >;
+
+/// Temporary, local storage of raw pointers to zero or more Config.peers.
+using RawCachePeers = std::vector<CachePeer *, PoolingAllocator<CachePeer*> >;
+
+#endif /* SQUID_CACHEPEERS_H */
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -199,6 +199,7 @@ squid_SOURCES = \
 	CacheManager.h \
 	CachePeer.cc \
 	CachePeer.h \
+	CachePeers.h \
 	ClientInfo.h \
 	ClientRequestContext.h \
 	CollapsedForwarding.cc \


### PR DESCRIPTION
Simplified and improved code safety by using CbcPointers instead.

Also fixed mgr:carp Cache Manager reports to detail relevant
cache_peers instead of all cache_peers. When mgr:carp report was added
in 2000 commit 8ee9b49, Squid did not index (or even distinguish!)
CARP cache_peers, and the reporting loop naturally iterated through all
cache_peers. 2002 commit b399543 added identification and indexing of
CARP peers but forgot to adjust the reporting loop.

Very similar changes will be applied to userhash and sourcehash
cache_peers. 2008 commit 63104e2 simply copied problematic CARP code to
add userhash and sourcehash cache_peer support. This change adds a few
reusable types with those upcoming improvements in mind.