### PR TITLE
Emulate fsync on mingw

### DIFF
--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -38,6 +38,7 @@
 #endif
 
 #if !HAVE_FSYNC
+// _commit(fd) is API-compatible with fsync(fd) and has equivalent behaviour
 inline int
 fsync(int fd)
 {

--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -32,6 +32,7 @@
 #include <windows.h>
 #endif
 
+// needed for _commmit and _get_osfhandle
 #if HAVE_IO_H
 #include <io.h>
 #endif

--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -32,5 +32,17 @@
 #include <windows.h>
 #endif
 
+#if HAVE_IO_H
+#include <io.h>
+#endif
+
+#if !HAVE_FSYNC
+inline int
+fsync(int fd)
+{
+    return _commit(fd);
+}
+#endif
+
 #endif /* _SQUID_MINGW_*/
 #endif /* SQUID_OS_MINGW_H */

--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,7 @@ AS_CASE(["$squid_host_os"],
     CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
     dnl Check for Winsock only on MinGW
     SQUID_CHECK_WINSOCK_LIB
+    AC_CHECK_FUNCS([fsync])
     AC_CHECK_HEADERS([ws2tcpip.h winsock2.h windows.h],,,[
 #if HAVE_WS2TCPIP_H
 #include <ws2tcpip.h>
@@ -2211,6 +2212,7 @@ AC_CHECK_HEADERS( \
   glob.h \
   gnumalloc.h \
   grp.h \
+  io.h \
   ipl.h \
   libc.h \
   limits.h \

--- a/configure.ac
+++ b/configure.ac
@@ -191,8 +191,7 @@ AS_CASE(["$squid_host_os"],
     CXXFLAGS="$CXXFLAGS -mthreads -static-libgcc -static-libstdc++"
     dnl Check for Winsock only on MinGW
     SQUID_CHECK_WINSOCK_LIB
-    AC_CHECK_FUNCS([fsync])
-    AC_CHECK_HEADERS([ws2tcpip.h winsock2.h windows.h],,,[
+    AC_CHECK_HEADERS([ws2tcpip.h winsock2.h windows.h io.h],,,[
 #if HAVE_WS2TCPIP_H
 #include <ws2tcpip.h>
 #endif
@@ -205,6 +204,7 @@ AS_CASE(["$squid_host_os"],
     ])
     MINGW_LIBS="-lmingwex"
     AC_SUBST(MINGW_LIBS)
+    AC_CHECK_FUNCS([fsync])
   ],
 
   [freebsd],[
@@ -2212,7 +2212,6 @@ AC_CHECK_HEADERS( \
   glob.h \
   gnumalloc.h \
   grp.h \
-  io.h \
   ipl.h \
   libc.h \
   limits.h \


### PR DESCRIPTION
MS Windows (and mingw) do not offer fsync(),
but they offer the API-compatible _commit().
