### PR TITLE
NoNewGlobals for ProxyProtocol::*::Magic

### DIFF
--- a/src/proxyp/Parser.cc
+++ b/src/proxyp/Parser.cc
@@ -30,7 +30,7 @@
 namespace ProxyProtocol {
 namespace One {
 /// magic octet prefix for PROXY protocol version 1
-static const auto&
+static const auto &
 Magic()
 {
     static const auto magic = new SBuf("PROXY", 5);


### PR DESCRIPTION
Detected by Coverity. CID 1554652: Initialization or destruction
ordering is unspecified (GLOBAL_INIT_ORDER).