### PR TITLE
CI: Test %err_code logging for "early" request handling errors

### DIFF
--- a/test-suite/test-functionality.sh
+++ b/test-suite/test-functionality.sh
@@ -246,6 +246,7 @@ main() {
             proxy-collapsed-forwarding
             busy-restart
             truncated-responses
+            malformed-request
         "
         tests="$default_tests"
     fi


### PR DESCRIPTION
Use Daft malformed-request test to monitor for bugs like those fixed
by master/v7 commit 8a628a1.
