### PR TITLE
Maintenance: No ptr copy in future CredentialsCache::insert()s

### DIFF
--- a/src/auth/CredentialsCache.cc
+++ b/src/auth/CredentialsCache.cc
@@ -102,7 +102,7 @@ CredentialsCache::cleanup()
 }
 
 void
-CredentialsCache::insert(const SBuf &userKey, Auth::User::Pointer anAuth_user)
+CredentialsCache::insert(const SBuf &userKey, const Auth::User::Pointer &anAuth_user)
 {
     debugs(29, 6, "adding " << userKey << " (" << anAuth_user->username() << ")");
     store_[userKey] = anAuth_user;

--- a/src/auth/CredentialsCache.h
+++ b/src/auth/CredentialsCache.h
@@ -33,7 +33,7 @@ public:
     Auth::User::Pointer lookup(const SBuf &userKey) const;
 
     /// add an user to the cache with the provided key
-    void insert(const SBuf &userKey, Auth::User::Pointer anAuth_user);
+    void insert(const SBuf &userKey, const Auth::User::Pointer &anAuth_user);
 
     /// clear cache
     void reset() { store_.clear(); }


### PR DESCRIPTION
Currently, the insert() method calls implicitly convert raw "this"
pointers to RefCount pointers. That self-registration code raises red
flags and may eventually be refactored. If it is refactored, insert()
calls are likely to start using RefCount pointers as parameters. This
change allows those future calls to avoid RefCount pointer copies. This
change does not affect current calls performance.

This change was triggered by Coverity CID 1554665: Unnecessary object
copies can affect performance (COPY_INSTEAD_OF_MOVE). However, the
insert() method is still calling RefCount copy assignment operator
rather than its (cheaper) move assignment operator. Safely removing that
overhead is only possible by reintroducing future parameter copying
overhead described above _and_ using an explicit std::move() call that
we are trying to avoid in general code. It is arguably not worth it.