### PR TITLE
Fix acl annotate_transaction reporting in mgr:config

### DIFF
--- a/src/acl/CharacterSetOption.h
+++ b/src/acl/CharacterSetOption.h
@@ -29,9 +29,8 @@ TypedOption<CharacterSetOptionValue>::import(const SBuf &rawValue) const
 }
 
 template <>
-inline
-void
-TypedOption<CharacterSetOptionValue>::print(std::ostream &os) const
+inline void
+TypedOption<CharacterSetOptionValue>::printValue(std::ostream &os) const
 {
     recipient_->value.printChars(os); // TODO: Quote if needed.
 }

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -182,10 +182,18 @@ public:
     {
         if (configured()) {
             os << ' ' << (disabled() ? offName : onName);
-            if (valued())
-                os << '=' << recipient_->value;
+            if (valued()) {
+                os << '=';
+                printValue(os);
+            }
         }
         // else do not report the implicit default
+    }
+
+    /// used in print() to print the option if configured
+    void printValue(std::ostream &os) const
+    {
+        os << '=' << recipient_->value;
     }
 
 private:

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -190,14 +190,9 @@ public:
         // else do not report the implicit default
     }
 
-    /// used in print() to print the option if configured
-    void printValue(std::ostream &os) const
-    {
-        os << recipient_->value;
-    }
-
 private:
     void import(const SBuf &rawValue) const { recipient_->value = rawValue; }
+    void printValue(std::ostream &os) const { os << recipient_->value; }
 
     // The "mutable" specifier demarcates set-once Option kind/behavior from the
     // ever-changing recipient of the actual admin-configured option value.

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -193,7 +193,7 @@ public:
     /// used in print() to print the option if configured
     void printValue(std::ostream &os) const
     {
-        os << '=' << recipient_->value;
+        os << recipient_->value;
     }
 
 private:


### PR DESCRIPTION
Possibly broken since commit 4eac340 that stopped printing `-m=` because
it customized/specialized too much of the TypedOption::print() code.
