### PR TITLE
Improve bounds checking in rfc1035NameUnpack

### DIFF
--- a/src/dns/rfc1035.cc
+++ b/src/dns/rfc1035.cc
@@ -265,6 +265,11 @@ rfc1035NameUnpack(const char *buf, size_t sz, unsigned int *off, unsigned short 
                 RFC1035_UNPACK_DEBUG;
                 return 1;
             }
+            /* before copying sizeof(unnsigned short), ensure we respect bounds */
+            if ((*off) + sizeof(s) > sz) {
+                RFC1035_UNPACK_DEBUG;
+                return 1;
+            }
             memcpy(&s, buf + (*off), sizeof(s));
             s = ntohs(s);
             (*off) += sizeof(s);


### PR DESCRIPTION
Code audit by Peter J Philipp found that under certain conditions
it is possible to craft a DNS message which causes Squid to read
one extra byte.
Add an extra check to prevent this from happening