### PR TITLE
Declutter FD_WRITE and FD_READ

### DIFF
--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -286,8 +286,6 @@ struct timezone {
 
 #undef FD_CLOSE
 #undef FD_OPEN
-#undef FD_READ
-#undef FD_WRITE
 
 #ifndef EISCONN
 #define EISCONN WSAEISCONN

--- a/compat/os/mswindows.h
+++ b/compat/os/mswindows.h
@@ -284,9 +284,6 @@ struct timezone {
 #define _PATH_DEVNULL "NUL"
 #endif
 
-#undef FD_CLOSE
-#undef FD_OPEN
-
 #ifndef EISCONN
 #define EISCONN WSAEISCONN
 #endif

--- a/include/snmp_impl.h
+++ b/include/snmp_impl.h
@@ -40,9 +40,6 @@ SOFTWARE.
 
 #define SID_MAX_LEN 64
 
-#define READ        1
-#define WRITE       0
-
 #define SNMP_RESERVE1    0
 #define SNMP_RESERVE2    1
 #define SNMP_COMMIT      2

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -741,7 +741,7 @@ diskerRead(IpcIoMsg &ipcIo)
     char *const buf = Ipc::Mem::PagePointer(ipcIo.page);
     const ssize_t read = pread(TheFile, buf, min(ipcIo.len, Ipc::Mem::PageSize()), ipcIo.offset);
     ++statCounter.syscalls.disk.reads;
-    fd_bytes(TheFile, read, FdOps::READ);
+    fd_bytes(TheFile, read, FdOps::Read);
 
     if (read >= 0) {
         ipcIo.xerrno = 0;
@@ -773,7 +773,7 @@ diskerWriteAttempts(IpcIoMsg &ipcIo)
     for (int attempts = 1; attempts <= attemptLimit; ++attempts) {
         const ssize_t result = pwrite(TheFile, buf, toWrite, offset);
         ++statCounter.syscalls.disk.writes;
-        fd_bytes(TheFile, result, FdOps::WRITE);
+        fd_bytes(TheFile, result, FdOps::Write);
 
         if (result < 0) {
             ipcIo.xerrno = errno;

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -741,7 +741,7 @@ diskerRead(IpcIoMsg &ipcIo)
     char *const buf = Ipc::Mem::PagePointer(ipcIo.page);
     const ssize_t read = pread(TheFile, buf, min(ipcIo.len, Ipc::Mem::PageSize()), ipcIo.offset);
     ++statCounter.syscalls.disk.reads;
-    fd_bytes(TheFile, read, FdOpts::READ);
+    fd_bytes(TheFile, read, FdOps::READ);
 
     if (read >= 0) {
         ipcIo.xerrno = 0;
@@ -773,7 +773,7 @@ diskerWriteAttempts(IpcIoMsg &ipcIo)
     for (int attempts = 1; attempts <= attemptLimit; ++attempts) {
         const ssize_t result = pwrite(TheFile, buf, toWrite, offset);
         ++statCounter.syscalls.disk.writes;
-        fd_bytes(TheFile, result, FdOpts::WRITE);
+        fd_bytes(TheFile, result, FdOps::WRITE);
 
         if (result < 0) {
             ipcIo.xerrno = errno;

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -741,7 +741,7 @@ diskerRead(IpcIoMsg &ipcIo)
     char *const buf = Ipc::Mem::PagePointer(ipcIo.page);
     const ssize_t read = pread(TheFile, buf, min(ipcIo.len, Ipc::Mem::PageSize()), ipcIo.offset);
     ++statCounter.syscalls.disk.reads;
-    fd_bytes(TheFile, read, FD_READ);
+    fd_bytes(TheFile, read, FdOpts::READ);
 
     if (read >= 0) {
         ipcIo.xerrno = 0;
@@ -773,7 +773,7 @@ diskerWriteAttempts(IpcIoMsg &ipcIo)
     for (int attempts = 1; attempts <= attemptLimit; ++attempts) {
         const ssize_t result = pwrite(TheFile, buf, toWrite, offset);
         ++statCounter.syscalls.disk.writes;
-        fd_bytes(TheFile, result, FD_WRITE);
+        fd_bytes(TheFile, result, FdOpts::WRITE);
 
         if (result < 0) {
             ipcIo.xerrno = errno;

--- a/src/DiskIO/IpcIo/IpcIoFile.cc
+++ b/src/DiskIO/IpcIo/IpcIoFile.cc
@@ -741,7 +741,7 @@ diskerRead(IpcIoMsg &ipcIo)
     char *const buf = Ipc::Mem::PagePointer(ipcIo.page);
     const ssize_t read = pread(TheFile, buf, min(ipcIo.len, Ipc::Mem::PageSize()), ipcIo.offset);
     ++statCounter.syscalls.disk.reads;
-    fd_bytes(TheFile, read, FdOps::Read);
+    fd_bytes(TheFile, read, IoDirection::Read);
 
     if (read >= 0) {
         ipcIo.xerrno = 0;
@@ -773,7 +773,7 @@ diskerWriteAttempts(IpcIoMsg &ipcIo)
     for (int attempts = 1; attempts <= attemptLimit; ++attempts) {
         const ssize_t result = pwrite(TheFile, buf, toWrite, offset);
         ++statCounter.syscalls.disk.writes;
-        fd_bytes(TheFile, result, FdOps::Write);
+        fd_bytes(TheFile, result, IoDirection::Write);
 
         if (result < 0) {
             ipcIo.xerrno = errno;

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -369,7 +369,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     requestSender = nullptr;
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::WRITE);
+        fd_bytes(io.fd, io.size, FdOps::Write);
         statCounter.server.all.kbytes_out += io.size;
         // kids should increment their counters
     }

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -369,7 +369,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     requestSender = nullptr;
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FD_WRITE);
+        fd_bytes(io.fd, io.size, FdOpts::WRITE);
         statCounter.server.all.kbytes_out += io.size;
         // kids should increment their counters
     }

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -369,7 +369,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     requestSender = nullptr;
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::Write);
+        fd_bytes(io.fd, io.size, IoDirection::Write);
         statCounter.server.all.kbytes_out += io.size;
         // kids should increment their counters
     }

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -369,7 +369,7 @@ Client::sentRequestBody(const CommIoCbParams &io)
     requestSender = nullptr;
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOpts::WRITE);
+        fd_bytes(io.fd, io.size, FdOps::WRITE);
         statCounter.server.all.kbytes_out += io.size;
         // kids should increment their counters
     }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -379,7 +379,7 @@ Ftp::Client::readControlReply(const CommIoCbParams &io)
     assert(ctrl.offset < ctrl.size);
 
     if (io.flag == Comm::OK && io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::READ);
+        fd_bytes(io.fd, io.size, FdOps::Read);
     }
 
     if (io.flag != Comm::OK) {
@@ -858,7 +858,7 @@ Ftp::Client::writeCommandCallback(const CommIoCbParams &io)
     debugs(9, 5, "wrote " << io.size << " bytes");
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::WRITE);
+        fd_bytes(io.fd, io.size, FdOps::Write);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.ftp.kbytes_out += io.size;
     }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -379,7 +379,7 @@ Ftp::Client::readControlReply(const CommIoCbParams &io)
     assert(ctrl.offset < ctrl.size);
 
     if (io.flag == Comm::OK && io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::Read);
+        fd_bytes(io.fd, io.size, IoDirection::Read);
     }
 
     if (io.flag != Comm::OK) {
@@ -858,7 +858,7 @@ Ftp::Client::writeCommandCallback(const CommIoCbParams &io)
     debugs(9, 5, "wrote " << io.size << " bytes");
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::Write);
+        fd_bytes(io.fd, io.size, IoDirection::Write);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.ftp.kbytes_out += io.size;
     }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -379,7 +379,7 @@ Ftp::Client::readControlReply(const CommIoCbParams &io)
     assert(ctrl.offset < ctrl.size);
 
     if (io.flag == Comm::OK && io.size > 0) {
-        fd_bytes(io.fd, io.size, FD_READ);
+        fd_bytes(io.fd, io.size, FdOpts::READ);
     }
 
     if (io.flag != Comm::OK) {
@@ -858,7 +858,7 @@ Ftp::Client::writeCommandCallback(const CommIoCbParams &io)
     debugs(9, 5, "wrote " << io.size << " bytes");
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FD_WRITE);
+        fd_bytes(io.fd, io.size, FdOpts::WRITE);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.ftp.kbytes_out += io.size;
     }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -379,7 +379,7 @@ Ftp::Client::readControlReply(const CommIoCbParams &io)
     assert(ctrl.offset < ctrl.size);
 
     if (io.flag == Comm::OK && io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOpts::READ);
+        fd_bytes(io.fd, io.size, FdOps::READ);
     }
 
     if (io.flag != Comm::OK) {
@@ -858,7 +858,7 @@ Ftp::Client::writeCommandCallback(const CommIoCbParams &io)
     debugs(9, 5, "wrote " << io.size << " bytes");
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOpts::WRITE);
+        fd_bytes(io.fd, io.size, FdOps::WRITE);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.ftp.kbytes_out += io.size;
     }

--- a/src/comm/Read.cc
+++ b/src/comm/Read.cc
@@ -94,7 +94,7 @@ Comm::ReadNow(CommIoCbParams &params, SBuf &buf)
 
     if (retval > 0) { // data read most common case
         buf.rawAppendFinish(inbuf, retval);
-        fd_bytes(params.conn->fd, retval, FD_READ);
+        fd_bytes(params.conn->fd, retval, FdOpts::READ);
         params.flag = Comm::OK;
         params.size = retval;
 
@@ -150,7 +150,7 @@ Comm::HandleRead(int fd, void *data)
     /* See if we read anything */
     /* Note - read 0 == socket EOF, which is a valid read */
     if (retval >= 0) {
-        fd_bytes(fd, retval, FD_READ);
+        fd_bytes(fd, retval, FdOpts::READ);
         ccb->offset = retval;
         ccb->finish(Comm::OK, 0);
         return;

--- a/src/comm/Read.cc
+++ b/src/comm/Read.cc
@@ -94,7 +94,7 @@ Comm::ReadNow(CommIoCbParams &params, SBuf &buf)
 
     if (retval > 0) { // data read most common case
         buf.rawAppendFinish(inbuf, retval);
-        fd_bytes(params.conn->fd, retval, FdOps::Read);
+        fd_bytes(params.conn->fd, retval, IoDirection::Read);
         params.flag = Comm::OK;
         params.size = retval;
 
@@ -150,7 +150,7 @@ Comm::HandleRead(int fd, void *data)
     /* See if we read anything */
     /* Note - read 0 == socket EOF, which is a valid read */
     if (retval >= 0) {
-        fd_bytes(fd, retval, FdOps::Read);
+        fd_bytes(fd, retval, IoDirection::Read);
         ccb->offset = retval;
         ccb->finish(Comm::OK, 0);
         return;

--- a/src/comm/Read.cc
+++ b/src/comm/Read.cc
@@ -94,7 +94,7 @@ Comm::ReadNow(CommIoCbParams &params, SBuf &buf)
 
     if (retval > 0) { // data read most common case
         buf.rawAppendFinish(inbuf, retval);
-        fd_bytes(params.conn->fd, retval, FdOpts::READ);
+        fd_bytes(params.conn->fd, retval, FdOps::READ);
         params.flag = Comm::OK;
         params.size = retval;
 
@@ -150,7 +150,7 @@ Comm::HandleRead(int fd, void *data)
     /* See if we read anything */
     /* Note - read 0 == socket EOF, which is a valid read */
     if (retval >= 0) {
-        fd_bytes(fd, retval, FdOpts::READ);
+        fd_bytes(fd, retval, FdOps::READ);
         ccb->offset = retval;
         ccb->finish(Comm::OK, 0);
         return;

--- a/src/comm/Read.cc
+++ b/src/comm/Read.cc
@@ -94,7 +94,7 @@ Comm::ReadNow(CommIoCbParams &params, SBuf &buf)
 
     if (retval > 0) { // data read most common case
         buf.rawAppendFinish(inbuf, retval);
-        fd_bytes(params.conn->fd, retval, FdOps::READ);
+        fd_bytes(params.conn->fd, retval, FdOps::Read);
         params.flag = Comm::OK;
         params.size = retval;
 
@@ -150,7 +150,7 @@ Comm::HandleRead(int fd, void *data)
     /* See if we read anything */
     /* Note - read 0 == socket EOF, which is a valid read */
     if (retval >= 0) {
-        fd_bytes(fd, retval, FdOps::READ);
+        fd_bytes(fd, retval, FdOps::Read);
         ccb->offset = retval;
         ccb->finish(Comm::OK, 0);
         return;

--- a/src/comm/Write.cc
+++ b/src/comm/Write.cc
@@ -91,7 +91,7 @@ Comm::HandleWrite(int fd, void *data)
     }
 #endif /* USE_DELAY_POOLS */
 
-    fd_bytes(fd, len, FdOps::WRITE);
+    fd_bytes(fd, len, FdOps::Write);
     ++statCounter.syscalls.sock.writes;
     // After each successful partial write,
     // reset fde::writeStart to the current time.

--- a/src/comm/Write.cc
+++ b/src/comm/Write.cc
@@ -91,7 +91,7 @@ Comm::HandleWrite(int fd, void *data)
     }
 #endif /* USE_DELAY_POOLS */
 
-    fd_bytes(fd, len, FdOps::Write);
+    fd_bytes(fd, len, IoDirection::Write);
     ++statCounter.syscalls.sock.writes;
     // After each successful partial write,
     // reset fde::writeStart to the current time.

--- a/src/comm/Write.cc
+++ b/src/comm/Write.cc
@@ -91,7 +91,7 @@ Comm::HandleWrite(int fd, void *data)
     }
 #endif /* USE_DELAY_POOLS */
 
-    fd_bytes(fd, len, FD_WRITE);
+    fd_bytes(fd, len, FdOps::WRITE);
     ++statCounter.syscalls.sock.writes;
     // After each successful partial write,
     // reset fde::writeStart to the current time.

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -998,10 +998,10 @@ idnsSendQuery(idns_query * q)
     } while ( (x<0 && y<0) && q->nsends % nsCount != 0);
 
     if (y > 0) {
-        fd_bytes(DnsSocketB, y, FdOps::WRITE);
+        fd_bytes(DnsSocketB, y, FdOps::Write);
     }
     if (x > 0) {
-        fd_bytes(DnsSocketA, x, FdOps::WRITE);
+        fd_bytes(DnsSocketA, x, FdOps::Write);
     }
 
     ++ nameservers[nsn].nqueries;
@@ -1357,7 +1357,7 @@ idnsRead(int fd, void *)
             break;
         }
 
-        fd_bytes(fd, len, FdOps::READ);
+        fd_bytes(fd, len, FdOps::Read);
 
         assert(N);
         ++(*N);

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -998,10 +998,10 @@ idnsSendQuery(idns_query * q)
     } while ( (x<0 && y<0) && q->nsends % nsCount != 0);
 
     if (y > 0) {
-        fd_bytes(DnsSocketB, y, FdOps::Write);
+        fd_bytes(DnsSocketB, y, IoDirection::Write);
     }
     if (x > 0) {
-        fd_bytes(DnsSocketA, x, FdOps::Write);
+        fd_bytes(DnsSocketA, x, IoDirection::Write);
     }
 
     ++ nameservers[nsn].nqueries;
@@ -1357,7 +1357,7 @@ idnsRead(int fd, void *)
             break;
         }
 
-        fd_bytes(fd, len, FdOps::Read);
+        fd_bytes(fd, len, IoDirection::Read);
 
         assert(N);
         ++(*N);

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -998,10 +998,10 @@ idnsSendQuery(idns_query * q)
     } while ( (x<0 && y<0) && q->nsends % nsCount != 0);
 
     if (y > 0) {
-        fd_bytes(DnsSocketB, y, FdOpts::WRITE);
+        fd_bytes(DnsSocketB, y, FdOps::WRITE);
     }
     if (x > 0) {
-        fd_bytes(DnsSocketA, x, FdOpts::WRITE);
+        fd_bytes(DnsSocketA, x, FdOps::WRITE);
     }
 
     ++ nameservers[nsn].nqueries;
@@ -1357,7 +1357,7 @@ idnsRead(int fd, void *)
             break;
         }
 
-        fd_bytes(fd, len, FdOpts::READ);
+        fd_bytes(fd, len, FdOps::READ);
 
         assert(N);
         ++(*N);

--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -998,10 +998,10 @@ idnsSendQuery(idns_query * q)
     } while ( (x<0 && y<0) && q->nsends % nsCount != 0);
 
     if (y > 0) {
-        fd_bytes(DnsSocketB, y, FD_WRITE);
+        fd_bytes(DnsSocketB, y, FdOpts::WRITE);
     }
     if (x > 0) {
-        fd_bytes(DnsSocketA, x, FD_WRITE);
+        fd_bytes(DnsSocketA, x, FdOpts::WRITE);
     }
 
     ++ nameservers[nsn].nqueries;
@@ -1357,7 +1357,7 @@ idnsRead(int fd, void *)
             break;
         }
 
-        fd_bytes(fd, len, FD_READ);
+        fd_bytes(fd, len, FdOpts::READ);
 
         assert(N);
         ++(*N);

--- a/src/enums.h
+++ b/src/enums.h
@@ -19,11 +19,6 @@ enum fd_type {
     FD_UNKNOWN
 };
 
-enum class FdOpts {
-    READ,
-    WRITE
-};
-
 typedef enum {
     PEER_NONE,
     PEER_SIBLING,

--- a/src/enums.h
+++ b/src/enums.h
@@ -19,9 +19,9 @@ enum fd_type {
     FD_UNKNOWN
 };
 
-enum {
-    FD_READ,
-    FD_WRITE
+enum class FdOpts {
+    READ,
+    WRITE
 };
 
 typedef enum {

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -223,16 +223,16 @@ fd_note(int fd, const char *s)
 }
 
 void
-fd_bytes(int fd, int len, unsigned int type)
+fd_bytes(int fd, int len, const FdOps type)
 {
     fde *F = &fd_table[fd];
 
     if (len < 0)
         return;
 
-    assert(type == FdOpts::READ || type == FdOpts::WRITE);
+    assert(type == FdOps::READ || type == FdOps::WRITE);
 
-    if (type == FdOpts::READ)
+    if (type == FdOps::READ)
         F->bytes_read += len;
     else
         F->bytes_written += len;

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -223,16 +223,16 @@ fd_note(int fd, const char *s)
 }
 
 void
-fd_bytes(int fd, int len, const FdOps type)
+fd_bytes(int fd, int len, const IoDirection type)
 {
     fde *F = &fd_table[fd];
 
     if (len < 0)
         return;
 
-    assert(type == FdOps::Read || type == FdOps::Write);
+    assert(type == IoDirection::Read || type == IoDirection::Write);
 
-    if (type == FdOps::Read)
+    if (type == IoDirection::Read)
         F->bytes_read += len;
     else
         F->bytes_written += len;

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -230,9 +230,9 @@ fd_bytes(int fd, int len, const FdOps type)
     if (len < 0)
         return;
 
-    assert(type == FdOps::READ || type == FdOps::WRITE);
+    assert(type == FdOps::Read || type == FdOps::Write);
 
-    if (type == FdOps::READ)
+    if (type == FdOps::Read)
         F->bytes_read += len;
     else
         F->bytes_written += len;

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -230,9 +230,9 @@ fd_bytes(int fd, int len, unsigned int type)
     if (len < 0)
         return;
 
-    assert(type == FD_READ || type == FD_WRITE);
+    assert(type == FdOpts::READ || type == FdOpts::WRITE);
 
-    if (type == FD_READ)
+    if (type == FdOpts::READ)
         F->bytes_read += len;
     else
         F->bytes_written += len;

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -223,7 +223,7 @@ fd_note(int fd, const char *s)
 }
 
 void
-fd_bytes(int fd, int len, const IoDirection type)
+fd_bytes(int fd, int len, IoDirection type)
 {
     fde *F = &fd_table[fd];
 

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -223,19 +223,21 @@ fd_note(int fd, const char *s)
 }
 
 void
-fd_bytes(int fd, int len, IoDirection type)
+fd_bytes(const int fd, const int len, const IoDirection direction)
 {
     fde *F = &fd_table[fd];
 
     if (len < 0)
         return;
 
-    assert(type == IoDirection::Read || type == IoDirection::Write);
-
-    if (type == IoDirection::Read)
+    switch (direction) {
+    case IoDirection::Read:
         F->bytes_read += len;
-    else
+        break;
+    case IoDirection::Write:
         F->bytes_written += len;
+        break;
+    }
 }
 
 void

--- a/src/fd.h
+++ b/src/fd.h
@@ -20,7 +20,7 @@ enum class FdOps {
 void fd_close(int fd);
 void fd_open(int fd, unsigned int type, const char *);
 void fd_note(int fd, const char *);
-void fd_bytes(int fd, int len, const FdOps type);
+void fd_bytes(int fd, int len, const FdOps);
 void fdDumpOpen(void);
 int fdUsageHigh(void);
 void fdAdjustReserved(void);

--- a/src/fd.h
+++ b/src/fd.h
@@ -11,6 +11,7 @@
 #ifndef SQUID_FD_H_
 #define SQUID_FD_H_
 
+/// what kind of operation to count traffic for in fd_bytes()
 enum class FdOps {
     READ,
     WRITE

--- a/src/fd.h
+++ b/src/fd.h
@@ -11,10 +11,15 @@
 #ifndef SQUID_FD_H_
 #define SQUID_FD_H_
 
+enum class FdOps {
+    READ,
+    WRITE
+};
+
 void fd_close(int fd);
 void fd_open(int fd, unsigned int type, const char *);
 void fd_note(int fd, const char *);
-void fd_bytes(int fd, int len, unsigned int type);
+void fd_bytes(int fd, int len, const FdOps type);
 void fdDumpOpen(void);
 int fdUsageHigh(void);
 void fdAdjustReserved(void);

--- a/src/fd.h
+++ b/src/fd.h
@@ -13,8 +13,8 @@
 
 /// what kind of operation to count traffic for in fd_bytes()
 enum class FdOps {
-    READ,
-    WRITE
+    Read,
+    Write
 };
 
 void fd_close(int fd);

--- a/src/fd.h
+++ b/src/fd.h
@@ -20,7 +20,7 @@ enum class IoDirection {
 void fd_close(int fd);
 void fd_open(int fd, unsigned int type, const char *);
 void fd_note(int fd, const char *);
-void fd_bytes(int fd, int len, const IoDirection);
+void fd_bytes(int fd, int len, IoDirection);
 void fdDumpOpen(void);
 int fdUsageHigh(void);
 void fdAdjustReserved(void);

--- a/src/fd.h
+++ b/src/fd.h
@@ -11,7 +11,7 @@
 #ifndef SQUID_FD_H_
 #define SQUID_FD_H_
 
-/// what kind of operation to count traffic for in fd_bytes()
+/// distinguishes reading/importing I/O operations from their writing/exporting counterparts
 enum class IoDirection {
     Read,
     Write

--- a/src/fd.h
+++ b/src/fd.h
@@ -12,7 +12,7 @@
 #define SQUID_FD_H_
 
 /// what kind of operation to count traffic for in fd_bytes()
-enum class FdOps {
+enum class IoDirection {
     Read,
     Write
 };
@@ -20,7 +20,7 @@ enum class FdOps {
 void fd_close(int fd);
 void fd_open(int fd, unsigned int type, const char *);
 void fd_note(int fd, const char *);
-void fd_bytes(int fd, int len, const FdOps);
+void fd_bytes(int fd, int len, const IoDirection);
 void fdDumpOpen(void);
 int fdUsageHigh(void);
 void fdAdjustReserved(void);

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -217,7 +217,7 @@ diskHandleWrite(int fd, void *)
 
     ++ statCounter.syscalls.disk.writes;
 
-    fd_bytes(fd, len, FdOps::WRITE);
+    fd_bytes(fd, len, FdOps::Write);
 
     if (len < 0) {
         if (!ignoreErrno(xerrno)) {
@@ -422,7 +422,7 @@ diskHandleRead(int fd, void *data)
 
     ++ statCounter.syscalls.disk.reads;
 
-    fd_bytes(fd, len, FdOps::READ);
+    fd_bytes(fd, len, FdOps::Read);
 
     if (len < 0) {
         if (ignoreErrno(xerrno)) {

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -217,7 +217,7 @@ diskHandleWrite(int fd, void *)
 
     ++ statCounter.syscalls.disk.writes;
 
-    fd_bytes(fd, len, FdOps::Write);
+    fd_bytes(fd, len, IoDirection::Write);
 
     if (len < 0) {
         if (!ignoreErrno(xerrno)) {
@@ -422,7 +422,7 @@ diskHandleRead(int fd, void *data)
 
     ++ statCounter.syscalls.disk.reads;
 
-    fd_bytes(fd, len, FdOps::Read);
+    fd_bytes(fd, len, IoDirection::Read);
 
     if (len < 0) {
         if (ignoreErrno(xerrno)) {

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -217,7 +217,7 @@ diskHandleWrite(int fd, void *)
 
     ++ statCounter.syscalls.disk.writes;
 
-    fd_bytes(fd, len, FdOpts::WRITE);
+    fd_bytes(fd, len, FdOps::WRITE);
 
     if (len < 0) {
         if (!ignoreErrno(xerrno)) {
@@ -422,7 +422,7 @@ diskHandleRead(int fd, void *data)
 
     ++ statCounter.syscalls.disk.reads;
 
-    fd_bytes(fd, len, FdOpts::READ);
+    fd_bytes(fd, len, FdOps::READ);
 
     if (len < 0) {
         if (ignoreErrno(xerrno)) {

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -217,7 +217,7 @@ diskHandleWrite(int fd, void *)
 
     ++ statCounter.syscalls.disk.writes;
 
-    fd_bytes(fd, len, FD_WRITE);
+    fd_bytes(fd, len, FdOpts::WRITE);
 
     if (len < 0) {
         if (!ignoreErrno(xerrno)) {
@@ -422,7 +422,7 @@ diskHandleRead(int fd, void *data)
 
     ++ statCounter.syscalls.disk.reads;
 
-    fd_bytes(fd, len, FD_READ);
+    fd_bytes(fd, len, FdOpts::READ);
 
     if (len < 0) {
         if (ignoreErrno(xerrno)) {

--- a/src/http.cc
+++ b/src/http.cc
@@ -1704,7 +1704,7 @@ HttpStateData::wroteLast(const CommIoCbParams &io)
     // TODO: Extract common parts.
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOpts::WRITE);
+        fd_bytes(io.fd, io.size, FdOps::WRITE);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.http.kbytes_out += io.size;
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -1704,7 +1704,7 @@ HttpStateData::wroteLast(const CommIoCbParams &io)
     // TODO: Extract common parts.
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::WRITE);
+        fd_bytes(io.fd, io.size, FdOps::Write);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.http.kbytes_out += io.size;
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -1704,7 +1704,7 @@ HttpStateData::wroteLast(const CommIoCbParams &io)
     // TODO: Extract common parts.
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FdOps::Write);
+        fd_bytes(io.fd, io.size, IoDirection::Write);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.http.kbytes_out += io.size;
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -1704,7 +1704,7 @@ HttpStateData::wroteLast(const CommIoCbParams &io)
     // TODO: Extract common parts.
 
     if (io.size > 0) {
-        fd_bytes(io.fd, io.size, FD_WRITE);
+        fd_bytes(io.fd, io.size, FdOpts::WRITE);
         statCounter.server.all.kbytes_out += io.size;
         statCounter.server.http.kbytes_out += io.size;
     }

--- a/src/log/ModStdio.cc
+++ b/src/log/ModStdio.cc
@@ -38,7 +38,7 @@ logfileWriteWrapper(Logfile * lf, const void *buf, size_t len)
     size_t s;
     s = FD_WRITE_METHOD(ll->fd, (char const *) buf, len);
     int xerrno = errno;
-    fd_bytes(ll->fd, s, FdOps::Write);
+    fd_bytes(ll->fd, s, IoDirection::Write);
 
     if (s == len)
         return;

--- a/src/log/ModStdio.cc
+++ b/src/log/ModStdio.cc
@@ -38,7 +38,7 @@ logfileWriteWrapper(Logfile * lf, const void *buf, size_t len)
     size_t s;
     s = FD_WRITE_METHOD(ll->fd, (char const *) buf, len);
     int xerrno = errno;
-    fd_bytes(ll->fd, s, FD_WRITE);
+    fd_bytes(ll->fd, s, FdOpts::WRITE);
 
     if (s == len)
         return;

--- a/src/log/ModStdio.cc
+++ b/src/log/ModStdio.cc
@@ -38,7 +38,7 @@ logfileWriteWrapper(Logfile * lf, const void *buf, size_t len)
     size_t s;
     s = FD_WRITE_METHOD(ll->fd, (char const *) buf, len);
     int xerrno = errno;
-    fd_bytes(ll->fd, s, FdOps::WRITE);
+    fd_bytes(ll->fd, s, FdOps::Write);
 
     if (s == len)
         return;

--- a/src/log/ModStdio.cc
+++ b/src/log/ModStdio.cc
@@ -38,7 +38,7 @@ logfileWriteWrapper(Logfile * lf, const void *buf, size_t len)
     size_t s;
     s = FD_WRITE_METHOD(ll->fd, (char const *) buf, len);
     int xerrno = errno;
-    fd_bytes(ll->fd, s, FdOpts::WRITE);
+    fd_bytes(ll->fd, s, FdOps::WRITE);
 
     if (s == len)
         return;

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -42,7 +42,7 @@ logfile_mod_udp_write(Logfile * lf, const char *buf, size_t len)
     l_udp_t *ll = (l_udp_t *) lf->data;
     ssize_t s;
     s = write(ll->fd, (char const *) buf, len);
-    fd_bytes(ll->fd, s, FdOps::Write);
+    fd_bytes(ll->fd, s, IoDirection::Write);
 #if 0
     // TODO: Enable after polishing to properly log these errors.
     if (s < 0) {

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -42,7 +42,7 @@ logfile_mod_udp_write(Logfile * lf, const char *buf, size_t len)
     l_udp_t *ll = (l_udp_t *) lf->data;
     ssize_t s;
     s = write(ll->fd, (char const *) buf, len);
-    fd_bytes(ll->fd, s, FdOps::WRITE);
+    fd_bytes(ll->fd, s, FdOps::Write);
 #if 0
     // TODO: Enable after polishing to properly log these errors.
     if (s < 0) {

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -42,7 +42,7 @@ logfile_mod_udp_write(Logfile * lf, const char *buf, size_t len)
     l_udp_t *ll = (l_udp_t *) lf->data;
     ssize_t s;
     s = write(ll->fd, (char const *) buf, len);
-    fd_bytes(ll->fd, s, FdOpts::WRITE);
+    fd_bytes(ll->fd, s, FdOps::WRITE);
 #if 0
     // TODO: Enable after polishing to properly log these errors.
     if (s < 0) {

--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -42,7 +42,7 @@ logfile_mod_udp_write(Logfile * lf, const char *buf, size_t len)
     l_udp_t *ll = (l_udp_t *) lf->data;
     ssize_t s;
     s = write(ll->fd, (char const *) buf, len);
-    fd_bytes(ll->fd, s, FD_WRITE);
+    fd_bytes(ll->fd, s, FdOpts::WRITE);
 #if 0
     // TODO: Enable after polishing to properly log these errors.
     if (s < 0) {

--- a/src/tests/stub_fd.cc
+++ b/src/tests/stub_fd.cc
@@ -18,7 +18,7 @@ fde *fde::Table = nullptr;
 int fdNFree(void) STUB_RETVAL(-1)
 void fd_open(int, unsigned int, const char *) STUB
 void fd_close(int) STUB
-void fd_bytes(int, int, const FdOps) STUB
+void fd_bytes(int, int, const IoDirection) STUB
 void fd_note(int, const char *) STUB
 void fdAdjustReserved() STUB
 

--- a/src/tests/stub_fd.cc
+++ b/src/tests/stub_fd.cc
@@ -18,7 +18,7 @@ fde *fde::Table = nullptr;
 int fdNFree(void) STUB_RETVAL(-1)
 void fd_open(int, unsigned int, const char *) STUB
 void fd_close(int) STUB
-void fd_bytes(int, int, unsigned int) STUB
+void fd_bytes(int, int, const FdOps) STUB
 void fd_note(int, const char *) STUB
 void fdAdjustReserved() STUB
 

--- a/src/tests/stub_fd.cc
+++ b/src/tests/stub_fd.cc
@@ -18,7 +18,7 @@ fde *fde::Table = nullptr;
 int fdNFree(void) STUB_RETVAL(-1)
 void fd_open(int, unsigned int, const char *) STUB
 void fd_close(int) STUB
-void fd_bytes(int, int, const IoDirection) STUB
+void fd_bytes(int, int, IoDirection) STUB
 void fd_note(int, const char *) STUB
 void fdAdjustReserved() STUB
 


### PR DESCRIPTION
Avoid clashes with same-name constants defined by MS WIndows Socket API.

Also removed a few related ununsed macros.