### PR TITLE
ESI: Fix build [-Wsingle-bit-bitfield-constant-conversion]

### DIFF
--- a/src/esi/Context.h
+++ b/src/esi/Context.h
@@ -75,20 +75,20 @@ public:
     ClientHttpRequest *http;
 
     struct {
-        int passthrough:1;
-        int oktosend:1;
-        int finished:1;
+        unsigned int passthrough:1;
+        unsigned int oktosend:1;
+        unsigned int finished:1;
 
         /* an error has occurred, send full body replies
          * regardless. Note that we don't fail midstream
          * because we buffer until we can not fail
          */
-        int error:1;
+        unsigned int error:1;
 
-        int finishedtemplate:1; /* we've read the entire template */
-        int clientwantsdata:1; /* we need to satisfy a read request */
-        int kicked:1; /* note on reentering the kick routine */
-        int detached:1; /* our downstream has detached */
+        unsigned int finishedtemplate:1; /* we've read the entire template */
+        unsigned int clientwantsdata:1; /* we need to satisfy a read request */
+        unsigned int kicked:1; /* note on reentering the kick routine */
+        unsigned int detached:1; /* our downstream has detached */
     } flags;
 
     err_type errorpage; /* if we error what page to use */
@@ -123,7 +123,7 @@ public:
         ParserState();
         void freeResources();
         void popAll();
-        int parsing:1; /* libexpat is not reentrant on the same context */
+        unsigned int parsing:1; /* libexpat is not reentrant on the same context */
 
     private:
         bool inited_;

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -141,10 +141,10 @@ public:
     ESIElement::Pointer except;
 
     struct {
-        int attemptok:1; /* the attempt branch process correctly */
-        int exceptok:1; /* likewise */
-        int attemptfailed:1; /* The attempt branch failed */
-        int exceptfailed:1; /* the except branch failed */
+        unsigned int attemptok:1; /* the attempt branch process correctly */
+        unsigned int exceptok:1; /* likewise */
+        unsigned int attemptfailed:1; /* The attempt branch failed */
+        unsigned int exceptfailed:1; /* the except branch failed */
     } flags;
     void finish() override;
 

--- a/src/esi/Include.h
+++ b/src/esi/Include.h
@@ -47,9 +47,9 @@ public:
     void subRequestDone (ESIStreamContext::Pointer, bool);
 
     struct {
-        int onerrorcontinue:1; /* on error return zero data */
-        int failed:1; /* Failed to process completely */
-        int finished:1; /* Finished getting subrequest data */
+        unsigned int onerrorcontinue:1; /* on error return zero data */
+        unsigned int failed:1; /* Failed to process completely */
+        unsigned int finished:1; /* Finished getting subrequest data */
     } flags;
     ESIStreamContext::Pointer src;
     ESIStreamContext::Pointer alt;

--- a/src/esi/Literal.h
+++ b/src/esi/Literal.h
@@ -32,7 +32,7 @@ public:
     ESISegment::Pointer buffer;
 
     struct {
-        int donevars:1;
+        unsigned int donevars:1;
     } flags;
 
     ESIVarState *varState;

--- a/src/esi/Sequence.h
+++ b/src/esi/Sequence.h
@@ -40,7 +40,7 @@ public:
     size_t processedcount;
 
     struct {
-        int dovars:1; /* for esiVar */
+        unsigned int dovars:1; /* for esiVar */
     } flags;
     void finish() override;
 

--- a/src/esi/VarState.h
+++ b/src/esi/VarState.h
@@ -63,11 +63,11 @@ private:
     HttpHeader hdr;
 
     struct {
-        int language:1;
-        int cookie:1;
-        int host:1;
-        int referer:1;
-        int useragent:1;
+        unsigned int language:1;
+        unsigned int cookie:1;
+        unsigned int host:1;
+        unsigned int referer:1;
+        unsigned int useragent:1;
     } flags;
 
 public:


### PR DESCRIPTION
clang 16, the default on current fedora rawhide and centos stream 9,
complains about several ESI places:

    error: implicit truncation from 'int' to a one-bit wide bit-field
    changes value from 1 to -1
    [-Werror,-Wsingle-bit-bitfield-constant-conversion]

Turn 1-bit flags in ESI data structures from ints to unsigned ints to
avoid the problem.
