### PR TITLE
testCacheManager: use cppunit exception tests

### DIFF
--- a/src/tests/testCacheManager.cc
+++ b/src/tests/testCacheManager.cc
@@ -50,26 +50,13 @@ public:
 void
 CacheManagerInternals::testValidUrl(const AnyP::Uri &url)
 {
-    try {
-        (void)ParseUrl(url);
-    } catch (...) {
-        std::cerr << "\nFAIL: " << url <<
-                  Debug::Extra << "error: " << CurrentException << "\n";
-        CPPUNIT_FAIL("rejected a valid URL");
-    }
+    CPPUNIT_ASSERT_NO_THROW(ParseUrl(url));
 }
 
 void
 CacheManagerInternals::testInvalidUrl(const AnyP::Uri &url, const char *const problem)
 {
-    try {
-        (void)ParseUrl(url);
-        std::cerr << "\nFAIL: " << url <<
-                  Debug::Extra << "error: should be rejected due to '" << problem << "'\n";
-    } catch (const TextException &) {
-        return; // success -- the parser signaled bad input
-    }
-    CPPUNIT_FAIL("failed to reject an invalid URL");
+    CPPUNIT_ASSERT_THROW_MESSAGE(problem, ParseUrl(url), TextException);
 }
 
 /// customizes our test setup


### PR DESCRIPTION
Do not hand-roll tests for exception-throwing code