### PR TITLE
Fix: Compilation error due to possible string over-read in src/acl/BoolOps.cc

### DIFF
--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -16,7 +16,7 @@
 
 Acl::NotNode::NotNode(ACL *acl)
 {
-    assert(acl);
+    assert(acl && acl->name && *acl->name);
     Must(strlen(acl->name) <= sizeof(name)-2);
     name[0] = '!';
     name[1] = '\0';


### PR DESCRIPTION
While attempting to build the Squid package version 6.1-2 on a fresh Ubuntu Jammy environment, I encountered a compilation error in the src/acl/BoolOps.cc file. The issue is related to a potential string over-read as indicated by the following error message:

```bash
__builtin_strlen' reading 1 or more bytes from a region of size 0 [-Werror=stringop-overread]
Must(strlen(acl->name) <= sizeof(name)-2)
```

My build environment is Ubuntu 22.04 Jammy, with gcc-12. The sources were obtained directly from http://http.debian.net/debian/pool/main/s/squid and the package was built using 

```bash
dpkg-buildpackage -rfakeroot -b -us -uc.
```

I am not familiar with the codebase and my understanding of C++ is limited. However, to address the error, I tried to adjust the assert line in the Acl::NotNode::NotNode(ACL *acl) function as follows:

```c++
// From
assert(acl);
// To
assert(acl && acl->name && *acl->name);
```

I attempted to ensure that the strlen(acl->name) is not called when acl->name is a null pointer or an empty string, hopefully preventing the over-read error. The change seemed to resolve the compilation error in my local environment.

However, as I am not deeply familiar with the project, I would greatly appreciate any feedback or further guidance on whether this is an appropriate fix and the potential ramifications of this change.

Thank you for your time and consideration.