### PR TITLE
Rewrite SplayNode to eliminate recursive calls

### DIFF
--- a/include/splay.h
+++ b/include/splay.h
@@ -24,7 +24,7 @@ public:
     Value data;
     mutable SplayNode<V> *left;
     mutable SplayNode<V> *right;
-    mutable SplayNode<V> *visit_thread_up;
+    mutable SplayNode<V> *visitThreadUp;
 
     SplayNode<V> const * start() const;
     SplayNode<V> const * finish() const;
@@ -92,7 +92,7 @@ private:
 SQUIDCEXTERN int splayLastResult;
 
 template<class V>
-SplayNode<V>::SplayNode(const Value &someData): data(someData), left(nullptr), right(nullptr), visit_thread_up(nullptr) {}
+SplayNode<V>::SplayNode(const Value &someData): data(someData), left(nullptr), right(nullptr), visitThreadUp(nullptr) {}
 
 template<class V>
 SplayNode<V> const *
@@ -235,7 +235,7 @@ Splay<V>::visitEach(Visitor &visitor) const
 {
     // In-order walk through tree using modified Morris Traversal: To avoid a
     // leftover thread up (and, therefore, a fatal loop in the tree) due to a
-    // visitor exception, we use an extra pointer visit_thread_up instead of
+    // visitor exception, we use an extra pointer visitThreadUp instead of
     // manipulating the right child link and interfering with other methods
     // that use that link.
     // This also helps to distinguish between up and down movements, eliminating
@@ -246,22 +246,22 @@ Splay<V>::visitEach(Visitor &visitor) const
         return;
 
     auto cur = head;
-    auto moved_up = false;
-    cur->visit_thread_up = nullptr;
+    auto movedUp = false;
+    cur->visitThreadUp = nullptr;
 
     while (cur) {
-        if (!cur->left || moved_up) {
+        if (!cur->left || movedUp) {
             // no (unvisited) left subtree, so handle current node ...
             const auto old = cur;
             if (cur->right) {
                 // ... and descent into right subtree
                 cur = cur->right;
-                moved_up = false;
+                movedUp = false;
             }
-            else if (cur->visit_thread_up) {
+            else if (cur->visitThreadUp) {
                 // ... or back up the thread
-                cur = cur->visit_thread_up;
-                moved_up = true;
+                cur = cur->visitThreadUp;
+                movedUp = true;
             } else {
                 // end of traversal
                 cur = nullptr;
@@ -274,15 +274,15 @@ Splay<V>::visitEach(Visitor &visitor) const
             // find right-most child in left tree
             auto rmc = cur->left;
             while (rmc->right) {
-                rmc->visit_thread_up = nullptr; // cleanup old threads on the way
+                rmc->visitThreadUp = nullptr; // cleanup old threads on the way
                 rmc = rmc->right;
             }
             // create thread up back to cur
-            rmc->visit_thread_up = cur;
+            rmc->visitThreadUp = cur;
 
             // finally descent into left subtree
             cur = cur->left;
-            moved_up = false;
+            movedUp = false;
         }
     }
 }

--- a/include/splay.h
+++ b/include/splay.h
@@ -359,14 +359,12 @@ template <class V>
 void
 Splay<V>:: destroy(SPLAYFREE *free_func)
 {
-    if (free_func) {
-        const auto destroyer = [free_func](SplayNode<V> *node) { free_func(node->data); delete node; };
-        visitEach(destroyer);
+    const auto destroyer = [free_func](SplayNode<V> *node) { free_func(node->data); delete node; };
+    visitEach(destroyer);
 
-        head = nullptr;
+    head = nullptr;
 
-        elements = 0;
-    }
+    elements = 0;
 }
 
 template <class V>

--- a/include/splay.h
+++ b/include/splay.h
@@ -81,7 +81,7 @@ private:
 
     /// internal left-to-right walk through all nodes
     // used by visit() and also by destroy()
-    template <typename NodeVisitor> void visitEach(NodeVisitor &);
+    template <typename NodeVisitor> void visitEach(NodeVisitor &) const;
 };
 
 SQUIDCEXTERN int splayLastResult;
@@ -228,7 +228,7 @@ SplayNode<V>::splay(FindValue const &dataToFind, int( * compare)(FindValue const
 template <class V>
 template <class Visitor>
 void
-Splay<V>::visitEach(Visitor &visitor)
+Splay<V>::visitEach(Visitor &visitor) const
 {
     // in-order walk through tree using modified Morris Traversal:
     // to avoid a left-over thread up due to an exception in this
@@ -291,9 +291,8 @@ template <class Visitor>
 void
 Splay<V>::visit(Visitor &visitor) const
 {
-    const auto internalVisitor = [&visitor](SplayNode<V> *node) { visitor(node->data); };
-    // we have to remove const-ness at this stage to use non-const visitEach
-    const_cast<Splay<V> *>(this)->visitEach(internalVisitor);
+    const auto internalVisitor = [&visitor](const SplayNode<V> *node) { visitor(node->data); };
+    visitEach(internalVisitor);
 }
 
 template <class V>

--- a/include/splay.h
+++ b/include/splay.h
@@ -240,7 +240,7 @@ Splay<V>::visitEach(Visitor &visitor) const
     // that use that link.
     // This also helps to distinguish between up and down movements, eliminating
     // the need to descent into left subtree a second time after traversing the
-    // thread to find the loop cut the thread.
+    // thread to find the loop and remove the temporary thread.
 
     if (!head)
         return;

--- a/include/splay.h
+++ b/include/splay.h
@@ -48,8 +48,10 @@ public:
     typedef V Value;
     typedef int SPLAYCMP(Value const &a, Value const &b);
     typedef void SPLAYFREE(Value &);
-    static void DefaultFree (Value &aValue) {delete aValue;}
     typedef const SplayConstIterator<V> const_iterator;
+
+    static void DefaultFree(Value &v) { delete v; }
+
     Splay():head(nullptr), elements (0) {}
 
     template <class FindValue> Value const *find (FindValue const &, int( * compare)(FindValue const &a, Value const &b)) const;
@@ -76,17 +78,17 @@ public:
     template <typename ValueVisitor> void visit(ValueVisitor &) const;
 
 private:
-    mutable SplayNode<V> * head;
-    size_t elements;
-
     /// left-to-right walk through all nodes
     template <typename NodeVisitor> void visitEach(NodeVisitor &) const;
+
+    mutable SplayNode<V> * head;
+    size_t elements;
 };
 
 SQUIDCEXTERN int splayLastResult;
 
 template<class V>
-SplayNode<V>::SplayNode (Value const &someData) : data(someData), left(nullptr), right(nullptr), visit_thread_up(nullptr) {}
+SplayNode<V>::SplayNode(const Value &someData): data(someData), left(nullptr), right(nullptr), visit_thread_up(nullptr) {}
 
 template<class V>
 SplayNode<V> const *
@@ -95,7 +97,6 @@ SplayNode<V>::start() const
     auto cur = this;
     while (cur->left)
         cur = cur->left;
-
     return cur;
 }
 
@@ -106,7 +107,6 @@ SplayNode<V>::finish() const
     auto cur = this;
     while (cur->right)
         cur = cur->right;
-
     return cur;
 }
 
@@ -238,17 +238,17 @@ Splay<V>::visitEach(Visitor &visitor) const
     // the need to descent into left subtree a second time after traversing the
     // thread to find the loop cut the thread.
 
-    if (head == nullptr)
+    if (!head)
         return;
 
     auto cur = head;
-    bool moved_up = false;
+    auto moved_up = false;
     cur->visit_thread_up = nullptr;
 
-    while (cur != nullptr) {
-        if (cur->left == nullptr or moved_up) {
+    while (cur) {
+        if (!cur->left || moved_up) {
             // no (unvisited) left subtree, so handle current node ...
-            auto old = cur;
+            const auto old = cur;
             if (cur->right) {
                 // ... and descent into right subtree
                 cur = cur->right;

--- a/include/splay.h
+++ b/include/splay.h
@@ -42,12 +42,16 @@ template <class V>
 class SplayConstIterator;
 
 template <class V>
+class SplayIterator;
+
+template <class V>
 class Splay
 {
 public:
     typedef V Value;
     typedef int SPLAYCMP(Value const &a, Value const &b);
     typedef void SPLAYFREE(Value &);
+    typedef SplayIterator<V> iterator;
     typedef const SplayConstIterator<V> const_iterator;
 
     static void DefaultFree(Value &v) { delete v; }

--- a/test-suite/splay.cc
+++ b/test-suite/splay.cc
@@ -136,8 +136,7 @@ main(int, char *[])
 
     {
         /* test void * splay containers */
-        Splay<void *> *top = new Splay<void *>();
-        top->insert(static_cast<void*>(new intnode(101)), compareintvoid);
+        const auto top = new Splay<void *>();
 
         for (int i = 0; i < 100; ++i) {
             intnode *I = (intnode *)xcalloc(sizeof(intnode), 1);
@@ -156,8 +155,7 @@ main(int, char *[])
     /* test typesafe splay containers */
     {
         /* intnode* */
-        Splay<intnode *> *safeTop = new Splay<intnode *>();
-        safeTop->insert(new intnode(101), compareint);
+        const auto safeTop = new Splay<intnode *>();
 
         for ( int i = 0; i < 100; ++i) {
             intnode *I;
@@ -173,8 +171,7 @@ main(int, char *[])
     }
     {
         /* intnode */
-        Splay<intnode> *safeTop = new Splay<intnode>();
-        safeTop->insert(101, compareintref);
+        const auto safeTop = new Splay<intnode>();
 
         for (int i = 0; i < 100; ++i) {
             intnode I;

--- a/test-suite/splay.cc
+++ b/test-suite/splay.cc
@@ -136,15 +136,13 @@ main(int, char *[])
 
     {
         /* test void * splay containers */
-        splayNode *top = nullptr;
+        Splay<void *> *top = new Splay<void *>();
+        top->insert(static_cast<void*>(new intnode(101)), compareintvoid);
 
         for (int i = 0; i < 100; ++i) {
             intnode *I = (intnode *)xcalloc(sizeof(intnode), 1);
             I->i = nextRandom();
-            if (top)
-                top = top->insert(I, compareintvoid);
-            else
-                top = new splayNode(static_cast<void*>(new intnode(101)));
+            top->insert(I, compareintvoid);
         }
 
         SplayCheck::BeginWalk();
@@ -158,13 +156,14 @@ main(int, char *[])
     /* test typesafe splay containers */
     {
         /* intnode* */
-        SplayNode<intnode *> *safeTop = new SplayNode<intnode *>(new intnode(101));
+        Splay<intnode *> *safeTop = new Splay<intnode *>();
+        safeTop->insert(new intnode(101), compareint);
 
         for ( int i = 0; i < 100; ++i) {
             intnode *I;
             I = new intnode;
             I->i = nextRandom();
-            safeTop = safeTop->insert(I, compareint);
+            safeTop->insert(I, compareint);
         }
 
         SplayCheck::BeginWalk();
@@ -174,12 +173,13 @@ main(int, char *[])
     }
     {
         /* intnode */
-        SplayNode<intnode> *safeTop = new SplayNode<intnode>(101);
+        Splay<intnode> *safeTop = new Splay<intnode>();
+        safeTop->insert(101, compareintref);
 
         for (int i = 0; i < 100; ++i) {
             intnode I;
             I.i = nextRandom();
-            safeTop = safeTop->insert(I, compareintref);
+            safeTop->insert(I, compareintref);
         }
 
         SplayCheck::BeginWalk();


### PR DESCRIPTION
Authored-by: Martin Grimm <magri@web.de>

Recursive method calls in SplayNode can lead to a stack overflow with
large (degenerate) trees, e.g. after creating a large dst acl from a
sorted ip list.
