### PR TITLE
CI: More HTTP caching and revalidation tests

### DIFF
--- a/test-suite/test-functionality.sh
+++ b/test-suite/test-functionality.sh
@@ -215,7 +215,9 @@ main() {
         local default_tests="
             pconn
             proxy-update-headers-after-304
+            accumulate-headers-after-304
             upgrade-protocols
+            cache-response
             proxy-collapsed-forwarding
             busy-restart
             truncated-responses


### PR DESCRIPTION
Use Daft cache-response test to monitor for bugs in basic caching code,
including bugs like the one fixed by commit c203754. Unlike the old
proxy-collapsed-forwarding test that uses concurrent requests, this test
varies basic response properties.

Use Daft accumulate-headers-after-304 test to monitor for bugs like the
one fixed by commit 55e1c6e. Unlike old proxy-update-headers-after-304,
this test focuses on certain _problematic_ HTTP 304 header updates.
