### PR TITLE
Fix detection of cppunit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2178,7 +2178,6 @@ AC_MSG_NOTICE([X-Accelerator-Vary support enabled: $enable_x_accelerator_vary])
 
 SQUID_AUTO_LIB(cppunit,[cppunit test framework],[LIBCPPUNIT])
 SQUID_CHECK_LIB_WORKS(cppunit,[
-  LIBCPPUNIT_LIBS="$LIBCPPUNIT_PATH -lcppunit"
   PKG_CHECK_MODULES([LIBCPPUNIT],[cppunit],[
     squid_cv_cppunit_version="`pkg-config --modversion cppunit`"
     AC_MSG_NOTICE([using system installed cppunit version $squid_cv_cppunit_version])


### PR DESCRIPTION
On MacOS / Homebrew, libcppunit is not part of the system path.
pkg-config will report it; use it.

This change also ensures squid honours the promise made
in configure's help text to let administrators specify a
LIBCPPUNIT_LIBS environment variable to
override automatic detection