### PR TITLE
Activate OpenSSL KTLS for SSL Bump

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1110,6 +1110,7 @@ SQUID_CHECK_LIB_WORKS(gnutls,[
 dnl User may specify OpenSSL is needed from a non-standard location
 SQUID_OPTIONAL_LIB(openssl,[OpenSSL],[LIBOPENSSL])
 AH_TEMPLATE(USE_OPENSSL,[OpenSSL support is available])
+AH_TEMPLATE(USE_OPENSSL_KTLS,[OpenSSL Kernel TLS Offload])
 ## OpenSSL is default disable due to licensing issues on some OS
 AS_IF([test "x$with_openssl" = "xyes"],[
   CPPFLAGS="$LIBOPENSSL_CFLAGS $CPPFLAGS"
@@ -1169,6 +1170,10 @@ AS_IF([test "x$with_openssl" = "xyes"],[
     CXXFLAGS="$LIBOPENSSL_CFLAGS $CXXFLAGS"
     SSLLIB="$LIBOPENSSL_PATH $LIBOPENSSL_LIBS $SSLLIB"
     AC_DEFINE(USE_OPENSSL,1,[OpenSSL support is available])
+    
+    AS_IF([ test "x$with_openssl_ktls" = "xyes" ],[
+      AC_DEFINE(USE_OPENSSL_KTLS,1,[Use OpenSSL Kernel TLS Offload])
+    ])
 
     # check for API functions
     SQUID_CHECK_LIBCRYPTO_API

--- a/src/cf_gen_defines
+++ b/src/cf_gen_defines
@@ -43,6 +43,7 @@ BEGIN {
 	define["USE_IDENT"]="--enable-ident-lookups"
 	define["USE_LOADABLE_MODULES"]="--enable-shared"
 	define["USE_OPENSSL"]="--with-openssl"
+	define["USE_OPENSSL_KTLS"]="--with-openssl-ktls"
 	define["USE_QOS_TOS"]="--enable-zph-qos"
 	define["USE_SQUID_ESI"]="--enable-esi"
 	define["USE_SQUID_EUI"]="--enable-eui"

--- a/src/security/Session.cc
+++ b/src/security/Session.cc
@@ -136,6 +136,10 @@ CreateSession(const Security::ContextPointer &ctx, const Comm::ConnectionPointer
         const int fd = conn->fd;
 
 #if USE_OPENSSL
+		#if USE_OPENSSL_KTLS
+	    SSL_set_options(session.get(), SSL_OP_ENABLE_KTLS);
+	    #endif
+    	
         // without BIO, we would call SSL_set_fd(ssl.get(), fd) instead
         if (BIO *bio = Ssl::Bio::Create(fd, type)) {
             Ssl::Bio::Link(session.get(), bio); // cannot fail

--- a/src/ssl/bio.cc
+++ b/src/ssl/bio.cc
@@ -80,6 +80,10 @@ Ssl::Bio::Create(const int fd, Security::Io::Type type)
 
     if (BIO *bio = BIO_new(useMethod)) {
         BIO_int_ctrl(bio, BIO_C_SET_FD, type, fd);
+        #if USE_OPENSSL_KTLS
+        BIO *bio_sock = BIO_new_socket(fd, BIO_NOCLOSE);
+        bio = BIO_push(bio, bio_sock);
+        #endif
         return bio;
     }
     return nullptr;
@@ -108,7 +112,11 @@ int Ssl::Bio::write(const char *buf, int size, BIO *table)
 #if _SQUID_WINDOWS_
     const int result = socket_write_method(fd_, buf, size);
 #else
+    #if USE_OPENSSL_KTLS
+    const int result = BIO_write(BIO_next(table), buf, size);
+    #else
     const int result = default_write_method(fd_, buf, size);
+    #endif
 #endif
     const int xerrno = errno;
     debugs(83, 5, "FD " << fd_ << " wrote " << result << " <= " << size);
@@ -131,7 +139,11 @@ Ssl::Bio::read(char *buf, int size, BIO *table)
 #if _SQUID_WINDOWS_
     const int result = socket_read_method(fd_, buf, size);
 #else
+    #if USE_OPENSSL_KTLS
+    const int result = BIO_read(BIO_next(table), buf, size);
+    #else
     const int result = default_read_method(fd_, buf, size);
+    #endif
 #endif
     const int xerrno = errno;
     debugs(83, 5, "FD " << fd_ << " read " << result << " <= " << size);
@@ -286,7 +298,7 @@ Ssl::ServerBio::readAndGive(char *buf, const int size, BIO *table)
         return giveBuffered(buf, size);
 
     if (record_) {
-        const int result = readAndBuffer(table);
+        const int result = readAndBuffer(table, size);
         if (result <= 0)
             return result;
         return giveBuffered(buf, size);
@@ -300,7 +312,7 @@ Ssl::ServerBio::readAndGive(char *buf, const int size, BIO *table)
 int
 Ssl::ServerBio::readAndParse(char *buf, const int size, BIO *table)
 {
-    const int result = readAndBuffer(table);
+    const int result = readAndBuffer(table, size);
     if (result <= 0)
         return result;
 
@@ -308,7 +320,11 @@ Ssl::ServerBio::readAndParse(char *buf, const int size, BIO *table)
         if (!parser_.parseHello(rbuf)) {
             // need more data to finish parsing
             BIO_set_retry_read(table);
+            #if USE_OPENSSL_KTLS
+            return giveBuffered(buf, size);
+            #else
             return -1;
+            #endif
         }
         parsedHandshake = true; // done parsing (successfully)
     }
@@ -324,10 +340,15 @@ Ssl::ServerBio::readAndParse(char *buf, const int size, BIO *table)
 /// Reads more data into the read buffer. Returns either the number of bytes
 /// read or, on errors (including "try again" errors), a negative number.
 int
-Ssl::ServerBio::readAndBuffer(BIO *table)
+Ssl::ServerBio::readAndBuffer(BIO *table, const int size)
 {
+    #if USE_OPENSSL_KTLS
+    char *space = rbuf.rawAppendStart(size);
+    const int result = Ssl::Bio::read(space, size, table);
+    #else
     char *space = rbuf.rawAppendStart(SQUID_TCP_SO_RCVBUF);
     const int result = Ssl::Bio::read(space, SQUID_TCP_SO_RCVBUF, table);
+    #endif
     if (result <= 0)
         return result;
 
@@ -549,7 +570,11 @@ squid_bio_ctrl(BIO *table, int cmd, long arg1, void *arg2)
         case BIO_CTRL_WPENDING:
     */
     default:
+        #if USE_OPENSSL_KTLS
+        return BIO_ctrl(BIO_next(table), cmd, arg1, arg2);
+        #else
         return 0;
+        #endif
 
     }
 

--- a/src/ssl/bio.h
+++ b/src/ssl/bio.h
@@ -172,7 +172,7 @@ public:
 private:
     int readAndGive(char *buf, const int size, BIO *table);
     int readAndParse(char *buf, const int size, BIO *table);
-    int readAndBuffer(BIO *table);
+    int readAndBuffer(BIO *table, const int size);
     int giveBuffered(char *buf, const int size);
 
     /// SSL client features extracted from ClientHello message or SSL object


### PR DESCRIPTION
Adding a build option "--with-openssl-ktls" which activates OpenSSL KTLS function (SSL_OP_ENABLE_KTLS).

This code is tested to work using squid v6.6 on FreeBSD 13.2 with OpenSSL 1.1.1t-freebsd  or  OpenSSL 3.1.4.

```
Requirements (test environment):
 FreeBSD kernel with KERN_TLS enabled
 OpenSSL built with KTLS enabled

% kldload ktls_ocf.ko
% sysctl kern.ipc.tls.enable=1


Results after some ssl bump traffic:

% sysctl -a | grep ipc.tls.stats.ocf
kern.ipc.tls.stats.ocf.retries: 0
kern.ipc.tls.stats.ocf.separate_output: 0
kern.ipc.tls.stats.ocf.inplace: 238607
kern.ipc.tls.stats.ocf.tls13_chacha20_encrypts: 32
kern.ipc.tls.stats.ocf.tls13_chacha20_decrypts: 162
kern.ipc.tls.stats.ocf.tls13_gcm_encrypts: 222917
kern.ipc.tls.stats.ocf.tls13_gcm_decrypts: 284010
kern.ipc.tls.stats.ocf.tls12_chacha20_encrypts: 265
kern.ipc.tls.stats.ocf.tls12_chacha20_decrypts: 1021
kern.ipc.tls.stats.ocf.tls12_gcm_encrypts: 15064
kern.ipc.tls.stats.ocf.tls12_gcm_decrypts: 14736
kern.ipc.tls.stats.ocf.tls11_cbc_encrypts: 329
kern.ipc.tls.stats.ocf.tls10_cbc_encrypts: 0
