### PR TITLE
Fix max-stale in default refresh_pattern

### DIFF
--- a/src/RefreshPattern.h
+++ b/src/RefreshPattern.h
@@ -35,7 +35,7 @@ public:
     explicit RefreshPattern(RegexPointer aRegex):
         min(0), pct(0.20), max(REFRESH_DEFAULT_MAX),
         next(nullptr),
-        max_stale(0),
+        max_stale(-1),
         regex_(std::move(aRegex))
     {
         memset(&flags, 0, sizeof(flags));


### PR DESCRIPTION
RefreshPattern constructor must set data fields to honor refresh_pattern
defaults promised in squid.conf.documented. For max-stale, that implies
making max_stale negative. A negative value allows refreshCheck() to use
a max_stale directive value (i.e. Config.maxStale that defaults to 1
week). The buggy constructor set max_stale to 0 instead and, hence,
refreshCheck() ignored max_stale directive when no refresh_pattern rules
were configured.

The fixed bug did not affect Squids configured using explicit
refresh_pattern rules because those rules are handled by
parse_refreshpattern() which sets max_stale to -1 by default. Our
squid.conf.default does have explicit refresh_pattern rules.
