### PR TITLE
Optimization: DelayUser::Id constructor copied user pointers

### DIFF
--- a/src/DelayUser.cc
+++ b/src/DelayUser.cc
@@ -139,7 +139,7 @@ DelayUserBucket::stats (StoreEntry *entry) const
     theBucket.stats(entry);
 }
 
-DelayUser::Id::Id(DelayUser::Pointer aDelayUser, Auth::User::Pointer aUser) : theUser(aDelayUser)
+DelayUser::Id::Id(DelayUser::Pointer aDelayUser, Auth::User::Pointer aUser) : theUser(std::move(aDelayUser))
 {
     theBucket = new DelayUserBucket(aUser);
     DelayUserBucket::Pointer const *existing = theUser->buckets.find(theBucket, DelayUserCmp);

--- a/src/DelayUser.cc
+++ b/src/DelayUser.cc
@@ -139,7 +139,7 @@ DelayUserBucket::stats (StoreEntry *entry) const
     theBucket.stats(entry);
 }
 
-DelayUser::Id::Id(DelayUser::Pointer aDelayUser, Auth::User::Pointer aUser) : theUser(std::move(aDelayUser))
+DelayUser::Id::Id(const DelayUser::Pointer &aDelayUser, const Auth::User::Pointer &aUser) : theUser(aDelayUser)
 {
     theBucket = new DelayUserBucket(aUser);
     DelayUserBucket::Pointer const *existing = theUser->buckets.find(theBucket, DelayUserCmp);

--- a/src/DelayUser.h
+++ b/src/DelayUser.h
@@ -60,7 +60,7 @@ private:
         MEMPROXY_CLASS(DelayUser::Id);
 
     public:
-        Id(RefCount<DelayUser>, Auth::User::Pointer);
+        Id(const DelayUser::Pointer &, const Auth::User::Pointer &);
         ~Id() override;
         int bytesWanted (int min, int max) const override;
         void bytesIn(int qty) override;


### PR DESCRIPTION
Detected by Coverity. CID 1529593: Unnecessary object copies can affect
performance (COPY_INSTEAD_OF_MOVE).