### PR TITLE
Remove deprecated string memory pools API

### DIFF
--- a/src/String.cc
+++ b/src/String.cc
@@ -18,7 +18,7 @@ void
 String::allocBuffer(String::size_type sz)
 {
     assert (undefined());
-    char *newBuffer = (char*)memAllocString(sz, &sz);
+    auto *newBuffer = static_cast<char*>(memAllocBuf(sz, &sz));
     setBuffer(newBuffer, sz);
 }
 
@@ -104,7 +104,7 @@ String::clean()
 {
     /* TODO if mempools has already closed this will FAIL!! */
     if (defined())
-        memFreeString(size_, buf_);
+        memFreeBuf(size_, buf_);
 
     len_ = 0;
 

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -73,7 +73,6 @@ void memFreeBuf(size_t size, void *);
 void memFreeRigid(void *, size_t net_size);
 FREE *memFreeBufFunc(size_t size);
 int memInUse(mem_type);
-void memDataInit(mem_type, const char *, size_t, int, bool doZero = true);
 void memCheckInit(void);
 size_t memStringCount();
 

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -39,6 +39,12 @@ typedef void FREE(void *);
 /// Types of memory pool which do not yet use MEMPROXY_CLASS() API
 typedef enum {
     MEM_NONE,
+    MEM_32B_BUF,
+    MEM_64B_BUF,
+    MEM_128B_BUF,
+    MEM_256B_BUF,
+    MEM_512B_BUF,
+    MEM_1K_BUF,
     MEM_2K_BUF,
     MEM_4K_BUF,
     MEM_8K_BUF,

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -73,7 +73,6 @@ void memFreeBuf(size_t size, void *);
 void memFreeRigid(void *, size_t net_size);
 FREE *memFreeBufFunc(size_t size);
 int memInUse(mem_type);
-void memDataInit(mem_type, const char *, size_t, int, bool doZero = true);
 size_t memStringCount();
 
 #endif /* _SQUID_SRC_MEM_FORWARD_H */

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -64,13 +64,11 @@ void memCleanModule(void);
 void memConfigure(void);
 /// Allocate one element from the typed pool
 void *memAllocate(mem_type);
-void *memAllocString(size_t net_size, size_t * gross_size);
 void *memAllocBuf(size_t net_size, size_t * gross_size);
 void *memAllocRigid(size_t net_size);
 void *memReallocBuf(void *buf, size_t net_size, size_t * gross_size);
 /// Free a element allocated by memAllocate()
 void memFree(void *, int type);
-void memFreeString(size_t size, void *);
 void memFreeBuf(size_t size, void *);
 void memFreeRigid(void *, size_t net_size);
 FREE *memFreeBufFunc(size_t size);

--- a/src/mem/minimal.cc
+++ b/src/mem/minimal.cc
@@ -63,18 +63,6 @@ memFree(void *memory, int)
 }
 
 void *
-memAllocString(const size_t netSize, size_t * const grossSize)
-{
-    return memAllocBuf(netSize, grossSize);
-}
-
-void
-memFreeString(size_t, void *memory)
-{
-    xfree(memory);
-}
-
-void *
 memAllocRigid(const size_t netSize)
 {
     return xmalloc(netSize);

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -430,7 +430,7 @@ Mem::Init(void)
     memDataInit(MEM_16K_BUF, "16K Buffer", 16384, 10, false);
     memDataInit(MEM_32K_BUF, "32K Buffer", 32768, 10, false);
     memDataInit(MEM_64K_BUF, "64K Buffer", 65536, 10, false);
-    // TODO: make these objects use MEMPROXY_CLASS() and drop the doZero parameter
+    // TODO: Carefully stop zeroing these objects memory and drop the doZero parameter
     memDataInit(MEM_DREAD_CTRL, "dread_ctrl", sizeof(dread_ctrl), 0, true);
     memDataInit(MEM_DWRITE_Q, "dwrite_q", sizeof(dwrite_q), 0, true);
     memDataInit(MEM_MD5_DIGEST, "MD5 digest", SQUID_MD5_DIGEST_LENGTH, 0, true);

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -191,16 +191,10 @@ Mem::Stats(StoreEntry * sentry)
 }
 
 /*
- * public routines
- */
-
-/*
  * we have a limit on _total_ amount of idle memory so we ignore max_pages for now.
  * Will ignore repeated calls for the same pool type.
- *
- * Relies on Mem::Init() having been called beforehand.
  */
-void
+static void
 memDataInit(mem_type type, const char *name, size_t size, int, bool doZero)
 {
     assert(name && size);
@@ -436,9 +430,10 @@ Mem::Init(void)
     memDataInit(MEM_16K_BUF, "16K Buffer", 16384, 10, false);
     memDataInit(MEM_32K_BUF, "32K Buffer", 32768, 10, false);
     memDataInit(MEM_64K_BUF, "64K Buffer", 65536, 10, false);
-    memDataInit(MEM_DREAD_CTRL, "dread_ctrl", sizeof(dread_ctrl), 0);
-    memDataInit(MEM_DWRITE_Q, "dwrite_q", sizeof(dwrite_q), 0);
-    memDataInit(MEM_MD5_DIGEST, "MD5 digest", SQUID_MD5_DIGEST_LENGTH, 0);
+    // TODO: make these objects use MEMPROXY_CLASS() and drop the doZero parameter
+    memDataInit(MEM_DREAD_CTRL, "dread_ctrl", sizeof(dread_ctrl), 0, true);
+    memDataInit(MEM_DWRITE_Q, "dwrite_q", sizeof(dwrite_q), 0, true);
+    memDataInit(MEM_MD5_DIGEST, "MD5 digest", SQUID_MD5_DIGEST_LENGTH, 0, true);
     GetPool(MEM_MD5_DIGEST)->setChunkSize(512 * 1024);
 
     MemIsInitialized = true;

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -230,30 +230,10 @@ memFree(void *p, int type)
     GetPool(type)->freeOne(p);
 }
 
-/* allocate a variable size buffer using best-fit string pool */
-void *
-memAllocString(size_t net_size, size_t * gross_size)
-{
-    assert(gross_size);
-
-    if (const auto pool = memFindStringPool(net_size, true)) {
-        *gross_size = pool->objectSize;
-        assert(*gross_size >= net_size);
-        ++StrCountMeter;
-        StrVolumeMeter += *gross_size;
-        return pool->alloc();
-    }
-
-    *gross_size = net_size;
-    ++StrCountMeter;
-    StrVolumeMeter += *gross_size;
-    return xcalloc(1, net_size);
-}
-
 void *
 memAllocRigid(size_t net_size)
 {
-    // TODO: Use memAllocString() instead (after it stops zeroing memory).
+    // TODO: Use memAllocBuf() instead (after it stops zeroing memory).
 
     if (const auto pool = memFindStringPool(net_size, true)) {
         ++StrCountMeter;
@@ -277,25 +257,10 @@ memStringCount()
     return result;
 }
 
-/* free buffer allocated with memAllocString() */
-void
-memFreeString(size_t size, void *buf)
-{
-    assert(buf);
-
-    if (const auto pool = memFindStringPool(size, false))
-        pool->freeOne(buf);
-    else
-        xfree(buf);
-
-    --StrCountMeter;
-    StrVolumeMeter -= size;
-}
-
 void
 memFreeRigid(void *buf, size_t net_size)
 {
-    // TODO: Use memFreeString() instead (after removing fuzzy=false pool search).
+    // TODO: Use memFreeBuf() instead (after removing fuzzy=false pool search).
 
     if (const auto pool = memFindStringPool(net_size, true)) {
         pool->freeOne(buf);

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -421,7 +421,7 @@ Mem::Init(void)
     /**
      * Then initialize all pools.
      * \par
-     * Starting with generic 32B - 64kB buffr pools, then specific object types.
+     * Starting with generic buffer pools, then specific object types.
      * \par
      * It does not hurt much to have a lot of pools since sizeof(MemPool) is
      * small; someday we will figure out what to do with all the entries here

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -27,6 +27,12 @@
 #include <iomanip>
 
 /* forward declarations */
+static void memFree32B(void *);
+static void memFree64B(void *);
+static void memFree128B(void *);
+static void memFree256B(void *);
+static void memFree512B(void *);
+static void memFree1K(void *);
 static void memFree2K(void *);
 static void memFree4K(void *);
 static void memFree8K(void *);
@@ -310,7 +316,25 @@ memFindBufSizeType(size_t net_size, size_t * gross_size)
     mem_type type;
     size_t size;
 
-    if (net_size <= 2 * 1024) {
+    if (net_size <= 32) {
+        type = MEM_32B_BUF;
+        size = 32;
+    } else if (net_size <= 64) {
+        type = MEM_64B_BUF;
+        size = 64;
+    } else if (net_size <= 128) {
+        type = MEM_128B_BUF;
+        size = 128;
+    } else if (net_size <= 256) {
+        type = MEM_256B_BUF;
+        size = 256;
+    } else if (net_size <= 512) {
+        type = MEM_512B_BUF;
+        size = 512;
+    } else if (net_size <= 1024) {
+        type = MEM_1K_BUF;
+        size = 1024;
+    } else if (net_size <= 2 * 1024) {
         type = MEM_2K_BUF;
         size = 2 * 1024;
     } else if (net_size <= 4 * 1024) {
@@ -439,6 +463,12 @@ Mem::Init(void)
      * that are never used or used only once; perhaps we should simply use
      * malloc() for those? @?@
      */
+    memDataInit(MEM_32B_BUF, "32B Buffer", 32, 10, false);
+    memDataInit(MEM_64B_BUF, "64B Buffer", 64, 10, false);
+    memDataInit(MEM_128B_BUF, "128B Buffer", 128, 10, false);
+    memDataInit(MEM_256B_BUF, "256B Buffer", 256, 10, false);
+    memDataInit(MEM_512B_BUF, "512B Buffer", 512, 10, false);
+    memDataInit(MEM_1K_BUF, "1K Buffer", 1024, 10, false);
     memDataInit(MEM_2K_BUF, "2K Buffer", 2048, 10, false);
     memDataInit(MEM_4K_BUF, "4K Buffer", 4096, 10, false);
     memDataInit(MEM_8K_BUF, "8K Buffer", 8192, 10, false);
@@ -506,6 +536,42 @@ memInUse(mem_type type)
 /* ick */
 
 void
+memFree32B(void *p)
+{
+    memFree(p, MEM_32B_BUF);
+}
+
+void
+memFree64B(void *p)
+{
+    memFree(p, MEM_64B_BUF);
+}
+
+void
+memFree128B(void *p)
+{
+    memFree(p, MEM_128B_BUF);
+}
+
+void
+memFree256B(void *p)
+{
+    memFree(p, MEM_256B_BUF);
+}
+
+void
+memFree512B(void *p)
+{
+    memFree(p, MEM_512B_BUF);
+}
+
+void
+memFree1K(void *p)
+{
+    memFree(p, MEM_1K_BUF);
+}
+
+void
 memFree2K(void *p)
 {
     memFree(p, MEM_2K_BUF);
@@ -551,6 +617,24 @@ FREE *
 memFreeBufFunc(size_t size)
 {
     switch (size) {
+
+    case 32:
+        return memFree32B;
+
+    case 64:
+        return memFree64B;
+
+    case 128:
+        return memFree128B;
+
+    case 256:
+        return memFree256B;
+
+    case 512:
+        return memFree512B;
+
+    case 1024:
+        return memFree1K;
 
     case 2 * 1024:
         return memFree2K;

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -421,7 +421,7 @@ Mem::Init(void)
     /**
      * Then initialize all pools.
      * \par
-     * Starting with generic 2kB - 64kB buffr pools, then specific object types.
+     * Starting with generic 32B - 64kB buffr pools, then specific object types.
      * \par
      * It does not hurt much to have a lot of pools since sizeof(MemPool) is
      * small; someday we will figure out what to do with all the entries here

--- a/src/sbuf/MemBlob.cc
+++ b/src/sbuf/MemBlob.cc
@@ -71,7 +71,7 @@ MemBlob::MemBlob(const char *buffer, const MemBlob::size_type bufSize) :
 MemBlob::~MemBlob()
 {
     if (mem || capacity)
-        memFreeString(capacity,mem);
+        memFreeBuf(capacity, mem);
     Stats.liveBytes -= capacity;
     --Stats.live;
     SBufStats::RecordMemBlobSizeAtDestruct(capacity);
@@ -91,7 +91,7 @@ MemBlob::memAlloc(const size_type minSize)
     size_t actualAlloc = minSize;
 
     Must(!mem);
-    mem = static_cast<char*>(memAllocString(actualAlloc, &actualAlloc));
+    mem = static_cast<char*>(memAllocBuf(actualAlloc, &actualAlloc));
     Must(mem);
 
     capacity = actualAlloc;

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -39,8 +39,6 @@ void *memAllocate(mem_type)
     return xmalloc(64*1024);
 }
 
-void *memAllocString(size_t net_size, size_t * gross_size) {return memAllocBuf(net_size, gross_size);}
-
 void *memAllocRigid(size_t net_size)
 {
     return xmalloc(net_size);
@@ -67,7 +65,6 @@ memReallocBuf(void *oldbuf, size_t net_size, size_t * gross_size)
 }
 
 void memFree(void *p, int) {xfree(p);}
-void memFreeString(size_t, void *buf) {xfree(buf);}
 void memFreeRigid(void *buf, size_t) {xfree(buf);}
 void memFreeBuf(size_t, void *buf) {xfree(buf);}
 static void cxx_xfree(void * ptr) {xfree(ptr);}

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -70,7 +70,6 @@ void memFreeBuf(size_t, void *buf) {xfree(buf);}
 static void cxx_xfree(void * ptr) {xfree(ptr);}
 FREE *memFreeBufFunc(size_t) {return cxx_xfree;}
 int memInUse(mem_type) STUB_RETVAL(0)
-void memDataInit(mem_type, const char *, size_t, int, bool) STUB_NOP
 
 #include "mem/Pool.h"
 static MemPools tmpMemPools;

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -70,7 +70,6 @@ void memFreeBuf(size_t, void *buf) {xfree(buf);}
 static void cxx_xfree(void * ptr) {xfree(ptr);}
 FREE *memFreeBufFunc(size_t) {return cxx_xfree;}
 int memInUse(mem_type) STUB_RETVAL(0)
-void memDataInit(mem_type, const char *, size_t, int, bool) STUB_NOP
 void memCheckInit(void) STUB_NOP
 
 #include "mem/Pool.h"


### PR DESCRIPTION
Also added 32-byte, 64-byte, 128-byte, 256-byte, 512-byte, and 1024-byte
memory pools.
