### PR TITLE
annotate_client and annotate_transaction ACLs must always match

### DIFF
--- a/src/acl/AnnotateClient.cc
+++ b/src/acl/AnnotateClient.cc
@@ -31,8 +31,8 @@ Acl::AnnotateClientCheck::match(ACLChecklist * const ch)
         tdata->annotate(request->notes(), &delimiters.value, checklist->al);
         annotated = true;
     } else if (conn && !conn->pipeline.empty()) {
-        debugs(28, DBG_IMPORTANT, "ERROR: Squid BUG: " << name << " ACL: " <<
-               "ACLChecklist lacks transaction information");
+        debugs(28, DBG_IMPORTANT, "ERROR: Squid BUG: " << name << " ACL is used in context with " <<
+               "an unexpectedly nil ACLFilledChecklist::request.");
     }
 
     if (!annotated) {
@@ -40,6 +40,6 @@ Acl::AnnotateClientCheck::match(ACLChecklist * const ch)
                "active client-to-Squid connection and current transaction information. Did not annotate.");
     }
 
-    return 1; // this is an 'always matching' ACL
+    return 1; // this is an "always matching" ACL
 }
 

--- a/src/acl/AnnotateClient.cc
+++ b/src/acl/AnnotateClient.cc
@@ -32,7 +32,7 @@ Acl::AnnotateClientCheck::match(ACLChecklist * const ch)
         annotated = true;
     } else if (conn && !conn->pipeline.empty()) {
         debugs(28, DBG_IMPORTANT, "ERROR: Squid BUG: " << name << " ACL is used in context with " <<
-               "an unexpectedly nil ACLFilledChecklist::request.");
+               "an unexpectedly nil ACLFilledChecklist::request. Did not annotate the current transaction.");
     }
 
     if (!annotated) {

--- a/src/acl/AnnotateClient.cc
+++ b/src/acl/AnnotateClient.cc
@@ -26,6 +26,7 @@ Acl::AnnotateClientCheck::match(ACLChecklist * const ch)
             tdata->annotate(request->notes(), &delimiters.value, checklist->al);
         return 1;
     }
+    debugs(28, 7, "fails: client has gone");
     return 0;
 }
 

--- a/src/acl/AnnotateClient.h
+++ b/src/acl/AnnotateClient.h
@@ -20,7 +20,6 @@ class AnnotateClientCheck: public Acl::AnnotationCheck
 public:
     /* Acl::Node API */
     int match(ACLChecklist *) override;
-    bool requiresRequest() const override { return true; }
 };
 
 } // namespace Acl

--- a/src/acl/AnnotateTransaction.cc
+++ b/src/acl/AnnotateTransaction.cc
@@ -22,10 +22,9 @@ Acl::AnnotateTransactionCheck::match(ACLChecklist * const ch)
         assert(tdata);
         tdata->annotate(request->notes(), &delimiters.value, checklist->al);
     } else {
-        debugs(28, DBG_IMPORTANT, "WARNING: " << name << " ACL cannot be used for annotation " <<
-               "because the HTTP request is missing.");
-        // this is an 'always matching' ACL
+        debugs(28, DBG_IMPORTANT, "WARNING: " << name << " ACL is used in context without " <<
+               "current transaction information. Did not annotate.");
     }
-    return 1;
+    return 1; // this is an "always matching" ACL
 }
 

--- a/src/acl/AnnotateTransaction.cc
+++ b/src/acl/AnnotateTransaction.cc
@@ -21,8 +21,11 @@ Acl::AnnotateTransactionCheck::match(ACLChecklist * const ch)
         const auto tdata = dynamic_cast<ACLAnnotationData*>(data.get());
         assert(tdata);
         tdata->annotate(request->notes(), &delimiters.value, checklist->al);
-        return 1;
+    } else {
+        debugs(28, DBG_IMPORTANT, "WARNING: " << name << " ACL cannot be used for annotation " <<
+               "because the HTTP request is missing.");
+        // this is an 'always matching' ACL
     }
-    return 0;
+    return 1;
 }
 

--- a/src/acl/AnnotateTransaction.h
+++ b/src/acl/AnnotateTransaction.h
@@ -20,7 +20,6 @@ class AnnotateTransactionCheck: public Acl::AnnotationCheck
 public:
     /* Acl::Node API */
     int match(ACLChecklist *) override;
-    bool requiresRequest() const override { return true; }
 };
 
 } // namespace Acl

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1401,7 +1401,7 @@ ENDIF
 
 	acl aclname annotate_transaction [-m[=delimiters]] key=value ...
 	acl aclname annotate_transaction [-m[=delimiters]] key+=value ...
-	  # Matches transactions containing an HTTP request. [fast]
+	  # Always matches. [fast]
 	  # Used for its side effect: This ACL immediately adds a
 	  # key=value annotation to the current master transaction.
 	  # The added annotation can then be tested using note ACL and

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1401,7 +1401,7 @@ ENDIF
 
 	acl aclname annotate_transaction [-m[=delimiters]] key=value ...
 	acl aclname annotate_transaction [-m[=delimiters]] key+=value ...
-	  # Always matches. [fast]
+	  # Matches transactions containing an HTTP request. [fast]
 	  # Used for its side effect: This ACL immediately adds a
 	  # key=value annotation to the current master transaction.
 	  # The added annotation can then be tested using note ACL and


### PR DESCRIPTION
    WARNING: markAsTunneled ACL is used in context without an HTTP
    request. Assuming mismatch.

Our annotate_client and annotate_transaction ACLs are documented as
"always matching", and some existing Squid configurations rely on that
invariant. Both ACLs did not match when they lacked access to the
current transaction information because their requiresRequest() method
returned true; annotate_client ACL also did not match after the
client-to-Squid connection was gone and when the transaction was not
associated with a client-to-Squid connection.

This change makes ACL code conform to documentation. Squid still warns
the admin if an ACL cannot annotate. Such warnings may indicate s Squid
bug or misconfiguration, but mismatching in those cases causes more harm
because it makes it impossible for the admin to rely on the primary
matching invariant. "One reliable invariant plus one unreliable side
effect" is the lesser evil than "two unreliable effects".

    # the following must deny even if it cannot annotate
    http_access deny markAsDenied

    # the following might not log denied traffic (with a prior warning)
    access_log syslog:daemon.err markedAsDenied

Also fixed annotate_client to annotate the current transaction even
after ConnStateData destruction. Such annotations may happen when, for
example, Squid continues a large download after the HTTP client is gone.