### PR TITLE
Do not double-check cbdataReferenceDone() argument

### DIFF
--- a/src/StoreIOState.cc
+++ b/src/StoreIOState.cc
@@ -45,11 +45,8 @@ StoreIOState::~StoreIOState()
 {
     debugs(20,3, "StoreIOState::~StoreIOState: " << this);
 
-    if (read.callback_data)
-        cbdataReferenceDone(read.callback_data);
-
-    if (callback_data)
-        cbdataReferenceDone(callback_data);
+    cbdataReferenceDone(read.callback_data);
+    cbdataReferenceDone(callback_data);
 }
 
 bool StoreIOState::touchingStoreEntry() const

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3918,8 +3918,7 @@ ConnStateData::unpinConnection(const bool andClose)
 {
     debugs(33, 3, pinning.serverConnection);
 
-    if (pinning.peer)
-        cbdataReferenceDone(pinning.peer);
+    cbdataReferenceDone(pinning.peer);
 
     if (Comm::IsConnOpen(pinning.serverConnection)) {
         if (pinning.closeHandler != nullptr) {

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -105,8 +105,7 @@ ClientRequestContext::~ClientRequestContext()
      * still have one
      */
 
-    if (http)
-        cbdataReferenceDone(http);
+    cbdataReferenceDone(http);
 
     delete error;
     debugs(85,3, "ClientRequestContext destructed, this=" << this);
@@ -257,8 +256,7 @@ ClientHttpRequest::~ClientHttpRequest()
 
     delete calloutContext;
 
-    if (conn_)
-        cbdataReferenceDone(conn_);
+    cbdataReferenceDone(conn_);
 
     /* moving to the next connection is handled by the context free */
     dlinkDelete(&active, &ClientActiveRequests);

--- a/src/esi/Assign.cc
+++ b/src/esi/Assign.cc
@@ -139,7 +139,7 @@ ESIAssign::makeUsable(esiTreeParentPtr aParent, ESIVarState &aVarState) const
 void
 ESIAssign::finish()
 {
-    cbdataReferenceDone (varState);
+    cbdataReferenceDone(varState);
 
     if (parent.getRaw())
         parent = nullptr;

--- a/src/esi/Assign.cc
+++ b/src/esi/Assign.cc
@@ -139,8 +139,7 @@ ESIAssign::makeUsable(esiTreeParentPtr aParent, ESIVarState &aVarState) const
 void
 ESIAssign::finish()
 {
-    if (varState)
-        cbdataReferenceDone (varState);
+    cbdataReferenceDone (varState);
 
     if (parent.getRaw())
         parent = nullptr;

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -2185,8 +2185,7 @@ esiWhen::~esiWhen()
 {
     safe_free (unevaluatedExpression);
 
-    if (varState)
-        cbdataReferenceDone (varState);
+    cbdataReferenceDone (varState);
 }
 
 void

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -2185,7 +2185,7 @@ esiWhen::~esiWhen()
 {
     safe_free (unevaluatedExpression);
 
-    cbdataReferenceDone (varState);
+    cbdataReferenceDone(varState);
 }
 
 void

--- a/src/fs/rock/RockIoState.cc
+++ b/src/fs/rock/RockIoState.cc
@@ -58,8 +58,7 @@ Rock::IoState::~IoState()
     // assert(!readableAnchor_);
     assert(shutting_down || !writeableAnchor_);
 
-    if (callback_data)
-        cbdataReferenceDone(callback_data);
+    cbdataReferenceDone(callback_data);
     theFile = nullptr;
 
     e->unlock("rock I/O");


### PR DESCRIPTION
cbdataReferenceDone internally checks that the argument is not null.
Remove duplicate check from all callsites that have it