### PR TITLE
Drop PRIuSIZE macro

### DIFF
--- a/compat/types.h
+++ b/compat/types.h
@@ -125,21 +125,6 @@
 #endif
 #endif
 
-#ifndef PRIuSIZE
-// NP: configure checks for support of %zu and defines where possible
-#if SIZEOF_SIZE_T == 4 && _SQUID_MINGW_
-#define PRIuSIZE "I32u"
-#elif SIZEOF_SIZE_T == 4
-#define PRIuSIZE "u"
-#elif SIZEOF_SIZE_T == 8 && _SQUID_MINGW_
-#define PRIuSIZE "I64u"
-#elif SIZEOF_SIZE_T == 8
-#define PRIuSIZE "lu"
-#else
-#error size_t is not 32-bit or 64-bit
-#endif
-#endif /* PRIuSIZE */
-
 #ifndef HAVE_MODE_T
 typedef unsigned short mode_t;
 #endif

--- a/compat/xalloc.cc
+++ b/compat/xalloc.cc
@@ -81,7 +81,7 @@ xcalloc(size_t n, size_t sz)
     if (!p) {
         if (failure_notify) {
             static char msg[128];
-            snprintf(msg, 128, "xcalloc: Unable to allocate %" PRIuSIZE " blocks of %" PRIuSIZE " bytes!\n", n, sz);
+            snprintf(msg, 128, "xcalloc: Unable to allocate %zu blocks of %zu bytes!\n", n, sz);
             failure_notify(msg);
         } else {
             perror("xcalloc");
@@ -107,7 +107,7 @@ xmalloc(size_t sz)
     if (!p) {
         if (failure_notify) {
             static char msg[128];
-            snprintf(msg, 128, "xmalloc: Unable to allocate %" PRIuSIZE " bytes!\n", sz);
+            snprintf(msg, 128, "xmalloc: Unable to allocate %zu bytes!\n", sz);
             failure_notify(msg);
         } else {
             perror("malloc");
@@ -133,7 +133,7 @@ xrealloc(void *s, size_t sz)
     if (!p) {
         if (failure_notify) {
             static char msg[128];
-            snprintf(msg, 128, "xrealloc: Unable to reallocate %" PRIuSIZE " bytes!\n", sz);
+            snprintf(msg, 128, "xrealloc: Unable to reallocate %zu bytes!\n", sz);
             failure_notify(msg);
         } else {
             perror("realloc");

--- a/configure.ac
+++ b/configure.ac
@@ -2400,8 +2400,6 @@ AC_CHECK_TYPE([bool])
 #need the defines for PRId64
 AC_CHECK_SIZEOF(int64_t)
 AC_CHECK_SIZEOF(long)
-#need the defines for PRIuSIZE
-AC_CHECK_SIZEOF(size_t)
 #need the define for overflow checks
 AC_CHECK_SIZEOF(off_t)
 AC_CHECK_SIZEOF(size_t)
@@ -2438,17 +2436,6 @@ AC_CHECK_TYPE(cpu_set_t,
 #include <sched.h>
 #endif
 ])
-
-# check for compiler support of %zu printf macro
-AH_TEMPLATE(PRIuSIZE,[Compiler supports %zu printf macro])
-AC_MSG_CHECKING([for compiler %zu support])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdio.h>
-  ]],[[size_t n=1;printf("%zu",n);]])],[
-    AC_DEFINE(PRIuSIZE,"zu")
-    AC_MSG_RESULT(yes)
-  ],[AC_MSG_RESULT(no)],[AC_MSG_RESULT(no)])
-
 
 dnl Check for special functions
 AC_FUNC_ALLOCA

--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.cc
@@ -242,7 +242,7 @@ local_printfx(const char *msg,...)
         *(dbuf) = '\0';
     } else {
         /* FAIL */
-        debug("local_printfx() FAILURE: %" PRIuSIZE "\n", x);
+        debug("local_printfx() FAILURE: %zu\n", x);
     }
 
     /* stdout needs to be flushed for it to work with Squid */
@@ -1086,7 +1086,7 @@ SearchIPLDAP(edui_ldap_t *l)
                     memcpy(bufa, l->val[i]->bv_val, j);
                     z = BinarySplit(bufa, j, '#', bufb, sizeof(bufb));
                     /* BINARY DEBUGGING *
-                                              local_printfx("value[%" PRIuSIZE "]: BinarySplit(", (size_t) i);
+                                              local_printfx("value[%zu]: BinarySplit(", (size_t) i);
                                               for (k = 0; k < z; ++k) {
                                                 c = (int) bufb[k];
                                                 if (c < 0)
@@ -1100,7 +1100,7 @@ SearchIPLDAP(edui_ldap_t *l)
                                                   c = c + 256;
                                                 local_printfx("%02X", c);
                                               }
-                                              local_printfx("): %" PRIuSIZE "\n", (size_t) z);
+                                              local_printfx("): %zu\n", (size_t) z);
                     * BINARY DEBUGGING */
                     z = j - z - 1;
                     j = atoi(bufb);
@@ -1553,7 +1553,7 @@ MainSafe(int argc, char **argv)
             edui_elap = 0;
         k = strlen(bufa);
         /* BINARY DEBUGGING *
-                    local_printfx("while() -> bufa[%" PRIuSIZE "]: %s", k, bufa);
+                    local_printfx("while() -> bufa[%zu]: %s", k, bufa);
                     for (i = 0; i < k; ++i)
                       local_printfx("%02X", static_cast<unsigned int>(static_cast<unsigned char>(bufa[i])));
                     local_printfx("\n");
@@ -1660,10 +1660,10 @@ MainSafe(int argc, char **argv)
         /* If we got a group string, split it */
         if (p != nullptr) {
             /* Split string */
-            debug("StringSplit(%s, ' ', %s, %" PRIuSIZE ")\n", bufa, bufb, sizeof(bufb));
+            debug("StringSplit(%s, ' ', %s, %zu)\n", bufa, bufb, sizeof(bufb));
             i = StringSplit(bufa, ' ', bufb, sizeof(bufb));
             if (i > 0) {
-                debug("StringSplit(%s, %s) done.  Result: %" PRIuSIZE "\n", bufa, bufb, i);
+                debug("StringSplit(%s, %s) done.  Result: %zu\n", bufa, bufb, i);
                 /* Got a group to match against */
                 x = ConvertIP(&edui_ldap, bufb);
                 if (x < 0) {
@@ -1704,8 +1704,8 @@ MainSafe(int argc, char **argv)
                     }
                 }
             } else {
-                debug("StringSplit() -> Error: %" PRIuSIZE "\n", i);
-                local_printfx("BH message=\"(StringSplit Error %" PRIuSIZE ")\"\n", i);
+                debug("StringSplit() -> Error: %zu\n", i);
+                local_printfx("BH message=\"(StringSplit Error %zu)\"\n", i);
             }
         } else {
             /* No group to match against, only an IP */

--- a/src/acl/external/kerberos_ldap_group/support_ldap.cc
+++ b/src/acl/external/kerberos_ldap_group/support_ldap.cc
@@ -433,21 +433,18 @@ search_group_tree(struct main_args *margs, LDAP * ld, char *bindp,
         }
         if (debug_enabled) {
             int n;
-            debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                  " \"%s\" in hex UTF-8 is ", LogTime(), PROGRAM, j + 1, av);
+            debug((char *) "%s| %s: DEBUG: Entry %zu \"%s\" in hex UTF-8 is ", LogTime(), PROGRAM, j + 1, av);
             for (n = 0; av[n] != '\0'; ++n)
                 fprintf(stderr, "%02x", (unsigned char) av[n]);
             fprintf(stderr, "\n");
         }
         if (!strcasecmp(group, av)) {
             retval = 1;
-            debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                  " \"%s\" matches group name \"%s\"\n", LogTime(), PROGRAM,
+            debug((char *) "%s| %s: DEBUG: Entry %zu \"%s\" matches group name \"%s\"\n", LogTime(), PROGRAM,
                   j + 1, av, group);
             break;
         } else
-            debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                  " \"%s\" does not match group name \"%s\"\n", LogTime(),
+            debug((char *) "%s| %s: DEBUG: Entry %zu \"%s\" does not match group name \"%s\"\n", LogTime(),
                   PROGRAM, j + 1, av, group);
         /*
          * Do recursive group search
@@ -466,8 +463,7 @@ search_group_tree(struct main_args *margs, LDAP * ld, char *bindp,
                 }
             }
             if (debug_enabled)
-                debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                      " \"%s\" is member of group named \"%s\"\n", LogTime(),
+                debug((char *) "%s| %s: DEBUG: Entry %zu \"%s\" is member of group named \"%s\"\n", LogTime(),
                       PROGRAM, j + 1, av, group);
             else
                 break;
@@ -715,8 +711,7 @@ get_attributes(LDAP * ld, LDAPMessage * res, const char *attribute,
         }
     }
 
-    debug((char *) "%s| %s: DEBUG: %" PRIuSIZE
-          " ldap entr%s found with attribute : %s\n", LogTime(), PROGRAM,
+    debug((char *) "%s| %s: DEBUG: %zu ldap entr%s found with attribute : %s\n", LogTime(), PROGRAM,
           max_attr, max_attr > 1 || max_attr == 0 ? "ies" : "y", attribute);
 
     *ret_value = attr_value;
@@ -795,8 +790,7 @@ get_bin_attributes(LDAP * ld, LDAPMessage * res, const char *attribute,
         }
     }
 
-    debug((char *) "%s| %s: DEBUG: %" PRIuSIZE
-          " ldap entr%s found with attribute : %s\n", LogTime(), PROGRAM,
+    debug((char *) "%s| %s: DEBUG: %zu ldap entr%s found with attribute : %s\n", LogTime(), PROGRAM,
           max_attr, max_attr > 1 || max_attr == 0 ? "ies" : "y", attribute);
 
     *ret_value = attr_value;
@@ -1276,8 +1270,7 @@ get_memberof(struct main_args *margs, char *user, char *domain, char *group)
                 }
             }
             if (debug_enabled) {
-                debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                      " \"%s\" in hex UTF-8 is ", LogTime(), PROGRAM, k + 1, av);
+                debug((char *) "%s| %s: DEBUG: Entry %zu \"%s\" in hex UTF-8 is ", LogTime(), PROGRAM, k + 1, av);
                 for (unsigned int n = 0; av[n] != '\0'; ++n)
                     fprintf(stderr, "%02x", (unsigned char) av[n]);
                 fprintf(stderr, "\n");
@@ -1285,14 +1278,12 @@ get_memberof(struct main_args *margs, char *user, char *domain, char *group)
             if (!strcasecmp(group, av)) {
                 retval = 1;
                 if (debug_enabled)
-                    debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                          " \"%s\" matches group name \"%s\"\n", LogTime(),
+                    debug((char *) "%s| %s: DEBUG: Entry %zu \"%s\" matches group name \"%s\"\n", LogTime(),
                           PROGRAM, k + 1, av, group);
                 else
                     break;
             } else
-                debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                      " \"%s\" does not match group name \"%s\"\n", LogTime(),
+                debug((char *) "%s| %s: DEBUG: Entry %zu \"%s\" does not match group name \"%s\"\n", LogTime(),
                       PROGRAM, k + 1, av, group);
         }
         /*
@@ -1318,8 +1309,7 @@ get_memberof(struct main_args *margs, char *user, char *domain, char *group)
                         }
                     }
                     if (debug_enabled)
-                        debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                              " group \"%s\" is (in)direct member of group \"%s\"\n",
+                        debug((char *) "%s| %s: DEBUG: Entry %zu group \"%s\" is (in)direct member of group \"%s\"\n",
                               LogTime(), PROGRAM, j + 1, av, group);
                     else
                         break;
@@ -1544,8 +1534,7 @@ get_memberof(struct main_args *margs, char *user, char *domain, char *group)
                             }
                         }
                         if (debug_enabled) {
-                            debug((char *) "%s| %s: DEBUG: Entry %" PRIuSIZE
-                                  " group \"%s\" is (in)direct member of group \"%s\"\n",
+                            debug((char *) "%s| %s: DEBUG: Entry %zu group \"%s\" is (in)direct member of group \"%s\"\n",
                                   LogTime(), PROGRAM, j + 1, av, group);
                         } else {
                             break;

--- a/src/auth/negotiate/wrapper/negotiate_wrapper.cc
+++ b/src/auth/negotiate/wrapper/negotiate_wrapper.cc
@@ -137,7 +137,7 @@ processingLoop(FILE *FDKIN, FILE *FDKOUT, FILE *FDNIN, FILE *FDNOUT)
             *c = '\0';
             length = c - buf;
             if (debug_enabled)
-                fprintf(stderr, "%s| %s: Got '%s' from squid (length: %" PRIuSIZE ").\n",
+                fprintf(stderr, "%s| %s: Got '%s' from squid (length: %zu).\n",
                         LogTime(), PROGRAM, buf, length);
         } else {
             if (debug_enabled)
@@ -182,7 +182,7 @@ processingLoop(FILE *FDKIN, FILE *FDKOUT, FILE *FDNIN, FILE *FDNOUT)
         }
         length = BASE64_DECODE_LENGTH(strlen(buf+3));
         if (debug_enabled)
-            fprintf(stderr, "%s| %s: Decode '%s' (decoded length: %" PRIuSIZE ").\n",
+            fprintf(stderr, "%s| %s: Decode '%s' (decoded length: %zu).\n",
                     LogTime(), PROGRAM, buf + 3, length);
 
         safe_free(token);

--- a/src/auth/ntlm/SMB_LM/ntlm_smb_lm_auth.cc
+++ b/src/auth/ntlm/SMB_LM/ntlm_smb_lm_auth.cc
@@ -197,7 +197,7 @@ make_challenge(char *domain, char *domain_controller)
     // validations later will expect to be limited to that size.
     static char b64buf[HELPER_INPUT_BUFFER-10]; /* 10 for other line fields, delimiters and terminator */
     if (base64_encode_len(len) < sizeof(b64buf)-1) {
-        debug("base64 encoding of the token challenge will exceed %" PRIuSIZE " bytes", sizeof(b64buf));
+        debug("base64 encoding of the token challenge will exceed %zu bytes", sizeof(b64buf));
         return NULL;
     }
 

--- a/src/security/ServerOptions.cc
+++ b/src/security/ServerOptions.cc
@@ -152,7 +152,7 @@ Security::ServerOptions::dumpCfg(Packable *p, const char *pfx) const
         p->appendf(" %sgenerate-host-certificates=off", pfx);
 
     if (dynamicCertMemCacheSize != 4*1024*1024) // 4MB default, no 'tls-' prefix
-        p->appendf(" dynamic_cert_mem_cache_size=%" PRIuSIZE "bytes", dynamicCertMemCacheSize);
+        p->appendf(" dynamic_cert_mem_cache_size=%zubytes", dynamicCertMemCacheSize);
 
     if (!staticContextSessionId.isEmpty())
         p->appendf(" %scontext=" SQUIDSBUFPH, pfx, SQUIDSBUFPRINT(staticContextSessionId));

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -901,7 +901,7 @@ store_client::dumpStats(MemBuf * output, int clientNumber) const
 
     output->appendf("\tClient #%d, %p\n", clientNumber, _callback.callback_data);
     output->appendf("\t\tcopy_offset: %" PRId64 "\n", copyInto.offset);
-    output->appendf("\t\tcopy_size: %" PRIuSIZE "\n", copyInto.length);
+    output->appendf("\t\tcopy_size: %zu\n", copyInto.length);
     output->append("\t\tflags:", 8);
 
     if (flags.disk_io_pending)


### PR DESCRIPTION
C++11 requires compiler support for %zu so
we no longer need to check for it.