### PR TITLE
testheaders.sh: force-remove temporary files

### DIFF
--- a/test-suite/testheaders.sh
+++ b/test-suite/testheaders.sh
@@ -41,7 +41,7 @@ EOF
             echo "Fail."
             exitCode=1
         fi
-        rm $t.cc $t.o
+        rm -f $t.cc $t.o
     fi
     test $exitCode -eq 0 || break
 done


### PR DESCRIPTION
At high levels of build parallelism on systems using GNU coreutils,
sometimes "make check" hangs on a request to confirm
removal of a read-only file temporary file.

Force-remove temporary test files to ensure removal is noniteractive.