### PR TITLE
basic_sspi_auth: Fix build on Windows with libnettle

### DIFF
--- a/src/auth/basic/SSPI/Makefile.am
+++ b/src/auth/basic/SSPI/Makefile.am
@@ -21,6 +21,7 @@ basic_sspi_auth_LDADD = \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
 	-lnetapi32 -ladvapi32 \
+	$(LIBNETTLE_LIBS) \
 	$(XTRA_LIBS)
 
 man_MANS = basic_sspi_auth.8


### PR DESCRIPTION
Our detection logic relies on nettle's base64 decoding, if available.
Add libnettle to the basic/SSPI helper when libnettle is available.