### PR TITLE
CI: Upgrade GitHub upload-artifact action to v4

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Publish test logs
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs
           path: |
@@ -163,9 +163,9 @@ jobs:
 
       - name: Publish build logs
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: build-logs-${{ matrix.os }}-${{ matrix.compiler }}
+          name: build-logs-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
           path: btlayer-*.log
 
   CodeQL-tests:


### PR DESCRIPTION
    The following artifacts were uploaded using a version of
    actions/upload-artifact that is scheduled for deprecation:
    "build-logs-macos-14-Object", "build-logs-ubuntu-22.04-Object",
    "test-logs".

This change finishes GitHub actions upgrade started in recent commit
8805c474 and removes all remaining GitHub Actions upgrade warnings.

Upgrading to actions/upload-artifact@v4 is not trivial because the new
action version uses "immutable (unless deleted)" artifacts: One GitHub
Actions job cannot add artifacts to a container created by another job.
We now add build layer dimension to the container name created inside
"build-tests" matrix, so that all layer logs are uploaded, with one
artifact container per matrix job.

Also fixed the compiler component in build-tests artifact names: Recent
commit 5a7811af intended to add "compiler dimension to avoid name
clashes" but only added a constant "-Object" suffix, resulting in log
name clashes on Ubuntu runners that test using two compilers.
