### PR TITLE
Bug 5343: Fix GCC v14 not finding std::find()

### DIFF
--- a/src/ResolvedPeers.cc
+++ b/src/ResolvedPeers.cc
@@ -13,6 +13,8 @@
 #include "ResolvedPeers.h"
 #include "SquidConfig.h"
 
+#include <algorithm>
+
 ResolvedPeers::ResolvedPeers()
 {
     if (Config.forward_max_tries > 0)

--- a/src/acl/AtStepData.cc
+++ b/src/acl/AtStepData.cc
@@ -16,6 +16,8 @@
 #include "sbuf/Stream.h"
 #include "wordlist.h"
 
+#include <algorithm>
+
 static inline const char *
 StepName(const XactionStep xstep)
 {

--- a/src/auth/SchemesConfig.cc
+++ b/src/auth/SchemesConfig.cc
@@ -11,6 +11,8 @@
 #include "fatal.h"
 #include "parser/Tokenizer.h"
 
+#include <algorithm>
+
 static void
 addUnique(const SBuf &scheme, std::vector<SBuf> &vec)
 {

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -92,6 +92,7 @@
 #include "snmp.h"
 #endif
 
+#include <algorithm>
 #if HAVE_GLOB_H
 #include <glob.h>
 #endif

--- a/src/helper/Reply.cc
+++ b/src/helper/Reply.cc
@@ -17,6 +17,8 @@
 #include "rfc1738.h"
 #include "SquidString.h"
 
+#include <algorithm>
+
 Helper::Reply::Reply() :
     result(Helper::Unknown)
 {

--- a/src/sbuf/List.cc
+++ b/src/sbuf/List.cc
@@ -10,6 +10,8 @@
 #include "sbuf/Algorithms.h"
 #include "sbuf/List.h"
 
+#include <algorithm>
+
 bool
 IsMember(const SBufList & sl, const SBuf &S, const SBufCaseSensitive case_sensitive)
 {

--- a/src/security/KeyData.cc
+++ b/src/security/KeyData.cc
@@ -15,6 +15,8 @@
 #include "ssl/bio.h"
 #include "ssl/gadgets.h"
 
+#include <algorithm>
+
 /// load the signing certificate and its chain, if any, from certFile
 /// \return true if the signing certificate was obtained
 bool


### PR DESCRIPTION
    Reply.cc:198: error: no matching function for call to find(...)

The required STL header was missed in 2023 commit 27c3677.