### PR TITLE
Restore support for legacy cache_object cache manager requests

### DIFF
--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -190,7 +190,7 @@ CacheManager::ParseUrl(const AnyP::Uri &uri)
 {
     Parser::Tokenizer tok(uri.path());
 
-    Assure(tok.skip(WellKnownUrlPathPrefix()));
+    Assure(tok.skip(WellKnownUrlPathPrefix()) || tok.skip('/'));
 
     Mgr::Command::Pointer cmd = new Mgr::Command();
     cmd->params.httpUri = SBufToString(uri.absolute());


### PR DESCRIPTION
Squid v6.3 commit 6695897 (i.e. a backport of master/v7 commit 3c383cc)
accidentally removed support of legacy cache_object URLs (that master/v7
does not support) from Squid v6. This fix restores that support in v6.
