### PR TITLE
Bug 5344: mgr:config segfaults without logformat

### DIFF
--- a/src/log/Config.h
+++ b/src/log/Config.h
@@ -36,7 +36,8 @@ public:
 
     void parseFormats();
     void dumpFormats(StoreEntry *e, const char *name) {
-        logformats->dump(e, name);
+        if (logformats)
+            logformats->dump(e, name);
     }
 
     /// File path to logging daemon executable


### PR DESCRIPTION
Since 2011 commit 38e16f9, Log::LogConfig::dumpFormats() dereferenced a
nil `logformats` pointer while reporting a non-existent logformat
configuration (e.g., squid.conf.default): `logformats->dump(e, name)`.

In most environments, that code "worked" because the corresponding
Format::Format::dump() method happens to do nothing if "this" is nil.
However, in some environments, Squid segfaulted.
