### PR TITLE
Remove dead "String debugging" code

### DIFF
--- a/src/SquidString.h
+++ b/src/SquidString.h
@@ -26,7 +26,7 @@ class String
 {
 
 public:
-    String();
+    String() = default;
     String(char const *);
     String(String const &);
     String(String && S) : size_(S.size_), len_(S.len_), buf_(S.buf_) {

--- a/src/String.cc
+++ b/src/String.cc
@@ -7,9 +7,8 @@
  */
 
 #include "squid.h"
-#include "base/TextException.h"
-#include "mgr/Registration.h"
-#include "Store.h"
+#include "mem/forward.h"
+#include "SquidString.h"
 
 #include <climits>
 
@@ -34,20 +33,10 @@ String::setBuffer(char *aBuf, String::size_type aSize)
     size_ = aSize;
 }
 
-String::String()
-{
-#if DEBUGSTRINGS
-    StringRegistry::Instance().add(this);
-#endif
-}
-
 String::String(char const *aString)
 {
     if (aString)
         allocAndFill(aString, strlen(aString));
-#if DEBUGSTRINGS
-    StringRegistry::Instance().add(this);
-#endif
 }
 
 String &
@@ -108,10 +97,6 @@ String::String(String const &old) : size_(0), len_(0), buf_(nullptr)
 {
     if (old.size() > 0)
         allocAndFill(old.rawBuf(), old.size());
-#if DEBUGSTRINGS
-
-    StringRegistry::Instance().add(this);
-#endif
 }
 
 void
@@ -131,10 +116,6 @@ String::clean()
 String::~String()
 {
     clean();
-#if DEBUGSTRINGS
-
-    StringRegistry::Instance().remove(this);
-#endif
 }
 
 void
@@ -300,66 +281,6 @@ String::caseCmp(char const *aString, String::size_type count) const
 
     return strncasecmp(termedBuf(), aString, count);
 }
-
-#if DEBUGSTRINGS
-void
-String::stat(StoreEntry *entry) const
-{
-    storeAppendPrintf(entry, "%p : %d/%d \"%.*s\"\n",this,len_, size_, size(), rawBuf());
-}
-
-StringRegistry &
-StringRegistry::Instance()
-{
-    return Instance_;
-}
-
-template <class C>
-int
-ptrcmp(C const &lhs, C const &rhs)
-{
-    return lhs - rhs;
-}
-
-StringRegistry::StringRegistry()
-{
-#if DEBUGSTRINGS
-    Mgr::RegisterAction("strings",
-                        "Strings in use in squid", Stat, 0, 1);
-#endif
-}
-
-void
-StringRegistry::add(String const *entry)
-{
-    entries.insert(entry, ptrcmp);
-}
-
-void
-StringRegistry::remove(String const *entry)
-{
-    entries.remove(entry, ptrcmp);
-}
-
-StringRegistry StringRegistry::Instance_;
-
-String::size_type memStringCount();
-
-void
-StringRegistry::Stat(StoreEntry *entry)
-{
-    storeAppendPrintf(entry, "%lu entries, %lu reported from MemPool\n", (unsigned long) Instance().entries.elements, (unsigned long) memStringCount());
-    Instance().entries.head->walk(Stater, entry);
-}
-
-void
-StringRegistry::Stater(String const * const & nodedata, void *state)
-{
-    StoreEntry *entry = (StoreEntry *) state;
-    nodedata->stat(entry);
-}
-
-#endif
 
 /* TODO: move onto String */
 int


### PR DESCRIPTION
The corresponding src/String.cc code does not build since 2013 commit
5082718 (at least): That commit removed StringRegistry class declaration
the debugging code relied on. Since inception, the code could not be
enabled using ./configure options or make flags -- one had to modify
Squid sources to alter hard-coded `#define DEBUGSTRINGS 0` setting.
