### PR TITLE
Refactor Ssl::ErrorDetailsManager to use SBuf

### DIFF
--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -98,7 +98,7 @@ Ssl::ErrorDetailsList::Pointer
 Ssl::ErrorDetailsManager::getCachedDetails(const char * const lang) const
 {
     Cache::iterator it;
-    it = cache.find(lang);
+    it = cache.find(SBuf(lang));
     if (it != cache.end()) {
         debugs(83, 8, "Found template details in cache for language: " << lang);
         return it->second;
@@ -110,8 +110,7 @@ Ssl::ErrorDetailsManager::getCachedDetails(const char * const lang) const
 void
 Ssl::ErrorDetailsManager::cacheDetails(const ErrorDetailsList::Pointer &errorDetails) const
 {
-    const char *lang = errorDetails->errLanguage.termedBuf();
-    assert(lang);
+    const auto &lang = errorDetails->errLanguage;
     if (cache.find(lang) == cache.end())
         cache[lang] = errorDetails;
 }

--- a/src/ssl/ErrorDetailManager.h
+++ b/src/ssl/ErrorDetailManager.h
@@ -12,7 +12,6 @@
 #include "base/RefCount.h"
 #include "HttpRequest.h"
 #include "sbuf/SBuf.h"
-#include "SquidString.h"
 #include "ssl/support.h"
 
 #include <map>
@@ -47,7 +46,7 @@ public:
     /// is invalidated by any non-constant operation on the list object
     const ErrorDetailEntry *findRecord(Security::ErrorCode) const;
 
-    String errLanguage; ///< The language of the error-details.txt template, if any
+    SBuf errLanguage; ///< The language of the error-details.txt template, if any
     typedef std::map<Security::ErrorCode, ErrorDetailEntry> ErrorDetails;
     ErrorDetails theList; ///< The list of error details entries
 };
@@ -84,7 +83,7 @@ private:
     /// cache the given error details list.
     void cacheDetails(const ErrorDetailsList::Pointer &errorDetails) const;
 
-    typedef std::map<std::string, ErrorDetailsList::Pointer> Cache;
+    typedef std::map<SBuf, ErrorDetailsList::Pointer> Cache;
     mutable Cache cache; ///< the error details list cache
     ErrorDetailsList::Pointer theDefaultErrorDetails; ///< the default error details list
 

--- a/src/ssl/ErrorDetailManager.h
+++ b/src/ssl/ErrorDetailManager.h
@@ -15,7 +15,6 @@
 #include "ssl/support.h"
 
 #include <map>
-#include <string>
 
 class HttpRequest;
 

--- a/src/ssl/ErrorDetailManager.h
+++ b/src/ssl/ErrorDetailManager.h
@@ -82,7 +82,7 @@ private:
     /// cache the given error details list.
     void cacheDetails(const ErrorDetailsList::Pointer &errorDetails) const;
 
-    typedef std::map<SBuf, ErrorDetailsList::Pointer> Cache;
+    using Cache = std::map<SBuf, ErrorDetailsList::Pointer>;
     mutable Cache cache; ///< the error details list cache
     ErrorDetailsList::Pointer theDefaultErrorDetails; ///< the default error details list
 


### PR DESCRIPTION
Have Ssl::ErrorDetailsList use SBuf instead of String, and
ErrorDetailsManager::cache index on SBuf and not std::string