### PR TITLE
Keep ::helper objects alive while in use by helper_servers

### DIFF
--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -36,7 +36,7 @@
 /* Basic Scheme */
 static AUTHSSTATS authenticateBasicStats;
 
-HelperPointer basicauthenticators = nullptr;
+HelperPointer basicauthenticators;
 
 static int authbasic_initialised = 0;
 

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -36,7 +36,7 @@
 /* Basic Scheme */
 static AUTHSSTATS authenticateBasicStats;
 
-helper *basicauthenticators = nullptr;
+HelperPointer basicauthenticators = nullptr;
 
 static int authbasic_initialised = 0;
 
@@ -109,7 +109,6 @@ Auth::Basic::Config::done()
         helperShutdown(basicauthenticators);
     }
 
-    delete basicauthenticators;
     basicauthenticators = nullptr;
 
     if (authenticateProgram)
@@ -305,7 +304,7 @@ Auth::Basic::Config::init(Auth::SchemeConfig *)
         authbasic_initialised = 1;
 
         if (basicauthenticators == nullptr)
-            basicauthenticators = new helper("basicauthenticator");
+            basicauthenticators = helper::Make("basicauthenticator");
 
         basicauthenticators->cmdline = authenticateProgram;
 

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -36,7 +36,7 @@
 /* Basic Scheme */
 static AUTHSSTATS authenticateBasicStats;
 
-HelperPointer basicauthenticators;
+Helper::ClientPointer basicauthenticators;
 
 static int authbasic_initialised = 0;
 

--- a/src/auth/basic/Config.h
+++ b/src/auth/basic/Config.h
@@ -50,7 +50,7 @@ private:
 } // namespace Basic
 } // namespace Auth
 
-extern helper *basicauthenticators;
+extern HelperPointer basicauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_BASIC */
 #endif /* __AUTH_BASIC_H__ */

--- a/src/auth/basic/Config.h
+++ b/src/auth/basic/Config.h
@@ -50,7 +50,7 @@ private:
 } // namespace Basic
 } // namespace Auth
 
-extern HelperPointer basicauthenticators;
+extern Helper::ClientPointer basicauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_BASIC */
 #endif /* __AUTH_BASIC_H__ */

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -46,7 +46,7 @@
 
 static AUTHSSTATS authenticateDigestStats;
 
-HelperPointer digestauthenticators = nullptr;
+HelperPointer digestauthenticators;
 
 static hash_table *digest_nonce_cache;
 

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -46,7 +46,7 @@
 
 static AUTHSSTATS authenticateDigestStats;
 
-helper *digestauthenticators = nullptr;
+HelperPointer digestauthenticators = nullptr;
 
 static hash_table *digest_nonce_cache;
 
@@ -525,7 +525,7 @@ Auth::Digest::Config::init(Auth::SchemeConfig *)
         authdigest_initialised = 1;
 
         if (digestauthenticators == nullptr)
-            digestauthenticators = new helper("digestauthenticator");
+            digestauthenticators = helper::Make("digestauthenticator");
 
         digestauthenticators->cmdline = authenticateProgram;
 
@@ -559,7 +559,6 @@ Auth::Digest::Config::done()
     if (!shutting_down)
         return;
 
-    delete digestauthenticators;
     digestauthenticators = nullptr;
 
     if (authenticateProgram)

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -46,7 +46,7 @@
 
 static AUTHSSTATS authenticateDigestStats;
 
-HelperPointer digestauthenticators;
+Helper::ClientPointer digestauthenticators;
 
 static hash_table *digest_nonce_cache;
 

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -100,7 +100,7 @@ public:
 /* strings */
 #define QOP_AUTH "auth"
 
-extern helper *digestauthenticators;
+extern HelperPointer digestauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_DIGEST */
 #endif

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -100,7 +100,7 @@ public:
 /* strings */
 #define QOP_AUTH "auth"
 
-extern HelperPointer digestauthenticators;
+extern Helper::ClientPointer digestauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_DIGEST */
 #endif

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -32,7 +32,7 @@
 
 static AUTHSSTATS authenticateNegotiateStats;
 
-StatefulHelperPointer negotiateauthenticators = nullptr;
+StatefulHelperPointer negotiateauthenticators;
 
 static int authnegotiate_initialised = 0;
 

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -32,7 +32,7 @@
 
 static AUTHSSTATS authenticateNegotiateStats;
 
-statefulhelper *negotiateauthenticators = nullptr;
+StatefulHelperPointer negotiateauthenticators = nullptr;
 
 static int authnegotiate_initialised = 0;
 
@@ -63,7 +63,6 @@ Auth::Negotiate::Config::done()
     if (!shutting_down)
         return;
 
-    delete negotiateauthenticators;
     negotiateauthenticators = nullptr;
 
     if (authenticateProgram)
@@ -90,7 +89,7 @@ Auth::Negotiate::Config::init(Auth::SchemeConfig *)
         authnegotiate_initialised = 1;
 
         if (negotiateauthenticators == nullptr)
-            negotiateauthenticators = new statefulhelper("negotiateauthenticator");
+            negotiateauthenticators = statefulhelper::Make("negotiateauthenticator");
 
         if (!proxy_auth_cache)
             proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -32,7 +32,7 @@
 
 static AUTHSSTATS authenticateNegotiateStats;
 
-StatefulHelperPointer negotiateauthenticators;
+Helper::StatefulClientPointer negotiateauthenticators;
 
 static int authnegotiate_initialised = 0;
 

--- a/src/auth/negotiate/Config.h
+++ b/src/auth/negotiate/Config.h
@@ -39,7 +39,7 @@ public:
 } // namespace Negotiate
 } // namespace Auth
 
-extern statefulhelper *negotiateauthenticators;
+extern StatefulHelperPointer negotiateauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_NEGOTIATE */
 #endif

--- a/src/auth/negotiate/Config.h
+++ b/src/auth/negotiate/Config.h
@@ -39,7 +39,7 @@ public:
 } // namespace Negotiate
 } // namespace Auth
 
-extern StatefulHelperPointer negotiateauthenticators;
+extern Helper::StatefulClientPointer negotiateauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_NEGOTIATE */
 #endif

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -33,7 +33,7 @@
 /* NTLM Scheme */
 static AUTHSSTATS authenticateNTLMStats;
 
-StatefulHelperPointer ntlmauthenticators = nullptr;
+StatefulHelperPointer ntlmauthenticators;
 static int authntlm_initialised = 0;
 
 static hash_table *proxy_auth_cache = nullptr;

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -33,7 +33,7 @@
 /* NTLM Scheme */
 static AUTHSSTATS authenticateNTLMStats;
 
-statefulhelper *ntlmauthenticators = nullptr;
+StatefulHelperPointer ntlmauthenticators = nullptr;
 static int authntlm_initialised = 0;
 
 static hash_table *proxy_auth_cache = nullptr;
@@ -64,7 +64,6 @@ Auth::Ntlm::Config::done()
     if (!shutting_down)
         return;
 
-    delete ntlmauthenticators;
     ntlmauthenticators = nullptr;
 
     if (authenticateProgram)
@@ -89,7 +88,7 @@ Auth::Ntlm::Config::init(Auth::SchemeConfig *)
         authntlm_initialised = 1;
 
         if (ntlmauthenticators == nullptr)
-            ntlmauthenticators = new statefulhelper("ntlmauthenticator");
+            ntlmauthenticators = statefulhelper::Make("ntlmauthenticator");
 
         if (!proxy_auth_cache)
             proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -33,7 +33,7 @@
 /* NTLM Scheme */
 static AUTHSSTATS authenticateNTLMStats;
 
-StatefulHelperPointer ntlmauthenticators;
+Helper::StatefulClientPointer ntlmauthenticators;
 static int authntlm_initialised = 0;
 
 static hash_table *proxy_auth_cache = nullptr;

--- a/src/auth/ntlm/Config.h
+++ b/src/auth/ntlm/Config.h
@@ -42,7 +42,7 @@ public:
 } // namespace Ntlm
 } // namespace Auth
 
-extern statefulhelper *ntlmauthenticators;
+extern StatefulHelperPointer ntlmauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_NTLM */
 #endif

--- a/src/auth/ntlm/Config.h
+++ b/src/auth/ntlm/Config.h
@@ -42,7 +42,7 @@ public:
 } // namespace Ntlm
 } // namespace Auth
 
-extern StatefulHelperPointer ntlmauthenticators;
+extern Helper::StatefulClientPointer ntlmauthenticators;
 
 #endif /* HAVE_AUTH_MODULE_NTLM */
 #endif

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -100,7 +100,7 @@ public:
 
     Helper::ChildConfig children;
 
-    helper *theHelper;
+    helper::Pointer theHelper;
 
     hash_table *cache;
 
@@ -157,7 +157,6 @@ external_acl::~external_acl()
 
     if (theHelper) {
         helperShutdown(theHelper);
-        delete theHelper;
         theHelper = nullptr;
     }
 
@@ -1114,7 +1113,7 @@ externalAclInit(void)
             p->cache = hash_create((HASHCMP *) strcmp, hashPrime(1024), hash4);
 
         if (!p->theHelper)
-            p->theHelper = new helper("external_acl_type");
+            p->theHelper = helper::Make("external_acl_type");
 
         p->theHelper->cmdline = p->cmdline;
 

--- a/src/helper/forward.h
+++ b/src/helper/forward.h
@@ -9,6 +9,8 @@
 #ifndef SQUID_SRC_HELPER_FORWARD_H
 #define SQUID_SRC_HELPER_FORWARD_H
 
+#include "base/forward.h"
+
 class helper;
 class statefulhelper;
 
@@ -23,6 +25,9 @@ class Reply;
 class Request;
 
 } // namespace Helper
+
+using HelperPointer = RefCount<helper>;
+using StatefulHelperPointer = RefCount<statefulhelper>;
 
 typedef void HLPCB(void *, const Helper::Reply &);
 

--- a/src/helper/forward.h
+++ b/src/helper/forward.h
@@ -24,10 +24,10 @@ namespace Helper
 class Reply;
 class Request;
 
-} // namespace Helper
+using ClientPointer = RefCount<helper>;
+using StatefulClientPointer = RefCount<statefulhelper>;
 
-using HelperPointer = RefCount<helper>;
-using StatefulHelperPointer = RefCount<statefulhelper>;
+} // namespace Helper
 
 typedef void HLPCB(void *, const Helper::Reply &);
 

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -54,8 +54,8 @@ public:
 
 static HLPCB redirectHandleReply;
 static HLPCB storeIdHandleReply;
-static helper::Pointer redirectors = nullptr;
-static helper::Pointer storeIds = nullptr;
+static helper::Pointer redirectors;
+static helper::Pointer storeIds;
 static OBJH redirectStats;
 static OBJH storeIdStats;
 static int redirectorBypassed = 0;

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -54,8 +54,8 @@ public:
 
 static HLPCB redirectHandleReply;
 static HLPCB storeIdHandleReply;
-static helper *redirectors = nullptr;
-static helper *storeIds = nullptr;
+static helper::Pointer redirectors = nullptr;
+static helper::Pointer storeIds = nullptr;
 static OBJH redirectStats;
 static OBJH storeIdStats;
 static int redirectorBypassed = 0;
@@ -223,7 +223,7 @@ storeIdStats(StoreEntry * sentry)
 }
 
 static void
-constructHelperQuery(const char *name, helper *hlp, HLPCB *replyHandler, ClientHttpRequest * http, HLPCB *handler, void *data, Format::Format *requestExtrasFmt)
+constructHelperQuery(const char *name, const helper::Pointer &hlp, HLPCB *replyHandler, ClientHttpRequest * http, HLPCB *handler, void *data, Format::Format *requestExtrasFmt)
 {
     char buf[MAX_REDIRECTOR_REQUEST_STRLEN];
     int sz;
@@ -342,7 +342,7 @@ redirectInit(void)
     if (Config.Program.redirect) {
 
         if (redirectors == nullptr)
-            redirectors = new helper("redirector");
+            redirectors = helper::Make("redirector");
 
         redirectors->cmdline = Config.Program.redirect;
 
@@ -369,7 +369,7 @@ redirectInit(void)
     if (Config.Program.store_id) {
 
         if (storeIds == nullptr)
-            storeIds = new helper("store_id");
+            storeIds = helper::Make("store_id");
 
         storeIds->cmdline = Config.Program.store_id;
 
@@ -418,10 +418,8 @@ redirectShutdown(void)
     if (!shutting_down)
         return;
 
-    delete redirectors;
     redirectors = nullptr;
 
-    delete storeIds;
     storeIds = nullptr;
 
     delete redirectorExtrasFmt;

--- a/src/ssl/helper.cc
+++ b/src/ssl/helper.cc
@@ -72,7 +72,7 @@ operator <<(std::ostream &os, const Ssl::GeneratorRequest &gr)
 /// pending Ssl::Helper requests (to all certificate generator helpers combined)
 static Ssl::GeneratorRequests TheGeneratorRequests;
 
-helper *Ssl::Helper::ssl_crtd = nullptr;
+helper::Pointer Ssl::Helper::ssl_crtd = nullptr;
 
 void Ssl::Helper::Init()
 {
@@ -86,7 +86,7 @@ void Ssl::Helper::Init()
     if (!found)
         return;
 
-    ssl_crtd = new helper("sslcrtd_program");
+    ssl_crtd = helper::Make("sslcrtd_program");
     ssl_crtd->childs.updateLimits(Ssl::TheConfig.ssl_crtdChildren);
     ssl_crtd->ipc_type = IPC_STREAM;
     // The crtd messages may contain the eol ('\n') character. We are
@@ -111,7 +111,6 @@ void Ssl::Helper::Shutdown()
         return;
     helperShutdown(ssl_crtd);
     wordlistDestroy(&ssl_crtd->cmdline);
-    delete ssl_crtd;
     ssl_crtd = nullptr;
 }
 
@@ -167,7 +166,7 @@ Ssl::HandleGeneratorReply(void *data, const ::Helper::Reply &reply)
 }
 #endif //USE_SSL_CRTD
 
-helper *Ssl::CertValidationHelper::ssl_crt_validator = nullptr;
+helper::Pointer Ssl::CertValidationHelper::ssl_crt_validator = nullptr;
 
 void Ssl::CertValidationHelper::Init()
 {
@@ -183,7 +182,7 @@ void Ssl::CertValidationHelper::Init()
     if (!found)
         return;
 
-    ssl_crt_validator = new helper("ssl_crt_validator");
+    ssl_crt_validator = helper::Make("ssl_crt_validator");
     ssl_crt_validator->childs.updateLimits(Ssl::TheConfig.ssl_crt_validator_Children);
     ssl_crt_validator->ipc_type = IPC_STREAM;
     // The crtd messages may contain the eol ('\n') character. We are
@@ -236,7 +235,6 @@ void Ssl::CertValidationHelper::Shutdown()
         return;
     helperShutdown(ssl_crt_validator);
     wordlistDestroy(&ssl_crt_validator->cmdline);
-    delete ssl_crt_validator;
     ssl_crt_validator = nullptr;
 
     // CertValidationHelper::HelperCache is a static member, it is not good policy to

--- a/src/ssl/helper.h
+++ b/src/ssl/helper.h
@@ -34,7 +34,7 @@ public:
     /// Submit crtd message to external crtd server.
     static void Submit(CrtdMessage const & message, HLPCB * callback, void *data);
 private:
-    static helper * ssl_crtd; ///< helper for management of ssl_crtd.
+    static HelperPointer ssl_crtd; ///< helper for management of ssl_crtd.
 };
 #endif
 
@@ -53,7 +53,7 @@ public:
     /// Submit crtd request message to external crtd server.
     static void Submit(const Ssl::CertValidationRequest &, const Callback &);
 private:
-    static helper * ssl_crt_validator; ///< helper for management of ssl_crtd.
+    static HelperPointer ssl_crt_validator; ///< helper for management of ssl_crtd.
 public:
     typedef ClpMap<SBuf, CertValidationResponse::Pointer, CertValidationResponse::MemoryUsedByResponse> CacheType;
     static CacheType *HelperCache; ///< cache for cert validation helper

--- a/src/ssl/helper.h
+++ b/src/ssl/helper.h
@@ -34,7 +34,7 @@ public:
     /// Submit crtd message to external crtd server.
     static void Submit(CrtdMessage const & message, HLPCB * callback, void *data);
 private:
-    static HelperPointer ssl_crtd; ///< helper for management of ssl_crtd.
+    static ::Helper::ClientPointer ssl_crtd; ///< helper for management of ssl_crtd.
 };
 #endif
 
@@ -53,7 +53,7 @@ public:
     /// Submit crtd request message to external crtd server.
     static void Submit(const Ssl::CertValidationRequest &, const Callback &);
 private:
-    static HelperPointer ssl_crt_validator; ///< helper for management of ssl_crtd.
+    static ::Helper::ClientPointer ssl_crt_validator; ///< helper for management of ssl_crtd.
 public:
     typedef ClpMap<SBuf, CertValidationResponse::Pointer, CertValidationResponse::MemoryUsedByResponse> CacheType;
     static CacheType *HelperCache; ///< cache for cert validation helper

--- a/src/tests/stub_helper.cc
+++ b/src/tests/stub_helper.cc
@@ -12,15 +12,14 @@
 #define STUB_API "helper.cc"
 #include "tests/STUB.h"
 
-void helperSubmit(helper *, const char *, HLPCB *, void *) STUB
-void helperStatefulSubmit(statefulhelper *, const char *, HLPCB *, void *, uint64_t) STUB
+void helperSubmit(const helper::Pointer &, const char *, HLPCB *, void *) STUB
+void helperStatefulSubmit(const statefulhelper::Pointer &, const char *, HLPCB *, void *, helper_stateful_server *) STUB
 helper::~helper() STUB
-CBDATA_CLASS_INIT(helper);
 void helper::packStatsInto(Packable *, const char *) const STUB
 
-void helperShutdown(helper *) STUB
-void helperStatefulShutdown(statefulhelper *) STUB
-void helperOpenServers(helper *) STUB
-void helperStatefulOpenServers(statefulhelper *) STUB
+void helperShutdown(const helper::Pointer &) STUB
+void helperStatefulShutdown(const statefulhelper::Pointer &) STUB
+void helperOpenServers(const helper::Pointer &) STUB
+void helperStatefulOpenServers(const statefulhelper::Pointer &) STUB
 CBDATA_CLASS_INIT(statefulhelper);
 

--- a/src/tests/stub_helper.cc
+++ b/src/tests/stub_helper.cc
@@ -13,7 +13,7 @@
 #include "tests/STUB.h"
 
 void helperSubmit(const helper::Pointer &, const char *, HLPCB *, void *) STUB
-void helperStatefulSubmit(const statefulhelper::Pointer &, const char *, HLPCB *, void *, helper_stateful_server *) STUB
+void helperStatefulSubmit(const statefulhelper::Pointer &, const char *, HLPCB *, void *, const Helper::ReservationId &) STUB
 helper::~helper() STUB
 void helper::packStatsInto(Packable *, const char *) const STUB
 
@@ -21,5 +21,4 @@ void helperShutdown(const helper::Pointer &) STUB
 void helperStatefulShutdown(const statefulhelper::Pointer &) STUB
 void helperOpenServers(const helper::Pointer &) STUB
 void helperStatefulOpenServers(const statefulhelper::Pointer &) STUB
-CBDATA_CLASS_INIT(statefulhelper);
 


### PR DESCRIPTION
Squid creates ::helper objects to manage a given configured helper. For
each ::helper object, Squid may create one or more helper_server objects
to manage communication with individual helper processes. A
helper_server object uses its so called "parent" ::helper object to
access configuration and for helper process death notification purposes.
There are no checks that the "parent" object is still alive when used.

The same problem applies to statefulhelper and helper_stateful_server.

helper_server code evidently attempted to extend their "parent" lifetime
using cbdata, but that does not work, especially in C++ world where the
object is destructed (and, hence, enters an undefined state) even though
its top-level memory is preserved by cbdata. Non-trivial members like
helper::queue (std::queue) and statefulhelper::reservations
(std::unordered_map) release their internal memory when destructed.

We now refcount ::helper objects to keep them alive until the last
object using them is gone. This does not result in reference loops
because the ::helper object uses raw dlink_node pointers to store its
helper_servers.

The following helpers (listed here by their container names) were
destructed while possibly still in use by their helper_server objects:
external_acl::theHelper, Ssl::CertValidationHelper::ssl_crt_validator,
Ssl::Helper::ssl_crtd. The following helpers are not destructed during
reconfiguration: redirectors, storeIds, basicauthenticators,
ntlmauthenticators, negotiateauthenticators, and digestauthenticators
(even though casual reading of relevant code may suggest otherwise).

This bug fix does not address or mark many remaining helper bugs.