### PR TITLE
Remove global AclMatchedName from ACL::match() virtual methods

### DIFF
--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -541,7 +541,7 @@ Acl::DestinationAsnCheck::match(ACLChecklist * const ch)
 
     } else if (!checklist->request->flags.destinationIpLookedUp) {
         /* No entry in cache, lookup not attempted */
-        debugs(28, 3, "can't yet compare '" << AclMatchedName << "' ACL for " << checklist->request->url.host());
+        debugs(28, 3, "can't yet compare '" << name << "' ACL for " << checklist->request->url.host());
         if (checklist->goAsync(ACLDestinationIP::StartLookup, *this))
             return -1;
         // else fall through to noaddr match, hiding the lookup failure (XXX)

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -56,7 +56,7 @@ Acl::DestinationDomainCheck::match(ACLChecklist * const ch)
     }
 
     if (lookupBanned) {
-        debugs(28, 3, "No-lookup DNS ACL '" << AclMatchedName << "' for " << checklist->request->url.host());
+        debugs(28, 3, "No-lookup DNS ACL '" << name << "' for " << checklist->request->url.host());
         return 0;
     }
 
@@ -67,7 +67,7 @@ Acl::DestinationDomainCheck::match(ACLChecklist * const ch)
 
     /* do we already have the rDNS? match on it if we do. */
     if (checklist->dst_rdns) {
-        debugs(28, 3, "'" << AclMatchedName << "' match with stored rDNS '" << checklist->dst_rdns << "' for " << checklist->request->url.host());
+        debugs(28, 3, "'" << name << "' match with stored rDNS '" << checklist->dst_rdns << "' for " << checklist->request->url.host());
         return data->match(checklist->dst_rdns);
     }
 
@@ -84,8 +84,7 @@ Acl::DestinationDomainCheck::match(ACLChecklist * const ch)
         checklist->dst_rdns = xstrdup(fqdn);
         return data->match(fqdn);
     } else if (!checklist->destinationDomainChecked()) {
-        // TODO: Using AclMatchedName here is not OO correct. Should find a way to the current acl
-        debugs(28, 3, "Can't yet compare '" << AclMatchedName << "' ACL for " << checklist->request->url.host());
+        debugs(28, 3, "Can't yet compare '" << name << "' ACL for " << checklist->request->url.host());
         if (checklist->goAsync(StartLookup, *this))
             return -1;
         // else fall through to "none" match, hiding the lookup failure (XXX)

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -53,7 +53,7 @@ ACLDestinationIP::match(ACLChecklist *cl)
 
     if (lookupBanned) {
         if (!checklist->request->url.hostIsNumeric()) {
-            debugs(28, 3, "No-lookup DNS ACL '" << AclMatchedName << "' for " << checklist->request->url.host());
+            debugs(28, 3, "No-lookup DNS ACL '" << name << "' for " << checklist->request->url.host());
             return 0;
         }
 

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -45,8 +45,7 @@ Acl::SourceDomainCheck::match(ACLChecklist * const ch)
     if (fqdn) {
         return data->match(fqdn);
     } else if (!checklist->sourceDomainChecked()) {
-        // TODO: Using AclMatchedName here is not OO correct. Should find a way to the current acl
-        debugs(28, 3, "aclMatchAcl: Can't yet compare '" << AclMatchedName << "' ACL for '" << checklist->src_addr << "'");
+        debugs(28, 3, "aclMatchAcl: Can't yet compare '" << name << "' ACL for '" << checklist->src_addr << "'");
         if (checklist->goAsync(StartLookup, *this))
             return -1;
         // else fall through to "none" match, hiding the lookup failure (XXX)


### PR DESCRIPTION
... and use ACL::name instead, which became accessible since 8319d47.
