### PR TITLE
Bug 5317: FATAL attempt to read data from memory

### DIFF
--- a/src/store_client.cc
+++ b/src/store_client.cc
@@ -409,8 +409,9 @@ store_client::doCopy(StoreEntry *anEntry)
             return; // failure
     }
 
-    // send any immediately available body bytes even if we also sendHttpHeaders
-    if (canReadFromMemory()) {
+    // Send any immediately available body bytes unless we sendHttpHeaders.
+    // TODO: Send those body bytes when we sendHttpHeaders as well.
+    if (!sendHttpHeaders && canReadFromMemory()) {
         readFromMemory();
         noteNews(); // will sendHttpHeaders (if needed) as well
         flags.store_copying = false;
@@ -496,6 +497,7 @@ store_client::canReadFromMemory() const
 {
     const auto &mem = entry->mem();
     const auto memReadOffset = nextHttpReadOffset();
+    // XXX: This (lo <= offset < end) logic does not support Content-Range gaps.
     return mem.inmem_lo <= memReadOffset && memReadOffset < mem.endOffset() &&
            parsingBuffer->spaceSize();
 }


### PR DESCRIPTION
    FATAL: Squid has attempted to read data ... that is not present.

Recent commit 122a6e3 attempted to deliver in-memory response body bytes
to a Store-reading client that requested (at least) response headers.
That optimization relied on the old canReadFromMemory() logic, but that
logic results in false positives when the checked read offset falls into
a gap between stored headers and the first body byte of a Content-Range.
In that case, a false positive leads to a readFromMemory() call and a
FATAL mem_hdr::copy() error.

This workaround disables the above optimization without fixing
canReadFromMemory(). We believe that a readFromMemory() call that comes
right after response headers are delivered to the Store-reading client
will not suffer from the same problem because the client will supply the
read offset of the first body byte, eliminating the false positive.
