### PR TITLE
NTLM/Negotiate: Fix crash on bad helper TT responses

### DIFF
--- a/src/auth/negotiate/UserRequest.cc
+++ b/src/auth/negotiate/UserRequest.cc
@@ -301,8 +301,11 @@ Auth::Negotiate::UserRequest::HandleReply(void *data, const Helper::Reply &reply
     case Helper::TT:
         /* we have been given a blob to send to the client */
         safe_free(lm_request->server_blob);
-        lm_request->request->flags.mustKeepalive = true;
-        if (lm_request->request->flags.proxyKeepalive) {
+
+        if (lm_request->request)
+            lm_request->request->flags.mustKeepalive = true;
+
+        if (lm_request->request && lm_request->request->flags.proxyKeepalive) {
             const char *tokenNote = reply.notes.findFirst("token");
             lm_request->server_blob = xstrdup(tokenNote);
             auth_user_request->user()->credentials(Auth::Handshake);

--- a/src/auth/ntlm/UserRequest.cc
+++ b/src/auth/ntlm/UserRequest.cc
@@ -295,8 +295,11 @@ Auth::Ntlm::UserRequest::HandleReply(void *data, const Helper::Reply &reply)
     case Helper::TT:
         /* we have been given a blob to send to the client */
         safe_free(lm_request->server_blob);
-        lm_request->request->flags.mustKeepalive = true;
-        if (lm_request->request->flags.proxyKeepalive) {
+
+        if (lm_request->request)
+            lm_request->request->flags.mustKeepalive = true;
+
+        if (lm_request->request && lm_request->request->flags.proxyKeepalive) {
             const char *serverBlob = reply.notes.findFirst("token");
             lm_request->server_blob = xstrdup(serverBlob);
             auth_user_request->user()->credentials(Auth::Handshake);


### PR DESCRIPTION
Helper lookup may be made without a client HTTP Request,
(stored in lm_request->request). But in Helper::TT cases the
lm_request->request was dereferenced without any checks.