### PR TITLE
CI: Build layers independently to speed up GitHub Actions tests

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -95,6 +95,11 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-22.04 ]
+        layer:
+          - layer-00-default
+          - layer-01-minimal
+          - layer-02-maximus
+          - layer-04-noauth-everything
 
     runs-on: ${{ matrix.os }}
 
@@ -112,7 +117,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - run: ./test-builds.sh
+      - run: ./test-builds.sh ${{ matrix.layer }}
 
       - name: Publish build logs
         if: success() || failure()


### PR DESCRIPTION
Adding a second matrix test dimension can decrease
testing wall time by about 75% by parallelizing tests