### PR TITLE
Bug 5337: workaround for crash on startup if -a option is used

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1536,6 +1536,9 @@ SquidMain(int argc, char **argv)
 
 #endif
 
+    Mem::Init();
+    AnyP::UriScheme::Init(); // needs to be before args parsing
+
     cmdLine.forEachOption(mainHandleCommandLineOption);
 
     Debug::SettleStderr();
@@ -1573,10 +1576,6 @@ SquidMain(int argc, char **argv)
             ConfigFile = xstrdup(DEFAULT_CONFIG_FILE);
 
         assert(!configured_once);
-
-        Mem::Init();
-
-        AnyP::UriScheme::Init();
 
         storeFsInit();      /* required for config parsing */
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1577,7 +1577,6 @@ SquidMain(int argc, char **argv)
 
         Mem::Init();
 
-
         storeFsInit();      /* required for config parsing */
 
         Fs::Init();

--- a/src/main.cc
+++ b/src/main.cc
@@ -1535,9 +1535,7 @@ SquidMain(int argc, char **argv)
     WIN32_svcstatusupdate(SERVICE_START_PENDING, 10000);
 
 #endif
-
-    Mem::Init();
-    AnyP::UriScheme::Init(); // needs to be before args parsing
+    AnyP::UriScheme::Init(); // needs to be before arg parsing, bug 5337
 
     cmdLine.forEachOption(mainHandleCommandLineOption);
 
@@ -1576,6 +1574,9 @@ SquidMain(int argc, char **argv)
             ConfigFile = xstrdup(DEFAULT_CONFIG_FILE);
 
         assert(!configured_once);
+
+        Mem::Init();
+
 
         storeFsInit();      /* required for config parsing */
 


### PR DESCRIPTION
Interpreting command-line arguments requires AnyP::UriScheme to be fully
initialized. Initialize AnyP::UriScheme earlier to ensure that happens.