### PR TITLE
Bug 5301: cachemgr.cgi not showing new manager interface URLs

### DIFF
--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -283,11 +283,10 @@ auth_html(const char *host, int port, const char *user_name)
     printf("     d.innerHTML = d.innerHTML + '<p>Host: <a href=\"http' + s + '://' + t + '/squid-internal-mgr/\">' + t + '</a></p>';\n");
     printf("     var sv = document.getElementById('server');\n");
     printf("     var op = sv.getElementsByTagName('OPTION');\n");
-    printf("     for(var i=0; i<op.length; i++) {\n");
-    printf("      if (op[i].innerHTML == t) {\n");
-    printf("       sv.removeChild(op[i]);\n");
-    printf("       i--;\n");
-    printf(" }}}}}}\n");
+    printf("     for(var i=0; i<op.length; i++) { if (op[i].innerHTML == t) { sv.removeChild(op[i]); i--; }}\n");
+    printf("     if (sv.getElementsByTagName('OPTION').length == 0) {\n");
+    printf("      document.getElementById('Cmgr').innerHTML = '';\n");
+    printf(" }}}}}\n");
     printf(" x.send(null);\n");
     printf("}\n");
     printf("</script>\n");

--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -277,7 +277,7 @@ auth_html(const char *host, int port, const char *user_name)
     printf("  if (x.readyState==4) {\n");
     printf("   if ((x.status>=200 && x.status <= 299) || x.status==401) {\n");
     printf("    var v = x.getResponseHeader('Server');\n");
-    printf("    if (v.substring(0,8) == 'squid/3.' && (v[8]=='H' || parseInt(v.substring(8)) >= 2)) {\n");
+    printf("    if (v.substring(0,6) == 'squid/' || v == 'squid') {\n");
     printf("     var d = document.getElementById('H' + s + 'mgr');\n");
     printf("     if (d.innerHTML == '') d.innerHTML = '<h2>HTTP' + (s=='s'?'S':'') + ' Managed Proxies</h2>';\n");
     printf("     d.innerHTML = d.innerHTML + '<p>Host: <a href=\"http' + s + '://' + t + '/squid-internal-mgr/\">' + t + '</a></p>';\n");

--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -281,7 +281,13 @@ auth_html(const char *host, int port, const char *user_name)
     printf("     var d = document.getElementById('H' + s + 'mgr');\n");
     printf("     if (d.innerHTML == '') d.innerHTML = '<h2>HTTP' + (s=='s'?'S':'') + ' Managed Proxies</h2>';\n");
     printf("     d.innerHTML = d.innerHTML + '<p>Host: <a href=\"http' + s + '://' + t + '/squid-internal-mgr/\">' + t + '</a></p>';\n");
-    printf(" }}}}\n");
+    printf("     var sv = document.getElementById('server');\n");
+    printf("     var op = sv.getElementsByTagName('OPTION');\n");
+    printf("     for(var i=0; i<op.length; i++) {\n");
+    printf("      if (op[i].innerHTML == t) {\n");
+    printf("       sv.removeChild(op[i]);\n");
+    printf("       i--;\n");
+    printf(" }}}}}}\n");
     printf(" x.send(null);\n");
     printf("}\n");
     printf("</script>\n");

--- a/tools/cachemgr.cc
+++ b/tools/cachemgr.cc
@@ -807,7 +807,7 @@ process_request(cachemgr_request * req)
     }
 
     if (req->action == nullptr) {
-        req->action = xstrdup("");
+        req->action = xstrdup("menu");
     }
 
     if (strcmp(req->action, "authenticate") == 0) {


### PR DESCRIPTION
Also fix several related UI issues uncovered during testing:

* Prune the list of servers accessible via the CGI tool login.
 Their responses would be badly mangled if accessed via
 the old tools parse logic.
Also, hide the old login form if all servers use the new
manager interface.

* Ensure the 'menu' report is always used by default after
the CGI tool login. This prevents errors about MGR_INDEX
not being available on recent Squid releases. Restoring the
expected CGI tool behavior.