### PR TITLE
MinGW: Fix 'error: cannot convert size_t*'

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -128,7 +128,7 @@ comm_udp_recvfrom(int fd, void *buf, size_t len, int flags, Ip::Address &from)
     debugs(5,8, "comm_udp_recvfrom: FD " << fd << " from " << from);
     struct addrinfo *AI = nullptr;
     Ip::Address::InitAddr(AI);
-    int x = recvfrom(fd, buf, len, flags, AI->ai_addr, &AI->ai_addrlen);
+    int x = recvfrom(fd, buf, len, flags, AI->ai_addr, reinterpret_cast<socklen_t*>(&(AI->ai_addrlen)));
     from = *AI;
     Ip::Address::FreeAddr(AI);
     return x;
@@ -182,7 +182,7 @@ comm_local_port(int fd)
 
     Ip::Address::InitAddr(addr);
 
-    if (getsockname(fd, addr->ai_addr, &(addr->ai_addrlen)) ) {
+    if (getsockname(fd, addr->ai_addr, reinterpret_cast<socklen_t*>(&(addr->ai_addrlen))) ) {
         int xerrno = errno;
         debugs(50, DBG_IMPORTANT, "ERROR: " << MYNAME << "Failed to retrieve TCP/UDP port number for socket: FD " << fd << ": " << xstrerr(xerrno));
         Ip::Address::FreeAddr(addr);

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -432,7 +432,7 @@ Comm::ConnOpener::lookupLocalAddress()
     struct addrinfo *addr = nullptr;
     Ip::Address::InitAddr(addr);
 
-    if (getsockname(conn_->fd, addr->ai_addr, &(addr->ai_addrlen)) != 0) {
+    if (getsockname(conn_->fd, addr->ai_addr, reinterpret_cast<socklen_t*>(&(addr->ai_addrlen))) != 0) {
         int xerrno = errno;
         debugs(50, DBG_IMPORTANT, "ERROR: Failed to retrieve TCP/UDP details for socket: " << conn_ << ": " << xstrerr(xerrno));
         Ip::Address::FreeAddr(addr);

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -349,7 +349,7 @@ Comm::TcpAcceptor::acceptInto(Comm::ConnectionPointer &details)
     Ip::Address::InitAddr(gai);
 
     errcode = 0; // reset local errno copy.
-    const auto rawSock = accept(conn->fd, gai->ai_addr, &gai->ai_addrlen);
+    const auto rawSock = accept(conn->fd, gai->ai_addr, reinterpret_cast<socklen_t*>(&(gai->ai_addrlen)));
     if (rawSock < 0) {
         errcode = errno; // store last accept errno locally.
 
@@ -378,7 +378,7 @@ Comm::TcpAcceptor::acceptInto(Comm::ConnectionPointer &details)
     // lookup the local-end details of this new connection
     Ip::Address::InitAddr(gai);
     details->local.setEmpty();
-    if (getsockname(sock, gai->ai_addr, &gai->ai_addrlen) != 0) {
+    if (getsockname(sock, gai->ai_addr, reinterpret_cast<socklen_t*>(&(gai->ai_addrlen))) != 0) {
         int xerrno = errno;
         Ip::Address::FreeAddr(gai);
         throw TextException(ToSBuf("getsockname() failed to locate local-IP on ", details, ": ", xstrerr(xerrno)), Here());


### PR DESCRIPTION
The WinSock2 API definitions use size_t instead of
POSIX socklen_t for struct addrinfo members.