### PR TITLE
Maintenance: add ostream report API to Mgr::Action

### DIFF
--- a/src/mgr/Action.cc
+++ b/src/mgr/Action.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 16    Cache Manager API */
 
 #include "squid.h"
+#include "base/PackableStream.h"
 #include "CacheManager.h"
 #include "comm/Connection.h"
 #include "HttpReply.h"
@@ -112,7 +113,7 @@ Mgr::Action::fillEntry(StoreEntry* entry, bool writeHttpHeader)
         entry->replaceHttpReply(rep);
     }
 
-    dump(entry);
+    dump(entry); // TODO: replace with report() when all children are converted
 
     entry->flush();
 
@@ -120,3 +121,9 @@ Mgr::Action::fillEntry(StoreEntry* entry, bool writeHttpHeader)
         entry->complete();
 }
 
+void
+Mgr::Action::dump(StoreEntry *entry)
+{
+    PackableStream os(*entry);
+    report(os);
+}

--- a/src/mgr/Action.h
+++ b/src/mgr/Action.h
@@ -84,8 +84,6 @@ protected:
     /** start writing action-specific info to Store entry;
      * may collect info during dump, especially if collect() did nothing
      * non-atomic() actions may continue writing asynchronously after returning
-     *
-     * \deprecated implement report() instead
      */
     virtual void dump(StoreEntry *);
 

--- a/src/mgr/Action.h
+++ b/src/mgr/Action.h
@@ -14,6 +14,8 @@
 #include "ipc/forward.h"
 #include "mgr/forward.h"
 
+#include <iosfwd>
+
 class StoreEntry;
 
 namespace Mgr
@@ -76,11 +78,16 @@ protected:
     /// calculate and keep local action-specific information
     virtual void collect() {}
 
+    /// write manager report output to a stream.
+    virtual void report(std::ostream &) {}
+
     /** start writing action-specific info to Store entry;
      * may collect info during dump, especially if collect() did nothing
      * non-atomic() actions may continue writing asynchronously after returning
+     *
+     * \deprecated implement report() instead
      */
-    virtual void dump(StoreEntry *) {}
+    virtual void dump(StoreEntry *);
 
 private:
     const CommandPointer cmd; ///< the command that caused this action

--- a/src/tests/stub_libmgr.cc
+++ b/src/tests/stub_libmgr.cc
@@ -34,6 +34,7 @@ const char * Mgr::Action::name() const STUB_RETVAL(nullptr)
 static Mgr::Command static_Command;
 const Mgr::Command & Mgr::Action::command() const STUB_RETVAL(static_Command)
 StoreEntry * Mgr::Action::createStoreEntry() const STUB_RETVAL(nullptr)
+void Mgr::Action::dump(StoreEntry *) STUB
 static Mgr::Action::Pointer dummyAction;
 
 #include "mgr/ActionParams.h"


### PR DESCRIPTION
This new API method allows new or updated cache manager reports
to write their output to a stream without having to import any
StoreEntry related API.