### PR TITLE
Optimization: DelayId::compositePosition() copied position ptr

### DIFF
--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -38,9 +38,9 @@ DelayId::~DelayId ()
 {}
 
 void
-DelayId::compositePosition(DelayIdComposite::Pointer newPosition)
+DelayId::compositePosition(const DelayIdComposite::Pointer &newPosition)
 {
-    compositeId = std::move(newPosition);
+    compositeId = newPosition;
 }
 
 unsigned short

--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -40,7 +40,7 @@ DelayId::~DelayId ()
 void
 DelayId::compositePosition(DelayIdComposite::Pointer newPosition)
 {
-    compositeId = newPosition;
+    compositeId = std::move(newPosition);
 }
 
 unsigned short

--- a/src/DelayId.h
+++ b/src/DelayId.h
@@ -29,7 +29,7 @@ public:
     unsigned short pool() const;
     DelayIdComposite::Pointer compositePosition();
     DelayIdComposite::Pointer const compositePosition() const;
-    void compositePosition(DelayIdComposite::Pointer );
+    void compositePosition(const DelayIdComposite::Pointer &);
     bool operator == (DelayId const &rhs) const;
     operator bool() const;
     int bytesWanted(int min, int max) const;


### PR DESCRIPTION
Detected by Coverity. CID 1529588: Unnecessary object copies can affect
performance (COPY_INSTEAD_OF_MOVE).