### PR TITLE
Fix const-correctness of ACLHTTPHeaderData::match() parameter

### DIFF
--- a/src/acl/HttpHeaderData.cc
+++ b/src/acl/HttpHeaderData.cc
@@ -36,20 +36,17 @@ ACLHTTPHeaderData::~ACLHTTPHeaderData()
 }
 
 bool
-ACLHTTPHeaderData::match(HttpHeader* hdr)
+ACLHTTPHeaderData::match(const HttpHeader &hdr)
 {
-    if (hdr == nullptr)
-        return false;
-
     debugs(28, 3, "aclHeaderData::match: checking '" << hdrName << "'");
 
     String value;
     if (hdrId != Http::HdrType::BAD_HDR) {
-        if (!hdr->has(hdrId))
+        if (!hdr.has(hdrId))
             return false;
-        value = hdr->getStrOrList(hdrId);
+        value = hdr.getStrOrList(hdrId);
     } else {
-        if (!hdr->hasNamed(hdrName, &value))
+        if (!hdr.hasNamed(hdrName, &value))
             return false;
     }
 

--- a/src/acl/HttpHeaderData.h
+++ b/src/acl/HttpHeaderData.h
@@ -14,14 +14,14 @@
 #include "sbuf/SBuf.h"
 #include "SquidString.h"
 
-class ACLHTTPHeaderData : public ACLData<HttpHeader*>
+class ACLHTTPHeaderData: public ACLData<const HttpHeader &>
 {
     MEMPROXY_CLASS(ACLHTTPHeaderData);
 
 public:
     ACLHTTPHeaderData();
     ~ACLHTTPHeaderData() override;
-    bool match(HttpHeader* hdr) override;
+    bool match(const HttpHeader &) override;
     SBufList dump() const override;
     void parse() override;
     bool empty() const override;

--- a/src/acl/HttpRepHeader.cc
+++ b/src/acl/HttpRepHeader.cc
@@ -8,7 +8,6 @@
 
 #include "squid.h"
 #include "acl/FilledChecklist.h"
-#include "acl/HttpHeaderData.h"
 #include "acl/HttpRepHeader.h"
 #include "HttpReply.h"
 

--- a/src/acl/HttpRepHeader.cc
+++ b/src/acl/HttpRepHeader.cc
@@ -15,8 +15,6 @@
 int
 Acl::HttpRepHeaderCheck::match(ACLChecklist * const ch)
 {
-    const auto checklist = Filled(ch);
-
-    return data->match (&checklist->reply->header);
+    return data->match(Filled(ch)->reply->header);
 }
 

--- a/src/acl/HttpRepHeader.h
+++ b/src/acl/HttpRepHeader.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "rep_header" ACL
-class HttpRepHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
+class HttpRepHeaderCheck: public ParameterizedNode< ACLData<const HttpHeader &> >
 {
 public:
     /* Acl::Node API */

--- a/src/acl/HttpRepHeader.h
+++ b/src/acl/HttpRepHeader.h
@@ -11,7 +11,7 @@
 
 #include "acl/Data.h"
 #include "acl/ParameterizedNode.h"
-#include "HttpHeader.h"
+#include "http/forward.h"
 
 namespace Acl
 {

--- a/src/acl/HttpReqHeader.cc
+++ b/src/acl/HttpReqHeader.cc
@@ -15,8 +15,6 @@
 int
 Acl::HttpReqHeaderCheck::match(ACLChecklist * const ch)
 {
-    const auto checklist = Filled(ch);
-
-    return data->match (&checklist->request->header);
+    return data->match(Filled(ch)->request->header);
 }
 

--- a/src/acl/HttpReqHeader.cc
+++ b/src/acl/HttpReqHeader.cc
@@ -8,7 +8,6 @@
 
 #include "squid.h"
 #include "acl/FilledChecklist.h"
-#include "acl/HttpHeaderData.h"
 #include "acl/HttpReqHeader.h"
 #include "HttpRequest.h"
 

--- a/src/acl/HttpReqHeader.h
+++ b/src/acl/HttpReqHeader.h
@@ -11,7 +11,7 @@
 
 #include "acl/Data.h"
 #include "acl/ParameterizedNode.h"
-#include "HttpHeader.h"
+#include "http/forward.h"
 
 namespace Acl
 {

--- a/src/acl/HttpReqHeader.h
+++ b/src/acl/HttpReqHeader.h
@@ -17,7 +17,7 @@ namespace Acl
 {
 
 /// a "req_header" ACL
-class HttpReqHeaderCheck: public ParameterizedNode< ACLData<HttpHeader*> >
+class HttpReqHeaderCheck: public ParameterizedNode< ACLData<const HttpHeader &> >
 {
 public:
     /* Acl::Node API */

--- a/src/http/forward.h
+++ b/src/http/forward.h
@@ -39,6 +39,8 @@ typedef enum {
 
 class HttpHdrSc;
 
+class HttpHeader;
+
 class HttpRequestMethod;
 
 class HttpRequest;


### PR DESCRIPTION
ACLHTTPHeaderData::match() required a pointer to non-const HttpHeader
but does not (and should not) modify the supplied HttpHeader.

Also removed support for nil HttpHeader in that method. All callers
already require HttpHeader presence. If that changes, it is the _caller_
that should decide what HttpHeader absence means (match, mismatch,
exception/dunno, etc.); ACLHTTPHeaderData does not have enough
information to make the right choice and, hence, should not be asked to
choose.

Also polished related #includes to remove unnecessary ones.

