### PR TITLE
Fix build on MacOS

### DIFF
--- a/src/security/LockingPointer.h
+++ b/src/security/LockingPointer.h
@@ -12,6 +12,8 @@
 #include "base/Assure.h"
 #include "base/HardFun.h"
 
+#include <cstddef>
+
 #if USE_OPENSSL
 #include "compat/openssl.h"
 #if HAVE_OPENSSL_CRYPTO_H


### PR DESCRIPTION
To use std::nullptr_t it is necessary to include <cstddef>
on MacOS Ventura 13.4.1 
with clang version 14.0.3 (Xcode 14.3.1) 