### PR TITLE
Fix marking of problematic cached IP addresses

### DIFF
--- a/src/ipcache.cc
+++ b/src/ipcache.cc
@@ -991,6 +991,7 @@ Dns::CachedIps::have(const Ip::Address &ip, size_t *positionOrNil) const
             debugs(14, 7, ip << " at " << pos << " in " << *this);
             return true;
         }
+        ++pos; // TODO: Replace with std::views::enumerate() after upgrading to C++23
     }
     // no such address; leave *position as is
     debugs(14, 7, " no " << ip << " in " << *this);


### PR DESCRIPTION
Since inception in 2017 commit fd9c47d, Dns::CachedIps::have() always
returned position zero after finding a matching IP address (at zero or
positive position). The bug affected two callers:

* markAsBad() always marked the first stored address (as bad);
* forgetMarking() always cleared the first stored address marking.

Buggy markings led to Squid sometimes not attempting to use a working
address (e.g., IPv4) while using a known problematic one (e.g., IPv6).
