### PR TITLE
Use -Werror when running configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -332,8 +332,8 @@ dnl CentOS (and RHEL) still define ntohs() using deprecated C++ features
 SQUID_CC_REQUIRE_ARGUMENT([ac_cv_require_wno_deprecated_register],[-Werror -Wno-deprecated-register],[[#include <arpa/inet.h>]],[[int fox=ntohs(1);]])
 
 AS_IF([test "x$enable_strict_error_checking" != "xno"],[
-  SQUID_CFLAGS="$SQUID_CFLAGS $squid_cv_cc_option_werror"
-  SQUID_CXXFLAGS="$SQUID_CXXFLAGS $squid_cv_cxx_option_werror"
+  CFLAGS="$CFLAGS $squid_cv_cc_option_werror"
+  CXXFLAGS="$CXXFLAGS $squid_cv_cxx_option_werror"
 ])
 
 AS_IF([test "x$ac_cv_require_wno_deprecated_register" = "xyes"],[


### PR DESCRIPTION
Configure currently sets -Werror in SQUID_C{,XX}FLAGS.
This makes it so that these flags are not used for configure tests,
but are used for building squid, and this can cause different
behaviours during build (e.g. with Apple's LDAP on MacOS).

This is a simple change, but the consequences can be profound
and tricky to figure out, as this may cause flips in detected
system features.

Opening as a draft to support discussion