### PR TITLE
Avoid UB when copying AnyP::Uri

### DIFF
--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -34,22 +34,12 @@ class Uri
 public:
     Uri(): hostIsNumeric_(false) { *host_ = 0; }
     Uri(AnyP::UriScheme const &aScheme);
-    Uri(const Uri &other) {
-        scheme_ = other.scheme_;
-        userInfo_ = other.userInfo_;
-        memcpy(host_, other.host_, sizeof(host_));
-        hostIsNumeric_ = other.hostIsNumeric_;
-        hostAddr_ = other.hostAddr_;
-        port_ = other.port_;
-        path_ = other.path_;
-        touch();
-    }
 
-    Uri &operator=(const Uri &other) {
-        Uri tmp(other);
-        swap(tmp);
-        return *this;
-    }
+    Uri(const Uri &other) = default;
+    Uri &operator=(const Uri &other) = default;
+
+    Uri(Uri &&other) = default;
+    Uri &operator=(Uri &&other) = default;
 
     void clear() {
         scheme_=AnyP::PROTO_NONE;
@@ -58,17 +48,6 @@ public:
         hostAddr_.setEmpty();
         port_ = std::nullopt;
         touch();
-    }
-
-    void swap(Uri& other)
-    {
-        std::swap(scheme_, other.scheme_);
-        std::swap(userInfo_, other.userInfo_);
-        memcpy(host_, other.host_, sizeof(host_));
-        std::swap(hostIsNumeric_, other.hostIsNumeric_);
-        std::swap(hostAddr_, other.hostAddr_);
-        std::swap(port_, other.port_);
-        std::swap(path_, other.path_);
     }
 
     void touch(); ///< clear the cached URI display forms

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -34,12 +34,10 @@ class Uri
 public:
     Uri(): hostIsNumeric_(false) { *host_ = 0; }
     Uri(AnyP::UriScheme const &aScheme);
-
-    Uri(const Uri &other) = default;
-    Uri &operator=(const Uri &other) = default;
-
-    Uri(Uri &&other) = default;
-    Uri &operator=(Uri &&other) = default;
+    Uri(const Uri &) = default;
+    Uri(Uri &&) = default;
+    Uri &operator =(const Uri &) = default;
+    Uri &operator =(Uri &&) = default;
 
     void clear() {
         scheme_=AnyP::PROTO_NONE;
@@ -49,7 +47,6 @@ public:
         port_ = std::nullopt;
         touch();
     }
-
     void touch(); ///< clear the cached URI display forms
 
     bool parse(const HttpRequestMethod &, const SBuf &url);

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -35,17 +35,19 @@ public:
     Uri(): hostIsNumeric_(false) { *host_ = 0; }
     Uri(AnyP::UriScheme const &aScheme);
     Uri(const Uri &other) {
-        this->operator =(other);
-    }
-    Uri &operator =(const Uri &o) {
-        scheme_ = o.scheme_;
-        userInfo_ = o.userInfo_;
-        memcpy(host_, o.host_, sizeof(host_));
-        hostIsNumeric_ = o.hostIsNumeric_;
-        hostAddr_ = o.hostAddr_;
-        port_ = o.port_;
-        path_ = o.path_;
+        scheme_ = other.scheme_;
+        userInfo_ = other.userInfo_;
+        memcpy(host_, other.host_, sizeof(host_));
+        hostIsNumeric_ = other.hostIsNumeric_;
+        hostAddr_ = other.hostAddr_;
+        port_ = other.port_;
+        path_ = other.path_;
         touch();
+    }
+
+    Uri &operator=(const Uri &other) {
+        Uri tmp(other);
+        swap(tmp);
         return *this;
     }
 
@@ -57,6 +59,18 @@ public:
         port_ = std::nullopt;
         touch();
     }
+
+    void swap(Uri& other)
+    {
+        std::swap(scheme_, other.scheme_);
+        std::swap(userInfo_, other.userInfo_);
+        memcpy(host_, other.host_, sizeof(host_));
+        std::swap(hostIsNumeric_, other.hostIsNumeric_);
+        std::swap(hostAddr_, other.hostAddr_);
+        std::swap(port_, other.port_);
+        std::swap(path_, other.path_);
+    }
+
     void touch(); ///< clear the cached URI display forms
 
     bool parse(const HttpRequestMethod &, const SBuf &url);


### PR DESCRIPTION
Without a self-assignment check, a memcpy(3) call in Uri copy assignment
operator could result in undefined behavior. Let the compiler generate
all this code instead.
