### PR TITLE
Optimization: Fs::Ufs::RebuildState constructor copied dir ptr

### DIFF
--- a/src/fs/ufs/RebuildState.cc
+++ b/src/fs/ufs/RebuildState.cc
@@ -30,7 +30,7 @@
 CBDATA_NAMESPACED_CLASS_INIT(Fs::Ufs,RebuildState);
 
 Fs::Ufs::RebuildState::RebuildState(RefCount<UFSSwapDir> aSwapDir) :
-    sd(aSwapDir),
+    sd(std::move(aSwapDir)),
     n_read(0),
     LogParser(nullptr),
     curlvl1(0),

--- a/src/fs/ufs/RebuildState.cc
+++ b/src/fs/ufs/RebuildState.cc
@@ -29,8 +29,8 @@
 
 CBDATA_NAMESPACED_CLASS_INIT(Fs::Ufs,RebuildState);
 
-Fs::Ufs::RebuildState::RebuildState(RefCount<UFSSwapDir> aSwapDir) :
-    sd(std::move(aSwapDir)),
+Fs::Ufs::RebuildState::RebuildState(const RefCount<UFSSwapDir> &aSwapDir) :
+    sd(aSwapDir),
     n_read(0),
     LogParser(nullptr),
     curlvl1(0),

--- a/src/fs/ufs/RebuildState.h
+++ b/src/fs/ufs/RebuildState.h
@@ -28,7 +28,7 @@ class RebuildState
 public:
     static EVH RebuildStep;
 
-    RebuildState(RefCount<UFSSwapDir> sd);
+    RebuildState(const RefCount<UFSSwapDir> &sd);
     virtual ~RebuildState();
 
     virtual bool error() const;


### PR DESCRIPTION
Detected by Coverity. CID 1529599: Unnecessary object copies can affect
performance (COPY_INSTEAD_OF_MOVE).