### PR TITLE
Reduced build warnings [-Wmissing-declarations]

### DIFF
--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -110,17 +110,17 @@ char *WIN32_ErrorMessage = nullptr;
 wchar_t **User_Groups;
 int User_Groups_Count = 0;
 
-wchar_t *My_NameTranslate(wchar_t *, int, int);
-char *Get_WIN32_ErrorMessage(HRESULT);
+static wchar_t *My_NameTranslate(wchar_t *, int, int);
+static char *Get_WIN32_ErrorMessage(HRESULT);
 
-void
+static void
 CloseCOM(void)
 {
     if (WIN32_COM_initialized == 1)
         CoUninitialize();
 }
 
-HRESULT
+static HRESULT
 GetLPBYTEtoOctetString(VARIANT * pVar, LPBYTE * ppByte)
 {
     HRESULT hr = E_FAIL;
@@ -150,7 +150,7 @@ GetLPBYTEtoOctetString(VARIANT * pVar, LPBYTE * ppByte)
     return hr;
 }
 
-wchar_t *
+static wchar_t *
 Get_primaryGroup(IADs * pUser)
 {
     HRESULT hr;
@@ -208,7 +208,7 @@ Get_primaryGroup(IADs * pUser)
     return result;
 }
 
-char *
+static char *
 Get_WIN32_ErrorMessage(HRESULT hr)
 {
     FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
@@ -222,7 +222,7 @@ Get_WIN32_ErrorMessage(HRESULT hr)
     return WIN32_ErrorMessage;
 }
 
-wchar_t *
+static wchar_t *
 My_NameTranslate(wchar_t * name, int in_format, int out_format)
 {
     IADsNameTranslate *pNto;
@@ -277,7 +277,7 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
     return wc;
 }
 
-wchar_t *
+static wchar_t *
 GetLDAPPath(wchar_t * Base_DN, int query_mode)
 {
     wchar_t *wc;
@@ -293,7 +293,7 @@ GetLDAPPath(wchar_t * Base_DN, int query_mode)
     return wc;
 }
 
-char *
+static char *
 GetDomainName(void)
 {
     static char *DomainName = nullptr;
@@ -343,7 +343,7 @@ GetDomainName(void)
     return DomainName;
 }
 
-int
+static int
 add_User_Group(wchar_t * Group)
 {
     wchar_t **array;
@@ -398,7 +398,7 @@ wcstrcmparray(const wchar_t * str, const char **array)
     return -1;
 }
 
-HRESULT
+static HRESULT
 Recursive_Memberof(IADs * pObj)
 {
     VARIANT var;
@@ -520,7 +520,7 @@ build_groups_DN_array(const char **array, char *userdomain)
 }
 
 /* returns 1 on success, 0 on failure */
-int
+static int
 Valid_Local_Groups(char *UserName, const char **Groups)
 {
     int result = 0;
@@ -598,7 +598,7 @@ Valid_Local_Groups(char *UserName, const char **Groups)
 }
 
 /* returns 1 on success, 0 on failure */
-int
+static int
 Valid_Global_Groups(char *UserName, const char **Groups)
 {
     int result = 0;
@@ -730,7 +730,7 @@ usage(const char *program)
             program);
 }
 
-void
+static void
 process_options(int argc, char *argv[])
 {
     int opt;

--- a/src/acl/external/LM_group/ext_lm_group_acl.cc
+++ b/src/acl/external/LM_group/ext_lm_group_acl.cc
@@ -105,7 +105,7 @@ int use_case_insensitive_compare = 0;
 char *DefaultDomain = nullptr;
 const char NTV_VALID_DOMAIN_SEPARATOR[] = "\\/";
 
-char *
+static char *
 AllocStrFromLSAStr(LSA_UNICODE_STRING LsaStr)
 {
     size_t len;
@@ -127,7 +127,7 @@ AllocStrFromLSAStr(LSA_UNICODE_STRING LsaStr)
     return target;
 }
 
-char *
+static char *
 GetDomainName(void)
 {
     LSA_HANDLE PolicyHandle;
@@ -233,7 +233,7 @@ wcstrcmparray(const wchar_t * str, const char **array)
 }
 
 /* returns 1 on success, 0 on failure */
-int
+static int
 Valid_Local_Groups(char *UserName, const char **Groups)
 {
     int result = 0;
@@ -308,7 +308,7 @@ Valid_Local_Groups(char *UserName, const char **Groups)
 }
 
 /* returns 1 on success, 0 on failure */
-int
+static int
 Valid_Global_Groups(char *UserName, const char **Groups)
 {
     int result = 0;
@@ -466,7 +466,7 @@ usage(const char *program)
             program);
 }
 
-void
+static void
 process_options(int argc, char *argv[])
 {
     int opt;

--- a/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
+++ b/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
@@ -70,8 +70,6 @@ static int have_serverblob;
 #define SEND3(X,Y,Z) debug("sending '" X "' to squid\n",Y,Z); printf(X "\n",Y,Z);
 #endif
 
-char *negotiate_check_auth(SSP_blobP auth, int auth_length);
-
 /*
  * options:
  * -d enable debugging.
@@ -79,7 +77,7 @@ char *negotiate_check_auth(SSP_blobP auth, int auth_length);
  */
 char *my_program_name = nullptr;
 
-void
+static void
 usage()
 {
     fprintf(stderr,
@@ -90,7 +88,7 @@ usage()
             my_program_name);
 }
 
-void
+static void
 process_options(int argc, char *argv[])
 {
     int opt, had_error = 0;
@@ -135,7 +133,7 @@ token_decode(size_t *decodedLen, uint8_t decoded[], const char *buf)
     return true;
 }
 
-int
+static int
 manage_request()
 {
     char buf[HELPER_INPUT_BUFFER];

--- a/src/auth/ntlm/SMB_LM/ntlm_smb_lm_auth.cc
+++ b/src/auth/ntlm/SMB_LM/ntlm_smb_lm_auth.cc
@@ -64,12 +64,6 @@
 #define SEND3 printf
 #endif
 
-const char *make_challenge(char *domain, char *controller);
-char *ntlm_check_auth(ntlm_authenticate * auth, int auth_length);
-void dc_disconnect(void);
-int connectedp(void);
-int is_dc_ok(char *domain, char *domain_controller);
-
 typedef struct _dc dc;
 struct _dc {
     char *domain;
@@ -79,10 +73,13 @@ struct _dc {
 };
 
 /* local functions */
-void usage(void);
-void process_options(int argc, char *argv[]);
-const char * obtain_challenge(void);
-void manage_request(void);
+static void usage(void);
+static void process_options(int argc, char *argv[]);
+static const char * obtain_challenge(void);
+static void manage_request(void);
+static const char *make_challenge(char *domain, char *controller);
+static char *ntlm_check_auth(ntlm_authenticate * auth, int auth_length);
+static void dc_disconnect(void);
 
 #define ENCODED_PASS_LEN 24
 #define MAX_USERNAME_LEN 255
@@ -108,29 +105,12 @@ char smb_error_buffer[1000];
 
 /* Disconnects from the DC. A reconnection will be done upon the next request
  */
-void
+static void
 dc_disconnect()
 {
     if (handle != NULL)
         SMB_Discon(handle, 0);
     handle = nullptr;
-}
-
-int
-connectedp()
-{
-    return (handle != NULL);
-}
-
-/* Tries to connect to a DC. Returns 0 on failure, 1 on OK */
-int
-is_dc_ok(char *domain, char *domain_controller)
-{
-    SMB_Handle_Type h = SMB_Connect_Server(nullptr, domain_controller, domain);
-    if (h == NULL)
-        return 0;
-    SMB_Discon(h, 0);
-    return 1;
 }
 
 /* returns 0 on success, > 0 on failure */
@@ -169,7 +149,7 @@ init_challenge(char *domain, char *domain_controller)
     return 0;
 }
 
-const char *
+static const char *
 make_challenge(char *domain, char *domain_controller)
 {
     /* trying to circumvent some strange problem with pointers in SMBLib */
@@ -215,7 +195,7 @@ make_challenge(char *domain, char *domain_controller)
  * In case of problem sets as side-effect ntlm_errno to one of the
  * codes defined in ntlm.h
  */
-char *
+static char *
 ntlm_check_auth(ntlm_authenticate * auth, int auth_length)
 {
     char pass[MAX_PASSWD_LEN+1];
@@ -383,7 +363,7 @@ timeout_during_auth(int)
  */
 char *my_program_name = nullptr;
 
-void
+static void
 usage()
 {
     fprintf(stderr,
@@ -399,7 +379,7 @@ usage()
 
 /* int debug_enabled=0; defined in libcompat */
 
-void
+static void
 process_options(int argc, char *argv[])
 {
     int opt, j, had_error = 0;
@@ -479,7 +459,7 @@ process_options(int argc, char *argv[])
  * tries connecting to the domain controllers in the "controllers" ring,
  * with failover if the adequate option is specified.
  */
-const char *
+static const char *
 obtain_challenge()
 {
     int j = 0;
@@ -516,7 +496,7 @@ obtain_challenge()
     return nullptr;
 }
 
-void
+static void
 manage_request()
 {
     ntlmhdr *fast_header;


### PR DESCRIPTION
This change fixes a few manually picked cases in sources that are not
normally compiled on our CI nodes. There are probably more missing
declarations, but we do not know how to find them automatically.

Also removed a few seemingly unused functions and declarations.
