### PR TITLE
Bug 5318: peer_digest.cc:399: "fetch->pd && receivedData.data"

### DIFF
--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -349,11 +349,11 @@ peerDigestHandleReply(void *data, StoreIOBuffer receivedData)
         return;
     }
 
-    assert(fetch->pd && receivedData.data);
+    assert(fetch->pd);
     /* The existing code assumes that the received pointer is
      * where we asked the data to be put
      */
-    assert(fetch->buf + fetch->bufofs == receivedData.data);
+    assert(!receivedData.data || fetch->buf + fetch->bufofs == receivedData.data);
 
     /* Update the buffer size */
     fetch->bufofs += receivedData.length;
@@ -635,7 +635,7 @@ peerDigestFetchedEnough(DigestFetchState * fetch, char *buf, ssize_t size, const
     }
 
     /* continue checking (maybe-successful eof case) */
-    if (!reason && !size) {
+    if (!reason && !size && fetch->state != DIGEST_READ_REPLY) {
         if (!pd->cd)
             reason = "null digest?!";
         else if (fetch->mask_offset != pd->cd->mask_size)


### PR DESCRIPTION
Recent commit 122a6e3 removed HTTP response headers from store_client
responses. That removal created the possibility of an empty
StoreIOBuffer at the beginning of the feeding sequence. Pending Bug 5317
fix will make such buffers even more frequent. Existing store_client
recipients have varying requirements with regard to empty response
buffers, as documented in store_client::finishCallback(). We missed this
requirement conflict in Cache Digest code. This fix adjusts Cache
Digests code to be compatible with empty StoreIOBuffer representation in
current store_client code.
