### PR TITLE
Handle helper program startup failure as its death

### DIFF
--- a/src/helper.h
+++ b/src/helper.h
@@ -103,6 +103,11 @@ public:
     /// \param needsNewServers true if new servers must started, false otherwise
     void handleKilledServer(HelperServerBase *srv, bool &needsNewServers);
 
+    /// Reacts to unexpected server death(s), including a failure to start server(s)
+    /// and an unexpected exit of a previously started server. \sa handleKilledServer()
+    /// \param madeProgress whether the died server responded to any requests
+    void handleFewerServers(bool madeProgress);
+
 public:
     wordlist *cmdline;
     dlink_list servers;

--- a/src/helper.h
+++ b/src/helper.h
@@ -105,7 +105,7 @@ public:
 
     /// Reacts to unexpected server death(s), including a failure to start server(s)
     /// and an unexpected exit of a previously started server. \sa handleKilledServer()
-    /// \param madeProgress whether the died server responded to any requests
+    /// \param madeProgress whether the died server(s) responded to any requests
     void handleFewerServers(bool madeProgress);
 
 public:


### PR DESCRIPTION
Squid quits when started helper programs die too fast without responding
to requests[^1] because such a Squid instance is unlikely to provide
acceptable service (and a full restart may actually fix the problem or,
at the very least, is more likely to bring the needed admin attention).

The same logic now applies when Squid fails to start a helper (i.e. when
ipcCreate() fails). There is no conceptual difference between those two
kinds of failures as far as helper handling code is concerned, so we now
treat them the same way.

Without these changes, helper start failures may result in an unusable
(but running) Squid instance, especially if no helpers can be started at
all, because new transactions get stuck waiting in the queue until
clients timeout. Such persistent ipcCreate() failures may be caused, for
example, by its fork() hitting an overcommit memory limits.

[^1]: The actual condition excludes cases where at least startup=N
helpers are still running. That exclusion and other helper failure
handling details are problematic, but adjusting that code is outside
_this_ fix scope: Here, we only apply _existing_ handling logic to a
missed case.