### PR TITLE
Move memory initialization check

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1260,8 +1260,6 @@ mainInitialize(void)
 
 #endif
 
-    memCheckInit();
-
 #if USE_LOADABLE_MODULES
     LoadableModulesConfigure(Config.loadable_module_names);
 #endif

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -70,7 +70,6 @@ void memFreeRigid(void *, size_t net_size);
 FREE *memFreeBufFunc(size_t size);
 int memInUse(mem_type);
 void memDataInit(mem_type, const char *, size_t, int, bool doZero = true);
-void memCheckInit(void);
 size_t memStringCount();
 
 #endif /* _SQUID_SRC_MEM_FORWARD_H */

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -421,6 +421,14 @@ memConfigure(void)
     MemPools::GetInstance().setIdleLimit(new_pool_limit);
 }
 
+static mem_type &
+operator++(mem_type &aMem)
+{
+    auto tmp = static_cast<int>(aMem);
+    aMem = static_cast<mem_type>(++tmp);
+    return aMem;
+}
+
 void
 Mem::Init(void)
 {
@@ -450,35 +458,17 @@ Mem::Init(void)
     memDataInit(MEM_MD5_DIGEST, "MD5 digest", SQUID_MD5_DIGEST_LENGTH, 0);
     GetPool(MEM_MD5_DIGEST)->setChunkSize(512 * 1024);
 
+    // Test that all entries are initialized
+    for (auto t = MEM_NONE; ++t < MEM_MAX;) {
+        // If you hit this assertion, then you forgot to add a
+        // memDataInit() line for type 't'.
+        assert(GetPool(t));
+    }
+
     MemIsInitialized = true;
 
     // finally register with the cache manager
     Mgr::RegisterAction("mem", "Memory Utilization", Mem::Stats, 0, 1);
-}
-
-static mem_type &
-operator++(mem_type &aMem)
-{
-    int tmp = (int)aMem;
-    aMem = (mem_type)(++tmp);
-    return aMem;
-}
-
-/*
- * Test that all entries are initialized
- */
-void
-memCheckInit(void)
-{
-    mem_type t = MEM_NONE;
-
-    while (++t < MEM_MAX) {
-        /*
-         * If you hit this assertion, then you forgot to add a
-         * memDataInit() line for type 't'.
-         */
-        assert(GetPool(t));
-    }
 }
 
 void

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -74,7 +74,6 @@ static void cxx_xfree(void * ptr) {xfree(ptr);}
 FREE *memFreeBufFunc(size_t) {return cxx_xfree;}
 int memInUse(mem_type) STUB_RETVAL(0)
 void memDataInit(mem_type, const char *, size_t, int, bool) STUB_NOP
-void memCheckInit(void) STUB_NOP
 
 #include "mem/Pool.h"
 static MemPools tmpMemPools;


### PR DESCRIPTION
mainInitialize() is far too late to be validating that memory
pools created with memDataInit() have been correctly initialized.
They will have already been used by debugging, and many other
components early-setup logic.

Instead run the check at the last possible moment before
declaring the memory pools to be fully initialized.