### PR TITLE
GCC complains because memrchr is not defined

### DIFF
--- a/src/sbuf/SBuf.cc
+++ b/src/sbuf/SBuf.cc
@@ -711,7 +711,7 @@ SBuf::rfind(char c, SBuf::size_type endPos) const
     if (length() == 0)
         return endPos;
 
-    const void *i = memrchr(buf(), (int)c, (size_type)endPos);
+    const void *i = *memrchr(buf(), (int)c, (size_type)endPos);
 
     if (i == nullptr)
         return npos;


### PR DESCRIPTION
And code must be *memrchr?

GCC complains because memrchr is not defined. Maybe it's a typo and code must be *memrchr? I'm not sure but it seems logically for the code