### PR TITLE
Fix test suite: actually run it

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -761,6 +761,8 @@ tests_testBoilerplate_LDFLAGS = $(LIBADD_DL)
 # dependency-based list so that simpler code is tested before more complex code
 # which uses it.
 
+TESTS += $(check_PROGRAMS)
+
 ## Tests of SquidMath.h
 check_PROGRAMS += tests/testMath
 tests_testMath_SOURCES = \


### PR DESCRIPTION
Fix a bug introduced by commit a7b75c6498, where unit tests
would be built but not actually run.