### PR TITLE
Documentation: Update stale SMP cache_dir caveats

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -4304,9 +4304,11 @@ DOC_START
 	The directory must exist and be writable by the Squid
 	process.  Squid will NOT create this directory for you.
 
-	In SMP configurations, cache_dir must not precede the workers option
-	and should use configuration macros or conditionals to give each
-	worker interested in disk caching a dedicated cache directory.
+	Rock is currently the only SMP-aware cache_dir type. Using other
+	store types in configurations with multiple workers is not
+	supported and may lead to HTTP violations or undefined behavior,
+	even when each such cache_dir is given a dedicated worker using
+	configuration conditionals.
 
 
 	====  The ufs store type  ====


### PR DESCRIPTION
The requirement to specify "workers" before "cache_dir" was added in 
2010 commit acf69d7. It became obsolete since 2011 commit 095ec2b.

The "dedicated cache directory" hack for UFS-based stores has always led
to HTTP violations, but the increased complexity of worker-to-worker
synchronization code (required to improve HTTP support) also increased
the probability of crashes or worse outcomes when SMP conditionals are
used. Those hacks violate the "all processes see the same configuration"
and similar basic code assumptions. We do not test (and usually do not
even consider the needs of) such unsupported configurations.
