### PR TITLE
Optimization: clientStreamInit() copied ClientStreamData

### DIFF
--- a/src/clientStream.cc
+++ b/src/clientStream.cc
@@ -110,7 +110,7 @@ clientStreamNode::~clientStreamNode()
  */
 void
 clientStreamInit(dlink_list * list, CSR * func, CSD * rdetach, CSS * readstatus,
-                 ClientStreamData readdata, CSCB * callback, CSD * cdetach, const ClientStreamData &callbackdata,
+                 const ClientStreamData &readdata, CSCB * callback, CSD * cdetach, const ClientStreamData &callbackdata,
                  StoreIOBuffer tailBuffer)
 {
     clientStreamNode *temp = new clientStreamNode(func, nullptr, rdetach, readstatus, readdata);

--- a/src/clientStream.cc
+++ b/src/clientStream.cc
@@ -110,7 +110,7 @@ clientStreamNode::~clientStreamNode()
  */
 void
 clientStreamInit(dlink_list * list, CSR * func, CSD * rdetach, CSS * readstatus,
-                 ClientStreamData readdata, CSCB * callback, CSD * cdetach, ClientStreamData callbackdata,
+                 ClientStreamData readdata, CSCB * callback, CSD * cdetach, const ClientStreamData &callbackdata,
                  StoreIOBuffer tailBuffer)
 {
     clientStreamNode *temp = new clientStreamNode(func, nullptr, rdetach, readstatus, readdata);

--- a/src/clientStream.h
+++ b/src/clientStream.h
@@ -95,7 +95,7 @@ public:
 };
 
 /// \ingroup ClientStreamAPI
-void clientStreamInit(dlink_list *, CSR *, CSD *, CSS *, ClientStreamData, CSCB *, CSD *, const ClientStreamData &, StoreIOBuffer tailBuffer);
+void clientStreamInit(dlink_list *, CSR *, CSD *, CSS *, const ClientStreamData &, CSCB *, CSD *, const ClientStreamData &, StoreIOBuffer tailBuffer);
 
 /// \ingroup ClientStreamAPI
 void clientStreamInsertHead(dlink_list *, CSR *, CSCB *, CSD *, CSS *, ClientStreamData);

--- a/src/clientStream.h
+++ b/src/clientStream.h
@@ -95,7 +95,7 @@ public:
 };
 
 /// \ingroup ClientStreamAPI
-void clientStreamInit(dlink_list *, CSR *, CSD *, CSS *, ClientStreamData, CSCB *, CSD *, ClientStreamData, StoreIOBuffer tailBuffer);
+void clientStreamInit(dlink_list *, CSR *, CSD *, CSS *, ClientStreamData, CSCB *, CSD *, const ClientStreamData &, StoreIOBuffer tailBuffer);
 
 /// \ingroup ClientStreamAPI
 void clientStreamInsertHead(dlink_list *, CSR *, CSCB *, CSD *, CSS *, ClientStreamData);

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1351,13 +1351,13 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     ClientHttpRequest *http = new ClientHttpRequest(this);
 
     http->req_sz = hp->messageHeaderSize();
-    auto result = new Http::Stream(clientConnection, http);
+    Http::Stream *result = new Http::Stream(clientConnection, http);
 
     StoreIOBuffer tempBuffer;
     tempBuffer.data = result->reqbuf;
     tempBuffer.length = HTTP_REQBUF_SZ;
 
-    auto newServer = new clientReplyContext(http);
+    ClientStreamData newServer = new clientReplyContext(http);
     ClientStreamData newClient = result;
     clientStreamInit(&http->client_stream, clientGetMoreData, clientReplyDetach,
                      clientReplyStatus, newServer, clientSocketRecipient,

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1361,7 +1361,7 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     ClientStreamData newClient = result;
     clientStreamInit(&http->client_stream, clientGetMoreData, clientReplyDetach,
                      clientReplyStatus, newServer, clientSocketRecipient,
-                     clientSocketDetach, newClient, tempBuffer);
+                     clientSocketDetach, std::move(newClient), tempBuffer);
 
     /* set url */
     debugs(33,5, "Prepare absolute URL from " <<

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1351,17 +1351,17 @@ ConnStateData::parseHttpRequest(const Http1::RequestParserPointer &hp)
     ClientHttpRequest *http = new ClientHttpRequest(this);
 
     http->req_sz = hp->messageHeaderSize();
-    Http::Stream *result = new Http::Stream(clientConnection, http);
+    auto result = new Http::Stream(clientConnection, http);
 
     StoreIOBuffer tempBuffer;
     tempBuffer.data = result->reqbuf;
     tempBuffer.length = HTTP_REQBUF_SZ;
 
-    ClientStreamData newServer = new clientReplyContext(http);
+    auto newServer = new clientReplyContext(http);
     ClientStreamData newClient = result;
     clientStreamInit(&http->client_stream, clientGetMoreData, clientReplyDetach,
                      clientReplyStatus, newServer, clientSocketRecipient,
-                     clientSocketDetach, std::move(newClient), tempBuffer);
+                     clientSocketDetach, newClient, tempBuffer);
 
     /* set url */
     debugs(33,5, "Prepare absolute URL from " <<


### PR DESCRIPTION
Detected by Coverity. CID 1529543 and CID 1529594: Unnecessary object
copies can affect performance (COPY_INSTEAD_OF_MOVE).
