### PR TITLE
Bug 5119: Null pointer dereference in makeMemNodeDataOffset()

### DIFF
--- a/src/mem_node.cc
+++ b/src/mem_node.cc
@@ -13,7 +13,7 @@
 #include "mem_node.h"
 
 #include <cstddef>
-
+#include <type_traits>
 
 static ptrdiff_t makeMemNodeDataOffset();
 

--- a/src/mem_node.cc
+++ b/src/mem_node.cc
@@ -14,7 +14,6 @@
 
 #include <cstddef>
 
-static_assert(std::is_standard_layout<mem_node>::value, "the behavior of offsetof(mem_node) is defined");
 
 static ptrdiff_t makeMemNodeDataOffset();
 
@@ -27,6 +26,7 @@ static ptrdiff_t _mem_node_data_offset = makeMemNodeDataOffset();
 static ptrdiff_t
 makeMemNodeDataOffset()
 {
+    static_assert(std::is_standard_layout<mem_node>::value, "the behavior of offsetof(mem_node) is defined");
     return ptrdiff_t(offsetof(mem_node, data));
 }
 

--- a/src/mem_node.cc
+++ b/src/mem_node.cc
@@ -12,6 +12,10 @@
 #include "mem/Pool.h"
 #include "mem_node.h"
 
+#include <cstddef>
+
+static_assert(std::is_standard_layout<mem_node>::value, "the behavior of offsetof(mem_node) is defined");
+
 static ptrdiff_t makeMemNodeDataOffset();
 
 static ptrdiff_t _mem_node_data_offset = makeMemNodeDataOffset();
@@ -23,8 +27,7 @@ static ptrdiff_t _mem_node_data_offset = makeMemNodeDataOffset();
 static ptrdiff_t
 makeMemNodeDataOffset()
 {
-    mem_node *p = nullptr;
-    return ptrdiff_t(&p->data);
+    return ptrdiff_t(offsetof(mem_node, data));
 }
 
 /*

--- a/src/mem_node.cc
+++ b/src/mem_node.cc
@@ -26,7 +26,7 @@ static ptrdiff_t _mem_node_data_offset = makeMemNodeDataOffset();
 static ptrdiff_t
 makeMemNodeDataOffset()
 {
-    static_assert(std::is_standard_layout<mem_node>::value, "the behavior of offsetof(mem_node) is defined");
+    static_assert(std::is_standard_layout<mem_node>::value, "offsetof(mem_node) is unconditionally supported");
     return ptrdiff_t(offsetof(mem_node, data));
 }
 


### PR DESCRIPTION
    UndefinedBehaviorSanitizer: undefined-behavior mem_node.cc:27:26 in
    runtime error: member access within null pointer of type 'mem_node'

Since only the address of the data member is computed, a compiler is
likely to perform pointer arithmetic rather than dereference a nullptr,
but it is best to replace this UB with a safe and clearer alternative.
