### PR TITLE
Bug 5328: Fix ESI build with libxml2 v2.12.0

### DIFF
--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -144,7 +144,7 @@ ESILibxml2Parser::lineNumber() const
 char const *
 ESILibxml2Parser::errorString() const
 {
-    xmlErrorPtr error = xmlGetLastError();
+    const xmlError *error = xmlGetLastError();
 
     if (error == nullptr)
         return nullptr;

--- a/src/esi/Libxml2Parser.cc
+++ b/src/esi/Libxml2Parser.cc
@@ -144,7 +144,7 @@ ESILibxml2Parser::lineNumber() const
 char const *
 ESILibxml2Parser::errorString() const
 {
-    const xmlError *error = xmlGetLastError();
+    const auto error = xmlGetLastError();
 
     if (error == nullptr)
         return nullptr;


### PR DESCRIPTION
    Libxml2Parser.cc:147:40: error: invalid conversion from
    'const xmlError*' to 'xmlErrorPtr' {aka 'xmlError*'} [-fpermissive]

libxml2 recently made xmlGetLastError() return a constant object.
