### PR TITLE
Allow unit tests to customize their initialization code

### DIFF
--- a/compat/testPreCompiler.cc
+++ b/compat/testPreCompiler.cc
@@ -193,3 +193,9 @@ TestPreCompiler::testIfDefOr()
     CPPUNIT_ASSERT(!undefinedOrUndefinedC);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/include/unitTestMain.h
+++ b/include/unitTestMain.h
@@ -21,9 +21,6 @@
 #include <cppunit/TestResultCollector.h>
 #include <cppunit/TestRunner.h>
 
-#include <memory>
-#include <stdexcept>
-
 /// implements test program's main() function while enabling customization
 class TestProgram
 {
@@ -37,14 +34,14 @@ public:
     /// Implements main(), combining all the steps.
     /// Must be called from main().
     /// \returns desired main() result.
-    int run();
+    int run(int argc, char *argv[]);
 
 private:
     bool runTests();
 };
 
 int
-TestProgram::run()
+TestProgram::run(int, char *[])
 {
 #if ENABLE_DEBUG_SECTION
     Debug::Levels[ENABLE_DEBUG_SECTION] = 99;
@@ -84,37 +81,6 @@ TestProgram::runTests()
     outputter.write();
 
     return result.wasSuccessful();
-}
-
-/// TestProgram object registered by RegisterTestProgram() (or nil).
-static std::unique_ptr<TestProgram> TestProgram_;
-
-/// Creates and registers a CustomTestProgram object. Optionally "uses" the
-/// static defined by RegisterTestProgram (by taking that variable address).
-/// Use RegisterTestProgram_() instead.
-template <class CustomTestProgram>
-static bool
-RegisterTestProgram_(void * = nullptr)
-{
-    // Avoid assert(): Some tests do not link with libcompatsquid.la (XXX?).
-    // assert(!TestProgram_);
-    if (TestProgram_)
-        throw std::runtime_error("attempt to register more than one TestProgram");
-
-    TestProgram_.reset(new CustomTestProgram());
-    return true;
-}
-
-/// A helper macro to create and register a CustomTestProgram object.
-#define RegisterTestProgram(CustomTestProgram) \
-    static bool CustomTestProgramRegistration_ = RegisterTestProgram_<CustomTestProgram>(&CustomTestProgramRegistration_)
-
-int
-main(int, char *[])
-{
-    if (!TestProgram_)
-        RegisterTestProgram(TestProgram);
-    return TestProgram_->run();
 }
 
 #endif /* SQUID_INCLUDE_UNITTESTMAIN_H */

--- a/include/unitTestMain.h
+++ b/include/unitTestMain.h
@@ -34,10 +34,6 @@ public:
     /// Does nothing by default.
     virtual void startup() {}
 
-    /// Runs after all tests, regardless of their outcome.
-    /// Does nothing by default.
-    virtual void shutdown() {}
-
     /// Implements main(), combining all the steps.
     /// Must be called from main().
     /// \returns desired main() result.
@@ -56,8 +52,6 @@ TestProgram::run()
 
     startup();
     const auto result = runTests();
-    shutdown();
-
     return result ? 0 : 1;
 }
 

--- a/include/unitTestMain.h
+++ b/include/unitTestMain.h
@@ -21,13 +21,51 @@
 #include <cppunit/TestResultCollector.h>
 #include <cppunit/TestRunner.h>
 
+#include <memory>
+#include <stdexcept>
+
+/// implements test program's main() function while enabling customization
+class TestProgram
+{
+public:
+    virtual ~TestProgram() = default;
+
+    /// Runs before all tests.
+    /// Does nothing by default.
+    virtual void startup() {std::cerr << "XXX1: Default Before\n";}
+
+    /// Runs after all tests, regardless of their outcome.
+    /// Does nothing by default.
+    virtual void shutdown() {std::cerr << "XXX9: Default After\n";}
+
+    /// Implements main(), combining all the steps.
+    /// Must be called from main().
+    /// \returns desired main() result.
+    int run();
+
+private:
+    bool runTests();
+};
+
 int
-main(int, char *[])
+TestProgram::run()
 {
 #if ENABLE_DEBUG_SECTION
     Debug::Levels[ENABLE_DEBUG_SECTION] = 99;
 #endif
 
+    startup();
+    const auto result = runTests();
+    shutdown();
+
+    return result ? 0 : 1;
+}
+
+/// runs all tests registered with CPPUNIT_TEST_SUITE_REGISTRATION() calls
+/// \returns whether all tests were successful
+bool
+TestProgram::runTests()
+{
     // Create the event manager and test controller
     CPPUNIT_NS::TestResult controller;
 
@@ -51,7 +89,38 @@ main(int, char *[])
     CPPUNIT_NS::CompilerOutputter outputter( &result, std::cerr );
     outputter.write();
 
-    return result.wasSuccessful() ? 0 : 1;
+    return result.wasSuccessful();
+}
+
+/// TestProgram object registered by RegisterTestProgram() (or nil).
+static std::unique_ptr<TestProgram> TestProgram_;
+
+/// Creates and registers a CustomTestProgram object. Optionally "uses" the
+/// static defined by RegisterTestProgram (by taking that variable address).
+/// Use RegisterTestProgram_() instead.
+template <class CustomTestProgram>
+static bool
+RegisterTestProgram_(void * = nullptr)
+{
+    // Avoid assert(): Some tests do not link with libcompatsquid.la (XXX?).
+    // assert(!TestProgram_);
+    if (TestProgram_)
+        throw std::runtime_error("attempt to register more than one TestProgram");
+
+    TestProgram_.reset(new CustomTestProgram());
+    return true;
+}
+
+/// A helper macro to create and register a CustomTestProgram object.
+#define RegisterTestProgram(CustomTestProgram) \
+    static bool CustomTestProgramRegistration_ = RegisterTestProgram_<CustomTestProgram>(&CustomTestProgramRegistration_)
+
+int
+main(int, char *[])
+{
+    if (!TestProgram_)
+        RegisterTestProgram(TestProgram);
+    return TestProgram_->run();
 }
 
 #endif /* SQUID_INCLUDE_UNITTESTMAIN_H */

--- a/include/unitTestMain.h
+++ b/include/unitTestMain.h
@@ -32,11 +32,11 @@ public:
 
     /// Runs before all tests.
     /// Does nothing by default.
-    virtual void startup() {std::cerr << "XXX1: Default Before\n";}
+    virtual void startup() {}
 
     /// Runs after all tests, regardless of their outcome.
     /// Does nothing by default.
-    virtual void shutdown() {std::cerr << "XXX9: Default After\n";}
+    virtual void shutdown() {}
 
     /// Implements main(), combining all the steps.
     /// Must be called from main().

--- a/lib/tests/testRFC1738.cc
+++ b/lib/tests/testRFC1738.cc
@@ -173,3 +173,9 @@ void TestRfc1738::PercentZeroNullDecoding()
     xfree(unescaped_str);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -63,8 +63,6 @@ public:
     void startup() override;
 };
 
-RegisterTestProgram(MyProgram);
-
 void
 MyProgram::startup()
 {
@@ -92,6 +90,12 @@ TestACLMaxUserIP::testParseLine()
     }
     delete anACL;
     xfree(line);
+}
+
+int
+main(int argc, char *argv[])
+{
+    return MyProgram().run(argc, argv);
 }
 
 #endif /* USE_AUTH */

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -54,17 +54,17 @@ TestACLMaxUserIP::testDefaults()
 }
 
 /// customizes our test setup
-class MyProgram: public TestProgram
+class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyProgram() = default;
+    virtual ~MyTestProgram() = default;
 
     /* TestProgram API */
     void startup() override;
 };
 
 void
-MyProgram::startup()
+MyTestProgram::startup()
 {
     Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->ACL* { return new ACLMaxUserIP(name); });
 }
@@ -95,7 +95,7 @@ TestACLMaxUserIP::testParseLine()
 int
 main(int argc, char *argv[])
 {
-    return MyProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 
 #endif /* USE_AUTH */

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -32,9 +32,6 @@ class TestACLMaxUserIP : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testParseLine);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testDefaults();
     void testParseLine();
@@ -56,10 +53,21 @@ TestACLMaxUserIP::testDefaults()
     CPPUNIT_ASSERT_EQUAL(false,anACL.valid());
 }
 
-void
-TestACLMaxUserIP::setUp()
+/// customizes our test setup
+class MyProgram: public TestProgram
 {
-    CPPUNIT_NS::TestFixture::setUp();
+public:
+    virtual ~MyProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
+
+RegisterTestProgram(MyProgram);
+
+void
+MyProgram::startup()
+{
     Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->ACL* { return new ACLMaxUserIP(name); });
 }
 

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -57,8 +57,6 @@ TestACLMaxUserIP::testDefaults()
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testAuth.cc
+++ b/src/tests/testAuth.cc
@@ -286,5 +286,12 @@ TestAuthNegotiateUserRequest::username()
 }
 
 #endif /* HAVE_AUTH_MODULE_NEGOTIATE */
+
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+
 #endif /* USE_AUTH */
 

--- a/src/tests/testBoilerplate.cc
+++ b/src/tests/testBoilerplate.cc
@@ -20,3 +20,9 @@ TestBoilerplate::testDemonstration()
     CPPUNIT_ASSERT_EQUAL(0, 0);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testCacheManager.cc
+++ b/src/tests/testCacheManager.cc
@@ -46,8 +46,6 @@ public:
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testCacheManager.cc
+++ b/src/tests/testCacheManager.cc
@@ -238,3 +238,9 @@ TestCacheManager::testParseUrl()
     }
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testCacheManager.cc
+++ b/src/tests/testCacheManager.cc
@@ -27,9 +27,6 @@ class TestCacheManager : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testParseUrl);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testCreate();
     void testRegister();
@@ -45,9 +42,18 @@ public:
     void ParseUrl(const AnyP::Uri &u) { CacheManager::ParseUrl(u); }
 };
 
-/* init memory pools */
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
 
-void TestCacheManager::setUp()
+    /* TestProgram API */
+    void startup() override;
+};
+
+void
+MyTestProgram::startup()
 {
     Mem::Init();
     AnyP::UriScheme::Init();
@@ -241,6 +247,6 @@ TestCacheManager::testParseUrl()
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testCharacterSet.cc
+++ b/src/tests/testCharacterSet.cc
@@ -143,3 +143,9 @@ TestCharacterSet::CharacterSetSubtract()
     CPPUNIT_ASSERT_EQUAL(CharacterSet::HEXDIG, sample - CharacterSet(nullptr, "qz"));
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testClpMap.cc
+++ b/src/tests/testClpMap.cc
@@ -105,8 +105,6 @@ TestClpMap::addOneEntry(Map &m, const Map::mapped_type value, const Map::Ttl ttl
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testClpMap.cc
+++ b/src/tests/testClpMap.cc
@@ -106,14 +106,8 @@ class MyTestProgram: public TestProgram
 {
 public:
     /* TestProgram API */
-    void startup() override;
+    void startup() override { squid_curtime = time(nullptr); }
 };
-
-void
-MyTestProgram::startup()
-{
-    squid_curtime = time(nullptr);
-}
 
 void
 TestClpMap::testPutGetDelete()

--- a/src/tests/testClpMap.cc
+++ b/src/tests/testClpMap.cc
@@ -387,3 +387,9 @@ TestClpMap::testRangeLoopTraversal()
     CPPUNIT_ASSERT_EQUAL(expectedEntryCount, iterations);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testClpMap.cc
+++ b/src/tests/testClpMap.cc
@@ -101,14 +101,6 @@ TestClpMap::addOneEntry(Map &m, const Map::mapped_type value, const Map::Ttl ttl
     CPPUNIT_ASSERT_EQUAL(value, *m.get(key));
 }
 
-/// customizes our test setup
-class MyTestProgram: public TestProgram
-{
-public:
-    /* TestProgram API */
-    void startup() override { squid_curtime = time(nullptr); }
-};
-
 void
 TestClpMap::testPutGetDelete()
 {
@@ -385,6 +377,14 @@ TestClpMap::testRangeLoopTraversal()
     }
     CPPUNIT_ASSERT_EQUAL(expectedEntryCount, iterations);
 }
+
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    /* TestProgram API */
+    void startup() override { squid_curtime = time(nullptr); }
+};
 
 int
 main(int argc, char *argv[])

--- a/src/tests/testClpMap.cc
+++ b/src/tests/testClpMap.cc
@@ -32,9 +32,6 @@ class TestClpMap: public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( testRangeLoopTraversal );
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     using Map = ClpMap<std::string, int>;
 
@@ -104,8 +101,18 @@ TestClpMap::addOneEntry(Map &m, const Map::mapped_type value, const Map::Ttl ttl
     CPPUNIT_ASSERT_EQUAL(value, *m.get(key));
 }
 
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
+
 void
-TestClpMap::setUp()
+MyTestProgram::startup()
 {
     squid_curtime = time(nullptr);
 }
@@ -390,6 +397,6 @@ TestClpMap::testRangeLoopTraversal()
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testConfigParser.cc
+++ b/src/tests/testConfigParser.cc
@@ -22,9 +22,6 @@ class TestConfigParser : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testParseQuoted);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     bool doParseQuotedTest(const char *, const char *);
     void testParseQuoted();
@@ -33,10 +30,6 @@ protected:
 CPPUNIT_TEST_SUITE_REGISTRATION( TestConfigParser );
 
 int shutting_down = 0;
-
-void TestConfigParser::setUp()
-{
-}
 
 bool TestConfigParser::doParseQuotedTest(const char *s, const char *expectInterp)
 {

--- a/src/tests/testConfigParser.cc
+++ b/src/tests/testConfigParser.cc
@@ -96,3 +96,9 @@ void TestConfigParser::testParseQuoted()
     CPPUNIT_ASSERT_EQUAL(true, doParseQuotedTest("\"\\\\\"", "\\"));
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testDiskIO.cc
+++ b/src/tests/testDiskIO.cc
@@ -29,17 +29,24 @@ class TestDiskIO : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testFindDefault);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testFindDefault();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( TestDiskIO );
 
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
+
 void
-TestDiskIO::setUp()
+MyTestProgram::startup()
 {
     Mem::Init();
     DiskIOModule::SetupAllModules();
@@ -61,6 +68,6 @@ TestDiskIO::testFindDefault()
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testDiskIO.cc
+++ b/src/tests/testDiskIO.cc
@@ -39,8 +39,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION( TestDiskIO );
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testDiskIO.cc
+++ b/src/tests/testDiskIO.cc
@@ -58,3 +58,9 @@ TestDiskIO::testFindDefault()
 #endif
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testEnumIterator.cc
+++ b/src/tests/testEnumIterator.cc
@@ -162,3 +162,9 @@ TestEnumIterator::testUnsignedEnum()
     CPPUNIT_ASSERT_EQUAL(5,j);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -43,8 +43,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION( TestEvent );
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -180,3 +180,9 @@ TestEvent::testSingleton()
     CPPUNIT_ASSERT(nullptr != scheduler);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -28,9 +28,6 @@ class TestEvent : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testCancel);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testCreate();
     void testDump();
@@ -42,10 +39,18 @@ protected:
 
 CPPUNIT_TEST_SUITE_REGISTRATION( TestEvent );
 
-/* init legacy static-initialized modules */
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
 
 void
-TestEvent::setUp()
+MyTestProgram::startup()
 {
     Mem::Init();
 }
@@ -183,6 +188,6 @@ TestEvent::testSingleton()
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -39,14 +39,6 @@ protected:
 
 CPPUNIT_TEST_SUITE_REGISTRATION( TestEvent );
 
-/// customizes our test setup
-class MyTestProgram: public TestProgram
-{
-public:
-    /* TestProgram API */
-    void startup() override { Mem::Init(); }
-};
-
 /*
  * Test creating a Scheduler
  */
@@ -176,6 +168,14 @@ TestEvent::testSingleton()
     EventScheduler *scheduler = dynamic_cast<EventScheduler *>(EventScheduler::GetInstance());
     CPPUNIT_ASSERT(nullptr != scheduler);
 }
+
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    /* TestProgram API */
+    void startup() override { Mem::Init(); }
+};
 
 int
 main(int argc, char *argv[])

--- a/src/tests/testEvent.cc
+++ b/src/tests/testEvent.cc
@@ -44,14 +44,8 @@ class MyTestProgram: public TestProgram
 {
 public:
     /* TestProgram API */
-    void startup() override;
+    void startup() override { Mem::Init(); }
 };
-
-void
-MyTestProgram::startup()
-{
-    Mem::Init();
-}
 
 /*
  * Test creating a Scheduler

--- a/src/tests/testEventLoop.cc
+++ b/src/tests/testEventLoop.cc
@@ -206,3 +206,9 @@ TestEventLoop::testSetPrimaryEngine()
     CPPUNIT_ASSERT_EQUAL(0, second_engine.lasttimeout);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testHttp1Parser.cc
+++ b/src/tests/testHttp1Parser.cc
@@ -1194,3 +1194,9 @@ TestHttp1Parser::testDripFeed()
 
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testHttpReply.cc
+++ b/src/tests/testHttpReply.cc
@@ -215,3 +215,9 @@ TestHttpReply::testSanityCheckFirstLine()
     error = Http::scNone;
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testHttpReply.cc
+++ b/src/tests/testHttpReply.cc
@@ -45,8 +45,6 @@ MemObject::endOffset() const
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testHttpReply.cc
+++ b/src/tests/testHttpReply.cc
@@ -22,9 +22,6 @@ class TestHttpReply : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testSanityCheckFirstLine);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testSanityCheckFirstLine();
 };
@@ -44,8 +41,18 @@ MemObject::endOffset() const
 
 /* end */
 
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
+
 void
-TestHttpReply::setUp()
+MyTestProgram::startup()
 {
     Mem::Init();
     httpHeaderInitModule();
@@ -218,6 +225,6 @@ TestHttpReply::testSanityCheckFirstLine()
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -50,8 +50,6 @@ public:
     void startup() override;
 };
 
-RegisterTestProgram(MyProgram);
-
 void
 MyProgram::startup()
 {
@@ -216,5 +214,11 @@ TestHttpRequest::testSanityCheckStartLine()
     CPPUNIT_ASSERT_EQUAL(error, Http::scInvalidHeader);
     input.reset();
     error = Http::scNone;
+}
+
+int
+main(int argc, char *argv[])
+{
+    return MyProgram().run(argc, argv);
 }
 

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -44,8 +44,6 @@ public:
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -25,7 +25,8 @@ class TestHttpRequest : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void setUp() override;
+    TestHttpRequest() { std::cerr << "XXX2: Default TestHttpRequest ctor\n"; }
+    ~TestHttpRequest() override { std::cerr << "XXX8: Default TestHttpRequest dtor\n"; }
 
 protected:
     void testCreateFromUrl();
@@ -43,11 +44,22 @@ public:
     bool doSanityCheckStartLine(const char *b, const size_t h, Http::StatusCode *e) { return sanityCheckStartLine(b,h,e); };
 };
 
-/* init memory pools */
+/// customizes our test setup
+class MyProgram: public TestProgram
+{
+public:
+    virtual ~MyProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
+
+RegisterTestProgram(MyProgram);
 
 void
-TestHttpRequest::setUp()
+MyProgram::startup()
 {
+    std::cerr << "XXX1b: Custom Before\n";
     Mem::Init();
     AnyP::UriScheme::Init();
     httpHeaderInitModule();

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -24,10 +24,6 @@ class TestHttpRequest : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testSanityCheckStartLine);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    TestHttpRequest() { std::cerr << "XXX2: Default TestHttpRequest ctor\n"; }
-    ~TestHttpRequest() override { std::cerr << "XXX8: Default TestHttpRequest dtor\n"; }
-
 protected:
     void testCreateFromUrl();
     void testIPv6HostColonBug();
@@ -59,7 +55,6 @@ RegisterTestProgram(MyProgram);
 void
 MyProgram::startup()
 {
-    std::cerr << "XXX1b: Custom Before\n";
     Mem::Init();
     AnyP::UriScheme::Init();
     httpHeaderInitModule();

--- a/src/tests/testHttpRequest.cc
+++ b/src/tests/testHttpRequest.cc
@@ -41,17 +41,17 @@ public:
 };
 
 /// customizes our test setup
-class MyProgram: public TestProgram
+class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyProgram() = default;
+    virtual ~MyTestProgram() = default;
 
     /* TestProgram API */
     void startup() override;
 };
 
 void
-MyProgram::startup()
+MyTestProgram::startup()
 {
     Mem::Init();
     AnyP::UriScheme::Init();
@@ -219,6 +219,6 @@ TestHttpRequest::testSanityCheckStartLine()
 int
 main(int argc, char *argv[])
 {
-    return MyProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testHttpRequestMethod.cc
+++ b/src/tests/testHttpRequestMethod.cc
@@ -195,3 +195,4 @@ TestHttpRequestMethod::testStream()
 }
 
 // This test uses main() from ./testHttpRequest.cc.
+

--- a/src/tests/testHttpRequestMethod.cc
+++ b/src/tests/testHttpRequestMethod.cc
@@ -194,3 +194,4 @@ TestHttpRequestMethod::testStream()
     CPPUNIT_ASSERT_EQUAL(String("get"), String(buffer2.str().c_str()));
 }
 
+// This test uses main() from ./testHttpRequest.cc.

--- a/src/tests/testIcmp.cc
+++ b/src/tests/testIcmp.cc
@@ -155,3 +155,9 @@ TestIcmp::testHops()
 #endif
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testIpAddress.cc
+++ b/src/tests/testIpAddress.cc
@@ -799,3 +799,9 @@ TestIpAddress::testBugNullingDisplay()
 
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testLookupTable.cc
+++ b/src/tests/testLookupTable.cc
@@ -66,3 +66,9 @@ TestLookupTable::testLookupTableLookup()
     CPPUNIT_ASSERT_EQUAL(lt.lookup(SBuf("eleventy")), ENUM_INVALID);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testMath.cc
+++ b/src/tests/testMath.cc
@@ -265,3 +265,9 @@ TestMath::testNaturalSum()
     CPPUNIT_ASSERT_EQUAL(expires, result);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testMem.cc
+++ b/src/tests/testMem.cc
@@ -80,3 +80,9 @@ TestMem::testMemProxy()
     CPPUNIT_ASSERT_EQUAL(otherthing->aValue, 0);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testNetDb.cc
+++ b/src/tests/testNetDb.cc
@@ -64,3 +64,9 @@ TestNetDb::testConstruct()
     }
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testPackableStream.cc
+++ b/src/tests/testPackableStream.cc
@@ -22,21 +22,11 @@ class TestPackableStream : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testGetStream);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testGetStream();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( TestPackableStream );
-
-/* init memory pools */
-
-void TestPackableStream::setUp()
-{
-    Mem::Init();
-}
 
 // TODO: test streaming to a MemBuf as well.
 

--- a/src/tests/testPackableStream.cc
+++ b/src/tests/testPackableStream.cc
@@ -72,3 +72,4 @@ TestPackableStream::testGetStream()
     Store::FreeMemory();
 }
 
+// This test uses main() from ./testStore.cc.

--- a/src/tests/testPackableStream.cc
+++ b/src/tests/testPackableStream.cc
@@ -63,3 +63,4 @@ TestPackableStream::testGetStream()
 }
 
 // This test uses main() from ./testStore.cc.
+

--- a/src/tests/testRFC1035.cc
+++ b/src/tests/testRFC1035.cc
@@ -162,3 +162,9 @@ void TestRfc1035::testBugPacketHeadersOnly()
     CPPUNIT_ASSERT(msg == nullptr);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testRandomUuid.cc
+++ b/src/tests/testRandomUuid.cc
@@ -90,3 +90,9 @@ TestRandomUuid::testInvalidIds()
     }
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testRefCount.cc
+++ b/src/tests/testRefCount.cc
@@ -196,3 +196,9 @@ TestRefCount::testDoubleInheritToSingleInherit()
     CPPUNIT_ASSERT_EQUAL(1, _ToRefCount::Instances);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -363,3 +363,9 @@ TestRock::testRockSwapOut()
     }
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testRock.cc
+++ b/src/tests/testRock.cc
@@ -85,8 +85,6 @@ addSwapDir(TestRock::SwapDirPointer aStore)
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 

--- a/src/tests/testSBuf.cc
+++ b/src/tests/testSBuf.cc
@@ -1190,3 +1190,9 @@ TestSBuf::testSBufHash()
     }
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testSBufList.cc
+++ b/src/tests/testSBufList.cc
@@ -62,3 +62,9 @@ TestSBufList::testSBufListJoin()
 
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testStatHist.cc
+++ b/src/tests/testStatHist.cc
@@ -120,3 +120,9 @@ TestStatHist::testStatHistSum()
 
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testStore.cc
+++ b/src/tests/testStore.cc
@@ -207,8 +207,6 @@ TestStore::testSwapMetaTypeClassification()
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testStore.cc
+++ b/src/tests/testStore.cc
@@ -203,9 +203,25 @@ TestStore::testSwapMetaTypeClassification()
     CPPUNIT_ASSERT(Store::HonoredSwapMetaType(Store::RawSwapMetaTypeTop()));
 }
 
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
+
+void
+MyTestProgram::startup()
+{
+    Mem::Init();
+}
+
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testStore.cc
+++ b/src/tests/testStore.cc
@@ -203,3 +203,9 @@ TestStore::testSwapMetaTypeClassification()
     CPPUNIT_ASSERT(Store::HonoredSwapMetaType(Store::RawSwapMetaTypeTop()));
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testStore.cc
+++ b/src/tests/testStore.cc
@@ -208,14 +208,8 @@ class MyTestProgram: public TestProgram
 {
 public:
     /* TestProgram API */
-    void startup() override;
+    void startup() override { Mem::Init(); }
 };
-
-void
-MyTestProgram::startup()
-{
-    Mem::Init();
-}
 
 int
 main(int argc, char *argv[])

--- a/src/tests/testStoreController.cc
+++ b/src/tests/testStoreController.cc
@@ -200,3 +200,4 @@ TestStoreController::testSearch()
 }
 
 // This test uses main() from ./testStore.cc.
+

--- a/src/tests/testStoreController.cc
+++ b/src/tests/testStoreController.cc
@@ -199,3 +199,4 @@ TestStoreController::testSearch()
     Store::FreeMemory();
 }
 
+// This test uses main() from ./testStore.cc.

--- a/src/tests/testStoreHashIndex.cc
+++ b/src/tests/testStoreHashIndex.cc
@@ -199,3 +199,4 @@ TestStoreHashIndex::testSearch()
     Store::FreeMemory();
 }
 
+// This test uses main() from ./testStore.cc.

--- a/src/tests/testStoreHashIndex.cc
+++ b/src/tests/testStoreHashIndex.cc
@@ -200,3 +200,4 @@ TestStoreHashIndex::testSearch()
 }
 
 // This test uses main() from ./testStore.cc.
+

--- a/src/tests/testString.cc
+++ b/src/tests/testString.cc
@@ -26,9 +26,6 @@ class TestString : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testCmpDefault();
     void testCmpEmptyString();
@@ -37,10 +34,18 @@ protected:
 };
 CPPUNIT_TEST_SUITE_REGISTRATION(TestString);
 
-/* init memory pools */
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
 
 void
-TestString::setUp()
+MyTestProgram::startup()
 {
     Mem::Init();
 }
@@ -96,6 +101,6 @@ void TestString::testSubstr()
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testString.cc
+++ b/src/tests/testString.cc
@@ -38,8 +38,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestString);
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testString.cc
+++ b/src/tests/testString.cc
@@ -34,14 +34,6 @@ protected:
 };
 CPPUNIT_TEST_SUITE_REGISTRATION(TestString);
 
-/// customizes our test setup
-class MyTestProgram: public TestProgram
-{
-public:
-    /* TestProgram API */
-    void startup() override { Mem::Init(); }
-};
-
 void
 TestString::testCmpDefault()
 {
@@ -89,6 +81,14 @@ void TestString::testSubstr()
     String ref("34");
     CPPUNIT_ASSERT(check == ref);
 }
+
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    /* TestProgram API */
+    void startup() override { Mem::Init(); }
+};
 
 int
 main(int argc, char *argv[])

--- a/src/tests/testString.cc
+++ b/src/tests/testString.cc
@@ -93,3 +93,9 @@ void TestString::testSubstr()
     CPPUNIT_ASSERT(check == ref);
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testString.cc
+++ b/src/tests/testString.cc
@@ -39,14 +39,8 @@ class MyTestProgram: public TestProgram
 {
 public:
     /* TestProgram API */
-    void startup() override;
+    void startup() override { Mem::Init(); }
 };
-
-void
-MyTestProgram::startup()
-{
-    Mem::Init();
-}
 
 void
 TestString::testCmpDefault()

--- a/src/tests/testTokenizer.cc
+++ b/src/tests/testTokenizer.cc
@@ -327,3 +327,9 @@ TestTokenizer::testTokenizerInt64()
     }
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testURL.cc
+++ b/src/tests/testURL.cc
@@ -37,8 +37,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestUri);
 class MyTestProgram: public TestProgram
 {
 public:
-    virtual ~MyTestProgram() = default;
-
     /* TestProgram API */
     void startup() override;
 };

--- a/src/tests/testURL.cc
+++ b/src/tests/testURL.cc
@@ -27,19 +27,24 @@ class TestUri : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testDefaultConstructor);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testConstructScheme();
     void testDefaultConstructor();
 };
 CPPUNIT_TEST_SUITE_REGISTRATION(TestUri);
 
-/* init memory pools */
+/// customizes our test setup
+class MyTestProgram: public TestProgram
+{
+public:
+    virtual ~MyTestProgram() = default;
+
+    /* TestProgram API */
+    void startup() override;
+};
 
 void
-TestUri::setUp()
+MyTestProgram::startup()
 {
     Mem::Init();
     AnyP::UriScheme::Init();
@@ -81,6 +86,6 @@ TestUri::testDefaultConstructor()
 int
 main(int argc, char *argv[])
 {
-    return TestProgram().run(argc, argv);
+    return MyTestProgram().run(argc, argv);
 }
 

--- a/src/tests/testURL.cc
+++ b/src/tests/testURL.cc
@@ -78,3 +78,9 @@ TestUri::testDefaultConstructor()
     delete urlPointer;
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testUfs.cc
+++ b/src/tests/testUfs.cc
@@ -266,3 +266,9 @@ TestUfs::testUfsDefaultEngine()
         throw std::runtime_error("Failed to clean test work directory");
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+

--- a/src/tests/testUriScheme.cc
+++ b/src/tests/testUriScheme.cc
@@ -31,9 +31,6 @@ class TestUriScheme : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testStream);
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    void setUp() override;
-
 protected:
     void testAssignFromprotocol_t();
     void testCastToprotocol_t();
@@ -151,13 +148,6 @@ TestUriScheme::testStream()
     SBuf http_str("http");
     SBuf from_buf(buffer.str());
     CPPUNIT_ASSERT_EQUAL(http_str, from_buf);
-}
-
-void
-TestUriScheme::setUp()
-{
-    Mem::Init();
-    AnyP::UriScheme::Init();
 }
 
 // This test uses main() from ./testURL.cc.

--- a/src/tests/testUriScheme.cc
+++ b/src/tests/testUriScheme.cc
@@ -160,3 +160,4 @@ TestUriScheme::setUp()
     AnyP::UriScheme::Init();
 }
 
+// This test uses main() from ./testURL.cc.

--- a/src/tests/testUriScheme.cc
+++ b/src/tests/testUriScheme.cc
@@ -151,3 +151,4 @@ TestUriScheme::testStream()
 }
 
 // This test uses main() from ./testURL.cc.
+

--- a/src/tests/testYesNoNone.cc
+++ b/src/tests/testYesNoNone.cc
@@ -71,3 +71,9 @@ TestYesNoNone::testBasics()
     }
 }
 
+int
+main(int argc, char *argv[])
+{
+    return TestProgram().run(argc, argv);
+}
+


### PR DESCRIPTION
CppUnit provides TestFixture::setUp() and tearDown() methods, but those
methods are executed before and after _each_ test case. Many single
TestFixture-derived classes register many test cases that need to run
some test program setup/initialization code just once. Counting past
setUp() calls would increase noise and likely introduce bugs.

Some of our test cases may actually need before/after cleanup -- the
functionality already provided by TestFixture::setUp()/tearDown()
methods.  Moreover, when multiple TestFixture-derived classes share the
same test executable, their collections of test cases are executed in
essentially random order (see commit 27685ef). In those use cases,
insuring one-time initialization via setUp() hacks would be especially
awkward and error-prone.

With this solution, a test program with custom needs just needs to
define a TestProgram-derived class that implements its one-time startup
logic. The same TestProgram class hierarchy might also prove useful in
future custom test execution adjustments.

Also migrated away from the "include main()" unit test design to avoid
adding risky hacks that register custom TestProgram-derived classes and
to reduce "magic" in test code (while following our style guidelines).
Every test programs now declares its own (trivial) main() rather than
getting it from include/unitTestMain.h.
