### PR TITLE
NoNewGlobals for MemBlob::Stats

### DIFF
--- a/src/sbuf/MemBlob.h
+++ b/src/sbuf/MemBlob.h
@@ -19,18 +19,16 @@
 class MemBlobStats
 {
 public:
-    MemBlobStats();
-
     /// dumps class-wide statistics
     std::ostream& dump(std::ostream& os) const;
 
     MemBlobStats& operator += (const MemBlobStats&);
 
 public:
-    uint64_t alloc;     ///< number of MemBlob instances created so far
-    uint64_t live;      ///< number of MemBlob instances currently alive
-    uint64_t append;    ///< number of MemBlob::append() calls
-    uint64_t liveBytes; ///< the total size of currently allocated storage
+    uint64_t alloc = 0;     ///< number of MemBlob instances created so far
+    uint64_t live = 0;      ///< number of MemBlob instances currently alive
+    uint64_t append = 0;    ///< number of MemBlob::append() calls
+    uint64_t liveBytes = 0; ///< the total size of currently allocated storage
 };
 
 /** Refcountable, fixed-size, content-agnostic memory buffer.
@@ -115,8 +113,6 @@ public:
     const InstanceId<MemBlob> id; ///< blob identifier
 
 private:
-    static MemBlobStats Stats; ///< class-wide statistics
-
     void memAlloc(const size_type memSize);
 
     /// whether the offset points to the end of the used area


### PR DESCRIPTION
Detected by Coverity. CID 1554656: Initialization or destruction
ordering is unspecified (GLOBAL_INIT_ORDER).

Also update MemBlobStats initialization.