### PR TITLE
MinGW: PRINTF_FORMAT_ARG workaround

### DIFF
--- a/compat/compat_shared.h
+++ b/compat/compat_shared.h
@@ -239,15 +239,15 @@ const char * squid_strnstr(const char *s, const char *find, size_t slen);
 #endif
 
 #if __GNUC__
-#if !defined(PRINTF_FORMAT_ARG1)
+#if _SQUID_MINGW_
+#define PRINTF_FORMAT_ARG1 __attribute__ ((format (gnu_printf, 1, 2)))
+#define PRINTF_FORMAT_ARG2 __attribute__ ((format (gnu_printf, 2, 3)))
+#define PRINTF_FORMAT_ARG3 __attribute__ ((format (gnu_printf, 3, 4)))
+#else
 #define PRINTF_FORMAT_ARG1 __attribute__ ((format (printf, 1, 2)))
-#endif
-#if !defined(PRINTF_FORMAT_ARG2)
 #define PRINTF_FORMAT_ARG2 __attribute__ ((format (printf, 2, 3)))
-#endif
-#if !defined(PRINTF_FORMAT_ARG3)
 #define PRINTF_FORMAT_ARG3 __attribute__ ((format (printf, 3, 4)))
-#endif
+#endif /* !_SQUID_MINGW_ */
 #else /* !__GNU__ */
 #define PRINTF_FORMAT_ARG1
 #define PRINTF_FORMAT_ARG2

--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -32,17 +32,5 @@
 #include <windows.h>
 #endif
 
-#if defined(__GNUC__)
-#if !defined(PRINTF_FORMAT_ARG1)
-#define PRINTF_FORMAT_ARG1 __attribute__ ((format (gnu_printf, 1, 2)))
-#endif
-#if !defined(PRINTF_FORMAT_ARG2)
-#define PRINTF_FORMAT_ARG2 __attribute__ ((format (gnu_printf, 2, 3)))
-#endif
-#if !defined(PRINTF_FORMAT_ARG3)
-#define PRINTF_FORMAT_ARG3 __attribute__ ((format (gnu_printf, 3, 4)))
-#endif
-#endif /* __GNUC__ */
-
 #endif /* _SQUID_MINGW_*/
 #endif /* SQUID_OS_MINGW_H */

--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -32,5 +32,17 @@
 #include <windows.h>
 #endif
 
+#if defined(__GNUC__)
+#if !defined(PRINTF_FORMAT_ARG1)
+#define PRINTF_FORMAT_ARG1 __attribute__ ((format (gnu_printf, 1, 2)))
+#endif
+#if !defined(PRINTF_FORMAT_ARG2)
+#define PRINTF_FORMAT_ARG2 __attribute__ ((format (gnu_printf, 2, 3)))
+#endif
+#if !defined(PRINTF_FORMAT_ARG3)
+#define PRINTF_FORMAT_ARG3 __attribute__ ((format (gnu_printf, 3, 4)))
+#endif
+#endif /* __GNUC__ */
+
 #endif /* _SQUID_MINGW_*/
 #endif /* SQUID_OS_MINGW_H */

--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -911,15 +911,6 @@ SQUIDCEXTERN void WIN32_ExceptionHandlerInit(void);
 SQUIDCEXTERN int Win32__WSAFDIsSet(int fd, fd_set* set);
 SQUIDCEXTERN DWORD WIN32_IpAddrChangeMonitorInit();
 
-/* gcc doesn't recognize the Windows native 64 bit formatting tags causing
- * the compile fail, so we must disable the check on native Windows.
- */
-#if __GNUC__
-#define PRINTF_FORMAT_ARG1
-#define PRINTF_FORMAT_ARG2
-#define PRINTF_FORMAT_ARG3
-#endif
-
 /* XXX: the logic around this is a bit warped:
  *   we #define ACL unconditionally at the top of this file,
  *   then #undef ACL unconditionally hafway down,


### PR DESCRIPTION
MinGW produces warnings about not supporting the printf '%zu' format
code when the 'printf' format archetype is used to validate code.

Checking against the 'gnu_printf' format archetype avoids this bad
warning. We accept the lower rate of error detection since other OS
builds verify against the 'printf' format archetype.

We also removed undocumented, inconsistent, and presumably unused
support for providing custom PRINTF_FORMAT_ARG macros during Squid
build. This removal simplifies code.
