### PR TITLE
Bug 5278: Log %err_code for "early" request handling errors

### DIFF
--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1352,6 +1352,11 @@ ErrorState::BuildHttpReply()
             request->detailError(type, detail);
         else
             request->detailError(type, SysErrorDetail::NewIfAny(xerrno));
+    } else if (ale) {
+        if (detail)
+            ale->updateError(Error(type, detail));
+        else
+            ale->updateError(Error(type, SysErrorDetail::NewIfAny(xerrno)));
     }
 
     return rep;


### PR DESCRIPTION
Certain "early" request handling errors (e.g., ERR_TOO_BIG,
ERR_UNSUP_REQ, ERR_UNSUP_HTTPVERSION, ERR_PROTOCOL_UNKNOWN, and
ERR_INVALID_URL) are handled with nil ClientHttpRequest::request object.
ErrorState relied on that object to record error type and details, so
%err_code expanded to "-" in the corresponding access.log records.

Now, ErrorState also uses ALE (where available). ALE already handles the
combination of an early error and late HttpRequest (e.g., the fake one
clientReplyContext::createStoreEntry() creates when handling the error).

This minimal fix does not address known problems with ErrorState::detail
and ErrorState::BuildHttpReply(). It also duplicates related xerrno
detailing code. We will address some of these problems shortly,
including the increased code duplication problem.
