### PR TITLE
negotiate_wrapper: Do not use vfork()

### DIFF
--- a/src/auth/negotiate/wrapper/negotiate_wrapper.cc
+++ b/src/auth/negotiate/wrapper/negotiate_wrapper.cc
@@ -367,7 +367,7 @@ main(int argc, char *const argv[])
         exit(EXIT_FAILURE);
     }
 
-    if  (( fpid = vfork()) < 0 ) {
+    if  (( fpid = fork()) < 0 ) {
         fprintf(stderr, "%s| %s: Failed first fork\n", LogTime(), PROGRAM);
         exit(EXIT_FAILURE);
     }
@@ -403,7 +403,7 @@ main(int argc, char *const argv[])
         exit(EXIT_FAILURE);
     }
 
-    if  (( fpid = vfork()) < 0 ) {
+    if  (( fpid = fork()) < 0 ) {
         fprintf(stderr, "%s| %s: Failed second fork\n", LogTime(), PROGRAM);
         exit(EXIT_FAILURE);
     }

--- a/src/auth/negotiate/wrapper/required.m4
+++ b/src/auth/negotiate/wrapper/required.m4
@@ -5,4 +5,4 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AC_CHECK_FUNCS(fork,[BUILD_HELPER="wrapper"])
+BUILD_HELPER="wrapper"

--- a/src/auth/negotiate/wrapper/required.m4
+++ b/src/auth/negotiate/wrapper/required.m4
@@ -5,4 +5,4 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AC_CHECK_FUNCS(vfork,[BUILD_HELPER="wrapper"])
+AC_CHECK_FUNCS(fork,[BUILD_HELPER="wrapper"])


### PR DESCRIPTION
POSIX.1-2001 marks vfork(2) OBSOLETE.
POSIX.1-2008 removes the specification of vfork(2).
MacOS system headers declare vfork(2) as deprecated.
We only use vfork(2) in negotiate_wrapper, where it is not necessary.
