### PR TITLE
Remove ADD_X_REQUEST_URI

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -1420,18 +1420,6 @@ clientReplyContext::buildReplyHeader()
     /* Signal keep-alive or close explicitly */
     hdr->putStr(Http::HdrType::CONNECTION, request->flags.proxyKeepalive ? "keep-alive" : "close");
 
-#if ADD_X_REQUEST_URI
-    /*
-     * Knowing the URI of the request is useful when debugging persistent
-     * connections in a client; we cannot guarantee the order of http headers,
-     * but X-Request-URI is likely to be the very last header to ease use from a
-     * debugger [hdr->entries.count-1].
-     */
-    hdr->putStr(Http::HdrType::X_REQUEST_URI,
-                http->memOjbect()->url ? http->memObject()->url : http->uri);
-
-#endif
-
     /* Surrogate-Control requires Surrogate-Capability from upstream to pass on */
     if ( hdr->has(Http::HdrType::SURROGATE_CONTROL) ) {
         if (!request->header.has(Http::HdrType::SURROGATE_CAPABILITY)) {

--- a/src/http/RegisteredHeaders.h
+++ b/src/http/RegisteredHeaders.h
@@ -106,7 +106,6 @@ enum HdrType {
     VIA,                            /**< RFC 7230 */
     WWW_AUTHENTICATE,               /**< RFC 7235, 4559 */
     X_FORWARDED_FOR,                /**< obsolete Squid custom header, RFC 7239 */
-    X_REQUEST_URI,                  /**< Squid custom header appended if ADD_X_REQUEST_URI is defined */
     X_SQUID_ERROR,                  /**< Squid custom header on generated error responses */
     HDR_X_ACCELERATOR_VARY,             /**< obsolete Squid custom header. */
     X_NEXT_SERVICES,                /**< Squid custom ICAP header */

--- a/src/http/RegisteredHeadersHash.cci
+++ b/src/http/RegisteredHeadersHash.cci
@@ -44,7 +44,7 @@
 class HeaderTableRecord;
     enum
 {
-    TOTAL_KEYWORDS = 87,
+    TOTAL_KEYWORDS = 86,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 25,
     MIN_HASH_VALUE = 12,
@@ -115,7 +115,7 @@ HttpHeaderHashTable::HttpHeaderHash (const char *str, size_t len)
         114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
         114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
         114, 114, 114, 114, 114, 114, 114, 114, 114, 114,
-        114, 114,  81, 114, 114,  13, 114, 114, 114, 114,
+        114, 114,  79, 114, 114,  13, 114, 114, 114, 114,
         26, 114, 114,  21, 114, 114, 114, 114,   9, 114,
         114, 114, 114, 114, 114,  24,  61,  30,  26,  10,
         34,  44,  14,  52, 114,   6,  37,  65,   6,   6,
@@ -168,7 +168,7 @@ static const unsigned char lengthtable[] =
     13, 19,  7, 12,  6,  7, 11, 15,  6, 16, 13, 19,  7, 16,
     14, 14,  4,  9, 21,  4, 16, 18, 20, 15, 11,  8, 12, 13,
     10, 10, 13, 16,  9, 12, 18, 17, 17,  5, 19, 15, 10,  6,
-    17, 12, 13, 11, 15, 11, 13, 13, 10, 13,  0,  0,  0,  0,
+    17, 12, 13, 11, 15, 11, 10, 13,  0, 13,  0,  0,  0,  0,
     0, 13
 };
 
@@ -195,7 +195,7 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Title", Http::HdrType::TITLE, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 37 "RegisteredHeadersHash.gperf"
     {"Connection", Http::HdrType::CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
-#line 109 "RegisteredHeadersHash.gperf"
+#line 108 "RegisteredHeadersHash.gperf"
     {"Other:", Http::HdrType::OTHER, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
     {""},
 #line 59 "RegisteredHeadersHash.gperf"
@@ -208,7 +208,7 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Proxy-Connection", Http::HdrType::PROXY_CONNECTION, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
 #line 56 "RegisteredHeadersHash.gperf"
     {"If-Match", Http::HdrType::IF_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 106 "RegisteredHeadersHash.gperf"
+#line 105 "RegisteredHeadersHash.gperf"
     {"FTP-Pre", Http::HdrType::FTP_PRE, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 51 "RegisteredHeadersHash.gperf"
     {"Expect", Http::HdrType::EXPECT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
@@ -218,7 +218,7 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Cookie2", Http::HdrType::COOKIE2, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 46 "RegisteredHeadersHash.gperf"
     {"Content-Type", Http::HdrType::CONTENT_TYPE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 108 "RegisteredHeadersHash.gperf"
+#line 107 "RegisteredHeadersHash.gperf"
     {"FTP-Reason", Http::HdrType::FTP_REASON, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 52 "RegisteredHeadersHash.gperf"
     {"Expires", Http::HdrType::EXPIRES, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
@@ -230,7 +230,7 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Key", Http::HdrType::KEY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 72 "RegisteredHeadersHash.gperf"
     {"Proxy-Authenticate", Http::HdrType::PROXY_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 100 "RegisteredHeadersHash.gperf"
+#line 99 "RegisteredHeadersHash.gperf"
     {"X-Next-Services", Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 24 "RegisteredHeadersHash.gperf"
     {"Accept", Http::HdrType::ACCEPT, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
@@ -262,13 +262,13 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Upgrade", Http::HdrType::UPGRADE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader|HdrKind::HopByHopHeader},
 #line 81 "RegisteredHeadersHash.gperf"
     {"Retry-After", Http::HdrType::RETRY_AFTER, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
-#line 103 "RegisteredHeadersHash.gperf"
+#line 102 "RegisteredHeadersHash.gperf"
     {"Front-End-Https", Http::HdrType::FRONT_END_HTTPS, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 69 "RegisteredHeadersHash.gperf"
     {"Origin", Http::HdrType::ORIGIN, Http::HdrFieldType::ftStr, HdrKind::RequestHeader},
 #line 43 "RegisteredHeadersHash.gperf"
     {"Content-Location", Http::HdrType::CONTENT_LOCATION, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 98 "RegisteredHeadersHash.gperf"
+#line 97 "RegisteredHeadersHash.gperf"
     {"X-Squid-Error", Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
 #line 32 "RegisteredHeadersHash.gperf"
     {"Authentication-Info", Http::HdrType::AUTHENTICATION_INFO, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
@@ -292,11 +292,11 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Content-Encoding", Http::HdrType::CONTENT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::EntityHeader},
 #line 31 "RegisteredHeadersHash.gperf"
     {"Alternate-Protocol", Http::HdrType::ALTERNATE_PROTOCOL, Http::HdrFieldType::ftStr, HdrKind::HopByHopHeader},
-#line 101 "RegisteredHeadersHash.gperf"
+#line 100 "RegisteredHeadersHash.gperf"
     {"Surrogate-Capability", Http::HdrType::SURROGATE_CAPABILITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
 #line 27 "RegisteredHeadersHash.gperf"
     {"Accept-Language", Http::HdrType::ACCEPT_LANGUAGE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader},
-#line 104 "RegisteredHeadersHash.gperf"
+#line 103 "RegisteredHeadersHash.gperf"
     {"FTP-Command", Http::HdrType::FTP_COMMAND, Http::HdrFieldType::ftStr, HdrKind::None},
 #line 71 "RegisteredHeadersHash.gperf"
     {"Priority", Http::HdrType::PRIORITY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
@@ -316,9 +316,9 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"Forwarded", Http::HdrType::FORWARDED, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
 #line 38 "RegisteredHeadersHash.gperf"
     {"Content-Base", Http::HdrType::CONTENT_BASE, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 99 "RegisteredHeadersHash.gperf"
+#line 98 "RegisteredHeadersHash.gperf"
     {"X-Accelerator-Vary", Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader},
-#line 102 "RegisteredHeadersHash.gperf"
+#line 101 "RegisteredHeadersHash.gperf"
     {"Surrogate-Control", Http::HdrType::SURROGATE_CONTROL, Http::HdrFieldType::ftPSc, HdrKind::ListHeader|HdrKind::ReplyHeader},
 #line 57 "RegisteredHeadersHash.gperf"
     {"If-Modified-Since", Http::HdrType::IF_MODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::RequestHeader},
@@ -328,7 +328,7 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"If-Unmodified-Since", Http::HdrType::IF_UNMODIFIED_SINCE, Http::HdrFieldType::ftDate_1123, HdrKind::None},
 #line 26 "RegisteredHeadersHash.gperf"
     {"Accept-Encoding", Http::HdrType::ACCEPT_ENCODING, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::RequestHeader|HdrKind::ReplyHeader},
-#line 107 "RegisteredHeadersHash.gperf"
+#line 106 "RegisteredHeadersHash.gperf"
     {"FTP-Status", Http::HdrType::FTP_STATUS, Http::HdrFieldType::ftInt, HdrKind::None},
 #line 77 "RegisteredHeadersHash.gperf"
     {"Public", Http::HdrType::PUBLIC, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
@@ -344,16 +344,15 @@ static const class HeaderTableRecord HttpHeaderDefinitionsTable[] =
     {"X-Forwarded-For", Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader},
 #line 44 "RegisteredHeadersHash.gperf"
     {"Content-MD5", Http::HdrType::CONTENT_MD5, Http::HdrFieldType::ftStr, HdrKind::EntityHeader},
-#line 97 "RegisteredHeadersHash.gperf"
-    {"X-Request-URI", Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader},
+#line 109 "RegisteredHeadersHash.gperf"
+    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
 #line 58 "RegisteredHeadersHash.gperf"
     {"If-None-Match", Http::HdrType::IF_NONE_MATCH, Http::HdrFieldType::ftStr, HdrKind::ListHeader},
-#line 110 "RegisteredHeadersHash.gperf"
-    {"*INVALID*:", Http::HdrType::BAD_HDR, Http::HdrFieldType::ftInvalid, HdrKind::None},
+    {""},
 #line 63 "RegisteredHeadersHash.gperf"
     {"Last-Modified", Http::HdrType::LAST_MODIFIED, Http::HdrFieldType::ftDate_1123, HdrKind::EntityHeader},
     {""}, {""}, {""}, {""}, {""},
-#line 105 "RegisteredHeadersHash.gperf"
+#line 104 "RegisteredHeadersHash.gperf"
     {"FTP-Arguments", Http::HdrType::FTP_ARGUMENTS, Http::HdrFieldType::ftStr, HdrKind::None}
 };
 
@@ -375,5 +374,5 @@ const class HeaderTableRecord *
     }
     return 0;
 }
-#line 111 "RegisteredHeadersHash.gperf"
+#line 110 "RegisteredHeadersHash.gperf"
 

--- a/src/http/RegisteredHeadersHash.gperf
+++ b/src/http/RegisteredHeadersHash.gperf
@@ -94,7 +94,6 @@ Vary, Http::HdrType::VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKin
 Via, Http::HdrType::VIA, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
 WWW-Authenticate, Http::HdrType::WWW_AUTHENTICATE, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader
 X-Forwarded-For, Http::HdrType::X_FORWARDED_FOR, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::GeneralHeader
-X-Request-URI, Http::HdrType::X_REQUEST_URI, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader
 X-Squid-Error, Http::HdrType::X_SQUID_ERROR, Http::HdrFieldType::ftStr, HdrKind::ReplyHeader
 X-Accelerator-Vary, Http::HdrType::HDR_X_ACCELERATOR_VARY, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader
 X-Next-Services, Http::HdrType::X_NEXT_SERVICES, Http::HdrFieldType::ftStr, HdrKind::ListHeader|HdrKind::ReplyHeader


### PR DESCRIPTION
This mechanism was supposed to add the client requested URI to
response messages. But in modern Squid the string it uses can
now be modified by adaptation and redirectors.

The following squid.conf setting does a better job of adding the
intended value and does not require a custom build:
  reply_header_add X-Request-URI "%>ru" all

Also, other %ru related format codes can be added at the admin
choice for more flexible troubleshooting.