### PR TITLE
Remove PEER_MULTICAST_SIBLINGS conditional

### DIFF
--- a/src/CachePeer.h
+++ b/src/CachePeer.h
@@ -19,9 +19,6 @@
 
 #include <iosfwd>
 
-//TODO: remove, it is unconditionally defined and always used.
-#define PEER_MULTICAST_SIBLINGS 1
-
 class NeighborTypeDomainList;
 class PconnPool;
 class PeerDigest;
@@ -141,9 +138,7 @@ public:
         bool sourcehash = false;
         bool originserver = false;
         bool no_tproxy = false;
-#if PEER_MULTICAST_SIBLINGS
         bool mcast_siblings = false;
-#endif
         bool auth_no_keytab = false;
     } options;
 

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -2197,10 +2197,8 @@ parse_peer(CachePeers **peers)
             p->options.no_tproxy = true;
         } else if (!strcmp(token, "multicast-responder")) {
             p->options.mcast_responder = true;
-#if PEER_MULTICAST_SIBLINGS
         } else if (!strcmp(token, "multicast-siblings")) {
             p->options.mcast_siblings = true;
-#endif
         } else if (!strncmp(token, "weight=", 7)) {
             p->weight = xatoi(token + 7);
         } else if (!strncmp(token, "basetime=", 9)) {

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -121,11 +121,9 @@ neighborType(const CachePeer * p, const AnyP::Uri &url)
             if (d->type != PEER_NONE)
                 return d->type;
     }
-#if PEER_MULTICAST_SIBLINGS
-    if (p->type == PEER_MULTICAST)
-        if (p->options.mcast_siblings)
-            return PEER_SIBLING;
-#endif
+
+    if (p->type == PEER_MULTICAST && p->options.mcast_siblings)
+        return PEER_SIBLING;
 
     return p->type;
 }
@@ -141,11 +139,10 @@ peerAllowedToUse(const CachePeer * p, PeerSelector * ps)
     assert(request != nullptr);
 
     if (neighborType(p, request->url) == PEER_SIBLING) {
-#if PEER_MULTICAST_SIBLINGS
         if (p->type == PEER_MULTICAST && p->options.mcast_siblings &&
                 (request->flags.noCache || request->flags.refresh || request->flags.loopDetected || request->flags.needValidation))
             debugs(15, 2, "multicast-siblings optimization match for " << *p << ", " << request->url.authority());
-#endif
+
         if (request->flags.noCache)
             return false;
 
@@ -1403,10 +1400,8 @@ dump_peer_options(StoreEntry * sentry, CachePeer * p)
     if (p->options.mcast_responder)
         os << " multicast-responder";
 
-#if PEER_MULTICAST_SIBLINGS
     if (p->options.mcast_siblings)
         os << " multicast-siblings";
-#endif
 
     if (p->weight != 1)
         os << " weight=" << p->weight;


### PR DESCRIPTION
Resolving an old TODO.

This is not a feature change, because the undocumented
macro was always set to 1 (enable).