### PR TITLE
Y2038: improve printing of time settings

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2950,7 +2950,8 @@ parse_TokenOrQuotedString(char **var)
 static void
 dump_time_t(StoreEntry * entry, const char *name, time_t var)
 {
-    storeAppendPrintf(entry, "%s %ld seconds\n", name, static_cast<long>(var));
+    PackableStream os(*entry);
+    os << name << ' ' << var << " seconds\n";
 }
 
 void
@@ -2972,10 +2973,11 @@ free_time_t(time_t * var)
 static void
 dump_time_msec(StoreEntry * entry, const char *name, time_msec_t var)
 {
+    PackableStream os(*entry);
     if (var % 1000)
-        storeAppendPrintf(entry, "%s %" PRId64 " milliseconds\n", name, var);
+        os << name << ' ' << var << " milliseconds\n";
     else
-        storeAppendPrintf(entry, "%s %d seconds\n", name, (int)(var/1000) );
+        os << name << ' ' << var/1000 << " seconds\n";
 }
 
 static void

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2950,7 +2950,7 @@ parse_TokenOrQuotedString(char **var)
 static void
 dump_time_t(StoreEntry * entry, const char *name, time_t var)
 {
-    storeAppendPrintf(entry, "%s %d seconds\n", name, (int) var);
+    storeAppendPrintf(entry, "%s %ld seconds\n", name, static_cast<long>(var));
 }
 
 void

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2977,7 +2977,7 @@ dump_time_msec(StoreEntry * entry, const char *name, time_msec_t var)
     if (var % 1000)
         os << name << ' ' << var << " milliseconds\n";
     else
-        os << name << ' ' << var/1000 << " seconds\n";
+        os << name << ' ' << (var/1000) << " seconds\n";
 }
 
 static void


### PR DESCRIPTION
Avoid truncation errors when printing time_t-based squid.conf directives
on platforms with 32-bit int and 64-bit time_t. Also avoid similar
errors when printing time_msec-based directives on platforms with 32-bit
int.

Detected by Coverity. CID 1529622: Use of 32-bit time_t (Y2K38_SAFETY).