### PR TITLE
Bug 5069: Keep listening after getsockname() error

### DIFF
--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -381,7 +381,10 @@ Comm::TcpAcceptor::acceptInto(Comm::ConnectionPointer &details)
     if (getsockname(sock, gai->ai_addr, &gai->ai_addrlen) != 0) {
         int xerrno = errno;
         Ip::Address::FreeAddr(gai);
-        throw TextException(ToSBuf("getsockname() failed to locate local-IP on ", details, ": ", xstrerr(xerrno)), Here());
+        debugs(50, DBG_IMPORTANT, "ERROR: Closing accepted TCP connection after failing to obtain its local IP address" <<
+               Debug::Extra << "accepted connection: " << details <<
+               Debug::Extra << "getsockname(2) error: " << xstrerr(xerrno));
+        return false;
     }
     details->local = *gai;
     Ip::Address::FreeAddr(gai);


### PR DESCRIPTION
    ERROR: Stopped accepting connections:
    error: getsockname() failed to locate local-IP on ...

In many cases, these failures are intermittent client-triggered errors
(e.g., client shut down the accepted socket); Squid will successfully
accept other connections and, hence, should keep listening for them.
