### PR TITLE
CI: Add clang to GitHub Actions build-tests matrix

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -126,7 +126,7 @@ jobs:
           sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
-          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin clang
+          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin ${{ matrix.compiler.CC }}
 
       - name: Install prerequisite MacOS packages
         if: runner.os == 'macOS'

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -101,16 +101,18 @@ jobs:
           - { CC: gcc, CXX: g++ }
           - { CC: clang, CXX: clang++ }
         layer:
-          - { layer: layer-00-default, nick: default }
-          - { layer: layer-01-minimal, nick: minimal }
-          - { layer: layer-02-maximus, nick: maximus }
-          - { layer: layer-04-noauth-everything, nick: noauth }
+          - { name: layer-00-default, nick: default }
+          - { name: layer-01-minimal, nick: minimal }
+          - { name: layer-02-maximus, nick: maximus }
+          - { name: layer-04-noauth-everything, nick: noauth }
         exclude:
             # Non-clang testing on MacOS is too much work for very little gain
             - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }
 
     runs-on: ${{ matrix.os }}
-    name: build-tests(${{ matrix.os }}/${{ matrix.compiler.CC }}/${{ matrix.layer.nick }})
+
+    name: build-tests(${{ matrix.os }},${{ matrix.compiler.CC }},${{ matrix.layer.nick }})
+
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}
@@ -139,8 +141,7 @@ jobs:
 
       - name: Run build on Linux
         if: runner.os == 'Linux'
-        run: |
-          ./test-builds.sh --cleanup ${{ matrix.layer.layer }}
+        run: ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Run build on MacOS
         if: runner.os == 'macOS'
@@ -196,4 +197,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
-

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -101,6 +101,7 @@ jobs:
           - gcc
           - clang
         exclude:
+            # on macos, we only test Xcode, aka clang
             - { os: macos-14, compiler: gcc }
 
     runs-on: ${{ matrix.os }}
@@ -129,11 +130,14 @@ jobs:
 
       - name: Run build on Linux
         if: runner.os == 'Linux'
-        env:
-          CC: ${{ matrix.compiler }}
         run: |
-          test "x$CC" = "xclang" && export CXX=clang++
-          ./test-builds.sh
+          case "${{ matrix.compiler }}" in
+          gcc) export CC=gcc CXX=g++;;
+          clang) export CC=clang CXX=clang++;;
+          *) exit 1;;
+          esac
+          env # TODO: remove to productionalise
+          # ./test-builds.sh
 
       - name: Run build on MacOS
         if: runner.os == 'macOS'

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -111,6 +111,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: build-tests(${{ matrix.os }}/${{ matrix.compiler.CC }}/${{ matrix.layer.nick }})
+    env:
+      CC: ${{ matrix.compiler.CC }}
+      CXX: ${{ matrix.compiler.CXX }}
 
     steps:
 
@@ -136,17 +139,11 @@ jobs:
 
       - name: Run build on Linux
         if: runner.os == 'Linux'
-        env:
-          CC: ${{ matrix.compiler.CC }}
-          CXX: ${{ matrix.compiler.CXX }}
         run: |
           ./test-builds.sh --cleanup ${{ matrix.layer.layer }}
 
       - name: Run build on MacOS
         if: runner.os == 'macOS'
-        env:
-          CC: ${{ matrix.compiler.CC }}
-          CXX: ${{ matrix.compiler.CXX }}
         run: |
           eval `brew shellenv`
           PKG_CONFIG_PATH="$HOMEBREW_PREFIX/lib/pkgconfig"

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -104,7 +104,7 @@ jobs:
           - layer-00-default
           - layer-01-minimal
           - layer-02-maximus
-          - layer-04-noauth-everything>>>>>>> master
+          - layer-04-noauth-everything
         exclude:
             # on macos, we only test Xcode, aka clang
             - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -101,15 +101,16 @@ jobs:
           - { CC: gcc, CXX: g++ }
           - { CC: clang, CXX: clang++ }
         layer:
-          - layer-00-default
-          - layer-01-minimal
-          - layer-02-maximus
-          - layer-04-noauth-everything
+          - { layer: layer-00-default, nick: default }
+          - { layer: layer-01-minimal, nick: minimal }
+          - { layer: layer-02-maximus, nick: maximus }
+          - { layer: layer-04-noauth-everything, nick: noauth }
         exclude:
-            # Non-clang testing on MacOS is too much work for very little gain.
+            # Non-clang testing on MacOS is too much work for very little gain
             - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }
 
     runs-on: ${{ matrix.os }}
+    name: build-tests((${{ matrix.os }}/${{ matrix.compiler.CC }}/${{ matrix.layer.nick }})
 
     steps:
 
@@ -139,7 +140,7 @@ jobs:
           CC: ${{ matrix.compiler.CC }}
           CXX: ${{ matrix.compiler.CXX }}
         run: |
-          ./test-builds.sh --cleanup ${{ matrix.layer }}
+          ./test-builds.sh --cleanup ${{ matrix.layer.layer }}
 
       - name: Run build on MacOS
         if: runner.os == 'macOS'
@@ -160,7 +161,7 @@ jobs:
           export CPPFLAGS="-I$HOMEBREW_PREFIX/include${CPPFLAGS:+ $CPPFLAGS}"
           export LDFLAGS="-L$HOMEBREW_PREFIX/lib${LDFLAGS:+ $LDFLAGS}"
           export CFLAGS="-Wno-compound-token-split-by-macro${CFLAGS:+ $CFLAGS}" # needed fir ltdl with Xcode
-          ./test-builds.sh ${{ matrix.layer }}
+          ./test-builds.sh ${{ matrix.layer.layer }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -198,3 +199,4 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -98,8 +98,8 @@ jobs:
           - ubuntu-22.04
           - macos-14
         compiler:
-          - gcc
-          - clang
+          - { CC: gcc, CXX: g++ }
+          - { CC: clang, CXX: clang++ }
         exclude:
             # on macos, we only test Xcode, aka clang
             - { os: macos-14, compiler: gcc }

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -104,7 +104,6 @@ jobs:
           - { name: layer-00-default, nick: default }
           - { name: layer-01-minimal, nick: minimal }
           - { name: layer-02-maximus, nick: maximus }
-          - { name: layer-04-noauth-everything, nick: noauth }
         exclude:
             # Non-clang testing on MacOS is too much work for very little gain
             - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -157,7 +157,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: build-logs-${{ runner.os }}
+          name: build-logs-${{ matrix.os }}-${{ matrix.compiler }}
           path: btlayer-*.log
 
   CodeQL-tests:

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -159,7 +159,7 @@ jobs:
           export CPPFLAGS="-I$HOMEBREW_PREFIX/include${CPPFLAGS:+ $CPPFLAGS}"
           export LDFLAGS="-L$HOMEBREW_PREFIX/lib${LDFLAGS:+ $LDFLAGS}"
           export CFLAGS="-Wno-compound-token-split-by-macro${CFLAGS:+ $CFLAGS}" # needed fir ltdl with Xcode
-          ./test-builds.sh ${{ matrix.layer.layer }}
+          ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -134,8 +134,7 @@ jobs:
           CC: ${{ matrix.compiler.CC }}
           CXX: ${{ matrix.compiler.CXX }}
         run: |
-          env # TODO: remove to productionalise
-          # ./test-builds.sh --cleanup
+          ./test-builds.sh --cleanup
 
       - name: Run build on MacOS
         if: runner.os == 'macOS'

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -3,7 +3,7 @@ name: GitHub CI
 on:
   push:
     # test this branch and staged PRs based on this branch code
-    branches: [ "master", "auto" ]
+    branches: [ "master", "auto", "github-actions-clang" ]
 
   pull_request:
     # test PRs targeting this branch code
@@ -19,6 +19,8 @@ env:
   # diffs against them (e.g., for `git diff --check`). This arbitrary limit
   # tries to balance the two concerns.
   CHECKOUT_FETCH_DEPTH: 1001
+
+  COMPILER: ${{ matrix.compiler }}
 
 jobs:
 
@@ -94,7 +96,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-22.04, macos-14 ]
+        os:
+          - ubuntu-22.04
+          - macos-14
+        compiler:
+          - gcc
+          - clang
+        exclude:
+            - { os: macos-14, compiler: gcc }
 
     runs-on: ${{ matrix.os }}
 
@@ -107,7 +116,7 @@ jobs:
           sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
-          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin
+          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin clang
 
       - name: Install prerequisite MacOS packages
         if: runner.os == 'macOS'
@@ -122,7 +131,9 @@ jobs:
 
       - name: Run build on Linux
         if: runner.os == 'Linux'
-        run: ./test-builds.sh
+        run: |
+          test "x$COMPILER" = "xclang" && export CC=clang CXX=clang++
+          ./test-builds.sh
 
       - name: Run build on MacOS
         if: runner.os == 'macOS'

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -102,7 +102,7 @@ jobs:
           - { CC: clang, CXX: clang++ }
         exclude:
             # on macos, we only test Xcode, aka clang
-            - { os: macos-14, compiler: gcc }
+            - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }
 
     runs-on: ${{ matrix.os }}
 
@@ -130,14 +130,12 @@ jobs:
 
       - name: Run build on Linux
         if: runner.os == 'Linux'
+        env:
+          CC: ${{ matrix.compiler.CC }}
+          CXX: ${{ matrix.compiler.CXX }}
         run: |
-          case "${{ matrix.compiler }}" in
-          gcc) export CC=gcc CXX=g++;;
-          clang) export CC=clang CXX=clang++;;
-          *) exit 1;;
-          esac
           env # TODO: remove to productionalise
-          # ./test-builds.sh
+          # ./test-builds.sh --cleanup
 
       - name: Run build on MacOS
         if: runner.os == 'macOS'

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -3,7 +3,7 @@ name: GitHub CI
 on:
   push:
     # test this branch and staged PRs based on this branch code
-    branches: [ "master", "auto", "github-actions-clang" ]
+    branches: [ "master", "auto" ]
 
   pull_request:
     # test PRs targeting this branch code

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -110,7 +110,7 @@ jobs:
             - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }
 
     runs-on: ${{ matrix.os }}
-    name: build-tests((${{ matrix.os }}/${{ matrix.compiler.CC }}/${{ matrix.layer.nick }})
+    name: build-tests(${{ matrix.os }}/${{ matrix.compiler.CC }}/${{ matrix.layer.nick }})
 
     steps:
 

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -20,8 +20,6 @@ env:
   # tries to balance the two concerns.
   CHECKOUT_FETCH_DEPTH: 1001
 
-  COMPILER: ${{ matrix.compiler }}
-
 jobs:
 
   functionality-tests:
@@ -131,8 +129,10 @@ jobs:
 
       - name: Run build on Linux
         if: runner.os == 'Linux'
+        env:
+          CC: ${{ matrix.compiler }}
         run: |
-          test "x$COMPILER" = "xclang" && export CC=clang CXX=clang++
+          test "x$CC" = "xclang" && export CXX=clang++
           ./test-builds.sh
 
       - name: Run build on MacOS

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -106,7 +106,7 @@ jobs:
           - layer-02-maximus
           - layer-04-noauth-everything
         exclude:
-            # on macos, we only test Xcode, aka clang
+            # Non-clang testing on MacOS is too much work for very little gain.
             - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Add "compiler" dimension to build-tests matrix.

Do not test layer-04-noauth-everything to partially compensate for the
new matrix dimension repeating other layer tests 3 times.

Change build-tests artifacts name pattern to include compiler dimension
to avoid name clashes that would result in logs being overwritten and
lost. Also use target environment instead of runner environment in
anticipation of adding container-based tests where the two differ.