### PR TITLE
Maintenance: increase portability of cf_gen automake rules

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -708,7 +708,7 @@ uninstall-local: squid.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_CONFIG_FILE) squid.conf.default
 
 distclean-local:
-	test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || true
+	test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || $(TRUE)
 
 CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 	test_tools.cc *.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -156,9 +156,11 @@ bin_PROGRAMS =
 libexec_PROGRAMS = \
 	$(UNLINKD)
 
-cf_gen_SOURCES = cf_gen.cc cf_gen_defines.cci
+cf_gen_SOURCES = cf_gen.cc
+nodist_cf_gen_HEADER = cf_gen_defines.cci
 ## cf_gen must be stand-alone executable. It is a purely build-time executable.
 cf_gen_LDADD=
+cf_gen.$(OBJEXT): cf_gen_defines.cci
 
 ## cf_gen.cc needs src/cf_gen_defines.cci
 AM_CPPFLAGS += -I$(top_builddir)/src
@@ -622,6 +624,10 @@ test_cache_digest: test_cache_digest.o CacheDigest.o debug.o globals.o store_key
 ## If autodependency works well this is not needed anymore
 cache_cf.o: cf_parser.cci
 
+# cf_gen builds the configuration files.
+cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
+	$(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
+
 # squid.conf.default is built by cf_gen when making cf_parser.cci
 squid.conf.default squid.conf.documented: cf_parser.cci
 	true
@@ -700,6 +706,9 @@ install-data-local: install-sysconfDATA install-dataDATA
 uninstall-local: squid.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_MIME_TABLE) $(srcdir)/mime.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_CONFIG_FILE) squid.conf.default
+
+distclean-local:
+	test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || $(TRUE)
 
 CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 	test_tools.cc *.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -708,7 +708,7 @@ uninstall-local: squid.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_CONFIG_FILE) squid.conf.default
 
 distclean-local:
-       test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || true
+	test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || true
 
 CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 	test_tools.cc *.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -707,6 +707,9 @@ uninstall-local: squid.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_MIME_TABLE) $(srcdir)/mime.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_CONFIG_FILE) squid.conf.default
 
+distclean-local:
+       test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || true
+
 CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 	test_tools.cc *.a
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -708,7 +708,7 @@ uninstall-local: squid.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_CONFIG_FILE) squid.conf.default
 
 clean-local:
-	test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || $(TRUE)
+	-rm -rf cf_gen.dSYM
 
 CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 	test_tools.cc *.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -156,11 +156,9 @@ bin_PROGRAMS =
 libexec_PROGRAMS = \
 	$(UNLINKD)
 
-cf_gen_SOURCES = cf_gen.cc
-nodist_cf_gen_HEADER = cf_gen_defines.cci
+cf_gen_SOURCES = cf_gen.cc cf_gen_defines.cci
 ## cf_gen must be stand-alone executable. It is a purely build-time executable.
 cf_gen_LDADD=
-cf_gen.$(OBJEXT): cf_gen_defines.cci
 
 ## cf_gen.cc needs src/cf_gen_defines.cci
 AM_CPPFLAGS += -I$(top_builddir)/src
@@ -624,10 +622,6 @@ test_cache_digest: test_cache_digest.o CacheDigest.o debug.o globals.o store_key
 ## If autodependency works well this is not needed anymore
 cache_cf.o: cf_parser.cci
 
-# cf_gen builds the configuration files.
-cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
-	$(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
-
 # squid.conf.default is built by cf_gen when making cf_parser.cci
 squid.conf.default squid.conf.documented: cf_parser.cci
 	true
@@ -706,9 +700,6 @@ install-data-local: install-sysconfDATA install-dataDATA
 uninstall-local: squid.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_MIME_TABLE) $(srcdir)/mime.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_CONFIG_FILE) squid.conf.default
-
-distclean-local:
-	test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || $(TRUE)
 
 CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 	test_tools.cc *.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -707,7 +707,7 @@ uninstall-local: squid.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_MIME_TABLE) $(srcdir)/mime.conf.default
 	@$(SHELL) $(top_srcdir)/scripts/remove-cfg.sh "$(RM)" $(DESTDIR)$(DEFAULT_CONFIG_FILE) squid.conf.default
 
-distclean-local:
+clean-local:
 	test -d "cf_gen.dSYM" && rm -rf "cf_gen.dSYM" || $(TRUE)
 
 CLEANFILES += cf.data squid.conf.default squid.conf.documented \


### PR DESCRIPTION
The MacOS linker uses a subdirectory named [target].dSYM to hold debug
information. Ensure it is removed by 'make clean'.