### PR TITLE
Do not die when parsing obsolete log_access and log_icap

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -1075,16 +1075,6 @@ parse_obsolete(const char *name)
         Config.redirectChildren.concurrency = cval;
     }
 
-    if (!strcmp(name, "log_access")) {
-        self_destruct();
-        return;
-    }
-
-    if (!strcmp(name, "log_icap")) {
-        self_destruct();
-        return;
-    }
-
     if (!strcmp(name, "ignore_ims_on_miss")) {
         // the replacement directive cache_revalidate_on_miss has opposite meanings for ON/OFF value
         // than the 2.7 directive. We need to parse and invert the configured value.


### PR DESCRIPTION
All obsolete directives except for log_access and log_icap do not result
in Squid instance death today. Treating those two directives specially
is not necessary but does complicate reconfiguration improvements a bit.

Future refactoring might add support for treating (some or all) obsolete
directives as fatal configuration errors, but we can simplify for now.
