### PR TITLE
Optimization: DiskThreadsDiskFile::readDone copied request ptr

### DIFF
--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
@@ -279,7 +279,7 @@ DiskThreadsDiskFile::readDone(int rvfd, const char *buf, int len, int errflag, R
 
     --inProgressIOs;
 
-    ioRequestor->readCompleted(buf, rlen, errflag, request);
+    ioRequestor->readCompleted(buf, rlen, errflag, std::move(request));
 }
 
 void

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.cc
@@ -247,7 +247,7 @@ DiskThreadsDiskFile::ReadDone(int fd, const char *buf, int len, int errflag, voi
 }
 
 void
-DiskThreadsDiskFile::readDone(int rvfd, const char *buf, int len, int errflag, RefCount<ReadRequest> request)
+DiskThreadsDiskFile::readDone(int rvfd, const char *buf, int len, int errflag, const RefCount<ReadRequest> &request)
 {
     debugs(79, 3, "DiskThreadsDiskFile::readDone: FD " << rvfd);
     assert (fd == rvfd);
@@ -279,7 +279,7 @@ DiskThreadsDiskFile::readDone(int rvfd, const char *buf, int len, int errflag, R
 
     --inProgressIOs;
 
-    ioRequestor->readCompleted(buf, rlen, errflag, std::move(request));
+    ioRequestor->readCompleted(buf, rlen, errflag, request);
 }
 
 void

--- a/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
+++ b/src/DiskIO/DiskThreads/DiskThreadsDiskFile.h
@@ -60,7 +60,7 @@ private:
     RefCount<IORequestor> ioRequestor;
     void doClose();
 
-    void readDone(int fd, const char *buf, int len, int errflag, RefCount<ReadRequest> request);
+    void readDone(int fd, const char *buf, int len, int errflag, const RefCount<ReadRequest> &request);
     void writeDone(int fd, int errflag, size_t len, RefCount<WriteRequest> request);
 };
 


### PR DESCRIPTION
Detected by Coverity. CID 1529587: Unnecessary object copies can affect
performance (COPY_INSTEAD_OF_MOVE).