### PR TITLE
NoNewGlobals: HttpUpgradeProtocolAccess::ProtoOther

### DIFF
--- a/src/HttpUpgradeProtocolAccess.cc
+++ b/src/HttpUpgradeProtocolAccess.cc
@@ -49,7 +49,7 @@ HttpUpgradeProtocolAccess::configureGuard(ConfigParser &parser)
 {
     const auto rawProto = parser.NextToken();
     if (!rawProto)
-        throw TextException(ToSBuf("expected a protocol name or ", ProtoOther), Here());
+        throw TextException(ToSBuf("expected a protocol name or ", ProtoOther()), Here());
 
     if (ProtoOther().cmp(rawProto) == 0) {
         aclParseAccessLine(cfg_directive, parser, &other);

--- a/src/HttpUpgradeProtocolAccess.cc
+++ b/src/HttpUpgradeProtocolAccess.cc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 
-const SBuf HttpUpgradeProtocolAccess::ProtoOther("OTHER");
 
 ProtocolView::ProtocolView(const char * const start, const size_t len):
     ProtocolView(SBuf(start, len))
@@ -53,7 +52,7 @@ HttpUpgradeProtocolAccess::configureGuard(ConfigParser &parser)
     if (!rawProto)
         throw TextException(ToSBuf("expected a protocol name or ", ProtoOther), Here());
 
-    if (ProtoOther.cmp(rawProto) == 0) {
+    if (ProtoOther().cmp(rawProto) == 0) {
         aclParseAccessLine(cfg_directive, parser, &other);
         return;
     }

--- a/src/HttpUpgradeProtocolAccess.cc
+++ b/src/HttpUpgradeProtocolAccess.cc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 
-
 ProtocolView::ProtocolView(const char * const start, const size_t len):
     ProtocolView(SBuf(start, len))
 {

--- a/src/HttpUpgradeProtocolAccess.h
+++ b/src/HttpUpgradeProtocolAccess.h
@@ -82,7 +82,7 @@ private:
     typedef std::deque<NamedGuard> NamedGuards;
 
     /// pseudonym to specify rules for "all other protocols"
-    static const SBuf ProtoOther;
+    static const inline SBuf& ProtoOther();
 
     /// rules governing upgrades to explicitly named protocols
     NamedGuards namedGuards;
@@ -98,7 +98,7 @@ HttpUpgradeProtocolAccess::forEach(const Visitor &visitor) const
     for (const auto &namedGuard: namedGuards)
         visitor(namedGuard.protocol, namedGuard.guard);
     if (other)
-        visitor(ProtoOther, other);
+        visitor(ProtoOther(), other);
 }
 
 template <typename Visitor>
@@ -114,7 +114,14 @@ HttpUpgradeProtocolAccess::forApplicable(const ProtocolView &offer, const Visito
         seenApplicable = true; // may already be true
     }
     if (!seenApplicable && other) // OTHER is applicable if named rules were not
-        (void)visitor(ProtoOther, other);
+        (void)visitor(ProtoOther(), other);
+}
+
+const inline SBuf &
+HttpUpgradeProtocolAccess::ProtoOther()
+{
+    const static auto *b = new SBuf("OTHER");
+    return *b;
 }
 
 #endif /* SQUID_SRC_HTTPUPGRADEPROTOCOLACCESS_H */

--- a/src/HttpUpgradeProtocolAccess.h
+++ b/src/HttpUpgradeProtocolAccess.h
@@ -82,7 +82,7 @@ private:
     typedef std::deque<NamedGuard> NamedGuards;
 
     /// pseudonym to specify rules for "all other protocols"
-    static const inline SBuf& ProtoOther();
+    inline static const SBuf &ProtoOther();
 
     /// rules governing upgrades to explicitly named protocols
     NamedGuards namedGuards;
@@ -117,11 +117,11 @@ HttpUpgradeProtocolAccess::forApplicable(const ProtocolView &offer, const Visito
         (void)visitor(ProtoOther(), other);
 }
 
-const inline SBuf &
+inline const SBuf &
 HttpUpgradeProtocolAccess::ProtoOther()
 {
-    const static auto *b = new SBuf("OTHER");
-    return *b;
+    static const auto proto = new SBuf("OTHER");
+    return *proto;
 }
 
 #endif /* SQUID_SRC_HTTPUPGRADEPROTOCOLACCESS_H */

--- a/src/tests/stub_HttpUpgradeProtocolAccess.cc
+++ b/src/tests/stub_HttpUpgradeProtocolAccess.cc
@@ -19,7 +19,6 @@ std::ostream &operator <<(std::ostream &os, const ProtocolView &) STUB_RETVAL(os
 HttpUpgradeProtocolAccess::~HttpUpgradeProtocolAccess() STUB
 const acl_access *HttpUpgradeProtocolAccess::findGuard(const SBuf &) const STUB_RETVAL(nullptr)
 void HttpUpgradeProtocolAccess::configureGuard(ConfigParser &) STUB
-const SBuf HttpUpgradeProtocolAccess::ProtoOther("STUB-OTHER");
 HttpUpgradeProtocolAccess::NamedGuard::~NamedGuard() STUB_NOP
 HttpUpgradeProtocolAccess::NamedGuard::NamedGuard(const char *, acl_access *): protocol("STUB-UNDEF"), proto(protocol) STUB_NOP
 


### PR DESCRIPTION
Detected by Coverity. CID 1554674: Initialization or destruction
ordering is unspecified (GLOBAL_INIT_ORDER).
