### PR TITLE
Define RefCount nullptr assignment operator

### DIFF
--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -66,6 +66,14 @@ public:
         return *this;
     }
 
+    /// Specialization to allow "foo = nullptr" to unset a refcounted Pointer.
+    /// Assignment of raw-pointers including void* are otherwise prohibited.
+    constexpr RefCount &operator =(const nullptr_t) {
+        if(p_)
+            dereference();
+        return *this;
+    }
+
     explicit operator bool() const { return p_; }
 
     bool operator !() const { return !p_; }

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -66,10 +66,7 @@ public:
         return *this;
     }
 
-    /// Specialization to allow "foo = nullptr" to unset a refcounted Pointer.
-    /// Assignment of raw-pointers including void* are otherwise prohibited.
-    constexpr RefCount &operator =(const nullptr_t) {
-        if(p_)
+    RefCount &operator =(std::nullptr_t) {
             dereference();
         return *this;
     }

--- a/src/base/RefCount.h
+++ b/src/base/RefCount.h
@@ -66,10 +66,7 @@ public:
         return *this;
     }
 
-    RefCount &operator =(std::nullptr_t) {
-            dereference();
-        return *this;
-    }
+    RefCount &operator =(std::nullptr_t) { dereference(); return *this; }
 
     explicit operator bool() const { return p_; }
 


### PR DESCRIPTION
If RefCount(C*) constructor becomes private, this change
will be needed to use 'foo=nullptr' syntax to clear a Pointer.