### PR TITLE
Fix use-after-free in statefulhelper::submit() level-9 debug

### DIFF
--- a/src/helper.cc
+++ b/src/helper.cc
@@ -681,12 +681,12 @@ statefulhelper::submit(const char *buf, HLPCB * callback, void *data, const Help
         helper_stateful_server *srv;
         if ((srv = StatefulGetFirstAvailable(this))) {
             reserveServer(srv);
-            helperStatefulDispatch(srv, r);
+            helperStatefulDispatch(srv, r); // may delete r
         } else
             StatefulEnqueue(this, r);
     }
 
-    debugs(84, DBG_DATA, "placeholder: '" << r->request.placeholder <<
+    debugs(84, DBG_DATA, "placeholder: '" << (r ? r->request.placeholder: -1) <<
            "', " << Raw("buf", buf, (!buf?0:strlen(buf))));
 
     syncQueueStats();

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -686,9 +686,7 @@ statefulhelper::submit(const char *buf, HLPCB * callback, void *data, const Help
             StatefulEnqueue(this, r);
     }
 
-    debugs(84, DBG_DATA, "placeholder: '" << (r ? r->request.placeholder: -1) <<
-           "', " << Raw("buf", buf, (!buf?0:strlen(buf))));
-
+    // r may be dangling here
     syncQueueStats();
 }
 


### PR DESCRIPTION
A debug statement in helper.cc dereferences a pointer which
might have been freed in helperStatefulDispatch.

Detected by Semgrep