### PR TITLE
Deduplicate HelperServerClosed()

### DIFF
--- a/src/helper.cc
+++ b/src/helper.cc
@@ -927,7 +927,7 @@ Helper::Client::handleFewerServers(const bool madeProgress)
 }
 
 void
-Helper::Session::HelperServerClosed(Session * const srv)
+Helper::SessionBase::HelperServerClosed(SessionBase * const srv)
 {
     srv->helper().handleKilledServer(srv);
     srv->dropQueued();

--- a/src/helper.h
+++ b/src/helper.h
@@ -194,7 +194,7 @@ public:
     ~SessionBase() override;
 
     /// close handler to handle exited server processes
-    void helperServerClosed(int &);
+    static void HelperServerClosed(SessionBase *);
 
     /** Closes pipes to the helper safely.
      * Handles the case where the read and write pipes are the same FD.

--- a/src/helper.h
+++ b/src/helper.h
@@ -198,16 +198,12 @@ public:
 
     /** Closes pipes to the helper safely.
      * Handles the case where the read and write pipes are the same FD.
-     *
-     * \param name displayed for the helper being shutdown if logging an error
      */
     void closePipesSafely();
 
     /** Closes the reading pipe.
      * If the read and write sockets are the same the write pipe will
      * also be closed. Otherwise its left open for later handling.
-     *
-     * \param name displayed for the helper being shutdown if logging an error
      */
     void closeWritePipeSafely();
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -322,7 +322,7 @@ public:
     void reserve();
     void clearReservation();
 
-    /* HelperServerBase API */
+    /* Helper::SessionBase API */
     bool reserved() override {return reservationId.reserved();}
     Helper::Client &helper() override { return *parent; }
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -193,6 +193,9 @@ class SessionBase: public CbdataParent
 public:
     ~SessionBase() override;
 
+    /// close handler to handle exited server processes
+    static void HelperServerClosed(SessionBase *);
+
     /** Closes pipes to the helper safely.
      * Handles the case where the read and write pipes are the same FD.
      *
@@ -211,6 +214,9 @@ public:
     // TODO: Teach each child to report its child-specific state instead.
     /// whether the server is locked for exclusive use by a client
     virtual bool reserved() = 0;
+
+    /// our creator (parent) object
+    virtual Client &helper() = 0;
 
     /// dequeues and sends an Unknown answer to all queued requests
     virtual void dropQueued(Client &);
@@ -296,12 +302,10 @@ public:
     /* SessionBase API */
     bool reserved() override {return false;}
     void dropQueued(Client &) override;
+    Client &helper() override { return *parent; }
 
     /// Read timeout handler
     static void requestTimeout(const CommTimeoutCbParams &io);
-
-    /// close handler to handle exited server processes
-    static void HelperServerClosed(Session *);
 };
 
 } // namespace Helper
@@ -320,9 +324,7 @@ public:
 
     /* HelperServerBase API */
     bool reserved() override {return reservationId.reserved();}
-
-    /// close handler to handle exited server processes
-    static void HelperServerClosed(helper_stateful_server *srv);
+    Helper::Client &helper() override { return *parent; }
 
     statefulhelper::Pointer parent;
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -194,14 +194,14 @@ public:
     ~SessionBase() override;
 
     /// close handler to handle exited server processes
-    static void HelperServerClosed(SessionBase *);
+    void helperServerClosed(int &);
 
     /** Closes pipes to the helper safely.
      * Handles the case where the read and write pipes are the same FD.
      *
      * \param name displayed for the helper being shutdown if logging an error
      */
-    void closePipesSafely(const char *name);
+    void closePipesSafely();
 
     /** Closes the reading pipe.
      * If the read and write sockets are the same the write pipe will
@@ -209,17 +209,17 @@ public:
      *
      * \param name displayed for the helper being shutdown if logging an error
      */
-    void closeWritePipeSafely(const char *name);
+    void closeWritePipeSafely();
 
     // TODO: Teach each child to report its child-specific state instead.
     /// whether the server is locked for exclusive use by a client
     virtual bool reserved() = 0;
 
     /// our creator (parent) object
-    virtual Client &helper() = 0;
+    virtual Client &helper() const = 0;
 
     /// dequeues and sends an Unknown answer to all queued requests
-    virtual void dropQueued(Client &);
+    virtual void dropQueued();
 
 public:
     /// Helper program identifier; does not change when contents do,
@@ -301,8 +301,8 @@ public:
 
     /* SessionBase API */
     bool reserved() override {return false;}
-    void dropQueued(Client &) override;
-    Client &helper() override { return *parent; }
+    void dropQueued() override;
+    Client &helper() const override { return *parent; }
 
     /// Read timeout handler
     static void requestTimeout(const CommTimeoutCbParams &io);
@@ -324,7 +324,7 @@ public:
 
     /* Helper::SessionBase API */
     bool reserved() override {return reservationId.reserved();}
-    Helper::Client &helper() override { return *parent; }
+    Helper::Client &helper() const override { return *parent; }
 
     statefulhelper::Pointer parent;
 


### PR DESCRIPTION
Also removed helper from Helper::SessionBase method parameters since
that base class now has access to the helper object.