### PR TITLE
Drop ClientHttpRequest::flags::internal

### DIFF
--- a/src/RequestFlags.h
+++ b/src/RequestFlags.h
@@ -75,7 +75,6 @@ public:
 
     /// whether the request targets a /squid-internal- resource (e.g., a MIME
     /// icon or a cache manager page) served by this Squid instance
-    /// \sa ClientHttpRequest::flags.internal
     /// TODO: Rename to avoid a false implication that this flag is true for
     /// requests for /squid-internal- resources served by other Squid instances.
     bool internal = false;

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -611,7 +611,7 @@ clientReplyContext::cacheHit(const StoreIOBuffer result)
         http->updateLoggingTags(LOG_TCP_MISS);
         processMiss();
         return;
-    } else if (!http->flags.internal && refreshCheckHTTP(e, r)) {
+    } else if (!r->flags.internal && refreshCheckHTTP(e, r)) {
         debugs(88, 5, "clientCacheHit: in refreshCheck() block");
         /*
          * We hold a stale copy; it needs to be validated
@@ -834,7 +834,7 @@ clientReplyContext::blockedHit() const
     if (!Config.accessList.sendHit)
         return false; // hits are not blocked by default
 
-    if (http->flags.internal)
+    if (http->request->flags.internal)
         return false; // internal content "hits" cannot be blocked
 
     const auto &rep = http->storeEntry()->mem().freshestReply();

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -157,7 +157,6 @@ public:
 
     struct Flags {
         bool accel = false;
-        bool internal = false;
         bool done_copying = false;
     } flags;
 


### PR DESCRIPTION
This flag is unnecessary when HttpRequest::flags::internal
is available, which is almost all code needing to detect
internal traffic.

The exception to this is parsing prior to HttpRequest
creation, which already uses internalCheck() API instead.