### PR TITLE
Bug 5343: Fix GCC v14 build

### DIFF
--- a/src/helper/Reply.cc
+++ b/src/helper/Reply.cc
@@ -17,6 +17,8 @@
 #include "rfc1738.h"
 #include "SquidString.h"
 
+#include <algorithm>
+
 Helper::Reply::Reply() :
     result(Helper::Unknown)
 {


### PR DESCRIPTION
    Reply.cc:198: error: no matching function for call to find(...)

The required STL header was missed in 2023 commit 27c3677.
