### PR TITLE
NoNewGlobals for HttpHdrCc:ccLookupTable

### DIFF
--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -56,11 +56,12 @@ CcAttrs() {
     return attrsList;
 }
 
-static const auto&
-ccLookupTable() {
+static auto
+ccTypeByName(const SBuf &name) {
     const static auto table = new LookupTable<HttpHdrCcType>(HttpHdrCcType::CC_OTHER, CcAttrs());
-    return *table;
+    return table->lookup(name);
 }
+
 std::vector<HttpHeaderFieldStat> ccHeaderStats(HttpHdrCcType::CC_ENUM_END);
 
 /// used to walk a table of http_header_cc_type structs
@@ -119,7 +120,7 @@ HttpHdrCc::parse(const String & str)
         }
 
         /* find type */
-        const HttpHdrCcType type = ccLookupTable().lookup(SBuf(item,nlen));
+        const HttpHdrCcType type = ccTypeByName(SBuf(item, nlen));
 
         // ignore known duplicate directives
         if (isSet(type)) {

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -366,7 +366,7 @@ httpHdrCcStatDumper(StoreEntry * sentry, int, double val, double, int count)
 std::ostream &
 operator<< (std::ostream &s, HttpHdrCcType c)
 {
-    s << ccNameByType(c).value_or("*invalid hdrcc*") << '[' << static_cast<int>(c) << ']';
+    s << ccNameByType(c).value_or("INVALID") << '[' << static_cast<int>(c) << ']';
     return s;
 }
 

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -62,6 +62,13 @@ ccTypeByName(const SBuf &name) {
     return table->lookup(name);
 }
 
+static auto
+ccNameByType(HttpHdrCcType type) {
+    if (type < HttpHdrCcType::CC_ENUM_END)
+        return CcAttrs()[static_cast<int>(type)].name;
+    return "*invalid hdrcc*";
+}
+
 std::vector<HttpHeaderFieldStat> ccHeaderStats(HttpHdrCcType::CC_ENUM_END);
 
 /// used to walk a table of http_header_cc_type structs
@@ -350,11 +357,7 @@ httpHdrCcStatDumper(StoreEntry * sentry, int, double val, double, int count)
 std::ostream &
 operator<< (std::ostream &s, HttpHdrCcType c)
 {
-    const unsigned char ic = static_cast<int>(c);
-    if (c < HttpHdrCcType::CC_ENUM_END)
-        s << CcAttrs()[ic].name << '[' << ic << ']' ;
-    else
-        s << "*invalid hdrcc* [" << ic << ']';
+    s << ccNameByType(c) << '[' << static_cast<int>(c) << ']';
     return s;
 }
 

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -272,7 +272,7 @@ HttpHdrCc::packInto(Packable * p) const
         if (isSet(flag) && flag != HttpHdrCcType::CC_OTHER) {
 
             /* print option name for all options */
-            p->appendf((pcount ? ", %s": "%s"), CcAttrs()[flag].name);
+            p->appendf((pcount ? ", %s": "%s"), ccNameByType(flag));
 
             /* for all options having values, "=value" after the name */
             switch (flag) {
@@ -345,9 +345,9 @@ void
 httpHdrCcStatDumper(StoreEntry * sentry, int, double val, double, int count)
 {
     extern const HttpHeaderStat *dump_stat; /* argh! */
-    const int id = static_cast<int>(val);
-    const bool valid_id = id >= 0 && id < static_cast<int>(HttpHdrCcType::CC_ENUM_END);
-    const char *name = valid_id ? CcAttrs()[id].name : "INVALID";
+    const auto id = static_cast<HttpHdrCcType>(val);
+    const bool valid_id = id >= HttpHdrCcType::CC_PUBLIC && id < HttpHdrCcType::CC_ENUM_END;
+    auto name = valid_id ? ccNameByType(id) : "INVALID";
 
     if (count || valid_id)
         storeAppendPrintf(sentry, "%2d\t %-20s\t %5d\t %6.2f\n",

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -66,8 +66,10 @@ ccTypeByName(const SBuf &name) {
 
 static auto
 ccNameByType(HttpHdrCcType type) {
+    // TODO: Store a by-ID index in (and move this functionality into) LookupTable.
+    const auto idx = static_cast<std::underlying_type<HttpHdrCcType>::type>(type);
     if (type < HttpHdrCcType::CC_ENUM_END)
-        return CcAttrs()[static_cast<int>(type)].name;
+        return CcAttrs()[idx].name;
     return "*invalid hdrcc*";
 }
 

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -49,7 +49,11 @@ CcAttrs() {
     return attrsList;
 }
 
-LookupTable<HttpHdrCcType> ccLookupTable(HttpHdrCcType::CC_OTHER,CcAttrs());
+static const auto&
+ccLookupTable() {
+    const static auto table = new LookupTable<HttpHdrCcType>(HttpHdrCcType::CC_OTHER, CcAttrs());
+    return *table;
+}
 std::vector<HttpHeaderFieldStat> ccHeaderStats(HttpHdrCcType::CC_ENUM_END);
 
 /// used to walk a table of http_header_cc_type structs
@@ -119,7 +123,7 @@ HttpHdrCc::parse(const String & str)
         }
 
         /* find type */
-        const HttpHdrCcType type = ccLookupTable.lookup(SBuf(item,nlen));
+        const HttpHdrCcType type = ccLookupTable().lookup(SBuf(item,nlen));
 
         // ignore known duplicate directives
         if (isSet(type)) {

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -25,6 +25,7 @@
 
 #include <map>
 #include <vector>
+#include <optional>
 #include <ostream>
 
 constexpr LookupTable<HttpHdrCcType>::Record attrsList[] = {
@@ -53,7 +54,7 @@ CcAttrs() {
         const auto idx = static_cast<std::underlying_type<HttpHdrCcType>::type>(ev);
         // invariant: each row has a name except the last one
         static_assert(!attrsList[idx].name == (ev == HttpHdrCcType::CC_ENUM_END));
-        // invariant: row[ev].id == ev
+        // invariant: row[idx].id == idx
         static_assert(attrsList[idx].id == ev);
     });
     return attrsList;

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -72,12 +72,6 @@ operator++ (HttpHdrCcType &aHeader)
     return aHeader;
 }
 
-/// Module initialization hook
-void
-httpHdrCcInitModule(void)
-{
-}
-
 void
 HttpHdrCc::clear()
 {

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -46,6 +46,13 @@ CcAttrs() {
         {"Other,", HttpHdrCcType::CC_OTHER}, /* ',' will protect from matches */
         {nullptr, HttpHdrCcType::CC_ENUM_END}
     };
+    static auto invariantChecked = false;
+    if (!invariantChecked) {
+        for (unsigned int j = 0; attrsList[j].name != nullptr; ++j) {
+            assert(static_cast<decltype(j)>(attrsList[j].id) == j);
+        }
+        invariantChecked = true;
+    }
     return attrsList;
 }
 
@@ -69,11 +76,6 @@ operator++ (HttpHdrCcType &aHeader)
 void
 httpHdrCcInitModule(void)
 {
-    const auto attrs = CcAttrs();
-    // check invariant on initialization table
-    for (unsigned int j = 0; attrs[j].name != nullptr; ++j) {
-        assert(static_cast<decltype(j)>(attrs[j].id) == j);
-    }
 }
 
 void

--- a/src/HttpHdrCc.cc
+++ b/src/HttpHdrCc.cc
@@ -127,7 +127,7 @@ HttpHdrCc::parse(const String & str)
         }
 
         /* find type */
-        const HttpHdrCcType type = ccTypeByName(SBuf(item, nlen));
+        const auto type = ccTypeByName(SBuf(item, nlen));
 
         // ignore known duplicate directives
         if (isSet(type)) {

--- a/src/HttpHdrCc.h
+++ b/src/HttpHdrCc.h
@@ -210,7 +210,6 @@ public:
 class StatHist;
 class StoreEntry;
 
-void httpHdrCcInitModule(void);
 void httpHdrCcUpdateStats(const HttpHdrCc * cc, StatHist * hist);
 void httpHdrCcStatDumper(StoreEntry * sentry, int idx, double val, double size, int count);
 

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -135,7 +135,6 @@ httpHeaderInitModule(void)
     assert(HttpHeaderStats[hoEnd-1].label && "HttpHeaderStats created with all elements");
 
     /* init dependent modules */
-    httpHdrCcInitModule();
     httpHdrScInitModule();
 
     httpHeaderRegisterWithCacheManager();

--- a/src/base/EnumIterator.h
+++ b/src/base/EnumIterator.h
@@ -228,10 +228,12 @@ public:
 /// inclusive. The given function is called once on each iteration, with the
 /// current enum value as an argument.
 template <auto First, auto Last, class F>
-constexpr void ConstexprForEnum(F &&f)
+constexpr void
+ConstexprForEnum(F &&f)
 {
     using enumType = decltype(First);
     using underlyingType = typename std::underlying_type<enumType>::type;
+    // std::integral_constant trick makes f(First) argument a constexpr
     f(std::integral_constant<enumType, First>()); // including when First is Last
     if constexpr (First < Last)
         ConstexprForEnum<enumType(static_cast<underlyingType>(First) + 1), Last>(f);

--- a/src/base/EnumIterator.h
+++ b/src/base/EnumIterator.h
@@ -224,5 +224,18 @@ public:
     WholeEnum() : EnumRangeT<EnumType>(EnumType::enumBegin_, EnumType::enumEnd_) {}
 };
 
+/// Compile-time iteration of sequential enum values from First to Last,
+/// inclusive. The given function is called once on each iteration, with the
+/// current enum value as an argument.
+template <auto First, auto Last, class F>
+constexpr void ConstexprForEnum(F &&f)
+{
+    using enumType = decltype(First);
+    using underlyingType = typename std::underlying_type<enumType>::type;
+    f(std::integral_constant<enumType, First>()); // including when First is Last
+    if constexpr (First < Last)
+        ConstexprForEnum<enumType(static_cast<underlyingType>(First) + 1), Last>(f);
+}
+
 #endif /* SQUID_SRC_BASE_ENUMITERATOR_H */
 


### PR DESCRIPTION
Detected by Coverity. CID 1554655: Initialization or destruction
ordering is unspecified (GLOBAL_INIT_ORDER).

Also switched to compile-time checks for table initialization records.