### PR TITLE
Maintenance: remove openssl-ism in Certificate acl

### DIFF
--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "user_cert" or "ca_cert" ACL
-class ClientCertificateCheck : public ParameterizedNode<ACLData<Security::Certificate *>>
+class ClientCertificateCheck: public ParameterizedNode<ACLData<Security::Certificate *> >
 {
 public:
     /* ACL API */

--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "user_cert" or "ca_cert" ACL
-class ClientCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
+class ClientCertificateCheck : public ParameterizedNode<ACLData<Security::Certificate *>>
 {
 public:
     /* ACL API */

--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "user_cert" or "ca_cert" ACL
-class ClientCertificateCheck: public ParameterizedNode<ACLData<Security::Certificate *> >
+class ClientCertificateCheck: public ParameterizedNode< ACLData<Security::Certificate *> >
 {
 public:
     /* ACL API */

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "server_cert_fingerprint" ACL
-class ServerCertificateCheck: public ParameterizedNode<ACLData<Security::Certificate *> >
+class ServerCertificateCheck: public ParameterizedNode< ACLData<Security::Certificate *> >
 {
 public:
     /* ACL API */

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "server_cert_fingerprint" ACL
-class ServerCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
+class ServerCertificateCheck : public ParameterizedNode<ACLData<Security::Certificate *>>
 {
 public:
     /* ACL API */

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "server_cert_fingerprint" ACL
-class ServerCertificateCheck : public ParameterizedNode<ACLData<Security::Certificate *>>
+class ServerCertificateCheck: public ParameterizedNode<ACLData<Security::Certificate *> >
 {
 public:
     /* ACL API */


### PR DESCRIPTION
When GnuTLS support was introduced, the class definitions
for Certificate and CertificateData were not updated to
use the generic Security names.