### PR TITLE
Fix eCAP header includes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -886,12 +886,41 @@ AS_IF([test "x$enable_ecap" != "xno"],[
   ])
 
   SQUID_STATE_SAVE(squid_ecap_state)
+  CPPFLAGS="$EXT_LIBECAP_CFLAGS $CPPFLAGS"
+  LIBS="$EXT_LIBECAP_LIBS $LIBS"
+  AC_CHECK_HEADERS([ \
+    libecap/adapter/service.h \
+    libecap/adapter/xaction.h \
+    libecap/common/area.h \
+    libecap/common/body.h \
+    libecap/common/delay.h \
+    libecap/common/forward.h \
+    libecap/common/header.h \
+    libecap/common/memory.h \
+    libecap/common/message.h \
+    libecap/common/name.h \
+    libecap/common/named_values.h \
+    libecap/common/names.h \
+    libecap/common/options.h \
+    libecap/common/registry.h \
+    libecap/common/version.h \
+    libecap/host/host.h \
+    libecap/host/xaction.h \
+  ],,,[
+/* libecap-1.0.1 headers do not build without autoconf.h magic */
+#define HAVE_CONFIG_H
+/* libecap/common/delay.h fails to include <string> */
+#include <string>
+  ])
   AC_MSG_CHECKING([whether -lecap will link])
-  CXXFLAGS="$CXXFLAGS $EXT_LIBECAP_CFLAGS"
-  LIBS="$LIBS $EXT_LIBECAP_LIBS"
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <libecap/common/names.h>]],[[
-    const libecap::Name test("test", libecap::Name::NextId());
-  ]])],[
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#if HAVE_LIBECAP_COMMON_NAMES_H
+#include <libecap/common/names.h>
+#endif
+    ]],[[
+      const libecap::Name test("test", libecap::Name::NextId());
+    ]])
+  ],[
     AC_MSG_RESULT(yes)
     squid_opt_use_adaptation=yes
   ],[

--- a/src/adaptation/ecap/Host.cc
+++ b/src/adaptation/ecap/Host.cc
@@ -9,9 +9,6 @@
 /* DEBUG: section 93    eCAP Interface */
 
 #include "squid.h"
-#include <libecap/adapter/service.h>
-#include <libecap/common/names.h>
-#include <libecap/common/registry.h>
 #include "adaptation/ecap/Host.h"
 #include "adaptation/ecap/MessageRep.h"
 #include "adaptation/ecap/ServiceRep.h"
@@ -19,6 +16,16 @@
 #include "HttpReply.h"
 #include "HttpRequest.h"
 #include "MasterXaction.h"
+
+#if HAVE_LIBECAP_ADAPTER_SERVICE_H
+#include <libecap/adapter/service.h>
+#endif
+#if HAVE_LIBECAP_COMMON_NAMES_H
+#include <libecap/common/names.h>
+#endif
+#if HAVE_LIBECAP_COMMON_REGISTRY_H
+#include <libecap/common/registry.h>
+#endif
 
 const libecap::Name Adaptation::Ecap::protocolInternal("internal", libecap::Name::NextId());
 const libecap::Name Adaptation::Ecap::protocolIcp("ICP", libecap::Name::NextId());

--- a/src/adaptation/ecap/Host.h
+++ b/src/adaptation/ecap/Host.h
@@ -11,7 +11,9 @@
 #ifndef SQUID_SRC_ADAPTATION_ECAP_HOST_H
 #define SQUID_SRC_ADAPTATION_ECAP_HOST_H
 
+#if HAVE_LIBECAP_HOST_HOST_H
 #include <libecap/host/host.h>
+#endif
 
 namespace Adaptation
 {

--- a/src/adaptation/ecap/MessageRep.cc
+++ b/src/adaptation/ecap/MessageRep.cc
@@ -9,19 +9,24 @@
 /* DEBUG: section 93    eCAP Interface */
 
 #include "squid.h"
-#include "BodyPipe.h"
-#include "HttpReply.h"
-#include "HttpRequest.h"
-#include <libecap/common/names.h>
-#include <libecap/common/area.h>
-#include <libecap/common/version.h>
-#include <libecap/common/named_values.h>
-#include "adaptation/ecap/Host.h" /* for protocol constants */
+#include "adaptation/ecap/Host.h"
 #include "adaptation/ecap/MessageRep.h"
 #include "adaptation/ecap/XactionRep.h"
 #include "base/TextException.h"
+#include "HttpReply.h"
 
-/* HeaderRep */
+#if HAVE_LIBECAP_COMMON_AREA_H
+#include <libecap/common/area.h>
+#endif
+#if HAVE_LIBECAP_COMMON_NAMED_VALUES_H
+#include <libecap/common/named_values.h>
+#endif
+#if HAVE_LIBECAP_COMMON_NAMES_H
+#include <libecap/common/names.h>
+#endif
+#if HAVE_LIBECAP_COMMON_VERSION_H
+#include <libecap/common/version.h>
+#endif
 
 Adaptation::Ecap::HeaderRep::HeaderRep(Http::Message &aMessage): theHeader(aMessage.header),
     theMessage(aMessage)

--- a/src/adaptation/ecap/MessageRep.h
+++ b/src/adaptation/ecap/MessageRep.h
@@ -18,9 +18,15 @@
 #include "http/forward.h"
 #include "HttpHeader.h"
 
-#include <libecap/common/message.h>
-#include <libecap/common/header.h>
+#if HAVE_LIBECAP_COMMON_BODY_H
 #include <libecap/common/body.h>
+#endif
+#if HAVE_LIBECAP_COMMON_HEADER_H
+#include <libecap/common/header.h>
+#endif
+#if HAVE_LIBECAP_COMMON_MESSAGE_H
+#include <libecap/common/message.h>
+#endif
 
 namespace Adaptation
 {

--- a/src/adaptation/ecap/ServiceRep.cc
+++ b/src/adaptation/ecap/ServiceRep.cc
@@ -18,10 +18,19 @@
 #include "debug/Stream.h"
 #include "EventLoop.h"
 
+#if HAVE_LIBECAP_ADAPTER_SERVICE_H
 #include <libecap/adapter/service.h>
+#endif
+#if HAVE_LIBECAP_COMMON_OPTIONS_H
 #include <libecap/common/options.h>
+#endif
+#if HAVE_LIBECAP_COMMON_NAME_H
 #include <libecap/common/name.h>
+#endif
+#if HAVE_LIBECAP_COMMON_NAMED_VALUES_H
 #include <libecap/common/named_values.h>
+#endif
+
 #include <limits>
 #include <map>
 

--- a/src/adaptation/ecap/ServiceRep.h
+++ b/src/adaptation/ecap/ServiceRep.h
@@ -13,8 +13,13 @@
 
 #include "adaptation/forward.h"
 #include "adaptation/Service.h"
+
+#if HAVE_LIBECAP_COMMON_FORWARD_H
 #include <libecap/common/forward.h>
+#endif
+#if HAVE_LIBECAP_COMMON_MEMORY_H
 #include <libecap/common/memory.h>
+#endif
 
 namespace Adaptation
 {

--- a/src/adaptation/ecap/XactionRep.cc
+++ b/src/adaptation/ecap/XactionRep.cc
@@ -9,11 +9,6 @@
 /* DEBUG: section 93    eCAP Interface */
 
 #include "squid.h"
-#include <libecap/common/area.h>
-#include <libecap/common/delay.h>
-#include <libecap/common/named_values.h>
-#include <libecap/common/names.h>
-#include <libecap/adapter/xaction.h>
 #include "adaptation/Answer.h"
 #include "adaptation/ecap/Config.h"
 #include "adaptation/ecap/XactionRep.h"
@@ -22,8 +17,20 @@
 #include "base/TextException.h"
 #include "format/Format.h"
 #include "HttpReply.h"
-#include "HttpRequest.h"
 #include "MasterXaction.h"
+
+#if HAVE_LIBECAP_COMMON_AREA_H
+#include <libecap/common/area.h>
+#endif
+#if HAVE_LIBECAP_COMMON_DELAY_H
+#include <libecap/common/delay.h>
+#endif
+#if HAVE_LIBECAP_COMMON_NAMED_VALUES_H
+#include <libecap/common/named_values.h>
+#endif
+#if HAVE_LIBECAP_COMMON_NAMES_H
+#include <libecap/common/names.h>
+#endif
 
 CBDATA_NAMESPACED_CLASS_INIT(Adaptation::Ecap::XactionRep, XactionRep);
 

--- a/src/adaptation/ecap/XactionRep.h
+++ b/src/adaptation/ecap/XactionRep.h
@@ -16,10 +16,13 @@
 #include "adaptation/Initiate.h"
 #include "adaptation/Message.h"
 #include "BodyPipe.h"
-#include <libecap/common/forward.h>
-#include <libecap/common/memory.h>
-#include <libecap/host/xaction.h>
+
+#if HAVE_LIBECAP_ADAPTER_XACTION_H
 #include <libecap/adapter/xaction.h>
+#endif
+#if HAVE_LIBECAP_HOST_XACTION_H
+#include <libecap/host/xaction.h>
+#endif
 
 namespace Adaptation
 {


### PR DESCRIPTION
Squid style guidelines require .h files to be wrapped with
HAVE_*_H protection and placed after all Squid internal file
includes.

Add the missing ./configure header checks to generate the
needed wrappers and refactor the include sequences to meet
current guidelines.