### PR TITLE
Make static analysis tools happier about peerDigestLookup()

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -732,7 +732,7 @@ peerDigestLookup(CachePeer * p, PeerSelector * ps)
     assert(p->digest->cd);
     /* does digest predict a hit? */
 
-    if (!p->digest->cd->contains(key))
+    if (key && !p->digest->cd->contains(key))
         return LOOKUP_MISS;
 
     debugs(15, 5, "HIT for cache_peer " << *p);

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -707,9 +707,9 @@ peerDigestLookup(CachePeer * p, PeerSelector * ps)
 #if USE_CACHE_DIGESTS
     assert(ps);
     HttpRequest *request = ps->request;
-    const cache_key *key = request ? storeKeyPublicByRequest(request) : nullptr;
-    assert(p);
     assert(request);
+
+    assert(p);
     debugs(15, 5, "cache_peer " << *p);
     /* does the peeer have a valid digest? */
 
@@ -732,7 +732,7 @@ peerDigestLookup(CachePeer * p, PeerSelector * ps)
     assert(p->digest->cd);
     /* does digest predict a hit? */
 
-    if (key && !p->digest->cd->contains(key))
+    if (!p->digest->cd->contains(storeKeyPublicByRequest(request)))
         return LOOKUP_MISS;
 
     debugs(15, 5, "HIT for cache_peer " << *p);


### PR DESCRIPTION
Some tools thought that `key` could be nil. Refactor a bit to convince
them otherwise.
