### PR TITLE
Do not use static initialization to register modules

### DIFF
--- a/src/CollapsedForwarding.cc
+++ b/src/CollapsedForwarding.cc
@@ -186,7 +186,7 @@ private:
     Ipc::MultiQueue::Owner *owner;
 };
 
-RunnerRegistrationEntry(CollapsedForwardingRr);
+DefineRunnerRegistrator(CollapsedForwardingRr);
 
 void CollapsedForwardingRr::create()
 {

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -1026,7 +1026,7 @@ private:
     Ipc::FewToFewBiQueue::Owner *owner;
 };
 
-RunnerRegistrationEntry(IpcIoRr);
+DefineRunnerRegistrator(IpcIoRr);
 
 void
 IpcIoRr::claimMemoryNeeds()

--- a/src/MemStore.cc
+++ b/src/MemStore.cc
@@ -987,7 +987,7 @@ private:
     Ipc::Mem::Owner<MemStoreMapExtras> *extrasOwner; ///< PageIds Owner
 };
 
-RunnerRegistrationEntry(MemStoreRr);
+DefineRunnerRegistrator(MemStoreRr);
 
 void
 MemStoreRr::claimMemoryNeeds()

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -239,7 +239,7 @@ public:
     void syncConfig() override;
 };
 
-RunnerRegistrationEntry(PeerPoolMgrsRr);
+DefineRunnerRegistrator(PeerPoolMgrsRr);
 
 void
 PeerPoolMgrsRr::syncConfig()

--- a/src/Transients.cc
+++ b/src/Transients.cc
@@ -393,7 +393,7 @@ private:
     TransientsMap::Owner *mapOwner = nullptr;
 };
 
-RunnerRegistrationEntry(TransientsRr);
+DefineRunnerRegistrator(TransientsRr);
 
 void
 TransientsRr::useConfig()

--- a/src/auth/ntlm/Scheme.cc
+++ b/src/auth/ntlm/Scheme.cc
@@ -23,7 +23,8 @@ public:
         debugs(29, 2, "Initialized Authentication Scheme '" << type << "'");
     }
 };
-RunnerRegistrationEntry(NtlmAuthRr);
+
+DefineRunnerRegistrator(NtlmAuthRr);
 
 Auth::Scheme::Pointer
 Auth::Ntlm::Scheme::GetInstance()

--- a/src/base/RunnersRegistry.cc
+++ b/src/base/RunnersRegistry.cc
@@ -108,9 +108,3 @@ IndependentRunner::registerRunner()
     // else do nothing past finishShutdown
 }
 
-bool
-UseThisStatic(const void *)
-{
-    return true;
-}
-

--- a/src/base/RunnersRegistry.h
+++ b/src/base/RunnersRegistry.h
@@ -118,16 +118,6 @@ protected:
     debugs(1, 2, "running " # m); \
     RunRegistered(&m)
 
-/// convenience function to "use" an otherwise unreferenced static variable
-bool UseThisStatic(const void *);
-
-// TODO: Remove, together with UseThisStatic(), after migrating to DefineRunnerRegistrator()
-/// convenience macro: register one RegisteredRunner kid as early as possible
-#define RunnerRegistrationEntry(Who) \
-    static const bool Who ## _Registered_ = \
-        RegisterRunner(new Who) > 0 && \
-        UseThisStatic(& Who ## _Registered_);
-
 /// helps DefineRunnerRegistrator() and CallRunnerRegistrator() (and their
 /// namespace-sensitive variants) to use the same registration function name
 #define NameRunnerRegistrator_(Namespace, ClassName) \

--- a/src/base/RunnersRegistry.h
+++ b/src/base/RunnersRegistry.h
@@ -121,11 +121,34 @@ protected:
 /// convenience function to "use" an otherwise unreferenced static variable
 bool UseThisStatic(const void *);
 
+// TODO: Remove, together with UseThisStatic(), after migrating to DefineRunnerRegistrator()
 /// convenience macro: register one RegisteredRunner kid as early as possible
 #define RunnerRegistrationEntry(Who) \
     static const bool Who ## _Registered_ = \
         RegisterRunner(new Who) > 0 && \
         UseThisStatic(& Who ## _Registered_);
+
+/// helps DefineRunnerRegistrator() and CallRunnerRegistrator() to use the same
+/// registration function name
+#define DeclareRunnerRegistrator(Who) \
+    void Register ## Who ## Now()
+
+/// Define registration code for the given RegisteredRunner class. A matching
+/// CallRunnerRegistrator(Who) call should run this code before any possible use
+/// of the being-registered module.
+#define DefineRunnerRegistrator(Who) \
+    DeclareRunnerRegistrator(Who); \
+    void Register ## Who ## Now() { \
+        const auto registered = RegisterRunner(new Who); \
+        assert(registered); \
+    }
+
+/// convenience macro: register one RegisteredRunner kid
+#define CallRunnerRegistrator(Who) \
+    do { \
+        DeclareRunnerRegistrator(Who); \
+        Register ## Who ## Now(); \
+    } while (false)
 
 #endif /* SQUID_BASE_RUNNERSREGISTRY_H */
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -4374,7 +4374,7 @@ public:
 
 Ssl::BumpMode sslBumpCfgRr::lastDeprecatedRule = Ssl::bumpEnd;
 
-RunnerRegistrationEntry(sslBumpCfgRr);
+DefineRunnerRegistrator(sslBumpCfgRr);
 
 void
 sslBumpCfgRr::finalizeConfig()

--- a/src/client_db.cc
+++ b/src/client_db.cc
@@ -102,7 +102,7 @@ public:
     /* RegisteredRunner API */
     void useConfig() override;
 };
-RunnerRegistrationEntry(ClientDbRr);
+DefineRunnerRegistrator(ClientDbRr);
 
 void
 ClientDbRr::useConfig()

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -210,9 +210,9 @@ public:
     void endingShutdown() override;
 };
 
-RunnerRegistrationEntry(ConfigRr);
-
 } // namespace Dns
+
+DefineRunnerRegistratorIn(Dns, ConfigRr);
 
 struct _sp {
     char domain[NS_MAXDNAME];

--- a/src/esi/ExpatParser.cc
+++ b/src/esi/ExpatParser.cc
@@ -32,9 +32,9 @@ private:
     std::unique_ptr<ESIParser::Register> registration;
 };
 
-RunnerRegistrationEntry(ExpatRr);
-
 }
+
+DefineRunnerRegistratorIn(Esi, ExpatRr);
 
 EsiParserDefinition(ESIExpatParser);
 

--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -36,9 +36,9 @@ private:
     std::unique_ptr<ESIParser::Register> registration;
 };
 
-RunnerRegistrationEntry(Libxml2Rr);
-
 }
+
+DefineRunnerRegistratorIn(Esi, Libxml2Rr);
 
 // the global document that will store the resolved entity
 // definitions

--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -1117,10 +1117,7 @@ Rock::SwapDir::hasReadableEntry(const StoreEntry &e) const
     return map->hasReadableEntry(reinterpret_cast<const cache_key*>(e.key));
 }
 
-namespace Rock
-{
-RunnerRegistrationEntry(SwapDirRr);
-}
+DefineRunnerRegistratorIn(Rock, SwapDirRr);
 
 void Rock::SwapDirRr::create()
 {

--- a/src/ipc/mem/Pages.cc
+++ b/src/ipc/mem/Pages.cc
@@ -103,7 +103,7 @@ private:
     Ipc::Mem::PagePool::Owner *owner;
 };
 
-RunnerRegistrationEntry(SharedMemPagesRr);
+DefineRunnerRegistrator(SharedMemPagesRr);
 
 void
 SharedMemPagesRr::useConfig()

--- a/src/main.cc
+++ b/src/main.cc
@@ -1440,6 +1440,14 @@ StartUsingConfig()
 int
 SquidMain(int argc, char **argv)
 {
+    // We must register all modules before the first RunRegisteredHere() call.
+    // We do it ASAP/here so that we do not need to move this code when we add
+    // earlier hooks to the RegisteredRunner API. This collection of
+    // registration calls is not a RegisteredRunner "event" in itself.
+#if HAVE_AUTH_MODULE_NTLM
+    CallRunnerRegistrator(NtlmAuthRr);
+#endif
+
     const CommandLine cmdLine(argc, argv, shortOpStr, squidOptions);
 
     ConfigureCurrentKid(cmdLine);

--- a/src/main.cc
+++ b/src/main.cc
@@ -1455,6 +1455,16 @@ RegisterModules()
     CallRunnerRegistrator(SharedMemPagesRr);
     CallRunnerRegistrator(SharedSessionCacheRr);
     CallRunnerRegistrator(TransientsRr);
+    CallRunnerRegistratorIn(Dns, ConfigRr);
+    CallRunnerRegistratorIn(Rock, SwapDirRr);
+
+#if USE_SQUID_ESI && HAVE_LIBEXPAT
+    CallRunnerRegistratorIn(Esi, ExpatRr);
+#endif
+
+#if USE_SQUID_ESI && HAVE_LIBXML2
+    CallRunnerRegistratorIn(Esi, Libxml2Rr);
+#endif
 
 #if HAVE_AUTH_MODULE_NTLM
     CallRunnerRegistrator(NtlmAuthRr);

--- a/src/main.cc
+++ b/src/main.cc
@@ -1449,14 +1449,24 @@ RegisterModules()
 
     CallRunnerRegistrator(ClientDbRr);
     CallRunnerRegistrator(CollapsedForwardingRr);
-    CallRunnerRegistrator(IpcIoRr);
     CallRunnerRegistrator(MemStoreRr);
     CallRunnerRegistrator(PeerPoolMgrsRr);
     CallRunnerRegistrator(SharedMemPagesRr);
     CallRunnerRegistrator(SharedSessionCacheRr);
     CallRunnerRegistrator(TransientsRr);
     CallRunnerRegistratorIn(Dns, ConfigRr);
-    CallRunnerRegistratorIn(Rock, SwapDirRr);
+
+#if HAVE_DISKIO_MODULE_IPCIO
+    CallRunnerRegistrator(IpcIoRr);
+#endif
+
+#if HAVE_AUTH_MODULE_NTLM
+    CallRunnerRegistrator(NtlmAuthRr);
+#endif
+
+#if USE_OPENSSL
+    CallRunnerRegistrator(sslBumpCfgRr);
+#endif
 
 #if USE_SQUID_ESI && HAVE_LIBEXPAT
     CallRunnerRegistratorIn(Esi, ExpatRr);
@@ -1466,12 +1476,8 @@ RegisterModules()
     CallRunnerRegistratorIn(Esi, Libxml2Rr);
 #endif
 
-#if HAVE_AUTH_MODULE_NTLM
-    CallRunnerRegistrator(NtlmAuthRr);
-#endif
-
-#if USE_OPENSSL
-    CallRunnerRegistrator(sslBumpCfgRr);
+#if HAVE_FS_ROCK
+    CallRunnerRegistratorIn(Rock, SwapDirRr);
 #endif
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1437,16 +1437,24 @@ StartUsingConfig()
     }
 }
 
+/// register all known modules for handling future RegisteredRunner events
+static void
+RegisterModules()
+{
+    // These registration calls do not represent a RegisteredRunner "event". The
+    // modules registered here should be initialized later, during those events.
+#if HAVE_AUTH_MODULE_NTLM
+    CallRunnerRegistrator(NtlmAuthRr);
+#endif
+}
+
 int
 SquidMain(int argc, char **argv)
 {
     // We must register all modules before the first RunRegisteredHere() call.
     // We do it ASAP/here so that we do not need to move this code when we add
-    // earlier hooks to the RegisteredRunner API. This collection of
-    // registration calls is not a RegisteredRunner "event" in itself.
-#if HAVE_AUTH_MODULE_NTLM
-    CallRunnerRegistrator(NtlmAuthRr);
-#endif
+    // earlier hooks to the RegisteredRunner API.
+    RegisterModules();
 
     const CommandLine cmdLine(argc, argv, shortOpStr, squidOptions);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1443,8 +1443,25 @@ RegisterModules()
 {
     // These registration calls do not represent a RegisteredRunner "event". The
     // modules registered here should be initialized later, during those events.
+
+    // RegisteredRunner event handlers should not depend on handler call order
+    // and, hence, should not depend on the registration call order below.
+
+    CallRunnerRegistrator(ClientDbRr);
+    CallRunnerRegistrator(CollapsedForwardingRr);
+    CallRunnerRegistrator(IpcIoRr);
+    CallRunnerRegistrator(MemStoreRr);
+    CallRunnerRegistrator(PeerPoolMgrsRr);
+    CallRunnerRegistrator(SharedMemPagesRr);
+    CallRunnerRegistrator(SharedSessionCacheRr);
+    CallRunnerRegistrator(TransientsRr);
+
 #if HAVE_AUTH_MODULE_NTLM
     CallRunnerRegistrator(NtlmAuthRr);
+#endif
+
+#if USE_OPENSSL
+    CallRunnerRegistrator(sslBumpCfgRr);
 #endif
 }
 

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -423,7 +423,7 @@ private:
     Ipc::MemMap::Owner *owner;
 };
 
-RunnerRegistrationEntry(SharedSessionCacheRr);
+DefineRunnerRegistrator(SharedSessionCacheRr);
 
 void
 SharedSessionCacheRr::useConfig()


### PR DESCRIPTION
    ERROR: ... Unknown authentication scheme 'ntlm'.

When a translation unit does not contain main() and its code is not used
by the rest of the executable, the linker may exclude that translation
unit from the executable. This exclusion by LTO may happen even if that
code _is_ used to initialize static variables in that translation unit:
"If no variable or function is odr-used from a given translation unit,
the non-local variables defined in that translation unit may never be
initialized"[^1].

[^1]: https://en.cppreference.com/w/cpp/language/initialization

For example, src/auth/ntlm/Scheme.o translation unit contains nothing
but NtlmAuthRr class definition and static initialization code. The
linker knows that the rest of Squid does not use NtlmAuthRr and excludes
that translation unit from the squid executable, effectively disabling
NTLM module registration required to parse "auth_param ntlm" directives.

The problem does affect existing NTLM module, and may affect any future
module code as we reduce module's external footprint. This change
converts all RegisteredRunner registrations from using side effects of
static initialization to explicit registration calls from SquidMain().
Relying on "life before main()" is a design bug. This PR fixes that bug
with respect to RegisteredRunner registrations.

Due to indeterminate C++ static initialization order, no module can
require registration before main() starts. Thus, moving registration
timing to the beginning of SquidMain() should have no negative effects.

The new registration API still does not expose main.cc to any module
details (other than the name of the registration function itself). We
still do not need to #include any module headers into main.cc. Compiler
or linker does catch most typos in RegisteredRunner names.

Unfortunately, explicit registration still cannot prevent bugs where we
forget to register a module or fail to register a module due to wrong
registration code guards. Eventually, CI will expose such bugs.
