### PR TITLE
Add tls_outgoing_options_for_retries

### DIFF
--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -59,6 +59,12 @@ CachePeer::~CachePeer()
     xfree(domain);
 }
 
+Security::FuturePeerContextPointer
+CachePeer::peerContext()
+{
+    return new Security::FuturePeerContext(secure, sslContext);
+}
+
 void
 CachePeer::noteSuccess()
 {

--- a/src/CachePeer.cc
+++ b/src/CachePeer.cc
@@ -62,7 +62,9 @@ CachePeer::~CachePeer()
 Security::FuturePeerContextPointer
 CachePeer::peerContext()
 {
-    return new Security::FuturePeerContext(secure, sslContext);
+    if (secure.encryptTransport)
+        return new Security::FuturePeerContext(secure, sslContext);
+    return nullptr;
 }
 
 void

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -48,6 +48,8 @@ public:
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
+    Security::FuturePeerContextPointer peerContext();
+
     u_int index = 0;
 
     /// cache_peer name (if explicitly configured) or hostname (otherwise).

--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -48,6 +48,7 @@ public:
     /// \returns the effective connect timeout for the given peer
     time_t connectTimeout() const;
 
+    /// TLS settings for communicating with this TLS cache_peer (or nil)
     Security::FuturePeerContextPointer peerContext();
 
     u_int index = 0;

--- a/src/ConfigOption.h
+++ b/src/ConfigOption.h
@@ -24,21 +24,32 @@ namespace Configuration {
 /// (i.e. the Config objects and similar/related global state). To facilitate
 /// reuse, implementations/specializations should also be independent from any
 /// specific configuration directive name and its squid.conf location.
-///
-/// TODO: Support multi-directive components of various kinds.
 template <class T>
 class Component
 {
 public:
-    /* the code adding "TYPE: T" to cf.data.pre must specialize these */
+    /* code adding "REPETITIONS: banned" to cf.data.pre must specialize these */
 
     /// creates a new T instance using the given parser; never returns nil
     static T Parse(ConfigParser &);
 
-    /// reports the current T instance configuration in squid.conf format
+    /// reports configuration parameters of the given T instance in squid.conf format
     static void Print(std::ostream &, const T &);
 
-    /// destroys Parse() result
+    /* code adding "REPETITIONS: update" to cf.data.pre must specialize these */
+
+    /// creates a new T instance for one or more ParseAndUpdate() calls
+    static T Create();
+
+    /// parses the first and any subsequent directive occurrence, updating T
+    static void ParseAndUpdate(T &, ConfigParser &);
+
+    /// reports the given T instance configuration in squid.conf format
+    static void PrintDirectives(std::ostream &, const T &, const char *directiveName);
+
+    /* code adding "TYPE: T" to cf.data.pre must specialize this */
+
+    /// destroys Parse() or Create() result
     static void Free(T);
 };
 

--- a/src/ConfigOption.h
+++ b/src/ConfigOption.h
@@ -44,8 +44,9 @@ public:
     /// parses the first and any subsequent directive occurrence, updating T
     static void ParseAndUpdate(T &, ConfigParser &);
 
+    // TODO: Upgrade to std::ostream after upgrading Security::PeerOptions::dumpCfg()
     /// reports the given T instance configuration in squid.conf format
-    static void PrintDirectives(std::ostream &, const T &, const char *directiveName);
+    static void PrintDirectives(StoreEntry *, const T &, const char *directiveName);
 
     /* code adding "TYPE: T" to cf.data.pre must specialize this */
 

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -511,6 +511,16 @@ FwdState::reactToSecureConnectFailure()
         return;
     }
 
+    if (const auto cachePeer = destinationReceipt->getPeer()) {
+        if (cachePeer->secure.encryptTransport) {
+            debugs(17, 5, "will not retry a connection to TLS cache_peer: " << destinationReceipt);
+            return;
+        }
+        // else: ERR_SECURE_CONNECT_FAIL implies that we were just tunneling
+        // through a plain-text cache_peer to a TLS origin server and may need
+        // to retry that TLS connection to the origin server with new options.
+    }
+
     if (destinationReceipt.tlsContext()) {
         debugs(17, 3, "will not retry twice: " << destinationReceipt);
         return;

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1034,7 +1034,7 @@ FwdState::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
     HttpRequest::Pointer requestPointer = request;
     const auto callback = asyncCallback(17, 4, FwdState::connectedToPeer, this);
     const auto sslNegotiationTimeout = connectingTimeout(conn);
-    auto &tlsOptions = destinationReceipt.tlsContext();
+    const auto &tlsOptions = destinationReceipt.tlsContext();
     Security::PeerConnector *connector = nullptr;
 #if USE_OPENSSL
     if (request->flags.sslPeek)

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -1044,7 +1044,7 @@ FwdState::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
     HttpRequest::Pointer requestPointer = request;
     const auto callback = asyncCallback(17, 4, FwdState::connectedToPeer, this);
     const auto sslNegotiationTimeout = connectingTimeout(conn);
-    const auto &tlsContext = MakeFuture(destinationReceipt.tlsContext());
+    const auto &tlsContext = PassThroughFuture(destinationReceipt.tlsContext());
     Security::PeerConnector *connector = nullptr;
 #if USE_OPENSSL
     if (request->flags.sslPeek)

--- a/src/FwdState.cc
+++ b/src/FwdState.cc
@@ -499,7 +499,7 @@ FwdState::reactToZeroSizeObject()
     }
 }
 
-/// ERR_SECURE_CONNECT_FAIL requires special adjustments
+/// ERR_SECURE_CONNECT_FAIL may require special adjustments
 void
 FwdState::reactToSecureConnectFailure()
 {
@@ -1044,14 +1044,14 @@ FwdState::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
     HttpRequest::Pointer requestPointer = request;
     const auto callback = asyncCallback(17, 4, FwdState::connectedToPeer, this);
     const auto sslNegotiationTimeout = connectingTimeout(conn);
-    const auto &tlsOptions = destinationReceipt.tlsContext();
+    const auto &tlsContext = MakeFuture(destinationReceipt.tlsContext());
     Security::PeerConnector *connector = nullptr;
 #if USE_OPENSSL
     if (request->flags.sslPeek)
-        connector = new Ssl::PeekingPeerConnector(requestPointer, conn, MakeFuture(tlsOptions), clientConn, callback, al, sslNegotiationTimeout);
+        connector = new Ssl::PeekingPeerConnector(requestPointer, conn, tlsContext, clientConn, callback, al, sslNegotiationTimeout);
     else
 #endif
-        connector = new Security::BlindPeerConnector(requestPointer, conn, MakeFuture(tlsOptions), callback, al, sslNegotiationTimeout);
+        connector = new Security::BlindPeerConnector(requestPointer, conn, tlsContext, callback, al, sslNegotiationTimeout);
     connector->noteFwdPconnUse = true;
     encryptionWait.start(connector, callback);
 }

--- a/src/FwdState.h
+++ b/src/FwdState.h
@@ -161,6 +161,7 @@ private:
 
     void notifyConnOpener();
     void reactToZeroSizeObject();
+    void reactToSecureConnectFailure();
 
     void updateAleWithFinalError();
 

--- a/src/PeerPoolMgr.cc
+++ b/src/PeerPoolMgr.cc
@@ -102,7 +102,7 @@ PeerPoolMgr::handleOpenedConnection(const CommConnectCbParams &params)
         const int timeUsed = squid_curtime - params.conn->startTime();
         // Use positive timeout when less than one second is left for conn.
         const int timeLeft = positiveTimeout(peerTimeout - timeUsed);
-        const auto connector = new Security::BlindPeerConnector(request, params.conn, callback, nullptr, timeLeft);
+        const auto connector = new Security::BlindPeerConnector(request, params.conn, nullptr, callback, nullptr, timeLeft);
         encryptionWait.start(connector, callback);
         return;
     }

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -28,12 +28,10 @@ ResolvedPeers::reinstatePath(const PeerConnectionPointer &path)
     const auto pos = path.position_;
     assert(pos < paths_.size());
 
-    // XXX: Undo out-of-scope refactoring in this method
-    auto &storedPath = paths_[pos];
-    assert(!storedPath.available);
-    storedPath.available = true;
+    assert(!paths_[pos].available);
+    paths_[pos].available = true;
     increaseAvailability();
-    // the other reinstatePath() method updates storedPath.tlsContext
+    // this reinstatePath() variation preserves paths_[pos].tlsContext
 
     // if we restored availability of a path that we used to skip, update
     const auto pathsToTheLeft = pos;

--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -33,7 +33,7 @@ ResolvedPeers::reinstatePath(const PeerConnectionPointer &path)
     assert(!storedPath.available);
     storedPath.available = true;
     increaseAvailability();
-    // the other reinstatePath() method updates storedPath.tlsOptions
+    // the other reinstatePath() method updates storedPath.tlsContext
 
     // if we restored availability of a path that we used to skip, update
     const auto pathsToTheLeft = pos;
@@ -46,10 +46,10 @@ ResolvedPeers::reinstatePath(const PeerConnectionPointer &path)
 }
 
 void
-ResolvedPeers::reinstatePath(const PeerConnectionPointer &path, const Security::PeerOptionsPointer &tlsOptions)
+ResolvedPeers::reinstatePath(const PeerConnectionPointer &path, const Security::PeerContextPointer &tlsContext)
 {
     reinstatePath(path);
-    paths_[path.position_].tlsOptions = tlsOptions;
+    paths_[path.position_].tlsContext = tlsContext;
 }
 
 void
@@ -162,7 +162,7 @@ ResolvedPeers::extractFound(const char *description, const Paths::iterator &foun
     }
 
     const auto cleanPath = path.connection->cloneProfile();
-    return PeerConnectionPointer(cleanPath, found - paths_.begin(), path.tlsOptions);
+    return PeerConnectionPointer(cleanPath, found - paths_.begin(), path.tlsContext);
 }
 
 bool
@@ -246,7 +246,7 @@ PeerConnectionPointer::print(std::ostream &os) const
     if (connection_)
         os << connection_;
 
-    if (tlsOptions_)
+    if (tlsContext_)
         os << " +tls";
 
     if (position_ != npos)

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -22,7 +22,7 @@ public:
     explicit ResolvedPeerPath(const Comm::ConnectionPointer &conn): connection(conn) {}
 
     Comm::ConnectionPointer connection; ///< (the address of) a path
-    Security::PeerOptionsPointer tlsOptions; ///< custom TLS session options (or nil)
+    Security::PeerContextPointer tlsContext; ///< custom TLS session options (or nil)
     bool available = true; ///< whether this path may be extracted
 };
 
@@ -54,7 +54,7 @@ public:
 
     /// makes the previously extracted path available for extraction at its
     /// original position and resets TLS parameters to use for that path
-    void reinstatePath(const PeerConnectionPointer &, const Security::PeerOptionsPointer &tlsOptions);
+    void reinstatePath(const PeerConnectionPointer &, const Security::PeerContextPointer &tlsContext);
 
     /// extracts and returns the first queued address
     PeerConnectionPointer extractFront();
@@ -129,7 +129,7 @@ public:
 
     PeerConnectionPointer() = default;
     PeerConnectionPointer(std::nullptr_t): PeerConnectionPointer() {} ///< implicit nullptr conversion
-    PeerConnectionPointer(const Comm::ConnectionPointer &conn, const size_type pos, const Security::PeerOptionsPointer &tlsParameters): connection_(conn), position_(pos), tlsOptions_(tlsParameters) {}
+    PeerConnectionPointer(const Comm::ConnectionPointer &conn, const size_type pos, const Security::PeerContextPointer &tlsParameters): connection_(conn), position_(pos), tlsContext_(tlsParameters) {}
 
     /* read-only pointer API; for Connection assignment, see finalize() */
     explicit operator bool() const { return static_cast<bool>(connection_); }
@@ -140,7 +140,7 @@ public:
     operator const Comm::ConnectionPointer&() const { return connection_; }
 
     /// custom TLS session options (or nil)
-    auto &tlsOptions() const { return tlsOptions_; }
+    auto &tlsContext() { return tlsContext_; }
 
     /// upgrade stored peer selection details with a matching actual connection
     void finalize(const Comm::ConnectionPointer &conn) { connection_ = conn; }
@@ -159,8 +159,8 @@ private:
     size_type position_ = npos;
     friend class ResolvedPeers;
 
-    /// \copydoc tlsOptions()
-    Security::PeerOptionsPointer tlsOptions_;
+    /// \copydoc tlsContext()
+    Security::PeerContextPointer tlsContext_;
 };
 
 /// summarized ResolvedPeers (for debugging)

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -140,7 +140,7 @@ public:
     operator const Comm::ConnectionPointer&() const { return connection_; }
 
     /// custom TLS communication settings (or nil)
-    auto &tlsContext() { return tlsContext_; }
+    auto &tlsContext() const { return tlsContext_; }
 
     /// upgrade stored peer selection details with a matching actual connection
     void finalize(const Comm::ConnectionPointer &conn) { connection_ = conn; }

--- a/src/ResolvedPeers.h
+++ b/src/ResolvedPeers.h
@@ -54,7 +54,7 @@ public:
 
     /// makes the previously extracted path available for extraction at its
     /// original position and resets TLS parameters to use for that path
-    void reinstatePath(const PeerConnectionPointer &, const Security::PeerContextPointer &tlsContext);
+    void reinstatePath(const PeerConnectionPointer &, const Security::PeerContextPointer &);
 
     /// extracts and returns the first queued address
     PeerConnectionPointer extractFront();
@@ -139,7 +139,7 @@ public:
     /// convenience conversion to Comm::ConnectionPointer
     operator const Comm::ConnectionPointer&() const { return connection_; }
 
-    /// custom TLS session options (or nil)
+    /// custom TLS communication settings (or nil)
     auto &tlsContext() { return tlsContext_; }
 
     /// upgrade stored peer selection details with a matching actual connection

--- a/src/SquidConfig.cc
+++ b/src/SquidConfig.cc
@@ -7,6 +7,7 @@
  */
 
 #include "squid.h"
+#include "security/PeerOptions.h" /* XXX */
 #include "SquidConfig.h"
 
 class SquidConfig Config;

--- a/src/SquidConfig.cc
+++ b/src/SquidConfig.cc
@@ -7,7 +7,7 @@
  */
 
 #include "squid.h"
-#include "security/PeerOptions.h" /* XXX */
+#include "security/PeerOptions.h" /* XXX: Will be gone with FuturePeerContextPointer */
 #include "SquidConfig.h"
 
 class SquidConfig Config;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -502,6 +502,7 @@ public:
 
     struct {
         Security::ContextPointer sslContext;
+        Security::ContextPointer sslContextForRetries; // XXX
 #if USE_OPENSSL
         char *foreignIntermediateCertsPath;
         acl_access *cert_error;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -502,7 +502,8 @@ public:
 
     struct {
         Security::ContextPointer sslContext;
-        Security::ContextPointer sslContextForRetries; // XXX
+        Security::FuturePeerContextPointer defaultContext;
+        Security::PeerContext *retriesContext; // XXX: there are many of these
 #if USE_OPENSSL
         char *foreignIntermediateCertsPath;
         acl_access *cert_error;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -502,7 +502,6 @@ public:
 
     struct {
         Security::ContextPointer sslContext;
-        Security::FuturePeerContextPointer defaultContext;
         Security::PeerContexts *retriesContexts;
 #if USE_OPENSSL
         char *foreignIntermediateCertsPath;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -502,7 +502,7 @@ public:
 
     struct {
         Security::ContextPointer sslContext;
-        Security::PeerContexts *retriesContexts;
+        Security::PeerContexts *retriesContexts; ///< tls_outgoing_options_for_retries
 #if USE_OPENSSL
         char *foreignIntermediateCertsPath;
         acl_access *cert_error;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -503,7 +503,7 @@ public:
     struct {
         Security::ContextPointer sslContext;
         Security::FuturePeerContextPointer defaultContext;
-        Security::PeerContext *retriesContext; // XXX: there are many of these
+        Security::PeerContexts *retriesContexts;
 #if USE_OPENSSL
         char *foreignIntermediateCertsPath;
         acl_access *cert_error;

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -54,8 +54,10 @@ public:
     /* Security::PeerConnector API */
     bool initialize(Security::SessionPointer &) override;
     void noteNegotiationDone(ErrorState *error) override;
-    Security::ContextPointer getTlsContext() override {
-        return icapService->sslContext;
+    Security::FuturePeerContextPointer peerContext() override {
+        // XXX: We should be able to keep the options part constant.
+        auto &cfg = const_cast<Adaptation::ServiceConfig&>(icapService->cfg());
+        return MakeFuture(cfg.secure, icapService->sslContext);
     }
 
 private:

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -57,7 +57,7 @@ public:
     Security::FuturePeerContextPointer peerContext() const override {
         // XXX: We should be able to keep the options part constant.
         auto &cfg = const_cast<Adaptation::ServiceConfig&>(icapService->cfg());
-        return MakeFuture(cfg.secure, icapService->sslContext);
+        return MakeLikeFuture(cfg.secure, icapService->sslContext);
     }
 
 private:

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -49,7 +49,7 @@ public:
         AccessLogEntry::Pointer const &alp,
         const time_t timeout = 0):
         AsyncJob("Ssl::IcapPeerConnector"),
-        Security::PeerConnector(aServerConn, aCallback, alp, timeout), icapService(service) {}
+        Security::PeerConnector(aServerConn, nullptr, aCallback, alp, timeout), icapService(service) {}
 
     /* Security::PeerConnector API */
     bool initialize(Security::SessionPointer &) override;

--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -54,7 +54,7 @@ public:
     /* Security::PeerConnector API */
     bool initialize(Security::SessionPointer &) override;
     void noteNegotiationDone(ErrorState *error) override;
-    Security::FuturePeerContextPointer peerContext() override {
+    Security::FuturePeerContextPointer peerContext() const override {
         // XXX: We should be able to keep the options part constant.
         auto &cfg = const_cast<Adaptation::ServiceConfig&>(icapService->cfg());
         return MakeFuture(cfg.secure, icapService->sslContext);

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -976,13 +976,8 @@ configDoConfigure(void)
 #endif
     }
 
-    if (Config.ssl_client.retriesContext) {
-        Config.ssl_client.retriesContext->open();
-#if USE_OPENSSL
-        // XXX: Check whether this is needed for retries.
-        Ssl::useSquidUntrusted(Config.ssl_client.retriesContext->raw.get());
-#endif
-    }
+    if (Config.ssl_client.retriesContexts)
+        Config.ssl_client.retriesContexts->open();
 
     for (CachePeer *p = Config.peers; p != nullptr; p = p->next) {
 
@@ -2522,14 +2517,13 @@ parse_peer_access(void)
 
 // XXX: Convert to new namespace-based Configuration API. See KeyLog.
 void
-parse_securePeerRetries(Security::PeerContext ** const contextStorage)
+parse_securePeerRetries(Security::PeerContexts ** const contextStorage)
 {
     assert(contextStorage);
-    auto &context = *contextStorage;
-    Assure(!context); // XXX: Until we support multiple directives
-    context = new Security::PeerContext(LegacyParser);
-    static Security::PeerContextPointer refcountingProtectionXXX;
-    refcountingProtectionXXX = context;
+    auto &contexts = *contextStorage;
+    if (!contexts)
+        contexts = new Security::PeerContexts();
+    contexts->parseOneDirective(LegacyParser);
 }
 
 static void

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -963,7 +963,6 @@ configDoConfigure(void)
     if (Security::ProxyOutgoingConfig.encryptTransport) {
         debugs(3, 2, "initializing https:// proxy context");
         Config.ssl_client.sslContext = Security::ProxyOutgoingConfig.createClientContext(false);
-        Config.ssl_client.defaultContext = MakeFuture(Security::ProxyOutgoingConfig, Config.ssl_client.sslContext);
         if (!Config.ssl_client.sslContext) {
 #if USE_OPENSSL
             fatal("ERROR: Could not initialize https:// proxy context");
@@ -974,6 +973,7 @@ configDoConfigure(void)
 #if USE_OPENSSL
         Ssl::useSquidUntrusted(Config.ssl_client.sslContext.get());
 #endif
+        Config.ssl_client.defaultContext = MakeFuture(Security::ProxyOutgoingConfig, Config.ssl_client.sslContext);
     }
 
     if (Config.ssl_client.retriesContexts)

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -694,30 +694,31 @@ ParseUpdatingDirective(T &raw, ConfigParser &parser)
 /// \param name the name of the configuration directive being dumped
 template <typename T>
 static void
-DumpUniqueDirective(const T &raw, std::ostream &osLine, const char * const directiveName)
+DumpUniqueDirective(const T &raw, StoreEntry * const entry, const char * const name)
 {
     if (!SawDirective(raw))
         return; // not configured
 
-    osLine << directiveName;
+    entry->append(name, strlen(name));
     SBufStream os;
     Configuration::Component<T>::Print(os, raw);
     const auto buf = os.buf();
-    if (buf.length())
-        osLine << ' ' << buf;
-    osLine << '\n';
+    if (buf.length()) {
+        entry->append(" ", 1);
+        entry->append(buf.rawContent(), buf.length());
+    }
+    entry->append("\n", 1);
 }
 
-/// reports raw SquidConfig data member configuration using squid.conf syntax
-/// \param name the name of the configuration directive being dumped
+/// Like DumpUniqueDirective() but supports multiple same-name directive occurrences.
 template <typename T>
 static void
-DumpUpdatingDirective(const T &raw, std::ostream &os, const char * const directiveName)
+DumpUpdatingDirective(const T &raw, StoreEntry * const entry, const char * const directiveName)
 {
     if (!SawDirective(raw))
         return; // not configured
 
-    Configuration::Component<T>::PrintDirectives(os, raw, directiveName);
+    Configuration::Component<T>::PrintDirectives(entry, raw, directiveName);
 }
 
 /// frees any resources associated with the given raw SquidConfig data member

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -975,6 +975,22 @@ configDoConfigure(void)
 #endif
     }
 
+    // XXX: Duplicates the above `if`
+    if (Security::ProxyOutgoingConfigForRetries.encryptTransport) {
+        debugs(3, 2, "initializing https:// proxy context");
+        Config.ssl_client.sslContextForRetries = Security::ProxyOutgoingConfigForRetries.createClientContext(false);
+        if (!Config.ssl_client.sslContextForRetries) {
+#if USE_OPENSSL
+            fatal("ERROR: Could not initialize https:// proxy context");
+#else
+            debugs(3, DBG_IMPORTANT, "ERROR: proxying https:// currently still requires --with-openssl");
+#endif
+        }
+#if USE_OPENSSL
+        Ssl::useSquidUntrusted(Config.ssl_client.sslContextForRetries.get());
+#endif
+    }
+
     for (CachePeer *p = Config.peers; p != nullptr; p = p->next) {
 
         // default value for ssldomain= is the peer host/IP

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2520,6 +2520,18 @@ parse_peer_access(void)
     aclParseAccessLine(directive.c_str(), LegacyParser, &p.access);
 }
 
+// XXX: Convert to new namespace-based Configuration API. See KeyLog.
+void
+parse_securePeerRetries(Security::PeerContext ** const contextStorage)
+{
+    assert(contextStorage);
+    auto &context = *contextStorage;
+    Assure(!context); // XXX: Until we support multiple directives
+    context = new Security::PeerContext(LegacyParser);
+    static Security::PeerContextPointer refcountingProtectionXXX;
+    refcountingProtectionXXX = context;
+}
+
 static void
 parse_hostdomaintype(void)
 {

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -998,7 +998,7 @@ configDoConfigure(void)
 #if USE_OPENSSL
         Ssl::useSquidUntrusted(Config.ssl_client.sslContext.get());
 #endif
-        Security::DefaultOutgoingContext = MakeFuture(Security::ProxyOutgoingConfig, Config.ssl_client.sslContext);
+        Security::DefaultOutgoingContext = MakeLikeFuture(Security::ProxyOutgoingConfig, Config.ssl_client.sslContext);
     }
 
     if (Config.ssl_client.retriesContexts)

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -998,7 +998,7 @@ configDoConfigure(void)
 #if USE_OPENSSL
         Ssl::useSquidUntrusted(Config.ssl_client.sslContext.get());
 #endif
-        Config.ssl_client.defaultContext = MakeFuture(Security::ProxyOutgoingConfig, Config.ssl_client.sslContext);
+        Security::DefaultOutgoingContext = MakeFuture(Security::ProxyOutgoingConfig, Config.ssl_client.sslContext);
     }
 
     if (Config.ssl_client.retriesContexts)
@@ -3944,7 +3944,7 @@ configFreeMemory(void)
     free_all();
     Dns::ResolveClientAddressesAsap = false;
     Config.ssl_client.sslContext.reset();
-    Config.ssl_client.defaultContext = nullptr;
+    Security::DefaultOutgoingContext = nullptr;
 #if USE_OPENSSL
     Ssl::unloadSquidUntrusted();
 #endif

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -59,9 +59,6 @@ carpInit(void)
 
     RawCachePeers rawCarpPeers;
     for (auto p = Config.peers; p; p = p->next) {
-        if (!cbdataReferenceValid(p))
-            continue;
-
         if (!p->options.carp)
             continue;
 

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -74,7 +74,7 @@ TokenOrQuotedString
 refreshpattern
 removalpolicy
 securePeerOptions
-securePeerRetries acl
+Security::PeerContexts* acl
 Security::KeyLog* acl
 size_t
 IpAddress_list

--- a/src/cf.data.depend
+++ b/src/cf.data.depend
@@ -74,6 +74,7 @@ TokenOrQuotedString
 refreshpattern
 removalpolicy
 securePeerOptions
+securePeerRetries acl
 Security::KeyLog* acl
 size_t
 IpAddress_list

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3078,7 +3078,8 @@ DOC_END
 
 NAME: tls_outgoing_options_for_retries
 IFDEF: USE_GNUTLS||USE_OPENSSL
-TYPE: securePeerRetries
+TYPE: Security::PeerContexts*
+REPETITIONS: update
 DEFAULT: none
 LOC: Config.ssl_client.retriesContexts
 DOC_START

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3081,13 +3081,71 @@ IFDEF: USE_GNUTLS||USE_OPENSSL
 TYPE: Security::PeerContexts*
 REPETITIONS: update
 DEFAULT: none
+DEFAULT_DOC: Do not retry the same destination after ERR_SECURE_CONNECT_FAIL.
 LOC: Config.ssl_client.retriesContexts
 DOC_START
-	XXX: Document.
 
-	    tls_outgoing_options_for_retries [option]... [if [!]<acl>...]
+	Enables same-destination retries (with new custom TLS options) after
+	ERR_SECURE_CONNECT_FAIL.
+
+		tls_outgoing_options_for_retries [option]... [if [!]<acl>...]
 
 	See tls_outgoing_options for options documentation.
+
+	This directive is consulted whenever an attempt to establish a TLS
+	connection with an origin server or cache_peer fails with
+	ERR_SECURE_CONNECT_FAIL:
+
+	* If no rules are configured or if no configured rules matched, Squid does
+	  not treat ERR_SECURE_CONNECT_FAIL outcome specially (i.e. Squid may
+	  still attempt to reforward the request to a different IP address, using
+	  regular reforwarding logic).
+
+	* If the failed destination IP address was already tried with custom TLS
+	  options (from the previous tls_outgoing_options_for_retries match),
+	  Squid stops treating ERR_SECURE_CONNECT_FAIL outcome specially: Squid
+	  does _not_ attempt to find another set of custom TLS options to retry
+	  the same failed destination with.
+
+	* Otherwise, if a configured rule matches, Squid returns the failed
+	  destination IP address to the set of candidate addresses to consider,
+	  together with the corresponding custom TLS options. During the
+	  subsequent reforwarding attempt (if any), that destination will usually
+	  be chosen by the Happy Eyeballs algorithm. If a reusable persistent
+	  connection to that destination is not available at that time, Squid will
+	  attempt to establish a new TCP connection and to negotiate a new TLS
+	  session using the previously matched custom TLS options.
+
+	Directives are evaluated in configuration order. The first matching
+	directive wins and stops further evaluation. A directive without ACLs
+	always matches when evaluated.
+
+	This directive is handy in environments where Squid should communicate
+	using strict TLS options by default (see tls_outgoing_options) but may
+	relax those restrictions to accommodate older origin servers that require
+	inferior (but still deemed "secure enough") settings.
+
+	Popular browsers also retry with special TLS options after certain TLS
+	failures, but Squid may be unable to relay enough TLS server information
+	to rely on browser-initiated retries or may be dealing with a user agent
+	that does not retry (to Squid admin's satisfaction).
+
+	This directive focuses on establishing a secure connection in an
+	environment where multiple TLS options are acceptable to the admin. Squid
+	does not yet check whether the available same-destination persistent
+	connection has matching TLS options. Similarly, Squid does not yet check
+	whether the matched custom TLS options differ from the options used for
+	the first attempt. Such verification may be unconditionally enabled later.
+
+	The following configuration sketch illustrates how to downgrade TLS
+	security level for transactions matching some custom shouldRetry ACL:
+
+		acl shouldRetry ...
+		tls_outgoing_options cipher=ALL@SECLEVEL=4
+		tls_outgoing_options_for_retries cipher=ALL@SECLEVEL=3 if shouldRetry
+
+	This clause only supports fast acl types.
+	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 DOC_END
 
 COMMENT_START

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3076,6 +3076,19 @@ DOC_START
 			used.
 DOC_END
 
+NAME: tls_outgoing_options_for_retries
+IFDEF: USE_GNUTLS||USE_OPENSSL
+TYPE: securePeerOptions
+DEFAULT: none
+LOC: Security::ProxyOutgoingConfigForRetries
+DOC_START
+	XXX: Document.
+
+	    tls_outgoing_options_for_retries [option]... [if [!]acl...]
+
+	See tls_outgoing_options for options documentation.
+DOC_END
+
 COMMENT_START
  SSL OPTIONS
  -----------------------------------------------------------------------------

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3080,7 +3080,7 @@ NAME: tls_outgoing_options_for_retries
 IFDEF: USE_GNUTLS||USE_OPENSSL
 TYPE: securePeerRetries
 DEFAULT: none
-LOC: Config.ssl_client.retriesContext
+LOC: Config.ssl_client.retriesContexts
 DOC_START
 	XXX: Document.
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3078,9 +3078,9 @@ DOC_END
 
 NAME: tls_outgoing_options_for_retries
 IFDEF: USE_GNUTLS||USE_OPENSSL
-TYPE: securePeerOptions
+TYPE: securePeerRetries
 DEFAULT: none
-LOC: Security::ProxyOutgoingConfigForRetries
+LOC: Config.ssl_client.retriesContext
 DOC_START
 	XXX: Document.
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3094,8 +3094,7 @@ DOC_START
 	including "ciphers=..." and "cafile=...".
 
 	This directive is consulted whenever an attempt to establish a TLS
-	connection with an origin server or cache_peer fails with
-	ERR_SECURE_CONNECT_FAIL:
+	connection with an origin server fails with ERR_SECURE_CONNECT_FAIL:
 
 	* If no rules are configured or if no configured rules matched, Squid does
 	  not treat ERR_SECURE_CONNECT_FAIL outcome specially (i.e. Squid may
@@ -3120,6 +3119,10 @@ DOC_START
 	Directives are evaluated in configuration order. The first matching
 	directive wins and stops further evaluation. A directive without ACLs
 	always matches when evaluated.
+
+	This feature has no effect on TLS cache_peers. Admins should use
+	cache_peer directives to customize TLS settings for those connections.
+	However, TLS connections through plain-text cache_peers may be retried.
 
 	This directive is handy in environments where Squid should communicate
 	using strict TLS options by default (see tls_outgoing_options) but may

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3084,7 +3084,7 @@ LOC: Config.ssl_client.retriesContext
 DOC_START
 	XXX: Document.
 
-	    tls_outgoing_options_for_retries [option]... [if [!]acl...]
+	    tls_outgoing_options_for_retries [option]... [if [!]<acl>...]
 
 	See tls_outgoing_options for options documentation.
 DOC_END

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3088,9 +3088,10 @@ DOC_START
 	Enables same-destination retries (with new custom TLS options) after
 	ERR_SECURE_CONNECT_FAIL.
 
-		tls_outgoing_options_for_retries [option]... [if [!]<acl>...]
+		tls_outgoing_options_for_retries <option>... [if [!]<acl>...]
 
-	See tls_outgoing_options for options documentation.
+	See tls_outgoing_options for documentation of recognized options,
+	including "ciphers=..." and "cafile=...".
 
 	This directive is consulted whenever an attempt to establish a TLS
 	connection with an origin server or cache_peer fails with

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3134,12 +3134,12 @@ DOC_START
 	to rely on browser-initiated retries or may be dealing with a user agent
 	that does not retry (to Squid admin's satisfaction).
 
-	This directive focuses on establishing a secure connection in an
-	environment where multiple TLS options are acceptable to the admin. Squid
-	does not yet check whether the available same-destination persistent
-	connection has matching TLS options. Similarly, Squid does not yet check
-	whether the matched custom TLS options differ from the options used for
-	the first attempt. Such verification may be unconditionally enabled later.
+	This feature focuses on establishing a secure connection in an environment
+	where multiple TLS options are acceptable to the admin. Squid does not yet
+	check whether the available same-destination persistent connection has
+	matching TLS options. Similarly, Squid does not yet check whether the
+	matched custom TLS options differ from the options used for the first
+	attempt. Such verification may be unconditionally enabled later.
 
 	The following configuration sketch illustrates how to downgrade TLS
 	security level for transactions matching some custom shouldRetry ACL:

--- a/src/cf_gen.cc
+++ b/src/cf_gen.cc
@@ -95,7 +95,11 @@ public:
     std::string ifdef;
     LineList doc;
     LineList cfgLines; ///< between CONFIG_START and CONFIG_END
+
     int array_flag = 0; ///< TYPE is a raw array[] declaration
+
+    /// whether this is a "REPETITIONS: update" entry
+    bool mayBeSeenMultipleTimes = false;
 
     void genParse(std::ostream &fout) const;
 
@@ -346,6 +350,21 @@ main(int argc, char *argv[])
 
                     checkDepend(curr.name, ptr, types, entries);
                     curr.type = ptr;
+                } else if (!strncmp(buff, "REPETITIONS:", 12)) {
+                    if ((ptr = strtok(buff + 12, WS)) == nullptr) {
+                        errorMsg(input_filename, linenum, buff);
+                        exit(EXIT_FAILURE);
+                    }
+
+                    // TODO: Support "REPETITIONS: overwrite"?
+                    if (strcmp(ptr, "update") == 0)
+                        curr.mayBeSeenMultipleTimes = true;
+                    else if (strcmp(ptr, "banned") == 0)
+                        curr.mayBeSeenMultipleTimes = false;
+                    else {
+                        errorMsg(input_filename, linenum, "expected 'update' or 'banned' attribute value");
+                        exit(EXIT_FAILURE);
+                    }
                 } else if (!strncmp(buff, "IFDEF:", 6)) {
                     if ((ptr = strtok(buff + 6, WS)) == nullptr) {
                         errorMsg(input_filename, linenum, buff);
@@ -610,7 +629,8 @@ Entry::genParseAlias(const std::string &aName, std::ostream &fout) const
     } else if (!loc.size() || loc.compare("none") == 0) {
         fout << "parse_" << type << "();";
     } else if (type.find("::") != std::string::npos) {
-        fout << "ParseDirective<" << type << ">(" << loc << ", LegacyParser);";
+        const auto method = mayBeSeenMultipleTimes ? "ParseUpdatingDirective" : "ParseUniqueDirective";
+        fout << method << "<" << type << ">(" << loc << ", LegacyParser);";
     } else {
         fout << "parse_" << type << "(&" << loc << (array_flag ? "[0]" : "") << ");";
     }
@@ -668,7 +688,9 @@ gen_dump(const EntryList &head, std::ostream &fout)
          "static void" << std::endl <<
          "dump_config(StoreEntry *entry)" << std::endl <<
          "{" << std::endl <<
-         "    debugs(5, 4, MYNAME);" << std::endl;
+         "    debugs(5, 4, MYNAME);" << std::endl <<
+         "    assert(entry);" << std::endl <<
+         "    PackableStream osCfg(*entry);" << std::endl;
 
     for (const auto &e : head) {
 
@@ -681,9 +703,10 @@ gen_dump(const EntryList &head, std::ostream &fout)
         if (e.ifdef.size())
             fout << "#if " << e.ifdef << std::endl;
 
-        if (e.type.find("::") != std::string::npos)
-            fout << "    DumpDirective<" << e.type << ">(" << e.loc << ", entry, \"" << e.name << "\");\n";
-        else
+        if (e.type.find("::") != std::string::npos) {
+            const auto method = e.mayBeSeenMultipleTimes ? "DumpUpdatingDirective" : "DumpUniqueDirective";
+            fout << "    " << method << "<" << e.type << ">(" << e.loc << ", osCfg, \"" << e.name << "\");\n";
+        } else
             fout << "    dump_" << e.type << "(entry, \"" << e.name << "\", " << e.loc << ");" << std::endl;
 
         if (e.ifdef.size())

--- a/src/cf_gen.cc
+++ b/src/cf_gen.cc
@@ -688,9 +688,7 @@ gen_dump(const EntryList &head, std::ostream &fout)
          "static void" << std::endl <<
          "dump_config(StoreEntry *entry)" << std::endl <<
          "{" << std::endl <<
-         "    debugs(5, 4, MYNAME);" << std::endl <<
-         "    assert(entry);" << std::endl <<
-         "    PackableStream osCfg(*entry);" << std::endl;
+         "    debugs(5, 4, MYNAME);" << std::endl;
 
     for (const auto &e : head) {
 
@@ -705,7 +703,7 @@ gen_dump(const EntryList &head, std::ostream &fout)
 
         if (e.type.find("::") != std::string::npos) {
             const auto method = e.mayBeSeenMultipleTimes ? "DumpUpdatingDirective" : "DumpUniqueDirective";
-            fout << "    " << method << "<" << e.type << ">(" << e.loc << ", osCfg, \"" << e.name << "\");\n";
+            fout << "    " << method << "<" << e.type << ">(" << e.loc << ", entry, \"" << e.name << "\");\n";
         } else
             fout << "    dump_" << e.type << "(entry, \"" << e.name << "\", " << e.loc << ");" << std::endl;
 

--- a/src/cf_gen.cc
+++ b/src/cf_gen.cc
@@ -95,7 +95,6 @@ public:
     std::string ifdef;
     LineList doc;
     LineList cfgLines; ///< between CONFIG_START and CONFIG_END
-
     int array_flag = 0; ///< TYPE is a raw array[] declaration
 
     /// whether this is a "REPETITIONS: update" entry

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -27,7 +27,7 @@ Security::BlindPeerConnector::peerContext() const
     if (peer && peer->secure.encryptTransport)
         return peer->peerContext();
 
-    return tlsContext_ ? tlsContext_ : ::Config.ssl_client.defaultContext;
+    return tlsContext_ ? tlsContext_ : DefaultOutgoingContext;
 }
 
 bool

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -27,7 +27,7 @@ Security::BlindPeerConnector::getTlsContext()
     if (peer && peer->secure.encryptTransport)
         return peer->sslContext;
 
-    return ::Config.ssl_client.sslContext;
+    return tlsOptions_ ? ::Config.ssl_client.sslContextForRetries : ::Config.ssl_client.sslContext;
 }
 
 bool

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -21,7 +21,7 @@
 CBDATA_NAMESPACED_CLASS_INIT(Security, BlindPeerConnector);
 
 Security::FuturePeerContextPointer
-Security::BlindPeerConnector::peerContext()
+Security::BlindPeerConnector::peerContext() const
 {
     const auto peer = serverConnection()->getPeer();
     if (peer && peer->secure.encryptTransport)

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -20,14 +20,15 @@
 
 CBDATA_NAMESPACED_CLASS_INIT(Security, BlindPeerConnector);
 
-Security::ContextPointer
-Security::BlindPeerConnector::getTlsContext()
+Security::FuturePeerContextPointer
+Security::BlindPeerConnector::peerContext()
 {
-    const CachePeer *peer = serverConnection()->getPeer();
+    const auto peer = serverConnection()->getPeer();
     if (peer && peer->secure.encryptTransport)
-        return peer->sslContext;
+        return peer->peerContext();
 
-    return tlsOptions_ ? ::Config.ssl_client.sslContextForRetries : ::Config.ssl_client.sslContext;
+    return tlsContext_ ? tlsContext_ :
+        MakeFuture(ProxyOutgoingConfig, ::Config.ssl_client.sslContext);
 }
 
 bool

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -27,8 +27,7 @@ Security::BlindPeerConnector::peerContext()
     if (peer && peer->secure.encryptTransport)
         return peer->peerContext();
 
-    return tlsContext_ ? tlsContext_ :
-        MakeFuture(ProxyOutgoingConfig, ::Config.ssl_client.sslContext);
+    return tlsContext_ ? tlsContext_ : ::Config.ssl_client.defaultContext;
 }
 
 bool

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -16,17 +16,18 @@ class ErrorState;
 namespace Security
 {
 
-/// A simple PeerConnector for SSL/TLS cache_peers. No SslBump capabilities.
+/// A PeerConnector for TLS cache_peers and origin servers. No SslBump capabilities.
 class BlindPeerConnector: public Security::PeerConnector {
     CBDATA_CHILD(BlindPeerConnector);
 public:
     BlindPeerConnector(HttpRequestPointer &aRequest,
                        const Comm::ConnectionPointer &aServerConn,
+                       const Security::PeerOptionsPointer &aPeerOptionsPointer,
                        const AsyncCallback<EncryptorAnswer> &aCallback,
                        const AccessLogEntryPointer &alp,
                        const time_t timeout = 0) :
         AsyncJob("Security::BlindPeerConnector"),
-        Security::PeerConnector(aServerConn, aCallback, alp, timeout)
+        Security::PeerConnector(aServerConn, aPeerOptionsPointer, aCallback, alp, timeout)
     {
         request = aRequest;
     }

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -40,7 +40,7 @@ public:
     /// \returns true on successful initialization
     bool initialize(Security::SessionPointer &) override;
 
-    FuturePeerContextPointer peerContext() override;
+    FuturePeerContextPointer peerContext() const override;
 
     /// On success, stores the used TLS session for later use.
     /// On error, informs the peer.

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -22,12 +22,12 @@ class BlindPeerConnector: public Security::PeerConnector {
 public:
     BlindPeerConnector(HttpRequestPointer &aRequest,
                        const Comm::ConnectionPointer &aServerConn,
-                       const Security::PeerOptionsPointer &aPeerOptionsPointer,
+                       const Security::FuturePeerContextPointer &aPeerContextPointer,
                        const AsyncCallback<EncryptorAnswer> &aCallback,
                        const AccessLogEntryPointer &alp,
                        const time_t timeout = 0) :
         AsyncJob("Security::BlindPeerConnector"),
-        Security::PeerConnector(aServerConn, aPeerOptionsPointer, aCallback, alp, timeout)
+        Security::PeerConnector(aServerConn, aPeerContextPointer, aCallback, alp, timeout)
     {
         request = aRequest;
     }
@@ -40,8 +40,7 @@ public:
     /// \returns true on successful initialization
     bool initialize(Security::SessionPointer &) override;
 
-    /// Return the configured TLS context object
-    Security::ContextPointer getTlsContext() override;
+    FuturePeerContextPointer peerContext() override;
 
     /// On success, stores the used TLS session for later use.
     /// On error, informs the peer.

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -148,7 +148,7 @@ Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
     const auto ctx = peerContext();
     debugs(83, 5, serverConnection() << ", ctx=" << ctx);
 
-    if (!ctx || !Security::CreateClientSession(ctx, serverConnection(), "server https start")) {
+    if (!ctx || !Security::CreateClientSession(*ctx, serverConnection(), "server https start")) {
         const auto xerrno = errno;
         if (!ctx) {
             debugs(83, DBG_IMPORTANT, "ERROR: initializing TLS connection: No security context.");

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "acl/FilledChecklist.h"
 #include "base/AsyncCallbacks.h"
+#include "base/Assure.h"
 #include "base/IoManip.h"
 #include "CachePeer.h"
 #include "comm/Loops.h"
@@ -35,11 +36,18 @@
 #include "ssl/helper.h"
 #endif
 
-Security::PeerConnector::PeerConnector(const Comm::ConnectionPointer &aServerConn, const AsyncCallback<EncryptorAnswer> &aCallback, const AccessLogEntryPointer &alp, const time_t timeout):
+Security::PeerConnector::PeerConnector(
+    const Comm::ConnectionPointer &aServerConn,
+    const Security::PeerOptionsPointer &tlsOptions,
+    const AsyncCallback<EncryptorAnswer> &aCallback,
+    const AccessLogEntryPointer &alp,
+    const time_t timeout):
+
     AsyncJob("Security::PeerConnector"),
     noteFwdPconnUse(false),
     serverConn(aServerConn),
     al(alp),
+    tlsOptions_(tlsOptions),
     callback(aCallback),
     negotiationTimeout(timeout),
     startTime(squid_curtime),

--- a/src/security/PeerConnector.cc
+++ b/src/security/PeerConnector.cc
@@ -145,7 +145,7 @@ Security::PeerConnector::initialize(Security::SessionPointer &serverSession)
 {
     Must(Comm::IsConnOpen(serverConnection()));
 
-    auto ctx = peerContext();
+    const auto ctx = peerContext();
     debugs(83, 5, serverConnection() << ", ctx=" << ctx);
 
     if (!ctx || !Security::CreateClientSession(ctx, serverConnection(), "server https start")) {

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -53,6 +53,7 @@ public:
     typedef CbcPointer<PeerConnector> Pointer;
 
     PeerConnector(const Comm::ConnectionPointer &aServerConn,
+                  const Security::PeerOptionsPointer &,
                   const AsyncCallback<EncryptorAnswer> &,
                   const AccessLogEntryPointer &alp,
                   const time_t timeout = 0);
@@ -165,6 +166,9 @@ protected:
     HttpRequestPointer request; ///< peer connection trigger or cause
     Comm::ConnectionPointer serverConn; ///< TCP connection to the peer
     AccessLogEntryPointer al; ///< info for the future access.log entry
+
+    /// TLS configuration for peer connection
+    Security::PeerOptionsPointer tlsOptions_;
 
     /// answer destination
     AsyncCallback<EncryptorAnswer> callback;

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -132,7 +132,7 @@ protected:
     virtual void noteNegotiationDone(ErrorState *) {}
 
     /// peer's security context; never nil
-    virtual FuturePeerContextPointer peerContext() = 0;
+    virtual FuturePeerContextPointer peerContext() const = 0;
 
     /// mimics FwdState to minimize changes to FwdState::initiate/negotiateSsl
     Comm::ConnectionPointer const &serverConnection() const { return serverConn; }

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -131,7 +131,7 @@ protected:
     /// \param error if not NULL the SSL negotiation was aborted with an error
     virtual void noteNegotiationDone(ErrorState *) {}
 
-    /// peer's security context (or nil)
+    /// peer's security context; never nil
     virtual FuturePeerContextPointer peerContext() = 0;
 
     /// mimics FwdState to minimize changes to FwdState::initiate/negotiateSsl
@@ -175,9 +175,6 @@ protected:
 private:
     PeerConnector(const PeerConnector &); // not implemented
     PeerConnector &operator =(const PeerConnector &); // not implemented
-
-    /// raw encryption context object (or nil)
-    ContextPointer getTlsContext();
 
 #if USE_OPENSSL
     unsigned int certDownloadNestingLevel() const;

--- a/src/security/PeerConnector.h
+++ b/src/security/PeerConnector.h
@@ -53,7 +53,7 @@ public:
     typedef CbcPointer<PeerConnector> Pointer;
 
     PeerConnector(const Comm::ConnectionPointer &aServerConn,
-                  const Security::PeerOptionsPointer &,
+                  const Security::FuturePeerContextPointer &,
                   const AsyncCallback<EncryptorAnswer> &,
                   const AccessLogEntryPointer &alp,
                   const time_t timeout = 0);
@@ -131,9 +131,8 @@ protected:
     /// \param error if not NULL the SSL negotiation was aborted with an error
     virtual void noteNegotiationDone(ErrorState *) {}
 
-    /// Must implemented by the kid classes to return the TLS context object to use
-    /// for building the encryption context objects.
-    virtual Security::ContextPointer getTlsContext() = 0;
+    /// peer's security context (or nil)
+    virtual FuturePeerContextPointer peerContext() = 0;
 
     /// mimics FwdState to minimize changes to FwdState::initiate/negotiateSsl
     Comm::ConnectionPointer const &serverConnection() const { return serverConn; }
@@ -168,7 +167,7 @@ protected:
     AccessLogEntryPointer al; ///< info for the future access.log entry
 
     /// TLS configuration for peer connection
-    Security::PeerOptionsPointer tlsOptions_;
+    FuturePeerContextPointer tlsContext_;
 
     /// answer destination
     AsyncCallback<EncryptorAnswer> callback;
@@ -176,6 +175,9 @@ protected:
 private:
     PeerConnector(const PeerConnector &); // not implemented
     PeerConnector &operator =(const PeerConnector &); // not implemented
+
+    /// raw encryption context object (or nil)
+    ContextPointer getTlsContext();
 
 #if USE_OPENSSL
     unsigned int certDownloadNestingLevel() const;

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -901,6 +901,9 @@ dump_securePeerRetries(StoreEntry *e, const char *directiveName, const Security:
             // TODO: Use Acl::dump() after fixing the XXX in dump_acl_list().
             for (const auto &acl: context->preconditions->treeDump("if", &Acl::AllowOrDeny))
                 os << ' ' << acl;
+            // the treeDump() hack above adds a new line
+        } else {
+            os << '\n';
         }
     }
 }

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -852,7 +852,6 @@ Security::PeerContext::open()
         throw TextException("failed to initialize a TLS context for Squid-originated connections", Here());
 
 #if USE_OPENSSL
-    // XXX: Check whether this is needed for retries.
     Ssl::useSquidUntrusted(raw.get());
 #endif
 }

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -27,6 +27,7 @@
 #include <bitset>
 
 Security::PeerOptions Security::ProxyOutgoingConfig;
+Security::FuturePeerContextPointer Security::DefaultOutgoingContext;
 
 Security::PeerOptions::PeerOptions()
 {

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -903,12 +903,15 @@ Configuration::Component<Security::PeerContexts*>::ParseAndUpdate(Security::Peer
 
 template <>
 void
-Configuration::Component<Security::PeerContexts*>::PrintDirectives(std::ostream &os, Security::PeerContexts * const & contexts, const char * const directiveName)
+Configuration::Component<Security::PeerContexts*>::PrintDirectives(StoreEntry * const e, Security::PeerContexts * const & contexts, const char * const directiveName)
 {
+    Assure(e);
+    PackableStream os(*e);
+
     Assure(contexts);
     for (const auto &context: contexts->contexts) {
         os << directiveName;
-        // XXX refactor: context->options.dumpCfg(os, "");
+        context->options.dumpCfg(e, "");
         if (context->preconditions) {
             // TODO: Use Acl::dump() after fixing the XXX in dump_acl_list().
             for (const auto &acl: context->preconditions->treeDump("if", &Acl::AllowOrDeny))

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -867,7 +867,7 @@ Security::PeerContexts::parseOneDirective(ConfigParser &parser)
 void
 Security::PeerContexts::open()
 {
-    for (auto &context: contexts)
+    for (const auto &context: contexts)
         context->open();
 }
 
@@ -910,14 +910,14 @@ dump_securePeerRetries(StoreEntry *e, const char *directiveName, const Security:
 
 /* Security::FuturePeerContext */
 
-Security::FuturePeerContext::FuturePeerContext(PeerOptions &o, ContextPointer &c):
+Security::FuturePeerContext::FuturePeerContext(PeerOptions &o, const ContextPointer &c):
     options(o),
     raw(c)
 {
 }
 
 Security::FuturePeerContextPointer
-MakeFuture(Security::PeerContextPointer &ctx)
+MakeFuture(const Security::PeerContextPointer &ctx)
 {
     if (!ctx)
         return nullptr;
@@ -925,7 +925,7 @@ MakeFuture(Security::PeerContextPointer &ctx)
 }
 
 Security::FuturePeerContextPointer
-MakeFuture(Security::PeerOptions &options, Security::ContextPointer &rawContext)
+MakeFuture(Security::PeerOptions &options, const Security::ContextPointer &rawContext)
 {
     return new Security::FuturePeerContext(options, rawContext);
 }

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -22,6 +22,7 @@
 #include <bitset>
 
 Security::PeerOptions Security::ProxyOutgoingConfig;
+Security::PeerOptions Security::ProxyOutgoingConfigForRetries;
 
 Security::PeerOptions::PeerOptions()
 {

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -833,6 +833,12 @@ Security::PeerContext::PeerContext(ConfigParser &parser)
             break; // no more options and no ACLs
     }
     options.parseOptions();
+
+    if (!options.encryptTransport) {
+        // either no explicit options at all, or the last option was "disable"
+        // TODO: Auto-report failed directive name when reporting parsing exceptions
+        throw TextException("tls_outgoing_options_for_retries requires TLS options", Here());
+    }
 }
 
 void

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -932,25 +932,3 @@ Configuration::Component<Security::PeerContexts*>::Free(Security::PeerContexts *
 
 } // namespace Configuration
 
-/* Security::FuturePeerContext */
-
-Security::FuturePeerContext::FuturePeerContext(PeerOptions &o, const ContextPointer &c):
-    options(o),
-    raw(c)
-{
-}
-
-Security::FuturePeerContextPointer
-MakeFuture(const Security::PeerContextPointer &ctx)
-{
-    if (!ctx)
-        return nullptr;
-    return new Security::FuturePeerContext(ctx->options, ctx->raw);
-}
-
-Security::FuturePeerContextPointer
-MakeFuture(Security::PeerOptions &options, const Security::ContextPointer &rawContext)
-{
-    return new Security::FuturePeerContext(options, rawContext);
-}
-

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -20,7 +20,7 @@ namespace Security
 {
 
 /// TLS squid.conf settings for a remote server peer
-class PeerOptions
+class PeerOptions: public RefCountable
 {
 public:
     PeerOptions();
@@ -147,6 +147,9 @@ public:
 
 /// configuration options for DIRECT server access
 extern PeerOptions ProxyOutgoingConfig;
+
+/// configuration options for retrying DIRECT server access
+extern PeerOptions ProxyOutgoingConfigForRetries;
 
 } // namespace Security
 

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -197,9 +197,9 @@ public:
 class FuturePeerContext: public RefCountable
 {
 public:
-    FuturePeerContext(PeerOptions &, ContextPointer &);
+    FuturePeerContext(PeerOptions &, const ContextPointer &);
     PeerOptions &options; ///< context configuration
-    ContextPointer &raw; ///< context configured using options
+    const ContextPointer &raw; ///< context configured using options
 };
 
 /// configuration options for DIRECT server access
@@ -216,9 +216,9 @@ void free_securePeerRetries(Security::PeerContexts **);
 void dump_securePeerRetries(StoreEntry *, const char *, const Security::PeerContexts *);
 
 // for modern code forced to use this shim
-Security::FuturePeerContextPointer MakeFuture(Security::PeerContextPointer &);
+Security::FuturePeerContextPointer MakeFuture(const Security::PeerContextPointer &);
 // for legacy code that will be refactored/removed together with this shim
-Security::FuturePeerContextPointer MakeFuture(Security::PeerOptions &, Security::ContextPointer &);
+Security::FuturePeerContextPointer MakeFuture(Security::PeerOptions &, const Security::ContextPointer &);
 
 #endif /* SQUID_SRC_SECURITY_PEEROPTIONS_H */
 

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -165,7 +165,7 @@ public:
     ContextPointer raw; ///< context configured using options
 
     /// restrict usage to matching transactions
-    std::unique_ptr<ACLList> preconditions; // XXX: Use std::unique_ptr<>
+    std::unique_ptr<ACLList> preconditions;
 };
 
 // TODO: Move this declaration.

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -205,6 +205,9 @@ public:
 /// configuration options for DIRECT server access
 extern PeerOptions ProxyOutgoingConfig;
 
+/// XXX: future Config.ssl_client.defaultContext
+extern FuturePeerContextPointer DefaultOutgoingContext;
+
 } // namespace Security
 
 // parse the tls_outgoing_options directive

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -215,18 +215,20 @@ void parse_securePeerOptions(Security::PeerOptions *);
 #define free_securePeerOptions(x) Security::ProxyOutgoingConfig.clear()
 #define dump_securePeerOptions(e,n,x) do { (e)->appendf(n); (x).dumpCfg((e),""); (e)->append("\n",1); } while(false)
 
-// for modern code forced to use this shim
+// For modern code forced to use this shim.
+// XXX: Replace calls with the call parameter.
 inline Security::FuturePeerContextPointer
-MakeFuture(const Security::PeerContextPointer &ctx)
+PassThroughFuture(const Security::PeerContextPointer &ctx)
 {
     if (!ctx)
         return nullptr;
     return new Security::FuturePeerContext(ctx->options, ctx->raw);
 }
 
-// for legacy code that will be refactored/removed together with this shim
+// For legacy code that will be refactored/removed together with this shim.
+// XXX: Replace calls with the right Security::ContextPointer object.
 inline Security::FuturePeerContextPointer
-MakeFuture(Security::PeerOptions &options, const Security::ContextPointer &rawContext)
+MakeLikeFuture(Security::PeerOptions &options, const Security::ContextPointer &rawContext)
 {
     return new Security::FuturePeerContext(options, rawContext);
 }

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -194,7 +194,10 @@ public:
 class FuturePeerContext: public RefCountable
 {
 public:
-    FuturePeerContext(PeerOptions &, const ContextPointer &);
+    FuturePeerContext(PeerOptions &o, const ContextPointer &c): options(o), raw(c)
+    {
+    }
+
     PeerOptions &options; ///< TLS context configuration
     const ContextPointer &raw; ///< TLS context configured using options
 };
@@ -210,9 +213,20 @@ void parse_securePeerOptions(Security::PeerOptions *);
 #define dump_securePeerOptions(e,n,x) do { (e)->appendf(n); (x).dumpCfg((e),""); (e)->append("\n",1); } while(false)
 
 // for modern code forced to use this shim
-Security::FuturePeerContextPointer MakeFuture(const Security::PeerContextPointer &);
+inline Security::FuturePeerContextPointer
+MakeFuture(const Security::PeerContextPointer &ctx)
+{
+    if (!ctx)
+        return nullptr;
+    return new Security::FuturePeerContext(ctx->options, ctx->raw);
+}
+
 // for legacy code that will be refactored/removed together with this shim
-Security::FuturePeerContextPointer MakeFuture(Security::PeerOptions &, const Security::ContextPointer &);
+inline Security::FuturePeerContextPointer
+MakeFuture(Security::PeerOptions &options, const Security::ContextPointer &rawContext)
+{
+    return new Security::FuturePeerContext(options, rawContext);
+}
 
 #endif /* SQUID_SRC_SECURITY_PEEROPTIONS_H */
 

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -198,8 +198,8 @@ class FuturePeerContext: public RefCountable
 {
 public:
     FuturePeerContext(PeerOptions &, const ContextPointer &);
-    PeerOptions &options; ///< context configuration
-    const ContextPointer &raw; ///< context configured using options
+    PeerOptions &options; ///< TLS context configuration
+    const ContextPointer &raw; ///< TLS context configured using options
 };
 
 /// configuration options for DIRECT server access

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -212,9 +212,6 @@ extern PeerOptions ProxyOutgoingConfig;
 void parse_securePeerOptions(Security::PeerOptions *);
 #define free_securePeerOptions(x) Security::ProxyOutgoingConfig.clear()
 #define dump_securePeerOptions(e,n,x) do { (e)->appendf(n); (x).dumpCfg((e),""); (e)->append("\n",1); } while(false)
-void parse_securePeerRetries(Security::PeerContexts **);
-void free_securePeerRetries(Security::PeerContexts **);
-void dump_securePeerRetries(StoreEntry *, const char *, const Security::PeerContexts *);
 
 // for modern code forced to use this shim
 Security::FuturePeerContextPointer MakeFuture(const Security::PeerContextPointer &);

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -151,13 +151,17 @@ public:
 class PeerContext: public RefCountable
 {
 public:
-    // TODO PeerContext(...);
+    explicit PeerContext(ConfigParser &);
+    ~PeerContext() override;
 
     /// XXX: Document.
     void open();
 
     PeerOptions options; ///< context configuration
     ContextPointer raw; ///< context configured using options
+
+    /// restrict usage to matching transactions
+    ACLList *preconditions; // XXX: Use std::unique_ptr<>
 };
 
 // XXX: Remove this shim after upgrading legacy code to store PeerContext

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -150,7 +150,7 @@ public:
     bool encryptTransport = false;
 };
 
-// TODO: Move this declaration?
+// TODO: Move this declaration.
 /// A combination of PeerOptions and the corresponding Context. Used by Squid
 /// TLS client code.
 class PeerContext: public RefCountable
@@ -158,7 +158,7 @@ class PeerContext: public RefCountable
 public:
     explicit PeerContext(ConfigParser &);
 
-    /// XXX: Document.
+    /// creates TLS context reflecting the configured options
     void open();
 
     PeerOptions options; ///< context configuration
@@ -168,8 +168,7 @@ public:
     std::unique_ptr<ACLList> preconditions; // XXX: Use std::unique_ptr<>
 };
 
-// TODO: Move this declaration
-
+// TODO: Move this declaration.
 /// Manages PeerContext objects representing all
 /// tls_outgoing_options_for_retries directives in squid.conf.
 class PeerContexts
@@ -178,11 +177,8 @@ public:
     /// parses a single tls_outgoing_options_for_retries directive
     void parseOneDirective(ConfigParser &);
 
-    /// XXX: Document.
+    /// opens all configured contexts; \sa PeerContext::open()
     void open();
-
-    /// report configured contexts using squid.conf syntax
-    // TODO: void dump(std::ostream &) const;
 
     /// transaction-matching PeerContext (or nil)
     PeerContextPointer findContext(ACLChecklist &) const;

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -9,12 +9,14 @@
 #ifndef SQUID_SRC_SECURITY_PEEROPTIONS_H
 #define SQUID_SRC_SECURITY_PEEROPTIONS_H
 
+#include "acl/Tree.h"
 #include "base/YesNoNone.h"
 #include "ConfigParser.h"
 #include "mem/PoolingAllocator.h"
 #include "security/forward.h"
 #include "security/KeyData.h"
 
+#include <memory>
 #include <vector>
 
 class Packable;
@@ -155,7 +157,6 @@ class PeerContext: public RefCountable
 {
 public:
     explicit PeerContext(ConfigParser &);
-    ~PeerContext() override;
 
     /// XXX: Document.
     void open();
@@ -164,7 +165,7 @@ public:
     ContextPointer raw; ///< context configured using options
 
     /// restrict usage to matching transactions
-    ACLList *preconditions; // XXX: Use std::unique_ptr<>
+    std::unique_ptr<ACLList> preconditions; // XXX: Use std::unique_ptr<>
 };
 
 // TODO: Move this declaration

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -180,14 +180,10 @@ CreateSession(const Security::ContextPointer &ctx, const Comm::ConnectionPointer
 }
 
 bool
-Security::CreateClientSession(const Security::ContextPointer &ctx, const Comm::ConnectionPointer &c, const char *squidCtx)
+Security::CreateClientSession(FuturePeerContextPointer &ctx, const Comm::ConnectionPointer &c, const char *squidCtx)
 {
-    if (!c || !c->getPeer())
-        return CreateSession(ctx, c, Security::ProxyOutgoingConfig, Security::Io::BIO_TO_SERVER, squidCtx);
-
-    // Bug 5293 - peer->secure is empty/wrong when c is a tunnel through a cache_peer
-    auto *peer = c->getPeer();
-    return CreateSession(ctx, c, peer->secure, Security::Io::BIO_TO_SERVER, squidCtx);
+    Assure(ctx); // this should be a reference then
+    return CreateSession(ctx->raw, c, ctx->options, Security::Io::BIO_TO_SERVER, squidCtx);
 }
 
 bool

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -185,6 +185,7 @@ Security::CreateClientSession(const Security::ContextPointer &ctx, const Comm::C
     if (!c || !c->getPeer())
         return CreateSession(ctx, c, Security::ProxyOutgoingConfig, Security::Io::BIO_TO_SERVER, squidCtx);
 
+    // Bug 5293 - peer->secure is empty/wrong when c is a tunnel through a cache_peer
     auto *peer = c->getPeer();
     return CreateSession(ctx, c, peer->secure, Security::Io::BIO_TO_SERVER, squidCtx);
 }

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -180,10 +180,14 @@ CreateSession(const Security::ContextPointer &ctx, const Comm::ConnectionPointer
 }
 
 bool
-Security::CreateClientSession(const FuturePeerContextPointer &ctx, const Comm::ConnectionPointer &c, const char *squidCtx)
+Security::CreateClientSession(FuturePeerContext &ctx, const Comm::ConnectionPointer &c, const char *squidCtx)
 {
-    Assure(ctx); // this should be a reference then
-    return CreateSession(ctx->raw, c, ctx->options, Security::Io::BIO_TO_SERVER, squidCtx);
+    // TODO: We cannot make ctx constant because CreateSession() takes
+    // non-constant ctx.options (PeerOptions). It does that because GnuTLS
+    // needs to call PeerOptions::updateSessionOptions(), which is not constant
+    // because it compiles options (just in case) every time. To achieve
+    // const-correctness, we should compile PeerOptions once, not every time.
+    return CreateSession(ctx.raw, c, ctx.options, Security::Io::BIO_TO_SERVER, squidCtx);
 }
 
 bool

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -180,7 +180,7 @@ CreateSession(const Security::ContextPointer &ctx, const Comm::ConnectionPointer
 }
 
 bool
-Security::CreateClientSession(FuturePeerContextPointer &ctx, const Comm::ConnectionPointer &c, const char *squidCtx)
+Security::CreateClientSession(const FuturePeerContextPointer &ctx, const Comm::ConnectionPointer &c, const char *squidCtx)
 {
     Assure(ctx); // this should be a reference then
     return CreateSession(ctx->raw, c, ctx->options, Security::Io::BIO_TO_SERVER, squidCtx);

--- a/src/security/Session.h
+++ b/src/security/Session.h
@@ -38,7 +38,7 @@ using FuturePeerContextPointer = RefCount<FuturePeerContext>;
 
 /// Creates TLS Client connection structure (aka 'session' state) and initializes TLS/SSL I/O (Comm and BIO).
 /// On errors, emits DBG_IMPORTANT with details and returns false.
-bool CreateClientSession(FuturePeerContextPointer &, const Comm::ConnectionPointer &, const char *squidCtx);
+bool CreateClientSession(const FuturePeerContextPointer &, const Comm::ConnectionPointer &, const char *squidCtx);
 
 class PeerOptions;
 

--- a/src/security/Session.h
+++ b/src/security/Session.h
@@ -38,7 +38,7 @@ using FuturePeerContextPointer = RefCount<FuturePeerContext>;
 
 /// Creates TLS Client connection structure (aka 'session' state) and initializes TLS/SSL I/O (Comm and BIO).
 /// On errors, emits DBG_IMPORTANT with details and returns false.
-bool CreateClientSession(const FuturePeerContextPointer &, const Comm::ConnectionPointer &, const char *squidCtx);
+bool CreateClientSession(FuturePeerContext &, const Comm::ConnectionPointer &, const char *squidCtx);
 
 class PeerOptions;
 

--- a/src/security/Session.h
+++ b/src/security/Session.h
@@ -31,9 +31,14 @@
 
 namespace Security {
 
+// XXX: Should be in src/security/forward.h (which should not include us because
+// that #include creates a circular reference and problems like this).
+class FuturePeerContext;
+using FuturePeerContextPointer = RefCount<FuturePeerContext>;
+
 /// Creates TLS Client connection structure (aka 'session' state) and initializes TLS/SSL I/O (Comm and BIO).
 /// On errors, emits DBG_IMPORTANT with details and returns false.
-bool CreateClientSession(const Security::ContextPointer &, const Comm::ConnectionPointer &, const char *squidCtx);
+bool CreateClientSession(FuturePeerContextPointer &, const Comm::ConnectionPointer &, const char *squidCtx);
 
 class PeerOptions;
 

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -200,6 +200,7 @@ typedef long ParsedPortFlags;
 class PeerConnector;
 class BlindPeerConnector;
 class PeerOptions;
+using PeerOptionsPointer = RefCount<PeerOptions>;
 
 class ServerOptions;
 

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -200,7 +200,8 @@ typedef long ParsedPortFlags;
 class PeerConnector;
 class BlindPeerConnector;
 class PeerOptions;
-using PeerOptionsPointer = RefCount<PeerOptions>;
+class PeerContext;
+using PeerContextPointer = RefCount<PeerContext>;
 
 class ServerOptions;
 

--- a/src/security/forward.h
+++ b/src/security/forward.h
@@ -200,8 +200,11 @@ typedef long ParsedPortFlags;
 class PeerConnector;
 class BlindPeerConnector;
 class PeerOptions;
+
 class PeerContext;
 using PeerContextPointer = RefCount<PeerContext>;
+
+class PeerContexts;
 
 class ServerOptions;
 

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -183,12 +183,7 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
         if (hostName)
             SSL_set_ex_data(serverSession.get(), ssl_ex_index_server, (void*)hostName);
 
-        auto &tlsOptions = tlsOptions_ ? *tlsOptions_ : Security::ProxyOutgoingConfig;
-
         if (csd->sslBumpMode == Ssl::bumpPeek || csd->sslBumpMode == Ssl::bumpStare) {
-            if (csd->sslBumpMode == Ssl::bumpStare)
-                tlsOptions.updateSessionOptions(serverSession);
-
             auto clientSession = fd_table[clientConn->fd].ssl.get();
             Must(clientSession);
             BIO *bc = SSL_get_rbio(clientSession);
@@ -205,9 +200,6 @@ Ssl::PeekingPeerConnector::initialize(Security::SessionPointer &serverSession)
             srvBio->recordInput(true);
             srvBio->mode(csd->sslBumpMode);
         } else {
-            // Set client SSL options
-            tlsOptions.updateSessionOptions(serverSession);
-
             const bool redirected = request->flags.redirected && ::Config.onoff.redir_rewrites_host;
             const char *sniServer = (!hostName || redirected) ?
                                     request->url.host() :

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -27,13 +27,13 @@ CBDATA_NAMESPACED_CLASS_INIT(Ssl, PeekingPeerConnector);
 
 Ssl::PeekingPeerConnector::PeekingPeerConnector(HttpRequestPointer &aRequest,
         const Comm::ConnectionPointer &aServerConn,
-        const Security::PeerOptionsPointer &aPeerOptionsPointer,
+        const Security::FuturePeerContextPointer &aPeerContextPointer,
         const Comm::ConnectionPointer &aClientConn,
         const AsyncCallback<Security::EncryptorAnswer> &aCallback,
         const AccessLogEntryPointer &alp,
         const time_t timeout):
     AsyncJob("Ssl::PeekingPeerConnector"),
-    Security::PeerConnector(aServerConn, aPeerOptionsPointer, aCallback, alp, timeout),
+    Security::PeerConnector(aServerConn, aPeerContextPointer, aCallback, alp, timeout),
     clientConn(aClientConn),
     splice(false),
     serverCertificateHandled(false)
@@ -143,10 +143,12 @@ Ssl::PeekingPeerConnector::checkForPeekAndSpliceGuess() const
     return Ssl::bumpSplice;
 }
 
-Security::ContextPointer
-Ssl::PeekingPeerConnector::getTlsContext()
+Security::FuturePeerContextPointer
+Ssl::PeekingPeerConnector::peerContext()
 {
-    return tlsOptions_ ? ::Config.ssl_client.sslContextForRetries : ::Config.ssl_client.sslContext;
+    if (tlsContext_)
+        return tlsContext_;
+    return Config.ssl_client.defaultContext;
 }
 
 bool

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -144,7 +144,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSpliceGuess() const
 }
 
 Security::FuturePeerContextPointer
-Ssl::PeekingPeerConnector::peerContext()
+Ssl::PeekingPeerConnector::peerContext() const
 {
     if (tlsContext_)
         return tlsContext_;

--- a/src/ssl/PeekingPeerConnector.cc
+++ b/src/ssl/PeekingPeerConnector.cc
@@ -146,9 +146,7 @@ Ssl::PeekingPeerConnector::checkForPeekAndSpliceGuess() const
 Security::FuturePeerContextPointer
 Ssl::PeekingPeerConnector::peerContext() const
 {
-    if (tlsContext_)
-        return tlsContext_;
-    return Config.ssl_client.defaultContext;
+    return tlsContext_ ? tlsContext_ : Security::DefaultOutgoingContext;
 }
 
 bool

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -22,6 +22,7 @@ class PeekingPeerConnector: public Security::PeerConnector {
 public:
     PeekingPeerConnector(HttpRequestPointer &aRequest,
                          const Comm::ConnectionPointer &aServerConn,
+                         const Security::PeerOptionsPointer &,
                          const Comm::ConnectionPointer &aClientConn,
                          const AsyncCallback<Security::EncryptorAnswer> &aCallback,
                          const AccessLogEntryPointer &alp,

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -22,7 +22,7 @@ class PeekingPeerConnector: public Security::PeerConnector {
 public:
     PeekingPeerConnector(HttpRequestPointer &aRequest,
                          const Comm::ConnectionPointer &aServerConn,
-                         const Security::PeerOptionsPointer &,
+                         const Security::FuturePeerContextPointer &,
                          const Comm::ConnectionPointer &aClientConn,
                          const AsyncCallback<Security::EncryptorAnswer> &aCallback,
                          const AccessLogEntryPointer &alp,
@@ -30,7 +30,7 @@ public:
 
     /* Security::PeerConnector API */
     bool initialize(Security::SessionPointer &) override;
-    Security::ContextPointer getTlsContext() override;
+    Security::FuturePeerContextPointer peerContext() override;
     void noteWantWrite() override;
     void noteNegotiationError(const Security::ErrorDetailPointer &) override;
     void noteNegotiationDone(ErrorState *error) override;

--- a/src/ssl/PeekingPeerConnector.h
+++ b/src/ssl/PeekingPeerConnector.h
@@ -30,7 +30,7 @@ public:
 
     /* Security::PeerConnector API */
     bool initialize(Security::SessionPointer &) override;
-    Security::FuturePeerContextPointer peerContext() override;
+    Security::FuturePeerContextPointer peerContext() const override;
     void noteWantWrite() override;
     void noteNegotiationError(const Security::ErrorDetailPointer &) override;
     void noteNegotiationDone(ErrorState *error) override;

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -80,7 +80,7 @@ PeerConnector::PeerConnector(
     const Security::FuturePeerContextPointer &,
     const AsyncCallback<EncryptorAnswer> &,
     const AccessLogEntryPointer &,
-    const time_t):
+    time_t):
     AsyncJob("Security::PeerConnector") {STUB}
 PeerConnector::~PeerConnector() STUB
 void PeerConnector::start() STUB

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -108,6 +108,8 @@ EncryptorAnswer &PeerConnector::answer() STUB_RETREF(EncryptorAnswer)
 
 #include "security/PeerOptions.h"
 Security::PeerOptions Security::ProxyOutgoingConfig;
+Security::FuturePeerContextPointer Security::DefaultOutgoingContext;
+
 Security::PeerOptions::PeerOptions() {
 #if USE_OPENSSL
     parsedOptions = 0;

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -19,7 +19,7 @@ CBDATA_NAMESPACED_CLASS_INIT(Security, BlindPeerConnector);
 namespace Security
 {
 bool BlindPeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
-Security::ContextPointer BlindPeerConnector::getTlsContext() STUB_RETVAL(Security::ContextPointer())
+FuturePeerContextPointer BlindPeerConnector::peerContext() const STUB_RETVAL(FuturePeerContextPointer())
 void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB
 }
 
@@ -75,7 +75,12 @@ const char *Security::NegotiationHistory::printTlsVersion(AnyP::ProtocolVersion 
 class TlsNegotiationDetails: public RefCountable {};
 namespace Security
 {
-PeerConnector::PeerConnector(const Comm::ConnectionPointer &, const AsyncCallback<EncryptorAnswer> &, const AccessLogEntryPointer &, const time_t):
+PeerConnector::PeerConnector(
+    const Comm::ConnectionPointer &,
+    const Security::FuturePeerContextPointer &,
+    const AsyncCallback<EncryptorAnswer> &,
+    const AccessLogEntryPointer &,
+    const time_t):
     AsyncJob("Security::PeerConnector") {STUB}
 PeerConnector::~PeerConnector() STUB
 void PeerConnector::start() STUB
@@ -92,7 +97,6 @@ void PeerConnector::handleNegotiationResult(const Security::IoResult &) STUB;
 void PeerConnector::noteWantRead() STUB
 void PeerConnector::noteWantWrite() STUB
 void PeerConnector::noteNegotiationError(const Security::ErrorDetailPointer &) STUB
-//    virtual Security::ContextPointer getTlsContext() = 0;
 void PeerConnector::bail(ErrorState *) STUB
 void PeerConnector::sendSuccess() STUB
 void PeerConnector::callBack() STUB
@@ -121,6 +125,7 @@ void Security::PeerOptions::updateSessionOptions(Security::SessionPointer &) STU
 void Security::PeerOptions::dumpCfg(Packable*, char const*) const STUB
 void Security::PeerOptions::parseOptions() STUB
 void parse_securePeerOptions(Security::PeerOptions *) STUB
+Security::PeerContextPointer Security::PeerContexts::findContext(ACLChecklist &) const STUB_RETVAL(nullptr)
 
 #include "security/ServerOptions.h"
 //Security::ServerOptions::ServerOptions(const Security::ServerOptions &) STUB
@@ -139,7 +144,7 @@ void Security::ServerOptions::updateContextSessionId(Security::ContextPointer &)
 
 #include "security/Session.h"
 namespace Security {
-bool CreateClientSession(const Security::ContextPointer &, const Comm::ConnectionPointer &, const char *) STUB_RETVAL(false)
+bool CreateClientSession(FuturePeerContext &, const Comm::ConnectionPointer &, const char *) STUB_RETVAL(false)
 bool CreateServerSession(const Security::ContextPointer &, const Comm::ConnectionPointer &, Security::PeerOptions &, const char *) STUB_RETVAL(false)
 void SessionSendGoodbye(const Security::SessionPointer &) STUB
 bool SessionIsResumed(const Security::SessionPointer &) STUB_RETVAL(false)

--- a/src/tests/testClpMap.cc
+++ b/src/tests/testClpMap.cc
@@ -9,7 +9,6 @@
 #include "squid.h"
 #include "base/ClpMap.h"
 #include "compat/cppunit.h"
-#include "SquidConfig.h"
 #include "unitTestMain.h"
 
 #include <ctime>
@@ -67,8 +66,6 @@ protected:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( TestClpMap );
-
-class SquidConfig Config;
 
 void
 TestClpMap::addSequenceOfEntriesToMap(Map &m, size_t count, const Map::mapped_type startWith, const Map::Ttl ttl)

--- a/src/tests/testClpMap.cc
+++ b/src/tests/testClpMap.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "base/ClpMap.h"
 #include "compat/cppunit.h"
+#include "SquidConfig.h"
 #include "unitTestMain.h"
 
 #include <ctime>
@@ -66,6 +67,8 @@ protected:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( TestClpMap );
+
+class SquidConfig Config;
 
 void
 TestClpMap::addSequenceOfEntriesToMap(Map &m, size_t count, const Map::mapped_type startWith, const Map::Ttl ttl)

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1195,12 +1195,12 @@ TunnelStateData::connectToPeer(const Comm::ConnectionPointer &conn)
     connectedToPeer(conn);
 }
 
-/// encrypts an established TCP connection to peer
+/// encrypts an established TCP connection to cache_peer
 void
 TunnelStateData::secureConnectionToPeer(const Comm::ConnectionPointer &conn)
 {
     const auto callback = asyncCallback(5, 4, TunnelStateData::noteSecurityPeerConnectorAnswer, this);
-    const auto connector = new Security::BlindPeerConnector(request, conn, callback, al);
+    const auto connector = new Security::BlindPeerConnector(request, conn, nullptr, callback, al);
     encryptionWait.start(connector, callback);
 }
 


### PR DESCRIPTION
    acl downgrade ...
    tls_outgoing_options cipher=ALL@SECLEVEL=4
    tls_outgoing_options_for_retries cipher=ALL@SECLEVEL=3 if downgrade

This directive is handy in environments where Squid should communicate
using strict TLS options by default (see tls_outgoing_options) but may
relax those restrictions to accommodate certain older origin servers
that require inferior (but still deemed "secure enough") settings.

Popular browsers also retry with special TLS options after certain TLS
failures, so we are not inventing something new here. Unfortunately,
Squid cannot rely on those client features, for several reasons. For
example, Squid may not have (or may be unable to relay) enough TLS
server information to trigger browser-initiated retries. Squid may also
be dealing with a user agent that does not retry (to Squid admin's
satisfaction).
