### PR TITLE
CI: Remove unnecessary test-functionality test wrappers

### DIFF
--- a/test-suite/test-functionality.sh
+++ b/test-suite/test-functionality.sh
@@ -165,33 +165,6 @@ run_confirmed_test() {
     return $result
 }
 
-check_proxy_collapsed_forwarding() {
-    if ! has_commit_by_message 1af789e 'Do not stall if xactions overwrite a recently active'
-    then
-        echo "No proxy-collapsed-forwarding due to stalling transactions"
-        return 0;
-    fi
-    run_confirmed_test proxy-collapsed-forwarding
-}
-
-check_proxy_update_headers_after_304() {
-    if grep 'AC_INIT.*Proxy.,.[1234][.]' configure.ac
-    then
-        echo "No proxy-update-headers-after-304 until v5";
-        return 0;
-    fi
-    run_confirmed_test proxy-update-headers-after-304
-}
-
-check_upgrade_protocols() {
-    if ! grep -q http_upgrade_request_protocols src/cf.data.pre
-    then
-        echo "No upgrade-protocols without http_upgrade_request_protocols support";
-        return 0;
-    fi
-    run_confirmed_test upgrade-protocols
-}
-
 # executes a single test named by the parameter
 run_one_test() {
     local testName=$1


### PR DESCRIPTION
These workarounds are not needed for the current and future code in this
branch. Other branches get their own test-functionality.sh files that
can be used to maintain a branch-specific collection of test wrappers.

The (now unused) has_commit_by_message() function was left in the script
because that function is likely to be used by future workarounds. Unlike
specific test workarounds that only apply to a subset of old code, this
and similar functions can be viewed as a reusable code "library".
