### PR TITLE
Fix parallel "make check": testHeaders for same-basename files

### DIFF
--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -20,7 +20,7 @@ testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite
 .h.hdrtest:
 	@SrcFilePath=`echo $< | $(SED) 's%^$(top_srcdir)/%%'`; \
 	SrcFileName=`basename $$SrcFilePath`; \
-	TargetFileName=`basename $@`; \
+	TargetFileName=tmp$$$$-`basename $@`; \
 	if test "$(EXCLUDE_FROM_HDR_TESTING)" != "" && echo "$(EXCLUDE_FROM_HDR_TESTING)" | $(TR) ' ' '\n' | $(FGREP) -x -q "$$SrcFileName" ; then \
 		echo "header-test: skip - $$SrcFilePath"; \
 		exit 0; \


### PR DESCRIPTION
    header-test: ok - src/ipc/forward.h
    header-test: ok - src/ipc/ReadWriteLock.h
    cc1plus: fatal error: forward.hdrtest.cc: No such file or directory
    header-test: not ok - src/ipc/mem/forward.h

In a parallel build, testHeaders often tests header files using multiple
concurrent "make" processes. When testing same-basename files (e.g.,
src/ipc/forward.h and src/ipc/mem/forward.h), one "make" process may
delete the file generated by another process (leading to random false
"make check" failures like the one shown above) or even substitute bad
file contents with valid one (leading to false positives).

Clashes among temporary generated files can be avoided using unique
temporary directories, but those are difficult to create in a portable
way. Instead, we use "make" PID to guarantee file name uniqueness across
parallel make processes.
