### PR TITLE
Y2038: Use time_t for commSetConnTimeout() timeout parameter

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -592,7 +592,7 @@ commUnsetFdTimeout(int fd)
 }
 
 int
-commSetConnTimeout(const Comm::ConnectionPointer &conn, int timeout, AsyncCall::Pointer &callback)
+commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t timeout, AsyncCall::Pointer &callback)
 {
     debugs(5, 3, conn << " timeout " << timeout);
     assert(Comm::IsConnOpen(conn));

--- a/src/comm.h
+++ b/src/comm.h
@@ -66,7 +66,7 @@ void commUnsetFdTimeout(int fd);
  * Set or clear the timeout for some action on an active connection.
  * API to replace commSetTimeout() when a Comm::ConnectionPointer is available.
  */
-int commSetConnTimeout(const Comm::ConnectionPointer &conn, int seconds, AsyncCall::Pointer &callback);
+int commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t seconds, AsyncCall::Pointer &callback);
 int commUnsetConnTimeout(const Comm::ConnectionPointer &conn);
 
 int ignoreErrno(int);

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -833,7 +833,7 @@ idnsDoSendQueryVC(nsvc *vc)
     vc->busy = 1;
 
     // Comm needs seconds but idnsCheckQueue() will check the exact timeout
-    const int timeout = (Config.Timeout.idns_query % 1000 ?
+    const time_t timeout = (Config.Timeout.idns_query % 1000 ?
                          Config.Timeout.idns_query + 1000 : Config.Timeout.idns_query) / 1000;
     AsyncCall::Pointer nil;
 

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -834,7 +834,7 @@ idnsDoSendQueryVC(nsvc *vc)
 
     // Comm needs seconds but idnsCheckQueue() will check the exact timeout
     const auto timeout = (Config.Timeout.idns_query % 1000 ?
-                         Config.Timeout.idns_query + 1000 : Config.Timeout.idns_query) / 1000;
+                          Config.Timeout.idns_query + 1000 : Config.Timeout.idns_query) / 1000;
     AsyncCall::Pointer nil;
 
     commSetConnTimeout(vc->conn, timeout, nil);

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1600,7 +1600,8 @@ Helper::Session::requestTimeout(const CommTimeoutCbParams &io)
                                      CommTimeoutCbPtrFun(Session::requestTimeout, srv));
 
     const time_t timeSpent = srv->requests.empty() ? 0 : (squid_curtime - srv->requests.front()->request.dispatch_time.tv_sec);
-    const auto timeLeft = max(static_cast<time_t>(1), srv->parent->timeout - timeSpent);
+    const time_t minimumNewTimeout = 1; // second
+    const auto timeLeft = max(minimumNewTimeout, srv->parent->timeout - timeSpent);
 
     commSetConnTimeout(io.conn, timeLeft, timeoutCall);
 }

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1600,7 +1600,7 @@ Helper::Session::requestTimeout(const CommTimeoutCbParams &io)
                                      CommTimeoutCbPtrFun(Session::requestTimeout, srv));
 
     const time_t timeSpent = srv->requests.empty() ? 0 : (squid_curtime - srv->requests.front()->request.dispatch_time.tv_sec);
-    const time_t timeLeft = max(static_cast<time_t>(1), srv->parent->timeout - timeSpent);
+    const auto timeLeft = max(static_cast<time_t>(1), srv->parent->timeout - timeSpent);
 
     commSetConnTimeout(io.conn, timeLeft, timeoutCall);
 }

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1599,8 +1599,8 @@ Helper::Session::requestTimeout(const CommTimeoutCbParams &io)
     AsyncCall::Pointer timeoutCall = commCbCall(84, 4, "Helper::Session::requestTimeout",
                                      CommTimeoutCbPtrFun(Session::requestTimeout, srv));
 
-    const int timeSpent = srv->requests.empty() ? 0 : (squid_curtime - srv->requests.front()->request.dispatch_time.tv_sec);
-    const int timeLeft = max(1, (static_cast<int>(srv->parent->timeout) - timeSpent));
+    const time_t timeSpent = srv->requests.empty() ? 0 : (squid_curtime - srv->requests.front()->request.dispatch_time.tv_sec);
+    const time_t timeLeft = max(static_cast<time_t>(1), srv->parent->timeout - timeSpent);
 
     commSetConnTimeout(io.conn, timeLeft, timeoutCall);
 }

--- a/src/ipc/UdsOp.cc
+++ b/src/ipc/UdsOp.cc
@@ -51,7 +51,7 @@ Ipc::UdsOp::conn()
     return conn_;
 }
 
-void Ipc::UdsOp::setTimeout(int seconds, const char *handlerName)
+void Ipc::UdsOp::setTimeout(time_t seconds, const char *handlerName)
 {
     typedef CommCbMemFunT<UdsOp, CommTimeoutCbParams> Dialer;
     AsyncCall::Pointer handler = asyncCall(54,5, handlerName,

--- a/src/ipc/UdsOp.h
+++ b/src/ipc/UdsOp.h
@@ -42,7 +42,7 @@ protected:
     Comm::ConnectionPointer &conn(); ///< creates if needed and returns raw UDS socket descriptor
 
     /// call timedout() if no UDS messages in a given number of seconds
-    void setTimeout(int seconds, const char *handlerName);
+    void setTimeout(time_t seconds, const char *handlerName);
     void clearTimeout(); ///< remove previously set timeout, if any
 
     void setOptions(int newOptions); ///< changes socket options
@@ -92,7 +92,7 @@ private:
 private:
     TypedMsgHdr message; ///< what to send
     int retries; ///< how many times to try after a write error
-    int timeout; ///< total time to send the message
+    time_t timeout; ///< total time to send the message
     bool sleeping; ///< whether we are waiting to retry a failed write
     bool writing; ///< whether Comm started and did not finish writing
 

--- a/src/tests/stub_comm.cc
+++ b/src/tests/stub_comm.cc
@@ -48,7 +48,7 @@ int comm_udp_sendto(int, const Ip::Address &, const void *, int) STUB_RETVAL(-1)
 void commCallCloseHandlers(int) STUB
 void commUnsetFdTimeout(int) STUB
 // int commSetTimeout(const Comm::ConnectionPointer &, int, AsyncCall::Pointer&) STUB_RETVAL(-1)
-int commSetConnTimeout(const Comm::ConnectionPointer &, int, AsyncCall::Pointer &) STUB_RETVAL(-1)
+int commSetConnTimeout(const Comm::ConnectionPointer &, time_t, AsyncCall::Pointer &) STUB_RETVAL(-1)
 int commUnsetConnTimeout(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
 int ignoreErrno(int) STUB_RETVAL(-1)
 void commCloseAllSockets(void) STUB


### PR DESCRIPTION
Change commSetConnTimeout() "timeout" parameter from int to time_t, to
match the common caller type and improve Year 2038-safety on systems
with 32-bit int.

Detected by Coverity. CID 1545129: Use of 32-bit time_t (Y2K38_SAFETY).