### PR TITLE
Fix ./configure after strnstr() replacement removal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2363,8 +2363,6 @@ AC_CHECK_TYPE(struct sockaddr_un,AC_DEFINE(HAVE_SOCKADDR_UN,1,[The system provid
   #endif
 ])
 
-SQUID_CHECK_FUNC_STRNSTR
-
 dnl IP-Filter support requires ipf header files. These aren't
 dnl installed by default, so we need to check for them
 AS_IF([test "x$enable_ipf_transparent" != "xno"],[


### PR DESCRIPTION
    configure: line 51104: SQUID_CHECK_FUNC_STRNSTR: command not found

The macro call should have been removed in recent commit 9d3433c.
