### PR TITLE
Be more careful when updating nameservers global

### DIFF
--- a/src/dns_internal.cc
+++ b/src/dns_internal.cc
@@ -885,7 +885,9 @@ nsvc::~nsvc()
 {
     delete queue;
     delete msg;
-    if (ns < nameservers.size()) // XXX: idnsShutdownAndFreeState may have freed nameservers[]
+    // we may outlive nameservers version that was pointing to us because
+    // reconfigurations repopulate nameservers
+    if (ns < nameservers.size() && nameservers[ns].vc == this)
         nameservers[ns].vc = nullptr;
 }
 


### PR DESCRIPTION
Due to I/O delays and timeouts, DNS nsvc objects may be deleted after
the `nameservers` global pointing to them was cleared and then populated
with new ns objects. Thus, nsvc destructor should check that nsvc and
`nameservers` states are still in sync before manipulating the latter.

DNS code should use similar validation in a few other places, but they
are all about read-only debugging that requires a rather noisy cleanup.
