### PR TITLE
Docs: Update all Squid Bugzilla URLs

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,7 @@ Please see the COPYING and CONTRIBUTORS files for details.
 For support, please use the following resources:
 
     * General help and support:  squid-users@lists.squid-cache.org
-    * Public bug reports:        http://bugs.squid-cache.org/
+    * Public bug reports:        https://bugs.squid-cache.org/
     * Security bug reports:      squid-bugs@lists.squid-cache.org
     * Development discussions:   squid-dev@lists.squid-cache.org
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AC_INIT([Squid Web Proxy],[7.0.0-VCS],[http://bugs.squid-cache.org/],[squid])
+AC_INIT([Squid Web Proxy],[7.0.0-VCS],[https://bugs.squid-cache.org/],[squid])
 AC_PREREQ(2.61)
 AC_CONFIG_HEADERS([include/autoconf.h])
 AC_CONFIG_AUX_DIR(cfgaux)

--- a/doc/manuals/ar.po
+++ b/doc/manuals/ar.po
@@ -749,7 +749,7 @@ msgstr ""
 #: src/security/cert_generators/file/security_file_certgen.8.in:169
 #: src/squid.8.in:263 tools/cachemgr.cgi.8.in:72 tools/purge/purge.1:278
 #: tools/squidclient/squidclient.1:254
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
 
 #. type: Plain text

--- a/doc/manuals/cs.po
+++ b/doc/manuals/cs.po
@@ -744,7 +744,7 @@ msgstr ""
 #: src/security/cert_generators/file/security_file_certgen.8.in:169
 #: src/squid.8.in:263 tools/cachemgr.cgi.8.in:72 tools/purge/purge.1:278
 #: tools/squidclient/squidclient.1:254
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
 
 #. type: Plain text

--- a/doc/manuals/de.po
+++ b/doc/manuals/de.po
@@ -756,8 +756,8 @@ msgstr ""
 #: src/security/cert_generators/file/security_file_certgen.8.in:169
 #: src/squid.8.in:263 tools/cachemgr.cgi.8.in:72 tools/purge/purge.1:278
 #: tools/squidclient/squidclient.1:254
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
-msgstr "Melden sie Bugs oder Bugfixes unter http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
+msgstr "Melden sie Bugs oder Bugfixes unter https://bugs.squid-cache.org/"
 
 #. type: Plain text
 #: src/acl/external/AD_group/ext_ad_group_acl.8:263

--- a/doc/manuals/en.po
+++ b/doc/manuals/en.po
@@ -795,8 +795,8 @@ msgstr ""
 #: src/security/cert_generators/file/security_file_certgen.8.in:169
 #: src/squid.8.in:263 tools/cachemgr.cgi.8.in:72 tools/purge/purge.1:278
 #: tools/squidclient/squidclient.1:254
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
-msgstr "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
+msgstr "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 
 #. type: Plain text
 #: src/acl/external/AD_group/ext_ad_group_acl.8:263

--- a/doc/manuals/en_AU.po
+++ b/doc/manuals/en_AU.po
@@ -751,8 +751,8 @@ msgstr ""
 #: src/security/cert_generators/file/security_file_certgen.8.in:169
 #: src/squid.8.in:263 tools/cachemgr.cgi.8.in:72 tools/purge/purge.1:278
 #: tools/squidclient/squidclient.1:254
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
-msgstr "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
+msgstr "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 
 #. type: Plain text
 #: src/acl/external/AD_group/ext_ad_group_acl.8:263

--- a/doc/manuals/es.po
+++ b/doc/manuals/es.po
@@ -1233,8 +1233,8 @@ msgstr ""
 
 #. type: Plain text
 #: helpers/basic_auth/getpwnam/basic_getpwnam_auth.8:88 helpers/basic_auth/LDAP/basic_ldap_auth.8:314 helpers/basic_auth/NCSA/basic_ncsa_auth.8:60 helpers/basic_auth/PAM/basic_pam_auth.8:102 helpers/basic_auth/RADIUS/basic_radius_auth.8:113 helpers/external_acl/ldap_group/squid_ldap_group.8:263 helpers/external_acl/session/squid_session.8:82 helpers/external_acl/unix_group/squid_unix_group.8:84 src/squid.8.in:253 tools/cachemgr.cgi.8.in:69 tools/squidclient.1:181
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
-msgstr "Notifique errores o parches usando http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
+msgstr "Notifique errores o parches usando https://bugs.squid-cache.org/"
 
 #. type: Plain text
 #: helpers/basic_auth/LDAP/basic_ldap_auth.8:241 helpers/external_acl/ldap_group/squid_ldap_group.8:82

--- a/doc/manuals/fr.po
+++ b/doc/manuals/fr.po
@@ -198,10 +198,10 @@ msgstr "RAPPORT de BUGS"
 
 #. type: Plain text
 #: helpers/basic_auth/getpwnam/basic_getpwnam_auth.8:85 helpers/basic_auth/LDAP/basic_ldap_auth.8:311 helpers/basic_auth/NCSA/basic_ncsa_auth.8:57 helpers/basic_auth/PAM/basic_pam_auth.8:99 helpers/basic_auth/RADIUS/basic_radius_auth.8:110 helpers/external_acl/ldap_group/squid_ldap_group.8:260 helpers/external_acl/session/squid_session.8:79 helpers/external_acl/unix_group/squid_unix_group.8:81 src/squid.8.in:250 tools/cachemgr.cgi.8.in:67 tools/squidclient.1:179
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
 "Pour signaler un bug ou une correction de bug utilisez "
-"http://bugs.squid-cache.org/"
+"https://bugs.squid-cache.org/"
 
 #. type: Plain text
 #: helpers/basic_auth/getpwnam/basic_getpwnam_auth.8:88 helpers/basic_auth/LDAP/basic_ldap_auth.8:314 helpers/basic_auth/NCSA/basic_ncsa_auth.8:60 helpers/basic_auth/PAM/basic_pam_auth.8:102 helpers/basic_auth/RADIUS/basic_radius_auth.8:113 helpers/external_acl/ldap_group/squid_ldap_group.8:263 helpers/external_acl/session/squid_session.8:82 helpers/external_acl/unix_group/squid_unix_group.8:84 src/squid.8.in:253 tools/cachemgr.cgi.8.in:70 tools/squidclient.1:182

--- a/doc/manuals/it.po
+++ b/doc/manuals/it.po
@@ -196,9 +196,9 @@ msgstr "SEGNALAZIONE BUGS"
 
 #. type: Plain text
 #: helpers/basic_auth/getpwnam/basic_getpwnam_auth.8:85 helpers/basic_auth/LDAP/basic_ldap_auth.8:311 helpers/basic_auth/NCSA/basic_ncsa_auth.8:57 helpers/basic_auth/PAM/basic_pam_auth.8:99 helpers/basic_auth/RADIUS/basic_radius_auth.8:110 helpers/external_acl/ldap_group/squid_ldap_group.8:260 helpers/external_acl/session/squid_session.8:79 helpers/external_acl/unix_group/squid_unix_group.8:81 src/squid.8.in:250 tools/cachemgr.cgi.8.in:67 tools/squidclient.1:179
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
-"Per segnalare bug o proporre codice o migliorie si può usare http://bugs"
+"Per segnalare bug o proporre codice o migliorie si può usare https://bugs"
 ".squid-cache.org/"
 
 #. type: Plain text

--- a/doc/manuals/manuals.pot
+++ b/doc/manuals/manuals.pot
@@ -365,7 +365,7 @@ msgstr ""
 
 #. type: Plain text
 #: src/acl/external/AD_group/ext_ad_group_acl.8:260 src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.8:224 src/acl/external/file_userip/ext_file_userip_acl.8:103 src/acl/external/kerberos_ldap_group/ext_kerberos_ldap_group_acl.8:247 src/acl/external/LDAP_group/ext_ldap_group_acl.8:268 src/acl/external/LM_group/ext_lm_group_acl.8:192 src/acl/external/session/ext_session_acl.8:122 src/acl/external/time_quota/ext_time_quota_acl.8:240 src/acl/external/unix_group/ext_unix_group_acl.8:95 src/auth/basic/getpwnam/basic_getpwnam_auth.8:97 src/auth/basic/LDAP/basic_ldap_auth.8:331 src/auth/basic/NCSA/basic_ncsa_auth.8:87 src/auth/basic/PAM/basic_pam_auth.8:107 src/auth/basic/RADIUS/basic_radius_auth.8:122 src/auth/basic/SASL/basic_sasl_auth.8:103 src/auth/basic/SSPI/basic_sspi_auth.8:157 src/auth/digest/file/digest_file_auth.8:94 src/auth/negotiate/kerberos/negotiate_kerberos_auth.8:123 src/auth/negotiate/SSPI/negotiate_sspi_auth.8:96 src/auth/ntlm/SSPI/ntlm_sspi_auth.8:124 src/security/cert_generators/file/security_file_certgen.8.in:169 src/squid.8.in:263 tools/cachemgr.cgi.8.in:72 tools/purge/purge.1:278 tools/squidclient/squidclient.1:254
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
 
 #. type: Plain text

--- a/doc/manuals/oc.po
+++ b/doc/manuals/oc.po
@@ -191,7 +191,7 @@ msgstr ""
 
 #. type: Plain text
 #: helpers/basic_auth/getpwnam/basic_getpwnam_auth.8:88 helpers/basic_auth/LDAP/basic_ldap_auth.8:314 helpers/basic_auth/NCSA/basic_ncsa_auth.8:60 helpers/basic_auth/PAM/basic_pam_auth.8:102 helpers/basic_auth/RADIUS/basic_radius_auth.8:113 helpers/external_acl/ldap_group/squid_ldap_group.8:263 helpers/external_acl/session/squid_session.8:82 helpers/external_acl/unix_group/squid_unix_group.8:84 src/squid.8.in:253 tools/cachemgr.cgi.8.in:69 tools/squidclient.1:181
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
 
 #. type: Plain text

--- a/doc/manuals/ro.po
+++ b/doc/manuals/ro.po
@@ -175,7 +175,7 @@ msgstr ""
 
 #. type: Plain text
 #: helpers/basic_auth/getpwnam/basic_getpwnam_auth.8:85 helpers/basic_auth/LDAP/basic_ldap_auth.8:311 helpers/basic_auth/NCSA/basic_ncsa_auth.8:57 helpers/basic_auth/PAM/basic_pam_auth.8:99 helpers/basic_auth/RADIUS/basic_radius_auth.8:110 helpers/external_acl/ldap_group/squid_ldap_group.8:260 helpers/external_acl/session/squid_session.8:79 helpers/external_acl/unix_group/squid_unix_group.8:81 src/squid.8.in:250 tools/cachemgr.cgi.8.in:67 tools/squidclient.1:179
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
 
 #. type: Plain text

--- a/doc/manuals/ru.po
+++ b/doc/manuals/ru.po
@@ -757,9 +757,9 @@ msgstr ""
 #: src/security/cert_generators/file/security_file_certgen.8.in:169
 #: src/squid.8.in:263 tools/cachemgr.cgi.8.in:72 tools/purge/purge.1:278
 #: tools/squidclient/squidclient.1:254
-msgid "Report bugs or bug fixes using http://bugs.squid-cache.org/"
+msgid "Report bugs or bug fixes using https://bugs.squid-cache.org/"
 msgstr ""
-"Сообщите об ошибках или их исправлениях используя http://bugs.squid-cache."
+"Сообщите об ошибках или их исправлениях используя https://bugs.squid-cache."
 "org/"
 
 #. type: Plain text

--- a/doc/release-notes/release-3.0.sgml
+++ b/doc/release-notes/release-3.0.sgml
@@ -24,7 +24,7 @@ report with a stack trace.
 
 <sect>Known issues
 <p>
-Although this release is deemed good enough for use in many setups, please note the existence of <url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;short_desc_type=allwordssubstr&amp;short_desc=&amp;target_milestone=3.0&amp;long_desc_type=allwordssubstr&amp;long_desc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailtype1=substring&amp;email1=&amp;emailtype2=substring&amp;email2=&amp;bugidtype=include&amp;bug_id=&amp;votes=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=bugs.bug_severity&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=" name="open bugs against Squid-3.0">.
+Although this release is deemed good enough for use in many setups, please note the existence of <url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;short_desc_type=allwordssubstr&amp;short_desc=&amp;target_milestone=3.0&amp;long_desc_type=allwordssubstr&amp;long_desc=&amp;bug_file_loc_type=allwordssubstr&amp;bug_file_loc=&amp;status_whiteboard_type=allwordssubstr&amp;status_whiteboard=&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;emailtype1=substring&amp;email1=&amp;emailtype2=substring&amp;email2=&amp;bugidtype=include&amp;bug_id=&amp;votes=&amp;chfieldfrom=&amp;chfieldto=Now&amp;chfieldvalue=&amp;cmdtype=doit&amp;order=bugs.bug_severity&amp;field0-0-0=noop&amp;type0-0-0=noop&amp;value0-0-0=" name="open bugs against Squid-3.0">.
 
 <sect>Changes since earlier STABLE releases of Squid-3.0
 <p>

--- a/doc/release-notes/release-3.1.sgml
+++ b/doc/release-notes/release-3.1.sgml
@@ -25,7 +25,7 @@ We welcome feedback and bug reports. If you find a new bug, please see <url url=
 <sect1>Known issues
 <p>
 Although this release is deemed good enough for use in many setups, please note the existence of 
-<url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;target_milestone=3.1&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;cmdtype=doit&amp;order=bugs.bug_severity" name="open bugs against Squid-3.1">.
+<url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;target_milestone=3.1&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;cmdtype=doit&amp;order=bugs.bug_severity" name="open bugs against Squid-3.1">.
 
 <p>Some issues to note as currently known in this release which are not able to be fixed in the 3.1 series are:
 

--- a/doc/release-notes/release-3.2.sgml
+++ b/doc/release-notes/release-3.2.sgml
@@ -27,7 +27,7 @@ report with a stack trace.
 <sect1>Known issues
 <p>
 Although this release is deemed good enough for use in many setups, please note the existence of 
-<url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.2" name="open bugs against Squid-3.2">.
+<url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.2" name="open bugs against Squid-3.2">.
 
 <p>Some issues to note as currently known in this release which are not able to be fixed in the 3.2 series are:
 

--- a/doc/release-notes/release-3.3.sgml
+++ b/doc/release-notes/release-3.3.sgml
@@ -27,7 +27,7 @@ While this release is not fully bug-free we believe it is ready for use in produ
 <sect1>Known issues
 <p>
 Although this release is deemed good enough for use in many setups, please note the existence of 
-<url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.3" name="open bugs against Squid-3.3">.
+<url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.3" name="open bugs against Squid-3.3">.
 
 
 <sect1>Changes since earlier releases of Squid-3.3

--- a/doc/release-notes/release-3.4.sgml
+++ b/doc/release-notes/release-3.4.sgml
@@ -27,7 +27,7 @@ This new release is available for download from <url url="http://www.squid-cache
 <sect1>Known issues
 <p>
 Although this release is deemed good enough for use in many setups, please note the existence of 
-<url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.4" name="open bugs against Squid-3.4">.
+<url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.4" name="open bugs against Squid-3.4">.
 
 <sect1>Changes since earlier releases of Squid-3.4
 <p>

--- a/doc/release-notes/release-3.5.sgml
+++ b/doc/release-notes/release-3.5.sgml
@@ -27,7 +27,7 @@ This new release is available for download from <url url="http://www.squid-cache
 <sect1>Known issues
 <p>
 Although this release is deemed good enough for use in many setups, please note the existence of 
-<url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.5" name="open bugs against Squid-3.5">.
+<url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=3.5" name="open bugs against Squid-3.5">.
 
 <sect1>Changes since earlier releases of Squid-3.5
 <p>

--- a/doc/release-notes/release-4.sgml
+++ b/doc/release-notes/release-4.sgml
@@ -22,7 +22,7 @@ This new release is available for download from <url url="http://www.squid-cache
 
 <sect1>Known issues
 <p>Although this release is deemed good enough for use in production, please note the existence of
-   <url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=4" name="open bugs against Squid-4">.
+   <url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=4" name="open bugs against Squid-4">.
 
 <p>This release adds a dependency on C++11 support in any compiler used to build Squid.
   As a result older C++03 -only and most C++0x compilers will no longer build successfully.

--- a/doc/release-notes/release-6.sgml.in
+++ b/doc/release-notes/release-6.sgml.in
@@ -18,7 +18,7 @@ This new release is available for download from <url url="http://www.squid-cache
 
 <sect1>Known issues
 <p>Although this release is deemed good enough for use in many setups, please note the existence of
-<url url="http://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=@SQUID_RELEASE@" name="open bugs against Squid-@SQUID_RELEASE@">.
+<url url="https://bugs.squid-cache.org/buglist.cgi?query_format=advanced&amp;product=Squid&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;version=@SQUID_RELEASE@" name="open bugs against Squid-@SQUID_RELEASE@">.
 
 <p>Support for compiling on HPUX with the native HP <em>xcc</em> compiler has been removed.
   To build on that OS/compiler combination, it is possible to pass these environment variables

--- a/src/acl/external/AD_group/ext_ad_group_acl.8
+++ b/src/acl/external/AD_group/ext_ad_group_acl.8
@@ -256,7 +256,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/LDAP_group/ext_ldap_group_acl.8
+++ b/src/acl/external/LDAP_group/ext_ldap_group_acl.8
@@ -264,7 +264,7 @@ LDAP than Squid.
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/LM_group/ext_lm_group_acl.8
+++ b/src/acl/external/LM_group/ext_lm_group_acl.8
@@ -188,7 +188,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/SQL_session/ext_sql_session_acl.pl.in
+++ b/src/acl/external/SQL_session/ext_sql_session_acl.pl.in
@@ -101,7 +101,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/acl/external/delayer/ext_delayer_acl.pl.in
+++ b/src/acl/external/delayer/ext_delayer_acl.pl.in
@@ -95,7 +95,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.8
+++ b/src/acl/external/eDirectory_userip/ext_edirectory_userip_acl.8
@@ -220,7 +220,7 @@ your servers are properly synchronizing partitions.
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/file_userip/ext_file_userip_acl.8
+++ b/src/acl/external/file_userip/ext_file_userip_acl.8
@@ -99,7 +99,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/kerberos_sid_group/ext_kerberos_sid_group_acl.pl.in
+++ b/src/acl/external/kerberos_sid_group/ext_kerberos_sid_group_acl.pl.in
@@ -99,7 +99,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/acl/external/session/ext_session_acl.8
+++ b/src/acl/external/session/ext_session_acl.8
@@ -118,7 +118,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/time_quota/ext_time_quota_acl.8
+++ b/src/acl/external/time_quota/ext_time_quota_acl.8
@@ -236,7 +236,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/unix_group/ext_unix_group_acl.8
+++ b/src/acl/external/unix_group/ext_unix_group_acl.8
@@ -91,7 +91,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/acl/external/wbinfo_group/ext_wbinfo_group_acl.pl.in
+++ b/src/acl/external/wbinfo_group/ext_wbinfo_group_acl.pl.in
@@ -82,7 +82,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/auth/basic/DB/basic_db_auth.pl.in
+++ b/src/auth/basic/DB/basic_db_auth.pl.in
@@ -113,7 +113,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/auth/basic/LDAP/basic_ldap_auth.8
+++ b/src/auth/basic/LDAP/basic_ldap_auth.8
@@ -327,7 +327,7 @@ LDAP than Squid.
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/basic/NCSA/basic_ncsa_auth.8
+++ b/src/auth/basic/NCSA/basic_ncsa_auth.8
@@ -83,7 +83,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/basic/PAM/basic_pam_auth.8
+++ b/src/auth/basic/PAM/basic_pam_auth.8
@@ -103,7 +103,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/basic/POP3/basic_pop3_auth.pl.in
+++ b/src/auth/basic/POP3/basic_pop3_auth.pl.in
@@ -65,7 +65,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/auth/basic/RADIUS/basic_radius_auth.8
+++ b/src/auth/basic/RADIUS/basic_radius_auth.8
@@ -118,7 +118,7 @@ RADIUS than Squid.
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/basic/SASL/basic_sasl_auth.8
+++ b/src/auth/basic/SASL/basic_sasl_auth.8
@@ -99,7 +99,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/basic/SSPI/basic_sspi_auth.8
+++ b/src/auth/basic/SSPI/basic_sspi_auth.8
@@ -153,7 +153,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/basic/getpwnam/basic_getpwnam_auth.8
+++ b/src/auth/basic/getpwnam/basic_getpwnam_auth.8
@@ -93,7 +93,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/digest/file/digest_file_auth.8
+++ b/src/auth/digest/file/digest_file_auth.8
@@ -90,7 +90,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/negotiate/SSPI/negotiate_sspi_auth.8
+++ b/src/auth/negotiate/SSPI/negotiate_sspi_auth.8
@@ -92,7 +92,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/auth/ntlm/SSPI/ntlm_sspi_auth.8
+++ b/src/auth/ntlm/SSPI/ntlm_sspi_auth.8
@@ -120,7 +120,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/base/File.cc
+++ b/src/base/File.cc
@@ -106,7 +106,7 @@ FileOpeningConfig::createdIfMissing()
 // XXX: fcntl() locks are incompatible with complex applications that may lock
 // multiple open descriptors corresponding to the same underlying file. There is
 // nothing better on Solaris, but do not be tempted to use this elsewhere. For
-// more info, see http://bugs.squid-cache.org/show_bug.cgi?id=4212#c14
+// more info, see https://bugs.squid-cache.org/show_bug.cgi?id=4212#c14
 /// fcntl(... struct flock) convenience wrapper
 static int
 fcntlLock(const int fd, const short lockType)

--- a/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
+++ b/src/http/url_rewriters/LFS/url_lfs_rewrite.pl.in
@@ -105,7 +105,7 @@ First Version: 26. May 1997
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/log/DB/log_db_daemon.pl.in
+++ b/src/log/DB/log_db_daemon.pl.in
@@ -309,7 +309,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/security/cert_generators/file/security_file_certgen.8.in
+++ b/src/security/cert_generators/file/security_file_certgen.8.in
@@ -172,7 +172,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/security/cert_validators/fake/security_fake_certverify.pl.in
+++ b/src/security/cert_validators/fake/security_fake_certverify.pl.in
@@ -67,7 +67,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/src/squid.8.in
+++ b/src/squid.8.in
@@ -271,7 +271,7 @@ Questions on the usage of this program can be sent to the
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/src/store/id_rewriters/file/storeid_file_rewrite.pl.in
+++ b/src/store/id_rewriters/file/storeid_file_rewrite.pl.in
@@ -76,7 +76,7 @@ Questions on the usage of this program can be sent to the I<Squid Users mailing 
 Bug reports need to be made in English.
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 
 Report serious security bugs to I<Squid Bugs <squid-bugs@lists.squid-cache.org>>
 

--- a/tools/cachemgr.cgi.8.in
+++ b/tools/cachemgr.cgi.8.in
@@ -68,7 +68,7 @@ Questions on the usage of this program can be sent to the
 .SH REPORTING BUGS
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/tools/purge/purge.1
+++ b/tools/purge/purge.1
@@ -274,7 +274,7 @@ Questions on the usage of this program can be sent to the
 .SH REPORTING BUGS
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>

--- a/tools/squidclient/squidclient.1
+++ b/tools/squidclient/squidclient.1
@@ -250,7 +250,7 @@ Questions on the usage of this program can be sent to the
 .SH REPORTING BUGS
 See http://wiki.squid-cache.org/SquidFaq/BugReporting for details of what you need to include with your bug report.
 .PP
-Report bugs or bug fixes using http://bugs.squid-cache.org/
+Report bugs or bug fixes using https://bugs.squid-cache.org/
 .PP
 Report serious security bugs to
 .I Squid Bugs <squid-bugs@lists.squid-cache.org>


### PR DESCRIPTION
The Squid Bugzilla now uses https:// instead of http://