### PR TITLE
Fix PRIuSIZE definition

### DIFF
--- a/acinclude/printf.m4
+++ b/acinclude/printf.m4
@@ -1,0 +1,33 @@
+## Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+dnl check which printf code to use for a type
+dnl $1 - the type being checked
+dnl $2 - the PRIxxx macro to define
+dnl $3 - a list of possible codes
+AC_DEFUN([SQUID_CHECK_PRINTF_CODES],[
+  AH_TEMPLATE([$2],[printf display of $1])
+  AC_CACHE_CHECK([which printf code displays $1],
+                 [squid_cv_printf_$2],[
+    SQUID_STATE_SAVE($2)
+    CXXFLAGS="$CXXFLAGS -Werror=format"
+    for code in $3; do
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <cstdio>
+      ]],[[$1 val={};printf("%$code", val);]])],[
+        squid_cv_printf_$2=$code
+        break
+      ])
+    done
+    SQUID_STATE_ROLLBACK($2)
+  ])
+  AS_IF([test -z "$squid_cv_printf_$2"],
+    AC_MSG_FAILURE([no printf support for $1 (tried: $3)])
+  )
+  AC_DEFINE_UNQUOTED($2,["$squid_cv_printf_$2"])
+  AC_MSG_RESULT($squid_cv_printf_$2)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ m4_include([acinclude/ldap.m4])
 m4_include([acinclude/nettle.m4])
 m4_include([acinclude/pam.m4])
 m4_include([acinclude/pkg.m4])
+m4_include([acinclude/printf.m4])
 m4_include([acinclude/tdb.m4])
 m4_include([acinclude/lib-checks.m4])
 m4_include([acinclude/ax_cxx_compile_stdcxx.m4])
@@ -2393,6 +2394,8 @@ AC_TYPE_INT64_T
 AC_TYPE_UINT64_T
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
+AC_CHECK_SIZEOF(size_t)
+SQUID_CHECK_PRINTF_CODES([size_t],[PRIuSIZE],[zu llu lu u I64u I32u])
 AC_TYPE_SSIZE_T
 AC_TYPE_OFF_T
 AC_TYPE_UID_T
@@ -2402,7 +2405,6 @@ AC_CHECK_SIZEOF(int64_t)
 AC_CHECK_SIZEOF(long)
 #need the define for overflow checks
 AC_CHECK_SIZEOF(off_t)
-AC_CHECK_SIZEOF(size_t)
 
 dnl On Solaris 9 x86, gcc may includes a "fixed" set of old system include files
 dnl that is incompatible with the updated Solaris header files.

--- a/src/acl/external/LM_group/ext_lm_group_acl.cc
+++ b/src/acl/external/LM_group/ext_lm_group_acl.cc
@@ -569,7 +569,7 @@ main(int argc, char *argv[])
         if ((p = strchr(buf, '\r')) != NULL)
             *p = '\0';      /* strip \r */
 
-        debug("Got '%s' from Squid (length: %d).\n", buf, strlen(buf));
+        debug("Got '%s' from Squid (length: %" PRIuSIZE ").\n", buf, strlen(buf));
 
         if (buf[0] == '\0') {
             SEND_BH(HLP_MSG("Invalid Request."));

--- a/src/ssl/crtd_message.cc
+++ b/src/ssl/crtd_message.cc
@@ -129,7 +129,7 @@ std::string Ssl::CrtdMessage::compose() const
 {
     if (code.empty()) return std::string();
     char buffer[10];
-    snprintf(buffer, sizeof(buffer), "%zd", body.length());
+    snprintf(buffer, sizeof(buffer), "%" PRIuSIZE, body.length());
     return code + ' ' + buffer + ' ' + body;
 }
 


### PR DESCRIPTION
This printf format-string helper was defined twice
with inconsistent criteria and values.

Define an M4 macro to perform the code checks in
./configure and allow other types to also reduce
their tests in future.

Also, fix several format strings which were using
bad %codes. Identified by MinGW cross-compile.