### PR TITLE
fix memory leak in clientAclChecklistCreate calls

### DIFF
--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -846,6 +846,7 @@ clientReplyContext::blockedHit() const
     const auto &rep = http->storeEntry()->mem().freshestReply();
     {
         std::unique_ptr<ACLFilledChecklist> chl(clientAclChecklistCreate(Config.accessList.sendHit, http));
+        HTTPMSGUNLOCK(chl->reply);
         chl->reply = const_cast<HttpReply*>(&rep); // ACLChecklist API bug
         HTTPMSGLOCK(chl->reply);
         return !chl->fastCheck().allowed(); // when in doubt, block
@@ -1838,6 +1839,7 @@ clientReplyContext::processReplyAccess ()
     /** Process http_reply_access lists */
     ACLFilledChecklist *replyChecklist =
         clientAclChecklistCreate(Config.accessList.reply, http);
+    HTTPMSGUNLOCK(replyChecklist->reply);
     replyChecklist->reply = reply;
     HTTPMSGLOCK(replyChecklist->reply);
     replyChecklist->nonBlockingCheck(ProcessReplyAccessResult, this);

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -291,6 +291,7 @@ Http::Stream::sendStartOfMessage(HttpReply *rep, StoreIOBuffer bodyData)
     for (const auto &pool: MessageDelayPools::Instance()->pools) {
         if (pool->access) {
             std::unique_ptr<ACLFilledChecklist> chl(clientAclChecklistCreate(pool->access, http));
+            HTTPMSGUNLOCK(chl->reply);
             chl->reply = rep;
             HTTPMSGLOCK(chl->reply);
             const auto answer = chl->fastCheck();


### PR DESCRIPTION
e227da8d1719b4b5f24a2fc62882ef9907348bc5 changed clientAclChecklistFill and clientAclChecklistCreate to add reply field into checklist and lock it. However calling side wasn't changed to reflect that change, and in some places it stomped this copied reference without unlocking it, leading to memory leak.