### PR TITLE
Upgrade Http::Stream::reply to Pointer

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -880,7 +880,7 @@ ClientSocketContextPushDeferredIfNeeded(Http::StreamPointer deferredRequest, Con
         /** defer now. */
         clientSocketRecipient(deferredRequest->deferredparams.node,
                               deferredRequest->http,
-                              deferredRequest->deferredparams.rep,
+                              deferredRequest->deferredparams.reply.getRaw(),
                               deferredRequest->deferredparams.queuedBuffer);
     }
 

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -33,7 +33,6 @@ Http::Stream::Stream(const Comm::ConnectionPointer &aConn, ClientHttpRequest *aR
     flags.deferred = 0;
     flags.parsed_ok = 0;
     deferredparams.node = nullptr;
-    deferredparams.rep = nullptr;
 }
 
 Http::Stream::~Stream()
@@ -554,13 +553,13 @@ Http::Stream::initiateClose(const char *reason)
 }
 
 void
-Http::Stream::deferRecipientForLater(clientStreamNode *node, HttpReply *rep, StoreIOBuffer receivedData)
+Http::Stream::deferRecipientForLater(clientStreamNode *node, const HttpReplyPointer &rep, StoreIOBuffer receivedData)
 {
     debugs(33, 2, "Deferring request " << http->uri);
     assert(flags.deferred == 0);
     flags.deferred = 1;
     deferredparams.node = node;
-    deferredparams.rep = rep;
+    deferredparams.reply = rep;
     deferredparams.queuedBuffer = receivedData;
 }
 

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -271,7 +271,7 @@ Http::Stream::sendStartOfMessage(const HttpReplyPointer &rep, StoreIOBuffer body
     if (http->request->range)
         buildRangeHeader();
 
-    MemBuf *mb = reply->pack();
+    const auto mb = reply->pack();
 
     // dump now, so we do not output any body.
     debugs(11, 2, "HTTP Client " << clientConnection);
@@ -419,7 +419,8 @@ clientIfRangeMatch(ClientHttpRequest * http, const HttpReplyPointer &reply)
 void
 Http::Stream::buildRangeHeader()
 {
-    auto *hdr = &reply->header;
+    Assure(reply);
+    const auto hdr = &reply->header;
     const char *range_err = nullptr;
     HttpRequest *request = http->request;
     assert(request->range);

--- a/src/http/Stream.h
+++ b/src/http/Stream.h
@@ -124,7 +124,7 @@ public:
     /// terminate due to a send/write error (may continue reading)
     void initiateClose(const char *reason);
 
-    void deferRecipientForLater(clientStreamNode *, HttpReply *, StoreIOBuffer receivedData);
+    void deferRecipientForLater(clientStreamNode *, const HttpReplyPointer &, StoreIOBuffer receivedData);
 
 public: // HTTP/1.x state data
 
@@ -149,7 +149,7 @@ public: // HTTP/1.x state data
 
     public:
         clientStreamNode *node;
-        HttpReply *rep;
+        HttpReplyPointer reply;
         StoreIOBuffer queuedBuffer;
     };
 

--- a/src/http/Stream.h
+++ b/src/http/Stream.h
@@ -103,15 +103,12 @@ public:
     clientStream_status_t socketState();
 
     /// send an HTTP reply message headers and maybe some initial payload
-    void sendStartOfMessage(HttpReply *, StoreIOBuffer bodyData);
+    void sendStartOfMessage(const HttpReplyPointer &, StoreIOBuffer);
     /// send some HTTP reply message payload
     void sendBody(StoreIOBuffer bodyData);
     /// update stream state when N bytes are being sent.
     /// NP: Http1Server bytes actually not sent yet, just packed into a MemBuf ready
     void noteSentBodyBytes(size_t);
-
-    /// add Range headers (if any) to the given HTTP reply message
-    void buildRangeHeader(HttpReply *);
 
     clientStreamNode * getTail() const;
     clientStreamNode * getClientReplyContext() const;
@@ -133,7 +130,7 @@ public: // HTTP/1.x state data
 
     Comm::ConnectionPointer clientConnection; ///< details about the client connection socket
     ClientHttpRequest *http;    /* we pretend to own that Job */
-    HttpReply *reply;
+    HttpReplyPointer reply;
     char reqbuf[HTTP_REQBUF_SZ];
     struct {
         unsigned deferred:1; ///< This is a pipelined request waiting for the current object to complete
@@ -160,7 +157,7 @@ public: // HTTP/1.x state data
     int64_t writtenToSocket;
 
 private:
-    void prepareReply(HttpReply *);
+    void buildRangeHeader();
     void packChunk(const StoreIOBuffer &bodyData, MemBuf &);
     void packRange(StoreIOBuffer const &, MemBuf *);
     void doClose();

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -111,10 +111,10 @@ int64_t Stream::getNextRangeOffset() const STUB_RETVAL(-1)
 bool Stream::canPackMoreRanges() const STUB_RETVAL(false)
 size_t Stream::lengthToSend(Range<int64_t> const &) const STUB_RETVAL(0)
 clientStream_status_t Stream::socketState() STUB_RETVAL(STREAM_NONE)
-void Stream::sendStartOfMessage(HttpReply *, StoreIOBuffer) STUB
+void Stream::sendStartOfMessage(const HttpReplyPointer &, StoreIOBuffer) STUB
 void Stream::sendBody(StoreIOBuffer) STUB
 void Stream::noteSentBodyBytes(size_t) STUB
-void Stream::buildRangeHeader(HttpReply *) STUB
+void Stream::buildRangeHeader() STUB
 clientStreamNode *Stream::getTail() const STUB_RETVAL(nullptr)
 clientStreamNode *Stream::getClientReplyContext() const STUB_RETVAL(nullptr)
 ConnStateData *Stream::getConn() const STUB_RETVAL(nullptr)

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -121,6 +121,6 @@ ConnStateData *Stream::getConn() const STUB_RETVAL(nullptr)
 void Stream::noteIoError(const Error &, const LogTagsErrors &) STUB
 void Stream::finished() STUB
 void Stream::initiateClose(const char *) STUB
-void Stream::deferRecipientForLater(clientStreamNode *, HttpReply *, StoreIOBuffer) STUB
+void Stream::deferRecipientForLater(clientStreamNode *, const HttpReplyPointer &, StoreIOBuffer) STUB
 }
 


### PR DESCRIPTION
Refactor to avoid storing a raw-pointer, with
missing reference-counting.