### PR TITLE
Extend cache_log_message to problematic from-helper annotations

### DIFF
--- a/doc/debug-messages.dox
+++ b/doc/debug-messages.dox
@@ -66,5 +66,6 @@ ID Message gist
 66 WARNING: BCP 177 violation. Detected non-functional IPv6 loopback.
 67 WARNING: BCP 177 violation. IPv6 transport forced OFF by build parameters.
 68 Processing Configuration File: ... (depth ...)
+69 WARNING: Unsupported or unexpected from-helper annotation ...
 \endverbatim
 */

--- a/doc/debug-messages.dox
+++ b/doc/debug-messages.dox
@@ -66,6 +66,6 @@ ID Message gist
 66 WARNING: BCP 177 violation. Detected non-functional IPv6 loopback.
 67 WARNING: BCP 177 violation. IPv6 transport forced OFF by build parameters.
 68 Processing Configuration File: ... (depth ...)
-69 WARNING: Unsupported or unexpected from-helper annotation ...
+69 WARNING: Unsupported or unexpected from-helper annotation with a name reserved for Squid use: ...advice: If this is a custom annotation, rename it to add a trailing underscore: ...
 \endverbatim
 */

--- a/src/debug/Messages.h
+++ b/src/debug/Messages.h
@@ -61,7 +61,7 @@ private:
 };
 
 /// The maximum used DebugMessage::id plus 1. Increase as you add new IDs.
-constexpr DebugMessageId DebugMessageIdUpperBound = 69;
+constexpr DebugMessageId DebugMessageIdUpperBound = 70;
 
 /// a collection of DebugMessage objects (with fast access by message IDs)
 class DebugMessages

--- a/src/helper/Reply.cc
+++ b/src/helper/Reply.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "ConfigParser.h"
+#include "debug/Messages.h"
 #include "debug/Stream.h"
 #include "helper.h"
 #include "helper/Reply.h"
@@ -197,7 +198,7 @@ Helper::Reply::CheckReceivedKey(const SBuf &key, const SBuf &value)
     if (std::find(recognized.begin(), recognized.end(), key) != recognized.end())
         return; // a Squid-recognized key
 
-    debugs(84, DBG_IMPORTANT, "WARNING: Unsupported or unexpected from-helper annotation with a name reserved for Squid use: " <<
+    debugs(84, Important(69), "WARNING: Unsupported or unexpected from-helper annotation with a name reserved for Squid use: " <<
            key << '=' << value <<
            Debug::Extra << "advice: If this is a custom annotation, rename it to add a trailing underscore: " <<
            key << '_');


### PR DESCRIPTION
    WARNING: Unsupported or unexpected from-helper annotation
        with a name reserved for Squid use

The above message is emitted for every helper response containing
problematic annotations. Let admins control this reporting using
cache_log_message directive and message id 69.