### PR TITLE
Use ERR_READ_ERROR for read-from-client I/O errors

### DIFF
--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -176,7 +176,7 @@ Server::doClientRead(const CommIoCbParams &io)
         LogTagsErrors lte;
         lte.timedout = rd.xerrno == ETIMEDOUT;
         lte.aborted = !lte.timedout; // intentionally true for zero rd.xerrno
-        terminateAll(Error(ERR_CLIENT_GONE, SysErrorDetail::NewIfAny(rd.xerrno)), lte);
+        terminateAll(Error(ERR_READ_ERROR, SysErrorDetail::NewIfAny(rd.xerrno)), lte);
         return;
     }
 


### PR DESCRIPTION
ERR_CLIENT_GONE is still used for unexpected zero-size reads on
client-to-Squid connections. The two cases are now distinct.