### PR TITLE
Fix handling of zero cache_peers with --enable-cache-digests

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -760,6 +760,9 @@ neighborsDigestSelect(PeerSelector *ps)
     int ichoice_count = 0;
     int p_rtt;
 
+    if (!Config.peers)
+        return nullptr;
+
     if (!request->flags.hierarchical)
         return nullptr;
 


### PR DESCRIPTION
The bug was introduced in recent commit 2e24d0b.