### PR TITLE
negotiate_wrapper_auth: protect from responses over 64KB

### DIFF
--- a/src/auth/negotiate/wrapper/negotiate_wrapper.cc
+++ b/src/auth/negotiate/wrapper/negotiate_wrapper.cc
@@ -224,6 +224,13 @@ processingLoop(FILE *FDKIN, FILE *FDKOUT, FILE *FDNIN, FILE *FDNOUT)
                         LogTime(), PROGRAM);
                 return 0;
             }
+
+            if (!memchr(tbuff, '\n', sizeof(tbuff) - 1)) {
+                fprintf(stderr, "%s| %s: Oversized NTLM helper response\n",
+                        LogTime(), PROGRAM);
+                return 0;
+            }
+
             /*
              * Need to translate NTLM reply to Negotiate reply:
              *  AF user => AF blob user
@@ -253,6 +260,12 @@ processingLoop(FILE *FDKIN, FILE *FDKOUT, FILE *FDNIN, FILE *FDNOUT)
                     return 1;
                 }
                 fprintf(stderr, "%s| %s: Error reading Kerberos helper response\n",
+                        LogTime(), PROGRAM);
+                return 0;
+            }
+
+            if (!memchr(buff, '\n', sizeof(buff) - 1)) {
+                fprintf(stderr, "%s| %s: Oversized Kerberos helper response\n",
                         LogTime(), PROGRAM);
                 return 0;
             }


### PR DESCRIPTION
... received from NTLM and Kerberos helpers.

This code uses MAX_AUTHTOKEN_LEN (~64KB) buffers to read response lines.
fgets(3) guarantees to terminate the supplied buffer, but it does not
return nil when the input line is larger than the buffer. We have
already detected such "Oversized message" cases for fgets(stdin) calls,
but not for fgets(FDNOUT) and fgets(FDKOUT) calls.
