### PR TITLE
Bug 5378: type mismatch in libTrie

### DIFF
--- a/lib/libTrie/TrieNode.cc
+++ b/lib/libTrie/TrieNode.cc
@@ -32,7 +32,7 @@ TrieNode::add(char const *aString, size_t theLength, void *privatedata, TrieChar
     /* We trust that privatedata and existent keys have already been checked */
 
     if (theLength) {
-        int index = transform ? (*transform)(*aString): *aString;
+        const unsigned char index = transform ? (*transform)(*aString): *aString;
 
         if (!internal[index])
             internal[index] = new TrieNode;


### PR DESCRIPTION
TrieNode::add() incorrectly computed an offset of an internal data
structure, resulting in out-of-bounds memory accesses that could cause
corruption or crashes.

This bug was discovered and detailed by Joshua Rogers at
https://megamansec.github.io/Squid-Security-Audit/esi-underflow.html
where it was filed as "Buffer Underflow in ESI".