### PR TITLE
Maintenance: automate header guards 1/3 (#1654)

### DIFF
--- a/lib/rfcnb/byteorder.h
+++ b/lib/rfcnb/byteorder.h
@@ -34,6 +34,9 @@
  * int manipulation
  */
 
+#ifndef SQUID_LIB_RFCNB_BYTEORDER_H
+#define SQUID_LIB_RFCNB_BYTEORDER_H
+
 #undef CAREFUL_ALIGNMENT
 
 /* we know that the 386 can handle misalignment and has the "right"
@@ -86,4 +89,6 @@
 #define RIVAL(buf,pos) IREV(IVAL(buf,pos))
 #define RSSVAL(buf,pos,val) SSVAL(buf,pos,SREV(val))
 #define RSIVAL(buf,pos,val) SIVAL(buf,pos,IREV(val))
+
+#endif /* SQUID_LIB_RFCNB_BYTEORDER_H */
 

--- a/lib/smblib/smbdes.h
+++ b/lib/smblib/smbdes.h
@@ -6,9 +6,13 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-/* smbdes.c */
+#ifndef SQUID_LIB_SMBLIB_SMBDES_H
+#define SQUID_LIB_SMBLIB_SMBDES_H
+
 void E_P16(unsigned char *p14, unsigned char *p16);
 void E_P24(unsigned char *p21, unsigned char *c8, unsigned char *p24);
 void cred_hash1(unsigned char *out, unsigned char *in, unsigned char *key);
 void cred_hash2(unsigned char *out, unsigned char *in, unsigned char *key);
+
+#endif /* SQUID_LIB_SMBLIB_SMBDES_H */
 

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -6,8 +6,8 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-#ifndef SQUID_ACLANNOTATECLIENT
-#define SQUID_ACLANNOTATECLIENT
+#ifndef SQUID_SRC_ACL_ANNOTATECLIENT_H
+#define SQUID_SRC_ACL_ANNOTATECLIENT_H
 
 #include "acl/Note.h"
 #include "Notes.h"
@@ -20,5 +20,5 @@ public:
     int match(ACLData<MatchType> * &, ACLFilledChecklist *) override;
 };
 
-#endif /* SQUID_ACLANNOTATECLIENT */
+#endif /* SQUID_SRC_ACL_ANNOTATECLIENT_H */
 

--- a/src/acl/AnnotateTransaction.h
+++ b/src/acl/AnnotateTransaction.h
@@ -6,8 +6,8 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-#ifndef SQUID_ACLANNOTATETRANSACTION
-#define SQUID_ACLANNOTATETRANSACTION
+#ifndef SQUID_SRC_ACL_ANNOTATETRANSACTION_H
+#define SQUID_SRC_ACL_ANNOTATETRANSACTION_H
 
 #include "acl/Note.h"
 #include "Notes.h"
@@ -20,5 +20,5 @@ public:
     bool requiresRequest() const override { return true; }
 };
 
-#endif /* SQUID_ACLANNOTATETRANSACTION */
+#endif /* SQUID_SRC_ACL_ANNOTATETRANSACTION_H */
 

--- a/src/acl/external/kerberos_ldap_group/support.h
+++ b/src/acl/external/kerberos_ldap_group/support.h
@@ -30,6 +30,9 @@
  * -----------------------------------------------------------------------------
  */
 
+#ifndef SQUID_SRC_ACL_EXTERNAL_KERBEROS_LDAP_GROUP_SUPPORT_H
+#define SQUID_SRC_ACL_EXTERNAL_KERBEROS_LDAP_GROUP_SUPPORT_H
+
 #define KERBEROS_LDAP_GROUP_VERSION "1.4.0sq"
 
 #include "compat/krb5.h"
@@ -164,4 +167,6 @@ void krb5_cleanup(void);
 #endif
 
 #define PROGRAM "kerberos_ldap_group"
+
+#endif /* SQUID_SRC_ACL_EXTERNAL_KERBEROS_LDAP_GROUP_SUPPORT_H */
 

--- a/src/adaptation/ecap/Registry.h
+++ b/src/adaptation/ecap/Registry.h
@@ -6,5 +6,10 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
+#ifndef SQUID_SRC_ADAPTATION_ECAP_REGISTRY_H
+#define SQUID_SRC_ADAPTATION_ECAP_REGISTRY_H
+
 // TBD
+
+#endif /* SQUID_SRC_ADAPTATION_ECAP_REGISTRY_H */
 

--- a/src/auth/State.h
+++ b/src/auth/State.h
@@ -6,8 +6,8 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-#ifndef __AUTH_AUTHENTICATE_STATE_T__
-#define __AUTH_AUTHENTICATE_STATE_T__
+#ifndef SQUID_SRC_AUTH_STATE_H
+#define SQUID_SRC_AUTH_STATE_H
 
 #if USE_AUTH
 
@@ -43,5 +43,5 @@ public:
 } // namespace Auth
 
 #endif /* USE_AUTH */
-#endif /* __AUTH_AUTHENTICATE_STATE_T__ */
+#endif /* SQUID_SRC_AUTH_STATE_H */
 

--- a/src/auth/basic/NIS/nis_support.h
+++ b/src/auth/basic/NIS/nis_support.h
@@ -6,5 +6,10 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
+#ifndef SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H
+#define SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H
+
 extern char * get_nis_password(char *user, char *nisdomain, char *nismap);
+
+#endif /* SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H */
 

--- a/src/auth/basic/RADIUS/radius-util.h
+++ b/src/auth/basic/RADIUS/radius-util.h
@@ -8,9 +8,14 @@
 
 // 2008-05-14: rename to radius-util.* to avoid name clashes with squid util.*
 
+#ifndef SQUID_SRC_AUTH_BASIC_RADIUS_RADIUS_UTIL_H
+#define SQUID_SRC_AUTH_BASIC_RADIUS_RADIUS_UTIL_H
+
 // uses the squid utilities
 #include "util.h"
 
 /* util.c */
 uint32_t        get_ipaddr (char *);
+
+#endif /* SQUID_SRC_AUTH_BASIC_RADIUS_RADIUS_UTIL_H */
 

--- a/src/auth/basic/RADIUS/radius.h
+++ b/src/auth/basic/RADIUS/radius.h
@@ -37,6 +37,9 @@
  *  @(#)radius.h    2.0  03-Aug-1996
  */
 
+#ifndef SQUID_SRC_AUTH_BASIC_RADIUS_RADIUS_H
+#define SQUID_SRC_AUTH_BASIC_RADIUS_RADIUS_H
+
 #define AUTH_VECTOR_LEN     16
 #define AUTH_PASS_LEN       16
 #define AUTH_STRING_LEN     128 /* maximum of 254 */
@@ -199,4 +202,6 @@ typedef struct pw_auth_hdr {
 #define PW_STATUS_ALIVE         3
 #define PW_STATUS_ACCOUNTING_ON     7
 #define PW_STATUS_ACCOUNTING_OFF    8
+
+#endif /* SQUID_SRC_AUTH_BASIC_RADIUS_RADIUS_H */
 

--- a/src/auth/digest/LDAP/ldap_backend.h
+++ b/src/auth/digest/LDAP/ldap_backend.h
@@ -10,8 +10,13 @@
  * AUTHOR: Flavio Pescuma. <flavio@marasystems.com>
  */
 
+#ifndef SQUID_SRC_AUTH_DIGEST_LDAP_LDAP_BACKEND_H
+#define SQUID_SRC_AUTH_DIGEST_LDAP_LDAP_BACKEND_H
+
 #include "auth/digest/LDAP/digest_common.h"
 
 extern int LDAPArguments(int argc, char **argv);
 extern void LDAPHHA1(RequestData * requestData);
+
+#endif /* SQUID_SRC_AUTH_DIGEST_LDAP_LDAP_BACKEND_H */
 

--- a/src/auth/digest/eDirectory/edir_ldapext.h
+++ b/src/auth/digest/eDirectory/edir_ldapext.h
@@ -6,5 +6,14 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
+#ifndef SQUID_SRC_AUTH_DIGEST_EDIRECTORY_EDIR_LDAPEXT_H
+#define SQUID_SRC_AUTH_DIGEST_EDIRECTORY_EDIR_LDAPEXT_H
+
+#if HAVE_LDAP_H
+#include <ldap.h>
+#endif
+
 int nds_get_password(LDAP *ld, char *object_dn, size_t * pwd_len, char *pwd);
+
+#endif /* SQUID_SRC_AUTH_DIGEST_EDIRECTORY_EDIR_LDAPEXT_H */
 

--- a/src/auth/digest/eDirectory/ldap_backend.h
+++ b/src/auth/digest/eDirectory/ldap_backend.h
@@ -10,7 +10,12 @@
  * AUTHOR: Flavio Pescuma. <flavio@marasystems.com>
  */
 
+#ifndef SQUID_SRC_AUTH_DIGEST_EDIRECTORY_LDAP_BACKEND_H
+#define SQUID_SRC_AUTH_DIGEST_EDIRECTORY_LDAP_BACKEND_H
+
 #include "auth/digest/eDirectory/digest_common.h"
 extern int LDAPArguments(int argc, char **argv);
 extern void LDAPHHA1(RequestData * requestData);
+
+#endif /* SQUID_SRC_AUTH_DIGEST_EDIRECTORY_LDAP_BACKEND_H */
 

--- a/src/auth/digest/file/text_backend.h
+++ b/src/auth/digest/file/text_backend.h
@@ -6,8 +6,13 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
+#ifndef SQUID_SRC_AUTH_DIGEST_FILE_TEXT_BACKEND_H
+#define SQUID_SRC_AUTH_DIGEST_FILE_TEXT_BACKEND_H
+
 #include "auth/digest/file/digest_common.h"
 
 extern void TextArguments(int argc, char **argv);
 extern void TextHHA1(RequestData * requestData);
+
+#endif /* SQUID_SRC_AUTH_DIGEST_FILE_TEXT_BACKEND_H */
 

--- a/src/auth/negotiate/kerberos/negotiate_kerberos.h
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos.h
@@ -35,6 +35,9 @@
  * -----------------------------------------------------------------------------
  */
 
+#ifndef SQUID_SRC_AUTH_NEGOTIATE_KERBEROS_NEGOTIATE_KERBEROS_H
+#define SQUID_SRC_AUTH_NEGOTIATE_KERBEROS_NEGOTIATE_KERBEROS_H
+
 #include <cstring>
 #include <ctime>
 #if HAVE_NETDB_H
@@ -147,4 +150,6 @@ char *get_ad_groups(char *ad_groups, krb5_context context, krb5_pac pac);
 #define HAVE_PAC_SUPPORT 0
 #endif
 int check_k5_err(krb5_context context, const char *msg, krb5_error_code code);
+
+#endif /* SQUID_SRC_AUTH_NEGOTIATE_KERBEROS_NEGOTIATE_KERBEROS_H */
 

--- a/src/dns/rfc3596.cc
+++ b/src/dns/rfc3596.cc
@@ -27,7 +27,7 @@
 #include <strings.h>
 #endif
 
-#ifndef SQUID_RFC1035_H
+#if !defined(RFC1035_MAXHOSTNAMESZ)
 #error RFC3596 Library depends on RFC1035
 #endif
 

--- a/src/tests/STUB.h
+++ b/src/tests/STUB.h
@@ -6,7 +6,8 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-#ifndef STUB
+#ifndef SQUID_SRC_TESTS_STUB_H
+#define SQUID_SRC_TESTS_STUB_H
 
 /** \group STUB
  *
@@ -53,5 +54,5 @@
 /** Same as STUB_RETREF(). TODO: Remove */
 #define STUB_RETSTATREF(x) STUB_RETREF(x)
 
-#endif /* STUB */
+#endif /* SQUID_SRC_TESTS_STUB_H */
 

--- a/src/tests/TestSwapDir.h
+++ b/src/tests/TestSwapDir.h
@@ -6,8 +6,8 @@
  * Please see the COPYING and CONTRIBUTORS files for details.
  */
 
-#ifndef TEST_TESTSWAPDIR
-#define TEST_TESTSWAPDIR
+#ifndef SQUID_SRC_TESTS_TESTSWAPDIR_H
+#define SQUID_SRC_TESTS_TESTSWAPDIR_H
 
 #include "store/Disk.h"
 
@@ -41,5 +41,5 @@ public:
 
 typedef RefCount<TestSwapDir> TestSwapDirPointer;
 
-#endif  /* TEST_TESTSWAPDIR */
+#endif /* SQUID_SRC_TESTS_TESTSWAPDIR_H */
 


### PR DESCRIPTION
In preparation for merging the automated header-guards maintenance script,
merge the manual changes required for that script to succeed.