### PR TITLE
mkrelease: allow two digits for minor release numbers

### DIFF
--- a/mkrelease.sh
+++ b/mkrelease.sh
@@ -25,7 +25,7 @@ RELEASE_TIME=`date +%s`
 #
 # check that $rev has the right syntax
 #
-checkrev=`expr $rev : '\([0-9]\.[0-9]\(\.[0-9\.]\)*\)'`
+checkrev=`expr $rev : '\([0-9]\.[0-9][0-9]*\(\.[0-9\.]\)*\)'`
 if test "$rev" != "$checkrev" ; then
 	echo "revision '$rev' has incorrect syntax.  Should be like '3.1.0.1'"
 	exit 1;


### PR DESCRIPTION
Fix a bug with mkrelease.sh which would
incorrectly abort unless the minor release is
only a single digit number