### PR TITLE
Optimization: clientBeginRequest() call copied streamData ptr

### DIFF
--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -279,7 +279,7 @@ ClientHttpRequest::~ClientHttpRequest()
  */
 int
 clientBeginRequest(const HttpRequestMethod &method, char const *url, CSCB *streamcallback,
-                   CSD *streamdetach, const ClientStreamData &streamdata, HttpHeader const *header,
+                   CSD *streamdetach, const ClientStreamData &streamdata, const HttpHeader *header,
                    char *tailbuf, size_t taillen, const MasterXaction::Pointer &mx)
 {
     size_t url_sz;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -278,8 +278,8 @@ ClientHttpRequest::~ClientHttpRequest()
  * determined by the user
  */
 int
-clientBeginRequest(const HttpRequestMethod& method, char const *url, CSCB * streamcallback,
-                   CSD * streamdetach, const ClientStreamData &streamdata, HttpHeader const *header,
+clientBeginRequest(const HttpRequestMethod &method, char const *url, CSCB *streamcallback,
+                   CSD *streamdetach, const ClientStreamData &streamdata, HttpHeader const *header,
                    char *tailbuf, size_t taillen, const MasterXaction::Pointer &mx)
 {
     size_t url_sz;

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -279,7 +279,7 @@ ClientHttpRequest::~ClientHttpRequest()
  */
 int
 clientBeginRequest(const HttpRequestMethod& method, char const *url, CSCB * streamcallback,
-                   CSD * streamdetach, ClientStreamData streamdata, HttpHeader const *header,
+                   CSD * streamdetach, const ClientStreamData &streamdata, HttpHeader const *header,
                    char *tailbuf, size_t taillen, const MasterXaction::Pointer &mx)
 {
     size_t url_sz;
@@ -295,7 +295,7 @@ clientBeginRequest(const HttpRequestMethod& method, char const *url, CSCB * stre
     /* client stream setup */
     clientStreamInit(&http->client_stream, clientGetMoreData, clientReplyDetach,
                      clientReplyStatus, new clientReplyContext(http), streamcallback,
-                     streamdetach, std::move(streamdata), tempBuffer);
+                     streamdetach, streamdata, tempBuffer);
     /* make it visible in the 'current acctive requests list' */
     /* Set flags */
     /* internal requests only makes sense in an

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -295,7 +295,7 @@ clientBeginRequest(const HttpRequestMethod& method, char const *url, CSCB * stre
     /* client stream setup */
     clientStreamInit(&http->client_stream, clientGetMoreData, clientReplyDetach,
                      clientReplyStatus, new clientReplyContext(http), streamcallback,
-                     streamdetach, streamdata, tempBuffer);
+                     streamdetach, std::move(streamdata), tempBuffer);
     /* make it visible in the 'current acctive requests list' */
     /* Set flags */
     /* internal requests only makes sense in an

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -28,7 +28,7 @@ class ConnStateData;
 class MemObject;
 
 /* client_side_request.c - client side request related routines (pure logic) */
-int clientBeginRequest(const HttpRequestMethod&, char const *, CSCB *, CSD *, const ClientStreamData&, HttpHeader const *, char *, size_t, const MasterXactionPointer &);
+int clientBeginRequest(const HttpRequestMethod &, char const *, CSCB *, CSD *, const ClientStreamData &, HttpHeader const *, char *, size_t, const MasterXactionPointer &);
 
 class ClientHttpRequest
 #if USE_ADAPTATION

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -28,7 +28,7 @@ class ConnStateData;
 class MemObject;
 
 /* client_side_request.c - client side request related routines (pure logic) */
-int clientBeginRequest(const HttpRequestMethod&, char const *, CSCB *, CSD *, ClientStreamData, HttpHeader const *, char *, size_t, const MasterXactionPointer &);
+int clientBeginRequest(const HttpRequestMethod&, char const *, CSCB *, CSD *, const ClientStreamData&, HttpHeader const *, char *, size_t, const MasterXactionPointer &);
 
 class ClientHttpRequest
 #if USE_ADAPTATION

--- a/src/client_side_request.h
+++ b/src/client_side_request.h
@@ -28,7 +28,7 @@ class ConnStateData;
 class MemObject;
 
 /* client_side_request.c - client side request related routines (pure logic) */
-int clientBeginRequest(const HttpRequestMethod &, char const *, CSCB *, CSD *, const ClientStreamData &, HttpHeader const *, char *, size_t, const MasterXactionPointer &);
+int clientBeginRequest(const HttpRequestMethod &, char const *, CSCB *, CSD *, const ClientStreamData &, const HttpHeader *, char *, size_t, const MasterXactionPointer &);
 
 class ClientHttpRequest
 #if USE_ADAPTATION

--- a/src/esi/Include.cc
+++ b/src/esi/Include.cc
@@ -283,7 +283,7 @@ ESIInclude::Start (ESIStreamContext::Pointer stream, char const *url, ESIVarStat
 
     debugs(86, 5, "ESIIncludeStart: Starting subrequest with url '" << tempUrl << "'");
     const auto mx = MasterXaction::MakePortless<XactionInitiator::initEsi>();
-    if (clientBeginRequest(Http::METHOD_GET, tempUrl, esiBufferRecipient, esiBufferDetach, stream.getRaw(), &tempheaders, stream->localbuffer->buf, HTTP_REQBUF_SZ, mx)) {
+    if (clientBeginRequest(Http::METHOD_GET, tempUrl, esiBufferRecipient, esiBufferDetach, stream, &tempheaders, stream->localbuffer->buf, HTTP_REQBUF_SZ, mx)) {
         debugs(86, DBG_CRITICAL, "ERROR: starting new ESI subrequest failed");
     }
 


### PR DESCRIPTION
Detected by Coverity. CID 1529581: Unnecessary object copies can affect
performance (COPY_INSTEAD_OF_MOVE).
