### PR TITLE
Fix stack buffer overflow when parsing Digest Authorization

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -833,6 +833,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
                 debugs(29, 9, "Found noncecount '" << digest_request->nc << "'");
             } else {
                 debugs(29, 9, "Invalid nc '" << value << "' in '" << temp << "'");
+                digest_request->nc[0] = 0;
             }
             break;
 

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -828,6 +828,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
         case DIGEST_NC:
             if (value.size() == 8) {
                 // for historical reasons, the nc value MUST be exactly 8 bytes
+                static_assert(sizeof(digest_request->nc) == 8 + 1);
                 xstrncpy(digest_request->nc, value.rawBuf(), value.size() + 1);
                 debugs(29, 9, "Found noncecount '" << digest_request->nc << "'");
             } else {

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -827,8 +827,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
 
         case DIGEST_NC:
             if (value.size() == 8) {
-                // For historical reasons, the nc value MUST be exactly 8 hexadecimal
-                // digits.
+                // for historical reasons, the nc value MUST be exactly 8 bytes
                 xstrncpy(digest_request->nc, value.rawBuf(), value.size() + 1);
                 debugs(29, 9, "Found noncecount '" << digest_request->nc << "'");
             } else {

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -826,11 +826,14 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
             break;
 
         case DIGEST_NC:
-            if (value.size() != 8) {
+            if (value.size() == 8) {
+                // For historical reasons, the nc value MUST be exactly 8 hexadecimal
+                // digits.
+                xstrncpy(digest_request->nc, value.rawBuf(), value.size() + 1);
+                debugs(29, 9, "Found noncecount '" << digest_request->nc << "'");
+            } else {
                 debugs(29, 9, "Invalid nc '" << value << "' in '" << temp << "'");
             }
-            xstrncpy(digest_request->nc, value.rawBuf(), value.size() + 1);
-            debugs(29, 9, "Found noncecount '" << digest_request->nc << "'");
             break;
 
         case DIGEST_CNONCE:


### PR DESCRIPTION
The bug was discovered and detailed by Joshua Rogers at
https://megamansec.github.io/Squid-Security-Audit/digest-overflow.html
where it was filed as "Stack Buffer Overflow in Digest Authentication".
