### PR TITLE
Fix validation of certificates with CN=*

### DIFF
--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -833,7 +833,7 @@ matchDomainName(const char *h, const char *d, MatchDomainNameFlags flags)
 
     dl = strlen(d);
     if (dl == 0)
-    	return 1;
+        return 1;
 
     /*
      * Start at the ends of the two strings and work towards the

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -175,6 +175,10 @@ urlInitialize(void)
     assert(0 == matchDomainName("*.foo.com", ".foo.com", mdnHonorWildcards));
     assert(0 != matchDomainName("*.foo.com", "foo.com", mdnHonorWildcards));
 
+    assert(0 != matchDomainName("foo.com", ""));
+    assert(0 != matchDomainName("foo.com", "", mdnHonorWildcards));
+    assert(0 != matchDomainName("foo.com", "", mdnRejectSubsubDomains));
+
     /* more cases? */
 }
 
@@ -828,6 +832,8 @@ matchDomainName(const char *h, const char *d, MatchDomainNameFlags flags)
         return -1;
 
     dl = strlen(d);
+    if (dl == 0)
+    	return 1;
 
     /*
      * Start at the ends of the two strings and work towards the


### PR DESCRIPTION
The bug was discovered and detailed by Joshua Rogers at
https://megamansec.github.io/Squid-Security-Audit/
where it was filed as "Buffer UnderRead in SSL CN Parsing".
