### PR TITLE
Bug 5309: frequent "lowestOffset () <= target_offset" assertion

### DIFF
--- a/src/MemObject.cc
+++ b/src/MemObject.cc
@@ -167,7 +167,7 @@ struct LowestMemReader : public unary_function<store_client, void> {
 
     void operator() (store_client const &x) {
         if (x.getType() == STORE_MEM_CLIENT)
-            current = std::min(current, x.readOffset());
+            current = std::min(current, x.discardableHttpEnd());
     }
 
     int64_t current;

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -82,7 +82,7 @@ public:
     /// \retval -N should not occur.
     // TODO: Callers do not expect negative offset. Verify that the return
     // value cannot be negative and convert to unsigned in this case.
-    int64_t readOffset() const { return nextHttpReadOffset(); }
+    int64_t readOffset() const { return copyInto.offset; }
 
     int getType() const;
 

--- a/src/StoreClient.h
+++ b/src/StoreClient.h
@@ -82,7 +82,7 @@ public:
     /// \retval -N should not occur.
     // TODO: Callers do not expect negative offset. Verify that the return
     // value cannot be negative and convert to unsigned in this case.
-    int64_t readOffset() const { return copyInto.offset; }
+    int64_t readOffset() const { return nextHttpReadOffset(); }
 
     int getType() const;
 

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -163,6 +163,16 @@ store_client::finishCallback()
         result = parsingBuffer->packBack();
     result.flags.error = object_ok ? 0 : 1;
 
+    // TODO: Move object_ok handling above into this `if` statement.
+    if (object_ok) {
+        // works for zero hdr_sz cases as well; see also: nextHttpReadOffset()
+        discardableHttpEnd_ = NaturalSum<int64_t>(entry->mem().baseReply().hdr_sz, result.offset, result.length).value();
+    } else {
+        // object_ok is sticky, so we will not be able to use any response bytes
+        discardableHttpEnd_ = entry->mem().endOffset();
+    }
+    debugs(90, 7, "with " << result << "; discardableHttpEnd_=" << discardableHttpEnd_);
+
     // no HTTP headers and no body bytes (but not because there was no space)
     atEof_ = !sendingHttpHeaders() && !result.length && copyInto.length;
 
@@ -264,6 +274,9 @@ store_client::copy(StoreEntry * anEntry,
     Assure(!copyInto.offset || answeredOnce());
 
     parsingBuffer.emplace(copyInto);
+
+    discardableHttpEnd_ = nextHttpReadOffset();
+    debugs(90, 7, "discardableHttpEnd_=" << discardableHttpEnd_);
 
     static bool copying (false);
     assert (!copying);

--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -487,22 +487,19 @@ store_client::canReadFromMemory() const
            parsingBuffer->spaceSize();
 }
 
-/// The minimum offset of the next stored HTTP response byte we expect to read.
-/// Depending on the timing of this call, the actual offset may be very
-/// different (e.g., when the client switches from getting response headers at
-/// offset zero to reading the first Content-Range range at some huge offset).
+/// The offset of the next stored HTTP response byte wanted by the client.
 int64_t
 store_client::nextHttpReadOffset() const
 {
+    Assure(parsingBuffer);
     const auto &mem = entry->mem();
     const auto hdr_sz = mem.baseReply().hdr_sz;
-    const auto parsedSize = parsingBuffer ? parsingBuffer->contentSize() : 0;
     // Certain SMP cache manager transactions do not store HTTP headers in
     // mem_hdr; they store just a kid-specific piece of the future report body.
     // In such cases, hdr_sz ought to be zero. In all other (known) cases,
     // mem_hdr contains HTTP response headers (positive hdr_sz if parsed)
     // followed by HTTP response body. This code math accommodates all cases.
-    return NaturalSum<int64_t>(hdr_sz, copyInto.offset, parsedSize).value();
+    return NaturalSum<int64_t>(hdr_sz, copyInto.offset, parsingBuffer->contentSize()).value();
 }
 
 /// Copies at least some of the requested body bytes from MemObject memory,


### PR DESCRIPTION
Recent commit 122a6e3 left store_client::readOffset() unchanged but
should have adjusted it to match changed copyInto.offset semantics:
Starting with that commit, storeClientCopy() callers supply HTTP
response _body_ offset rather than HTTP response offset.

This bug decreased readOffset() values (by the size of stored HTTP
response headers), effectively telling Store that we are not yet done
with some of the MemObject/mem_hdr bytes. This bug could cause slightly
higher transaction memory usage because the same response bytes are
trimmed later. This bug should not have caused any assertions.

However, the old mem_hdr::freeDataUpto() code that uses readOffset() is
also broken -- the assertion in that method only "works" when
readOffset() returns values matching a memory node boundary. The smaller
values returned by buggy readOffset() triggered buggy assertions.

This minimal fix removes the recent store_client::readOffset() bug
described above. We will address old mem_hdr problems separately.
