### PR TITLE
Fix memory leak when reconfiguring multiline all-of ACLs

### DIFF
--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -10,6 +10,7 @@
 #include "acl/AllOf.h"
 #include "acl/BoolOps.h"
 #include "acl/Checklist.h"
+#include "acl/Gadgets.h"
 #include "cache_cf.h"
 #include "MemBuf.h"
 #include "sbuf/SBuf.h"
@@ -61,6 +62,7 @@ Acl::AllOf::parse()
         wholeCtx.terminate();
 
         Acl::OrNode *newWhole = new Acl::OrNode;
+        aclRegister(newWhole);
         newWhole->context(wholeCtx.content(), oldNode->cfgline);
         newWhole->add(oldNode); // old (i.e. first) line
         nodes.front() = whole = newWhole;

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -62,10 +62,10 @@ Acl::AllOf::parse()
         wholeCtx.terminate();
 
         Acl::OrNode *newWhole = new Acl::OrNode;
-        aclRegister(newWhole);
         newWhole->context(wholeCtx.content(), oldNode->cfgline);
         newWhole->add(oldNode); // old (i.e. first) line
         nodes.front() = whole = newWhole;
+        aclRegister(newWhole);
     } else {
         // this is the first line for this acl; just use it as is
         whole = this;


### PR DESCRIPTION
Normally, Acl::InnerNode::add() automatically registers stored ACL nodes
for future cleanup, but when we find the second all-of rule/line (with
the same ACL name), we do not add() the newly created OrNode and have to
explicitly register it to avoid memory leaks on reconfiguration.

Leaking since all-of ACL support was added in 2013 commit 6f58d7d.

