### PR TITLE
Optimization: esiChoose constructor call copied parent pointer

### DIFF
--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -1892,7 +1892,7 @@ esiChoose::~esiChoose()
 esiChoose::esiChoose(esiTreeParentPtr aParent) :
     elements(),
     chosenelement(-1),
-    parent(aParent)
+    parent(std::move(aParent))
 {}
 
 void

--- a/src/esi/Esi.cc
+++ b/src/esi/Esi.cc
@@ -163,7 +163,7 @@ class esiChoose : public ESIElement
     MEMPROXY_CLASS(esiChoose);
 
 public:
-    esiChoose(esiTreeParentPtr);
+    esiChoose(const esiTreeParentPtr &);
     ~esiChoose() override;
 
     void render(ESISegment::Pointer) override;
@@ -1889,10 +1889,10 @@ esiChoose::~esiChoose()
     FinishAllElements(elements); // finish if not already done
 }
 
-esiChoose::esiChoose(esiTreeParentPtr aParent) :
+esiChoose::esiChoose(const esiTreeParentPtr & aParent) :
     elements(),
     chosenelement(-1),
-    parent(std::move(aParent))
+    parent(aParent)
 {}
 
 void


### PR DESCRIPTION
Detected by Coverity. CID 1529569: Unnecessary object copies can affect
performance (COPY_INSTEAD_OF_MOVE).