### PR TITLE
Add "virtual" specifier to class destructor

### DIFF
--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -74,7 +74,7 @@ class CtrlChannel: public Ftp::Channel
 {
 public:
     CtrlChannel();
-    ~CtrlChannel();
+    virtual ~CtrlChannel();
 
     char *buf;
     size_t size;

--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -63,6 +63,8 @@ public:
      * the callback will still happen and needs to be handled (usually dropped).
      */
     Comm::ConnectionPointer listenConn;
+    
+    virtual ~Channel() = default;
 
 private:
     AsyncCall::Pointer closer; ///< Comm close handler callback
@@ -74,7 +76,7 @@ class CtrlChannel: public Ftp::Channel
 {
 public:
     CtrlChannel();
-    virtual ~CtrlChannel();
+    ~CtrlChannel() override;
 
     char *buf;
     size_t size;
@@ -95,7 +97,7 @@ class DataChannel: public Ftp::Channel
 {
 public:
     DataChannel();
-    ~DataChannel();
+    ~DataChannel() override;
 
     void addr(const Ip::Address &addr); ///< import host and port
 


### PR DESCRIPTION
Ftp::CtrlChannel allocating dynamic memory in constructor by call:
buf = static_cast<char*>(memAllocBuf(4096, &size));
but since its destructor not virtual only desctructor of base class
called and memory not freed