### PR TITLE
Maintenance: Remove unused xstrtoul() from the global scope

### DIFF
--- a/compat/xstrto.cc
+++ b/compat/xstrto.cc
@@ -57,7 +57,7 @@
 
 #include <cerrno>
 
-bool
+static bool
 xstrtoul(const char *s, char **end, unsigned long *value,
          unsigned long min, unsigned long max)
 {

--- a/compat/xstrto.h
+++ b/compat/xstrto.h
@@ -9,11 +9,11 @@
 #ifndef _SQUID_XSTRTO_H
 #define _SQUID_XSTRTO_H
 
-// these functions are not used by the remaining Squid C code.
+// this function is not used by the remaining Squid C code
 #if defined(__cplusplus)
 
 /**
- * xstrtoui - string to number conversion
+ * Convert a c-string (or its prefix) into an unsigned integer.
  * \param s     input string
  * \param end   like strtoul's "end" pointer
  * \param value pointer for result. Undefined on failure

--- a/compat/xstrto.h
+++ b/compat/xstrto.h
@@ -13,7 +13,7 @@
 #if defined(__cplusplus)
 
 /**
- * xstrtou{i,l} - string to number conversion
+ * xstrtoui - string to number conversion
  * \param s     input string
  * \param end   like strtoul's "end" pointer
  * \param value pointer for result. Undefined on failure
@@ -28,9 +28,6 @@
  * \return true/false whether number was accepted. On failure, *value has
  * undefined contents.
  */
-bool xstrtoul(const char *s, char **end, unsigned long *value,
-              unsigned long min, unsigned long max);
-
 bool xstrtoui(const char *s, char **end, unsigned int *value,
               unsigned int min, unsigned int max);
 


### PR DESCRIPTION
xstrtoul() is only used by xstrtoui() in the same module, no need to
export it to the global namespace