### PR TITLE
Maintenance: Include inttypes instead of stdint

### DIFF
--- a/acinclude/nettle.m4
+++ b/acinclude/nettle.m4
@@ -15,8 +15,8 @@ AC_DEFUN([SQUID_CHECK_NETTLE_BASE64],[
   AH_TEMPLATE(HAVE_NETTLE34_BASE64,[set to 1 if Nettle 3.4 API will link])
   SQUID_STATE_SAVE(squid_nettle_base64_state)
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#   include <cinttypes>
 #   include <cstddef>
-#   include <cstdint>
 #   include <nettle/base64.h>
   ]],[[
     char inData[10]; inData[0] = '\0';

--- a/compat/types.h
+++ b/compat/types.h
@@ -31,7 +31,9 @@
 #if HAVE_STDDEF_H
 #include <stddef.h>
 #endif
-#if HAVE_INTTYPES_H
+#if __cplusplus
+#include <cinttypes>
+#elif HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
 #if HAVE_SYS_BITYPES_H
@@ -48,15 +50,6 @@
 /******************************************************/
 /* Typedefs for missing entries on a system           */
 /******************************************************/
-
-/*
- * Ensure that standard type limits are defined for use
- */
-#if __cplusplus
-#include <cstdint>
-#elif HAVE_STDINT_H
-#include <stdint.h>
-#endif
 
 /* explicit bit sizes */
 #if !defined(UINT32_MIN)

--- a/configure.ac
+++ b/configure.ac
@@ -389,7 +389,7 @@ AC_DEFUN([LIBATOMIC_CHECKER],[
   AC_LINK_IFELSE([
     AC_LANG_SOURCE([[
 #include <atomic>
-#include <cstdint>
+#include <cinttypes>
       int
       main(int argc, char **) {
           return (
@@ -2264,6 +2264,7 @@ AC_CHECK_HEADERS( \
   gnumalloc.h \
   grp.h \
   ipl.h \
+  inttypes.h \
   libc.h \
   limits.h \
   linux/posix_types.h \
@@ -2320,8 +2321,6 @@ AC_CHECK_HEADERS( \
   varargs.h \
   byteswap.h \
   glib.h \
-  stdint.h \
-  inttypes.h \
   wchar.h
 )
 

--- a/src/base/Stopwatch.h
+++ b/src/base/Stopwatch.h
@@ -10,7 +10,6 @@
 #define SQUID_SRC_BASE_STOPWATCH_H
 
 #include <chrono>
-#include <cinttypes>
 
 /// Quickly accumulates related real-time (a.k.a. "physical time" or "wall
 /// clock") periods. Continues to run if the caller is blocked on a system call.

--- a/src/base/Stopwatch.h
+++ b/src/base/Stopwatch.h
@@ -10,7 +10,7 @@
 #define SQUID_SRC_BASE_STOPWATCH_H
 
 #include <chrono>
-#include <cstdint>
+#include <cinttypes>
 
 /// Quickly accumulates related real-time (a.k.a. "physical time" or "wall
 /// clock") periods. Continues to run if the caller is blocked on a system call.


### PR DESCRIPTION
With current C/C++ standard, intypes.h includes stdint.h.