### PR TITLE
Fix reported assertion condition always being "EX"

### DIFF
--- a/compat/GnuRegex.c
+++ b/compat/GnuRegex.c
@@ -53,7 +53,7 @@
 
 /* We used to test for `BSTRING' here, but only GCC and Emacs define
  * `BSTRING', as far as I know, and neither of them use this code.  */
-#if HAVE_STRING_H || STDC_HEADERS
+#if HAVE_STRING_H
 #include <string.h>
 #else
 #include <strings.h>

--- a/compat/assert.h
+++ b/compat/assert.h
@@ -13,10 +13,8 @@
 #define assert(EX) ((void)0)
 #elif defined(NODEBUG)
 #define assert(EX) ((void)0)
-#elif STDC_HEADERS
-#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 #else
-#define assert(EX)  ((EX)?((void)0):xassert("EX", __FILE__, __LINE__))
+#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 #endif
 
 #ifdef __cplusplus

--- a/configure.ac
+++ b/configure.ac
@@ -2859,7 +2859,6 @@ esac
 
 dnl Check for headers
 AC_HEADER_DIRENT
-AC_HEADER_STDC
 
 AC_CHECK_HEADERS( \
   arpa/inet.h \
@@ -3069,10 +3068,9 @@ AC_CHECK_TYPE(fd_mask,  AC_DEFINE(HAVE_FD_MASK,1,[fd_mask is defined by the syst
 AC_CHECK_TYPE(socklen_t,AC_DEFINE(HAVE_SOCKLEN_T,1,[socklen_t is defined by the system headers]),,[
 #include <sys/types.h>
 #include <sys/socket.h>
-#if STDC_HEADERS
 #include <stdlib.h>
 #include <stddef.h>
-#endif])
+])
 
 AC_CHECK_TYPE(mtyp_t,AC_DEFINE(HAVE_MTYP_T,1,
    [mtyp_t is defined by the system headers]),,[#include <sys/types.h>

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -27,10 +27,8 @@
 #define assert(EX) ((void)0)
 #elif defined(NODEBUG)
 #define assert(EX) ((void)0)
-#elif STDC_HEADERS
-#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 #else
-#define assert(EX)  ((EX)?((void)0):xassert("EX", __FILE__, __LINE__))
+#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 #endif
 
 /* context-based debugging, the actual type is subject to change */


### PR DESCRIPTION
    FATAL: assertion failed: foobar.cc:123: "EX"

Autoconf v2.71 provides AC_HEADER_STDC macro that does not define
STDC_HEADERS. As a result, our assert() macro definitions print "EX"
instead of the actual failed condition when Squid is bootstrapped with
Autoconf v2.71 or later.

Autoconf documentation suggests writing code as if STDC_HEADERS is true
(but without actually checking it). This change follows that suggestion:
Squid no longer uses AC_HEADER_STDC and STDC_HEADERS.

A `#define STDC_HEADERS 1` line may still be present in generated
./configure because AC_USE_SYSTEM_EXTENSIONS places it there. However,
in Squid v5 ./configure, AC_USE_SYSTEM_EXTENSIONS only runs on Solaris.

----

This change contains a tiny portion of master/v6 commit a1c2236, a
commit that does not disclose the assert() message fix and contains many
more changes (some of which needed fixups). That commit also did not
remove STDC_HEADERS from compat/GnuRegex.c.
