### PR TITLE
Bug 4981: Work around in-call job invalidation bugs

### DIFF
--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -179,7 +179,7 @@ JobDialer<Job>::dial(AsyncCall &call)
         if (!job) {
             debugs(call.debugSection, DBG_CRITICAL, "ERROR: Squid BUG: Job invalidated during " <<
                    call.name << " that threw exception: " << e.what());
-            return; // See also: Bug 4981, commit e3b6f15, and XXX in Http::Stream class description.
+            return; // see also: bug 4981, commit e3b6f15, and XXX in Http::Stream class description
         }
         job->callException(e);
     }

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -176,16 +176,14 @@ JobDialer<Job>::dial(AsyncCall &call)
     } catch (const std::exception &e) {
         debugs(call.debugSection, 3,
                call.name << " threw exception: " << e.what());
-        if (!job.valid())
-        {
+        if (!job.valid()) {
             debugs(call.debugSection, DBG_CRITICAL,
                    "BUG: job invalidated during " << call.name << " that threw exception: " << e.what());
             return; // See also: Bug 4981, commit e3b6f15, and XXX in Http::Stream class description.
         }
         job->callException(e);
     }
-    if (!job.valid())
-    {
+    if (!job.valid()) {
         debugs(call.debugSection, DBG_CRITICAL,
                "BUG 4981: job invalidated during " << call.name);
         return;

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -177,7 +177,7 @@ JobDialer<Job>::dial(AsyncCall &call)
         debugs(call.debugSection, 3,
                call.name << " threw exception: " << e.what());
         if (!job) {
-            debugs(call.debugSection, 3, "ERROR: Squid BUG: Job invalidated during " <<
+            debugs(call.debugSection, DBG_CRITICAL, "ERROR: Squid BUG: Job invalidated during " <<
                    call.name << " that threw exception: " << e.what());
             return; // see also: bug 4981, commit e3b6f15, and XXX in Http::Stream class description
         }
@@ -185,7 +185,7 @@ JobDialer<Job>::dial(AsyncCall &call)
     }
 
     if (!job) {
-        debugs(call.debugSection, 3, "ERROR: Squid BUG: Job invalidated during " << call.name);
+        debugs(call.debugSection, DBG_CRITICAL, "ERROR: Squid BUG: Job invalidated during " << call.name);
         return;
     }
     job->callEnd(); // may delete job

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -22,7 +22,7 @@
  * below implement for us, calling the job's method with the right params.
  */
 template <class Job>
-class JobDialer: public CallDialer
+class JobDialer : public CallDialer
 {
 public:
     typedef Job DestClass;
@@ -41,7 +41,7 @@ protected:
 
 private:
     // not implemented and should not be needed
-    JobDialer &operator =(const JobDialer &);
+    JobDialer &operator=(const JobDialer &);
 };
 
 /// schedule an async job call using a dialer; use CallJobHere macros instead
@@ -56,19 +56,19 @@ CallJob(int debugSection, int debugLevel, const char *fileName, int fileLine,
 }
 
 #define CallJobHere(debugSection, debugLevel, job, Class, method) \
-    CallJob((debugSection), (debugLevel), __FILE__, __LINE__, \
-        (#Class "::" #method), \
-        JobMemFun<Class>((job), &Class::method))
+    CallJob((debugSection), (debugLevel), __FILE__, __LINE__,     \
+            (#Class "::" #method),                                \
+            JobMemFun<Class>((job), &Class::method))
 
 #define CallJobHere1(debugSection, debugLevel, job, Class, method, arg1) \
-    CallJob((debugSection), (debugLevel), __FILE__, __LINE__, \
-        (#Class "::" #method), \
-        JobMemFun((job), &Class::method, (arg1)))
+    CallJob((debugSection), (debugLevel), __FILE__, __LINE__,            \
+            (#Class "::" #method),                                       \
+            JobMemFun((job), &Class::method, (arg1)))
 
 /// Convenience macro to create a Dialer-based job callback
 #define JobCallback(dbgSection, dbgLevel, Dialer, job, method) \
-    asyncCall((dbgSection), (dbgLevel), #method, \
-        Dialer(CbcPointer<Dialer::DestClass>(job), &method))
+    asyncCall((dbgSection), (dbgLevel), #method,               \
+              Dialer(CbcPointer<Dialer::DestClass>(job), &method))
 
 /*
  * *MemFunT are member function (i.e., class method) wrappers. They store
@@ -87,14 +87,13 @@ CallJob(int debugSection, int debugLevel, const char *fileName, int fileLine,
 // Arity names are from http://en.wikipedia.org/wiki/Arity
 
 template <class Job>
-class NullaryMemFunT: public JobDialer<Job>
+class NullaryMemFunT : public JobDialer<Job>
 {
 public:
     typedef void (Job::*Method)();
-    explicit NullaryMemFunT(const CbcPointer<Job> &aJob, Method aMethod):
-        JobDialer<Job>(aJob), method(aMethod) {}
+    explicit NullaryMemFunT(const CbcPointer<Job> &aJob, Method aMethod) : JobDialer<Job>(aJob), method(aMethod) {}
 
-    void print(std::ostream &os) const override {  os << "()"; }
+    void print(std::ostream &os) const override { os << "()"; }
 
 public:
     Method method;
@@ -104,15 +103,15 @@ protected:
 };
 
 template <class Job, class Data, class Argument1 = Data>
-class UnaryMemFunT: public JobDialer<Job>
+class UnaryMemFunT : public JobDialer<Job>
 {
 public:
     typedef void (Job::*Method)(Argument1);
     explicit UnaryMemFunT(const CbcPointer<Job> &aJob, Method aMethod,
-                          const Data &anArg1): JobDialer<Job>(aJob),
-        method(aMethod), arg1(anArg1) {}
+                          const Data &anArg1) : JobDialer<Job>(aJob),
+                                                method(aMethod), arg1(anArg1) {}
 
-    void print(std::ostream &os) const override {  os << '(' << arg1 << ')'; }
+    void print(std::ostream &os) const override { os << '(' << arg1 << ')'; }
 
 public:
     Method method;
@@ -145,19 +144,18 @@ JobMemFun(const CbcPointer<C> &job, typename UnaryMemFunT<C, Argument1>::Method 
 
 // inlined methods
 
-template<class Job>
-JobDialer<Job>::JobDialer(const JobPointer &aJob): job(aJob)
+template <class Job>
+JobDialer<Job>::JobDialer(const JobPointer &aJob) : job(aJob)
 {
 }
 
-template<class Job>
-JobDialer<Job>::JobDialer(const JobDialer<Job> &d): CallDialer(d), job(d.job)
+template <class Job>
+JobDialer<Job>::JobDialer(const JobDialer<Job> &d) : CallDialer(d), job(d.job)
 {
 }
 
-template<class Job>
-bool
-JobDialer<Job>::canDial(AsyncCall &call)
+template <class Job>
+bool JobDialer<Job>::canDial(AsyncCall &call)
 {
     if (!job)
         return call.cancel("job gone");
@@ -165,22 +163,34 @@ JobDialer<Job>::canDial(AsyncCall &call)
     return job->canBeCalled(call);
 }
 
-template<class Job>
-void
-JobDialer<Job>::dial(AsyncCall &call)
+template <class Job>
+void JobDialer<Job>::dial(AsyncCall &call)
 {
     job->callStart(call);
 
-    try {
+    try
+    {
         doDial();
-    } catch (const std::exception &e) {
+    }
+    catch (const std::exception &e)
+    {
         debugs(call.debugSection, 3,
                call.name << " threw exception: " << e.what());
+        if (!job.valid())
+        {
+            debugs(call.debugSection, DBG_CRITICAL,
+                   "BUG: job invalidated during " << call.name << " that threw exception: " << e.what());
+            return; // See also: Bug 4981, commit e3b6f15, and XXX in Http::Stream class description.
+        }
         job->callException(e);
     }
-
+    if (!job.valid())
+    {
+        debugs(call.debugSection, DBG_CRITICAL,
+               "BUG 4981: job invalidated during " << call.name);
+        return;
+    }
     job->callEnd(); // may delete job
 }
 
 #endif /* SQUID_ASYNCJOBCALLS_H */
-

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -176,14 +176,14 @@ JobDialer<Job>::dial(AsyncCall &call)
     } catch (const std::exception &e) {
         debugs(call.debugSection, 3,
                call.name << " threw exception: " << e.what());
-        if (!job.valid()) {
+        if (!job) {
             debugs(call.debugSection, DBG_CRITICAL,
                    "ERROR: Squid BUG: Job invalidated during " << call.name << " that threw exception: " << e.what());
             return; // See also: Bug 4981, commit e3b6f15, and XXX in Http::Stream class description.
         }
         job->callException(e);
     }
-    if (!job.valid()) {
+    if (!job) {
         debugs(call.debugSection, DBG_CRITICAL,
                "ERROR: Squid BUG 4981: Job invalidated during " << call.name);
         return;

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -177,16 +177,15 @@ JobDialer<Job>::dial(AsyncCall &call)
         debugs(call.debugSection, 3,
                call.name << " threw exception: " << e.what());
         if (!job) {
-            debugs(call.debugSection, DBG_CRITICAL,
-                   "ERROR: Squid BUG: Job invalidated during " << call.name << " that threw exception: " << e.what());
+            debugs(call.debugSection, DBG_CRITICAL, "ERROR: Squid BUG: Job invalidated during " <<
+                   call.name << " that threw exception: " << e.what());
             return; // See also: Bug 4981, commit e3b6f15, and XXX in Http::Stream class description.
         }
         job->callException(e);
     }
 
     if (!job) {
-        debugs(call.debugSection, DBG_CRITICAL,
-               "ERROR: Squid BUG 4981: Job invalidated during " << call.name);
+        debugs(call.debugSection, DBG_CRITICAL, "ERROR: Squid BUG 4981: Job invalidated during " << call.name);
         return;
     }
     job->callEnd(); // may delete job

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -178,14 +178,14 @@ JobDialer<Job>::dial(AsyncCall &call)
                call.name << " threw exception: " << e.what());
         if (!job.valid()) {
             debugs(call.debugSection, DBG_CRITICAL,
-                   "BUG: job invalidated during " << call.name << " that threw exception: " << e.what());
+                   "ERROR: Squid BUG: Job invalidated during " << call.name << " that threw exception: " << e.what());
             return; // See also: Bug 4981, commit e3b6f15, and XXX in Http::Stream class description.
         }
         job->callException(e);
     }
     if (!job.valid()) {
         debugs(call.debugSection, DBG_CRITICAL,
-               "BUG 4981: job invalidated during " << call.name);
+               "ERROR: Squid BUG 4981: Job invalidated during " << call.name);
         return;
     }
     job->callEnd(); // may delete job

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -177,7 +177,7 @@ JobDialer<Job>::dial(AsyncCall &call)
         debugs(call.debugSection, 3,
                call.name << " threw exception: " << e.what());
         if (!job) {
-            debugs(call.debugSection, DBG_CRITICAL, "ERROR: Squid BUG: Job invalidated during " <<
+            debugs(call.debugSection, 3, "ERROR: Squid BUG: Job invalidated during " <<
                    call.name << " that threw exception: " << e.what());
             return; // see also: bug 4981, commit e3b6f15, and XXX in Http::Stream class description
         }
@@ -185,7 +185,7 @@ JobDialer<Job>::dial(AsyncCall &call)
     }
 
     if (!job) {
-        debugs(call.debugSection, DBG_CRITICAL, "ERROR: Squid BUG 4981: Job invalidated during " << call.name);
+        debugs(call.debugSection, 3, "ERROR: Squid BUG: Job invalidated during " << call.name);
         return;
     }
     job->callEnd(); // may delete job

--- a/src/base/AsyncJobCalls.h
+++ b/src/base/AsyncJobCalls.h
@@ -183,6 +183,7 @@ JobDialer<Job>::dial(AsyncCall &call)
         }
         job->callException(e);
     }
+
     if (!job) {
         debugs(call.debugSection, DBG_CRITICAL,
                "ERROR: Squid BUG 4981: Job invalidated during " << call.name);
@@ -192,3 +193,4 @@ JobDialer<Job>::dial(AsyncCall &call)
 }
 
 #endif /* SQUID_ASYNCJOBCALLS_H */
+


### PR DESCRIPTION
Bug 4981 is one known case of such invalidation, but this workaround is
much broader than that bug context. We can speculate that architectural
problems described in commit e3b6f15 are behind (some of) these bugs.