### PR TITLE
Reduce ACLChecklist::AsyncState to a function pointer

### DIFF
--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -40,7 +40,7 @@ public:
     bool empty () const override;
 
 private:
-    static ACLChecklist::AsyncStarter StartLookup;
+    static void StartLookup(ACLFilledChecklist &, const ACL &);
     static void LookupDone(void *data, const ExternalACLEntryPointer &);
     void startLookup(ACLFilledChecklist *, external_acl_data *, bool inBackground) const;
     Acl::Answer aclMatchExternal(external_acl_data *, ACLFilledChecklist *) const;

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -9,6 +9,7 @@
 #ifndef SQUID_EXTERNALACL_H
 #define SQUID_EXTERNALACL_H
 
+#include "acl/Acl.h"
 #include "acl/Checklist.h"
 #include "base/RefCount.h"
 
@@ -16,31 +17,11 @@ class external_acl;
 class external_acl_data;
 class StoreEntry;
 
-class ExternalACLLookup : public ACLChecklist::AsyncState
-{
-
-public:
-    static ExternalACLLookup *Instance();
-    void checkForAsync(ACLChecklist *)const override;
-
-    // If possible, starts an asynchronous lookup of an external ACL.
-    // Otherwise, asserts (or bails if background refresh is requested).
-    static void Start(ACLChecklist *checklist, external_acl_data *acl, bool bg);
-
-private:
-    static ExternalACLLookup instance_;
-    static void LookupDone(void *data, const ExternalACLEntryPointer &result);
-};
-
-#include "acl/Acl.h"
-
 class ACLExternal : public ACL
 {
     MEMPROXY_CLASS(ACLExternal);
 
 public:
-    static void ExternalAclLookup(ACLChecklist * ch, ACLExternal *);
-
     ACLExternal(char const *);
     ~ACLExternal() override;
 
@@ -58,7 +39,13 @@ public:
     bool valid () const override;
     bool empty () const override;
 
-protected:
+private:
+    static ACLChecklist::AsyncStarter StartLookup;
+    static void LookupDone(void *data, const ExternalACLEntryPointer &);
+    void startLookup(ACLChecklist *, external_acl_data *, bool inBackground) const;
+    Acl::Answer aclMatchExternal(external_acl_data *, ACLFilledChecklist *) const;
+    char *makeExternalAclKey(ACLFilledChecklist *, external_acl_data *) const;
+
     external_acl_data *data;
     char const *class_;
 };

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -42,7 +42,7 @@ public:
 private:
     static ACLChecklist::AsyncStarter StartLookup;
     static void LookupDone(void *data, const ExternalACLEntryPointer &);
-    void startLookup(ACLChecklist *, external_acl_data *, bool inBackground) const;
+    void startLookup(ACLFilledChecklist *, external_acl_data *, bool inBackground) const;
     Acl::Answer aclMatchExternal(external_acl_data *, ACLFilledChecklist *) const;
     char *makeExternalAclKey(ACLFilledChecklist *, external_acl_data *) const;
 

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -542,7 +542,7 @@ Acl::DestinationAsnCheck::match(ACLChecklist * const ch)
     } else if (!checklist->request->flags.destinationIpLookedUp) {
         /* No entry in cache, lookup not attempted */
         debugs(28, 3, "can't yet compare '" << AclMatchedName << "' ACL for " << checklist->request->url.host());
-        if (checklist->goAsync(DestinationIPLookup::Instance()))
+        if (checklist->goAsync(ACLDestinationIP::StartLookup, *this))
             return -1;
         // else fall through to noaddr match, hiding the lookup failure (XXX)
     }

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -112,7 +112,7 @@ ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterat
 }
 
 bool
-ACLChecklist::goAsync(const AsyncStarter starter, const ACL &acl)
+ACLChecklist::goAsync(AsyncStarter starter, const ACL &acl)
 {
     assert(!asyncInProgress());
     assert(matchLoc_.parent);

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "acl/Checklist.h"
+#include "acl/FilledChecklist.h"
 #include "acl/Tree.h"
 #include "debug/Stream.h"
 
@@ -136,7 +137,7 @@ ACLChecklist::goAsync(const AsyncStarter &starter, const ACL &acl)
     ++asyncLoopDepth_;
 
     asyncStage_ = asyncStarting;
-    starter(*this, acl); // this is supposed to go async
+    starter(*Filled(this), acl); // this is supposed to go async
 
     // Did starter() actually go async? If not, tell the caller.
     if (asyncStage_ != asyncStarting) {

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -112,7 +112,7 @@ ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterat
 }
 
 bool
-ACLChecklist::goAsync(const AsyncStarter &starter, const ACL &acl)
+ACLChecklist::goAsync(const AsyncStarter starter, const ACL &acl)
 {
     assert(!asyncInProgress());
     assert(matchLoc_.parent);

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -139,7 +139,7 @@ ACLChecklist::goAsync(const AsyncStarter &starter, const ACL &acl)
     changeState(&starter);
     starter(*this, acl); // this is supposed to go async
 
-    // Did AsyncState object actually go async? If not, tell the caller.
+    // Did starter() actually go async? If not, tell the caller.
     if (asyncStage_ != asyncStarting) {
         assert(asyncStage_ == asyncFailed);
         asyncStage_ = asyncNone; // sanity restored
@@ -196,7 +196,7 @@ ACLChecklist::~ACLChecklist()
 }
 
 void
-ACLChecklist::changeState (AsyncState *newState)
+ACLChecklist::changeState (AsyncStarter *newState)
 {
     /* only change from null to active and back again,
      * not active to active.
@@ -207,7 +207,7 @@ ACLChecklist::changeState (AsyncState *newState)
     state_ = newState;
 }
 
-ACLChecklist::AsyncState *
+ACLChecklist::AsyncStarter *
 ACLChecklist::asyncState() const
 {
     return state_;

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -29,7 +29,7 @@ class ACLChecklist
 public:
 
     /// a function that initiates asynchronous ACL checks; see goAsync()
-    using AsyncStarter = void (ACLChecklist &, const ACL &);
+    using AsyncStarter = void (ACLFilledChecklist &, const ACL &);
 
 public:
     ACLChecklist();

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -151,16 +151,13 @@ public:
     }
 
 private:
-    // TODO: Remove diff reduction.
-    using AsyncState = AsyncStarter;
-
     /// Calls non-blocking check callback with the answer and destroys self.
     void checkCallback(Acl::Answer answer);
 
     void matchAndFinish();
 
-    void changeState(AsyncState *);
-    AsyncState *asyncState() const;
+    void changeState(AsyncStarter *);
+    AsyncStarter *asyncState() const;
 
     const Acl::Tree *accessList;
 public:
@@ -203,7 +200,7 @@ private: /* internal methods */
 
     enum AsyncStage { asyncNone, asyncStarting, asyncRunning, asyncFailed };
     AsyncStage asyncStage_;
-    AsyncState *state_;
+    AsyncStarter *state_;
     Breadcrumb matchLoc_; ///< location of the node running matches() now
     Breadcrumb asyncLoc_; ///< currentNode_ that called goAsync()
     unsigned asyncLoopDepth_; ///< how many times the current async state has resumed

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -104,7 +104,7 @@ public:
 
     /// If slow lookups are allowed, switches into "async in progress" state.
     /// Otherwise, returns false; the caller is expected to handle the failure.
-    bool goAsync(const AsyncStarter &, const ACL &);
+    bool goAsync(AsyncStarter, const ACL &);
 
     /// Matches (or resumes matching of) a child node while maintaning
     /// resumption breadcrumbs if a [grand]child node goes async.

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -156,9 +156,6 @@ private:
 
     void matchAndFinish();
 
-    void changeState(AsyncStarter *);
-    AsyncStarter *asyncState() const;
-
     const Acl::Tree *accessList;
 public:
 
@@ -167,7 +164,7 @@ public:
 
     /// Resumes non-blocking check started by nonBlockingCheck() and
     /// suspended until some async operation updated Squid state.
-    void resumeNonBlockingCheck(const AsyncStarter &);
+    void resumeNonBlockingCheck();
 
 private: /* internal methods */
     /// Position of a child node within an ACL tree.
@@ -200,7 +197,6 @@ private: /* internal methods */
 
     enum AsyncStage { asyncNone, asyncStarting, asyncRunning, asyncFailed };
     AsyncStage asyncStage_;
-    AsyncStarter *state_;
     Breadcrumb matchLoc_; ///< location of the node running matches() now
     Breadcrumb asyncLoc_; ///< currentNode_ that called goAsync()
     unsigned asyncLoopDepth_; ///< how many times the current async state has resumed

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -29,7 +29,7 @@ class ACLChecklist
 public:
 
     /// a function that initiates asynchronous ACL checks; see goAsync()
-    using AsyncStarter = void (ACLChecklist &, const ACL &acl);
+    using AsyncStarter = void (ACLChecklist &, const ACL &);
 
 public:
     ACLChecklist();
@@ -104,7 +104,7 @@ public:
 
     /// If slow lookups are allowed, switches into "async in progress" state.
     /// Otherwise, returns false; the caller is expected to handle the failure.
-    bool goAsync(const AsyncStarter &, const ACL &acl);
+    bool goAsync(const AsyncStarter &, const ACL &);
 
     /// Matches (or resumes matching of) a child node while maintaning
     /// resumption breadcrumbs if a [grand]child node goes async.

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -28,40 +28,8 @@ class ACLChecklist
 
 public:
 
-    /**
-     * State class.
-     * This abstract class defines the behaviour of
-     * async lookups - which can vary for different ACL types.
-     * Today, every state object must be a singleton.
-     * See NULLState for an example.
-     *
-     \note *no* state should be stored in the state object,
-     * they are used to change the behaviour of the checklist, not
-     * to hold information. If you need to store information in the
-     * state object, consider subclassing ACLChecklist, converting it
-     * to a composite, or changing the state objects from singletons to
-     * refcounted objects.
-     */
-
-    class AsyncState
-    {
-
-    public:
-        virtual void checkForAsync(ACLChecklist *) const = 0;
-        virtual ~AsyncState() {}
-    };
-
-    class NullState : public AsyncState
-    {
-
-    public:
-        static NullState *Instance();
-        void checkForAsync(ACLChecklist *) const override;
-        ~NullState() override {}
-
-    private:
-        static NullState _instance;
-    };
+    /// a function that initiates asynchronous ACL checks; see goAsync()
+    using AsyncStarter = void (ACLChecklist &, const ACL &acl);
 
 public:
     ACLChecklist();
@@ -136,7 +104,7 @@ public:
 
     /// If slow lookups are allowed, switches into "async in progress" state.
     /// Otherwise, returns false; the caller is expected to handle the failure.
-    bool goAsync(AsyncState *);
+    bool goAsync(const AsyncStarter &, const ACL &acl);
 
     /// Matches (or resumes matching of) a child node while maintaning
     /// resumption breadcrumbs if a [grand]child node goes async.
@@ -183,6 +151,9 @@ public:
     }
 
 private:
+    // TODO: Remove diff reduction.
+    using AsyncState = AsyncStarter;
+
     /// Calls non-blocking check callback with the answer and destroys self.
     void checkCallback(Acl::Answer answer);
 
@@ -199,7 +170,7 @@ public:
 
     /// Resumes non-blocking check started by nonBlockingCheck() and
     /// suspended until some async operation updated Squid state.
-    void resumeNonBlockingCheck(AsyncState *state);
+    void resumeNonBlockingCheck(const AsyncStarter &);
 
 private: /* internal methods */
     /// Position of a child node within an ACL tree.

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -19,10 +19,9 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLChecklist &cl, const ACL &)
+StartLookup(ACLFilledChecklist &cl, const ACL &)
 {
-    const auto checklist = Filled(&cl);
-    fqdncache_nbgethostbyaddr(checklist->dst_addr, LookupDone, checklist);
+    fqdncache_nbgethostbyaddr(cl.dst_addr, LookupDone, &cl);
 }
 
 static void

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -16,28 +16,22 @@
 #include "fqdncache.h"
 #include "HttpRequest.h"
 
-DestinationDomainLookup DestinationDomainLookup::instance_;
+static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
-DestinationDomainLookup *
-DestinationDomainLookup::Instance()
+static void
+StartLookup(ACLChecklist &cl, const ACL &)
 {
-    return &instance_;
-}
-
-void
-DestinationDomainLookup::checkForAsync(ACLChecklist *cl) const
-{
-    ACLFilledChecklist *checklist = Filled(cl);
+    const auto checklist = Filled(&cl);
     fqdncache_nbgethostbyaddr(checklist->dst_addr, LookupDone, checklist);
 }
 
-void
-DestinationDomainLookup::LookupDone(const char *, const Dns::LookupDetails &details, void *data)
+static void
+LookupDone(const char *, const Dns::LookupDetails &details, void *data)
 {
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->markDestinationDomainChecked();
     checklist->request->recordLookup(details);
-    checklist->resumeNonBlockingCheck(DestinationDomainLookup::Instance());
+    checklist->resumeNonBlockingCheck(StartLookup);
 }
 
 /* Acl::DestinationDomainCheck */
@@ -93,7 +87,7 @@ Acl::DestinationDomainCheck::match(ACLChecklist * const ch)
     } else if (!checklist->destinationDomainChecked()) {
         // TODO: Using AclMatchedName here is not OO correct. Should find a way to the current acl
         debugs(28, 3, "Can't yet compare '" << AclMatchedName << "' ACL for " << checklist->request->url.host());
-        if (checklist->goAsync(DestinationDomainLookup::Instance()))
+        if (checklist->goAsync(StartLookup, *this))
             return -1;
         // else fall through to "none" match, hiding the lookup failure (XXX)
     }

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -31,7 +31,7 @@ LookupDone(const char *, const Dns::LookupDetails &details, void *data)
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->markDestinationDomainChecked();
     checklist->request->recordLookup(details);
-    checklist->resumeNonBlockingCheck(StartLookup);
+    checklist->resumeNonBlockingCheck();
 }
 
 /* Acl::DestinationDomainCheck */

--- a/src/acl/DestinationDomain.h
+++ b/src/acl/DestinationDomain.h
@@ -32,18 +32,5 @@ private:
 
 } // namespace Acl
 
-/// \ingroup ACLAPI
-class DestinationDomainLookup : public ACLChecklist::AsyncState
-{
-
-public:
-    static DestinationDomainLookup *Instance();
-    void checkForAsync(ACLChecklist *)const override;
-
-private:
-    static DestinationDomainLookup instance_;
-    static void LookupDone(const char *, const Dns::LookupDetails &, void *);
-};
-
 #endif /* SQUID_ACLDESTINATIONDOMAIN_H */
 

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -99,6 +99,6 @@ LookupDone(const ipcache_addrs *, const Dns::LookupDetails &details, void *data)
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->request->flags.destinationIpLookedUp = true;
     checklist->request->recordLookup(details);
-    checklist->resumeNonBlockingCheck(ACLDestinationIP::StartLookup);
+    checklist->resumeNonBlockingCheck();
 }
 

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -87,10 +87,9 @@ ACLDestinationIP::match(ACLChecklist *cl)
 }
 
 void
-ACLDestinationIP::StartLookup(ACLChecklist &cl, const ACL &)
+ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const ACL &)
 {
-    const auto checklist = Filled(&cl);
-    ipcache_nbgethostbyname(checklist->request->url.host(), LookupDone, checklist);
+    ipcache_nbgethostbyname(cl.request->url.host(), LookupDone, &cl);
 }
 
 static void

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -17,8 +17,6 @@
 #include "HttpRequest.h"
 #include "SquidConfig.h"
 
-static void LookupDone(const ipcache_addrs *, const Dns::LookupDetails &, void *data);
-
 char const *
 ACLDestinationIP::typeString() const
 {
@@ -92,8 +90,8 @@ ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const ACL &)
     ipcache_nbgethostbyname(cl.request->url.host(), LookupDone, &cl);
 }
 
-static void
-LookupDone(const ipcache_addrs *, const Dns::LookupDetails &details, void *data)
+void
+ACLDestinationIP::LookupDone(const ipcache_addrs *, const Dns::LookupDetails &details, void *data)
 {
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->request->flags.destinationIpLookedUp = true;

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -13,23 +13,13 @@
 #include "acl/Ip.h"
 #include "ipcache.h"
 
-class DestinationIPLookup : public ACLChecklist::AsyncState
-{
-
-public:
-    static DestinationIPLookup *Instance();
-    void checkForAsync(ACLChecklist *)const override;
-
-private:
-    static DestinationIPLookup instance_;
-    static IPH LookupDone;
-};
-
 class ACLDestinationIP : public ACLIP
 {
     MEMPROXY_CLASS(ACLDestinationIP);
 
 public:
+    static ACLChecklist::AsyncStarter StartLookup;
+
     char const *typeString() const override;
     const Acl::Options &options() override;
     int match(ACLChecklist *checklist) override;

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -25,6 +25,8 @@ public:
     int match(ACLChecklist *checklist) override;
 
 private:
+    static void LookupDone(const ipcache_addrs *, const Dns::LookupDetails &, void *data);
+
     Acl::BooleanOptionValue lookupBanned; ///< are DNS lookups allowed?
 };
 

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -18,7 +18,7 @@ class ACLDestinationIP : public ACLIP
     MEMPROXY_CLASS(ACLDestinationIP);
 
 public:
-    static ACLChecklist::AsyncStarter StartLookup;
+    static void StartLookup(ACLFilledChecklist &, const ACL &);
 
     char const *typeString() const override;
     const Acl::Options &options() override;

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -20,9 +20,9 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLChecklist &checklist, const ACL &)
+StartLookup(ACLFilledChecklist &checklist, const ACL &)
 {
-    fqdncache_nbgethostbyaddr(Filled(&checklist)->src_addr, LookupDone, &checklist);
+    fqdncache_nbgethostbyaddr(checklist.src_addr, LookupDone, &checklist);
 }
 
 static void

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -31,7 +31,7 @@ LookupDone(const char *, const Dns::LookupDetails &details, void *data)
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->markSourceDomainChecked();
     checklist->request->recordLookup(details);
-    checklist->resumeNonBlockingCheck(StartLookup);
+    checklist->resumeNonBlockingCheck();
 }
 
 int

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -17,27 +17,21 @@
 #include "fqdncache.h"
 #include "HttpRequest.h"
 
-SourceDomainLookup SourceDomainLookup::instance_;
+static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
-SourceDomainLookup *
-SourceDomainLookup::Instance()
+static void
+StartLookup(ACLChecklist &checklist, const ACL &)
 {
-    return &instance_;
+    fqdncache_nbgethostbyaddr(Filled(&checklist)->src_addr, LookupDone, &checklist);
 }
 
-void
-SourceDomainLookup::checkForAsync(ACLChecklist *checklist) const
-{
-    fqdncache_nbgethostbyaddr(Filled(checklist)->src_addr, LookupDone, checklist);
-}
-
-void
-SourceDomainLookup::LookupDone(const char *, const Dns::LookupDetails &details, void *data)
+static void
+LookupDone(const char *, const Dns::LookupDetails &details, void *data)
 {
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->markSourceDomainChecked();
     checklist->request->recordLookup(details);
-    checklist->resumeNonBlockingCheck(SourceDomainLookup::Instance());
+    checklist->resumeNonBlockingCheck(StartLookup);
 }
 
 int
@@ -53,7 +47,7 @@ Acl::SourceDomainCheck::match(ACLChecklist * const ch)
     } else if (!checklist->sourceDomainChecked()) {
         // TODO: Using AclMatchedName here is not OO correct. Should find a way to the current acl
         debugs(28, 3, "aclMatchAcl: Can't yet compare '" << AclMatchedName << "' ACL for '" << checklist->src_addr << "'");
-        if (checklist->goAsync(SourceDomainLookup::Instance()))
+        if (checklist->goAsync(StartLookup, *this))
             return -1;
         // else fall through to "none" match, hiding the lookup failure (XXX)
     }

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -27,17 +27,5 @@ public:
 
 } // namespace Acl
 
-class SourceDomainLookup : public ACLChecklist::AsyncState
-{
-
-public:
-    static SourceDomainLookup *Instance();
-    void checkForAsync(ACLChecklist *)const override;
-
-private:
-    static SourceDomainLookup instance_;
-    static void LookupDone(const char *, const Dns::LookupDetails &, void *);
-};
-
 #endif /* SQUID_ACLSOURCEDOMAIN_H */
 

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -25,7 +25,7 @@
  * \retval ACCESS_ALLOWED       user authenticated and authorized
  */
 Acl::Answer
-AuthenticateAcl(ACLChecklist *ch)
+AuthenticateAcl(ACLChecklist *ch, const ACL &acl)
 {
     ACLFilledChecklist *checklist = Filled(ch);
     const auto request = checklist->request;
@@ -68,7 +68,7 @@ AuthenticateAcl(ACLChecklist *ch)
         break;
 
     case AUTH_ACL_HELPER:
-        if (checklist->goAsync(ProxyAuthLookup::Instance()))
+        if (checklist->goAsync(ACLProxyAuth::StartLookup, acl))
             debugs(28, 4, "returning " << ACCESS_DUNNO << " sending credentials to helper.");
         else
             debugs(28, 2, "cannot go async; returning " << ACCESS_DUNNO);

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -19,7 +19,7 @@
 
 class ACLChecklist;
 /// \ingroup AuthAPI
-Acl::Answer AuthenticateAcl(ACLChecklist *ch);
+Acl::Answer AuthenticateAcl(ACLChecklist *, const ACL &);
 
 #endif /* USE_AUTH */
 #endif /* SQUID_AUTH_ACL_H */

--- a/src/auth/AclMaxUserIp.cc
+++ b/src/auth/AclMaxUserIp.cc
@@ -116,7 +116,7 @@ int
 ACLMaxUserIP::match(ACLChecklist *cl)
 {
     ACLFilledChecklist *checklist = Filled(cl);
-    auto answer = AuthenticateAcl(checklist);
+    auto answer = AuthenticateAcl(checklist, *this);
     int ti;
 
     // convert to tri-state ACL match 1,0,-1

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -103,16 +103,14 @@ ACLProxyAuth::valid() const
 }
 
 void
-ACLProxyAuth::StartLookup(ACLChecklist &cl, const ACL &)
+ACLProxyAuth::StartLookup(ACLFilledChecklist &cl, const ACL &)
 {
-    const auto checklist = Filled(&cl);
-
     debugs(28, 3, "checking password via authenticator");
 
     /* make sure someone created auth_user_request for us */
-    assert(checklist->auth_user_request != nullptr);
-    assert(checklist->auth_user_request->valid());
-    checklist->auth_user_request->start(checklist->request.getRaw(), checklist->al, LookupDone, checklist);
+    assert(cl.auth_user_request != nullptr);
+    assert(cl.auth_user_request->valid());
+    cl.auth_user_request->start(cl.request.getRaw(), cl.al, LookupDone, &cl);
 }
 
 void

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -131,7 +131,7 @@ ACLProxyAuth::LookupDone(void *data)
         }
     }
 
-    checklist->resumeNonBlockingCheck(StartLookup);
+    checklist->resumeNonBlockingCheck();
 }
 
 int

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -52,7 +52,7 @@ ACLProxyAuth::parse()
 int
 ACLProxyAuth::match(ACLChecklist *checklist)
 {
-    auto answer = AuthenticateAcl(checklist);
+    auto answer = AuthenticateAcl(checklist, *this);
 
     // convert to tri-state ACL match 1,0,-1
     switch (answer) {
@@ -102,18 +102,10 @@ ACLProxyAuth::valid() const
     return true;
 }
 
-ProxyAuthLookup ProxyAuthLookup::instance_;
-
-ProxyAuthLookup *
-ProxyAuthLookup::Instance()
-{
-    return &instance_;
-}
-
 void
-ProxyAuthLookup::checkForAsync(ACLChecklist *cl) const
+ACLProxyAuth::StartLookup(ACLChecklist &cl, const ACL &)
 {
-    ACLFilledChecklist *checklist = Filled(cl);
+    const auto checklist = Filled(&cl);
 
     debugs(28, 3, "checking password via authenticator");
 
@@ -124,7 +116,7 @@ ProxyAuthLookup::checkForAsync(ACLChecklist *cl) const
 }
 
 void
-ProxyAuthLookup::LookupDone(void *data)
+ACLProxyAuth::LookupDone(void *data)
 {
     ACLFilledChecklist *checklist = Filled(static_cast<ACLChecklist*>(data));
 
@@ -139,7 +131,7 @@ ProxyAuthLookup::LookupDone(void *data)
         }
     }
 
-    checklist->resumeNonBlockingCheck(ProxyAuthLookup::Instance());
+    checklist->resumeNonBlockingCheck(StartLookup);
 }
 
 int

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -20,7 +20,7 @@ class ACLProxyAuth : public ACL
     MEMPROXY_CLASS(ACLProxyAuth);
 
 public:
-    static ACLChecklist::AsyncStarter StartLookup;
+    static void StartLookup(ACLFilledChecklist &, const ACL &);
 
     ~ACLProxyAuth() override;
     ACLProxyAuth(ACLData<char const *> *, char const *);

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -15,23 +15,13 @@
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ProxyAuthLookup : public ACLChecklist::AsyncState
-{
-
-public:
-    static ProxyAuthLookup *Instance();
-    void checkForAsync(ACLChecklist *) const override;
-
-private:
-    static ProxyAuthLookup instance_;
-    static void LookupDone(void *data);
-};
-
 class ACLProxyAuth : public ACL
 {
     MEMPROXY_CLASS(ACLProxyAuth);
 
 public:
+    static ACLChecklist::AsyncStarter StartLookup;
+
     ~ACLProxyAuth() override;
     ACLProxyAuth(ACLData<char const *> *, char const *);
 
@@ -47,6 +37,8 @@ public:
     int matchForCache(ACLChecklist *checklist) override;
 
 private:
+    static void LookupDone(void *data);
+
     /* ACL API */
     const Acl::Options &lineOptions() override;
 

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1150,7 +1150,7 @@ ACLExternal::LookupDone(void *data, const ExternalACLEntryPointer &result)
 {
     ACLFilledChecklist *checklist = Filled(static_cast<ACLChecklist*>(data));
     checklist->extacl_entry = result;
-    checklist->resumeNonBlockingCheck(ACLExternal::StartLookup);
+    checklist->resumeNonBlockingCheck();
 }
 
 ACLExternal::ACLExternal(char const *theClass) : data(nullptr), class_(xstrdup(theClass))

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1014,7 +1014,7 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
 /// Asks the helper (if needed) or returns the [cached] result (otherwise).
 /// Does not support "background" lookups. See also: ACLExternal::Start().
 void
-ACLExternal::StartLookup(ACLChecklist &checklist, const ACL &acl)
+ACLExternal::StartLookup(ACLFilledChecklist &checklist, const ACL &acl)
 {
     const auto &me = dynamic_cast<const ACLExternal&>(acl);
     me.startLookup(&checklist, me.data, false);
@@ -1023,11 +1023,10 @@ ACLExternal::StartLookup(ACLChecklist &checklist, const ACL &acl)
 // If possible, starts an asynchronous lookup of an external ACL.
 // Otherwise, asserts (or bails if background refresh is requested).
 void
-ACLExternal::startLookup(ACLChecklist *checklist, external_acl_data *acl, bool inBackground) const
+ACLExternal::startLookup(ACLFilledChecklist *ch, external_acl_data *acl, bool inBackground) const
 {
     external_acl *def = acl->def;
 
-    ACLFilledChecklist *ch = Filled(checklist);
     const char *key = makeExternalAclKey(ch, acl);
     assert(key); // XXX: will fail if EXT_ACL_IDENT case needs an async lookup
 
@@ -1059,7 +1058,7 @@ ACLExternal::startLookup(ACLChecklist *checklist, external_acl_data *acl, bool i
 
     if (!inBackground) {
         state->callback = &LookupDone;
-        state->callback_data = cbdataReference(checklist);
+        state->callback_data = cbdataReference(ch);
     }
 
     if (oldstate) {

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -55,7 +55,6 @@
 #define DEFAULT_EXTERNAL_ACL_CHILDREN 5
 #endif
 
-static char *makeExternalAclKey(ACLFilledChecklist * ch, external_acl_data * acl_data);
 static void external_acl_cache_delete(external_acl * def, const ExternalACLEntryPointer &entry);
 static int external_acl_entry_expired(external_acl * def, const ExternalACLEntryPointer &entry);
 static int external_acl_grace_expired(external_acl * def, const ExternalACLEntryPointer &entry);
@@ -593,8 +592,9 @@ copyResultsFromEntry(const HttpRequest::Pointer &req, const ExternalACLEntryPoin
     }
 }
 
-static Acl::Answer
-aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
+// TODO: Diff reduction. Rename this helper method to match_() or similar.
+Acl::Answer
+ACLExternal::aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch) const
 {
     debugs(82, 9, "acl=\"" << acl->def->name << "\"");
     ExternalACLEntryPointer entry = ch->extacl_entry;
@@ -630,7 +630,7 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
         if (acl->def->require_auth) {
             /* Make sure the user is authenticated */
             debugs(82, 3, acl->def->name << " check user authenticated.");
-            const auto ti = AuthenticateAcl(ch);
+            const auto ti = AuthenticateAcl(ch, *this);
             if (!ti.allowed()) {
                 debugs(82, 2, acl->def->name << " user not authenticated (" << ti << ")");
                 return ti;
@@ -653,7 +653,7 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
 
         if (entry != nullptr && external_acl_grace_expired(acl->def, entry)) {
             // refresh in the background
-            ExternalACLLookup::Start(ch, acl, true);
+            startLookup(ch, acl, true);
             debugs(82, 4, "no need to wait for the refresh of '" <<
                    key << "' in '" << acl->def->name << "' (ch=" << ch << ").");
         }
@@ -664,7 +664,7 @@ aclMatchExternal(external_acl_data *acl, ACLFilledChecklist *ch)
             // TODO: All other helpers allow temporary overload. Should not we?
             if (!acl->def->theHelper->willOverload()) {
                 debugs(82, 2, "\"" << key << "\": queueing a call.");
-                if (!ch->goAsync(ExternalACLLookup::Instance()))
+                if (!ch->goAsync(StartLookup, *this))
                     debugs(82, 2, "\"" << key << "\": no async support!");
                 debugs(82, 2, "\"" << key << "\": return -1.");
                 return ACCESS_DUNNO; // expired cached or simply absent entry
@@ -757,8 +757,8 @@ external_acl_cache_touch(external_acl * def, const ExternalACLEntryPointer &entr
     dlinkAdd(e, &entry->lru, &def->lru_list);
 }
 
-static char *
-makeExternalAclKey(ACLFilledChecklist * ch, external_acl_data * acl_data)
+char *
+ACLExternal::makeExternalAclKey(ACLFilledChecklist * ch, external_acl_data * acl_data) const
 {
     static MemBuf mb;
     mb.reset();
@@ -799,7 +799,7 @@ makeExternalAclKey(ACLFilledChecklist * ch, external_acl_data * acl_data)
             if (!*ch->rfc931) {
                 // if we fail to go async, we still return NULL and the caller
                 // will detect the failure in ACLExternal::match().
-                (void)ch->goAsync(IdentLookup::Instance());
+                (void)ch->goAsync(ACLIdent::StartLookup, *this);
                 return nullptr;
             }
         }
@@ -1011,14 +1011,19 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
     } while (state);
 }
 
+/// Asks the helper (if needed) or returns the [cached] result (otherwise).
+/// Does not support "background" lookups. See also: ACLExternal::Start().
 void
-ACLExternal::ExternalAclLookup(ACLChecklist *checklist, ACLExternal * me)
+ACLExternal::StartLookup(ACLChecklist &checklist, const ACL &acl)
 {
-    ExternalACLLookup::Start(checklist, me->data, false);
+    const auto &me = dynamic_cast<const ACLExternal&>(acl);
+    me.startLookup(&checklist, me.data, false);
 }
 
+// If possible, starts an asynchronous lookup of an external ACL.
+// Otherwise, asserts (or bails if background refresh is requested).
 void
-ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool inBackground)
+ACLExternal::startLookup(ACLChecklist *checklist, external_acl_data *acl, bool inBackground) const
 {
     external_acl *def = acl->def;
 
@@ -1053,7 +1058,7 @@ ExternalACLLookup::Start(ACLChecklist *checklist, external_acl_data *acl, bool i
     externalAclState *state = new externalAclState(def, key);
 
     if (!inBackground) {
-        state->callback = &ExternalACLLookup::LookupDone;
+        state->callback = &LookupDone;
         state->callback_data = cbdataReference(checklist);
     }
 
@@ -1139,32 +1144,13 @@ externalAclShutdown(void)
     }
 }
 
-ExternalACLLookup ExternalACLLookup::instance_;
-ExternalACLLookup *
-ExternalACLLookup::Instance()
-{
-    return &instance_;
-}
-
-void
-ExternalACLLookup::checkForAsync(ACLChecklist *checklist)const
-{
-    /* TODO: optimise this - we probably have a pointer to this
-     * around somewhere */
-    ACL *acl = ACL::FindByName(AclMatchedName);
-    assert(acl);
-    ACLExternal *me = dynamic_cast<ACLExternal *> (acl);
-    assert (me);
-    ACLExternal::ExternalAclLookup(checklist, me);
-}
-
 /// Called when an async lookup returns
 void
-ExternalACLLookup::LookupDone(void *data, const ExternalACLEntryPointer &result)
+ACLExternal::LookupDone(void *data, const ExternalACLEntryPointer &result)
 {
     ACLFilledChecklist *checklist = Filled(static_cast<ACLChecklist*>(data));
     checklist->extacl_entry = result;
-    checklist->resumeNonBlockingCheck(ExternalACLLookup::Instance());
+    checklist->resumeNonBlockingCheck(ACLExternal::StartLookup);
 }
 
 ACLExternal::ACLExternal(char const *theClass) : data(nullptr), class_(xstrdup(theClass))

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -61,7 +61,7 @@ ACLIdent::match(ACLChecklist *cl)
     } else if (checklist->conn() != nullptr && checklist->conn()->clientConnection != nullptr && checklist->conn()->clientConnection->rfc931[0]) {
         return data->match(checklist->conn()->clientConnection->rfc931);
     } else if (checklist->conn() != nullptr && Comm::IsConnOpen(checklist->conn()->clientConnection)) {
-        if (checklist->goAsync(IdentLookup::Instance())) {
+        if (checklist->goAsync(StartLookup, *this)) {
             debugs(28, 3, "switching to ident lookup state");
             return -1;
         }
@@ -87,18 +87,10 @@ ACLIdent::empty () const
     return data->empty();
 }
 
-IdentLookup IdentLookup::instance_;
-
-IdentLookup *
-IdentLookup::Instance()
-{
-    return &instance_;
-}
-
 void
-IdentLookup::checkForAsync(ACLChecklist *cl)const
+ACLIdent::StartLookup(ACLChecklist &cl, const ACL &)
 {
-    ACLFilledChecklist *checklist = Filled(cl);
+    ACLFilledChecklist *checklist = Filled(&cl);
     const ConnStateData *conn = checklist->conn();
     // check that ACLIdent::match() tested this lookup precondition
     assert(conn && Comm::IsConnOpen(conn->clientConnection));
@@ -107,7 +99,7 @@ IdentLookup::checkForAsync(ACLChecklist *cl)const
 }
 
 void
-IdentLookup::LookupDone(const char *ident, void *data)
+ACLIdent::LookupDone(const char *ident, void *data)
 {
     ACLFilledChecklist *checklist = Filled(static_cast<ACLChecklist*>(data));
 
@@ -124,7 +116,7 @@ IdentLookup::LookupDone(const char *ident, void *data)
     if (checklist->conn() != nullptr && checklist->conn()->clientConnection != nullptr && !checklist->conn()->clientConnection->rfc931[0])
         xstrncpy(checklist->conn()->clientConnection->rfc931, checklist->rfc931, USER_IDENT_SZ);
 
-    checklist->resumeNonBlockingCheck(IdentLookup::Instance());
+    checklist->resumeNonBlockingCheck(ACLIdent::StartLookup);
 }
 
 #endif /* USE_IDENT */

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -55,7 +55,7 @@ ACLIdent::parse()
 int
 ACLIdent::match(ACLChecklist *cl)
 {
-    ACLFilledChecklist *checklist = Filled(cl);
+    const auto checklist = Filled(cl);
     if (checklist->rfc931[0]) {
         return data->match(checklist->rfc931);
     } else if (checklist->conn() != nullptr && checklist->conn()->clientConnection != nullptr && checklist->conn()->clientConnection->rfc931[0]) {

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -88,14 +88,13 @@ ACLIdent::empty () const
 }
 
 void
-ACLIdent::StartLookup(ACLChecklist &cl, const ACL &)
+ACLIdent::StartLookup(ACLFilledChecklist &cl, const ACL &)
 {
-    ACLFilledChecklist *checklist = Filled(&cl);
-    const ConnStateData *conn = checklist->conn();
+    const ConnStateData *conn = cl.conn();
     // check that ACLIdent::match() tested this lookup precondition
     assert(conn && Comm::IsConnOpen(conn->clientConnection));
     debugs(28, 3, "Doing ident lookup" );
-    Ident::Start(checklist->conn()->clientConnection, LookupDone, checklist);
+    Ident::Start(cl.conn()->clientConnection, LookupDone, &cl);
 }
 
 void

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -116,7 +116,7 @@ ACLIdent::LookupDone(const char *ident, void *data)
     if (checklist->conn() != nullptr && checklist->conn()->clientConnection != nullptr && !checklist->conn()->clientConnection->rfc931[0])
         xstrncpy(checklist->conn()->clientConnection->rfc931, checklist->rfc931, USER_IDENT_SZ);
 
-    checklist->resumeNonBlockingCheck(ACLIdent::StartLookup);
+    checklist->resumeNonBlockingCheck();
 }
 
 #endif /* USE_IDENT */

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -21,7 +21,7 @@ class ACLIdent : public ACL
     MEMPROXY_CLASS(ACLIdent);
 
 public:
-    static ACLChecklist::AsyncStarter StartLookup;
+    static void StartLookup(ACLFilledChecklist &, const ACL &);
 
     ACLIdent(ACLData<char const *> *newData, char const *);
     ~ACLIdent() override;

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -11,22 +11,8 @@
 
 #if USE_IDENT
 
-#include "acl/Checklist.h"
-
-/// \ingroup ACLAPI
-class IdentLookup : public ACLChecklist::AsyncState
-{
-
-public:
-    static IdentLookup *Instance();
-    void checkForAsync(ACLChecklist *)const override;
-
-private:
-    static IdentLookup instance_;
-    static void LookupDone(const char *ident, void *data);
-};
-
 #include "acl/Acl.h"
+#include "acl/Checklist.h"
 #include "acl/Data.h"
 
 /// \ingroup ACLAPI
@@ -35,6 +21,8 @@ class ACLIdent : public ACL
     MEMPROXY_CLASS(ACLIdent);
 
 public:
+    static ACLChecklist::AsyncStarter StartLookup;
+
     ACLIdent(ACLData<char const *> *newData, char const *);
     ~ACLIdent() override;
 
@@ -47,6 +35,8 @@ public:
     bool empty () const override;
 
 private:
+    static void LookupDone(const char *ident, void *data);
+
     /* ACL API */
     const Acl::Options &lineOptions() override;
 

--- a/src/tests/stub_external_acl.cc
+++ b/src/tests/stub_external_acl.cc
@@ -22,11 +22,6 @@ bool ACLExternal::valid () const STUB_RETVAL(false)
 bool ACLExternal::empty () const STUB_RETVAL(false)
 int ACLExternal::match(ACLChecklist *) STUB_RETVAL(0)
 SBufList ACLExternal::dump() const STUB_RETVAL(SBufList())
-void ACLExternal::ExternalAclLookup(ACLChecklist *, ACLExternal *) STUB
-void ExternalACLLookup::Start(ACLChecklist *, external_acl_data *, bool) STUB
 void externalAclInit(void) STUB_NOP
 void externalAclShutdown(void) STUB_NOP
-ExternalACLLookup * ExternalACLLookup::Instance() STUB_RETVAL(nullptr)
-void ExternalACLLookup::checkForAsync(ACLChecklist *) const STUB
-void ExternalACLLookup::LookupDone(void *, const ExternalACLEntryPointer &) STUB
 

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -15,7 +15,7 @@
 #include "acl/Acl.h" /* for Acl::Answer */
 
 #include "auth/Acl.h"
-Acl::Answer AuthenticateAcl(ACLChecklist *) STUB_RETVAL(ACCESS_DENIED)
+Acl::Answer AuthenticateAcl(ACLChecklist *, const ACL &) STUB_RETVAL(ACCESS_DENIED)
 
 #include "auth/AclMaxUserIp.h"
 ACLMaxUserIP::ACLMaxUserIP (char const *) STUB
@@ -37,9 +37,6 @@ int ACLProxyAuth::match(ACLChecklist *) STUB_RETVAL(0)
 SBufList ACLProxyAuth::dump() const STUB_RETVAL(SBufList())
 bool ACLProxyAuth::empty () const STUB_RETVAL(false)
 bool ACLProxyAuth::valid () const STUB_RETVAL(false)
-ProxyAuthLookup * ProxyAuthLookup::Instance() STUB_RETVAL(nullptr)
-void ProxyAuthLookup::checkForAsync(ACLChecklist *) const STUB
-void ProxyAuthLookup::LookupDone(void *) STUB
 int ACLProxyAuth::matchForCache(ACLChecklist *) STUB_RETVAL(0)
 int ACLProxyAuth::matchProxyAuth(ACLChecklist *) STUB_RETVAL(0)
 const Acl::Options &ACLProxyAuth::lineOptions() STUB_RETVAL(Acl::NoOptions())


### PR DESCRIPTION
ExternalACLLookup::checkForAsync() -- the code that starts communication
with the external ACL helper -- relies on two implicit assumptions:

* AclMatchedName global matches this->name during ACLExternal::match().
* FindByName("x") result never changes during same-Checklist evaluation.

The first assumption might hold[^1], but the second assumption will fail
once we finally start refcounting ACLs instead of allowing
reconfiguration to break in-flight transactions waiting for a slow ACL
match with ACCESS_DUNNO answers. Today, reconfiguration invalidates all
ACL objects, making repeated same-Checklist checkForAsync() calls
impossible across reconfiguration. Tomorrow, such calls will happen and
violation of the second assumption will lead to assertions or worse[^2].
Thus, removing that assumption is a precondition on ACL refcounting and
smooth reconfiguration support.

ExternalACLLookup used FindByName() to find the ACL being matched. The
source code comment suggested that we "have a pointer to this around
somewhere". That pointer is "this" pointer of an ACL calling goAsync().
It is available in the call stack two frames higher, but is not stored
by the Checklist in any usable form.

To remove that FindByName() call, we could just add a second goAsync()
parameter to pass the ACL pointer to Checklist. Doing that would require
changing all the goAsync() callers and the corresponding
ACLChecklist::AsyncState API. Since that very complex and confusing API
was actually used as a basic function pointer, we decided it is best to
replace the has-to-be-changed-anyway API with a function pointer. That
plan worked well, removing a lot of unnecessary and confusing code!

[^1]: It is difficult to be sure: AclMatchedName global was named and
added for a very different purpose, and no API enforces that invariant.

[^2]: When ACLs are refcountered, ACLExternal::match() will continue to
set AclMatchedName global to the name (e.g., "x") of an ACL object that
resumes matching after Squid reconfigures and receives a helper reply.
However, the same FindByName("x") call may now return nil or a
completely different ACL object (still named "x" in the new
configuration, but possibly no longer an ACLExternal object)!
