### PR TITLE
Remove Splay::walk() method

### DIFF
--- a/include/splay.h
+++ b/include/splay.h
@@ -28,7 +28,6 @@ public:
     mutable SplayNode<V> *left;
     mutable SplayNode<V> *right;
     void destroy(SPLAYFREE * = DefaultFree);
-    void walk(SPLAYWALKEE *, void *callerState);
     SplayNode<V> const * start() const;
     SplayNode<V> const * finish() const;
 
@@ -95,19 +94,6 @@ SQUIDCEXTERN int splayLastResult;
 
 template<class V>
 SplayNode<V>::SplayNode (Value const &someData) : data(someData), left(nullptr), right (nullptr) {}
-
-template<class V>
-void
-SplayNode<V>::walk(SPLAYWALKEE * walkee, void *state)
-{
-    if (left)
-        left->walk(walkee, state);
-
-    walkee(data, state);
-
-    if (right)
-        right->walk(walkee, state);
-}
 
 template<class V>
 SplayNode<V> const *

--- a/test-suite/splay.cc
+++ b/test-suite/splay.cc
@@ -54,9 +54,9 @@ public:
     static void BeginWalk();
     static int LastValue;
     static bool ExpectedFail;
-    static void WalkVoid(void *const &, void *);
-    static void WalkNode(intnode *const &, void *);
-    static void WalkNodeRef(intnode const &, void *);
+    static void VisitVoid(void *const &);
+    static void VisitNode(intnode *const &);
+    static void VisitNodeRef(intnode const &);
     static void CheckNode(intnode const &);
 };
 
@@ -70,7 +70,7 @@ SplayCheck::BeginWalk()
 }
 
 void
-SplayCheck::WalkVoid(void *const &node, void *)
+SplayCheck::VisitVoid(void *const &node)
 {
     intnode *A = (intnode *)node;
     CheckNode(*A);
@@ -93,13 +93,13 @@ SplayCheck::CheckNode(intnode const &A)
 }
 
 void
-SplayCheck::WalkNode (intnode *const &a, void *)
+SplayCheck::VisitNode(intnode *const &a)
 {
     CheckNode (*a);
 }
 
 void
-SplayCheck::WalkNodeRef (intnode const &a, void *)
+SplayCheck::VisitNodeRef(intnode const &a)
 {
     CheckNode (a);
 }
@@ -148,10 +148,10 @@ main(int, char *[])
         }
 
         SplayCheck::BeginWalk();
-        top->walk(SplayCheck::WalkVoid, nullptr);
+        top->visit(SplayCheck::VisitVoid);
 
         SplayCheck::BeginWalk();
-        top->walk(SplayCheck::WalkVoid, nullptr);
+        top->visit(SplayCheck::VisitVoid);
         top->destroy(destintvoid);
     }
 
@@ -168,7 +168,7 @@ main(int, char *[])
         }
 
         SplayCheck::BeginWalk();
-        safeTop->walk(SplayCheck::WalkNode, nullptr);
+        safeTop->visit(SplayCheck::VisitNode);
 
         safeTop->destroy(destint);
     }
@@ -183,7 +183,7 @@ main(int, char *[])
         }
 
         SplayCheck::BeginWalk();
-        safeTop->walk(SplayCheck::WalkNodeRef, nullptr);
+        safeTop->visit(SplayCheck::VisitNodeRef);
 
         safeTop->destroy(destintref);
     }
@@ -194,10 +194,10 @@ main(int, char *[])
         intnode I;
         I.i = 1;
         /* check we don't segfault on NULL splay calls */
-        SplayCheck::WalkNodeRef(I, nullptr);
+        SplayCheck::VisitNodeRef(I);
         I.i = 0;
         SplayCheck::ExpectedFail = true;
-        SplayCheck::WalkNodeRef(I, nullptr);
+        SplayCheck::VisitNodeRef(I);
     }
 
     {


### PR DESCRIPTION
Splay template class provided two traversal APIs: walk() and visit().
Primary code is only using visit(). Our tests were only testing walk().
