### PR TITLE
Fix type mismatch in new/delete of addrinfo::ai_addr

### DIFF
--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -685,8 +685,7 @@ Ip::Address::InitAddr(struct addrinfo *&ai)
 void
 Ip::Address::FreeAddr(struct addrinfo *&ai)
 {
-    if (!ai)
-        return;
+    if (ai == nullptr) return;
 
     FreeAddrMember(*ai);
 

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -710,6 +710,7 @@ Ip::AllocateAddrMember(struct addrinfo &ai)
     const auto ai_addr = new SockAddrType;
     // We do not use `new SockAddrType{}` above instead of memset() below
     // because, since C++14, doing so may not initialize SockAddrType padding.
+    static_assert(std::is_trivial<SockAddrType>::value, "can memset() this addrinfo::ai_addr type");
     memset(ai_addr, 0, sizeof(*ai_addr));
 
     ai.ai_addr = reinterpret_cast<struct sockaddr*>(ai_addr);

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -725,15 +725,14 @@ Ip::AllocateAddrMember(struct addrinfo &ai)
 void
 Ip::FreeAddrMember(struct addrinfo &ai)
 {
-    if (!ai.ai_addr) {
+    if (!ai.ai_addr)
         return;
-    }
 
-    if (ai.ai_addrlen == sizeof(struct sockaddr_in)) {
+    if (ai.ai_addrlen == sizeof(struct sockaddr_in))
         delete reinterpret_cast<struct sockaddr_in*>(ai.ai_addr);
-    } else if (ai.ai_addrlen == sizeof(struct sockaddr_in6)) {
+    else if (ai.ai_addrlen == sizeof(struct sockaddr_in6))
         delete reinterpret_cast<struct sockaddr_in6*>(ai.ai_addr);
-    } else {
+    else {
         debugs(14, DBG_CRITICAL, "ERROR: Squid Bug: Unexpected addrinfo::ai_addr size: " << ai.ai_addrlen <<
                Debug::Extra << "sockaddr_in size: " << sizeof(struct sockaddr_in) <<
                Debug::Extra << "sockaddr_in6 size: " << sizeof(struct sockaddr_in6));

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -707,6 +707,8 @@ Ip::AllocateAddrMember(struct addrinfo * const ai)
         std::is_same<SockAddrType, struct sockaddr_in6>::value,
         "FreeAddrMember() supports this addrinfo::ai_addr type");
     ai->ai_addr = reinterpret_cast<struct sockaddr*>(new SockAddrType);
+    // We do not use `new SockAddrType{}` above instead of memset() below
+    // because, since C++14, doing so may not initialize SockAddrType padding.
     memset(ai->ai_addr, 0, sizeof(SockAddrType));
     ai->ai_addrlen = sizeof(SockAddrType);
 }

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -697,7 +697,7 @@ Ip::Address::FreeAddr(struct addrinfo *&ai)
 {
     if (ai == nullptr) return;
 
-    if (ai->ai_addr) delete ai->ai_addr;
+    if (ai->ai_addr) delete (struct sockaddr_in6*)ai->ai_addr;
 
     ai->ai_addr = nullptr;
 

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -671,17 +671,7 @@ Ip::Address::InitAddr(struct addrinfo *&ai)
     }
 
     // remove any existing data.
-<<<<<<< HEAD
     releaseSockAddr(ai);
-=======
-    if (ai->ai_addr)
-        delete ai->ai_addr;
-
-    ai->ai_addr = static_cast<struct sockaddr*>(new sockaddr_in6);
-    memset(ai->ai_addr, 0, sizeof(struct sockaddr_in6));
-
-    ai->ai_addrlen = sizeof(struct sockaddr_in6);
->>>>>>> 6ffe15818c6f5e144017b7bb1f6f5e68b6921c75
 
     initSockAddr(ai, SockAddrType::SockAddrIn6);
 }
@@ -692,16 +682,7 @@ Ip::Address::FreeAddr(struct addrinfo *&ai)
     if (!ai)
         return;
 
-<<<<<<< HEAD
     releaseSockAddr(ai);
-=======
-    if (ai->ai_addr)
-        delete static_cast<struct sockaddr*>(struct sockaddr_in6*>(ai->ai_addr);
-
-    ai->ai_addr = nullptr;
-
-    ai->ai_addrlen = 0;
->>>>>>> 6ffe15818c6f5e144017b7bb1f6f5e68b6921c75
 
     // NP: name fields are NOT allocated at present.
     delete ai;

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -9,8 +9,6 @@
 /* DEBUG: section 14    IP Storage and Handling */
 
 #include "squid.h"
-
-#include "base/TextException.h"
 #include "debug/Stream.h"
 #include "ip/Address.h"
 #include "ip/tools.h"
@@ -725,7 +723,10 @@ Ip::FreeAddrMember(struct addrinfo &ai)
     } else if (ai.ai_addrlen == sizeof(struct sockaddr_in6)) {
         delete reinterpret_cast<struct sockaddr_in6*>(ai.ai_addr);
     } else {
-        throw TextException("Bad sockaddr structure", Here());
+        debugs(14, DBG_CRITICAL, "ERROR: Squid Bug: Unexpected addrinfo::ai_addr size: " << ai.ai_addrlen <<
+               Debug::Extra << "sockaddr_in size: " << sizeof(struct sockaddr_in) <<
+               Debug::Extra << "sockaddr_in6 size: " << sizeof(struct sockaddr_in6));
+        // leak memory
     }
 
     ai.ai_addr = nullptr;

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -42,6 +42,18 @@
         } printf("\n"); assert(b); \
     }
 
+namespace Ip {
+
+enum class SockAddrType {
+    SockAddrIn,
+    SockAddrIn6
+};
+
+static void initSockAddr(struct addrinfo *, SockAddrType);
+static void releaseSockAddr(struct addrinfo *);
+
+} // namespace Ip
+
 int
 Ip::Address::cidr() const
 {
@@ -691,7 +703,7 @@ Ip::Address::FreeAddr(struct addrinfo *&ai)
 }
 
 void
-Ip::Address::initSockAddr(struct addrinfo* ai, SockAddrType sockaddrType) {
+Ip::initSockAddr(struct addrinfo* ai, SockAddrType sockaddrType) {
     switch (sockaddrType) {
         case Ip::SockAddrType::SockAddrIn: {
             ai->ai_addr = reinterpret_cast<struct sockaddr*>(new struct sockaddr_in);
@@ -709,7 +721,7 @@ Ip::Address::initSockAddr(struct addrinfo* ai, SockAddrType sockaddrType) {
 }
 
 void
-Ip::Address::releaseSockAddr(struct addrinfo* ai) 
+Ip::releaseSockAddr(struct addrinfo* ai)
 {
     if (!ai) {
         return;

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -719,6 +719,9 @@ Ip::AllocateAddrMember(struct addrinfo &ai)
     return *ai_addr;
 }
 
+/// Deallocates addrinfo::ai_addr member of the given structure and adjusts that
+/// structure accordingly. Safe for structures with a nil ai_addr member.
+/// \sa Ip::AllocateAddrMember()
 void
 Ip::FreeAddrMember(struct addrinfo &ai)
 {

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -34,11 +34,6 @@
 namespace Ip
 {
 
-enum class SockAddrType {
-    SockAddrIn,
-    SockAddrIn6
-};
-
 /**
  * Holds and manipulates IPv4, IPv6, and Socket Addresses.
  */
@@ -341,9 +336,6 @@ private:
 
     // Worker behind GetHostName and char* converters
     bool lookupHostIP(const char *s, bool nodns);
-
-    static void initSockAddr(struct addrinfo* ai, SockAddrType sockaddrType);
-    static void releaseSockAddr(struct addrinfo* ai);
 
     /* variables */
     struct sockaddr_in6 mSocketAddr_;

--- a/src/ip/Address.h
+++ b/src/ip/Address.h
@@ -34,6 +34,11 @@
 namespace Ip
 {
 
+enum class SockAddrType {
+    SockAddrIn,
+    SockAddrIn6
+};
+
 /**
  * Holds and manipulates IPv4, IPv6, and Socket Addresses.
  */
@@ -336,6 +341,9 @@ private:
 
     // Worker behind GetHostName and char* converters
     bool lookupHostIP(const char *s, bool nodns);
+
+    static void initSockAddr(struct addrinfo* ai, SockAddrType sockaddrType);
+    static void releaseSockAddr(struct addrinfo* ai);
 
     /* variables */
     struct sockaddr_in6 mSocketAddr_;


### PR DESCRIPTION
    ERROR: AddressSanitizer: new-delete-type-mismatch...:
    size of the allocated type: 28 bytes;
    size of the deallocated type: 16 bytes.
    in Ip::Address::InitAddr(addrinfo*&) src/ip/Address.cc:678
    in Ip::Address::FreeAddr(addrinfo*&) src/ip/Address.cc:690

* `delete` used addrinfo::ai_addr type (i.e. sockaddr)
* some `new` calls use sockaddr_in type
* some `new` calls use sockaddr_in6 type

Mismatching new/delete types result in undefined behavior. However,
since these are all PODs, the bug may not have resulted in runtime
problems in most environments, even though sockaddr_in6 is usually
larger than sockaddr and sockaddr_in tructure (e.g., 28 vs. 16 bytes).