### PR TITLE
Enable EDNS for DNS A queries and reverse IPv4 lookups

### DIFF
--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -172,6 +172,17 @@ This section gives an account of those changes in three categories:
 	<p>Removed the <em>non_peers</em> action. See the Cache Manager
 	<ref id="mgr" name="section"> for details.
 
+	<tag>dns_packet_max</tag>
+	<p>Honor positive <em>dns_packet_max</em> values when sending DNS A queries
+	and PTR queries containing IPv4 addresses. Prior to this change, Squid did
+	not add EDNS extension (RFC 6891) to those DNS queries because 2010 tests
+	revealed compatibility problems with some DNS resolvers. We hope that those
+	problems are now sufficiently rare to enable this useful optimization for
+	all DNS queries, as originally intended. Squid still sends EDNS extension
+	with DNS AAAA queries and PTR queries containing IPv6 addresses (when
+	dns_packet_max is set to a positive value). Rare deployments that must use
+	buggy DNS resolvers should not set <em>dns_packet_max</em>.
+
 	<tag>access_log</tag>
 	<p>Built-in <em>common</em> and <em>combined</em> logformats now always
 	receive a dash character ("-") in the position of what used to be a

--- a/src/dns/rfc3596.cc
+++ b/src/dns/rfc3596.cc
@@ -7,6 +7,7 @@
  */
 
 #include "squid.h"
+#include "SquidConfig.h"
 #include "dns/rfc2671.h"
 #include "dns/rfc3596.h"
 #include "util.h"
@@ -54,7 +55,7 @@
  * Returns the size of the query
  */
 ssize_t
-rfc3596BuildHostQuery(const char *hostname, char *buf, size_t sz, unsigned short qid, rfc1035_query * query, int qtype, ssize_t edns_sz)
+rfc3596BuildHostQuery(const char *hostname, char *buf, size_t sz, unsigned short qid, rfc1035_query * query, int qtype)
 {
     static rfc1035_message h;
     size_t offset = 0;
@@ -64,7 +65,10 @@ rfc3596BuildHostQuery(const char *hostname, char *buf, size_t sz, unsigned short
     h.rd = 1;
     h.opcode = 0;               /* QUERY */
     h.qdcount = (unsigned int) 1;
+
+    const auto edns_sz = Config.dns.packet_max;
     h.arcount = (edns_sz > 0 ? 1 : 0);
+
     offset += rfc1035HeaderPack(buf + offset, sz - offset, &h);
     offset += rfc1035QuestionPack(buf + offset,
                                   sz - offset,
@@ -93,9 +97,9 @@ rfc3596BuildHostQuery(const char *hostname, char *buf, size_t sz, unsigned short
  * \return the size of the query
  */
 ssize_t
-rfc3596BuildAQuery(const char *hostname, char *buf, size_t sz, unsigned short qid, rfc1035_query * query, ssize_t edns_sz)
+rfc3596BuildAQuery(const char *hostname, char *buf, size_t sz, unsigned short qid, rfc1035_query * query)
 {
-    return rfc3596BuildHostQuery(hostname, buf, sz, qid, query, RFC1035_TYPE_A, edns_sz);
+    return rfc3596BuildHostQuery(hostname, buf, sz, qid, query, RFC1035_TYPE_A);
 }
 
 /**
@@ -107,9 +111,9 @@ rfc3596BuildAQuery(const char *hostname, char *buf, size_t sz, unsigned short qi
  * \return the size of the query
  */
 ssize_t
-rfc3596BuildAAAAQuery(const char *hostname, char *buf, size_t sz, unsigned short qid, rfc1035_query * query, ssize_t edns_sz)
+rfc3596BuildAAAAQuery(const char *hostname, char *buf, size_t sz, unsigned short qid, rfc1035_query * query)
 {
-    return rfc3596BuildHostQuery(hostname, buf, sz, qid, query, RFC1035_TYPE_AAAA, edns_sz);
+    return rfc3596BuildHostQuery(hostname, buf, sz, qid, query, RFC1035_TYPE_AAAA);
 }
 
 /**
@@ -121,7 +125,7 @@ rfc3596BuildAAAAQuery(const char *hostname, char *buf, size_t sz, unsigned short
  * \return the size of the query
  */
 ssize_t
-rfc3596BuildPTRQuery4(const struct in_addr addr, char *buf, size_t sz, unsigned short qid, rfc1035_query * query, ssize_t edns_sz)
+rfc3596BuildPTRQuery4(const struct in_addr addr, char *buf, size_t sz, unsigned short qid, rfc1035_query * query)
 {
     static char rev[RFC1035_MAXHOSTNAMESZ];
     unsigned int i;
@@ -133,11 +137,11 @@ rfc3596BuildPTRQuery4(const struct in_addr addr, char *buf, size_t sz, unsigned 
              (i >> 16) & 255,
              (i >> 24) & 255);
 
-    return rfc3596BuildHostQuery(rev, buf, sz, qid, query, RFC1035_TYPE_PTR, edns_sz);
+    return rfc3596BuildHostQuery(rev, buf, sz, qid, query, RFC1035_TYPE_PTR);
 }
 
 ssize_t
-rfc3596BuildPTRQuery6(const struct in6_addr addr, char *buf, size_t sz, unsigned short qid, rfc1035_query * query, ssize_t edns_sz)
+rfc3596BuildPTRQuery6(const struct in6_addr addr, char *buf, size_t sz, unsigned short qid, rfc1035_query * query)
 {
     static char rev[RFC1035_MAXHOSTNAMESZ];
     const uint8_t* r = addr.s6_addr;
@@ -152,6 +156,6 @@ rfc3596BuildPTRQuery6(const struct in6_addr addr, char *buf, size_t sz, unsigned
 
     snprintf(p,10,"ip6.arpa.");
 
-    return rfc3596BuildHostQuery(rev, buf, sz, qid, query, RFC1035_TYPE_PTR, edns_sz);
+    return rfc3596BuildHostQuery(rev, buf, sz, qid, query, RFC1035_TYPE_PTR);
 }
 

--- a/src/dns/rfc3596.cc
+++ b/src/dns/rfc3596.cc
@@ -7,9 +7,9 @@
  */
 
 #include "squid.h"
-#include "SquidConfig.h"
 #include "dns/rfc2671.h"
 #include "dns/rfc3596.h"
+#include "SquidConfig.h"
 #include "util.h"
 
 #if HAVE_UNISTD_H

--- a/src/dns/rfc3596.h
+++ b/src/dns/rfc3596.h
@@ -16,29 +16,25 @@ ssize_t rfc3596BuildAQuery(const char *hostname,
                            char *buf,
                            size_t sz,
                            unsigned short qid,
-                           rfc1035_query * query,
-                           ssize_t edns_sz);
+                           rfc1035_query *);
 
 ssize_t rfc3596BuildAAAAQuery(const char *hostname,
                               char *buf,
                               size_t sz,
                               unsigned short qid,
-                              rfc1035_query * query,
-                              ssize_t edns_sz);
+                              rfc1035_query *);
 
 ssize_t rfc3596BuildPTRQuery4(const struct in_addr,
                               char *buf,
                               size_t sz,
                               unsigned short qid,
-                              rfc1035_query * query,
-                              ssize_t edns_sz);
+                              rfc1035_query *);
 
 ssize_t rfc3596BuildPTRQuery6(const struct in6_addr,
                               char *buf,
                               size_t sz,
                               unsigned short qid,
-                              rfc1035_query * query,
-                              ssize_t edns_sz);
+                              rfc1035_query *);
 
 /* RFC3596 library implements RFC1035 generic host interface */
 ssize_t rfc3596BuildHostQuery(const char *hostname,
@@ -46,8 +42,7 @@ ssize_t rfc3596BuildHostQuery(const char *hostname,
                               size_t sz,
                               unsigned short qid,
                               rfc1035_query * query,
-                              int qtype,
-                              ssize_t edns_sz);
+                              int qtype);
 
 /* RFC3596 section 2.1 defines new RR type AAAA as 28 */
 #define RFC1035_TYPE_AAAA 28


### PR DESCRIPTION
This change brings Squid code in sync with existing dns_packet_max
directive documentation and allows admins to enable a useful performance
optimization for still very popular IPv4-related DNS queries.

An enabled dns_packet_max feature may now break Squid compatibility with
more buggy nameservers (that appeared to "work" before), but we should
not penalize many Squid deployments (or complicate configuration and
spend a lot of development time) to accommodate a few exceptional ones,
at least until such heroic efforts are proven to be necessary.
