### PR TITLE
Maintenance: Remove Red Hat Linux workarounds predating RHEL

### DIFF
--- a/acinclude/os-deps.m4
+++ b/acinclude/os-deps.m4
@@ -732,31 +732,6 @@ void squid_getprotobynumber(void) {
   SQUID_STATE_ROLLBACK(winsock)
 ])
 
-dnl check that setresuid is properly implemented.
-dnl sets squid_cv_resuid_works to "yes" or "no"
-AC_DEFUN([SQUID_CHECK_SETRESUID_WORKS],[
-  AC_CACHE_CHECK(if setresuid is actually implemented, squid_cv_resuid_works,
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#if HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#if HAVE_STDIO_H
-#include <stdio.h>
-#endif
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-  int main(int argc, char **argv) {
-    if(setresuid(-1,-1,-1)) {
-      perror("setresuid:");
-      return 1;
-    }
-    return 0;
-  }
-    ]])],[squid_cv_resuid_works="yes"],[squid_cv_resuid_works="no"],[:])
-  )
-])
-
 dnl check whether Solaris has broken IPFilter headers (Solaris 10 at least does)
 AC_DEFUN([SQUID_CHECK_BROKEN_SOLARIS_IPFILTER],[
   AS_IF([test "x$squid_cv_broken_ipfilter_minor_t" = "x"],[

--- a/configure.ac
+++ b/configure.ac
@@ -1158,12 +1158,6 @@ AS_IF([test "x$with_openssl" = "xyes"],[
     ],$LIBOPENSSL_LIBS)
   ])
 
-  # This is a workaround for RedHat 9 brain damage..
-  AS_IF([test -d /usr/kerberos/include -a -f /usr/include/openssl/kssl.h],[
-    AC_MSG_NOTICE([OpenSSL depends on Kerberos])
-    LIBOPENSSL_LIBS="-L/usr/kerberos/lib $LIBOPENSSL_LIBS"
-    CPPFLAGS="$CPPFLAGS -I/usr/kerberos/include"
-  ])
   SQUID_STATE_ROLLBACK(squid_openssl_state) #de-pollute LIBS
 
   AS_IF([test "x$LIBOPENSSL_LIBS" != "x"],[
@@ -2628,6 +2622,7 @@ AC_CHECK_FUNCS(\
 	setpflags \
 	setpgrp \
 	setsid \
+	setresuid \
 	sigaction \
 	snprintf \
 	socketpair \
@@ -2686,11 +2681,6 @@ AS_CASE([$squid_opt_io_loop_engine],
 
 AS_IF([test "x$ac_cv_func_sched_getaffinity" = "xyes" -a "x$ac_cv_func_sched_setaffinity" = "xyes"],[
   AC_DEFINE(HAVE_CPU_AFFINITY,1,[Support setting CPU affinity for workers])
-])
-
-SQUID_CHECK_SETRESUID_WORKS
-AS_IF([test "x$squid_cv_resuid_works" = "xyes"],[
-  AC_DEFINE(HAVE_SETRESUID,1,[Yay! Another Linux brokenness. Knowing that setresuid() exists is not enough, because RedHat 5.0 declares setresuid() but does not implement it.])
 ])
 
 AC_CHECK_HEADERS(mswsock.h)


### PR DESCRIPTION
The last Red Hat Linux release went EOL in 2004, replaced by Red Hat
Enterprise Linux and Fedora Linux. We no longer support Red Hat Linux
releases and expect that these hacks are no longer necessary in
supported environments.