### PR TITLE
Fix a use-after-free bug in peerDigestFetchReply()

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -198,8 +198,7 @@ typedef enum {
     DIGEST_READ_NONE,
     DIGEST_READ_REPLY,
     DIGEST_READ_CBLOCK,
-    DIGEST_READ_MASK,
-    DIGEST_READ_DONE
+    DIGEST_READ_MASK
 } digest_read_state_t;
 
 /* CygWin & Windows NT Port */

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -386,10 +386,6 @@ peerDigestHandleReply(void *data, StoreIOBuffer receivedData)
         case DIGEST_READ_NONE:
             break;
 
-        case DIGEST_READ_DONE:
-            return;
-            break;
-
         default:
             fatal("Bad digest transfer mode!\n");
         }
@@ -491,7 +487,7 @@ peerDigestFetchReply(void *data, char *buf, ssize_t size)
 
             // stay with the old in-memory digest
             peerDigestFetchStop(fetch, buf, "Not modified");
-            fetch->state = DIGEST_READ_DONE;
+            return -1;
         } else if (status == Http::scOkay) {
             /* get rid of old entry if any */
 


### PR DESCRIPTION
The problem occurred when handling an HTTP 304 cache digest response.

Also removed effectively unused DIGEST_READ_DONE enum value.
