### PR TITLE
Convert hostname_aliases to SBufList

### DIFF
--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -227,7 +227,7 @@ public:
     char *etcHostsPath;
     char *visibleHostname;
     char *uniqueHostname;
-    wordlist *hostnameAliases;
+    SBufList hostnameAliases;
     char *errHtmlText;
 
     struct {

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -7602,7 +7602,7 @@ DOC_START
 DOC_END
 
 NAME: hostname_aliases
-TYPE: wordlist
+TYPE: SBufList
 LOC: Config.hostnameAliases
 DEFAULT: none
 DOC_START

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1662,7 +1662,7 @@ ClientHttpRequest::checkForInternalAccess()
     if (!internalCheck(request->url.path()))
         return;
 
-    if (internalHostnameIs(request->url.host()) && request->url.port() == getMyPort()) {
+    if (internalHostnameIs(SBuf(request->url.host())) && request->url.port() == getMyPort()) {
         debugs(33, 3, "internal URL found: " << request->url.getScheme() << "://" << request->url.authority(true));
         request->flags.internal = true;
     } else if (Config.onoff.global_internal_static && internalStaticCheck(request->url.path())) {

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1662,7 +1662,7 @@ ClientHttpRequest::checkForInternalAccess()
     if (!internalCheck(request->url.path()))
         return;
 
-    if (internalHostnameIs(SBuf(request->url.host())) && request->url.port() == getMyPort()) {
+    if (request->url.port() == getMyPort() && internalHostnameIs(SBuf(request->url.host()))) {
         debugs(33, 3, "internal URL found: " << request->url.getScheme() << "://" << request->url.authority(true));
         request->flags.internal = true;
     } else if (Config.onoff.global_internal_static && internalStaticCheck(request->url.path())) {

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -23,7 +23,6 @@
 #include "Store.h"
 #include "tools.h"
 #include "util.h"
-#include "wordlist.h"
 
 /* called when we "miss" on an internal object;
  * generate known dynamic objects,
@@ -162,18 +161,17 @@ internalHostname(void)
     return host;
 }
 
-int
-internalHostnameIs(const char *arg)
+bool
+internalHostnameIs(const SBuf &arg)
 {
-    wordlist *w;
+    if (arg.caseCmp(internalHostname()) == 0)
+        return true;
 
-    if (0 == strcmp(arg, internalHostname()))
-        return 1;
+    for (const auto &w : Config.hostnameAliases) {
+        if (w.caseCmp(arg) == 0)
+            return true;
+    }
 
-    for (w = Config.hostnameAliases; w; w = w->next)
-        if (0 == strcmp(arg, w->key))
-            return 1;
-
-    return 0;
+    return false;
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -27,7 +27,7 @@ bool internalStaticCheck(const SBuf &urlPath);
 char *internalLocalUri(const char *dir, const SBuf &name);
 char *internalRemoteUri(bool, const char *, unsigned short, const char *, const SBuf &);
 const char *internalHostname(void);
-int internalHostnameIs(const char *);
+bool internalHostnameIs(const SBuf &);
 
 /// whether the given request URL path points to a cache manager (not
 /// necessarily running on this Squid instance)


### PR DESCRIPTION
Fix a bug where hostname_aliases was being
compared case-sensitively with HTTP request
Host / URL domain.