### PR TITLE
Bug 5187: Work around REQMOD satisfaction regression in v6

### DIFF
--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -2057,8 +2057,13 @@ ClientHttpRequest::noteMoreBodyDataAvailable(BodyPipe::Pointer)
         bpc.checkIn();
     }
 
-    if (adaptedBodySource->exhausted())
+    if (adaptedBodySource->exhausted()) {
+        // XXX: Setting receivedWholeAdaptedReply here is a workaround for a
+        // regression, as described in https://bugs.squid-cache.org/show_bug.cgi?id=5187#c6
+        receivedWholeAdaptedReply = true;
+        debugs(85, DBG_IMPORTANT, "WARNING: Squid bug 5187 workaround triggered");
         endRequestSatisfaction();
+    }
     // else wait for more body data
 }
 


### PR DESCRIPTION
Commit ba3fe8d broke ICAP REQMOD satisfaction transactions. In some cases, this workaround may resurrect Squid Bug 5187. Triage available at https://bugs.squid-cache.org/show_bug.cgi?id=5187#c6