### PR TITLE
RFC 1123: Fix date parsing

### DIFF
--- a/src/time/rfc1123.cc
+++ b/src/time/rfc1123.cc
@@ -44,7 +44,13 @@ make_month(const char *s)
     char month[3];
 
     month[0] = xtoupper(*s);
+    if (!month[0])
+        return -1; // protects *(s + 1) below
+
     month[1] = xtolower(*(s + 1));
+    if (!month[1])
+        return -1; // protects *(s + 2) below
+
     month[2] = xtolower(*(s + 2));
 
     for (i = 0; i < 12; i++)


### PR DESCRIPTION
The bug was discovered and detailed by Joshua Rogers at
https://megamansec.github.io/Squid-Security-Audit/datetime-overflow.html
where it was filed as "1-Byte Buffer OverRead in RFC 1123 date/time
Handling".
