### PR TITLE
Improve PSAPI.dll detection

### DIFF
--- a/compat/mswindows.cc
+++ b/compat/mswindows.cc
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <sys/timeb.h>
-#if HAVE_WIN32_PSAPI
+#if HAVE_PSAPI_H
 #include <psapi.h>
 #endif
 #ifndef _MSWSOCK_
@@ -62,7 +62,7 @@ void
 GetProcessName(pid_t pid, char *ProcessName)
 {
     strcpy(ProcessName, "unknown");
-#if HAVE_WIN32_PSAPI
+#if defined(PSAPI_VERSION)
     /* Get a handle to the process. */
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     /* Get the process name. */
@@ -79,7 +79,7 @@ GetProcessName(pid_t pid, char *ProcessName)
     } else
         return;
     CloseHandle(hProcess);
-#endif /* HAVE_WIN32_PSAPI */
+#endif
 }
 
 int

--- a/configure.ac
+++ b/configure.ac
@@ -186,16 +186,8 @@ AM_CONDITIONAL(ENABLE_WIN32_IPC,[test "x$squid_host_os" = "xmingw"])
 
 AS_CASE(["$squid_host_os"],
   [mingw],[
-    AC_PATH_PROG(WIN32_PSAPI, psapi.dll, none)
     CFLAGS="$CFLAGS -mthreads"
     CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
-    AS_IF([test "x$ac_cv_path_WIN32_PSAPI" = "xnone"],[
-      AC_MSG_NOTICE([PSAPI.DLL is recommended to run Squid on Windows NT Platform])
-      AC_MSG_NOTICE([Please see PSAPI.DLL section on doc/win32-relnotes.html.])
-    ],[
-      AC_DEFINE(HAVE_WIN32_PSAPI,1,[Define if you have PSAPI.DLL on Windows systems])
-      LIBS="$LIBS -lpsapi"
-    ])
     MINGW_LIBS="-lmingwex"
     AC_SUBST(MINGW_LIBS)
   ],
@@ -423,6 +415,30 @@ AS_IF([test "x$libatomic_checker_result" = "xno"],[
 ])])
 SQUID_STATE_ROLLBACK(LIBATOMIC)
 AC_SUBST(ATOMICLIB)
+
+SQUID_AUTO_LIB(psapi,[Windows PSAPI.dll],[LIBPSAPI])
+AS_IF([test "x$with_psapi" != "xno"],[
+  SQUID_STATE_SAVE(squid_psapi_state)
+  CPPFLAGS="$LIBPSAPI_CFLAGS $CPPFLAGS"
+  LIBS="$LIBPSAPI_PATH $LIBS"
+  AC_CHECK_LIB([psapi],[K32GetProcessMemoryInfo],[LIBPSAPI_LIBS="-lpsapi"])
+  AC_CHECK_HEADER([psapi.h],,,[
+#if HAVE_WINDOWS_H
+#include <windows.h>
+#endif
+  ])
+  SQUID_STATE_ROLLBACK(squid_psapi_state)
+  AS_IF([test "x$LIBPSAPI_LIBS" != "x"],[
+    CXXFLAGS="$LIBPSAPI_CFLAGS $CXXFLAGS"
+    LIBPSAPI_LIBS="$LIBPSAPI_PATH $LIBPSAPI_LIBS"
+  ],[test "x$with_psapi" = "xyes"],[
+    AC_MSG_ERROR([Required library PSAPI.dll not found])
+  ],[
+    AC_MSG_NOTICE([Library PSAPI.dll not found.])
+  ])
+])
+AC_MSG_NOTICE([Using Windows PSAPI.dll library: ${with_psapi:=auto}])
+AC_SUBST(LIBPSAPI_LIBS)
 
 AC_SEARCH_LIBS([shm_open], [rt])
 AS_IF([test "x$ac_cv_search_shm_open" != "xno"],[
@@ -2347,20 +2363,13 @@ AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[
 #endif
 ])
 
-dnl Override rusage() detect on MinGW because is emulated in source code
-AS_IF([test "$squid_host_os" = "mingw"],[
-  AC_DEFINE(HAVE_STRUCT_RUSAGE)
-  ac_cv_func_getrusage="yes"
-  AC_MSG_NOTICE([Using own rusage on Windows.])
-],[
-  AC_CHECK_TYPE(struct rusage,AC_DEFINE(HAVE_STRUCT_RUSAGE,1,[The system provides struct rusage]),,[
+AC_CHECK_TYPE(struct rusage,AC_DEFINE(HAVE_STRUCT_RUSAGE,1,[The system provides struct rusage]),,[
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 #if HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
-  ])
 ])
 
 AC_CHECK_MEMBERS([struct iphdr.ip_hl],,,[

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -99,7 +99,8 @@ This section gives an account of those changes in three categories:
 <sect1>New options<label id="newoptions">
 <p>
 <descrip>
-	<p>No new options in this version.
+	<tag>--without-psapi</tag>
+	<p>Disable auto-detection of Windows PSAPI library.
 
 </descrip>
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -526,6 +526,7 @@ squid_LDADD = \
 	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(LIBNETTLE_LIBS) \
+	$(LIBPSAPI_LIBS) \
 	$(XTRA_LIBS)
 
 if ENABLE_LOADABLE_MODULES
@@ -1954,6 +1955,7 @@ tests_test_http_range_LDADD = \
 	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(LIBNETTLE_LIBS) \
+	$(LIBPSAPI_LIBS) \
 	$(XTRA_LIBS)
 tests_test_http_range_LDFLAGS = $(LIBADD_DL)
 
@@ -2337,6 +2339,7 @@ tests_testHttpRequest_LDADD = \
 	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(LIBNETTLE_LIBS) \
+	$(LIBPSAPI_LIBS) \
 	$(XTRA_LIBS)
 tests_testHttpRequest_LDFLAGS = $(LIBADD_DL)
 
@@ -2632,6 +2635,7 @@ tests_testCacheManager_LDADD = \
 	$(LIBSYSTEMD_LIBS) \
 	$(COMPAT_LIB) \
 	$(LIBNETTLE_LIBS) \
+	$(LIBPSAPI_LIBS) \
 	$(XTRA_LIBS)
 tests_testCacheManager_LDFLAGS = $(LIBADD_DL)
 

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -45,7 +45,7 @@
 #if HAVE_PRIV_H
 #include <priv.h>
 #endif
-#if HAVE_WIN32_PSAPI
+#if HAVE_PSAPI_H
 #include <psapi.h>
 #endif
 #if HAVE_SYS_STAT_H
@@ -180,7 +180,7 @@ void
 squid_getrusage(struct rusage *r)
 {
     memset(r, '\0', sizeof(struct rusage));
-#if HAVE_GETRUSAGE && defined(RUSAGE_SELF) && !_SQUID_WINDOWS_
+#if HAVE_GETRUSAGE && defined(RUSAGE_SELF)
 #if _SQUID_SOLARIS_
     /* Solaris 2.5 has getrusage() permission bug -- Arjan de Vet */
     enter_suid();
@@ -192,7 +192,7 @@ squid_getrusage(struct rusage *r)
     leave_suid();
 #endif
 
-#elif _SQUID_WINDOWS_ && HAVE_WIN32_PSAPI
+#elif defined(PSAPI_VERSION)
     // Windows has an alternative method if there is no POSIX getrusage defined.
     if (WIN32_OS_version >= _WIN_OS_WINNT) {
         /* On Windows NT and later call PSAPI.DLL for process Memory */

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -16,7 +16,7 @@
 #include "win32.h"
 
 #include <csignal>
-#if HAVE_WIN32_PSAPI
+#if HAVE_PSAPI_H
 #include <psapi.h>
 #endif
 #if HAVE_MSWSOCK_H

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -106,6 +106,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--without-gnutls \
 	--without-openssl \
 	--without-po2html \
+	--without-psapi \
 	--without-systemd \
 	--without-tdb \
 	"


### PR DESCRIPTION
Detect Windows PSAPI library like any other library dependency. Allowing
build --with(out) options to disable or to set paths.

Detect the psapi.h properly and set HAVE_* macro for proper include
wrapping.

Wrap PSAPI logic in check for PSAPI_VERSION which is defined whenever
the API support is actually available.
