### PR TITLE
Maintenance: Removed unused bits of Format::FmtConfig code

### DIFF
--- a/src/format/Config.cc
+++ b/src/format/Config.cc
@@ -8,41 +8,10 @@
 
 #include "squid.h"
 #include "cache_cf.h"
-#include "ConfigParser.h"
 #include "debug/Stream.h"
 #include "format/Config.h"
-#include <list>
 
 Format::FmtConfig Format::TheConfig;
-
-void
-Format::FmtConfig::parseFormats()
-{
-    char *name, *def;
-
-    if ((name = ConfigParser::NextToken()) == nullptr) {
-        self_destruct();
-        return;
-    }
-
-    if ((def = ConfigParser::NextQuotedOrToEol()) == nullptr) {
-        self_destruct();
-        return;
-    }
-
-    debugs(3, 2, "Custom Format for '" << name << "' is '" << def << "'");
-
-    Format *nlf = new Format(name);
-
-    if (!nlf->parse(def)) {
-        self_destruct();
-        return;
-    }
-
-    // add to global config list
-    nlf->next = formats;
-    formats = nlf;
-}
 
 void
 Format::FmtConfig::registerTokens(const SBuf &nsName, TokenTableEntry const *tokenArray)

--- a/src/format/Config.h
+++ b/src/format/Config.h
@@ -9,12 +9,9 @@
 #ifndef SQUID_SRC_FORMAT_CONFIG_H
 #define SQUID_SRC_FORMAT_CONFIG_H
 
-#include "format/Format.h"
-#include "SquidString.h"
+#include "sbuf/SBuf.h"
 
 #include <list>
-
-class StoreEntry;
 
 namespace Format
 {
@@ -38,18 +35,9 @@ public:
 };
 
 /// The set of custom formats defined in squid.conf
-///
 class FmtConfig
 {
 public:
-    /// Parse a log format directive line (logfile_format)
-    void parseFormats();
-
-    /// Dump/display the formats currently known to the provided StoreEntry object
-    void dumpFormats(StoreEntry *e, const char *name) {
-        formats->dump(e, name);
-    }
-
     /* Register a namespace set of tokens to be accepted by the format parser.
      * Multiple arrays can be registered, they will be scanned for
      * in order registered. So care needs to be taken that arrays registered
@@ -57,29 +45,13 @@ public:
      */
     void registerTokens(const SBuf &nsName, TokenTableEntry const *tokenArray);
 
-    /// Linked list of custom formats
-    Format *formats;
-
     /// list of token namespaces registered
     std::list<TokenNamespace> tokens;
-
-#if USE_ADAPTATION
-    bool hasAdaptToken;
-#endif
-
-#if ICAP_CLIENT
-    bool hasIcapToken;
-#endif
 };
 
 extern FmtConfig TheConfig;
 
 } // namespace Format
-
-// Legacy parsing wrappers
-#define parse_format(X)  (X)->parseFormats()
-#define free_format(X)   do{ delete (*(X)).formats; (*(X)).formats=NULL; }while(false)
-#define dump_format(E,N,D) (D).dumpFormats((E),(N))
 
 #endif /* SQUID_SRC_FORMAT_CONFIG_H */
 


### PR DESCRIPTION
This code was probably accidentally copied from Log::LogConfig when
FmtConfig was created in 2011 commit 31971e6. It mentions logfile_format
directive that never existed. The code also duplicates a dangerous
Log::LogConfig snippet (see Bug 5344).
