### PR TITLE
Docs: update doxygen support

### DIFF
--- a/doc/Programming-Guide/doxygen.header.dyn
+++ b/doc/Programming-Guide/doxygen.header.dyn
@@ -6,3 +6,4 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
 -->
 <div id="doxypage">
+<div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/squid.dox
+++ b/squid.dox
@@ -349,7 +349,7 @@ SIP_SUPPORT            = NO
 # should set this option to NO.
 # The default value is: YES.
 
-IDL_PROPERTY_SUPPORT   = YES
+IDL_PROPERTY_SUPPORT   = NO
 
 # If member grouping is used in the documentation and the DISTRIBUTE_GROUP_DOC
 # tag is set to YES then doxygen will reuse the documentation of the first
@@ -816,7 +816,8 @@ FILE_PATTERNS          = *.dox \
                          *.h \
                          *.c \
                          *.cc \
-                         *.cci
+                         *.cci \
+                         *.md
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/squid.dox
+++ b/squid.dox
@@ -816,8 +816,7 @@ FILE_PATTERNS          = *.dox \
                          *.h \
                          *.c \
                          *.cc \
-                         *.cci \
-                         *.md
+                         *.cci
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.


### PR DESCRIPTION
Doxygen v1.7.5 changed HTML_HEADER requirements: We now need to add an
open div element to the header that Doxygen then closes for us. This
change also fixes the corresponding generated content on Squid website.

Also, disable IDL_PROPERTY_SUPPORT which has been causing some errors
with output getter/setter matching in the generated output.