### PR TITLE
NoNewGlobals for digestFieldsLookupTable

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -80,13 +80,6 @@ DigestAttrs[] = {
     {nullptr, DIGEST_INVALID_ATTR}
 };
 
-static const auto&
-DigestFieldsLookupTable()
-{
-    static const auto *t = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
-    return *t;
-}
-
 /*
  *
  * Nonce Functions
@@ -778,7 +771,8 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
         }
 
         /* find type */
-        const http_digest_attr_type t = DigestFieldsLookupTable().lookup(keyName);
+        static const auto digestFieldsLookupTable = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
+        const auto t = digestFieldsLookupTable->lookup(keyName);
 
         switch (t) {
         case DIGEST_USERNAME:

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -80,6 +80,13 @@ DigestAttrs[] = {
     {nullptr, DIGEST_INVALID_ATTR}
 };
 
+static const auto&
+DigestFieldsLookupTable()
+{
+    static const auto table = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
+    return *table;
+}
+
 /*
  *
  * Nonce Functions
@@ -771,8 +778,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
         }
 
         /* find type */
-        static LookupTable<http_digest_attr_type> DigestFieldsLookupTable(DIGEST_INVALID_ATTR, DigestAttrs);
-        const http_digest_attr_type t = DigestFieldsLookupTable.lookup(keyName);
+        const http_digest_attr_type t = DigestFieldsLookupTable().lookup(keyName);
 
         switch (t) {
         case DIGEST_USERNAME:

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -83,8 +83,8 @@ DigestAttrs[] = {
 static const auto&
 DigestFieldsLookupTable()
 {
-    static const auto table = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
-    return *table;
+    static const auto *t = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
+    return *t;
 }
 
 /*

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -66,19 +66,25 @@ enum http_digest_attr_type {
     DIGEST_INVALID_ATTR
 };
 
-static const LookupTable<http_digest_attr_type>::Record
-DigestAttrs[] = {
-    {"username", DIGEST_USERNAME},
-    {"realm", DIGEST_REALM},
-    {"qop", DIGEST_QOP},
-    {"algorithm", DIGEST_ALGORITHM},
-    {"uri", DIGEST_URI},
-    {"nonce", DIGEST_NONCE},
-    {"nc", DIGEST_NC},
-    {"cnonce", DIGEST_CNONCE},
-    {"response", DIGEST_RESPONSE},
-    {nullptr, DIGEST_INVALID_ATTR}
-};
+inline static const auto&
+digestFieldsLookupTable()
+{
+    static const LookupTable<http_digest_attr_type>::Record
+    DigestAttrs[] = {
+        {"username", DIGEST_USERNAME},
+        {"realm", DIGEST_REALM},
+        {"qop", DIGEST_QOP},
+        {"algorithm", DIGEST_ALGORITHM},
+        {"uri", DIGEST_URI},
+        {"nonce", DIGEST_NONCE},
+        {"nc", DIGEST_NC},
+        {"cnonce", DIGEST_CNONCE},
+        {"response", DIGEST_RESPONSE},
+        {nullptr, DIGEST_INVALID_ATTR}
+    };
+    static const auto proto = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
+    return *proto;
+}
 
 /*
  *
@@ -771,8 +777,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
         }
 
         /* find type */
-        static const auto digestFieldsLookupTable = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
-        const auto t = digestFieldsLookupTable->lookup(keyName);
+        const auto t = digestFieldsLookupTable().lookup(keyName);
 
         switch (t) {
         case DIGEST_USERNAME:

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -80,9 +80,6 @@ DigestAttrs[] = {
     {nullptr, DIGEST_INVALID_ATTR}
 };
 
-LookupTable<http_digest_attr_type>
-DigestFieldsLookupTable(DIGEST_INVALID_ATTR, DigestAttrs);
-
 /*
  *
  * Nonce Functions
@@ -774,6 +771,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
         }
 
         /* find type */
+        static LookupTable<http_digest_attr_type> DigestFieldsLookupTable(DIGEST_INVALID_ATTR, DigestAttrs);
         const http_digest_attr_type t = DigestFieldsLookupTable.lookup(keyName);
 
         switch (t) {

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -82,8 +82,8 @@ digestFieldsLookupTable()
         {"response", DIGEST_RESPONSE},
         {nullptr, DIGEST_INVALID_ATTR}
     };
-    static const auto proto = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
-    return *proto;
+    static const auto table = new LookupTable<http_digest_attr_type>(DIGEST_INVALID_ATTR, DigestAttrs);
+    return *table;
 }
 
 /*

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -66,11 +66,10 @@ enum http_digest_attr_type {
     DIGEST_INVALID_ATTR
 };
 
-inline static const auto&
+static const auto &
 digestFieldsLookupTable()
 {
-    static const LookupTable<http_digest_attr_type>::Record
-    DigestAttrs[] = {
+    static const LookupTable<http_digest_attr_type>::Record DigestAttrs[] = {
         {"username", DIGEST_USERNAME},
         {"realm", DIGEST_REALM},
         {"qop", DIGEST_QOP},


### PR DESCRIPTION
Detected by Coverity. CID 1554677: Initialization or destruction
ordering is unspecified (GLOBAL_INIT_ORDER).