### PR TITLE
Parallelize testHeaders

### DIFF
--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -93,7 +93,7 @@ TESTS += testHeaders
 ## Special Universal .h dependency test script
 ## aborts if error encountered
 testHeaders: $(srcdir)/*.h $(srcdir)/os/*.h
-	$(SHELL) $(top_srcdir)/test-suite/testheaders.sh "$(CXXCOMPILE)" $^ || exit 1
+	$(MAKE) $(^:.h=.hdrtest)
 
 CLEANFILES += testHeaders
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -81,7 +81,7 @@ tests_testRFC1738_LDFLAGS = $(LIBADD_DL)
 ## Special Universal .h dependency test script
 ## aborts if error encountered
 testHeaders: $(top_srcdir)/include/*.h
-	$(SHELL) $(top_srcdir)/test-suite/testheaders.sh "$(CXXCOMPILE)" $^ || exit 1
+	$(MAKE) $(^:.h=.hdrtest)
 
 TESTS += testHeaders
 CLEANFILES += testHeaders

--- a/src/Common.am
+++ b/src/Common.am
@@ -73,3 +73,7 @@ COMPAT_LIB = $(top_builddir)/compat/libcompatsquid.la $(LIBPROFILER)
 
 ## Some helpers are written in Perl and need the local shell defined properly
 subst_perlshell = sed -e 's,[@]PERL[@],$(PERL),g' <$(srcdir)/$@.pl.in >$@ || ($(RM) -f $@ ; exit 1)
+
+EXTENSIONS=.hdrtest
+.h.hdrtest:
+	$(SHELL) $(top_srcdir)/test-suite/testheaders.sh "$(CXXCOMPILE)" $^ || exit 1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2744,7 +2744,7 @@ TESTS += $(check_PROGRAMS) testHeaders
 ## Special Universal .h dependency test script
 ## aborts if error encountered
 testHeaders: $(srcdir)/*.h $(srcdir)/DiskIO/*.h $(srcdir)/DiskIO/*/*.h
-	$(SHELL) $(top_srcdir)/test-suite/testheaders.sh "$(CXXCOMPILE)" $^ || exit 1
+	$(MAKE) $(^:.h=.hdrtest)
 ## src/repl/ has no .h files and its own makefile.
 
 CLEANFILES += testHeaders

--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -14,7 +14,7 @@ TESTS += testHeaders
 ## .h dependency test script
 ## aborts build process on errors; XXX: even with "make -k"
 testHeaders: $(srcdir)/*.h
-	$(SHELL) $(top_srcdir)/test-suite/testheaders.sh "$(CXXCOMPILE)" $^ || exit 1
+	$(MAKE) $(^:.h=.hdrtest)
 
 ## XXX: this is only needed because testheaders.sh creates a dummy file called
 ## testHeaders and distclean does not know about it.

--- a/src/fs/Makefile.am
+++ b/src/fs/Makefile.am
@@ -71,7 +71,7 @@ TESTS += testHeaders
 ## Special Universal .h dependency test script
 ## aborts if error encountered
 testHeaders: $(srcdir)/ufs/*.h $(srcdir)/rock/*.h
-	$(SHELL) $(top_srcdir)/test-suite/testheaders.sh "$(CXXCOMPILE)" $^ || exit 1
+	$(MAKE) $(^:.h=.hdrtest)
 ## diskd/ has no .h files
 ## aufs/ has no .h files
 ## ./ has no .h files

--- a/src/repl/Makefile.am
+++ b/src/repl/Makefile.am
@@ -28,7 +28,7 @@ TESTS += testHeaders
 ## Special Universal .h dependency test script
 ## aborts if error encountered
 testHeaders: $(srcdir)/heap/*.h
-	$(SHELL) $(top_srcdir)/test-suite/testheaders.sh "$(CXXCOMPILE)" $^ || exit 1
+	$(MAKE) $(^:.h=.hdrtest)
 ## ./ has no .h files.
 ## ./lru/ has no .h files.
 

--- a/test-suite/testheaders.sh
+++ b/test-suite/testheaders.sh
@@ -26,7 +26,6 @@ TRUE=${TRUE:-/bin/true}
 exitCode=0
 
 for f in $@; do
-	echo -n "Testing ${f} ..."
     t="testhdr_`basename ${f}`"
     if [ ! -f "$t.o" -o $f -nt "$t.o" ]; then
         echo >$t.cc <<EOF
@@ -36,9 +35,9 @@ for f in $@; do
 int main( int argc, char* argv[] ) { return 0; }
 EOF
         if ${cc} -c -o $t.o $t.cc ; then
-            echo "Ok."
+            echo "Testing ${f} ... Ok."
         else
-            echo "Fail."
+            echo "Testing ${f} ... Fail."
             exitCode=1
         fi
         rm $t.cc $t.o


### PR DESCRIPTION
Ensure that header tests during "make check" can be run mostly in parallel.
This enables a an improved full build wall-clock at the expense of total CPU load.

On a NUC6i7KYB, with an Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz (quad-core, hyperthreaded)
Timing a 10-way parallel cycle bootstrap.sh-configure-build-check with ccache disabled on ubuntu 22.04, results in:

no ccache, parallel:
real	9m14.838s
user	42m56.461s
sys	4m20.099s

no ccache, master:
real	9m42.640s
user	44m37.154s
sys	4m29.273s

fully warm ccache, parallel:
real	0m46.748s
user	0m48.995s
sys	0m12.082s

fully warm ccache, master:
real	0m51.291s
user	0m47.513s
sys	0m11.077s
