### PR TITLE
Fix SMP mgr:userhash, mgr:sourcehash, and mgr:carp reports

### DIFF
--- a/src/carp.cc
+++ b/src/carp.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 39    Cache Array Routing Protocol */
 
 #include "squid.h"
+#include "base/RunnersRegistry.h"
 #include "CachePeer.h"
 #include "CachePeers.h"
 #include "carp.h"
@@ -47,7 +48,7 @@ carpRegisterWithCacheManager(void)
     Mgr::RegisterAction("carp", "CARP information", carpCachemgr, 0, 1);
 }
 
-void
+static void
 carpInit(void)
 {
     int W = 0;
@@ -133,6 +134,17 @@ carpInit(void)
 
     CarpPeers().assign(rawCarpPeers.begin(), rawCarpPeers.end());
 }
+
+/// reacts to RegisteredRunner events relevant to this module
+class CarpRr: public RegisteredRunner
+{
+public:
+    /* RegisteredRunner API */
+    void useConfig() override { carpInit(); }
+    void syncConfig() override { carpInit(); }
+};
+
+DefineRunnerRegistrator(CarpRr);
 
 CachePeer *
 carpSelectParent(PeerSelector *ps)

--- a/src/carp.h
+++ b/src/carp.h
@@ -14,7 +14,6 @@
 class CachePeer;
 class PeerSelector;
 
-void carpInit(void);
 CachePeer *carpSelectParent(PeerSelector *);
 
 #endif /* SQUID_SRC_CARP_H */

--- a/src/main.cc
+++ b/src/main.cc
@@ -22,7 +22,6 @@
 #include "base/TextException.h"
 #include "cache_cf.h"
 #include "CachePeer.h"
-#include "carp.h"
 #include "client_db.h"
 #include "client_side.h"
 #include "comm.h"
@@ -61,8 +60,6 @@
 #include "parser/Tokenizer.h"
 #include "Parsing.h"
 #include "pconn.h"
-#include "peer_sourcehash.h"
-#include "peer_userhash.h"
 #include "PeerSelectState.h"
 #include "protos.h"
 #include "redirect.h"
@@ -808,12 +805,6 @@ serverConnectionsOpen(void)
         asnInit();
         Acl::Node::Initialize();
         peerSelectInit();
-
-        carpInit();
-#if USE_AUTH
-        peerUserHashInit();
-#endif
-        peerSourceHashInit();
     }
 }
 
@@ -1447,10 +1438,12 @@ RegisterModules()
     // RegisteredRunner event handlers should not depend on handler call order
     // and, hence, should not depend on the registration call order below.
 
+    CallRunnerRegistrator(CarpRr);
     CallRunnerRegistrator(ClientDbRr);
     CallRunnerRegistrator(CollapsedForwardingRr);
     CallRunnerRegistrator(MemStoreRr);
     CallRunnerRegistrator(PeerPoolMgrsRr);
+    CallRunnerRegistrator(PeerSourceHashRr);
     CallRunnerRegistrator(SharedMemPagesRr);
     CallRunnerRegistrator(SharedSessionCacheRr);
     CallRunnerRegistrator(TransientsRr);
@@ -1462,6 +1455,10 @@ RegisterModules()
 
 #if HAVE_AUTH_MODULE_NTLM
     CallRunnerRegistrator(NtlmAuthRr);
+#endif
+
+#if USE_AUTH
+    CallRunnerRegistrator(PeerUserHashRr);
 #endif
 
 #if USE_OPENSSL

--- a/src/peer_sourcehash.cc
+++ b/src/peer_sourcehash.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 39    Peer source hash based selection */
 
 #include "squid.h"
+#include "base/RunnersRegistry.h"
 #include "CachePeer.h"
 #include "CachePeers.h"
 #include "HttpRequest.h"
@@ -42,7 +43,7 @@ peerSortWeight(const void *a, const void *b)
     return (*p1)->weight - (*p2)->weight;
 }
 
-void
+static void
 peerSourceHashInit(void)
 {
     int W = 0;
@@ -126,6 +127,17 @@ peerSourceHashInit(void)
 
     SourceHashPeers().assign(rawSourceHashPeers.begin(), rawSourceHashPeers.end());
 }
+
+/// reacts to RegisteredRunner events relevant to this module
+class PeerSourceHashRr: public RegisteredRunner
+{
+public:
+    /* RegisteredRunner API */
+    void useConfig() override { peerSourceHashInit(); }
+    void syncConfig() override { peerSourceHashInit(); }
+};
+
+DefineRunnerRegistrator(PeerSourceHashRr);
 
 static void
 peerSourceHashRegisterWithCacheManager(void)

--- a/src/peer_sourcehash.h
+++ b/src/peer_sourcehash.h
@@ -14,7 +14,6 @@
 class CachePeer;
 class PeerSelector;
 
-void peerSourceHashInit(void);
 CachePeer * peerSourceHashSelectParent(PeerSelector*);
 
 #endif /* SQUID_SRC_PEER_SOURCEHASH_H */

--- a/src/peer_userhash.cc
+++ b/src/peer_userhash.cc
@@ -13,6 +13,7 @@
 #if USE_AUTH
 
 #include "auth/UserRequest.h"
+#include "base/RunnersRegistry.h"
 #include "CachePeer.h"
 #include "CachePeers.h"
 #include "globals.h"
@@ -47,7 +48,7 @@ peerSortWeight(const void *a, const void *b)
     return (*p1)->weight - (*p2)->weight;
 }
 
-void
+static void
 peerUserHashInit(void)
 {
     int W = 0;
@@ -138,6 +139,17 @@ peerUserHashRegisterWithCacheManager(void)
     Mgr::RegisterAction("userhash", "peer userhash information", peerUserHashCachemgr,
                         0, 1);
 }
+
+/// reacts to RegisteredRunner events relevant to this module
+class PeerUserHashRr: public RegisteredRunner
+{
+public:
+    /* RegisteredRunner API */
+    void useConfig() override { peerUserHashInit(); }
+    void syncConfig() override { peerUserHashInit(); }
+};
+
+DefineRunnerRegistrator(PeerUserHashRr);
 
 CachePeer *
 peerUserHashSelectParent(PeerSelector *ps)

--- a/src/peer_userhash.h
+++ b/src/peer_userhash.h
@@ -12,10 +12,8 @@
 #define SQUID_SRC_PEER_USERHASH_H
 
 class CachePeer;
-class HttpRequest;
 class PeerSelector;
 
-void peerUserHashInit(void);
 CachePeer * peerUserHashSelectParent(PeerSelector *);
 
 #endif /* SQUID_SRC_PEER_USERHASH_H */

--- a/src/tests/stub_carp.cc
+++ b/src/tests/stub_carp.cc
@@ -13,9 +13,5 @@
 
 #include "carp.h"
 
-class CachePeer;
-class PeerSelector;
-
-void carpInit(void) STUB
 CachePeer *carpSelectParent(PeerSelector *) STUB_RETVAL(nullptr)
 


### PR DESCRIPTION
    ERROR: Squid BUG: cannot aggregate mgr:userhash:
        check failed: cmd->profile != nullptr
        exception location: cache_manager.cc(102) createRequestedAction

Since 2010 commit 7de94c8c, only worker processes made RegisterAction()
calls associated with the affected cache manager reports. Coordinator
process needs these registrations as well because it uses Mgr::Action
code while iterating report-generating kids[^1].

When fixed Coordinator asks a disker process for an Action report, that
process must recognize the action as well (even when disker has no
information to supply) to avoid triggering similar Action lookup BUGs.

[^1]: Coordinator mostly needs Mgr::Action for stats aggregation, but
even non-aggregating actions (like the fixed three) need registered
Mgr::ActionProfile objects for Coordinator to know whether to aggregate.
