### PR TITLE
Fix build on GNU/Hurd

### DIFF
--- a/src/base/RandomUuid.cc
+++ b/src/base/RandomUuid.cc
@@ -15,6 +15,13 @@
 
 #include <iostream>
 
+#if HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
+#if HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
+
 static_assert(sizeof(RandomUuid) == 128/8, "RandomUuid has RFC 4122-prescribed 128-bit size");
 
 RandomUuid::RandomUuid()


### PR DESCRIPTION
Definitions of htonl() and htons() require these headers, in this order.