### PR TITLE
Do not update StoreEntry expiration after errorAppendEntry()

### DIFF
--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -306,7 +306,6 @@ CacheManager::start(const Comm::ConnectionPointer &client, HttpRequest *request,
         err->url = xstrdup(entry->url());
         err->detailError(new ExceptionErrorDetail(Here().id()));
         errorAppendEntry(entry, err);
-        entry->expires = squid_curtime;
         return;
     }
 


### PR DESCRIPTION
errorAppendEntry() is responsible for setting entry expiration times,
which it does by calling StoreEntry::storeErrorResponse() that calls
StoreEntry::negativeCache().

This change was triggered by a vulnerability report by Joshua Rogers at
https://megamansec.github.io/Squid-Security-Audit/cache-uaf.html where
it was filed as "Use-After-Free in Cache Manager Errors". The reported
"use after free" vulnerability was unknowingly addressed by 2022 commit
1fa761a that removed excessively long "reentrant" store_client calls
responsible for the disappearance of the properly locked StoreEntry in
this (and probably other) contexts.
