### PR TITLE
Fix memory leak in ssl/gadgets/mimicAuthorityKeyId()

### DIFF
--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -376,7 +376,6 @@ mimicAuthorityKeyId(Security::CertPointer &cert, Security::CertPointer const &mi
     if (!extAuthKeyId.get())
         return false;
 
-    extOct.release();
     if (!X509_add_ext(cert.get(), extAuthKeyId.get(), -1))
         return false;
 


### PR DESCRIPTION
An unnecessary std::unique_ptr::release() call prevented temporary
extOct string from being automatically deallocated. The leak usually
happened when SslBump mimicked certificates with an Authority Key
Identifier extension. The leak was added in 2016 commit 5f1318b.
