### PR TITLE
Fix cbdata assertion in carpInit()

### DIFF
--- a/src/carp.cc
+++ b/src/carp.cc
@@ -59,9 +59,6 @@ carpInit(void)
 
     RawCachePeers rawCarpPeers;
     for (auto p = Config.peers; p; p = p->next) {
-        if (!cbdataReferenceValid(p))
-            continue;
-
         if (!p->options.carp)
             continue;
 


### PR DESCRIPTION
... after commit e7959b5

    FATAL: assertion failed: cbdata.cc:276: "c->locks > 0"

We cannot test cbdata validity of CachePeer pointers stored in
Config.peers because Config.peers own CachePeer objects. By definition,
owners should not lock their objects and do not need to test object
validity: Owners determine the lifetime of those objects! Naturally,
unlocked objects must not be tested for validity by others because to
test an object validity one has to have a lock that preserves object
metadata even after the object is invalidated (by its owner).
