### PR TITLE
Fix NIS helper header-guard

### DIFF
--- a/src/auth/basic/NIS/nis_support.h
+++ b/src/auth/basic/NIS/nis_support.h
@@ -8,9 +8,6 @@
 #ifndef SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H
 #define SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H
 
-#ifndef SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H
-#define SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H
-
 extern char * get_nis_password(char *user, char *nisdomain, char *nismap);
 
 #endif /* SQUID_SRC_AUTH_BASIC_NIS_NIS_SUPPORT_H */


### PR DESCRIPTION
Fix double header guard error in Squid v6