### PR TITLE
Log %err_code for ERR_RELAY_REMOTE transactions

### DIFF
--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -339,7 +339,7 @@ Http::Tunneler::bailOnResponseError(const char *error, HttpReply *errorReply)
 
     ErrorState *err;
     if (errorReply) {
-        err = new ErrorState(request.getRaw(), errorReply);
+        err = new ErrorState(request.getRaw(), errorReply, al);
     } else {
         // with no reply suitable for relaying, answer with 502 (Bad Gateway)
         err = new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al);

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1277,8 +1277,7 @@ HttpReply *
 ErrorState::BuildHttpReply()
 {
     // Make sure error codes get back to the client side for logging and
-    // error tracking. XXX: ErrorState should only reflect already recorded
-    // information instead of being responsible for updating records.
+    // error tracking.
     if (request) {
         request->error.update(type, detail);
         request->error.update(SysErrorDetail::NewIfAny(xerrno));

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -95,7 +95,7 @@ public:
     ErrorState() = delete; // not implemented.
 
     /// creates an ERR_RELAY_REMOTE error
-    ErrorState(HttpRequest * request, HttpReply *);
+    ErrorState(HttpRequest * request, HttpReply *, const AccessLogEntryPointer &);
 
     ~ErrorState();
 
@@ -120,7 +120,7 @@ private:
     typedef ErrorPage::Build Build;
 
     /// initializations shared by public constructors
-    explicit ErrorState(err_type type);
+    ErrorState(err_type, const AccessLogEntryPointer &);
 
     /// locates the right error page template for this error and compiles it
     SBuf buildBody();

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -446,7 +446,6 @@ TunnelStateData::retryOrBail(const char *context)
     // sendNewError() and sendSavedErrorOr(), used in "error detected" cases.
     if (!savedError)
         saveError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al));
-
     const auto canSendError = Comm::IsConnOpen(client.conn) && !client.dirty &&
                               clientExpectsConnectResponse();
     if (canSendError)

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -453,10 +453,6 @@ TunnelStateData::retryOrBail(const char *context)
         return sendError(savedError, bailDescription ? bailDescription : context);
     *status_ptr = savedError->httpStatus;
 
-    // TODO: Refactor FwdState::updateAleWithFinalError(), this code, and
-    // ErrorState::BuildHttpReply() to ensure consistent/efficient ALE updates.
-    al->updateError(Error(savedError->type, savedError->detail));
-
     if (noConnections())
         return deleteThis();
 

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -446,6 +446,9 @@ TunnelStateData::retryOrBail(const char *context)
     // sendNewError() and sendSavedErrorOr(), used in "error detected" cases.
     if (!savedError)
         saveError(new ErrorState(ERR_CANNOT_FORWARD, Http::scInternalServerError, request.getRaw(), al));
+
+    al->updateError(Error(savedError->type, savedError->detail));
+
     const auto canSendError = Comm::IsConnOpen(client.conn) && !client.dirty &&
                               clientExpectsConnectResponse();
     if (canSendError)
@@ -1166,6 +1169,7 @@ tunnelStart(ClientHttpRequest * http)
             http->updateLoggingTags(LOG_TCP_TUNNEL);
             err = new ErrorState(ERR_FORWARDING_DENIED, Http::scForbidden, request, http->al);
             http->al->http.code = Http::scForbidden;
+            http->al->updateError(Error(err->type, err->detail));
             errorSend(http->getConn()->clientConnection, err);
             return;
         }

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1169,7 +1169,6 @@ tunnelStart(ClientHttpRequest * http)
             http->updateLoggingTags(LOG_TCP_TUNNEL);
             err = new ErrorState(ERR_FORWARDING_DENIED, Http::scForbidden, request, http->al);
             http->al->http.code = Http::scForbidden;
-            http->al->updateError(Error(err->type, err->detail));
             errorSend(http->getConn()->clientConnection, err);
             return;
         }

--- a/test-suite/test-functionality.sh
+++ b/test-suite/test-functionality.sh
@@ -214,6 +214,7 @@ main() {
     then
         local default_tests="
             pconn
+            dead-peer
             proxy-update-headers-after-304
             accumulate-headers-after-304
             upgrade-protocols


### PR DESCRIPTION
For ERR_RELAY_REMOTE transactions, Squid was logging %err_code as "-"
because BuildHttpReply() was not updating HttpRequest::error or ALE.
That update was missing because the pre-computed response in those
transactions triggered a premature exit from BuildHttpReply().

BuildHttpReply() should not be updating errors at all, but significant
code refactoring required to fix that problem needs a dedicated change.

