### PR TITLE
Bug 5312: Startup aborts if OPEN_MAX exceeds RLIMIT_NOFILE

### DIFF
--- a/src/comm/ModDevPoll.cc
+++ b/src/comm/ModDevPoll.cc
@@ -17,10 +17,7 @@
  *
  * Ported by Peter Payne from Squid 2.7.STABLE9 comm_devpoll.c
  * on August 11, 2010 at 3pm (GMT+0100 Europe/London).
- *
- * Last modified 2010-10-08
  */
-
 /*
  * There are several poll types in Squid, ALL of which are compiled and linked
  * in. Thus conditional compile-time flags are used to prevent the different
@@ -47,10 +44,6 @@
 #endif
 
 #define DEBUG_DEVPOLL 0
-
-// OPEN_MAX is defined in <climits>
-#define DEVPOLL_UPDATESIZE  OPEN_MAX
-#define DEVPOLL_QUERYSIZE   OPEN_MAX
 
 /* TYPEDEFS */
 typedef short pollfd_events_t; /* type of pollfd.events from sys/poll.h */
@@ -128,7 +121,7 @@ comm_flush_updates(void)
  * @param events events to register (usually POLLIN, POLLOUT, or POLLREMOVE)
  */
 static void
-comm_update_fd(int fd, int events)
+comm_update_fd(int fd, pollfd_events_t events)
 {
     debugs(
         5,
@@ -178,20 +171,23 @@ Comm::SelectLoopInit(void)
     /* allocate memory first before attempting to open poll device */
     /* This tracks the FD devpoll offset+state */
     devpoll_state = (struct _devpoll_state *)xcalloc(
-                        SQUID_MAXFD, sizeof(struct _devpoll_state)
+                        Squid_MaxFD, sizeof(struct _devpoll_state)
                     );
 
-    /* And this is the stuff we use to read events */
+    /* This is the stuff we use to read events.  If it's larger than
+       the current RLIMIT_NOFILE, the Solaris kernel returns EINVAL. */
+    dpoll_nfds = Squid_MaxFD;
     do_poll.dp_fds = (struct pollfd *)xcalloc(
-                         DEVPOLL_QUERYSIZE, sizeof(struct pollfd)
+                         dpoll_nfds, sizeof(struct pollfd)
                      );
-    dpoll_nfds = DEVPOLL_QUERYSIZE;
 
-    devpoll_update.pfds = (struct pollfd *)xcalloc(
-                              DEVPOLL_UPDATESIZE, sizeof(struct pollfd)
-                          );
+    /* This is the stuff we use to write requests to change tracking state.
+       It's also limited to the current RLIMIT_NOFILE by the Solaris kernel. */
     devpoll_update.cur = -1;
-    devpoll_update.size = DEVPOLL_UPDATESIZE;
+    devpoll_update.size = Squid_MaxFD;
+    devpoll_update.pfds = (struct pollfd *)xcalloc(
+                              devpoll_update.size, sizeof(struct pollfd)
+                          );
 
     /* attempt to open /dev/poll device */
     devpoll_fd = open("/dev/poll", O_RDWR);


### PR DESCRIPTION
    FATAL: Event loop exited with failure

The DP_POLL ioctl on Solaris fails with EINVAL when the number of
supplied descriptors (OPEN_MAX) is higher than the current RLIMIT_NOFILE
setting. When it comes to the maximum number of descriptors, we should
use Squid_MaxFD (which already reflects RLIMIT_NOFILE setting).