### PR TITLE
Fix heap buffer overead in ConfigParser::UnQuote()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -300,6 +300,7 @@ Thank you!
     Leeann Bent <lbent@cs.ucsd.edu>
     Leonardo Taccari
     Leonid Evdokimov <leon@darkk.net.ru>
+    Liangliang Zhai <zhailiangliang@loongson.cn>
     libit <sambabug.lb@gmail.com>
     Lubos Uhliarik <luhliari@redhat.com>
     Luigi Gangitano <luigi@debian.org>

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -181,7 +181,7 @@ ConfigParser::UnQuote(const char *token, const char **next)
     *d = '\0';
 
     // We are expecting a separator after quoted string, space or one of "()#"
-    if (*(s + 1) != '\0' && !strchr(w_space "()#", *(s + 1)) && !errorStr) {
+    if (!errorStr && *(s + 1) != '\0' && !strchr(w_space "()#", *(s + 1))) {
         errorStr = "Expecting space after the end of quoted token";
         errorPos = token;
     }


### PR DESCRIPTION
Detected by using AddressSanitizer.