### PR TITLE
Limit the number of allowed X-Forwarded-For hops 

### DIFF
--- a/src/ClientRequestContext.h
+++ b/src/ClientRequestContext.h
@@ -83,7 +83,7 @@ public:
     ErrorState *error = nullptr; ///< saved error page for centralized/delayed processing
     bool readNextRequest = false; ///< whether Squid should read after error handling
 #if FOLLOW_X_FORWARDED_FOR
-    uint32_t currentXffHopNumber = 0; ///< number of X-Forwarded-For header values processed so far
+    size_t currentXffHopNumber = 0; ///< number of X-Forwarded-For header values processed so far
 #endif
 };
 

--- a/src/ClientRequestContext.h
+++ b/src/ClientRequestContext.h
@@ -77,11 +77,13 @@ public:
     bool no_cache_done = false;
     bool interpreted_req_hdrs = false;
     bool toClientMarkingDone = false;
+    bool readNextRequest = false; ///< whether Squid should read after error handling
 #if USE_OPENSSL
     bool sslBumpCheckDone = false;
 #endif
+
     ErrorState *error = nullptr; ///< saved error page for centralized/delayed processing
-    bool readNextRequest = false; ///< whether Squid should read after error handling
+
 #if FOLLOW_X_FORWARDED_FOR
     size_t currentXffHopNumber = 0; ///< number of X-Forwarded-For header values processed so far
 #endif

--- a/src/ClientRequestContext.h
+++ b/src/ClientRequestContext.h
@@ -82,6 +82,9 @@ public:
 #endif
     ErrorState *error = nullptr; ///< saved error page for centralized/delayed processing
     bool readNextRequest = false; ///< whether Squid should read after error handling
+#if FOLLOW_X_FORWARDED_FOR
+    uint32_t currentXffHopNumber = 0; ///< number of X-Forwarded-For header values processed so far
+#endif
 };
 
 #endif /* SQUID_CLIENTREQUESTCONTEXT_H */

--- a/src/ClientRequestContext.h
+++ b/src/ClientRequestContext.h
@@ -77,11 +77,11 @@ public:
     bool no_cache_done = false;
     bool interpreted_req_hdrs = false;
     bool toClientMarkingDone = false;
-    bool readNextRequest = false; ///< whether Squid should read after error handling
 #if USE_OPENSSL
     bool sslBumpCheckDone = false;
 #endif
 
+    bool readNextRequest = false; ///< whether Squid should read after error handling
     ErrorState *error = nullptr; ///< saved error page for centralized/delayed processing
 
 #if FOLLOW_X_FORWARDED_FOR

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -442,9 +442,11 @@ clientFollowXForwardedForCheck(Acl::Answer answer, void *data)
                 /* override the default src_addr tested if we have to go deeper than one level into XFF */
                 Filled(calloutContext->acl_checklist)->src_addr = request->indirect_client_addr;
             }
-            if (++calloutContext->currentXffHopNumber < SQUID_X_FORWARDED_FOR_HOP_MAX)
+            if (++calloutContext->currentXffHopNumber < SQUID_X_FORWARDED_FOR_HOP_MAX) {
                 calloutContext->acl_checklist->nonBlockingCheck(clientFollowXForwardedForCheck, data);
-            return;
+                return;
+            }
+            // fall through to resume clientAccessCheck() processing
         }
     }
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -75,6 +75,9 @@
 #endif
 
 #if FOLLOW_X_FORWARDED_FOR
+#if !defined(MAX_X_FORWARDED_HOP)
+#define MAX_X_FORWARDED_HOP 16
+#endif
 static void clientFollowXForwardedForCheck(Acl::Answer answer, void *data);
 #endif /* FOLLOW_X_FORWARDED_FOR */
 
@@ -437,7 +440,8 @@ clientFollowXForwardedForCheck(Acl::Answer answer, void *data)
                 /* override the default src_addr tested if we have to go deeper than one level into XFF */
                 Filled(calloutContext->acl_checklist)->src_addr = request->indirect_client_addr;
             }
-            calloutContext->acl_checklist->nonBlockingCheck(clientFollowXForwardedForCheck, data);
+            if (++calloutContext->currentXffHopNumber < MAX_X_FORWARDED_HOP)
+                calloutContext->acl_checklist->nonBlockingCheck(clientFollowXForwardedForCheck, data);
             return;
         }
     }

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -75,9 +75,11 @@
 #endif
 
 #if FOLLOW_X_FORWARDED_FOR
+
 #if !defined(SQUID_X_FORWARDED_FOR_HOP_MAX)
 #define SQUID_X_FORWARDED_FOR_HOP_MAX 16
 #endif
+
 static void clientFollowXForwardedForCheck(Acl::Answer answer, void *data);
 #endif /* FOLLOW_X_FORWARDED_FOR */
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -75,8 +75,8 @@
 #endif
 
 #if FOLLOW_X_FORWARDED_FOR
-#if !defined(MAX_X_FORWARDED_HOP)
-#define MAX_X_FORWARDED_HOP 16
+#if !defined(SQUID_X_FORWARDED_FOR_HOP_MAX)
+#define SQUID_X_FORWARDED_FOR_HOP_MAX 16
 #endif
 static void clientFollowXForwardedForCheck(Acl::Answer answer, void *data);
 #endif /* FOLLOW_X_FORWARDED_FOR */
@@ -440,7 +440,7 @@ clientFollowXForwardedForCheck(Acl::Answer answer, void *data)
                 /* override the default src_addr tested if we have to go deeper than one level into XFF */
                 Filled(calloutContext->acl_checklist)->src_addr = request->indirect_client_addr;
             }
-            if (++calloutContext->currentXffHopNumber < MAX_X_FORWARDED_HOP)
+            if (++calloutContext->currentXffHopNumber < SQUID_X_FORWARDED_FOR_HOP_MAX)
                 calloutContext->acl_checklist->nonBlockingCheck(clientFollowXForwardedForCheck, data);
             return;
         }

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -446,6 +446,11 @@ clientFollowXForwardedForCheck(Acl::Answer answer, void *data)
                 calloutContext->acl_checklist->nonBlockingCheck(clientFollowXForwardedForCheck, data);
                 return;
             }
+            const auto headerName = Http::HeaderLookupTable.lookup(Http::HdrType::X_FORWARDED_FOR).name;
+            debugs(28, DBG_CRITICAL, "ERROR: Ignoring trailing " << headerName << " addresses" <<
+                   Debug::Extra << "addresses allowed by follow_x_forwarded_for: " << calloutContext->currentXffHopNumber <<
+                   Debug::Extra << "last/accepted address: " << request->indirect_client_addr <<
+                   Debug::Extra << "ignored trailing addresses: " << request->x_forwarded_for_iterator);
             // fall through to resume clientAccessCheck() processing
         }
     }

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -77,7 +77,7 @@
 #if FOLLOW_X_FORWARDED_FOR
 
 #if !defined(SQUID_X_FORWARDED_FOR_HOP_MAX)
-#define SQUID_X_FORWARDED_FOR_HOP_MAX 16
+#define SQUID_X_FORWARDED_FOR_HOP_MAX 64
 #endif
 
 static void clientFollowXForwardedForCheck(Acl::Answer answer, void *data);


### PR DESCRIPTION
Squid will ignore all X-Forwarded-For elements listed after the first 64
addresses allowed by the follow_x_forwarded_for directive. A different
limit can be specified by defining a C++ SQUID_X_FORWARDED_FOR_HOP_MAX
macro, but that macro is not a supported Squid configuration interface
and may change or disappear at any time.

Squid will log a cache.log ERROR if the hop limit has been reached.

This change works around problematic ACLChecklist and/or slow ACLs
implementation that results in immediate nonBlockingCheck() callbacks.
Such callbacks have caused many bugs and development complications. In
clientFollowXForwardedForCheck() context, they lead to indirect
recursion that was bound only by the number of allowed XFF entries,
which could reach thousands and exhaust Squid process call stack.

This recursion bug was discovered and detailed by Joshua Rogers at
https://megamansec.github.io/Squid-Security-Audit/xff-stackoverflow.html
where it was filed as "X-Forwarded-For Stack Overflow".
