### PR TITLE
Add "virtual" specifier to class destructor

### DIFF
--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -74,7 +74,7 @@ class CtrlChannel: public Ftp::Channel
 {
 public:
     CtrlChannel();
-    ~CtrlChannel();
+    virtual ~CtrlChannel();
 
     char *buf;
     size_t size;


### PR DESCRIPTION
Ftp::CtrlChannel allocating dynamic memory in constructor by call:
```buf = static_cast<char*>(memAllocBuf(4096, &size));``` 
but since its destructor not virtual only desctructor of base class 
called and memory not freed