### PR TITLE
NoNewGlobals for Adaptation::Config::metaHeaders

### DIFF
--- a/src/adaptation/Config.cc
+++ b/src/adaptation/Config.cc
@@ -34,7 +34,7 @@ int Adaptation::Config::use_indirect_client = true;
 Notes&
 Adaptation::Config::metaHeaders()
 {
-    static const char *protectedFieldNamesRaw[] = {
+    static const auto protectedFieldNamesRaw = {
         "Allow",
         "Date",
         "Encapsulated",
@@ -51,7 +51,7 @@ Adaptation::Config::metaHeaders()
         "Transfer-Preview"
     };
     static const Notes::Keys protectedFieldNames(std::begin(protectedFieldNamesRaw), std::end(protectedFieldNamesRaw));
-    static auto metaHeaders = new Notes("ICAP header", &protectedFieldNames);
+    static const auto metaHeaders = new Notes("ICAP header", &protectedFieldNames);
     return *metaHeaders;
 }
 bool Adaptation::Config::needHistory = false;

--- a/src/adaptation/Config.cc
+++ b/src/adaptation/Config.cc
@@ -30,24 +30,30 @@ int Adaptation::Config::service_iteration_limit = 16;
 int Adaptation::Config::send_client_ip = false;
 int Adaptation::Config::send_username = false;
 int Adaptation::Config::use_indirect_client = true;
-static const char *protectedFieldNamesRaw[] = {
-    "Allow",
-    "Date",
-    "Encapsulated",
-    "ISTag",
-    "Max-Connections",
-    "Methods",
-    "Opt-body-type",
-    "Options-TTL",
-    "Preview",
-    "Service",
-    "Service-ID",
-    "Transfer-Complete",
-    "Transfer-Ignore",
-    "Transfer-Preview"
-};
-static const Notes::Keys protectedFieldNames(std::begin(protectedFieldNamesRaw), std::end(protectedFieldNamesRaw));
-Notes Adaptation::Config::metaHeaders("ICAP header", &protectedFieldNames);
+
+Notes&
+Adaptation::Config::metaHeaders()
+{
+    static const char *protectedFieldNamesRaw[] = {
+        "Allow",
+        "Date",
+        "Encapsulated",
+        "ISTag",
+        "Max-Connections",
+        "Methods",
+        "Opt-body-type",
+        "Options-TTL",
+        "Preview",
+        "Service",
+        "Service-ID",
+        "Transfer-Complete",
+        "Transfer-Ignore",
+        "Transfer-Preview"
+    };
+    static const Notes::Keys protectedFieldNames(std::begin(protectedFieldNamesRaw), std::end(protectedFieldNamesRaw));
+    static auto metaHeaders = new Notes("ICAP header", &protectedFieldNames);
+    return *metaHeaders;
+}
 bool Adaptation::Config::needHistory = false;
 
 Adaptation::ServiceConfig*

--- a/src/adaptation/Config.h
+++ b/src/adaptation/Config.h
@@ -55,7 +55,7 @@ public:
     time_t oldest_service_failure;
     int service_revival_delay;
 
-    static Notes metaHeaders; ///< The list of configured meta headers
+    static Notes& metaHeaders(); ///< The list of configured meta headers
 
     static bool needHistory; ///< HttpRequest adaptation history should recorded
 

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1482,7 +1482,7 @@ void Adaptation::Icap::ModXact::makeRequestHeaders(MemBuf &buf)
         makeUsernameHeader(request, buf);
 
     // Adaptation::Config::metaHeaders
-    for (auto &h: Adaptation::Config::metaHeaders()) {
+    for (const auto &h: Adaptation::Config::metaHeaders()) {
         HttpRequest *r = virgin.cause ?
                          virgin.cause : dynamic_cast<HttpRequest*>(virgin.header);
         Must(r);

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1482,7 +1482,7 @@ void Adaptation::Icap::ModXact::makeRequestHeaders(MemBuf &buf)
         makeUsernameHeader(request, buf);
 
     // Adaptation::Config::metaHeaders
-    for (const auto &h: Adaptation::Config::metaHeaders()) {
+    for (const auto h: Adaptation::Config::metaHeaders()) {
         HttpRequest *r = virgin.cause ?
                          virgin.cause : dynamic_cast<HttpRequest*>(virgin.header);
         Must(r);

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1482,7 +1482,7 @@ void Adaptation::Icap::ModXact::makeRequestHeaders(MemBuf &buf)
         makeUsernameHeader(request, buf);
 
     // Adaptation::Config::metaHeaders
-    for (const auto h: Adaptation::Config::metaHeaders()) {
+    for (const auto &h: Adaptation::Config::metaHeaders()) {
         HttpRequest *r = virgin.cause ?
                          virgin.cause : dynamic_cast<HttpRequest*>(virgin.header);
         Must(r);

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1482,7 +1482,7 @@ void Adaptation::Icap::ModXact::makeRequestHeaders(MemBuf &buf)
         makeUsernameHeader(request, buf);
 
     // Adaptation::Config::metaHeaders
-    for (auto h: Adaptation::Config::metaHeaders) {
+    for (auto &h: Adaptation::Config::metaHeaders()) {
         HttpRequest *r = virgin.cause ?
                          virgin.cause : dynamic_cast<HttpRequest*>(virgin.header);
         Must(r);

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -9959,7 +9959,7 @@ DOC_END
 NAME: adaptation_meta
 TYPE: note
 IFDEF: USE_ADAPTATION
-LOC: Adaptation::Config::metaHeaders
+LOC: Adaptation::Config::metaHeaders()
 DEFAULT: none
 DOC_START
 	This option allows Squid administrator to add custom ICAP request

--- a/src/log/access_log.cc
+++ b/src/log/access_log.cc
@@ -338,7 +338,7 @@ accessLogInit(void)
                     curr_token->type == Format::LFT_ADAPTATION_LAST_HEADER ||
                     curr_token->type == Format::LFT_ADAPTATION_LAST_HEADER_ELEM ||
                     curr_token->type == Format::LFT_ADAPTATION_LAST_ALL_HEADERS||
-                    (curr_token->type == Format::LFT_NOTE && !Adaptation::Config::metaHeaders.empty())) {
+                    (curr_token->type == Format::LFT_NOTE && !Adaptation::Config::metaHeaders().empty())) {
                 Log::TheConfig.hasAdaptToken = true;
             }
 #if ICAP_CLIENT


### PR DESCRIPTION
Detected by Coverity. CID 1554662: Initialization or destruction
ordering is unspecified (GLOBAL_INIT_ORDER).