### PR TITLE
Rename class ACL to Acl::Node

### DIFF
--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -194,8 +194,8 @@ Acl::Init()
     /* the registration order does not matter */
 
     // The explicit return type (Acl::Node*) for lambdas is needed because the type
-    // of the return expression inside lambda is not Acl::Node* but AclFoo* while
-    // Acl::Maker is defined to return Acl::Node*.
+    // of the return expression inside lambda is not Node* but AclFoo* while
+    // Maker is defined to return Node*.
 
     RegisterMaker("all-of", [](TypeName)->Node* { return new AllOf; }); // XXX: Add name parameter to ctor
     RegisterMaker("any-of", [](TypeName)->Node* { return new AnyOf; }); // XXX: Add name parameter to ctor

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -192,105 +192,105 @@ Acl::Init()
 {
     /* the registration order does not matter */
 
-    // The explicit return type (Acl::AclNode*) for lambdas is needed because the type
-    // of the return expression inside lambda is not Acl::AclNode* but AclFoo* while
-    // Acl::Maker is defined to return Acl::AclNode*.
+    // The explicit return type (Acl::Node*) for lambdas is needed because the type
+    // of the return expression inside lambda is not Acl::Node* but AclFoo* while
+    // Acl::Maker is defined to return Acl::Node*.
 
-    RegisterMaker("all-of", [](TypeName)->Acl::AclNode* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("any-of", [](TypeName)->Acl::AclNode* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("random", [](TypeName name)->Acl::AclNode* { return new ACLRandom(name); });
-    RegisterMaker("time", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
-    RegisterMaker("src_as", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
-    RegisterMaker("dst_as", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
-    RegisterMaker("browser", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
+    RegisterMaker("all-of", [](TypeName)->Acl::Node* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("any-of", [](TypeName)->Acl::Node* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("random", [](TypeName name)->Acl::Node* { return new ACLRandom(name); });
+    RegisterMaker("time", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
+    RegisterMaker("src_as", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
+    RegisterMaker("dst_as", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
+    RegisterMaker("browser", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
 
-    RegisterMaker("dstdomain", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("dstdom_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("dstdomain", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("dstdom_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>::PreferAllocatorLabelPrefix("dstdomain+");
 
-    RegisterMaker("dst", [](TypeName)->Acl::AclNode* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("hier_code", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
-    RegisterMaker("rep_header", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("req_header", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("http_status", [](TypeName name)->Acl::AclNode* { return new ACLHTTPStatus(name); });
-    RegisterMaker("maxconn", [](TypeName name)->Acl::AclNode* { return new ACLMaxConnection(name); });
-    RegisterMaker("method", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
-    RegisterMaker("localip", [](TypeName)->Acl::AclNode* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("localport", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("myportname", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
+    RegisterMaker("dst", [](TypeName)->Acl::Node* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("hier_code", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
+    RegisterMaker("rep_header", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("req_header", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("http_status", [](TypeName name)->Acl::Node* { return new ACLHTTPStatus(name); });
+    RegisterMaker("maxconn", [](TypeName name)->Acl::Node* { return new ACLMaxConnection(name); });
+    RegisterMaker("method", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
+    RegisterMaker("localip", [](TypeName)->Acl::Node* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("localport", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("myportname", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
 
-    RegisterMaker("peername", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
-    RegisterMaker("peername_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("peername", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
+    RegisterMaker("peername_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>::PreferAllocatorLabelPrefix("peername+");
 
-    RegisterMaker("proto", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
-    RegisterMaker("referer_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
-    RegisterMaker("rep_mime_type", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
-    RegisterMaker("req_mime_type", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("proto", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
+    RegisterMaker("referer_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
+    RegisterMaker("rep_mime_type", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("req_mime_type", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
 
-    RegisterMaker("srcdomain", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("srcdom_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("srcdomain", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("srcdom_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>::PreferAllocatorLabelPrefix("srcdomain+");
 
-    RegisterMaker("src", [](TypeName)->Acl::AclNode* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("url_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
-    RegisterMaker("urllogin", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
-    RegisterMaker("urlpath_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
-    RegisterMaker("port", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("external", [](TypeName name)->Acl::AclNode* { return new ACLExternal(name); });
-    RegisterMaker("squid_error", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
-    RegisterMaker("connections_encrypted", [](TypeName name)->Acl::AclNode* { return new Acl::ConnectionsEncrypted(name); });
-    RegisterMaker("tag", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
-    RegisterMaker("note", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
-    RegisterMaker("annotate_client", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("annotate_transaction", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("has", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
-    RegisterMaker("transaction_initiator", [](TypeName name)->Acl::AclNode* {return new TransactionInitiator(name);});
+    RegisterMaker("src", [](TypeName)->Acl::Node* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("url_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
+    RegisterMaker("urllogin", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
+    RegisterMaker("urlpath_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
+    RegisterMaker("port", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("external", [](TypeName name)->Acl::Node* { return new ACLExternal(name); });
+    RegisterMaker("squid_error", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
+    RegisterMaker("connections_encrypted", [](TypeName name)->Acl::Node* { return new Acl::ConnectionsEncrypted(name); });
+    RegisterMaker("tag", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
+    RegisterMaker("note", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
+    RegisterMaker("annotate_client", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("annotate_transaction", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("has", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
+    RegisterMaker("transaction_initiator", [](TypeName name)->Acl::Node* {return new TransactionInitiator(name);});
 
 #if USE_LIBNETFILTERCONNTRACK
-    RegisterMaker("clientside_mark", [](TypeName)->Acl::AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
-    RegisterMaker("client_connection_mark", [](TypeName)->Acl::AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("clientside_mark", [](TypeName)->Acl::Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("client_connection_mark", [](TypeName)->Acl::Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
 #endif
 
 #if USE_OPENSSL
-    RegisterMaker("ssl_error", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
+    RegisterMaker("ssl_error", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
 
-    RegisterMaker("user_cert", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
-    RegisterMaker("ca_cert", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
+    RegisterMaker("user_cert", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
+    RegisterMaker("ca_cert", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
     Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>::PreferAllocatorLabelPrefix("user_cert+");
 
-    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
-    RegisterMaker("at_step", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
+    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
+    RegisterMaker("at_step", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
 
-    RegisterMaker("ssl::server_name", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
-    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("ssl::server_name", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
+    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
 #endif
 
 #if USE_SQUID_EUI
-    RegisterMaker("arp", [](TypeName name)->Acl::AclNode* { return new ACLARP(name); });
-    RegisterMaker("eui64", [](TypeName name)->Acl::AclNode* { return new ACLEui64(name); });
+    RegisterMaker("arp", [](TypeName name)->Acl::Node* { return new ACLARP(name); });
+    RegisterMaker("eui64", [](TypeName name)->Acl::Node* { return new ACLEui64(name); });
 #endif
 
 #if USE_IDENT
-    RegisterMaker("ident", [](TypeName name)->Acl::AclNode* { return new ACLIdent(new ACLUserData, name); });
-    RegisterMaker("ident_regex", [](TypeName name)->Acl::AclNode* { return new ACLIdent(new ACLRegexData, name); });
+    RegisterMaker("ident", [](TypeName name)->Acl::Node* { return new ACLIdent(new ACLUserData, name); });
+    RegisterMaker("ident_regex", [](TypeName name)->Acl::Node* { return new ACLIdent(new ACLRegexData, name); });
 #endif
 
 #if USE_AUTH
-    RegisterMaker("ext_user", [](TypeName name)->Acl::AclNode* { return new ACLExtUser(new ACLUserData, name); });
-    RegisterMaker("ext_user_regex", [](TypeName name)->Acl::AclNode* { return new ACLExtUser(new ACLRegexData, name); });
-    RegisterMaker("proxy_auth", [](TypeName name)->Acl::AclNode* { return new ACLProxyAuth(new ACLUserData, name); });
-    RegisterMaker("proxy_auth_regex", [](TypeName name)->Acl::AclNode* { return new ACLProxyAuth(new ACLRegexData, name); });
-    RegisterMaker("max_user_ip", [](TypeName name)->Acl::AclNode* { return new ACLMaxUserIP(name); });
+    RegisterMaker("ext_user", [](TypeName name)->Acl::Node* { return new ACLExtUser(new ACLUserData, name); });
+    RegisterMaker("ext_user_regex", [](TypeName name)->Acl::Node* { return new ACLExtUser(new ACLRegexData, name); });
+    RegisterMaker("proxy_auth", [](TypeName name)->Acl::Node* { return new ACLProxyAuth(new ACLUserData, name); });
+    RegisterMaker("proxy_auth_regex", [](TypeName name)->Acl::Node* { return new ACLProxyAuth(new ACLRegexData, name); });
+    RegisterMaker("max_user_ip", [](TypeName name)->Acl::Node* { return new ACLMaxUserIP(name); });
 #endif
 
 #if USE_ADAPTATION
-    RegisterMaker("adaptation_service", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
+    RegisterMaker("adaptation_service", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
 #endif
 
 #if SQUID_SNMP
-    RegisterMaker("snmp_community", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
+    RegisterMaker("snmp_community", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
 #endif
 }
 

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -192,105 +192,105 @@ Acl::Init()
 {
     /* the registration order does not matter */
 
-    // The explicit return type (ACL*) for lambdas is needed because the type
-    // of the return expression inside lambda is not ACL* but AclFoo* while
-    // Acl::Maker is defined to return ACL*.
+    // The explicit return type (AclNode*) for lambdas is needed because the type
+    // of the return expression inside lambda is not AclNode* but AclFoo* while
+    // Acl::Maker is defined to return AclNode*.
 
-    RegisterMaker("all-of", [](TypeName)->ACL* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("any-of", [](TypeName)->ACL* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("random", [](TypeName name)->ACL* { return new ACLRandom(name); });
-    RegisterMaker("time", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
-    RegisterMaker("src_as", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
-    RegisterMaker("dst_as", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
-    RegisterMaker("browser", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
+    RegisterMaker("all-of", [](TypeName)->AclNode* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("any-of", [](TypeName)->AclNode* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("random", [](TypeName name)->AclNode* { return new ACLRandom(name); });
+    RegisterMaker("time", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
+    RegisterMaker("src_as", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
+    RegisterMaker("dst_as", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
+    RegisterMaker("browser", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
 
-    RegisterMaker("dstdomain", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("dstdom_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("dstdomain", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("dstdom_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>::PreferAllocatorLabelPrefix("dstdomain+");
 
-    RegisterMaker("dst", [](TypeName)->ACL* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("hier_code", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
-    RegisterMaker("rep_header", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("req_header", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("http_status", [](TypeName name)->ACL* { return new ACLHTTPStatus(name); });
-    RegisterMaker("maxconn", [](TypeName name)->ACL* { return new ACLMaxConnection(name); });
-    RegisterMaker("method", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
-    RegisterMaker("localip", [](TypeName)->ACL* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("localport", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("myportname", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
+    RegisterMaker("dst", [](TypeName)->AclNode* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("hier_code", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
+    RegisterMaker("rep_header", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("req_header", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("http_status", [](TypeName name)->AclNode* { return new ACLHTTPStatus(name); });
+    RegisterMaker("maxconn", [](TypeName name)->AclNode* { return new ACLMaxConnection(name); });
+    RegisterMaker("method", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
+    RegisterMaker("localip", [](TypeName)->AclNode* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("localport", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("myportname", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
 
-    RegisterMaker("peername", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
-    RegisterMaker("peername_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("peername", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
+    RegisterMaker("peername_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>::PreferAllocatorLabelPrefix("peername+");
 
-    RegisterMaker("proto", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
-    RegisterMaker("referer_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
-    RegisterMaker("rep_mime_type", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
-    RegisterMaker("req_mime_type", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("proto", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
+    RegisterMaker("referer_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
+    RegisterMaker("rep_mime_type", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("req_mime_type", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
 
-    RegisterMaker("srcdomain", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("srcdom_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("srcdomain", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("srcdom_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>::PreferAllocatorLabelPrefix("srcdomain+");
 
-    RegisterMaker("src", [](TypeName)->ACL* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("url_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
-    RegisterMaker("urllogin", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
-    RegisterMaker("urlpath_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
-    RegisterMaker("port", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("external", [](TypeName name)->ACL* { return new ACLExternal(name); });
-    RegisterMaker("squid_error", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
-    RegisterMaker("connections_encrypted", [](TypeName name)->ACL* { return new Acl::ConnectionsEncrypted(name); });
-    RegisterMaker("tag", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
-    RegisterMaker("note", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
-    RegisterMaker("annotate_client", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("annotate_transaction", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("has", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
-    RegisterMaker("transaction_initiator", [](TypeName name)->ACL* {return new TransactionInitiator(name);});
+    RegisterMaker("src", [](TypeName)->AclNode* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("url_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
+    RegisterMaker("urllogin", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
+    RegisterMaker("urlpath_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
+    RegisterMaker("port", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("external", [](TypeName name)->AclNode* { return new ACLExternal(name); });
+    RegisterMaker("squid_error", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
+    RegisterMaker("connections_encrypted", [](TypeName name)->AclNode* { return new Acl::ConnectionsEncrypted(name); });
+    RegisterMaker("tag", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
+    RegisterMaker("note", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
+    RegisterMaker("annotate_client", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("annotate_transaction", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("has", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
+    RegisterMaker("transaction_initiator", [](TypeName name)->AclNode* {return new TransactionInitiator(name);});
 
 #if USE_LIBNETFILTERCONNTRACK
-    RegisterMaker("clientside_mark", [](TypeName)->ACL* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
-    RegisterMaker("client_connection_mark", [](TypeName)->ACL* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("clientside_mark", [](TypeName)->AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("client_connection_mark", [](TypeName)->AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
 #endif
 
 #if USE_OPENSSL
-    RegisterMaker("ssl_error", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
+    RegisterMaker("ssl_error", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
 
-    RegisterMaker("user_cert", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
-    RegisterMaker("ca_cert", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
+    RegisterMaker("user_cert", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
+    RegisterMaker("ca_cert", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
     Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>::PreferAllocatorLabelPrefix("user_cert+");
 
-    RegisterMaker("server_cert_fingerprint", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
-    RegisterMaker("at_step", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
+    RegisterMaker("server_cert_fingerprint", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
+    RegisterMaker("at_step", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
 
-    RegisterMaker("ssl::server_name", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
-    RegisterMaker("ssl::server_name_regex", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("ssl::server_name", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
+    RegisterMaker("ssl::server_name_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
 #endif
 
 #if USE_SQUID_EUI
-    RegisterMaker("arp", [](TypeName name)->ACL* { return new ACLARP(name); });
-    RegisterMaker("eui64", [](TypeName name)->ACL* { return new ACLEui64(name); });
+    RegisterMaker("arp", [](TypeName name)->AclNode* { return new ACLARP(name); });
+    RegisterMaker("eui64", [](TypeName name)->AclNode* { return new ACLEui64(name); });
 #endif
 
 #if USE_IDENT
-    RegisterMaker("ident", [](TypeName name)->ACL* { return new ACLIdent(new ACLUserData, name); });
-    RegisterMaker("ident_regex", [](TypeName name)->ACL* { return new ACLIdent(new ACLRegexData, name); });
+    RegisterMaker("ident", [](TypeName name)->AclNode* { return new ACLIdent(new ACLUserData, name); });
+    RegisterMaker("ident_regex", [](TypeName name)->AclNode* { return new ACLIdent(new ACLRegexData, name); });
 #endif
 
 #if USE_AUTH
-    RegisterMaker("ext_user", [](TypeName name)->ACL* { return new ACLExtUser(new ACLUserData, name); });
-    RegisterMaker("ext_user_regex", [](TypeName name)->ACL* { return new ACLExtUser(new ACLRegexData, name); });
-    RegisterMaker("proxy_auth", [](TypeName name)->ACL* { return new ACLProxyAuth(new ACLUserData, name); });
-    RegisterMaker("proxy_auth_regex", [](TypeName name)->ACL* { return new ACLProxyAuth(new ACLRegexData, name); });
-    RegisterMaker("max_user_ip", [](TypeName name)->ACL* { return new ACLMaxUserIP(name); });
+    RegisterMaker("ext_user", [](TypeName name)->AclNode* { return new ACLExtUser(new ACLUserData, name); });
+    RegisterMaker("ext_user_regex", [](TypeName name)->AclNode* { return new ACLExtUser(new ACLRegexData, name); });
+    RegisterMaker("proxy_auth", [](TypeName name)->AclNode* { return new ACLProxyAuth(new ACLUserData, name); });
+    RegisterMaker("proxy_auth_regex", [](TypeName name)->AclNode* { return new ACLProxyAuth(new ACLRegexData, name); });
+    RegisterMaker("max_user_ip", [](TypeName name)->AclNode* { return new ACLMaxUserIP(name); });
 #endif
 
 #if USE_ADAPTATION
-    RegisterMaker("adaptation_service", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
+    RegisterMaker("adaptation_service", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
 #endif
 
 #if SQUID_SNMP
-    RegisterMaker("snmp_community", [](TypeName name)->ACL* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
+    RegisterMaker("snmp_community", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
 #endif
 }
 

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -197,75 +197,75 @@ Acl::Init()
     // of the return expression inside lambda is not Acl::Node* but AclFoo* while
     // Acl::Maker is defined to return Acl::Node*.
 
-    RegisterMaker("all-of", [](TypeName)->Node* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("any-of", [](TypeName)->Node* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("all-of", [](TypeName)->Node* { return new AllOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("any-of", [](TypeName)->Node* { return new AnyOf; }); // XXX: Add name parameter to ctor
     RegisterMaker("random", [](TypeName name)->Node* { return new ACLRandom(name); });
-    RegisterMaker("time", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
-    RegisterMaker("src_as", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
-    RegisterMaker("dst_as", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
-    RegisterMaker("browser", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
+    RegisterMaker("time", [](TypeName name)->Node* { return new FinalizedParameterizedNode<CurrentTimeCheck>(name, new ACLTimeData); });
+    RegisterMaker("src_as", [](TypeName name)->Node* { return new FinalizedParameterizedNode<SourceAsnCheck>(name, new ACLASN); });
+    RegisterMaker("dst_as", [](TypeName name)->Node* { return new FinalizedParameterizedNode<DestinationAsnCheck>(name, new ACLASN); });
+    RegisterMaker("browser", [](TypeName name)->Node* { return new FinalizedParameterizedNode<RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
 
-    RegisterMaker("dstdomain", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("dstdom_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
-    Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>::PreferAllocatorLabelPrefix("dstdomain+");
+    RegisterMaker("dstdomain", [](TypeName name)->Node* { return new FinalizedParameterizedNode<DestinationDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("dstdom_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<DestinationDomainCheck>(name, new ACLRegexData); });
+    FinalizedParameterizedNode<DestinationDomainCheck>::PreferAllocatorLabelPrefix("dstdomain+");
 
     RegisterMaker("dst", [](TypeName)->Node* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("hier_code", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
-    RegisterMaker("rep_header", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("req_header", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("hier_code", [](TypeName name)->Node* { return new FinalizedParameterizedNode<HierCodeCheck>(name, new ACLHierCodeData); });
+    RegisterMaker("rep_header", [](TypeName name)->Node* { return new FinalizedParameterizedNode<HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("req_header", [](TypeName name)->Node* { return new FinalizedParameterizedNode<HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
     RegisterMaker("http_status", [](TypeName name)->Node* { return new ACLHTTPStatus(name); });
     RegisterMaker("maxconn", [](TypeName name)->Node* { return new ACLMaxConnection(name); });
-    RegisterMaker("method", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
+    RegisterMaker("method", [](TypeName name)->Node* { return new FinalizedParameterizedNode<MethodCheck>(name, new ACLMethodData); });
     RegisterMaker("localip", [](TypeName)->Node* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("localport", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("myportname", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
+    RegisterMaker("localport", [](TypeName name)->Node* { return new FinalizedParameterizedNode<LocalPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("myportname", [](TypeName name)->Node* { return new FinalizedParameterizedNode<MyPortNameCheck>(name, new ACLStringData); });
 
-    RegisterMaker("peername", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
-    RegisterMaker("peername_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
-    Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>::PreferAllocatorLabelPrefix("peername+");
+    RegisterMaker("peername", [](TypeName name)->Node* { return new FinalizedParameterizedNode<PeerNameCheck>(name, new ACLStringData); });
+    RegisterMaker("peername_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<PeerNameCheck>(name, new ACLRegexData); });
+    FinalizedParameterizedNode<PeerNameCheck>::PreferAllocatorLabelPrefix("peername+");
 
-    RegisterMaker("proto", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
-    RegisterMaker("referer_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
-    RegisterMaker("rep_mime_type", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
-    RegisterMaker("req_mime_type", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("proto", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ProtocolCheck>(name, new ACLProtocolData); });
+    RegisterMaker("referer_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
+    RegisterMaker("rep_mime_type", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("req_mime_type", [](TypeName name)->Node* { return new FinalizedParameterizedNode<RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
 
-    RegisterMaker("srcdomain", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("srcdom_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
-    Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>::PreferAllocatorLabelPrefix("srcdomain+");
+    RegisterMaker("srcdomain", [](TypeName name)->Node* { return new FinalizedParameterizedNode<SourceDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("srcdom_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<SourceDomainCheck>(name, new ACLRegexData); });
+    FinalizedParameterizedNode<SourceDomainCheck>::PreferAllocatorLabelPrefix("srcdomain+");
 
     RegisterMaker("src", [](TypeName)->Node* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("url_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
-    RegisterMaker("urllogin", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
-    RegisterMaker("urlpath_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
-    RegisterMaker("port", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("url_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<UrlCheck>(name, new ACLRegexData); });
+    RegisterMaker("urllogin", [](TypeName name)->Node* { return new FinalizedParameterizedNode<UrlLoginCheck>(name, new ACLRegexData); });
+    RegisterMaker("urlpath_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<UrlPathCheck>(name, new ACLRegexData); });
+    RegisterMaker("port", [](TypeName name)->Node* { return new FinalizedParameterizedNode<UrlPortCheck>(name, new ACLIntRange); });
     RegisterMaker("external", [](TypeName name)->Node* { return new ACLExternal(name); });
-    RegisterMaker("squid_error", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
-    RegisterMaker("connections_encrypted", [](TypeName name)->Node* { return new Acl::ConnectionsEncrypted(name); });
-    RegisterMaker("tag", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
-    RegisterMaker("note", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
-    RegisterMaker("annotate_client", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("annotate_transaction", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("has", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
+    RegisterMaker("squid_error", [](TypeName name)->Node* { return new FinalizedParameterizedNode<SquidErrorCheck>(name, new ACLSquidErrorData); });
+    RegisterMaker("connections_encrypted", [](TypeName name)->Node* { return new ConnectionsEncrypted(name); });
+    RegisterMaker("tag", [](TypeName name)->Node* { return new FinalizedParameterizedNode<TagCheck>(name, new ACLStringData); });
+    RegisterMaker("note", [](TypeName name)->Node* { return new FinalizedParameterizedNode<NoteCheck>(name, new ACLNoteData); });
+    RegisterMaker("annotate_client", [](TypeName name)->Node* { return new FinalizedParameterizedNode<AnnotateClientCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("annotate_transaction", [](TypeName name)->Node* { return new FinalizedParameterizedNode<AnnotateTransactionCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("has", [](TypeName name)->Node* { return new FinalizedParameterizedNode<HasComponentCheck>(name, new ACLHasComponentData); });
     RegisterMaker("transaction_initiator", [](TypeName name)->Node* {return new TransactionInitiator(name);});
 
 #if USE_LIBNETFILTERCONNTRACK
-    RegisterMaker("clientside_mark", [](TypeName)->Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
-    RegisterMaker("client_connection_mark", [](TypeName)->Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("clientside_mark", [](TypeName)->Node* { return new ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("client_connection_mark", [](TypeName)->Node* { return new ConnMark; }); // XXX: Add name parameter to ctor
 #endif
 
 #if USE_OPENSSL
-    RegisterMaker("ssl_error", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
+    RegisterMaker("ssl_error", [](TypeName name)->Node* { return new FinalizedParameterizedNode<CertificateErrorCheck>(name, new ACLSslErrorData); });
 
-    RegisterMaker("user_cert", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
-    RegisterMaker("ca_cert", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
-    Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>::PreferAllocatorLabelPrefix("user_cert+");
+    RegisterMaker("user_cert", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
+    RegisterMaker("ca_cert", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
+    FinalizedParameterizedNode<ClientCertificateCheck>::PreferAllocatorLabelPrefix("user_cert+");
 
-    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
-    RegisterMaker("at_step", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
+    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
+    RegisterMaker("at_step", [](TypeName name)->Node* { return new FinalizedParameterizedNode<AtStepCheck>(name, new ACLAtStepData); });
 
-    RegisterMaker("ssl::server_name", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
-    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
-    Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
+    RegisterMaker("ssl::server_name", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ServerNameCheck>(name, new ACLServerNameData); });
+    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ServerNameCheck>(name, new ACLRegexData); });
+    FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
 #endif
 
 #if USE_SQUID_EUI

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -59,6 +59,7 @@
 #include "acl/MethodData.h"
 #include "acl/MyPortName.h"
 #include "acl/Note.h"
+#include "acl/Node.h"
 #include "acl/NoteData.h"
 #include "acl/PeerName.h"
 #include "acl/Protocol.h"

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -192,105 +192,105 @@ Acl::Init()
 {
     /* the registration order does not matter */
 
-    // The explicit return type (AclNode*) for lambdas is needed because the type
-    // of the return expression inside lambda is not AclNode* but AclFoo* while
-    // Acl::Maker is defined to return AclNode*.
+    // The explicit return type (Acl::AclNode*) for lambdas is needed because the type
+    // of the return expression inside lambda is not Acl::AclNode* but AclFoo* while
+    // Acl::Maker is defined to return Acl::AclNode*.
 
-    RegisterMaker("all-of", [](TypeName)->AclNode* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("any-of", [](TypeName)->AclNode* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("random", [](TypeName name)->AclNode* { return new ACLRandom(name); });
-    RegisterMaker("time", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
-    RegisterMaker("src_as", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
-    RegisterMaker("dst_as", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
-    RegisterMaker("browser", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
+    RegisterMaker("all-of", [](TypeName)->Acl::AclNode* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("any-of", [](TypeName)->Acl::AclNode* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("random", [](TypeName name)->Acl::AclNode* { return new ACLRandom(name); });
+    RegisterMaker("time", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
+    RegisterMaker("src_as", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
+    RegisterMaker("dst_as", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
+    RegisterMaker("browser", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
 
-    RegisterMaker("dstdomain", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("dstdom_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("dstdomain", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("dstdom_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>::PreferAllocatorLabelPrefix("dstdomain+");
 
-    RegisterMaker("dst", [](TypeName)->AclNode* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("hier_code", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
-    RegisterMaker("rep_header", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("req_header", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("http_status", [](TypeName name)->AclNode* { return new ACLHTTPStatus(name); });
-    RegisterMaker("maxconn", [](TypeName name)->AclNode* { return new ACLMaxConnection(name); });
-    RegisterMaker("method", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
-    RegisterMaker("localip", [](TypeName)->AclNode* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("localport", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("myportname", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
+    RegisterMaker("dst", [](TypeName)->Acl::AclNode* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("hier_code", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
+    RegisterMaker("rep_header", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("req_header", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("http_status", [](TypeName name)->Acl::AclNode* { return new ACLHTTPStatus(name); });
+    RegisterMaker("maxconn", [](TypeName name)->Acl::AclNode* { return new ACLMaxConnection(name); });
+    RegisterMaker("method", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
+    RegisterMaker("localip", [](TypeName)->Acl::AclNode* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("localport", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("myportname", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
 
-    RegisterMaker("peername", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
-    RegisterMaker("peername_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("peername", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
+    RegisterMaker("peername_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>::PreferAllocatorLabelPrefix("peername+");
 
-    RegisterMaker("proto", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
-    RegisterMaker("referer_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
-    RegisterMaker("rep_mime_type", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
-    RegisterMaker("req_mime_type", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("proto", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
+    RegisterMaker("referer_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
+    RegisterMaker("rep_mime_type", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("req_mime_type", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
 
-    RegisterMaker("srcdomain", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("srcdom_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("srcdomain", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("srcdom_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>::PreferAllocatorLabelPrefix("srcdomain+");
 
-    RegisterMaker("src", [](TypeName)->AclNode* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("url_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
-    RegisterMaker("urllogin", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
-    RegisterMaker("urlpath_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
-    RegisterMaker("port", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("external", [](TypeName name)->AclNode* { return new ACLExternal(name); });
-    RegisterMaker("squid_error", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
-    RegisterMaker("connections_encrypted", [](TypeName name)->AclNode* { return new Acl::ConnectionsEncrypted(name); });
-    RegisterMaker("tag", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
-    RegisterMaker("note", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
-    RegisterMaker("annotate_client", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("annotate_transaction", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("has", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
-    RegisterMaker("transaction_initiator", [](TypeName name)->AclNode* {return new TransactionInitiator(name);});
+    RegisterMaker("src", [](TypeName)->Acl::AclNode* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("url_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
+    RegisterMaker("urllogin", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
+    RegisterMaker("urlpath_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
+    RegisterMaker("port", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("external", [](TypeName name)->Acl::AclNode* { return new ACLExternal(name); });
+    RegisterMaker("squid_error", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
+    RegisterMaker("connections_encrypted", [](TypeName name)->Acl::AclNode* { return new Acl::ConnectionsEncrypted(name); });
+    RegisterMaker("tag", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
+    RegisterMaker("note", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
+    RegisterMaker("annotate_client", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("annotate_transaction", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("has", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
+    RegisterMaker("transaction_initiator", [](TypeName name)->Acl::AclNode* {return new TransactionInitiator(name);});
 
 #if USE_LIBNETFILTERCONNTRACK
-    RegisterMaker("clientside_mark", [](TypeName)->AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
-    RegisterMaker("client_connection_mark", [](TypeName)->AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("clientside_mark", [](TypeName)->Acl::AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("client_connection_mark", [](TypeName)->Acl::AclNode* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
 #endif
 
 #if USE_OPENSSL
-    RegisterMaker("ssl_error", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
+    RegisterMaker("ssl_error", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
 
-    RegisterMaker("user_cert", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
-    RegisterMaker("ca_cert", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
+    RegisterMaker("user_cert", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
+    RegisterMaker("ca_cert", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
     Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>::PreferAllocatorLabelPrefix("user_cert+");
 
-    RegisterMaker("server_cert_fingerprint", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
-    RegisterMaker("at_step", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
+    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
+    RegisterMaker("at_step", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
 
-    RegisterMaker("ssl::server_name", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
-    RegisterMaker("ssl::server_name_regex", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("ssl::server_name", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
+    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
 #endif
 
 #if USE_SQUID_EUI
-    RegisterMaker("arp", [](TypeName name)->AclNode* { return new ACLARP(name); });
-    RegisterMaker("eui64", [](TypeName name)->AclNode* { return new ACLEui64(name); });
+    RegisterMaker("arp", [](TypeName name)->Acl::AclNode* { return new ACLARP(name); });
+    RegisterMaker("eui64", [](TypeName name)->Acl::AclNode* { return new ACLEui64(name); });
 #endif
 
 #if USE_IDENT
-    RegisterMaker("ident", [](TypeName name)->AclNode* { return new ACLIdent(new ACLUserData, name); });
-    RegisterMaker("ident_regex", [](TypeName name)->AclNode* { return new ACLIdent(new ACLRegexData, name); });
+    RegisterMaker("ident", [](TypeName name)->Acl::AclNode* { return new ACLIdent(new ACLUserData, name); });
+    RegisterMaker("ident_regex", [](TypeName name)->Acl::AclNode* { return new ACLIdent(new ACLRegexData, name); });
 #endif
 
 #if USE_AUTH
-    RegisterMaker("ext_user", [](TypeName name)->AclNode* { return new ACLExtUser(new ACLUserData, name); });
-    RegisterMaker("ext_user_regex", [](TypeName name)->AclNode* { return new ACLExtUser(new ACLRegexData, name); });
-    RegisterMaker("proxy_auth", [](TypeName name)->AclNode* { return new ACLProxyAuth(new ACLUserData, name); });
-    RegisterMaker("proxy_auth_regex", [](TypeName name)->AclNode* { return new ACLProxyAuth(new ACLRegexData, name); });
-    RegisterMaker("max_user_ip", [](TypeName name)->AclNode* { return new ACLMaxUserIP(name); });
+    RegisterMaker("ext_user", [](TypeName name)->Acl::AclNode* { return new ACLExtUser(new ACLUserData, name); });
+    RegisterMaker("ext_user_regex", [](TypeName name)->Acl::AclNode* { return new ACLExtUser(new ACLRegexData, name); });
+    RegisterMaker("proxy_auth", [](TypeName name)->Acl::AclNode* { return new ACLProxyAuth(new ACLUserData, name); });
+    RegisterMaker("proxy_auth_regex", [](TypeName name)->Acl::AclNode* { return new ACLProxyAuth(new ACLRegexData, name); });
+    RegisterMaker("max_user_ip", [](TypeName name)->Acl::AclNode* { return new ACLMaxUserIP(name); });
 #endif
 
 #if USE_ADAPTATION
-    RegisterMaker("adaptation_service", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
+    RegisterMaker("adaptation_service", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
 #endif
 
 #if SQUID_SNMP
-    RegisterMaker("snmp_community", [](TypeName name)->AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
+    RegisterMaker("snmp_community", [](TypeName name)->Acl::AclNode* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
 #endif
 }
 

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -197,101 +197,101 @@ Acl::Init()
     // of the return expression inside lambda is not Acl::Node* but AclFoo* while
     // Acl::Maker is defined to return Acl::Node*.
 
-    RegisterMaker("all-of", [](TypeName)->Acl::Node* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("any-of", [](TypeName)->Acl::Node* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
-    RegisterMaker("random", [](TypeName name)->Acl::Node* { return new ACLRandom(name); });
-    RegisterMaker("time", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
-    RegisterMaker("src_as", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
-    RegisterMaker("dst_as", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
-    RegisterMaker("browser", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
+    RegisterMaker("all-of", [](TypeName)->Node* { return new Acl::AllOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("any-of", [](TypeName)->Node* { return new Acl::AnyOf; }); // XXX: Add name parameter to ctor
+    RegisterMaker("random", [](TypeName name)->Node* { return new ACLRandom(name); });
+    RegisterMaker("time", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::CurrentTimeCheck>(name, new ACLTimeData); });
+    RegisterMaker("src_as", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceAsnCheck>(name, new ACLASN); });
+    RegisterMaker("dst_as", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationAsnCheck>(name, new ACLASN); });
+    RegisterMaker("browser", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::USER_AGENT> >(name, new ACLRegexData); });
 
-    RegisterMaker("dstdomain", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("dstdom_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("dstdomain", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("dstdom_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::DestinationDomainCheck>::PreferAllocatorLabelPrefix("dstdomain+");
 
-    RegisterMaker("dst", [](TypeName)->Acl::Node* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("hier_code", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
-    RegisterMaker("rep_header", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("req_header", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
-    RegisterMaker("http_status", [](TypeName name)->Acl::Node* { return new ACLHTTPStatus(name); });
-    RegisterMaker("maxconn", [](TypeName name)->Acl::Node* { return new ACLMaxConnection(name); });
-    RegisterMaker("method", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
-    RegisterMaker("localip", [](TypeName)->Acl::Node* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("localport", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("myportname", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
+    RegisterMaker("dst", [](TypeName)->Node* { return new ACLDestinationIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("hier_code", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HierCodeCheck>(name, new ACLHierCodeData); });
+    RegisterMaker("rep_header", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpRepHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("req_header", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HttpReqHeaderCheck>(name, new ACLHTTPHeaderData); });
+    RegisterMaker("http_status", [](TypeName name)->Node* { return new ACLHTTPStatus(name); });
+    RegisterMaker("maxconn", [](TypeName name)->Node* { return new ACLMaxConnection(name); });
+    RegisterMaker("method", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::MethodCheck>(name, new ACLMethodData); });
+    RegisterMaker("localip", [](TypeName)->Node* { return new ACLLocalIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("localport", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::LocalPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("myportname", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::MyPortNameCheck>(name, new ACLStringData); });
 
-    RegisterMaker("peername", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
-    RegisterMaker("peername_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("peername", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLStringData); });
+    RegisterMaker("peername_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::PeerNameCheck>::PreferAllocatorLabelPrefix("peername+");
 
-    RegisterMaker("proto", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
-    RegisterMaker("referer_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
-    RegisterMaker("rep_mime_type", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
-    RegisterMaker("req_mime_type", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("proto", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ProtocolCheck>(name, new ACLProtocolData); });
+    RegisterMaker("referer_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::REFERER> >(name, new ACLRegexData); });
+    RegisterMaker("rep_mime_type", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ReplyHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
+    RegisterMaker("req_mime_type", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::RequestHeaderCheck<Http::HdrType::CONTENT_TYPE> >(name, new ACLRegexData); });
 
-    RegisterMaker("srcdomain", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
-    RegisterMaker("srcdom_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
+    RegisterMaker("srcdomain", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLDomainData); });
+    RegisterMaker("srcdom_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::SourceDomainCheck>::PreferAllocatorLabelPrefix("srcdomain+");
 
-    RegisterMaker("src", [](TypeName)->Acl::Node* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
-    RegisterMaker("url_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
-    RegisterMaker("urllogin", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
-    RegisterMaker("urlpath_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
-    RegisterMaker("port", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
-    RegisterMaker("external", [](TypeName name)->Acl::Node* { return new ACLExternal(name); });
-    RegisterMaker("squid_error", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
-    RegisterMaker("connections_encrypted", [](TypeName name)->Acl::Node* { return new Acl::ConnectionsEncrypted(name); });
-    RegisterMaker("tag", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
-    RegisterMaker("note", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
-    RegisterMaker("annotate_client", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("annotate_transaction", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
-    RegisterMaker("has", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
-    RegisterMaker("transaction_initiator", [](TypeName name)->Acl::Node* {return new TransactionInitiator(name);});
+    RegisterMaker("src", [](TypeName)->Node* { return new ACLSourceIP; }); // XXX: Add name parameter to ctor
+    RegisterMaker("url_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlCheck>(name, new ACLRegexData); });
+    RegisterMaker("urllogin", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlLoginCheck>(name, new ACLRegexData); });
+    RegisterMaker("urlpath_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPathCheck>(name, new ACLRegexData); });
+    RegisterMaker("port", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::UrlPortCheck>(name, new ACLIntRange); });
+    RegisterMaker("external", [](TypeName name)->Node* { return new ACLExternal(name); });
+    RegisterMaker("squid_error", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SquidErrorCheck>(name, new ACLSquidErrorData); });
+    RegisterMaker("connections_encrypted", [](TypeName name)->Node* { return new Acl::ConnectionsEncrypted(name); });
+    RegisterMaker("tag", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::TagCheck>(name, new ACLStringData); });
+    RegisterMaker("note", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::NoteCheck>(name, new ACLNoteData); });
+    RegisterMaker("annotate_client", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateClientCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("annotate_transaction", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AnnotateTransactionCheck>(name, new ACLAnnotationData); });
+    RegisterMaker("has", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::HasComponentCheck>(name, new ACLHasComponentData); });
+    RegisterMaker("transaction_initiator", [](TypeName name)->Node* {return new TransactionInitiator(name);});
 
 #if USE_LIBNETFILTERCONNTRACK
-    RegisterMaker("clientside_mark", [](TypeName)->Acl::Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
-    RegisterMaker("client_connection_mark", [](TypeName)->Acl::Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("clientside_mark", [](TypeName)->Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
+    RegisterMaker("client_connection_mark", [](TypeName)->Node* { return new Acl::ConnMark; }); // XXX: Add name parameter to ctor
 #endif
 
 #if USE_OPENSSL
-    RegisterMaker("ssl_error", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
+    RegisterMaker("ssl_error", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::CertificateErrorCheck>(name, new ACLSslErrorData); });
 
-    RegisterMaker("user_cert", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
-    RegisterMaker("ca_cert", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
+    RegisterMaker("user_cert", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509UserAttribute, "*")); });
+    RegisterMaker("ca_cert", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509CAAttribute, "*")); });
     Acl::FinalizedParameterizedNode<Acl::ClientCertificateCheck>::PreferAllocatorLabelPrefix("user_cert+");
 
-    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
-    RegisterMaker("at_step", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
+    RegisterMaker("server_cert_fingerprint", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerCertificateCheck>(name, new ACLCertificateData(Ssl::GetX509Fingerprint, nullptr, true)); });
+    RegisterMaker("at_step", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AtStepCheck>(name, new ACLAtStepData); });
 
-    RegisterMaker("ssl::server_name", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
-    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
+    RegisterMaker("ssl::server_name", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLServerNameData); });
+    RegisterMaker("ssl::server_name_regex", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>(name, new ACLRegexData); });
     Acl::FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
 #endif
 
 #if USE_SQUID_EUI
-    RegisterMaker("arp", [](TypeName name)->Acl::Node* { return new ACLARP(name); });
-    RegisterMaker("eui64", [](TypeName name)->Acl::Node* { return new ACLEui64(name); });
+    RegisterMaker("arp", [](TypeName name)->Node* { return new ACLARP(name); });
+    RegisterMaker("eui64", [](TypeName name)->Node* { return new ACLEui64(name); });
 #endif
 
 #if USE_IDENT
-    RegisterMaker("ident", [](TypeName name)->Acl::Node* { return new ACLIdent(new ACLUserData, name); });
-    RegisterMaker("ident_regex", [](TypeName name)->Acl::Node* { return new ACLIdent(new ACLRegexData, name); });
+    RegisterMaker("ident", [](TypeName name)->Node* { return new ACLIdent(new ACLUserData, name); });
+    RegisterMaker("ident_regex", [](TypeName name)->Node* { return new ACLIdent(new ACLRegexData, name); });
 #endif
 
 #if USE_AUTH
-    RegisterMaker("ext_user", [](TypeName name)->Acl::Node* { return new ACLExtUser(new ACLUserData, name); });
-    RegisterMaker("ext_user_regex", [](TypeName name)->Acl::Node* { return new ACLExtUser(new ACLRegexData, name); });
-    RegisterMaker("proxy_auth", [](TypeName name)->Acl::Node* { return new ACLProxyAuth(new ACLUserData, name); });
-    RegisterMaker("proxy_auth_regex", [](TypeName name)->Acl::Node* { return new ACLProxyAuth(new ACLRegexData, name); });
-    RegisterMaker("max_user_ip", [](TypeName name)->Acl::Node* { return new ACLMaxUserIP(name); });
+    RegisterMaker("ext_user", [](TypeName name)->Node* { return new ACLExtUser(new ACLUserData, name); });
+    RegisterMaker("ext_user_regex", [](TypeName name)->Node* { return new ACLExtUser(new ACLRegexData, name); });
+    RegisterMaker("proxy_auth", [](TypeName name)->Node* { return new ACLProxyAuth(new ACLUserData, name); });
+    RegisterMaker("proxy_auth_regex", [](TypeName name)->Node* { return new ACLProxyAuth(new ACLRegexData, name); });
+    RegisterMaker("max_user_ip", [](TypeName name)->Node* { return new ACLMaxUserIP(name); });
 #endif
 
 #if USE_ADAPTATION
-    RegisterMaker("adaptation_service", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
+    RegisterMaker("adaptation_service", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
 #endif
 
 #if SQUID_SNMP
-    RegisterMaker("snmp_community", [](TypeName name)->Acl::Node* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
+    RegisterMaker("snmp_community", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
 #endif
 }
 

--- a/src/AclRegs.cc
+++ b/src/AclRegs.cc
@@ -119,7 +119,7 @@ namespace Acl
 template <class Parent>
 class FinalizedParameterizedNode: public Parent
 {
-    MEMPROXY_CLASS(Acl::FinalizedParameterizedNode<Parent>);
+    MEMPROXY_CLASS(FinalizedParameterizedNode<Parent>);
 
 public:
     using Parameters = typename Parent::Parameters;
@@ -265,7 +265,7 @@ Acl::Init()
 
     RegisterMaker("ssl::server_name", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ServerNameCheck>(name, new ACLServerNameData); });
     RegisterMaker("ssl::server_name_regex", [](TypeName name)->Node* { return new FinalizedParameterizedNode<ServerNameCheck>(name, new ACLRegexData); });
-    FinalizedParameterizedNode<Acl::ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
+    FinalizedParameterizedNode<ServerNameCheck>::PreferAllocatorLabelPrefix("ssl::server_name+");
 #endif
 
 #if USE_SQUID_EUI
@@ -287,11 +287,11 @@ Acl::Init()
 #endif
 
 #if USE_ADAPTATION
-    RegisterMaker("adaptation_service", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
+    RegisterMaker("adaptation_service", [](TypeName name)->Node* { return new FinalizedParameterizedNode<AdaptationServiceCheck>(name, new ACLAdaptationServiceData); });
 #endif
 
 #if SQUID_SNMP
-    RegisterMaker("snmp_community", [](TypeName name)->Node* { return new Acl::FinalizedParameterizedNode<Acl::SnmpCommunityCheck>(name, new ACLStringData); });
+    RegisterMaker("snmp_community", [](TypeName name)->Node* { return new FinalizedParameterizedNode<SnmpCommunityCheck>(name, new ACLStringData); });
 #endif
 }
 

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -17,7 +17,7 @@ class external_acl;
 class external_acl_data;
 class StoreEntry;
 
-class ACLExternal : public Acl::AclNode
+class ACLExternal : public Acl::Node
 {
     MEMPROXY_CLASS(ACLExternal);
 
@@ -40,7 +40,7 @@ public:
     bool empty () const override;
 
 private:
-    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::Node &);
     static void LookupDone(void *data, const ExternalACLEntryPointer &);
     void startLookup(ACLFilledChecklist *, external_acl_data *, bool inBackground) const;
     Acl::Answer aclMatchExternal(external_acl_data *, ACLFilledChecklist *) const;

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -17,7 +17,7 @@ class external_acl;
 class external_acl_data;
 class StoreEntry;
 
-class ACLExternal : public AclNode
+class ACLExternal : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLExternal);
 
@@ -40,7 +40,7 @@ public:
     bool empty () const override;
 
 private:
-    static void StartLookup(ACLFilledChecklist &, const AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
     static void LookupDone(void *data, const ExternalACLEntryPointer &);
     void startLookup(ACLFilledChecklist *, external_acl_data *, bool inBackground) const;
     Acl::Answer aclMatchExternal(external_acl_data *, ACLFilledChecklist *) const;

--- a/src/ExternalACL.h
+++ b/src/ExternalACL.h
@@ -17,7 +17,7 @@ class external_acl;
 class external_acl_data;
 class StoreEntry;
 
-class ACLExternal : public ACL
+class ACLExternal : public AclNode
 {
     MEMPROXY_CLASS(ACLExternal);
 
@@ -40,7 +40,7 @@ public:
     bool empty () const override;
 
 private:
-    static void StartLookup(ACLFilledChecklist &, const ACL &);
+    static void StartLookup(ACLFilledChecklist &, const AclNode &);
     static void LookupDone(void *data, const ExternalACLEntryPointer &);
     void startLookup(ACLFilledChecklist *, external_acl_data *, bool inBackground) const;
     Acl::Answer aclMatchExternal(external_acl_data *, ACLFilledChecklist *) const;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -353,7 +353,7 @@ public:
 
     std::chrono::nanoseconds paranoid_hit_validation;
 
-    class Acl::AclNode *aclList;
+    class Acl::Node *aclList;
 
     struct {
         acl_access *http;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -353,7 +353,7 @@ public:
 
     std::chrono::nanoseconds paranoid_hit_validation;
 
-    class ACL *aclList;
+    class AclNode *aclList;
 
     struct {
         acl_access *http;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -353,7 +353,7 @@ public:
 
     std::chrono::nanoseconds paranoid_hit_validation;
 
-    class AclNode *aclList;
+    class Acl::AclNode *aclList;
 
     struct {
         acl_access *http;

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -118,13 +118,13 @@ AclNode *
 AclNode::FindByName(const char *name)
 {
     AclNode *a;
-    debugs(28, 9, "AclNode::FindByName '" << name << "'");
+    debugs(28, 9, "name=" << name);
 
     for (a = Config.aclList; a; a = a->next)
         if (!strcasecmp(a->name, name))
             return a;
 
-    debugs(28, 9, "AclNode::FindByName found no match");
+    debugs(28, 9, "found no match");
 
     return nullptr;
 }
@@ -364,7 +364,7 @@ AclNode::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
         auth_match = (acl_proxy_auth_match_cache *)link->data;
 
         if (auth_match->acl_data == this) {
-            debugs(28, 4, "AclNode::cacheMatchAcl: cache hit on acl '" << name << "' (" << this << ")");
+            debugs(28, 4, "cache hit on acl '" << name << "' (" << this << ")");
             return auth_match->matchrv;
         }
 
@@ -373,7 +373,7 @@ AclNode::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
 
     auth_match = new acl_proxy_auth_match_cache(matchForCache(checklist), this);
     dlinkAddTail(auth_match, &auth_match->link, cache);
-    debugs(28, 4, "AclNode::cacheMatchAcl: miss for '" << name << "'. Adding result " << auth_match->matchrv);
+    debugs(28, 4, "miss for acl '" << name << "'. Adding result " << auth_match->matchrv);
     return auth_match->matchrv;
 }
 
@@ -427,7 +427,7 @@ AclNode::~AclNode()
 void
 AclNode::Initialize()
 {
-    AclNode *a = Config.aclList;
+    auto *a = Config.aclList;
     debugs(53, 3, "AclNode::Initialize");
 
     while (a) {

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -31,16 +31,16 @@ const char *AclMatchedName = nullptr;
 
 namespace Acl {
 
-/// Acl::AclNode type name comparison functor
+/// Acl::Node type name comparison functor
 class TypeNameCmp {
 public:
     bool operator()(TypeName a, TypeName b) const { return strcmp(a, b) < 0; }
 };
 
-/// Acl::AclNode makers indexed by Acl::AclNode type name
+/// Acl::Node makers indexed by Acl::Node type name
 typedef std::map<TypeName, Maker, TypeNameCmp> Makers;
 
-/// registered Acl::AclNode Makers
+/// registered Acl::Node Makers
 static Makers &
 TheMakers()
 {
@@ -48,9 +48,9 @@ TheMakers()
     return Registry;
 }
 
-/// creates an Acl::AclNode object of the named (and already registered) Acl::AclNode child type
+/// creates an Acl::Node object of the named (and already registered) Acl::Node child type
 static
-Acl::AclNode *
+Acl::Node *
 Make(TypeName typeName)
 {
     const auto pos = TheMakers().find(typeName);
@@ -103,19 +103,19 @@ Acl::SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey)
 }
 
 void *
-Acl::AclNode::operator new (size_t)
+Acl::Node::operator new (size_t)
 {
-    fatal ("unusable Acl::AclNode::new");
+    fatal ("unusable Acl::Node::new");
     return (void *)1;
 }
 
-void Acl::AclNode::operator delete(void *)
+void Acl::Node::operator delete(void *)
 {
-    fatal ("unusable Acl::AclNode::delete");
+    fatal ("unusable Acl::Node::delete");
 }
 
-Acl::AclNode *
-Acl::AclNode::FindByName(const char *name)
+Acl::Node *
+Acl::Node::FindByName(const char *name)
 {
     debugs(28, 9, "name=" << name);
 
@@ -128,7 +128,7 @@ Acl::AclNode::FindByName(const char *name)
     return nullptr;
 }
 
-Acl::AclNode::AclNode() :
+Acl::Node::Node() :
     cfgline(nullptr),
     next(nullptr),
     registered(false)
@@ -137,13 +137,13 @@ Acl::AclNode::AclNode() :
 }
 
 bool
-Acl::AclNode::valid() const
+Acl::Node::valid() const
 {
     return true;
 }
 
 bool
-Acl::AclNode::matches(ACLChecklist *checklist) const
+Acl::Node::matches(ACLChecklist *checklist) const
 {
     debugs(28, 5, "checking " << name);
 
@@ -168,7 +168,7 @@ Acl::AclNode::matches(ACLChecklist *checklist) const
             checklist->verifyAle();
 
         // have to cast because old match() API is missing const
-        result = const_cast<Acl::AclNode*>(this)->match(checklist);
+        result = const_cast<Acl::Node*>(this)->match(checklist);
     }
 
     const char *extra = checklist->asyncInProgress() ? " async" : "";
@@ -177,7 +177,7 @@ Acl::AclNode::matches(ACLChecklist *checklist) const
 }
 
 void
-Acl::AclNode::context(const char *aName, const char *aCfgLine)
+Acl::Node::context(const char *aName, const char *aCfgLine)
 {
     name[0] = '\0';
     if (aName)
@@ -188,11 +188,11 @@ Acl::AclNode::context(const char *aName, const char *aCfgLine)
 }
 
 void
-Acl::AclNode::ParseAclLine(ConfigParser &parser, Acl::AclNode ** head)
+Acl::Node::ParseAclLine(ConfigParser &parser, Acl::Node ** head)
 {
     /* we're already using strtok() to grok the line */
     char *t = nullptr;
-    Acl::AclNode *A = nullptr;
+    Acl::Node *A = nullptr;
     LOCAL_ARRAY(char, aclname, ACL_NAME_SZ);
     int new_acl = 0;
 
@@ -306,13 +306,13 @@ Acl::AclNode::ParseAclLine(ConfigParser &parser, Acl::AclNode ** head)
 }
 
 bool
-Acl::AclNode::isProxyAuth() const
+Acl::Node::isProxyAuth() const
 {
     return false;
 }
 
 void
-Acl::AclNode::parseFlags()
+Acl::Node::parseFlags()
 {
     Acl::Options allOptions = options();
     for (const auto lineOption: lineOptions()) {
@@ -323,7 +323,7 @@ Acl::AclNode::parseFlags()
 }
 
 void
-Acl::AclNode::dumpWhole(const char * const directiveName, std::ostream &os)
+Acl::Node::dumpWhole(const char * const directiveName, std::ostream &os)
 {
     // XXX: No lineOptions() call here because we do not remember ACL "line"
     // boundaries and associated "line" options; we cannot report them.
@@ -335,7 +335,7 @@ Acl::AclNode::dumpWhole(const char * const directiveName, std::ostream &os)
 /* ACL result caching routines */
 
 int
-Acl::AclNode::matchForCache(ACLChecklist *)
+Acl::Node::matchForCache(ACLChecklist *)
 {
     /* This is a fatal to ensure that cacheMatchAcl calls are _only_
      * made for supported acl types */
@@ -353,7 +353,7 @@ Acl::AclNode::matchForCache(ACLChecklist *)
  * TODO: does a dlink_list perform well enough? Kinkie
  */
 int
-Acl::AclNode::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
+Acl::Node::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
 {
     acl_proxy_auth_match_cache *auth_match;
     dlink_node *link;
@@ -395,19 +395,19 @@ aclCacheMatchFlush(dlink_list * cache)
 }
 
 bool
-Acl::AclNode::requiresAle() const
+Acl::Node::requiresAle() const
 {
     return false;
 }
 
 bool
-Acl::AclNode::requiresReply() const
+Acl::Node::requiresReply() const
 {
     return false;
 }
 
 bool
-Acl::AclNode::requiresRequest() const
+Acl::Node::requiresRequest() const
 {
     return false;
 }
@@ -416,7 +416,7 @@ Acl::AclNode::requiresRequest() const
 /* Destroy functions */
 /*********************/
 
-Acl::AclNode::~AclNode()
+Acl::Node::~Node()
 {
     debugs(28, 3, "freeing ACL " << name);
     safe_free(cfgline);
@@ -424,10 +424,10 @@ Acl::AclNode::~AclNode()
 }
 
 void
-Acl::AclNode::Initialize()
+Acl::Node::Initialize()
 {
     auto *a = Config.aclList;
-    debugs(53, 3, "Acl::AclNode::Initialize");
+    debugs(53, 3, "Acl::Node::Initialize");
 
     while (a) {
         a->prepareForUse();

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -60,7 +60,7 @@ Make(TypeName typeName)
         assert(false); // not reached
     }
 
-    AclNode *result = (pos->second)(pos->first);
+    auto *result = (pos->second)(pos->first);
     debugs(28, 4, typeName << '=' << result);
     assert(result);
     return result;
@@ -117,10 +117,9 @@ void AclNode::operator delete(void *)
 AclNode *
 AclNode::FindByName(const char *name)
 {
-    AclNode *a;
     debugs(28, 9, "name=" << name);
 
-    for (a = Config.aclList; a; a = a->next)
+    for (auto *a = Config.aclList; a; a = a->next)
         if (!strcasecmp(a->name, name))
             return a;
 

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -37,7 +37,7 @@ public:
     bool operator()(TypeName a, TypeName b) const { return strcmp(a, b) < 0; }
 };
 
-/// Acl::Node makers indexed by Acl::Node type name
+/// Acl::Node makers indexed by Node type name
 typedef std::map<TypeName, Maker, TypeNameCmp> Makers;
 
 /// registered Acl::Node Makers
@@ -48,7 +48,7 @@ TheMakers()
     return Registry;
 }
 
-/// creates an Acl::Node object of the named (and already registered) Acl::Node child type
+/// creates an Acl::Node object of the named (and already registered) Node child type
 static
 Acl::Node *
 Make(TypeName typeName)
@@ -168,7 +168,7 @@ Acl::Node::matches(ACLChecklist *checklist) const
             checklist->verifyAle();
 
         // have to cast because old match() API is missing const
-        result = const_cast<Acl::Node*>(this)->match(checklist);
+        result = const_cast<Node*>(this)->match(checklist);
     }
 
     const char *extra = checklist->asyncInProgress() ? " async" : "";
@@ -188,11 +188,11 @@ Acl::Node::context(const char *aName, const char *aCfgLine)
 }
 
 void
-Acl::Node::ParseAclLine(ConfigParser &parser, Acl::Node ** head)
+Acl::Node::ParseAclLine(ConfigParser &parser, Node ** head)
 {
     /* we're already using strtok() to grok the line */
     char *t = nullptr;
-    Acl::Node *A = nullptr;
+    Node *A = nullptr;
     LOCAL_ARRAY(char, aclname, ACL_NAME_SZ);
     int new_acl = 0;
 

--- a/src/acl/Acl.cc
+++ b/src/acl/Acl.cc
@@ -31,16 +31,16 @@ const char *AclMatchedName = nullptr;
 
 namespace Acl {
 
-/// AclNode type name comparison functor
+/// Acl::AclNode type name comparison functor
 class TypeNameCmp {
 public:
     bool operator()(TypeName a, TypeName b) const { return strcmp(a, b) < 0; }
 };
 
-/// AclNode makers indexed by AclNode type name
+/// Acl::AclNode makers indexed by Acl::AclNode type name
 typedef std::map<TypeName, Maker, TypeNameCmp> Makers;
 
-/// registered AclNode Makers
+/// registered Acl::AclNode Makers
 static Makers &
 TheMakers()
 {
@@ -48,9 +48,9 @@ TheMakers()
     return Registry;
 }
 
-/// creates an AclNode object of the named (and already registered) AclNode child type
+/// creates an Acl::AclNode object of the named (and already registered) Acl::AclNode child type
 static
-AclNode *
+Acl::AclNode *
 Make(TypeName typeName)
 {
     const auto pos = TheMakers().find(typeName);
@@ -103,19 +103,19 @@ Acl::SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey)
 }
 
 void *
-AclNode::operator new (size_t)
+Acl::AclNode::operator new (size_t)
 {
-    fatal ("unusable AclNode::new");
+    fatal ("unusable Acl::AclNode::new");
     return (void *)1;
 }
 
-void AclNode::operator delete(void *)
+void Acl::AclNode::operator delete(void *)
 {
-    fatal ("unusable AclNode::delete");
+    fatal ("unusable Acl::AclNode::delete");
 }
 
-AclNode *
-AclNode::FindByName(const char *name)
+Acl::AclNode *
+Acl::AclNode::FindByName(const char *name)
 {
     debugs(28, 9, "name=" << name);
 
@@ -128,7 +128,7 @@ AclNode::FindByName(const char *name)
     return nullptr;
 }
 
-AclNode::AclNode() :
+Acl::AclNode::AclNode() :
     cfgline(nullptr),
     next(nullptr),
     registered(false)
@@ -137,13 +137,13 @@ AclNode::AclNode() :
 }
 
 bool
-AclNode::valid() const
+Acl::AclNode::valid() const
 {
     return true;
 }
 
 bool
-AclNode::matches(ACLChecklist *checklist) const
+Acl::AclNode::matches(ACLChecklist *checklist) const
 {
     debugs(28, 5, "checking " << name);
 
@@ -168,7 +168,7 @@ AclNode::matches(ACLChecklist *checklist) const
             checklist->verifyAle();
 
         // have to cast because old match() API is missing const
-        result = const_cast<AclNode*>(this)->match(checklist);
+        result = const_cast<Acl::AclNode*>(this)->match(checklist);
     }
 
     const char *extra = checklist->asyncInProgress() ? " async" : "";
@@ -177,7 +177,7 @@ AclNode::matches(ACLChecklist *checklist) const
 }
 
 void
-AclNode::context(const char *aName, const char *aCfgLine)
+Acl::AclNode::context(const char *aName, const char *aCfgLine)
 {
     name[0] = '\0';
     if (aName)
@@ -188,11 +188,11 @@ AclNode::context(const char *aName, const char *aCfgLine)
 }
 
 void
-AclNode::ParseAclLine(ConfigParser &parser, AclNode ** head)
+Acl::AclNode::ParseAclLine(ConfigParser &parser, Acl::AclNode ** head)
 {
     /* we're already using strtok() to grok the line */
     char *t = nullptr;
-    AclNode *A = nullptr;
+    Acl::AclNode *A = nullptr;
     LOCAL_ARRAY(char, aclname, ACL_NAME_SZ);
     int new_acl = 0;
 
@@ -306,13 +306,13 @@ AclNode::ParseAclLine(ConfigParser &parser, AclNode ** head)
 }
 
 bool
-AclNode::isProxyAuth() const
+Acl::AclNode::isProxyAuth() const
 {
     return false;
 }
 
 void
-AclNode::parseFlags()
+Acl::AclNode::parseFlags()
 {
     Acl::Options allOptions = options();
     for (const auto lineOption: lineOptions()) {
@@ -323,7 +323,7 @@ AclNode::parseFlags()
 }
 
 void
-AclNode::dumpWhole(const char * const directiveName, std::ostream &os)
+Acl::AclNode::dumpWhole(const char * const directiveName, std::ostream &os)
 {
     // XXX: No lineOptions() call here because we do not remember ACL "line"
     // boundaries and associated "line" options; we cannot report them.
@@ -335,7 +335,7 @@ AclNode::dumpWhole(const char * const directiveName, std::ostream &os)
 /* ACL result caching routines */
 
 int
-AclNode::matchForCache(ACLChecklist *)
+Acl::AclNode::matchForCache(ACLChecklist *)
 {
     /* This is a fatal to ensure that cacheMatchAcl calls are _only_
      * made for supported acl types */
@@ -353,7 +353,7 @@ AclNode::matchForCache(ACLChecklist *)
  * TODO: does a dlink_list perform well enough? Kinkie
  */
 int
-AclNode::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
+Acl::AclNode::cacheMatchAcl(dlink_list * cache, ACLChecklist *checklist)
 {
     acl_proxy_auth_match_cache *auth_match;
     dlink_node *link;
@@ -395,19 +395,19 @@ aclCacheMatchFlush(dlink_list * cache)
 }
 
 bool
-AclNode::requiresAle() const
+Acl::AclNode::requiresAle() const
 {
     return false;
 }
 
 bool
-AclNode::requiresReply() const
+Acl::AclNode::requiresReply() const
 {
     return false;
 }
 
 bool
-AclNode::requiresRequest() const
+Acl::AclNode::requiresRequest() const
 {
     return false;
 }
@@ -416,7 +416,7 @@ AclNode::requiresRequest() const
 /* Destroy functions */
 /*********************/
 
-AclNode::~AclNode()
+Acl::AclNode::~AclNode()
 {
     debugs(28, 3, "freeing ACL " << name);
     safe_free(cfgline);
@@ -424,10 +424,10 @@ AclNode::~AclNode()
 }
 
 void
-AclNode::Initialize()
+Acl::AclNode::Initialize()
 {
     auto *a = Config.aclList;
-    debugs(53, 3, "AclNode::Initialize");
+    debugs(53, 3, "Acl::AclNode::Initialize");
 
     while (a) {
         a->prepareForUse();

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -24,9 +24,9 @@ class ConfigParser;
 namespace Acl {
 
 /// the ACL type name known to admins
-typedef const char *TypeName;
+using TypeName = const char *;
 /// a "factory" function for making AclNode objects (of some AclNode child type)
-typedef AclNode *(*Maker)(TypeName typeName);
+using Maker = AclNode *(*)(TypeName typeName);
 /// use the given AclNode Maker for all ACLs of the named type
 void RegisterMaker(TypeName typeName, Maker maker);
 

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -25,9 +25,9 @@ namespace Acl {
 
 /// the ACL type name known to admins
 typedef const char *TypeName;
-/// a "factory" function for making ACL objects (of some ACL child type)
-typedef ACL *(*Maker)(TypeName typeName);
-/// use the given ACL Maker for all ACLs of the named type
+/// a "factory" function for making AclNode objects (of some AclNode child type)
+typedef AclNode *(*Maker)(TypeName typeName);
+/// use the given AclNode Maker for all ACLs of the named type
 void RegisterMaker(TypeName typeName, Maker maker);
 
 /// Validate and store the ACL key parameter for ACL types
@@ -42,31 +42,31 @@ void SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey);
 /// Can evaluate itself in FilledChecklist context.
 /// Does not change during evaluation.
 /// \ingroup ACLAPI
-class ACL
+class AclNode
 {
 
 public:
     void *operator new(size_t);
     void operator delete(void *);
 
-    static void ParseAclLine(ConfigParser &parser, ACL ** head);
+    static void ParseAclLine(ConfigParser &parser, AclNode ** head);
     static void Initialize();
-    static ACL *FindByName(const char *name);
+    static AclNode *FindByName(const char *name);
 
-    ACL();
-    ACL(ACL &&) = delete; // no copying of any kind
-    virtual ~ACL();
+    AclNode();
+    AclNode(AclNode &&) = delete; // no copying of any kind
+    virtual ~AclNode();
 
     /// sets user-specified ACL name and squid.conf context
     void context(const char *name, const char *configuration);
 
-    /// Orchestrates matching checklist against the ACL using match(),
+    /// Orchestrates matching checklist against the AclNode using match(),
     /// after checking preconditions and while providing debugging.
     /// \return true if and only if there was a successful match.
     /// Updates the checklist state on match, async, and failure.
     bool matches(ACLChecklist *checklist) const;
 
-    /// configures ACL options, throwing on configuration errors
+    /// configures AclNode options, throwing on configuration errors
     void parseFlags();
 
     /// parses node representation in squid.conf; dies on failures
@@ -90,11 +90,11 @@ public:
 
     char name[ACL_NAME_SZ];
     char *cfgline;
-    ACL *next; // XXX: remove or at least use refcounting
+    AclNode *next; // XXX: remove or at least use refcounting
     bool registered; ///< added to the global list of ACLs via aclRegister()
 
 private:
-    /// Matches the actual data in checklist against this ACL.
+    /// Matches the actual data in checklist against this AclNode.
     virtual int match(ACLChecklist *checklist) = 0; // XXX: missing const
 
     /// whether our (i.e. shallow) match() requires checklist to have a AccessLogEntry
@@ -105,27 +105,27 @@ private:
     virtual bool requiresReply() const;
 
     // TODO: Rename to globalOptions(); these are not the only supported options
-    /// \returns (linked) 'global' Options supported by this ACL
+    /// \returns (linked) 'global' Options supported by this AclNode
     virtual const Acl::Options &options() { return Acl::NoOptions(); }
 
-    /// \returns (linked) "line" Options supported by this ACL
-    /// \see ACL::options()
+    /// \returns (linked) "line" Options supported by this AclNode
+    /// \see AclNode::options()
     virtual const Acl::Options &lineOptions() { return Acl::NoOptions(); }
 };
 
 /// \ingroup ACLAPI
 typedef enum {
-    // Authorization ACL result states
+    // Authorization AclNode result states
     ACCESS_DENIED,
     ACCESS_ALLOWED,
     ACCESS_DUNNO,
 
-    // Authentication ACL result states
+    // Authentication AclNode result states
     ACCESS_AUTH_REQUIRED,    // Missing Credentials
 } aclMatchCode;
 
 /// \ingroup ACLAPI
-/// ACL check answer
+/// AclNode check answer
 namespace Acl {
 
 class Answer
@@ -216,7 +216,7 @@ public:
 };
 
 /// \ingroup ACLAPI
-/// XXX: find a way to remove or at least use a refcounted ACL pointer
+/// XXX: find a way to remove or at least use a refcounted AclNode pointer
 extern const char *AclMatchedName;  /* NULL */
 
 #endif /* SQUID_ACL_H */

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -25,9 +25,9 @@ namespace Acl {
 
 /// the ACL type name known to admins
 using TypeName = const char *;
-/// a "factory" function for making Acl::AclNode objects (of some Acl::AclNode child type)
-using Maker = AclNode *(*)(TypeName typeName);
-/// use the given Acl::AclNode Maker for all ACLs of the named type
+/// a "factory" function for making Acl::Node objects (of some Acl::Node child type)
+using Maker = Node *(*)(TypeName typeName);
+/// use the given Acl::Node Maker for all ACLs of the named type
 void RegisterMaker(TypeName typeName, Maker maker);
 
 /// Validate and store the ACL key parameter for ACL types
@@ -40,31 +40,31 @@ void SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey);
 /// Can evaluate itself in FilledChecklist context.
 /// Does not change during evaluation.
 /// \ingroup ACLAPI
-class AclNode
+class Node
 {
 
 public:
     void *operator new(size_t);
     void operator delete(void *);
 
-    static void ParseAclLine(ConfigParser &parser, Acl::AclNode ** head);
+    static void ParseAclLine(ConfigParser &parser, Acl::Node ** head);
     static void Initialize();
-    static Acl::AclNode *FindByName(const char *name);
+    static Acl::Node *FindByName(const char *name);
 
-    AclNode();
-    AclNode(AclNode &&) = delete; // no copying of any kind
-    virtual ~AclNode();
+    Node();
+    Node(Node &&) = delete; // no copying of any kind
+    virtual ~Node();
 
     /// sets user-specified ACL name and squid.conf context
     void context(const char *name, const char *configuration);
 
-    /// Orchestrates matching checklist against the Acl::AclNode using match(),
+    /// Orchestrates matching checklist against the Acl::Node using match(),
     /// after checking preconditions and while providing debugging.
     /// \return true if and only if there was a successful match.
     /// Updates the checklist state on match, async, and failure.
     bool matches(ACLChecklist *checklist) const;
 
-    /// configures Acl::AclNode options, throwing on configuration errors
+    /// configures Acl::Node options, throwing on configuration errors
     void parseFlags();
 
     /// parses node representation in squid.conf; dies on failures
@@ -88,11 +88,11 @@ public:
 
     char name[ACL_NAME_SZ];
     char *cfgline;
-    Acl::AclNode *next; // XXX: remove or at least use refcounting
+    Acl::Node *next; // XXX: remove or at least use refcounting
     bool registered; ///< added to the global list of ACLs via aclRegister()
 
 private:
-    /// Matches the actual data in checklist against this Acl::AclNode.
+    /// Matches the actual data in checklist against this Acl::Node.
     virtual int match(ACLChecklist *checklist) = 0; // XXX: missing const
 
     /// whether our (i.e. shallow) match() requires checklist to have a AccessLogEntry
@@ -103,11 +103,11 @@ private:
     virtual bool requiresReply() const;
 
     // TODO: Rename to globalOptions(); these are not the only supported options
-    /// \returns (linked) 'global' Options supported by this Acl::AclNode
+    /// \returns (linked) 'global' Options supported by this Acl::Node
     virtual const Acl::Options &options() { return Acl::NoOptions(); }
 
-    /// \returns (linked) "line" Options supported by this Acl::AclNode
-    /// \see Acl::AclNode::options()
+    /// \returns (linked) "line" Options supported by this Acl::Node
+    /// \see Acl::Node::options()
     virtual const Acl::Options &lineOptions() { return Acl::NoOptions(); }
 };
 
@@ -115,17 +115,17 @@ private:
 
 /// \ingroup ACLAPI
 typedef enum {
-    // Authorization Acl::AclNode result states
+    // Authorization Acl::Node result states
     ACCESS_DENIED,
     ACCESS_ALLOWED,
     ACCESS_DUNNO,
 
-    // Authentication Acl::AclNode result states
+    // Authentication Acl::Node result states
     ACCESS_AUTH_REQUIRED,    // Missing Credentials
 } aclMatchCode;
 
 /// \ingroup ACLAPI
-/// Acl::AclNode check answer
+/// Acl::Node check answer
 namespace Acl {
 
 class Answer
@@ -216,7 +216,7 @@ public:
 };
 
 /// \ingroup ACLAPI
-/// XXX: find a way to remove or at least use a refcounted Acl::AclNode pointer
+/// XXX: find a way to remove or at least use a refcounted Acl::Node pointer
 extern const char *AclMatchedName;  /* NULL */
 
 #endif /* SQUID_ACL_H */

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -21,7 +21,7 @@ namespace Acl {
 
 /// the ACL type name known to admins
 using TypeName = const char *;
-/// a "factory" function for making Acl::Node objects (of some Acl::Node child type)
+/// a "factory" function for making Acl::Node objects (of some Node child type)
 using Maker = Node *(*)(TypeName typeName);
 /// use the given Acl::Node Maker for all ACLs of the named type
 void RegisterMaker(TypeName typeName, Maker maker);
@@ -36,7 +36,7 @@ void SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey);
 
 /// \ingroup ACLAPI
 typedef enum {
-    // Authorization Acl::Node result states
+    // Authorization ACL result states
     ACCESS_DENIED,
     ACCESS_ALLOWED,
     ACCESS_DUNNO,

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -25,9 +25,9 @@ namespace Acl {
 
 /// the ACL type name known to admins
 using TypeName = const char *;
-/// a "factory" function for making AclNode objects (of some AclNode child type)
+/// a "factory" function for making Acl::AclNode objects (of some Acl::AclNode child type)
 using Maker = AclNode *(*)(TypeName typeName);
-/// use the given AclNode Maker for all ACLs of the named type
+/// use the given Acl::AclNode Maker for all ACLs of the named type
 void RegisterMaker(TypeName typeName, Maker maker);
 
 /// Validate and store the ACL key parameter for ACL types
@@ -35,8 +35,6 @@ void RegisterMaker(TypeName typeName, Maker maker);
 /// require unique key values (if any) for each aclname+type combination.
 /// Key comparison is case-insensitive.
 void SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey);
-
-} // namespace Acl
 
 /// A configurable condition. A node in the ACL expression tree.
 /// Can evaluate itself in FilledChecklist context.
@@ -49,9 +47,9 @@ public:
     void *operator new(size_t);
     void operator delete(void *);
 
-    static void ParseAclLine(ConfigParser &parser, AclNode ** head);
+    static void ParseAclLine(ConfigParser &parser, Acl::AclNode ** head);
     static void Initialize();
-    static AclNode *FindByName(const char *name);
+    static Acl::AclNode *FindByName(const char *name);
 
     AclNode();
     AclNode(AclNode &&) = delete; // no copying of any kind
@@ -60,13 +58,13 @@ public:
     /// sets user-specified ACL name and squid.conf context
     void context(const char *name, const char *configuration);
 
-    /// Orchestrates matching checklist against the AclNode using match(),
+    /// Orchestrates matching checklist against the Acl::AclNode using match(),
     /// after checking preconditions and while providing debugging.
     /// \return true if and only if there was a successful match.
     /// Updates the checklist state on match, async, and failure.
     bool matches(ACLChecklist *checklist) const;
 
-    /// configures AclNode options, throwing on configuration errors
+    /// configures Acl::AclNode options, throwing on configuration errors
     void parseFlags();
 
     /// parses node representation in squid.conf; dies on failures
@@ -90,11 +88,11 @@ public:
 
     char name[ACL_NAME_SZ];
     char *cfgline;
-    AclNode *next; // XXX: remove or at least use refcounting
+    Acl::AclNode *next; // XXX: remove or at least use refcounting
     bool registered; ///< added to the global list of ACLs via aclRegister()
 
 private:
-    /// Matches the actual data in checklist against this AclNode.
+    /// Matches the actual data in checklist against this Acl::AclNode.
     virtual int match(ACLChecklist *checklist) = 0; // XXX: missing const
 
     /// whether our (i.e. shallow) match() requires checklist to have a AccessLogEntry
@@ -105,27 +103,29 @@ private:
     virtual bool requiresReply() const;
 
     // TODO: Rename to globalOptions(); these are not the only supported options
-    /// \returns (linked) 'global' Options supported by this AclNode
+    /// \returns (linked) 'global' Options supported by this Acl::AclNode
     virtual const Acl::Options &options() { return Acl::NoOptions(); }
 
-    /// \returns (linked) "line" Options supported by this AclNode
-    /// \see AclNode::options()
+    /// \returns (linked) "line" Options supported by this Acl::AclNode
+    /// \see Acl::AclNode::options()
     virtual const Acl::Options &lineOptions() { return Acl::NoOptions(); }
 };
 
+}  // namespace Acl
+
 /// \ingroup ACLAPI
 typedef enum {
-    // Authorization AclNode result states
+    // Authorization Acl::AclNode result states
     ACCESS_DENIED,
     ACCESS_ALLOWED,
     ACCESS_DUNNO,
 
-    // Authentication AclNode result states
+    // Authentication Acl::AclNode result states
     ACCESS_AUTH_REQUIRED,    // Missing Credentials
 } aclMatchCode;
 
 /// \ingroup ACLAPI
-/// AclNode check answer
+/// Acl::AclNode check answer
 namespace Acl {
 
 class Answer
@@ -216,7 +216,7 @@ public:
 };
 
 /// \ingroup ACLAPI
-/// XXX: find a way to remove or at least use a refcounted AclNode pointer
+/// XXX: find a way to remove or at least use a refcounted Acl::AclNode pointer
 extern const char *AclMatchedName;  /* NULL */
 
 #endif /* SQUID_ACL_H */

--- a/src/acl/Acl.h
+++ b/src/acl/Acl.h
@@ -10,16 +10,12 @@
 #define SQUID_ACL_H
 
 #include "acl/forward.h"
-#include "acl/Options.h"
-#include "cbdata.h"
 #include "defines.h"
 #include "dlink.h"
 #include "sbuf/forward.h"
 
 #include <algorithm>
 #include <ostream>
-
-class ConfigParser;
 
 namespace Acl {
 
@@ -35,81 +31,6 @@ void RegisterMaker(TypeName typeName, Maker maker);
 /// require unique key values (if any) for each aclname+type combination.
 /// Key comparison is case-insensitive.
 void SetKey(SBuf &keyStorage, const char *keyParameterName, const char *newKey);
-
-/// A configurable condition. A node in the ACL expression tree.
-/// Can evaluate itself in FilledChecklist context.
-/// Does not change during evaluation.
-/// \ingroup ACLAPI
-class Node
-{
-
-public:
-    void *operator new(size_t);
-    void operator delete(void *);
-
-    static void ParseAclLine(ConfigParser &parser, Acl::Node ** head);
-    static void Initialize();
-    static Acl::Node *FindByName(const char *name);
-
-    Node();
-    Node(Node &&) = delete; // no copying of any kind
-    virtual ~Node();
-
-    /// sets user-specified ACL name and squid.conf context
-    void context(const char *name, const char *configuration);
-
-    /// Orchestrates matching checklist against the Acl::Node using match(),
-    /// after checking preconditions and while providing debugging.
-    /// \return true if and only if there was a successful match.
-    /// Updates the checklist state on match, async, and failure.
-    bool matches(ACLChecklist *checklist) const;
-
-    /// configures Acl::Node options, throwing on configuration errors
-    void parseFlags();
-
-    /// parses node representation in squid.conf; dies on failures
-    virtual void parse() = 0;
-    virtual char const *typeString() const = 0;
-    virtual bool isProxyAuth() const;
-    virtual SBufList dump() const = 0;
-    virtual bool empty() const = 0;
-    virtual bool valid() const;
-
-    int cacheMatchAcl(dlink_list * cache, ACLChecklist *);
-    virtual int matchForCache(ACLChecklist *checklist);
-
-    virtual void prepareForUse() {}
-
-    // TODO: Find a way to make options() and this method constant
-    /// Prints aggregated "acl" (or similar) directive configuration, including
-    /// the given directive name, ACL name, ACL type, and ACL parameters. The
-    /// printed parameters are collected from all same-name "acl" directives.
-    void dumpWhole(const char *directiveName, std::ostream &);
-
-    char name[ACL_NAME_SZ];
-    char *cfgline;
-    Acl::Node *next; // XXX: remove or at least use refcounting
-    bool registered; ///< added to the global list of ACLs via aclRegister()
-
-private:
-    /// Matches the actual data in checklist against this Acl::Node.
-    virtual int match(ACLChecklist *checklist) = 0; // XXX: missing const
-
-    /// whether our (i.e. shallow) match() requires checklist to have a AccessLogEntry
-    virtual bool requiresAle() const;
-    /// whether our (i.e. shallow) match() requires checklist to have a request
-    virtual bool requiresRequest() const;
-    /// whether our (i.e. shallow) match() requires checklist to have a reply
-    virtual bool requiresReply() const;
-
-    // TODO: Rename to globalOptions(); these are not the only supported options
-    /// \returns (linked) 'global' Options supported by this Acl::Node
-    virtual const Acl::Options &options() { return Acl::NoOptions(); }
-
-    /// \returns (linked) "line" Options supported by this Acl::Node
-    /// \see Acl::Node::options()
-    virtual const Acl::Options &lineOptions() { return Acl::NoOptions(); }
-};
 
 }  // namespace Acl
 

--- a/src/acl/AdaptationService.h
+++ b/src/acl/AdaptationService.h
@@ -19,7 +19,7 @@ namespace Acl
 class AdaptationServiceCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/AdaptationService.h
+++ b/src/acl/AdaptationService.h
@@ -19,7 +19,7 @@ namespace Acl
 class AdaptationServiceCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/AdaptationService.h
+++ b/src/acl/AdaptationService.h
@@ -19,7 +19,7 @@ namespace Acl
 class AdaptationServiceCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Address.h
+++ b/src/acl/Address.h
@@ -10,6 +10,7 @@
 #define _SQUID_SRC_ACL_ADDRESS_H
 
 #include "acl/Acl.h"
+#include "cbdata.h"
 #include "ip/Address.h"
 
 namespace Acl

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -47,7 +47,7 @@ void
 Acl::AllOf::parse()
 {
     Acl::InnerNode *whole = nullptr;
-    Acl::AclNode *oldNode = empty() ? nullptr : nodes.front();
+    Acl::Node *oldNode = empty() ? nullptr : nodes.front();
 
     // optimization: this logic reduces subtree hight (number of tree levels)
     if (Acl::OrNode *oldWhole = dynamic_cast<Acl::OrNode*>(oldNode)) {

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -47,7 +47,7 @@ void
 Acl::AllOf::parse()
 {
     Acl::InnerNode *whole = nullptr;
-    AclNode *oldNode = empty() ? nullptr : nodes.front();
+    Acl::AclNode *oldNode = empty() ? nullptr : nodes.front();
 
     // optimization: this logic reduces subtree hight (number of tree levels)
     if (Acl::OrNode *oldWhole = dynamic_cast<Acl::OrNode*>(oldNode)) {

--- a/src/acl/AllOf.cc
+++ b/src/acl/AllOf.cc
@@ -47,7 +47,7 @@ void
 Acl::AllOf::parse()
 {
     Acl::InnerNode *whole = nullptr;
-    ACL *oldNode = empty() ? nullptr : nodes.front();
+    AclNode *oldNode = empty() ? nullptr : nodes.front();
 
     // optimization: this logic reduces subtree hight (number of tree levels)
     if (Acl::OrNode *oldWhole = dynamic_cast<Acl::OrNode*>(oldNode)) {

--- a/src/acl/AllOf.h
+++ b/src/acl/AllOf.h
@@ -22,7 +22,7 @@ class AllOf: public Acl::InnerNode
     MEMPROXY_CLASS(AllOf);
 
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;

--- a/src/acl/AllOf.h
+++ b/src/acl/AllOf.h
@@ -22,7 +22,7 @@ class AllOf: public Acl::InnerNode
     MEMPROXY_CLASS(AllOf);
 
 public:
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;

--- a/src/acl/AllOf.h
+++ b/src/acl/AllOf.h
@@ -22,7 +22,7 @@ class AllOf: public Acl::InnerNode
     MEMPROXY_CLASS(AllOf);
 
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -18,7 +18,7 @@ namespace Acl
 class AnnotateClientCheck: public Acl::AnnotationCheck
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -18,7 +18,7 @@ namespace Acl
 class AnnotateClientCheck: public Acl::AnnotationCheck
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -18,7 +18,7 @@ namespace Acl
 class AnnotateClientCheck: public Acl::AnnotationCheck
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/AnnotateTransaction.h
+++ b/src/acl/AnnotateTransaction.h
@@ -18,7 +18,7 @@ namespace Acl
 class AnnotateTransactionCheck: public Acl::AnnotationCheck
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/AnnotateTransaction.h
+++ b/src/acl/AnnotateTransaction.h
@@ -18,7 +18,7 @@ namespace Acl
 class AnnotateTransactionCheck: public Acl::AnnotationCheck
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/AnnotateTransaction.h
+++ b/src/acl/AnnotateTransaction.h
@@ -18,7 +18,7 @@ namespace Acl
 class AnnotateTransactionCheck: public Acl::AnnotationCheck
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/AnyOf.h
+++ b/src/acl/AnyOf.h
@@ -20,7 +20,7 @@ class AnyOf: public Acl::OrNode
     MEMPROXY_CLASS(AnyOf);
 
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
 };

--- a/src/acl/AnyOf.h
+++ b/src/acl/AnyOf.h
@@ -20,7 +20,7 @@ class AnyOf: public Acl::OrNode
     MEMPROXY_CLASS(AnyOf);
 
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
 };

--- a/src/acl/AnyOf.h
+++ b/src/acl/AnyOf.h
@@ -20,7 +20,7 @@ class AnyOf: public Acl::OrNode
     MEMPROXY_CLASS(AnyOf);
 
 public:
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
 };

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -15,7 +15,7 @@
 #include <set>
 
 /// \ingroup ACLAPI
-class ACLARP : public ACL
+class ACLARP : public AclNode
 {
     MEMPROXY_CLASS(ACLARP);
 

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -15,7 +15,7 @@
 #include <set>
 
 /// \ingroup ACLAPI
-class ACLARP : public Acl::AclNode
+class ACLARP : public Acl::Node
 {
     MEMPROXY_CLASS(ACLARP);
 

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACLARP_H
 #define SQUID_ACLARP_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "eui/Eui48.h"
 
 #include <set>

--- a/src/acl/Arp.h
+++ b/src/acl/Arp.h
@@ -15,7 +15,7 @@
 #include <set>
 
 /// \ingroup ACLAPI
-class ACLARP : public AclNode
+class ACLARP : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLARP);
 

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -116,7 +116,7 @@ static int printRadixNode(struct squid_radix_node *rn, void *sentry);
 }
 #endif
 
-void asnAclInitialize(AclNode * acls);
+void asnAclInitialize(Acl::AclNode * acls);
 
 static void destroyRadixNodeInfo(as_info *);
 

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -116,7 +116,7 @@ static int printRadixNode(struct squid_radix_node *rn, void *sentry);
 }
 #endif
 
-void asnAclInitialize(Acl::AclNode * acls);
+void asnAclInitialize(Acl::Node * acls);
 
 static void destroyRadixNodeInfo(as_info *);
 

--- a/src/acl/Asn.cc
+++ b/src/acl/Asn.cc
@@ -116,7 +116,7 @@ static int printRadixNode(struct squid_radix_node *rn, void *sentry);
 }
 #endif
 
-void asnAclInitialize(ACL * acls);
+void asnAclInitialize(AclNode * acls);
 
 static void destroyRadixNodeInfo(as_info *);
 

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -20,7 +20,7 @@ namespace Acl
 class AtStepCheck: public ParameterizedNode< ACLData<XactionStep> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -20,7 +20,7 @@ namespace Acl
 class AtStepCheck: public ParameterizedNode< ACLData<XactionStep> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/AtStep.h
+++ b/src/acl/AtStep.h
@@ -20,7 +20,7 @@ namespace Acl
 class AtStepCheck: public ParameterizedNode< ACLData<XactionStep> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -14,7 +14,7 @@
 
 /* Acl::NotNode */
 
-Acl::NotNode::NotNode(AclNode *acl)
+Acl::NotNode::NotNode(Acl::AclNode *acl)
 {
     assert(acl);
     Must(strlen(acl->name) <= sizeof(name)-2);

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -14,7 +14,7 @@
 
 /* Acl::NotNode */
 
-Acl::NotNode::NotNode(ACL *acl)
+Acl::NotNode::NotNode(AclNode *acl)
 {
     assert(acl);
     Must(strlen(acl->name) <= sizeof(name)-2);

--- a/src/acl/BoolOps.cc
+++ b/src/acl/BoolOps.cc
@@ -14,7 +14,7 @@
 
 /* Acl::NotNode */
 
-Acl::NotNode::NotNode(Acl::AclNode *acl)
+Acl::NotNode::NotNode(Acl::Node *acl)
 {
     assert(acl);
     Must(strlen(acl->name) <= sizeof(name)-2);

--- a/src/acl/BoolOps.h
+++ b/src/acl/BoolOps.h
@@ -24,10 +24,10 @@ class NotNode: public InnerNode
     MEMPROXY_CLASS(NotNode);
 
 public:
-    explicit NotNode(Acl::AclNode *acl);
+    explicit NotNode(Acl::Node *acl);
 
 private:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;
@@ -64,7 +64,7 @@ public:
     /// on its action
     virtual bool bannedAction(ACLChecklist *, Nodes::const_iterator) const;
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
 

--- a/src/acl/BoolOps.h
+++ b/src/acl/BoolOps.h
@@ -24,10 +24,10 @@ class NotNode: public InnerNode
     MEMPROXY_CLASS(NotNode);
 
 public:
-    explicit NotNode(ACL *acl);
+    explicit NotNode(AclNode *acl);
 
 private:
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;
@@ -64,7 +64,7 @@ public:
     /// on its action
     virtual bool bannedAction(ACLChecklist *, Nodes::const_iterator) const;
 
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
 

--- a/src/acl/BoolOps.h
+++ b/src/acl/BoolOps.h
@@ -24,10 +24,10 @@ class NotNode: public InnerNode
     MEMPROXY_CLASS(NotNode);
 
 public:
-    explicit NotNode(AclNode *acl);
+    explicit NotNode(Acl::AclNode *acl);
 
 private:
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
     SBufList dump() const override;
@@ -64,7 +64,7 @@ public:
     /// on its action
     virtual bool bannedAction(ACLChecklist *, Nodes::const_iterator) const;
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
 

--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -21,7 +21,7 @@ namespace Acl
 class ClientCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -21,7 +21,7 @@ namespace Acl
 class ClientCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Certificate.h
+++ b/src/acl/Certificate.h
@@ -21,7 +21,7 @@ namespace Acl
 class ClientCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -207,7 +207,7 @@ ACLChecklist::nonBlockingCheck(ACLCB * callback_, void *callback_data_)
     callback_data = cbdataReference(callback_data_);
     asyncCaller_ = true;
 
-    /** The Acl::Node List should NEVER be NULL when calling this method.
+    /** The ACL list should NEVER be NULL when calling this method.
      * Always caller should check for NULL and handle appropriate to its needs first.
      * We cannot select a sensible default for all callers here. */
     if (accessList == nullptr) {

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -79,7 +79,7 @@ ACLChecklist::preCheck(const char *what)
 }
 
 bool
-ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const Acl::AclNode *child)
+ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const Acl::Node *child)
 {
     assert(current && child);
 
@@ -112,7 +112,7 @@ ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterat
 }
 
 bool
-ACLChecklist::goAsync(AsyncStarter starter, const Acl::AclNode &acl)
+ACLChecklist::goAsync(AsyncStarter starter, const Acl::Node &acl)
 {
     assert(!asyncInProgress());
     assert(matchLoc_.parent);
@@ -207,7 +207,7 @@ ACLChecklist::nonBlockingCheck(ACLCB * callback_, void *callback_data_)
     callback_data = cbdataReference(callback_data_);
     asyncCaller_ = true;
 
-    /** The Acl::AclNode List should NEVER be NULL when calling this method.
+    /** The Acl::Node List should NEVER be NULL when calling this method.
      * Always caller should check for NULL and handle appropriate to its needs first.
      * We cannot select a sensible default for all callers here. */
     if (accessList == nullptr) {

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -79,7 +79,7 @@ ACLChecklist::preCheck(const char *what)
 }
 
 bool
-ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const ACL *child)
+ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const AclNode *child)
 {
     assert(current && child);
 
@@ -112,7 +112,7 @@ ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterat
 }
 
 bool
-ACLChecklist::goAsync(AsyncStarter starter, const ACL &acl)
+ACLChecklist::goAsync(AsyncStarter starter, const AclNode &acl)
 {
     assert(!asyncInProgress());
     assert(matchLoc_.parent);
@@ -207,7 +207,7 @@ ACLChecklist::nonBlockingCheck(ACLCB * callback_, void *callback_data_)
     callback_data = cbdataReference(callback_data_);
     asyncCaller_ = true;
 
-    /** The ACL List should NEVER be NULL when calling this method.
+    /** The AclNode List should NEVER be NULL when calling this method.
      * Always caller should check for NULL and handle appropriate to its needs first.
      * We cannot select a sensible default for all callers here. */
     if (accessList == nullptr) {

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -79,7 +79,7 @@ ACLChecklist::preCheck(const char *what)
 }
 
 bool
-ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const AclNode *child)
+ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterator pos, const Acl::AclNode *child)
 {
     assert(current && child);
 
@@ -112,7 +112,7 @@ ACLChecklist::matchChild(const Acl::InnerNode *current, Acl::Nodes::const_iterat
 }
 
 bool
-ACLChecklist::goAsync(AsyncStarter starter, const AclNode &acl)
+ACLChecklist::goAsync(AsyncStarter starter, const Acl::AclNode &acl)
 {
     assert(!asyncInProgress());
     assert(matchLoc_.parent);
@@ -207,7 +207,7 @@ ACLChecklist::nonBlockingCheck(ACLCB * callback_, void *callback_data_)
     callback_data = cbdataReference(callback_data_);
     asyncCaller_ = true;
 
-    /** The AclNode List should NEVER be NULL when calling this method.
+    /** The Acl::AclNode List should NEVER be NULL when calling this method.
      * Always caller should check for NULL and handle appropriate to its needs first.
      * We cannot select a sensible default for all callers here. */
     if (accessList == nullptr) {

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -132,7 +132,7 @@ public:
 
     // XXX: ACLs that need request or reply have to use ACLFilledChecklist and
     // should do their own checks so that we do not have to povide these two
-    // for Acl::Node::checklistMatches to use
+    // for ACL::checklistMatches to use
     virtual bool hasRequest() const = 0;
     virtual bool hasReply() const = 0;
     virtual bool hasAle() const = 0;
@@ -178,11 +178,11 @@ private: /* internal methods */
         bool operator ==(const Breadcrumb &b) const { return parent == b.parent && (!parent || position == b.position); }
         bool operator !=(const Breadcrumb &b) const { return !this->operator ==(b); }
         void clear() { parent = nullptr; }
-        const Acl::InnerNode *parent; ///< intermediate node in the Acl::Node tree
+        const Acl::InnerNode *parent; ///< intermediate node in the ACL tree
         Acl::Nodes::const_iterator position; ///< child position inside parent
     };
 
-    /// possible outcomes when trying to match a single Acl::Node node in a list
+    /// possible outcomes when trying to match a single ACL node in a list
     typedef enum { nmrMatch, nmrMismatch, nmrFinished, nmrNeedsAsync }
     NodeMatchingResult;
 
@@ -205,7 +205,7 @@ private: /* internal methods */
 
     bool callerGone();
 
-    /// suspended (due to an async lookup) matches() in the Acl::Node tree
+    /// suspended (due to an async lookup) matches() in the ACL tree
     std::stack<Breadcrumb> matchPath;
     /// the list of actions which must ignored during acl checks
     std::vector<Acl::Answer> bannedActions_;

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -9,7 +9,9 @@
 #ifndef SQUID_ACLCHECKLIST_H
 #define SQUID_ACLCHECKLIST_H
 
+#include "acl/Acl.h"
 #include "acl/InnerNode.h"
+#include "cbdata.h"
 #include <stack>
 #include <vector>
 

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -29,7 +29,7 @@ class ACLChecklist
 public:
 
     /// a function that initiates asynchronous ACL checks; see goAsync()
-    using AsyncStarter = void (ACLFilledChecklist &, const AclNode &);
+    using AsyncStarter = void (ACLFilledChecklist &, const Acl::AclNode &);
 
 public:
     ACLChecklist();
@@ -104,11 +104,11 @@ public:
 
     /// If slow lookups are allowed, switches into "async in progress" state.
     /// Otherwise, returns false; the caller is expected to handle the failure.
-    bool goAsync(AsyncStarter, const AclNode &);
+    bool goAsync(AsyncStarter, const Acl::AclNode &);
 
     /// Matches (or resumes matching of) a child node while maintaning
     /// resumption breadcrumbs if a [grand]child node goes async.
-    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const AclNode *child);
+    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const Acl::AclNode *child);
 
     /// Whether we should continue to match tree nodes or stop/pause.
     bool keepMatching() const { return !finished() && !asyncInProgress(); }
@@ -130,7 +130,7 @@ public:
 
     // XXX: ACLs that need request or reply have to use ACLFilledChecklist and
     // should do their own checks so that we do not have to povide these two
-    // for AclNode::checklistMatches to use
+    // for Acl::AclNode::checklistMatches to use
     virtual bool hasRequest() const = 0;
     virtual bool hasReply() const = 0;
     virtual bool hasAle() const = 0;
@@ -167,7 +167,7 @@ public:
     void resumeNonBlockingCheck();
 
 private: /* internal methods */
-    /// Position of a child node within an AclNode tree.
+    /// Position of a child node within an Acl::AclNode tree.
     class Breadcrumb
     {
     public:
@@ -176,11 +176,11 @@ private: /* internal methods */
         bool operator ==(const Breadcrumb &b) const { return parent == b.parent && (!parent || position == b.position); }
         bool operator !=(const Breadcrumb &b) const { return !this->operator ==(b); }
         void clear() { parent = nullptr; }
-        const Acl::InnerNode *parent; ///< intermediate node in the AclNode tree
+        const Acl::InnerNode *parent; ///< intermediate node in the Acl::AclNode tree
         Acl::Nodes::const_iterator position; ///< child position inside parent
     };
 
-    /// possible outcomes when trying to match a single AclNode node in a list
+    /// possible outcomes when trying to match a single Acl::AclNode node in a list
     typedef enum { nmrMatch, nmrMismatch, nmrFinished, nmrNeedsAsync }
     NodeMatchingResult;
 
@@ -203,7 +203,7 @@ private: /* internal methods */
 
     bool callerGone();
 
-    /// suspended (due to an async lookup) matches() in the AclNode tree
+    /// suspended (due to an async lookup) matches() in the Acl::AclNode tree
     std::stack<Breadcrumb> matchPath;
     /// the list of actions which must ignored during acl checks
     std::vector<Acl::Answer> bannedActions_;

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -29,7 +29,7 @@ class ACLChecklist
 public:
 
     /// a function that initiates asynchronous ACL checks; see goAsync()
-    using AsyncStarter = void (ACLFilledChecklist &, const ACL &);
+    using AsyncStarter = void (ACLFilledChecklist &, const AclNode &);
 
 public:
     ACLChecklist();
@@ -104,11 +104,11 @@ public:
 
     /// If slow lookups are allowed, switches into "async in progress" state.
     /// Otherwise, returns false; the caller is expected to handle the failure.
-    bool goAsync(AsyncStarter, const ACL &);
+    bool goAsync(AsyncStarter, const AclNode &);
 
     /// Matches (or resumes matching of) a child node while maintaning
     /// resumption breadcrumbs if a [grand]child node goes async.
-    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const ACL *child);
+    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const AclNode *child);
 
     /// Whether we should continue to match tree nodes or stop/pause.
     bool keepMatching() const { return !finished() && !asyncInProgress(); }
@@ -130,7 +130,7 @@ public:
 
     // XXX: ACLs that need request or reply have to use ACLFilledChecklist and
     // should do their own checks so that we do not have to povide these two
-    // for ACL::checklistMatches to use
+    // for AclNode::checklistMatches to use
     virtual bool hasRequest() const = 0;
     virtual bool hasReply() const = 0;
     virtual bool hasAle() const = 0;
@@ -167,7 +167,7 @@ public:
     void resumeNonBlockingCheck();
 
 private: /* internal methods */
-    /// Position of a child node within an ACL tree.
+    /// Position of a child node within an AclNode tree.
     class Breadcrumb
     {
     public:
@@ -176,11 +176,11 @@ private: /* internal methods */
         bool operator ==(const Breadcrumb &b) const { return parent == b.parent && (!parent || position == b.position); }
         bool operator !=(const Breadcrumb &b) const { return !this->operator ==(b); }
         void clear() { parent = nullptr; }
-        const Acl::InnerNode *parent; ///< intermediate node in the ACL tree
+        const Acl::InnerNode *parent; ///< intermediate node in the AclNode tree
         Acl::Nodes::const_iterator position; ///< child position inside parent
     };
 
-    /// possible outcomes when trying to match a single ACL node in a list
+    /// possible outcomes when trying to match a single AclNode node in a list
     typedef enum { nmrMatch, nmrMismatch, nmrFinished, nmrNeedsAsync }
     NodeMatchingResult;
 
@@ -203,7 +203,7 @@ private: /* internal methods */
 
     bool callerGone();
 
-    /// suspended (due to an async lookup) matches() in the ACL tree
+    /// suspended (due to an async lookup) matches() in the AclNode tree
     std::stack<Breadcrumb> matchPath;
     /// the list of actions which must ignored during acl checks
     std::vector<Acl::Answer> bannedActions_;

--- a/src/acl/Checklist.h
+++ b/src/acl/Checklist.h
@@ -29,7 +29,7 @@ class ACLChecklist
 public:
 
     /// a function that initiates asynchronous ACL checks; see goAsync()
-    using AsyncStarter = void (ACLFilledChecklist &, const Acl::AclNode &);
+    using AsyncStarter = void (ACLFilledChecklist &, const Acl::Node &);
 
 public:
     ACLChecklist();
@@ -104,11 +104,11 @@ public:
 
     /// If slow lookups are allowed, switches into "async in progress" state.
     /// Otherwise, returns false; the caller is expected to handle the failure.
-    bool goAsync(AsyncStarter, const Acl::AclNode &);
+    bool goAsync(AsyncStarter, const Acl::Node &);
 
     /// Matches (or resumes matching of) a child node while maintaning
     /// resumption breadcrumbs if a [grand]child node goes async.
-    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const Acl::AclNode *child);
+    bool matchChild(const Acl::InnerNode *parent, Acl::Nodes::const_iterator pos, const Acl::Node *child);
 
     /// Whether we should continue to match tree nodes or stop/pause.
     bool keepMatching() const { return !finished() && !asyncInProgress(); }
@@ -130,7 +130,7 @@ public:
 
     // XXX: ACLs that need request or reply have to use ACLFilledChecklist and
     // should do their own checks so that we do not have to povide these two
-    // for Acl::AclNode::checklistMatches to use
+    // for Acl::Node::checklistMatches to use
     virtual bool hasRequest() const = 0;
     virtual bool hasReply() const = 0;
     virtual bool hasAle() const = 0;
@@ -167,7 +167,7 @@ public:
     void resumeNonBlockingCheck();
 
 private: /* internal methods */
-    /// Position of a child node within an Acl::AclNode tree.
+    /// Position of a child node within an Acl::Node tree.
     class Breadcrumb
     {
     public:
@@ -176,11 +176,11 @@ private: /* internal methods */
         bool operator ==(const Breadcrumb &b) const { return parent == b.parent && (!parent || position == b.position); }
         bool operator !=(const Breadcrumb &b) const { return !this->operator ==(b); }
         void clear() { parent = nullptr; }
-        const Acl::InnerNode *parent; ///< intermediate node in the Acl::AclNode tree
+        const Acl::InnerNode *parent; ///< intermediate node in the Acl::Node tree
         Acl::Nodes::const_iterator position; ///< child position inside parent
     };
 
-    /// possible outcomes when trying to match a single Acl::AclNode node in a list
+    /// possible outcomes when trying to match a single Acl::Node node in a list
     typedef enum { nmrMatch, nmrMismatch, nmrFinished, nmrNeedsAsync }
     NodeMatchingResult;
 
@@ -203,7 +203,7 @@ private: /* internal methods */
 
     bool callerGone();
 
-    /// suspended (due to an async lookup) matches() in the Acl::AclNode tree
+    /// suspended (due to an async lookup) matches() in the Acl::Node tree
     std::stack<Breadcrumb> matchPath;
     /// the list of actions which must ignored during acl checks
     std::vector<Acl::Answer> bannedActions_;

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -18,12 +18,12 @@
 
 namespace Acl {
 
-class ConnMark : public AclNode
+class ConnMark : public Acl::AclNode
 {
     MEMPROXY_CLASS(ConnMark);
 
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -18,12 +18,12 @@
 
 namespace Acl {
 
-class ConnMark : public ACL
+class ConnMark : public AclNode
 {
     MEMPROXY_CLASS(ConnMark);
 
 public:
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -18,12 +18,12 @@
 
 namespace Acl {
 
-class ConnMark : public Acl::AclNode
+class ConnMark : public Acl::Node
 {
     MEMPROXY_CLASS(ConnMark);
 
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;

--- a/src/acl/ConnMark.h
+++ b/src/acl/ConnMark.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACLCONNMARK_H
 #define SQUID_ACLCONNMARK_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "ip/forward.h"
 #include "ip/NfMarkConfig.h"
 #include "parser/Tokenizer.h"

--- a/src/acl/ConnectionsEncrypted.h
+++ b/src/acl/ConnectionsEncrypted.h
@@ -15,7 +15,7 @@
 namespace Acl
 {
 
-class ConnectionsEncrypted : public AclNode
+class ConnectionsEncrypted : public Acl::AclNode
 {
     MEMPROXY_CLASS(ConnectionsEncrypted);
 

--- a/src/acl/ConnectionsEncrypted.h
+++ b/src/acl/ConnectionsEncrypted.h
@@ -15,7 +15,7 @@
 namespace Acl
 {
 
-class ConnectionsEncrypted : public Acl::AclNode
+class ConnectionsEncrypted : public Acl::Node
 {
     MEMPROXY_CLASS(ConnectionsEncrypted);
 

--- a/src/acl/ConnectionsEncrypted.h
+++ b/src/acl/ConnectionsEncrypted.h
@@ -15,7 +15,7 @@
 namespace Acl
 {
 
-class ConnectionsEncrypted : public ACL
+class ConnectionsEncrypted : public AclNode
 {
     MEMPROXY_CLASS(ConnectionsEncrypted);
 

--- a/src/acl/DestinationAsn.h
+++ b/src/acl/DestinationAsn.h
@@ -20,7 +20,7 @@ namespace Acl
 class DestinationAsnCheck: public ParameterizedNode< ACLData<Ip::Address> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/DestinationAsn.h
+++ b/src/acl/DestinationAsn.h
@@ -20,7 +20,7 @@ namespace Acl
 class DestinationAsnCheck: public ParameterizedNode< ACLData<Ip::Address> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/DestinationAsn.h
+++ b/src/acl/DestinationAsn.h
@@ -20,7 +20,7 @@ namespace Acl
 class DestinationAsnCheck: public ParameterizedNode< ACLData<Ip::Address> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -19,7 +19,7 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLFilledChecklist &cl, const ACL &)
+StartLookup(ACLFilledChecklist &cl, const AclNode &)
 {
     fqdncache_nbgethostbyaddr(cl.dst_addr, LookupDone, &cl);
 }

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -19,7 +19,7 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLFilledChecklist &cl, const AclNode &)
+StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
 {
     fqdncache_nbgethostbyaddr(cl.dst_addr, LookupDone, &cl);
 }

--- a/src/acl/DestinationDomain.cc
+++ b/src/acl/DestinationDomain.cc
@@ -19,7 +19,7 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
+StartLookup(ACLFilledChecklist &cl, const Acl::Node &)
 {
     fqdncache_nbgethostbyaddr(cl.dst_addr, LookupDone, &cl);
 }

--- a/src/acl/DestinationDomain.h
+++ b/src/acl/DestinationDomain.h
@@ -21,7 +21,7 @@ namespace Acl
 class DestinationDomainCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
     const Acl::Options &options() override;

--- a/src/acl/DestinationDomain.h
+++ b/src/acl/DestinationDomain.h
@@ -21,7 +21,7 @@ namespace Acl
 class DestinationDomainCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
     const Acl::Options &options() override;

--- a/src/acl/DestinationDomain.h
+++ b/src/acl/DestinationDomain.h
@@ -21,7 +21,7 @@ namespace Acl
 class DestinationDomainCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
     const Acl::Options &options() override;

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -85,7 +85,7 @@ ACLDestinationIP::match(ACLChecklist *cl)
 }
 
 void
-ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const AclNode &)
+ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
 {
     ipcache_nbgethostbyname(cl.request->url.host(), LookupDone, &cl);
 }

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -85,7 +85,7 @@ ACLDestinationIP::match(ACLChecklist *cl)
 }
 
 void
-ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const ACL &)
+ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const AclNode &)
 {
     ipcache_nbgethostbyname(cl.request->url.host(), LookupDone, &cl);
 }

--- a/src/acl/DestinationIp.cc
+++ b/src/acl/DestinationIp.cc
@@ -85,7 +85,7 @@ ACLDestinationIP::match(ACLChecklist *cl)
 }
 
 void
-ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
+ACLDestinationIP::StartLookup(ACLFilledChecklist &cl, const Acl::Node &)
 {
     ipcache_nbgethostbyname(cl.request->url.host(), LookupDone, &cl);
 }

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -18,7 +18,7 @@ class ACLDestinationIP : public ACLIP
     MEMPROXY_CLASS(ACLDestinationIP);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::Node &);
 
     char const *typeString() const override;
     const Acl::Options &options() override;

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -18,7 +18,7 @@ class ACLDestinationIP : public ACLIP
     MEMPROXY_CLASS(ACLDestinationIP);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const ACL &);
+    static void StartLookup(ACLFilledChecklist &, const AclNode &);
 
     char const *typeString() const override;
     const Acl::Options &options() override;

--- a/src/acl/DestinationIp.h
+++ b/src/acl/DestinationIp.h
@@ -18,7 +18,7 @@ class ACLDestinationIP : public ACLIP
     MEMPROXY_CLASS(ACLDestinationIP);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
 
     char const *typeString() const override;
     const Acl::Options &options() override;

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACLEUI64_H
 #define SQUID_ACLEUI64_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "eui/Eui64.h"
 
 #include <set>

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -14,7 +14,7 @@
 
 #include <set>
 
-class ACLEui64 : public Acl::AclNode
+class ACLEui64 : public Acl::Node
 {
     MEMPROXY_CLASS(ACLEui64);
 

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -14,7 +14,7 @@
 
 #include <set>
 
-class ACLEui64 : public ACL
+class ACLEui64 : public AclNode
 {
     MEMPROXY_CLASS(ACLEui64);
 

--- a/src/acl/Eui64.h
+++ b/src/acl/Eui64.h
@@ -14,7 +14,7 @@
 
 #include <set>
 
-class ACLEui64 : public AclNode
+class ACLEui64 : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLEui64);
 

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -15,7 +15,7 @@
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ACLExtUser : public ACL
+class ACLExtUser : public AclNode
 {
     MEMPROXY_CLASS(ACLExtUser);
 
@@ -23,7 +23,7 @@ public:
     ACLExtUser(ACLData<char const *> *newData, char const *);
     ~ACLExtUser() override;
 
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;
@@ -31,7 +31,7 @@ public:
     bool empty () const override;
 
 private:
-    /* ACL API */
+    /* AclNode API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -15,7 +15,7 @@
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ACLExtUser : public AclNode
+class ACLExtUser : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLExtUser);
 
@@ -23,7 +23,7 @@ public:
     ACLExtUser(ACLData<char const *> *newData, char const *);
     ~ACLExtUser() override;
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;
@@ -31,7 +31,7 @@ public:
     bool empty () const override;
 
 private:
-    /* AclNode API */
+    /* Acl::AclNode API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -15,7 +15,7 @@
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ACLExtUser : public Acl::AclNode
+class ACLExtUser : public Acl::Node
 {
     MEMPROXY_CLASS(ACLExtUser);
 
@@ -23,7 +23,7 @@ public:
     ACLExtUser(ACLData<char const *> *newData, char const *);
     ~ACLExtUser() override;
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;
@@ -31,7 +31,7 @@ public:
     bool empty () const override;
 
 private:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/acl/FilledChecklist.h
+++ b/src/acl/FilledChecklist.h
@@ -10,6 +10,7 @@
 #define SQUID_ACLFILLED_CHECKLIST_H
 
 #include "AccessLogEntry.h"
+#include "acl/Acl.h"
 #include "acl/Checklist.h"
 #include "acl/forward.h"
 #include "base/CbcPointer.h"

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -30,7 +30,7 @@
 #include <set>
 #include <algorithm>
 
-typedef std::set<Acl::Node*> AclSet;
+using AclSet = std::set<Acl::Node *>;
 /// Accumulates all ACLs to facilitate their clean deletion despite reuse.
 static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
@@ -185,7 +185,7 @@ aclParseAccessLine(const char *directive, ConfigParser &, acl_access **treep)
 size_t
 aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 {
-    // accommodate callers unable to convert their Acl::Node list context to string
+    // accommodate callers unable to convert their ACL list context to string
     if (!label)
         label = "...";
 

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -10,9 +10,9 @@
  * DEBUG: section 28    Access Control
  *
  * This file contains ACL routines that are not part of the
- * Acl::AclNode class, nor any other class yet, and that need to be
+ * Acl::Node class, nor any other class yet, and that need to be
  * factored into appropriate places. They are here to reduce
- * unneeded dependencies between the Acl::AclNode class and the rest
+ * unneeded dependencies between the Acl::Node class and the rest
  * of squid.
  */
 
@@ -30,7 +30,7 @@
 #include <set>
 #include <algorithm>
 
-typedef std::set<Acl::AclNode*> AclSet;
+typedef std::set<Acl::Node*> AclSet;
 /// Accumulates all ACLs to facilitate their clean deletion despite reuse.
 static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
@@ -76,7 +76,7 @@ aclIsProxyAuth(const char *name)
 
     debugs(28, 5, "aclIsProxyAuth: called for " << name);
 
-    if (const auto *a = Acl::AclNode::FindByName(name)) {
+    if (const auto *a = Acl::Node::FindByName(name)) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }
@@ -185,7 +185,7 @@ aclParseAccessLine(const char *directive, ConfigParser &, acl_access **treep)
 size_t
 aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 {
-    // accommodate callers unable to convert their Acl::AclNode list context to string
+    // accommodate callers unable to convert their Acl::Node list context to string
     if (!label)
         label = "...";
 
@@ -216,7 +216,7 @@ aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 }
 
 void
-aclRegister(Acl::AclNode *acl)
+aclRegister(Acl::Node *acl)
 {
     if (!acl->registered) {
         if (!RegisteredAcls)
@@ -229,7 +229,7 @@ aclRegister(Acl::AclNode *acl)
 /// remove registered acl from the centralized deletion set
 static
 void
-aclDeregister(Acl::AclNode *acl)
+aclDeregister(Acl::Node *acl)
 {
     if (acl->registered) {
         if (RegisteredAcls)
@@ -244,16 +244,16 @@ aclDeregister(Acl::AclNode *acl)
 
 /// called to delete ALL Acls.
 void
-aclDestroyAcls(Acl::AclNode ** head)
+aclDestroyAcls(Acl::Node ** head)
 {
     *head = nullptr; // Config.aclList
     if (AclSet *acls = RegisteredAcls) {
         debugs(28, 8, "deleting all " << acls->size() << " ACLs");
         while (!acls->empty()) {
             auto *acl = *acls->begin();
-            // We use centralized deletion (this function) so ~Acl::AclNode should not
+            // We use centralized deletion (this function) so ~Acl::Node should not
             // delete other ACLs, but we still deregister first to prevent any
-            // accesses to the being-deleted Acl::AclNode via RegisteredAcls.
+            // accesses to the being-deleted Acl::Node via RegisteredAcls.
             assert(acl->registered); // make sure we are making progress
             aclDeregister(acl);
             delete acl;

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -10,9 +10,9 @@
  * DEBUG: section 28    Access Control
  *
  * This file contains ACL routines that are not part of the
- * AclNode class, nor any other class yet, and that need to be
+ * Acl::AclNode class, nor any other class yet, and that need to be
  * factored into appropriate places. They are here to reduce
- * unneeded dependencies between the AclNode class and the rest
+ * unneeded dependencies between the Acl::AclNode class and the rest
  * of squid.
  */
 
@@ -30,7 +30,7 @@
 #include <set>
 #include <algorithm>
 
-typedef std::set<AclNode*> AclSet;
+typedef std::set<Acl::AclNode*> AclSet;
 /// Accumulates all ACLs to facilitate their clean deletion despite reuse.
 static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
@@ -76,7 +76,7 @@ aclIsProxyAuth(const char *name)
 
     debugs(28, 5, "aclIsProxyAuth: called for " << name);
 
-    if (const auto *a = AclNode::FindByName(name)) {
+    if (const auto *a = Acl::AclNode::FindByName(name)) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }
@@ -185,7 +185,7 @@ aclParseAccessLine(const char *directive, ConfigParser &, acl_access **treep)
 size_t
 aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 {
-    // accommodate callers unable to convert their AclNode list context to string
+    // accommodate callers unable to convert their Acl::AclNode list context to string
     if (!label)
         label = "...";
 
@@ -216,7 +216,7 @@ aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 }
 
 void
-aclRegister(AclNode *acl)
+aclRegister(Acl::AclNode *acl)
 {
     if (!acl->registered) {
         if (!RegisteredAcls)
@@ -229,7 +229,7 @@ aclRegister(AclNode *acl)
 /// remove registered acl from the centralized deletion set
 static
 void
-aclDeregister(AclNode *acl)
+aclDeregister(Acl::AclNode *acl)
 {
     if (acl->registered) {
         if (RegisteredAcls)
@@ -244,16 +244,16 @@ aclDeregister(AclNode *acl)
 
 /// called to delete ALL Acls.
 void
-aclDestroyAcls(AclNode ** head)
+aclDestroyAcls(Acl::AclNode ** head)
 {
     *head = nullptr; // Config.aclList
     if (AclSet *acls = RegisteredAcls) {
         debugs(28, 8, "deleting all " << acls->size() << " ACLs");
         while (!acls->empty()) {
             auto *acl = *acls->begin();
-            // We use centralized deletion (this function) so ~AclNode should not
+            // We use centralized deletion (this function) so ~Acl::AclNode should not
             // delete other ACLs, but we still deregister first to prevent any
-            // accesses to the being-deleted AclNode via RegisteredAcls.
+            // accesses to the being-deleted Acl::AclNode via RegisteredAcls.
             assert(acl->registered); // make sure we are making progress
             aclDeregister(acl);
             delete acl;

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -76,9 +76,7 @@ aclIsProxyAuth(const char *name)
 
     debugs(28, 5, "aclIsProxyAuth: called for " << name);
 
-    AclNode *a;
-
-    if ((a = AclNode::FindByName(name))) {
+    if (const auto *a = AclNode::FindByName(name)) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }
@@ -252,7 +250,7 @@ aclDestroyAcls(AclNode ** head)
     if (AclSet *acls = RegisteredAcls) {
         debugs(28, 8, "deleting all " << acls->size() << " ACLs");
         while (!acls->empty()) {
-            AclNode *acl = *acls->begin();
+            auto *acl = *acls->begin();
             // We use centralized deletion (this function) so ~AclNode should not
             // delete other ACLs, but we still deregister first to prevent any
             // accesses to the being-deleted AclNode via RegisteredAcls.

--- a/src/acl/Gadgets.cc
+++ b/src/acl/Gadgets.cc
@@ -10,9 +10,9 @@
  * DEBUG: section 28    Access Control
  *
  * This file contains ACL routines that are not part of the
- * ACL class, nor any other class yet, and that need to be
+ * AclNode class, nor any other class yet, and that need to be
  * factored into appropriate places. They are here to reduce
- * unneeded dependencies between the ACL class and the rest
+ * unneeded dependencies between the AclNode class and the rest
  * of squid.
  */
 
@@ -30,7 +30,7 @@
 #include <set>
 #include <algorithm>
 
-typedef std::set<ACL*> AclSet;
+typedef std::set<AclNode*> AclSet;
 /// Accumulates all ACLs to facilitate their clean deletion despite reuse.
 static AclSet *RegisteredAcls; // TODO: Remove when ACLs are refcounted
 
@@ -76,9 +76,9 @@ aclIsProxyAuth(const char *name)
 
     debugs(28, 5, "aclIsProxyAuth: called for " << name);
 
-    ACL *a;
+    AclNode *a;
 
-    if ((a = ACL::FindByName(name))) {
+    if ((a = AclNode::FindByName(name))) {
         debugs(28, 5, "aclIsProxyAuth: returning " << a->isProxyAuth());
         return a->isProxyAuth();
     }
@@ -187,7 +187,7 @@ aclParseAccessLine(const char *directive, ConfigParser &, acl_access **treep)
 size_t
 aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 {
-    // accommodate callers unable to convert their ACL list context to string
+    // accommodate callers unable to convert their AclNode list context to string
     if (!label)
         label = "...";
 
@@ -218,7 +218,7 @@ aclParseAclList(ConfigParser &, Acl::Tree **treep, const char *label)
 }
 
 void
-aclRegister(ACL *acl)
+aclRegister(AclNode *acl)
 {
     if (!acl->registered) {
         if (!RegisteredAcls)
@@ -231,7 +231,7 @@ aclRegister(ACL *acl)
 /// remove registered acl from the centralized deletion set
 static
 void
-aclDeregister(ACL *acl)
+aclDeregister(AclNode *acl)
 {
     if (acl->registered) {
         if (RegisteredAcls)
@@ -246,16 +246,16 @@ aclDeregister(ACL *acl)
 
 /// called to delete ALL Acls.
 void
-aclDestroyAcls(ACL ** head)
+aclDestroyAcls(AclNode ** head)
 {
     *head = nullptr; // Config.aclList
     if (AclSet *acls = RegisteredAcls) {
         debugs(28, 8, "deleting all " << acls->size() << " ACLs");
         while (!acls->empty()) {
-            ACL *acl = *acls->begin();
-            // We use centralized deletion (this function) so ~ACL should not
+            AclNode *acl = *acls->begin();
+            // We use centralized deletion (this function) so ~AclNode should not
             // delete other ACLs, but we still deregister first to prevent any
-            // accesses to the being-deleted ACL via RegisteredAcls.
+            // accesses to the being-deleted AclNode via RegisteredAcls.
             assert(acl->registered); // make sure we are making progress
             aclDeregister(acl);
             delete acl;

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -19,13 +19,13 @@ class dlink_list;
 class StoreEntry;
 class wordlist;
 
-/// Register an ACL object for future deletion. Repeated registrations are OK.
+/// Register an AclNode object for future deletion. Repeated registrations are OK.
 /// \ingroup ACLAPI
-void aclRegister(ACL *acl);
+void aclRegister(AclNode *acl);
 /// \ingroup ACLAPI
 void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
-void aclDestroyAcls(ACL **);
+void aclDestroyAcls(AclNode **);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 /// Parses a single line of a "action followed by acls" directive (e.g., http_access).
@@ -54,7 +54,7 @@ void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI
 void aclDestroyDenyInfoList(AclDenyInfoList **);
 /// \ingroup ACLAPI
-wordlist *aclDumpGeneric(const ACL *);
+wordlist *aclDumpGeneric(const AclNode *);
 /// \ingroup ACLAPI
 void aclCacheMatchFlush(dlink_list * cache);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -19,13 +19,13 @@ class dlink_list;
 class StoreEntry;
 class wordlist;
 
-/// Register an AclNode object for future deletion. Repeated registrations are OK.
+/// Register an Acl::AclNode object for future deletion. Repeated registrations are OK.
 /// \ingroup ACLAPI
-void aclRegister(AclNode *acl);
+void aclRegister(Acl::AclNode *acl);
 /// \ingroup ACLAPI
 void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
-void aclDestroyAcls(AclNode **);
+void aclDestroyAcls(Acl::AclNode **);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 /// Parses a single line of a "action followed by acls" directive (e.g., http_access).
@@ -54,7 +54,7 @@ void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI
 void aclDestroyDenyInfoList(AclDenyInfoList **);
 /// \ingroup ACLAPI
-wordlist *aclDumpGeneric(const AclNode *);
+wordlist *aclDumpGeneric(const Acl::AclNode *);
 /// \ingroup ACLAPI
 void aclCacheMatchFlush(dlink_list * cache);
 /// \ingroup ACLAPI

--- a/src/acl/Gadgets.h
+++ b/src/acl/Gadgets.h
@@ -19,13 +19,13 @@ class dlink_list;
 class StoreEntry;
 class wordlist;
 
-/// Register an Acl::AclNode object for future deletion. Repeated registrations are OK.
+/// Register an Acl::Node object for future deletion. Repeated registrations are OK.
 /// \ingroup ACLAPI
-void aclRegister(Acl::AclNode *acl);
+void aclRegister(Acl::Node *acl);
 /// \ingroup ACLAPI
 void aclDestroyAccessList(acl_access **list);
 /// \ingroup ACLAPI
-void aclDestroyAcls(Acl::AclNode **);
+void aclDestroyAcls(Acl::Node **);
 /// \ingroup ACLAPI
 void aclDestroyAclList(ACLList **);
 /// Parses a single line of a "action followed by acls" directive (e.g., http_access).
@@ -54,7 +54,7 @@ void aclParseDenyInfoLine(AclDenyInfoList **);
 /// \ingroup ACLAPI
 void aclDestroyDenyInfoList(AclDenyInfoList **);
 /// \ingroup ACLAPI
-wordlist *aclDumpGeneric(const Acl::AclNode *);
+wordlist *aclDumpGeneric(const Acl::Node *);
 /// \ingroup ACLAPI
 void aclCacheMatchFlush(dlink_list * cache);
 /// \ingroup ACLAPI

--- a/src/acl/HasComponent.h
+++ b/src/acl/HasComponent.h
@@ -19,7 +19,7 @@ namespace Acl
 class HasComponentCheck: public ParameterizedNode< ACLData<ACLChecklist *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/HasComponent.h
+++ b/src/acl/HasComponent.h
@@ -19,7 +19,7 @@ namespace Acl
 class HasComponentCheck: public ParameterizedNode< ACLData<ACLChecklist *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/HasComponent.h
+++ b/src/acl/HasComponent.h
@@ -19,7 +19,7 @@ namespace Acl
 class HasComponentCheck: public ParameterizedNode< ACLData<ACLChecklist *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/HierCode.h
+++ b/src/acl/HierCode.h
@@ -20,7 +20,7 @@ namespace Acl
 class HierCodeCheck: public ParameterizedNode< ACLData<hier_code> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/HierCode.h
+++ b/src/acl/HierCode.h
@@ -20,7 +20,7 @@ namespace Acl
 class HierCodeCheck: public ParameterizedNode< ACLData<hier_code> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/HierCode.h
+++ b/src/acl/HierCode.h
@@ -20,7 +20,7 @@ namespace Acl
 class HierCodeCheck: public ParameterizedNode< ACLData<hier_code> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/HttpRepHeader.h
+++ b/src/acl/HttpRepHeader.h
@@ -20,7 +20,7 @@ namespace Acl
 class HttpRepHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresReply() const override { return true; }
 };

--- a/src/acl/HttpRepHeader.h
+++ b/src/acl/HttpRepHeader.h
@@ -20,7 +20,7 @@ namespace Acl
 class HttpRepHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresReply() const override { return true; }
 };

--- a/src/acl/HttpRepHeader.h
+++ b/src/acl/HttpRepHeader.h
@@ -20,7 +20,7 @@ namespace Acl
 class HttpRepHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresReply() const override { return true; }
 };

--- a/src/acl/HttpReqHeader.h
+++ b/src/acl/HttpReqHeader.h
@@ -20,7 +20,7 @@ namespace Acl
 class HttpReqHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/HttpReqHeader.h
+++ b/src/acl/HttpReqHeader.h
@@ -20,7 +20,7 @@ namespace Acl
 class HttpReqHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/HttpReqHeader.h
+++ b/src/acl/HttpReqHeader.h
@@ -20,7 +20,7 @@ namespace Acl
 class HttpReqHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 };

--- a/src/acl/HttpStatus.h
+++ b/src/acl/HttpStatus.h
@@ -24,7 +24,7 @@ struct acl_httpstatus_data {
 };
 
 /// \ingroup ACLAPI
-class ACLHTTPStatus : public AclNode
+class ACLHTTPStatus : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLHTTPStatus);
 

--- a/src/acl/HttpStatus.h
+++ b/src/acl/HttpStatus.h
@@ -24,7 +24,7 @@ struct acl_httpstatus_data {
 };
 
 /// \ingroup ACLAPI
-class ACLHTTPStatus : public ACL
+class ACLHTTPStatus : public AclNode
 {
     MEMPROXY_CLASS(ACLHTTPStatus);
 

--- a/src/acl/HttpStatus.h
+++ b/src/acl/HttpStatus.h
@@ -24,7 +24,7 @@ struct acl_httpstatus_data {
 };
 
 /// \ingroup ACLAPI
-class ACLHTTPStatus : public Acl::AclNode
+class ACLHTTPStatus : public Acl::Node
 {
     MEMPROXY_CLASS(ACLHTTPStatus);
 

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -57,7 +57,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        AclNode *a = AclNode::FindByName(t);
+        auto *a = AclNode::FindByName(t);
 
         if (a == nullptr) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -33,7 +33,7 @@ Acl::InnerNode::empty() const
 }
 
 void
-Acl::InnerNode::add(ACL *node)
+Acl::InnerNode::add(AclNode *node)
 {
     assert(node != nullptr);
     nodes.push_back(node);
@@ -57,7 +57,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        ACL *a = ACL::FindByName(t);
+        AclNode *a = AclNode::FindByName(t);
 
         if (a == nullptr) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -33,7 +33,7 @@ Acl::InnerNode::empty() const
 }
 
 void
-Acl::InnerNode::add(Acl::AclNode *node)
+Acl::InnerNode::add(Acl::Node *node)
 {
     assert(node != nullptr);
     nodes.push_back(node);
@@ -57,7 +57,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        auto *a = Acl::AclNode::FindByName(t);
+        auto *a = Acl::Node::FindByName(t);
 
         if (a == nullptr) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);

--- a/src/acl/InnerNode.cc
+++ b/src/acl/InnerNode.cc
@@ -33,7 +33,7 @@ Acl::InnerNode::empty() const
 }
 
 void
-Acl::InnerNode::add(AclNode *node)
+Acl::InnerNode::add(Acl::AclNode *node)
 {
     assert(node != nullptr);
     nodes.push_back(node);
@@ -57,7 +57,7 @@ Acl::InnerNode::lineParse()
             ++t;
 
         debugs(28, 3, "looking for ACL " << t);
-        auto *a = AclNode::FindByName(t);
+        auto *a = Acl::AclNode::FindByName(t);
 
         if (a == nullptr) {
             debugs(28, DBG_CRITICAL, "ERROR: ACL not found: " << t);

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -15,7 +15,7 @@
 namespace Acl
 {
 
-typedef std::vector<AclNode*> Nodes; ///< a collection of nodes
+using Nodes = std::vector<AclNode*>; ///< a collection of nodes
 
 /// An intermediate AclNode tree node. Manages a collection of child tree nodes.
 class InnerNode: public AclNode
@@ -50,7 +50,7 @@ protected:
     int match(ACLChecklist *checklist) override;
 
     // XXX: use refcounting instead of raw pointers
-    std::vector<AclNode*> nodes; ///< children nodes of this intermediate node
+    Nodes nodes; ///< children nodes of this intermediate node
 };
 
 } // namespace Acl

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACL_INNER_NODE_H
 #define SQUID_ACL_INNER_NODE_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include <vector>
 
 namespace Acl

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -15,10 +15,10 @@
 namespace Acl
 {
 
-using Nodes = std::vector<Acl::AclNode*>; ///< a collection of nodes
+using Nodes = std::vector<Acl::Node*>; ///< a collection of nodes
 
-/// An intermediate Acl::AclNode tree node. Manages a collection of child tree nodes.
-class InnerNode: public Acl::AclNode
+/// An intermediate Acl::Node tree node. Manages a collection of child tree nodes.
+class InnerNode: public Acl::Node
 {
 public:
     // No ~InnerNode() to delete children. They are aclRegister()ed instead.
@@ -29,7 +29,7 @@ public:
     /// the number of children nodes
     Nodes::size_type childrenCount() const { return nodes.size(); }
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     void prepareForUse() override;
     bool empty() const override;
     SBufList dump() const override;
@@ -39,14 +39,14 @@ public:
     size_t lineParse();
 
     /// appends the node to the collection and takes control over it
-    void add(Acl::AclNode *node);
+    void add(Acl::Node *node);
 
 protected:
     /// checks whether the nodes match, starting with the given one
     /// kids determine what a match means for their type of intermediate nodes
     virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const = 0;
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *checklist) override;
 
     // XXX: use refcounting instead of raw pointers

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -15,10 +15,10 @@
 namespace Acl
 {
 
-typedef std::vector<ACL*> Nodes; ///< a collection of nodes
+typedef std::vector<AclNode*> Nodes; ///< a collection of nodes
 
-/// An intermediate ACL tree node. Manages a collection of child tree nodes.
-class InnerNode: public ACL
+/// An intermediate AclNode tree node. Manages a collection of child tree nodes.
+class InnerNode: public AclNode
 {
 public:
     // No ~InnerNode() to delete children. They are aclRegister()ed instead.
@@ -29,7 +29,7 @@ public:
     /// the number of children nodes
     Nodes::size_type childrenCount() const { return nodes.size(); }
 
-    /* ACL API */
+    /* AclNode API */
     void prepareForUse() override;
     bool empty() const override;
     SBufList dump() const override;
@@ -39,18 +39,18 @@ public:
     size_t lineParse();
 
     /// appends the node to the collection and takes control over it
-    void add(ACL *node);
+    void add(AclNode *node);
 
 protected:
     /// checks whether the nodes match, starting with the given one
     /// kids determine what a match means for their type of intermediate nodes
     virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const = 0;
 
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *checklist) override;
 
     // XXX: use refcounting instead of raw pointers
-    std::vector<ACL*> nodes; ///< children nodes of this intermediate node
+    std::vector<AclNode*> nodes; ///< children nodes of this intermediate node
 };
 
 } // namespace Acl

--- a/src/acl/InnerNode.h
+++ b/src/acl/InnerNode.h
@@ -15,10 +15,10 @@
 namespace Acl
 {
 
-using Nodes = std::vector<AclNode*>; ///< a collection of nodes
+using Nodes = std::vector<Acl::AclNode*>; ///< a collection of nodes
 
-/// An intermediate AclNode tree node. Manages a collection of child tree nodes.
-class InnerNode: public AclNode
+/// An intermediate Acl::AclNode tree node. Manages a collection of child tree nodes.
+class InnerNode: public Acl::AclNode
 {
 public:
     // No ~InnerNode() to delete children. They are aclRegister()ed instead.
@@ -29,7 +29,7 @@ public:
     /// the number of children nodes
     Nodes::size_type childrenCount() const { return nodes.size(); }
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     void prepareForUse() override;
     bool empty() const override;
     SBufList dump() const override;
@@ -39,14 +39,14 @@ public:
     size_t lineParse();
 
     /// appends the node to the collection and takes control over it
-    void add(AclNode *node);
+    void add(Acl::AclNode *node);
 
 protected:
     /// checks whether the nodes match, starting with the given one
     /// kids determine what a match means for their type of intermediate nodes
     virtual int doMatch(ACLChecklist *checklist, Nodes::const_iterator start) const = 0;
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *checklist) override;
 
     // XXX: use refcounting instead of raw pointers

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -41,7 +41,7 @@ private:
     static bool DecodeMask(const char *asc, Ip::Address &mask, int string_format_type);
 };
 
-class ACLIP : public Acl::AclNode
+class ACLIP : public Acl::Node
 {
 public:
     void *operator new(size_t);

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -9,8 +9,8 @@
 #ifndef SQUID_ACLIP_H
 #define SQUID_ACLIP_H
 
-#include "acl/Acl.h"
 #include "acl/Data.h"
+#include "acl/Node.h"
 #include "ip/Address.h"
 #include "splay.h"
 

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -41,7 +41,7 @@ private:
     static bool DecodeMask(const char *asc, Ip::Address &mask, int string_format_type);
 };
 
-class ACLIP : public ACL
+class ACLIP : public AclNode
 {
 public:
     void *operator new(size_t);

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -41,7 +41,7 @@ private:
     static bool DecodeMask(const char *asc, Ip::Address &mask, int string_format_type);
 };
 
-class ACLIP : public AclNode
+class ACLIP : public Acl::AclNode
 {
 public:
     void *operator new(size_t);

--- a/src/acl/LocalPort.h
+++ b/src/acl/LocalPort.h
@@ -19,7 +19,7 @@ namespace Acl
 class LocalPortCheck: public ParameterizedNode< ACLData<int> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/LocalPort.h
+++ b/src/acl/LocalPort.h
@@ -19,7 +19,7 @@ namespace Acl
 class LocalPortCheck: public ParameterizedNode< ACLData<int> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/LocalPort.h
+++ b/src/acl/LocalPort.h
@@ -19,7 +19,7 @@ namespace Acl
 class LocalPortCheck: public ParameterizedNode< ACLData<int> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Makefile.am
+++ b/src/acl/Makefile.am
@@ -22,6 +22,7 @@ libapi_la_SOURCES = \
 	ChecklistFiller.h \
 	InnerNode.cc \
 	InnerNode.h \
+	Node.h \
 	Options.cc \
 	Options.h \
 	Tree.cc \

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -12,7 +12,7 @@
 #include "acl/Acl.h"
 
 /// \ingroup ACLAPI
-class ACLMaxConnection : public ACL
+class ACLMaxConnection : public AclNode
 {
     MEMPROXY_CLASS(ACLMaxConnection);
 

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -12,7 +12,7 @@
 #include "acl/Acl.h"
 
 /// \ingroup ACLAPI
-class ACLMaxConnection : public AclNode
+class ACLMaxConnection : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLMaxConnection);
 

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACLMAXCONNECTION_H
 #define SQUID_ACLMAXCONNECTION_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 
 /// \ingroup ACLAPI
 class ACLMaxConnection : public Acl::Node

--- a/src/acl/MaxConnection.h
+++ b/src/acl/MaxConnection.h
@@ -12,7 +12,7 @@
 #include "acl/Acl.h"
 
 /// \ingroup ACLAPI
-class ACLMaxConnection : public Acl::AclNode
+class ACLMaxConnection : public Acl::Node
 {
     MEMPROXY_CLASS(ACLMaxConnection);
 

--- a/src/acl/Method.h
+++ b/src/acl/Method.h
@@ -20,7 +20,7 @@ namespace Acl
 class MethodCheck: public ParameterizedNode< ACLData<HttpRequestMethod> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/Method.h
+++ b/src/acl/Method.h
@@ -20,7 +20,7 @@ namespace Acl
 class MethodCheck: public ParameterizedNode< ACLData<HttpRequestMethod> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/Method.h
+++ b/src/acl/Method.h
@@ -20,7 +20,7 @@ namespace Acl
 class MethodCheck: public ParameterizedNode< ACLData<HttpRequestMethod> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/MyPortName.h
+++ b/src/acl/MyPortName.h
@@ -19,7 +19,7 @@ namespace Acl
 class MyPortNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/MyPortName.h
+++ b/src/acl/MyPortName.h
@@ -19,7 +19,7 @@ namespace Acl
 class MyPortNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/MyPortName.h
+++ b/src/acl/MyPortName.h
@@ -19,7 +19,7 @@ namespace Acl
 class MyPortNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Node.h
+++ b/src/acl/Node.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_ACL_NODE_H
+#define SQUID_SRC_ACL_NODE_H
+
+#include "acl/forward.h"
+#include "acl/Options.h"
+#include "dlink.h"
+
+class ConfigParser;
+
+namespace Acl {
+
+/// A configurable condition. A node in the ACL expression tree.
+/// Can evaluate itself in FilledChecklist context.
+/// Does not change during evaluation.
+/// \ingroup ACLAPI
+class Node
+{
+
+public:
+    void *operator new(size_t);
+    void operator delete(void *);
+
+    static void ParseAclLine(ConfigParser &parser, Acl::Node **head);
+    static void Initialize();
+    static Acl::Node *FindByName(const char *name);
+
+    Node();
+    Node(Node &&) = delete;  // no copying of any kind
+    virtual ~Node();
+
+    /// sets user-specified ACL name and squid.conf context
+    void context(const char *name, const char *configuration);
+
+    /// Orchestrates matching checklist against the Acl::Node using match(),
+    /// after checking preconditions and while providing debugging.
+    /// \return true if and only if there was a successful match.
+    /// Updates the checklist state on match, async, and failure.
+    bool matches(ACLChecklist *checklist) const;
+
+    /// configures Acl::Node options, throwing on configuration errors
+    void parseFlags();
+
+    /// parses node representation in squid.conf; dies on failures
+    virtual void parse() = 0;
+    virtual char const *typeString() const = 0;
+    virtual bool isProxyAuth() const;
+    virtual SBufList dump() const = 0;
+    virtual bool empty() const = 0;
+    virtual bool valid() const;
+
+    int cacheMatchAcl(dlink_list *cache, ACLChecklist *);
+    virtual int matchForCache(ACLChecklist *checklist);
+
+    virtual void prepareForUse() {}
+
+    // TODO: Find a way to make options() and this method constant
+    /// Prints aggregated "acl" (or similar) directive configuration, including
+    /// the given directive name, ACL name, ACL type, and ACL parameters. The
+    /// printed parameters are collected from all same-name "acl" directives.
+    void dumpWhole(const char *directiveName, std::ostream &);
+
+    char name[ACL_NAME_SZ];
+    char *cfgline;
+    Acl::Node *next;  // XXX: remove or at least use refcounting
+    bool registered;  ///< added to the global list of ACLs via aclRegister()
+
+private:
+    /// Matches the actual data in checklist against this Acl::Node.
+    virtual int match(ACLChecklist *checklist) = 0;  // XXX: missing const
+
+    /// whether our (i.e. shallow) match() requires checklist to have a AccessLogEntry
+    virtual bool requiresAle() const;
+    /// whether our (i.e. shallow) match() requires checklist to have a request
+    virtual bool requiresRequest() const;
+    /// whether our (i.e. shallow) match() requires checklist to have a reply
+    virtual bool requiresReply() const;
+
+    // TODO: Rename to globalOptions(); these are not the only supported options
+    /// \returns (linked) 'global' Options supported by this Acl::Node
+    virtual const Acl::Options &options() { return Acl::NoOptions(); }
+
+    /// \returns (linked) "line" Options supported by this Acl::Node
+    /// \see Acl::Node::options()
+    virtual const Acl::Options &lineOptions() { return Acl::NoOptions(); }
+};
+
+} // namespace Acl
+
+#endif /* SQUID_SRC_ACL_NODE_H */

--- a/src/acl/Note.h
+++ b/src/acl/Note.h
@@ -31,7 +31,7 @@ public:
 class NoteCheck: public Acl::AnnotationCheck
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 

--- a/src/acl/Note.h
+++ b/src/acl/Note.h
@@ -31,7 +31,7 @@ public:
 class NoteCheck: public Acl::AnnotationCheck
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 

--- a/src/acl/Note.h
+++ b/src/acl/Note.h
@@ -31,7 +31,7 @@ public:
 class NoteCheck: public Acl::AnnotationCheck
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override { return true; }
 

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -15,7 +15,7 @@
 #include <iosfwd>
 #include <vector>
 
-// After line continuation is handled by the preprocessor, an Acl::AclNode object
+// After line continuation is handled by the preprocessor, an Acl::Node object
 // configuration can be visualized as a sequence of same-name "acl ..." lines:
 //
 // L1: acl exampleA typeT parameter1 -i parameter2 parameter3
@@ -27,7 +27,7 @@
 //
 // * Global (e.g., "-n"): Applies to all parameters regardless of where the
 //   option was discovered/parsed (e.g., "-n" on L3 affects parameter2 on L1).
-//   Declared by Acl::AclNode class kids (or equivalent) via Acl::AclNode::options().
+//   Declared by Acl::Node class kids (or equivalent) via Acl::Node::options().
 //
 // * Line (e.g., "-i"): Applies to the yet unparsed ACL parameters of the
 //   current "acl ..." line (e.g., "-i" on L1 has no effect on parameter4 on L2)

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -15,7 +15,7 @@
 #include <iosfwd>
 #include <vector>
 
-// After line continuation is handled by the preprocessor, an AclNode object
+// After line continuation is handled by the preprocessor, an Acl::AclNode object
 // configuration can be visualized as a sequence of same-name "acl ..." lines:
 //
 // L1: acl exampleA typeT parameter1 -i parameter2 parameter3
@@ -27,7 +27,7 @@
 //
 // * Global (e.g., "-n"): Applies to all parameters regardless of where the
 //   option was discovered/parsed (e.g., "-n" on L3 affects parameter2 on L1).
-//   Declared by AclNode class kids (or equivalent) via AclNode::options().
+//   Declared by Acl::AclNode class kids (or equivalent) via Acl::AclNode::options().
 //
 // * Line (e.g., "-i"): Applies to the yet unparsed ACL parameters of the
 //   current "acl ..." line (e.g., "-i" on L1 has no effect on parameter4 on L2)

--- a/src/acl/Options.h
+++ b/src/acl/Options.h
@@ -15,7 +15,7 @@
 #include <iosfwd>
 #include <vector>
 
-// After line continuation is handled by the preprocessor, an ACL object
+// After line continuation is handled by the preprocessor, an AclNode object
 // configuration can be visualized as a sequence of same-name "acl ..." lines:
 //
 // L1: acl exampleA typeT parameter1 -i parameter2 parameter3
@@ -27,7 +27,7 @@
 //
 // * Global (e.g., "-n"): Applies to all parameters regardless of where the
 //   option was discovered/parsed (e.g., "-n" on L3 affects parameter2 on L1).
-//   Declared by ACL class kids (or equivalent) via ACL::options().
+//   Declared by AclNode class kids (or equivalent) via AclNode::options().
 //
 // * Line (e.g., "-i"): Applies to the yet unparsed ACL parameters of the
 //   current "acl ..." line (e.g., "-i" on L1 has no effect on parameter4 on L2)

--- a/src/acl/ParameterizedNode.h
+++ b/src/acl/ParameterizedNode.h
@@ -20,7 +20,7 @@ namespace Acl
 /// An ACL that manages squid.conf-configured ACL parameters using a given class
 /// P. That P class must support the ACLData<> or equivalent API.
 template <class P>
-class ParameterizedNode: public Acl::AclNode
+class ParameterizedNode: public Acl::Node
 {
 public:
     using Parameters = P;
@@ -31,15 +31,15 @@ public:
     ~ParameterizedNode() override = default;
 
 protected:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     void parse() override { Assure(data); data->parse(); }
     void prepareForUse() override { data->prepareForUse(); }
     SBufList dump() const override { return data->dump(); }
     bool empty() const override { return data->empty(); }
     const Acl::Options &lineOptions() override { return data->lineOptions(); }
 
-    /// Points to items this Acl::AclNode is configured to match. A derived class ensures
-    /// that this pointer is never nil after the Acl::AclNode object construction ends.
+    /// Points to items this Acl::Node is configured to match. A derived class ensures
+    /// that this pointer is never nil after the Acl::Node object construction ends.
     std::unique_ptr<Parameters> data;
 };
 

--- a/src/acl/ParameterizedNode.h
+++ b/src/acl/ParameterizedNode.h
@@ -20,7 +20,7 @@ namespace Acl
 /// An ACL that manages squid.conf-configured ACL parameters using a given class
 /// P. That P class must support the ACLData<> or equivalent API.
 template <class P>
-class ParameterizedNode: public AclNode
+class ParameterizedNode: public Acl::AclNode
 {
 public:
     using Parameters = P;
@@ -31,15 +31,15 @@ public:
     ~ParameterizedNode() override = default;
 
 protected:
-    /* AclNode API */
+    /* Acl::AclNode API */
     void parse() override { Assure(data); data->parse(); }
     void prepareForUse() override { data->prepareForUse(); }
     SBufList dump() const override { return data->dump(); }
     bool empty() const override { return data->empty(); }
     const Acl::Options &lineOptions() override { return data->lineOptions(); }
 
-    /// Points to items this AclNode is configured to match. A derived class ensures
-    /// that this pointer is never nil after the AclNode object construction ends.
+    /// Points to items this Acl::AclNode is configured to match. A derived class ensures
+    /// that this pointer is never nil after the Acl::AclNode object construction ends.
     std::unique_ptr<Parameters> data;
 };
 

--- a/src/acl/ParameterizedNode.h
+++ b/src/acl/ParameterizedNode.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_SRC_ACL_PARAMETERIZEDNODE_H
 #define SQUID_SRC_ACL_PARAMETERIZEDNODE_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "base/Assure.h"
 
 #include <memory>

--- a/src/acl/ParameterizedNode.h
+++ b/src/acl/ParameterizedNode.h
@@ -38,8 +38,8 @@ protected:
     bool empty() const override { return data->empty(); }
     const Acl::Options &lineOptions() override { return data->lineOptions(); }
 
-    /// Points to items this Acl::Node is configured to match. A derived class ensures
-    /// that this pointer is never nil after the Acl::Node object construction ends.
+    /// Points to items this ACL is configured to match. A derived class ensures
+    /// that this pointer is never nil after object construction ends.
     std::unique_ptr<Parameters> data;
 };
 

--- a/src/acl/ParameterizedNode.h
+++ b/src/acl/ParameterizedNode.h
@@ -20,7 +20,7 @@ namespace Acl
 /// An ACL that manages squid.conf-configured ACL parameters using a given class
 /// P. That P class must support the ACLData<> or equivalent API.
 template <class P>
-class ParameterizedNode: public ACL
+class ParameterizedNode: public AclNode
 {
 public:
     using Parameters = P;
@@ -31,15 +31,15 @@ public:
     ~ParameterizedNode() override = default;
 
 protected:
-    /* ACL API */
+    /* AclNode API */
     void parse() override { Assure(data); data->parse(); }
     void prepareForUse() override { data->prepareForUse(); }
     SBufList dump() const override { return data->dump(); }
     bool empty() const override { return data->empty(); }
     const Acl::Options &lineOptions() override { return data->lineOptions(); }
 
-    /// Points to items this ACL is configured to match. A derived class ensures
-    /// that this pointer is never nil after the ACL object construction ends.
+    /// Points to items this AclNode is configured to match. A derived class ensures
+    /// that this pointer is never nil after the AclNode object construction ends.
     std::unique_ptr<Parameters> data;
 };
 

--- a/src/acl/PeerName.h
+++ b/src/acl/PeerName.h
@@ -19,7 +19,7 @@ namespace Acl
 class PeerNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/PeerName.h
+++ b/src/acl/PeerName.h
@@ -19,7 +19,7 @@ namespace Acl
 class PeerNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/PeerName.h
+++ b/src/acl/PeerName.h
@@ -19,7 +19,7 @@ namespace Acl
 class PeerNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Protocol.h
+++ b/src/acl/Protocol.h
@@ -20,7 +20,7 @@ namespace Acl
 class ProtocolCheck: public ParameterizedNode< ACLData<AnyP::ProtocolType> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/Protocol.h
+++ b/src/acl/Protocol.h
@@ -20,7 +20,7 @@ namespace Acl
 class ProtocolCheck: public ParameterizedNode< ACLData<AnyP::ProtocolType> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/Protocol.h
+++ b/src/acl/Protocol.h
@@ -20,7 +20,7 @@ namespace Acl
 class ProtocolCheck: public ParameterizedNode< ACLData<AnyP::ProtocolType> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -11,7 +11,7 @@
 
 #include "acl/Acl.h"
 
-class ACLRandom : public AclNode
+class ACLRandom : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLRandom);
 

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -9,7 +9,7 @@
 #ifndef SQUID_ACL_RANDOM_H
 #define SQUID_ACL_RANDOM_H
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 
 class ACLRandom : public Acl::Node
 {

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -11,7 +11,7 @@
 
 #include "acl/Acl.h"
 
-class ACLRandom : public ACL
+class ACLRandom : public AclNode
 {
     MEMPROXY_CLASS(ACLRandom);
 

--- a/src/acl/Random.h
+++ b/src/acl/Random.h
@@ -11,7 +11,7 @@
 
 #include "acl/Acl.h"
 
-class ACLRandom : public Acl::AclNode
+class ACLRandom : public Acl::Node
 {
     MEMPROXY_CLASS(ACLRandom);
 

--- a/src/acl/ReplyHeaderStrategy.h
+++ b/src/acl/ReplyHeaderStrategy.h
@@ -23,7 +23,7 @@ template <Http::HdrType header>
 class ReplyHeaderCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresReply() const override {return true;}
 };

--- a/src/acl/ReplyHeaderStrategy.h
+++ b/src/acl/ReplyHeaderStrategy.h
@@ -23,7 +23,7 @@ template <Http::HdrType header>
 class ReplyHeaderCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresReply() const override {return true;}
 };

--- a/src/acl/ReplyHeaderStrategy.h
+++ b/src/acl/ReplyHeaderStrategy.h
@@ -23,7 +23,7 @@ template <Http::HdrType header>
 class ReplyHeaderCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresReply() const override {return true;}
 };

--- a/src/acl/RequestHeaderStrategy.h
+++ b/src/acl/RequestHeaderStrategy.h
@@ -22,7 +22,7 @@ template <Http::HdrType header>
 class RequestHeaderCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/RequestHeaderStrategy.h
+++ b/src/acl/RequestHeaderStrategy.h
@@ -22,7 +22,7 @@ template <Http::HdrType header>
 class RequestHeaderCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/RequestHeaderStrategy.h
+++ b/src/acl/RequestHeaderStrategy.h
@@ -22,7 +22,7 @@ template <Http::HdrType header>
 class RequestHeaderCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -21,7 +21,7 @@ namespace Acl
 class ServerCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -21,7 +21,7 @@ namespace Acl
 class ServerCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/ServerCertificate.h
+++ b/src/acl/ServerCertificate.h
@@ -21,7 +21,7 @@ namespace Acl
 class ServerCertificateCheck: public ParameterizedNode< ACLData<X509 *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/ServerName.h
+++ b/src/acl/ServerName.h
@@ -26,7 +26,7 @@ namespace Acl
 class ServerNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
     const Acl::Options &options() override;

--- a/src/acl/ServerName.h
+++ b/src/acl/ServerName.h
@@ -26,7 +26,7 @@ namespace Acl
 class ServerNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
     const Acl::Options &options() override;

--- a/src/acl/ServerName.h
+++ b/src/acl/ServerName.h
@@ -26,7 +26,7 @@ namespace Acl
 class ServerNameCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
     const Acl::Options &options() override;

--- a/src/acl/SourceAsn.h
+++ b/src/acl/SourceAsn.h
@@ -20,7 +20,7 @@ namespace Acl
 class SourceAsnCheck: public ParameterizedNode< ACLData<Ip::Address> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SourceAsn.h
+++ b/src/acl/SourceAsn.h
@@ -20,7 +20,7 @@ namespace Acl
 class SourceAsnCheck: public ParameterizedNode< ACLData<Ip::Address> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SourceAsn.h
+++ b/src/acl/SourceAsn.h
@@ -20,7 +20,7 @@ namespace Acl
 class SourceAsnCheck: public ParameterizedNode< ACLData<Ip::Address> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -20,7 +20,7 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLFilledChecklist &checklist, const Acl::AclNode &)
+StartLookup(ACLFilledChecklist &checklist, const Acl::Node &)
 {
     fqdncache_nbgethostbyaddr(checklist.src_addr, LookupDone, &checklist);
 }

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -20,7 +20,7 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLFilledChecklist &checklist, const AclNode &)
+StartLookup(ACLFilledChecklist &checklist, const Acl::AclNode &)
 {
     fqdncache_nbgethostbyaddr(checklist.src_addr, LookupDone, &checklist);
 }

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -20,7 +20,7 @@
 static void LookupDone(const char *, const Dns::LookupDetails &, void *data);
 
 static void
-StartLookup(ACLFilledChecklist &checklist, const ACL &)
+StartLookup(ACLFilledChecklist &checklist, const AclNode &)
 {
     fqdncache_nbgethostbyaddr(checklist.src_addr, LookupDone, &checklist);
 }

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -21,7 +21,7 @@ namespace Acl
 class SourceDomainCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -21,7 +21,7 @@ namespace Acl
 class SourceDomainCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -21,7 +21,7 @@ namespace Acl
 class SourceDomainCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SquidError.h
+++ b/src/acl/SquidError.h
@@ -20,7 +20,7 @@ namespace Acl
 class SquidErrorCheck: public ParameterizedNode< ACLData<err_type> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SquidError.h
+++ b/src/acl/SquidError.h
@@ -20,7 +20,7 @@ namespace Acl
 class SquidErrorCheck: public ParameterizedNode< ACLData<err_type> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SquidError.h
+++ b/src/acl/SquidError.h
@@ -20,7 +20,7 @@ namespace Acl
 class SquidErrorCheck: public ParameterizedNode< ACLData<err_type> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SslError.h
+++ b/src/acl/SslError.h
@@ -20,7 +20,7 @@ namespace Acl
 class CertificateErrorCheck: public ParameterizedNode< ACLData<const Security::CertErrors *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SslError.h
+++ b/src/acl/SslError.h
@@ -20,7 +20,7 @@ namespace Acl
 class CertificateErrorCheck: public ParameterizedNode< ACLData<const Security::CertErrors *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/SslError.h
+++ b/src/acl/SslError.h
@@ -20,7 +20,7 @@ namespace Acl
 class CertificateErrorCheck: public ParameterizedNode< ACLData<const Security::CertErrors *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Tag.h
+++ b/src/acl/Tag.h
@@ -19,7 +19,7 @@ namespace Acl
 class TagCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Tag.h
+++ b/src/acl/Tag.h
@@ -19,7 +19,7 @@ namespace Acl
 class TagCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Tag.h
+++ b/src/acl/Tag.h
@@ -19,7 +19,7 @@ namespace Acl
 class TagCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Time.h
+++ b/src/acl/Time.h
@@ -20,7 +20,7 @@ namespace Acl
 class CurrentTimeCheck: public ParameterizedNode<ACLTimeData>
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Time.h
+++ b/src/acl/Time.h
@@ -20,7 +20,7 @@ namespace Acl
 class CurrentTimeCheck: public ParameterizedNode<ACLTimeData>
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/Time.h
+++ b/src/acl/Time.h
@@ -20,7 +20,7 @@ namespace Acl
 class CurrentTimeCheck: public ParameterizedNode<ACLTimeData>
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/acl/TransactionInitiator.h
+++ b/src/acl/TransactionInitiator.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// transaction_initiator ACL
-class TransactionInitiator : public Acl::AclNode
+class TransactionInitiator : public Acl::Node
 {
     MEMPROXY_CLASS(TransactionInitiator);
 

--- a/src/acl/TransactionInitiator.h
+++ b/src/acl/TransactionInitiator.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// transaction_initiator ACL
-class TransactionInitiator : public ACL
+class TransactionInitiator : public AclNode
 {
     MEMPROXY_CLASS(TransactionInitiator);
 

--- a/src/acl/TransactionInitiator.h
+++ b/src/acl/TransactionInitiator.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// transaction_initiator ACL
-class TransactionInitiator : public AclNode
+class TransactionInitiator : public Acl::AclNode
 {
     MEMPROXY_CLASS(TransactionInitiator);
 

--- a/src/acl/Tree.cc
+++ b/src/acl/Tree.cc
@@ -41,7 +41,7 @@ Acl::Tree::actionAt(const Nodes::size_type pos) const
 }
 
 void
-Acl::Tree::add(ACL *rule, const Acl::Answer &action)
+Acl::Tree::add(AclNode *rule, const Acl::Answer &action)
 {
     // either all rules have actions or none
     assert(nodes.size() == actions.size());
@@ -50,7 +50,7 @@ Acl::Tree::add(ACL *rule, const Acl::Answer &action)
 }
 
 void
-Acl::Tree::add(ACL *rule)
+Acl::Tree::add(AclNode *rule)
 {
     // either all rules have actions or none
     assert(actions.empty());

--- a/src/acl/Tree.cc
+++ b/src/acl/Tree.cc
@@ -41,7 +41,7 @@ Acl::Tree::actionAt(const Nodes::size_type pos) const
 }
 
 void
-Acl::Tree::add(Acl::AclNode *rule, const Acl::Answer &action)
+Acl::Tree::add(Acl::Node *rule, const Acl::Answer &action)
 {
     // either all rules have actions or none
     assert(nodes.size() == actions.size());
@@ -50,7 +50,7 @@ Acl::Tree::add(Acl::AclNode *rule, const Acl::Answer &action)
 }
 
 void
-Acl::Tree::add(Acl::AclNode *rule)
+Acl::Tree::add(Acl::Node *rule)
 {
     // either all rules have actions or none
     assert(actions.empty());

--- a/src/acl/Tree.cc
+++ b/src/acl/Tree.cc
@@ -41,7 +41,7 @@ Acl::Tree::actionAt(const Nodes::size_type pos) const
 }
 
 void
-Acl::Tree::add(AclNode *rule, const Acl::Answer &action)
+Acl::Tree::add(Acl::AclNode *rule, const Acl::Answer &action)
 {
     // either all rules have actions or none
     assert(nodes.size() == actions.size());
@@ -50,7 +50,7 @@ Acl::Tree::add(AclNode *rule, const Acl::Answer &action)
 }
 
 void
-Acl::Tree::add(AclNode *rule)
+Acl::Tree::add(Acl::AclNode *rule)
 {
     // either all rules have actions or none
     assert(actions.empty());

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -17,7 +17,7 @@
 namespace Acl
 {
 
-/// An ORed set of rules at the top of the Acl::Node expression tree, providing two
+/// An ORed set of rules at the top of the ACL expression tree, providing two
 /// unique properties: cbdata protection and optional rule actions.
 class Tree: public OrNode
 {

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -15,7 +15,7 @@
 namespace Acl
 {
 
-/// An ORed set of rules at the top of the Acl::AclNode expression tree, providing two
+/// An ORed set of rules at the top of the Acl::Node expression tree, providing two
 /// unique properties: cbdata protection and optional rule actions.
 class Tree: public OrNode
 {
@@ -36,8 +36,8 @@ public:
     Answer lastAction() const;
 
     /// appends and takes control over the rule with a given action
-    void add(Acl::AclNode *rule, const Answer &action);
-    void add(Acl::AclNode *rule); ///< same as InnerNode::add()
+    void add(Acl::Node *rule, const Answer &action);
+    void add(Acl::Node *rule); ///< same as InnerNode::add()
 
 protected:
     /// Acl::OrNode API

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -15,7 +15,7 @@
 namespace Acl
 {
 
-/// An ORed set of rules at the top of the ACL expression tree, providing two
+/// An ORed set of rules at the top of the AclNode expression tree, providing two
 /// unique properties: cbdata protection and optional rule actions.
 class Tree: public OrNode
 {
@@ -36,8 +36,8 @@ public:
     Answer lastAction() const;
 
     /// appends and takes control over the rule with a given action
-    void add(ACL *rule, const Answer &action);
-    void add(ACL *rule); ///< same as InnerNode::add()
+    void add(AclNode *rule, const Answer &action);
+    void add(AclNode *rule); ///< same as InnerNode::add()
 
 protected:
     /// Acl::OrNode API

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -15,7 +15,7 @@
 namespace Acl
 {
 
-/// An ORed set of rules at the top of the AclNode expression tree, providing two
+/// An ORed set of rules at the top of the Acl::AclNode expression tree, providing two
 /// unique properties: cbdata protection and optional rule actions.
 class Tree: public OrNode
 {
@@ -36,8 +36,8 @@ public:
     Answer lastAction() const;
 
     /// appends and takes control over the rule with a given action
-    void add(AclNode *rule, const Answer &action);
-    void add(AclNode *rule); ///< same as InnerNode::add()
+    void add(Acl::AclNode *rule, const Answer &action);
+    void add(Acl::AclNode *rule); ///< same as InnerNode::add()
 
 protected:
     /// Acl::OrNode API

--- a/src/acl/Tree.h
+++ b/src/acl/Tree.h
@@ -9,7 +9,9 @@
 #ifndef SQUID_ACL_TREE_H
 #define SQUID_ACL_TREE_H
 
+#include "acl/Acl.h"
 #include "acl/BoolOps.h"
+#include "cbdata.h"
 #include "sbuf/List.h"
 
 namespace Acl

--- a/src/acl/Url.h
+++ b/src/acl/Url.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/Url.h
+++ b/src/acl/Url.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/Url.h
+++ b/src/acl/Url.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlLogin.h
+++ b/src/acl/UrlLogin.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlLoginCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlLogin.h
+++ b/src/acl/UrlLogin.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlLoginCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlLogin.h
+++ b/src/acl/UrlLogin.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlLoginCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlPath.h
+++ b/src/acl/UrlPath.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlPathCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlPath.h
+++ b/src/acl/UrlPath.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlPathCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlPath.h
+++ b/src/acl/UrlPath.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlPathCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlPort.h
+++ b/src/acl/UrlPort.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlPortCheck: public ParameterizedNode< ACLData<int> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlPort.h
+++ b/src/acl/UrlPort.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlPortCheck: public ParameterizedNode< ACLData<int> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/UrlPort.h
+++ b/src/acl/UrlPort.h
@@ -19,7 +19,7 @@ namespace Acl
 class UrlPortCheck: public ParameterizedNode< ACLData<int> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
     bool requiresRequest() const override {return true;}
 };

--- a/src/acl/forward.h
+++ b/src/acl/forward.h
@@ -11,7 +11,6 @@
 
 #include "base/RefCount.h"
 
-class AclNode;
 class ACLChecklist;
 class ACLFilledChecklist;
 class ACLList;
@@ -22,6 +21,7 @@ class AclSizeLimit;
 namespace Acl
 {
 
+class AclNode;
 class Address;
 class AndNode;
 class Answer;

--- a/src/acl/forward.h
+++ b/src/acl/forward.h
@@ -21,7 +21,7 @@ class AclSizeLimit;
 namespace Acl
 {
 
-class AclNode;
+class Node;
 class Address;
 class AndNode;
 class Answer;

--- a/src/acl/forward.h
+++ b/src/acl/forward.h
@@ -11,7 +11,7 @@
 
 #include "base/RefCount.h"
 
-class ACL;
+class AclNode;
 class ACLChecklist;
 class ACLFilledChecklist;
 class ACLList;

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -25,7 +25,7 @@
  * \retval ACCESS_ALLOWED       user authenticated and authorized
  */
 Acl::Answer
-AuthenticateAcl(ACLChecklist *ch, const Acl::AclNode &acl)
+AuthenticateAcl(ACLChecklist *ch, const Acl::Node &acl)
 {
     ACLFilledChecklist *checklist = Filled(ch);
     const auto request = checklist->request;

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -25,7 +25,7 @@
  * \retval ACCESS_ALLOWED       user authenticated and authorized
  */
 Acl::Answer
-AuthenticateAcl(ACLChecklist *ch, const AclNode &acl)
+AuthenticateAcl(ACLChecklist *ch, const Acl::AclNode &acl)
 {
     ACLFilledChecklist *checklist = Filled(ch);
     const auto request = checklist->request;

--- a/src/auth/Acl.cc
+++ b/src/auth/Acl.cc
@@ -25,7 +25,7 @@
  * \retval ACCESS_ALLOWED       user authenticated and authorized
  */
 Acl::Answer
-AuthenticateAcl(ACLChecklist *ch, const ACL &acl)
+AuthenticateAcl(ACLChecklist *ch, const AclNode &acl)
 {
     ACLFilledChecklist *checklist = Filled(ch);
     const auto request = checklist->request;

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -13,13 +13,13 @@
 
 #include "acl/Acl.h"
 
-// ACL-related code used by authentication-related code. This code is not in
+// AclNode-related code used by authentication-related code. This code is not in
 // auth/Gadgets to avoid making auth/libauth dependent on acl/libstate because
 // acl/libstate already depends on auth/libauth.
 
 class ACLChecklist;
 /// \ingroup AuthAPI
-Acl::Answer AuthenticateAcl(ACLChecklist *, const ACL &);
+Acl::Answer AuthenticateAcl(ACLChecklist *, const AclNode &);
 
 #endif /* USE_AUTH */
 #endif /* SQUID_AUTH_ACL_H */

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -13,7 +13,7 @@
 
 #include "acl/Acl.h"
 
-// Acl::Node-related code used by authentication-related code. This code is not in
+// ACL-related code used by authentication-related code. This code is not in
 // auth/Gadgets to avoid making auth/libauth dependent on acl/libstate because
 // acl/libstate already depends on auth/libauth.
 

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -13,13 +13,13 @@
 
 #include "acl/Acl.h"
 
-// AclNode-related code used by authentication-related code. This code is not in
+// Acl::AclNode-related code used by authentication-related code. This code is not in
 // auth/Gadgets to avoid making auth/libauth dependent on acl/libstate because
 // acl/libstate already depends on auth/libauth.
 
 class ACLChecklist;
 /// \ingroup AuthAPI
-Acl::Answer AuthenticateAcl(ACLChecklist *, const AclNode &);
+Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::AclNode &);
 
 #endif /* USE_AUTH */
 #endif /* SQUID_AUTH_ACL_H */

--- a/src/auth/Acl.h
+++ b/src/auth/Acl.h
@@ -13,13 +13,13 @@
 
 #include "acl/Acl.h"
 
-// Acl::AclNode-related code used by authentication-related code. This code is not in
+// Acl::Node-related code used by authentication-related code. This code is not in
 // auth/Gadgets to avoid making auth/libauth dependent on acl/libstate because
 // acl/libstate already depends on auth/libauth.
 
 class ACLChecklist;
 /// \ingroup AuthAPI
-Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::AclNode &);
+Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::Node &);
 
 #endif /* USE_AUTH */
 #endif /* SQUID_AUTH_ACL_H */

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -11,7 +11,7 @@
 
 #if USE_AUTH
 
-#include "acl/Acl.h"
+#include "acl/Node.h"
 #include "auth/UserRequest.h"
 
 class ACLMaxUserIP : public Acl::Node

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -14,7 +14,7 @@
 #include "acl/Acl.h"
 #include "auth/UserRequest.h"
 
-class ACLMaxUserIP : public Acl::AclNode
+class ACLMaxUserIP : public Acl::Node
 {
     MEMPROXY_CLASS(ACLMaxUserIP);
 

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -14,7 +14,7 @@
 #include "acl/Acl.h"
 #include "auth/UserRequest.h"
 
-class ACLMaxUserIP : public ACL
+class ACLMaxUserIP : public AclNode
 {
     MEMPROXY_CLASS(ACLMaxUserIP);
 

--- a/src/auth/AclMaxUserIp.h
+++ b/src/auth/AclMaxUserIp.h
@@ -14,7 +14,7 @@
 #include "acl/Acl.h"
 #include "auth/UserRequest.h"
 
-class ACLMaxUserIP : public AclNode
+class ACLMaxUserIP : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLMaxUserIP);
 

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -103,7 +103,7 @@ ACLProxyAuth::valid() const
 }
 
 void
-ACLProxyAuth::StartLookup(ACLFilledChecklist &cl, const ACL &)
+ACLProxyAuth::StartLookup(ACLFilledChecklist &cl, const AclNode &)
 {
     debugs(28, 3, "checking password via authenticator");
 

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -103,7 +103,7 @@ ACLProxyAuth::valid() const
 }
 
 void
-ACLProxyAuth::StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
+ACLProxyAuth::StartLookup(ACLFilledChecklist &cl, const Acl::Node &)
 {
     debugs(28, 3, "checking password via authenticator");
 

--- a/src/auth/AclProxyAuth.cc
+++ b/src/auth/AclProxyAuth.cc
@@ -103,7 +103,7 @@ ACLProxyAuth::valid() const
 }
 
 void
-ACLProxyAuth::StartLookup(ACLFilledChecklist &cl, const AclNode &)
+ACLProxyAuth::StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
 {
     debugs(28, 3, "checking password via authenticator");
 

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -15,17 +15,17 @@
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ACLProxyAuth : public ACL
+class ACLProxyAuth : public AclNode
 {
     MEMPROXY_CLASS(ACLProxyAuth);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const ACL &);
+    static void StartLookup(ACLFilledChecklist &, const AclNode &);
 
     ~ACLProxyAuth() override;
     ACLProxyAuth(ACLData<char const *> *, char const *);
 
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -39,7 +39,7 @@ public:
 private:
     static void LookupDone(void *data);
 
-    /* ACL API */
+    /* AclNode API */
     const Acl::Options &lineOptions() override;
 
     int matchProxyAuth(ACLChecklist *);

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -15,17 +15,17 @@
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ACLProxyAuth : public Acl::AclNode
+class ACLProxyAuth : public Acl::Node
 {
     MEMPROXY_CLASS(ACLProxyAuth);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::Node &);
 
     ~ACLProxyAuth() override;
     ACLProxyAuth(ACLData<char const *> *, char const *);
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -39,7 +39,7 @@ public:
 private:
     static void LookupDone(void *data);
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     const Acl::Options &lineOptions() override;
 
     int matchProxyAuth(ACLChecklist *);

--- a/src/auth/AclProxyAuth.h
+++ b/src/auth/AclProxyAuth.h
@@ -15,17 +15,17 @@
 #include "acl/Checklist.h"
 #include "acl/Data.h"
 
-class ACLProxyAuth : public AclNode
+class ACLProxyAuth : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLProxyAuth);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
 
     ~ACLProxyAuth() override;
     ACLProxyAuth(ACLData<char const *> *, char const *);
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -39,7 +39,7 @@ public:
 private:
     static void LookupDone(void *data);
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     const Acl::Options &lineOptions() override;
 
     int matchProxyAuth(ACLChecklist *);

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -255,7 +255,7 @@ static void free_configuration_includes_quoted_values(bool *recognizeQuotedValue
 static void parse_on_unsupported_protocol(acl_access **access);
 static void dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *access);
 static void free_on_unsupported_protocol(acl_access **access);
-static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::AclNode *acl = nullptr);
+static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::Node *acl = nullptr);
 static void parse_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
 static void dump_http_upgrade_request_protocols(StoreEntry *entry, const char *name, HttpUpgradeProtocolAccess *protoGuards);
 static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
@@ -1491,7 +1491,7 @@ free_SBufList(SBufList *list)
 }
 
 static void
-dump_acl(StoreEntry * entry, const char *name, Acl::AclNode * ae)
+dump_acl(StoreEntry * entry, const char *name, Acl::Node * ae)
 {
     PackableStream os(*entry);
     while (ae != nullptr) {
@@ -1502,13 +1502,13 @@ dump_acl(StoreEntry * entry, const char *name, Acl::AclNode * ae)
 }
 
 static void
-parse_acl(Acl::AclNode ** ae)
+parse_acl(Acl::Node ** ae)
 {
-    Acl::AclNode::ParseAclLine(LegacyParser, ae);
+    Acl::Node::ParseAclLine(LegacyParser, ae);
 }
 
 static void
-free_acl(Acl::AclNode ** ae)
+free_acl(Acl::Node ** ae)
 {
     aclDestroyAcls(ae);
 }
@@ -2024,7 +2024,7 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 #endif /* USE_AUTH */
 
 static void
-ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::AclNode *acl)
+ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::Node *acl)
 {
     assert(access);
     SBuf name;
@@ -4724,7 +4724,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         *ftp_epsv = nullptr;
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
-            if (auto *a = Acl::AclNode::FindByName("all"))
+            if (auto *a = Acl::Node::FindByName("all"))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -15,6 +15,7 @@
 #include "acl/Address.h"
 #include "acl/Gadgets.h"
 #include "acl/MethodData.h"
+#include "acl/Node.h"
 #include "acl/Tree.h"
 #include "anyp/PortCfg.h"
 #include "anyp/UriScheme.h"

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -4724,7 +4724,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         *ftp_epsv = nullptr;
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
-            if (AclNode *a = AclNode::FindByName("all"))
+            if (auto *a = AclNode::FindByName("all"))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -255,7 +255,7 @@ static void free_configuration_includes_quoted_values(bool *recognizeQuotedValue
 static void parse_on_unsupported_protocol(acl_access **access);
 static void dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *access);
 static void free_on_unsupported_protocol(acl_access **access);
-static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, ACL *acl = nullptr);
+static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, AclNode *acl = nullptr);
 static void parse_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
 static void dump_http_upgrade_request_protocols(StoreEntry *entry, const char *name, HttpUpgradeProtocolAccess *protoGuards);
 static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
@@ -1491,7 +1491,7 @@ free_SBufList(SBufList *list)
 }
 
 static void
-dump_acl(StoreEntry * entry, const char *name, ACL * ae)
+dump_acl(StoreEntry * entry, const char *name, AclNode * ae)
 {
     PackableStream os(*entry);
     while (ae != nullptr) {
@@ -1502,13 +1502,13 @@ dump_acl(StoreEntry * entry, const char *name, ACL * ae)
 }
 
 static void
-parse_acl(ACL ** ae)
+parse_acl(AclNode ** ae)
 {
-    ACL::ParseAclLine(LegacyParser, ae);
+    AclNode::ParseAclLine(LegacyParser, ae);
 }
 
 static void
-free_acl(ACL ** ae)
+free_acl(AclNode ** ae)
 {
     aclDestroyAcls(ae);
 }
@@ -2024,7 +2024,7 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 #endif /* USE_AUTH */
 
 static void
-ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, ACL *acl)
+ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, AclNode *acl)
 {
     assert(access);
     SBuf name;
@@ -4724,7 +4724,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         *ftp_epsv = nullptr;
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
-            if (ACL *a = ACL::FindByName("all"))
+            if (AclNode *a = AclNode::FindByName("all"))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -255,7 +255,7 @@ static void free_configuration_includes_quoted_values(bool *recognizeQuotedValue
 static void parse_on_unsupported_protocol(acl_access **access);
 static void dump_on_unsupported_protocol(StoreEntry *entry, const char *name, acl_access *access);
 static void free_on_unsupported_protocol(acl_access **access);
-static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, AclNode *acl = nullptr);
+static void ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::AclNode *acl = nullptr);
 static void parse_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
 static void dump_http_upgrade_request_protocols(StoreEntry *entry, const char *name, HttpUpgradeProtocolAccess *protoGuards);
 static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **protoGuards);
@@ -1491,7 +1491,7 @@ free_SBufList(SBufList *list)
 }
 
 static void
-dump_acl(StoreEntry * entry, const char *name, AclNode * ae)
+dump_acl(StoreEntry * entry, const char *name, Acl::AclNode * ae)
 {
     PackableStream os(*entry);
     while (ae != nullptr) {
@@ -1502,13 +1502,13 @@ dump_acl(StoreEntry * entry, const char *name, AclNode * ae)
 }
 
 static void
-parse_acl(AclNode ** ae)
+parse_acl(Acl::AclNode ** ae)
 {
-    AclNode::ParseAclLine(LegacyParser, ae);
+    Acl::AclNode::ParseAclLine(LegacyParser, ae);
 }
 
 static void
-free_acl(AclNode ** ae)
+free_acl(Acl::AclNode ** ae)
 {
     aclDestroyAcls(ae);
 }
@@ -2024,7 +2024,7 @@ dump_AuthSchemes(StoreEntry *entry, const char *name, acl_access *authSchemes)
 #endif /* USE_AUTH */
 
 static void
-ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, AclNode *acl)
+ParseAclWithAction(acl_access **access, const Acl::Answer &action, const char *desc, Acl::AclNode *acl)
 {
     assert(access);
     SBuf name;
@@ -4724,7 +4724,7 @@ static void parse_ftp_epsv(acl_access **ftp_epsv)
         *ftp_epsv = nullptr;
 
         if (ftpEpsvDeprecatedAction == Acl::Answer(ACCESS_DENIED)) {
-            if (auto *a = AclNode::FindByName("all"))
+            if (auto *a = Acl::AclNode::FindByName("all"))
                 ParseAclWithAction(ftp_epsv, ftpEpsvDeprecatedAction, "ftp_epsv", a);
             else {
                 self_destruct();

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1014,7 +1014,7 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
 /// Asks the helper (if needed) or returns the [cached] result (otherwise).
 /// Does not support "background" lookups. See also: ACLExternal::Start().
 void
-ACLExternal::StartLookup(ACLFilledChecklist &checklist, const AclNode &acl)
+ACLExternal::StartLookup(ACLFilledChecklist &checklist, const Acl::AclNode &acl)
 {
     const auto &me = dynamic_cast<const ACLExternal&>(acl);
     me.startLookup(&checklist, me.data, false);

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1014,7 +1014,7 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
 /// Asks the helper (if needed) or returns the [cached] result (otherwise).
 /// Does not support "background" lookups. See also: ACLExternal::Start().
 void
-ACLExternal::StartLookup(ACLFilledChecklist &checklist, const ACL &acl)
+ACLExternal::StartLookup(ACLFilledChecklist &checklist, const AclNode &acl)
 {
     const auto &me = dynamic_cast<const ACLExternal&>(acl);
     me.startLookup(&checklist, me.data, false);

--- a/src/external_acl.cc
+++ b/src/external_acl.cc
@@ -1014,7 +1014,7 @@ externalAclHandleReply(void *data, const Helper::Reply &reply)
 /// Asks the helper (if needed) or returns the [cached] result (otherwise).
 /// Does not support "background" lookups. See also: ACLExternal::Start().
 void
-ACLExternal::StartLookup(ACLFilledChecklist &checklist, const Acl::AclNode &acl)
+ACLExternal::StartLookup(ACLFilledChecklist &checklist, const Acl::Node &acl)
 {
     const auto &me = dynamic_cast<const ACLExternal&>(acl);
     me.startLookup(&checklist, me.data, false);

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -88,7 +88,7 @@ ACLIdent::empty () const
 }
 
 void
-ACLIdent::StartLookup(ACLFilledChecklist &cl, const ACL &)
+ACLIdent::StartLookup(ACLFilledChecklist &cl, const AclNode &)
 {
     const ConnStateData *conn = cl.conn();
     // check that ACLIdent::match() tested this lookup precondition

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -88,7 +88,7 @@ ACLIdent::empty () const
 }
 
 void
-ACLIdent::StartLookup(ACLFilledChecklist &cl, const AclNode &)
+ACLIdent::StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
 {
     const ConnStateData *conn = cl.conn();
     // check that ACLIdent::match() tested this lookup precondition

--- a/src/ident/AclIdent.cc
+++ b/src/ident/AclIdent.cc
@@ -88,7 +88,7 @@ ACLIdent::empty () const
 }
 
 void
-ACLIdent::StartLookup(ACLFilledChecklist &cl, const Acl::AclNode &)
+ACLIdent::StartLookup(ACLFilledChecklist &cl, const Acl::Node &)
 {
     const ConnStateData *conn = cl.conn();
     // check that ACLIdent::match() tested this lookup precondition

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -16,17 +16,17 @@
 #include "acl/Data.h"
 
 /// \ingroup ACLAPI
-class ACLIdent : public AclNode
+class ACLIdent : public Acl::AclNode
 {
     MEMPROXY_CLASS(ACLIdent);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
 
     ACLIdent(ACLData<char const *> *newData, char const *);
     ~ACLIdent() override;
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -37,7 +37,7 @@ public:
 private:
     static void LookupDone(const char *ident, void *data);
 
-    /* AclNode API */
+    /* Acl::AclNode API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -16,17 +16,17 @@
 #include "acl/Data.h"
 
 /// \ingroup ACLAPI
-class ACLIdent : public ACL
+class ACLIdent : public AclNode
 {
     MEMPROXY_CLASS(ACLIdent);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const ACL &);
+    static void StartLookup(ACLFilledChecklist &, const AclNode &);
 
     ACLIdent(ACLData<char const *> *newData, char const *);
     ~ACLIdent() override;
 
-    /* ACL API */
+    /* AclNode API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -37,7 +37,7 @@ public:
 private:
     static void LookupDone(const char *ident, void *data);
 
-    /* ACL API */
+    /* AclNode API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/ident/AclIdent.h
+++ b/src/ident/AclIdent.h
@@ -16,17 +16,17 @@
 #include "acl/Data.h"
 
 /// \ingroup ACLAPI
-class ACLIdent : public Acl::AclNode
+class ACLIdent : public Acl::Node
 {
     MEMPROXY_CLASS(ACLIdent);
 
 public:
-    static void StartLookup(ACLFilledChecklist &, const Acl::AclNode &);
+    static void StartLookup(ACLFilledChecklist &, const Acl::Node &);
 
     ACLIdent(ACLData<char const *> *newData, char const *);
     ~ACLIdent() override;
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     char const *typeString() const override;
     void parse() override;
     bool isProxyAuth() const override {return true;}
@@ -37,7 +37,7 @@ public:
 private:
     static void LookupDone(const char *ident, void *data);
 
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     const Acl::Options &lineOptions() override;
 
     ACLData<char const *> *data;

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -28,7 +28,7 @@
 
 class fde;
 
-// TODO: move to new Acl::AclNode framework
+// TODO: move to new Acl::Node framework
 class acl_tos
 {
     CBDATA_CLASS(acl_tos);
@@ -42,7 +42,7 @@ public:
     tos_t tos;
 };
 
-// TODO: move to new Acl::AclNode framework
+// TODO: move to new Acl::Node framework
 class acl_nfmark
 {
     CBDATA_CLASS(acl_nfmark);

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -28,7 +28,7 @@
 
 class fde;
 
-// TODO: move to new AclNode framework
+// TODO: move to new Acl::AclNode framework
 class acl_tos
 {
     CBDATA_CLASS(acl_tos);
@@ -42,7 +42,7 @@ public:
     tos_t tos;
 };
 
-// TODO: move to new AclNode framework
+// TODO: move to new Acl::AclNode framework
 class acl_nfmark
 {
     CBDATA_CLASS(acl_nfmark);

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -28,7 +28,7 @@
 
 class fde;
 
-// TODO: move to new ACL framework
+// TODO: move to new AclNode framework
 class acl_tos
 {
     CBDATA_CLASS(acl_tos);
@@ -42,7 +42,7 @@ public:
     tos_t tos;
 };
 
-// TODO: move to new ACL framework
+// TODO: move to new AclNode framework
 class acl_nfmark
 {
     CBDATA_CLASS(acl_nfmark);

--- a/src/main.cc
+++ b/src/main.cc
@@ -806,7 +806,7 @@ serverConnectionsOpen(void)
         icmpEngine.Open();
         netdbInit();
         asnInit();
-        AclNode::Initialize();
+        Acl::AclNode::Initialize();
         peerSelectInit();
 
         carpInit();

--- a/src/main.cc
+++ b/src/main.cc
@@ -806,7 +806,7 @@ serverConnectionsOpen(void)
         icmpEngine.Open();
         netdbInit();
         asnInit();
-        ACL::Initialize();
+        AclNode::Initialize();
         peerSelectInit();
 
         carpInit();

--- a/src/main.cc
+++ b/src/main.cc
@@ -806,7 +806,7 @@ serverConnectionsOpen(void)
         icmpEngine.Open();
         netdbInit();
         asnInit();
-        Acl::AclNode::Initialize();
+        Acl::Node::Initialize();
         peerSelectInit();
 
         carpInit();

--- a/src/snmp_core.h
+++ b/src/snmp_core.h
@@ -61,7 +61,7 @@ namespace Acl
 class SnmpCommunityCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* ACL API */
+    /* AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/snmp_core.h
+++ b/src/snmp_core.h
@@ -61,7 +61,7 @@ namespace Acl
 class SnmpCommunityCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* Acl::AclNode API */
+    /* Acl::Node API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/snmp_core.h
+++ b/src/snmp_core.h
@@ -61,7 +61,7 @@ namespace Acl
 class SnmpCommunityCheck: public ParameterizedNode< ACLData<const char *> >
 {
 public:
-    /* AclNode API */
+    /* Acl::AclNode API */
     int match(ACLChecklist *) override;
 };
 

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -15,7 +15,7 @@
 #include "acl/Acl.h" /* for Acl::Answer */
 
 #include "auth/Acl.h"
-Acl::Answer AuthenticateAcl(ACLChecklist *, const AclNode &) STUB_RETVAL(ACCESS_DENIED)
+Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::AclNode &) STUB_RETVAL(ACCESS_DENIED)
 
 #include "auth/AclMaxUserIp.h"
 ACLMaxUserIP::ACLMaxUserIP (char const *) STUB

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -15,7 +15,7 @@
 #include "acl/Acl.h" /* for Acl::Answer */
 
 #include "auth/Acl.h"
-Acl::Answer AuthenticateAcl(ACLChecklist *, const ACL &) STUB_RETVAL(ACCESS_DENIED)
+Acl::Answer AuthenticateAcl(ACLChecklist *, const AclNode &) STUB_RETVAL(ACCESS_DENIED)
 
 #include "auth/AclMaxUserIp.h"
 ACLMaxUserIP::ACLMaxUserIP (char const *) STUB

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -15,7 +15,7 @@
 #include "acl/Acl.h" /* for Acl::Answer */
 
 #include "auth/Acl.h"
-Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::AclNode &) STUB_RETVAL(ACCESS_DENIED)
+Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::Node &) STUB_RETVAL(ACCESS_DENIED)
 
 #include "auth/AclMaxUserIp.h"
 ACLMaxUserIP::ACLMaxUserIP (char const *) STUB

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -64,7 +64,7 @@ public:
 void
 MyTestProgram::startup()
 {
-    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->AclNode* { return new ACLMaxUserIP(name); });
+    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->Acl::AclNode* { return new ACLMaxUserIP(name); });
 }
 
 void
@@ -74,9 +74,9 @@ TestACLMaxUserIP::testParseLine()
     char * line = xstrdup("test max_user_ip -s 1");
     /* seed the parser */
     ConfigParser::SetCfgLine(line);
-    AclNode *anACL = nullptr;
+    Acl::AclNode *anACL = nullptr;
     ConfigParser LegacyParser;
-    AclNode::ParseAclLine(LegacyParser, &anACL);
+    Acl::AclNode::ParseAclLine(LegacyParser, &anACL);
     ACLMaxUserIP *maxUserIpACL = dynamic_cast<ACLMaxUserIP *>(anACL);
     CPPUNIT_ASSERT(maxUserIpACL);
     if (maxUserIpACL) {

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -64,7 +64,7 @@ public:
 void
 MyTestProgram::startup()
 {
-    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->Acl::AclNode* { return new ACLMaxUserIP(name); });
+    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->Acl::Node* { return new ACLMaxUserIP(name); });
 }
 
 void
@@ -74,9 +74,9 @@ TestACLMaxUserIP::testParseLine()
     char * line = xstrdup("test max_user_ip -s 1");
     /* seed the parser */
     ConfigParser::SetCfgLine(line);
-    Acl::AclNode *anACL = nullptr;
+    Acl::Node *anACL = nullptr;
     ConfigParser LegacyParser;
-    Acl::AclNode::ParseAclLine(LegacyParser, &anACL);
+    Acl::Node::ParseAclLine(LegacyParser, &anACL);
     ACLMaxUserIP *maxUserIpACL = dynamic_cast<ACLMaxUserIP *>(anACL);
     CPPUNIT_ASSERT(maxUserIpACL);
     if (maxUserIpACL) {

--- a/src/tests/testACLMaxUserIP.cc
+++ b/src/tests/testACLMaxUserIP.cc
@@ -64,7 +64,7 @@ public:
 void
 MyTestProgram::startup()
 {
-    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->ACL* { return new ACLMaxUserIP(name); });
+    Acl::RegisterMaker("max_user_ip", [](Acl::TypeName name)->AclNode* { return new ACLMaxUserIP(name); });
 }
 
 void
@@ -74,9 +74,9 @@ TestACLMaxUserIP::testParseLine()
     char * line = xstrdup("test max_user_ip -s 1");
     /* seed the parser */
     ConfigParser::SetCfgLine(line);
-    ACL *anACL = nullptr;
+    AclNode *anACL = nullptr;
     ConfigParser LegacyParser;
-    ACL::ParseAclLine(LegacyParser, &anACL);
+    AclNode::ParseAclLine(LegacyParser, &anACL);
     ACLMaxUserIP *maxUserIpACL = dynamic_cast<ACLMaxUserIP *>(anACL);
     CPPUNIT_ASSERT(maxUserIpACL);
     if (maxUserIpACL) {


### PR DESCRIPTION
There is a name clash between Squid's ACL and
MS Windows' ACL (http://tinyurl.com/ns-winnt-acl).

