### PR TITLE
scripts/find-alive.pl: Auto-detect auto-added ctors/dtors names

### DIFF
--- a/scripts/find-alive.pl
+++ b/scripts/find-alive.pl
@@ -75,8 +75,8 @@ my %Pairs = (
 if (!$Pairs{$Thing}) {
     warn("guessing construction/destruction pattern for $Thing\n");
     $Pairs{$Thing} = [
-        "\\b$Thing construct.*, this=(\\S+)",
-        "\\b$Thing destruct.*, this=(\\S+)",
+        "\\b${Thing}:? construct.*, this=(\\S+)",
+        "\\b${Thing}:? destruct.*, this=(\\S+)",
         ];
 }
 


### PR DESCRIPTION
    debugs(24, 9, "constructed, this=" << static_cast<void*>(this) ...

    MemBlob.cc(54) MemBlob: constructed, this=0x557f06b3ef00 ...

Class constructor and destructor sources should not manually duplicate
class names in debugs() statements. Many existing classes do the right
thing, but find-alive.pl still insists on a manually added class name,
forcing its users to add a colon: `find-alive.pl MemBlob:`.

We now accommodate both legacy/manual and modern/auto use cases.
