### PR TITLE
Fix build with clang v18 [-Wvla-cxx-extension]

### DIFF
--- a/src/fs/rock/RockSwapDir.cc
+++ b/src/fs/rock/RockSwapDir.cc
@@ -37,8 +37,6 @@
 #include <sys/stat.h>
 #endif
 
-const int64_t Rock::SwapDir::HeaderSize = 16*1024;
-
 Rock::SwapDir::SwapDir(): ::SwapDir("rock"),
     slotSize(HeaderSize), filePath(nullptr), map(nullptr), io(nullptr),
     waitingForPage(nullptr)

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -148,7 +148,7 @@ private:
     /* configurable options */
     DiskFile::Config fileConfig; ///< file-level configuration options
 
-    static const int64_t HeaderSize  = 16*1024; ///< on-disk db header size
+    static const int64_t HeaderSize = 16*1024; ///< on-disk db header size
 };
 
 /// initializes shared memory segments used by Rock::SwapDir

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -148,7 +148,7 @@ private:
     /* configurable options */
     DiskFile::Config fileConfig; ///< file-level configuration options
 
-    static const int64_t HeaderSize; ///< on-disk db header size
+    static constexpr int64_t HeaderSize  = 16*1024; ///< on-disk db header size
 };
 
 /// initializes shared memory segments used by Rock::SwapDir

--- a/src/fs/rock/RockSwapDir.h
+++ b/src/fs/rock/RockSwapDir.h
@@ -148,7 +148,7 @@ private:
     /* configurable options */
     DiskFile::Config fileConfig; ///< file-level configuration options
 
-    static constexpr int64_t HeaderSize  = 16*1024; ///< on-disk db header size
+    static const int64_t HeaderSize  = 16*1024; ///< on-disk db header size
 };
 
 /// initializes shared memory segments used by Rock::SwapDir


### PR DESCRIPTION
    src/fs/rock/RockRebuild.cc:356:17: error: variable length arrays
    in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
        char hdrBuf[SwapDir::HeaderSize];
    note: initializer of 'HeaderSize' is unknown