### PR TITLE
Bug 5319: QOS Netfilter MARK preservation is always disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2852,7 +2852,7 @@ SQUID_DEFINE_BOOL(USE_QOS_TOS,${enable_zph_qos:=yes},
           [Enable Zero Penalty Hit QOS. When set, Squid will alter the
            TOS field of HIT responses to help policing network traffic])
 AC_MSG_NOTICE([ZPH QOS enabled: $enable_zph_qos])
-AS_IF(test "x$enable_zph_qos" = "xyes"],[
+AS_IF([test "x$enable_zph_qos" = "xyes"],[
   AC_MSG_NOTICE([QOS netfilter mark preservation enabled: $with_netfilter_conntrack])
   SQUID_DEFINE_BOOL(USE_LIBNETFILTERCONNTRACK,${with_netfilter_conntrack:=no},
     [Enable support for QOS netfilter mark preservation])


### PR DESCRIPTION
Default ./configure options and explicit --enable-zph-qos enabled ZPH
QOS support (USE_QOS_TOS) as expected but did not enable QOS Netfilter
MARK preservation support (USE_LIBNETFILTERCONNTRACK). For example,
qos_flows directive became available, but clientside_mark and
client_connection_mark ACL types were not recognized.

The missing opening bracket before AS_IF() condition injected a trailing
closing bracket into that condition, resulting in an always-false
condition for setting USE_LIBNETFILTERCONNTRACK.

Broken since 2022 commit a1c2236.
