### PR TITLE
Removed unused HttpHeader member functions

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -145,12 +145,6 @@ httpHeaderInitModule(void)
  * HttpHeader Implementation
  */
 
-HttpHeader::HttpHeader() : owner (hoNone), len (0), conflictingContentLength_(false)
-{
-    entries.reserve(32);
-    httpHeaderMaskInit(&mask, 0);
-}
-
 HttpHeader::HttpHeader(const http_hdr_owner_type anOwner): owner(anOwner), len(0), conflictingContentLength_(false)
 {
     assert(anOwner > hoNone && anOwner < hoEnd);
@@ -757,30 +751,6 @@ HttpHeader::addEntry(HttpHeaderEntry * e)
     }
 
     entries.push_back(e);
-
-    /* increment header length, allow for ": " and crlf */
-    len += e->name.length() + 2 + e->value.size() + 2;
-}
-
-/* inserts an entry;
- * does not call e->clone() so one should not reuse "*e"
- */
-void
-HttpHeader::insertEntry(HttpHeaderEntry * e)
-{
-    assert(e);
-    assert(any_valid_header(e->id));
-
-    debugs(55, 7, this << " adding entry: " << e->id << " at " << entries.size());
-
-    // Http::HdrType::BAD_HDR is filtered out by assert_any_valid_header
-    if (CBIT_TEST(mask, e->id)) {
-        ++ headerStatsTable[e->id].repCount;
-    } else {
-        CBIT_SET(mask, e->id);
-    }
-
-    entries.insert(entries.begin(),e);
 
     /* increment header length, allow for ": " and crlf */
     len += e->name.length() + 2 + e->value.size() + 2;

--- a/src/HttpHeader.h
+++ b/src/HttpHeader.h
@@ -72,7 +72,6 @@ class HttpHeader
 {
 
 public:
-    HttpHeader();
     explicit HttpHeader(const http_hdr_owner_type owner);
     HttpHeader(const HttpHeader &other);
     ~HttpHeader();
@@ -106,7 +105,6 @@ public:
     void delAt(HttpHeaderPos pos, int &headers_deleted);
     void refreshMask();
     void addEntry(HttpHeaderEntry * e);
-    void insertEntry(HttpHeaderEntry * e);
     String getList(Http::HdrType id) const;
     bool getList(Http::HdrType id, String *s) const;
     bool conflictingContentLength() const { return conflictingContentLength_; }

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -21,7 +21,6 @@ HttpHeaderEntry *HttpHeaderEntry::clone() const STUB_RETVAL(nullptr)
 void HttpHeaderEntry::packInto(Packable *) const STUB
 int HttpHeaderEntry::getInt() const STUB_RETVAL(0)
 int64_t HttpHeaderEntry::getInt64() const STUB_RETVAL(0)
-HttpHeader::HttpHeader() {STUB}
 HttpHeader::HttpHeader(const http_hdr_owner_type) {STUB}
 HttpHeader::HttpHeader(const HttpHeader &) {STUB}
 HttpHeader::~HttpHeader() {STUB}
@@ -40,7 +39,6 @@ int HttpHeader::delById(Http::HdrType) STUB_RETVAL(0)
 void HttpHeader::delAt(HttpHeaderPos, int &) STUB
 void HttpHeader::refreshMask() STUB
 void HttpHeader::addEntry(HttpHeaderEntry *) STUB
-void HttpHeader::insertEntry(HttpHeaderEntry *) STUB
 String HttpHeader::getList(Http::HdrType) const STUB_RETVAL(String())
 bool HttpHeader::getList(Http::HdrType, String *) const STUB_RETVAL(false)
 String HttpHeader::getStrOrList(Http::HdrType) const STUB_RETVAL(String())

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -37,7 +37,10 @@ bool ContentLengthInterpreter::checkList(const String &) STUB_RETVAL(false)
 #include "http/Message.h"
 namespace Http
 {
-Message::Message(http_hdr_owner_type) {STUB}
+Message::Message(http_hdr_owner_type owner):
+    http_ver(Http::ProtocolVersion()),
+    header(owner)
+{}
 Message::~Message() {STUB}
 void Message::packInto(Packable *, bool) const STUB
 void Message::setContentLength(int64_t) STUB

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -37,10 +37,7 @@ bool ContentLengthInterpreter::checkList(const String &) STUB_RETVAL(false)
 #include "http/Message.h"
 namespace Http
 {
-Message::Message(http_hdr_owner_type owner):
-    http_ver(Http::ProtocolVersion()),
-    header(owner)
-{}
+Message::Message(const http_hdr_owner_type owner): header(owner) {STUB}
 Message::~Message() {STUB}
 void Message::packInto(Packable *, bool) const STUB
 void Message::setContentLength(int64_t) STUB


### PR DESCRIPTION
HttpHeader::insertEntry() is unused since 2015 commit 81ab22b.