### PR TITLE
Fix "overriding recipe" gmake warnings in src/html/Makefile.am

### DIFF
--- a/src/html/Makefile.am
+++ b/src/html/Makefile.am
@@ -6,7 +6,6 @@
 ##
 
 include $(top_srcdir)/src/Common.am
-include $(top_srcdir)/src/TestHeaders.am
 
 noinst_LTLIBRARIES = libhtml.la
 


### PR DESCRIPTION
    Makefile:1254: warning: overriding recipe for target 'testHeaders'
    Makefile:1233: warning: ignoring old recipe for target 'testHeaders'
    Makefile:1257: warning: overriding recipe for target '.h.hdrtest'
    Makefile:1236: warning: ignoring old recipe for target '.h.hdrtest'

Makefile.am included a second TestHeaders.am since inception in recent
commit 1d0bc8e: Common.am already includes TestHeaders.am.
