### PR TITLE
Allow creation of RefCountable objects via Make()

### DIFF
--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -27,6 +27,8 @@ class RefCount
 {
 
 public:
+    /// creates a new C object using given C constructor arguments (if any)
+    /// \returns a refcounting pointer to the created object
     template<typename... Args>
     inline static auto Make(Args&&... args) {
         return RefCount<C>(new C(std::forward<Args>(args)...));

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -102,10 +102,11 @@ public:
         return p != p_;
     }
 
-private:
+    // TODO private:
     /// use public Make() instead
     RefCount(C * const p): p_(p) { reference(*this); }
 
+private:
     void dereference(C const *newP = nullptr) {
         /* Setting p_ first is important:
         * we may be freed ourselves as a result of

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -15,6 +15,7 @@
 #include "base/Lock.h"
 
 #include <iostream>
+#include <utility>
 
 /**
  * Template for Reference Counting pointers.

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -31,8 +31,9 @@ public:
     inline static auto Make(Args&&... args) {
         return RefCount<C>(new C(std::forward<Args>(args)...));
     }
-
     RefCount () : p_ (nullptr) {}
+
+    RefCount (C const *p) : p_(p) { reference (*this); }
 
     ~RefCount() {
         dereference();
@@ -103,10 +104,6 @@ public:
     {
         return p != p_;
     }
-
-    // TODO private:
-    /// use public Make() instead
-    RefCount(C * const p): p_(p) { reference(*this); }
 
 private:
     void dereference(C const *newP = nullptr) {

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -31,6 +31,7 @@ public:
     inline static auto Make(Args&&... args) {
         return RefCount<C>(new C(std::forward<Args>(args)...));
     }
+
     RefCount () : p_ (nullptr) {}
 
     ~RefCount() {
@@ -102,8 +103,8 @@ public:
     }
 
 private:
-    /// use public Pointer::Make(p) API instead
-    RefCount(const C *p): p_(p) { reference(*this); }
+    /// use public Make() instead
+    RefCount(C * const p): p_(p) { reference(*this); }
 
     void dereference(C const *newP = nullptr) {
         /* Setting p_ first is important:

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -31,11 +31,7 @@ public:
     inline static auto Make(Args&&... args) {
         return RefCount<C>(new C(std::forward<Args>(args)...));
     }
-
-public:
     RefCount () : p_ (nullptr) {}
-
-    RefCount (C const *p) : p_(p) { reference (*this); }
 
     ~RefCount() {
         dereference();
@@ -106,6 +102,9 @@ public:
     }
 
 private:
+    /// use public Pointer::Make(p) API instead
+    RefCount(const C *p): p_(p) { reference(*this); }
+
     void dereference(C const *newP = nullptr) {
         /* Setting p_ first is important:
         * we may be freed ourselves as a result of

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -27,6 +27,12 @@ class RefCount
 {
 
 public:
+    template<typename... Args>
+    inline static auto Make(Args&&... args) {
+        return RefCount<C>(new C(std::forward<Args>(args)...));
+    }
+
+public:
     RefCount () : p_ (nullptr) {}
 
     RefCount (C const *p) : p_(p) { reference (*this); }


### PR DESCRIPTION
Compared to calling new() directly, using a Pointer-returning Make()
reduces memory leaks related to freshly allocated heap objects. Perfect
forwarding of constructor parameters through Make() minimizes overhead.

    const auto foo1 = new Foo(...); // XXX: leak-prone
    const auto foo2 = Foo::Pointer::Make(...); // OK

Future changes will prohibit RefCountable object creation via direct
new() calls and require using Make() or an equivalent safety API.