### PR TITLE
Refactor Security::BlindPeerConnector constructor

### DIFF
--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -90,7 +90,7 @@ Security::BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &aRequest,
         const Comm::ConnectionPointer &aServerConn,
         const AsyncCallback<EncryptorAnswer> &aCallback,
         const AccessLogEntryPointer &alp,
-        const time_t timeout) :
+        time_t timeout) :
     AsyncJob("Security::BlindPeerConnector"),
     Security::PeerConnector(aServerConn, aCallback, alp, timeout)
 {

--- a/src/security/BlindPeerConnector.cc
+++ b/src/security/BlindPeerConnector.cc
@@ -86,3 +86,13 @@ Security::BlindPeerConnector::noteNegotiationDone(ErrorState *error)
     }
 }
 
+Security::BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &aRequest,
+        const Comm::ConnectionPointer &aServerConn,
+        const AsyncCallback<EncryptorAnswer> &aCallback,
+        const AccessLogEntryPointer &alp,
+        const time_t timeout) :
+    AsyncJob("Security::BlindPeerConnector"),
+    Security::PeerConnector(aServerConn, aCallback, alp, timeout)
+{
+    request = aRequest;
+}

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -25,7 +25,7 @@ public:
                        const Comm::ConnectionPointer &aServerConn,
                        const AsyncCallback<EncryptorAnswer> &aCallback,
                        const AccessLogEntryPointer &alp,
-                       const time_t timeout = 0);
+                       time_t timeout = 0);
 
     /* Security::PeerConnector API */
 

--- a/src/security/BlindPeerConnector.h
+++ b/src/security/BlindPeerConnector.h
@@ -10,7 +10,6 @@
 #define SQUID_SRC_SECURITY_BLINDPEERCONNECTOR_H
 
 #include "http/forward.h"
-#include "HttpRequest.h"
 #include "security/PeerConnector.h"
 
 class ErrorState;
@@ -26,12 +25,7 @@ public:
                        const Comm::ConnectionPointer &aServerConn,
                        const AsyncCallback<EncryptorAnswer> &aCallback,
                        const AccessLogEntryPointer &alp,
-                       const time_t timeout = 0) :
-        AsyncJob("Security::BlindPeerConnector"),
-        Security::PeerConnector(aServerConn, aCallback, alp, timeout)
-    {
-        request = aRequest;
-    }
+                       const time_t timeout = 0);
 
     /* Security::PeerConnector API */
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -24,7 +24,7 @@ BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &, const Comm::Connect
                                        const time_t) :
     AsyncJob("Security::BlindPeerConnector"),
     Security::PeerConnector(aServerConn, aCallback, alp, 0)
-STUB_NOP
+{STUB_NOP}
 
 bool BlindPeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
 Security::ContextPointer BlindPeerConnector::getTlsContext() STUB_RETVAL(Security::ContextPointer())

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -21,7 +21,7 @@ namespace Security
 BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &, const Comm::ConnectionPointer & aServerConn,
                                        const AsyncCallback<EncryptorAnswer> & aCallback,
                                        const AccessLogEntryPointer &alp,
-                                       const time_t) :
+                                       time_t) :
     AsyncJob("Security::BlindPeerConnector"),
     Security::PeerConnector(aServerConn, aCallback, alp, 0)
 {STUB_NOP}

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -24,7 +24,7 @@ BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &, const Comm::Connect
                                        const time_t) :
     AsyncJob("Security::BlindPeerConnector"),
     Security::PeerConnector(aServerConn, aCallback, alp, 0)
-{}
+STUB_NOP
 
 bool BlindPeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
 Security::ContextPointer BlindPeerConnector::getTlsContext() STUB_RETVAL(Security::ContextPointer()) void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -18,9 +18,16 @@
 CBDATA_NAMESPACED_CLASS_INIT(Security, BlindPeerConnector);
 namespace Security
 {
+BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &, const Comm::ConnectionPointer & aServerConn,
+                                       const AsyncCallback<EncryptorAnswer> & aCallback,
+                                       const AccessLogEntryPointer &alp,
+                                       const time_t) :
+    AsyncJob("Security::BlindPeerConnector"),
+    Security::PeerConnector(aServerConn, aCallback, alp, 0)
+{}
+
 bool BlindPeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
-Security::ContextPointer BlindPeerConnector::getTlsContext() STUB_RETVAL(Security::ContextPointer())
-void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB
+Security::ContextPointer BlindPeerConnector::getTlsContext() STUB_RETVAL(Security::ContextPointer()) void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB
 }
 
 #include "security/EncryptorAnswer.h"

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -27,7 +27,8 @@ BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &, const Comm::Connect
 STUB_NOP
 
 bool BlindPeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
-Security::ContextPointer BlindPeerConnector::getTlsContext() STUB_RETVAL(Security::ContextPointer()) void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB
+Security::ContextPointer BlindPeerConnector::getTlsContext() STUB_RETVAL(Security::ContextPointer())
+void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB
 }
 
 #include "security/EncryptorAnswer.h"


### PR DESCRIPTION
Avoid having to include HttpRequest.h in
BlindPeerConnector.h by moving the
definition of the constructor to the .cc file