### PR TITLE
CI: Upgrade GitHub Setup Node and CodeQL actions to Node 20

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -33,9 +33,9 @@ jobs:
           sudo apt-get --quiet=2 install libtool-bin
 
       - name: Setup a nodejs environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Checkout Squid sources
         uses: actions/checkout@v4
@@ -189,10 +189,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
 
       - name: Build Squid
         run: ./test-builds.sh ./test-suite/buildtests/layer-02-maximus.opts
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
These major action version upgrades are recommended by GitHub that is
deprecating Node 16: Node 16 stopped receiving security updates in
September 2023. Node 20 will reach that state around April 2026.

* actions/setup-node@v4: The primary difference is that Setup Node
  action v4 uses Node 20, while v3 uses Node 16. Also, Setup Node v4
  adds support for arm64 Windows and other secondary improvements.

* github/codeql-action@v3: The only difference is that CodeQL Action v3
  runs on Node 20, while CodeQL Action v2 runs on Node 16.

This change is necessary but not sufficient to address current GitHub
Actions upgrade warnings. We also need to upgrade upload-artifact@v3,
but that upgrade has side effects that deserve a dedicate change.
