### PR TITLE
Bootstrap libltdl to fix libtool v2.4 + automake v1.17 build

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -22,72 +22,72 @@ env:
 
 jobs:
 
-  # functionality-tests:
+  functionality-tests:
 
-  #   runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04
 
-  #   steps:
-  #     - name: Install prerequisite packages
-  #       run: |
-  #         sudo apt-get --quiet=2 update
-  #         sudo apt-get --quiet=2 install libtool-bin
+    steps:
+      - name: Install prerequisite packages
+        run: |
+          sudo apt-get --quiet=2 update
+          sudo apt-get --quiet=2 install libtool-bin
 
-  #     - name: Setup a nodejs environment
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 20
+      - name: Setup a nodejs environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-  #     - name: Checkout Squid sources
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+      - name: Checkout Squid sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
 
-  #     - run: ./bootstrap.sh
-  #     - run: ./configure --with-openssl
-  #     - run: make -j`nproc`
-  #     - run: |
-  #         sudo make install
-  #         sudo chown -R nobody:nogroup /usr/local/squid
+      - run: ./bootstrap.sh
+      - run: ./configure --with-openssl
+      - run: make -j`nproc`
+      - run: |
+          sudo make install
+          sudo chown -R nobody:nogroup /usr/local/squid
 
-  #     - run: ./test-suite/test-functionality.sh
+      - run: ./test-suite/test-functionality.sh
 
-  #     # Squid logs are not readable to actions/upload-artifact below
-  #     - name: Prep test logs
-  #       if: success() || failure()
-  #       run: sudo chmod -R a+rX /usr/local/squid
+      # Squid logs are not readable to actions/upload-artifact below
+      - name: Prep test logs
+        if: success() || failure()
+        run: sudo chmod -R a+rX /usr/local/squid
 
-  #     - name: Publish test logs
-  #       if: success() || failure()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: test-logs
-  #         path: |
-  #           ${{ runner.temp }}/*.log
-  #           /usr/local/squid/var/logs/overlord/*.log
+      - name: Publish test logs
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: |
+            ${{ runner.temp }}/*.log
+            /usr/local/squid/var/logs/overlord/*.log
 
-  # source-maintenance-tests:
+  source-maintenance-tests:
 
-  #   runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04
 
-  #   steps:
-  #     - name: Install prerequisite packages
-  #       run: |
-  #         sudo apt-get --quiet=2 update
-  #         sudo apt-get --quiet=2 install astyle
-  #         sudo apt-get --quiet=2 install gperf
-  #         pip install \
-  #             --user \
-  #             --no-cache-dir \
-  #             --disable-pip-version-check \
-  #             --quiet \
-  #             --progress-bar off \
-  #             codespell==1.16 # TODO: Upgrade to codespell v2
+    steps:
+      - name: Install prerequisite packages
+        run: |
+          sudo apt-get --quiet=2 update
+          sudo apt-get --quiet=2 install astyle
+          sudo apt-get --quiet=2 install gperf
+          pip install \
+              --user \
+              --no-cache-dir \
+              --disable-pip-version-check \
+              --quiet \
+              --progress-bar off \
+              codespell==1.16 # TODO: Upgrade to codespell v2
 
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
 
-  #     - run: ./test-suite/test-sources.sh
+      - run: ./test-suite/test-sources.sh
 
   build-tests:
 
@@ -95,15 +95,15 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          # - ubuntu-22.04
+          - ubuntu-22.04
           - macos-14
         compiler:
           - { CC: gcc, CXX: g++ }
           - { CC: clang, CXX: clang++ }
         layer:
           - { name: layer-00-default, nick: default }
-          # - { name: layer-01-minimal, nick: minimal }
-          # - { name: layer-02-maximus, nick: maximus }
+          - { name: layer-01-minimal, nick: minimal }
+          - { name: layer-02-maximus, nick: maximus }
         exclude:
           # Non-clang testing on MacOS is too much work for very little gain
           - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }
@@ -161,9 +161,10 @@ jobs:
           export CFLAGS="-Wno-compound-token-split-by-macro${CFLAGS:+ $CFLAGS}" # needed fir ltdl with Xcode
 
           # libtool package referenced below fails to copy its configure*
-          # files. We do not know whether that is a brewing bug, but the
-          # following sed command restores installed libtoolize code to its
-          # earlier(and working) variation.
+          # files, possibly due to a packaging/brewing bug. The following sed
+          # command restores installed libtoolize code to its earlier (and
+          # working) variation.
+          echo "brew libtool package details:"
           brew info libtool --json | grep -E 'rebuild|tap_git_head'
           # This hack was tested on libtoolize package with the following output:
           # "rebuild": 2,
@@ -180,37 +181,34 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-logs-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
-          path: |
-            btlayer-*.log
-            /opt/homebrew/bin/glibtoolize
-            /opt/homebrew/Cellar/libtool/2.4.7
+          path: btlayer-*.log
 
-  # CodeQL-tests:
+  CodeQL-tests:
 
-  #   runs-on: [ ubuntu-22.04 ]
+    runs-on: [ ubuntu-22.04 ]
 
-  #   permissions:
-  #     security-events: write
+    permissions:
+      security-events: write
 
-  #   steps:
+    steps:
 
-  #     - name: Install Squid prerequisite Linux packages
-  #       if: runner.os == 'Linux'
-  #       run: |
-  #         # required for "apt-get build-dep" to work
-  #         sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
-  #         sudo apt-get --quiet=2 update
-  #         sudo apt-get --quiet=2 build-dep squid
-  #         sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin
+      - name: Install Squid prerequisite Linux packages
+        if: runner.os == 'Linux'
+        run: |
+          # required for "apt-get build-dep" to work
+          sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
+          sudo apt-get --quiet=2 update
+          sudo apt-get --quiet=2 build-dep squid
+          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin
 
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  #     - name: Initialize CodeQL
-  #       uses: github/codeql-action/init@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
 
-  #     - name: Build Squid
-  #       run: ./test-builds.sh ./test-suite/buildtests/layer-02-maximus.opts
+      - name: Build Squid
+        run: ./test-builds.sh ./test-suite/buildtests/layer-02-maximus.opts
 
-  #     - name: Perform CodeQL Analysis
-  #       uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -159,6 +159,21 @@ jobs:
           export CPPFLAGS="-I$HOMEBREW_PREFIX/include${CPPFLAGS:+ $CPPFLAGS}"
           export LDFLAGS="-L$HOMEBREW_PREFIX/lib${LDFLAGS:+ $LDFLAGS}"
           export CFLAGS="-Wno-compound-token-split-by-macro${CFLAGS:+ $CFLAGS}" # needed fir ltdl with Xcode
+
+          # libtool package referenced below fails to copy its configure*
+          # files, possibly due to a packaging/brewing bug. The following sed
+          # command restores installed libtoolize code to its earlier (and
+          # working) variation.
+          echo "brew libtool package details:"
+          brew info libtool --json | grep -E 'rebuild|tap_git_head'
+          # This hack was tested on libtoolize package with the following output:
+          # "rebuild": 2,
+          # "tap_git_head": "5cede8ea3b7b12c7f68215f75a951430b38d945f",
+          #
+          editable=/opt/homebrew/Cellar/libtool/2.4.7/bin/glibtoolize
+          sed -i.bak 's@ltdl_ac_aux_dir=""@ltdl_ac_aux_dir="../build-aux"@' $editable || true
+          diff -u $editable.bak $editable || true
+
           ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -170,7 +170,7 @@ jobs:
           # "rebuild": 2,
           # "tap_git_head": "5cede8ea3b7b12c7f68215f75a951430b38d945f",
           #
-          editable=/opt/homebrew/Cellar/libtool/2.4.7/bin/glibtoolize
+          editable=$HOMEBREW_CELLAR/libtool/2.4.7/bin/glibtoolize
           sed -i.bak 's@ltdl_ac_aux_dir=""@ltdl_ac_aux_dir="../build-aux"@' $editable || true
           diff -u $editable.bak $editable || true
 

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -22,72 +22,72 @@ env:
 
 jobs:
 
-  functionality-tests:
+  # functionality-tests:
 
-    runs-on: ubuntu-22.04
+  #   runs-on: ubuntu-22.04
 
-    steps:
-      - name: Install prerequisite packages
-        run: |
-          sudo apt-get --quiet=2 update
-          sudo apt-get --quiet=2 install libtool-bin
+  #   steps:
+  #     - name: Install prerequisite packages
+  #       run: |
+  #         sudo apt-get --quiet=2 update
+  #         sudo apt-get --quiet=2 install libtool-bin
 
-      - name: Setup a nodejs environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+  #     - name: Setup a nodejs environment
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
 
-      - name: Checkout Squid sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+  #     - name: Checkout Squid sources
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
 
-      - run: ./bootstrap.sh
-      - run: ./configure --with-openssl
-      - run: make -j`nproc`
-      - run: |
-          sudo make install
-          sudo chown -R nobody:nogroup /usr/local/squid
+  #     - run: ./bootstrap.sh
+  #     - run: ./configure --with-openssl
+  #     - run: make -j`nproc`
+  #     - run: |
+  #         sudo make install
+  #         sudo chown -R nobody:nogroup /usr/local/squid
 
-      - run: ./test-suite/test-functionality.sh
+  #     - run: ./test-suite/test-functionality.sh
 
-      # Squid logs are not readable to actions/upload-artifact below
-      - name: Prep test logs
-        if: success() || failure()
-        run: sudo chmod -R a+rX /usr/local/squid
+  #     # Squid logs are not readable to actions/upload-artifact below
+  #     - name: Prep test logs
+  #       if: success() || failure()
+  #       run: sudo chmod -R a+rX /usr/local/squid
 
-      - name: Publish test logs
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-logs
-          path: |
-            ${{ runner.temp }}/*.log
-            /usr/local/squid/var/logs/overlord/*.log
+  #     - name: Publish test logs
+  #       if: success() || failure()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: test-logs
+  #         path: |
+  #           ${{ runner.temp }}/*.log
+  #           /usr/local/squid/var/logs/overlord/*.log
 
-  source-maintenance-tests:
+  # source-maintenance-tests:
 
-    runs-on: ubuntu-22.04
+  #   runs-on: ubuntu-22.04
 
-    steps:
-      - name: Install prerequisite packages
-        run: |
-          sudo apt-get --quiet=2 update
-          sudo apt-get --quiet=2 install astyle
-          sudo apt-get --quiet=2 install gperf
-          pip install \
-              --user \
-              --no-cache-dir \
-              --disable-pip-version-check \
-              --quiet \
-              --progress-bar off \
-              codespell==1.16 # TODO: Upgrade to codespell v2
+  #   steps:
+  #     - name: Install prerequisite packages
+  #       run: |
+  #         sudo apt-get --quiet=2 update
+  #         sudo apt-get --quiet=2 install astyle
+  #         sudo apt-get --quiet=2 install gperf
+  #         pip install \
+  #             --user \
+  #             --no-cache-dir \
+  #             --disable-pip-version-check \
+  #             --quiet \
+  #             --progress-bar off \
+  #             codespell==1.16 # TODO: Upgrade to codespell v2
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
 
-      - run: ./test-suite/test-sources.sh
+  #     - run: ./test-suite/test-sources.sh
 
   build-tests:
 
@@ -95,15 +95,15 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-22.04
+          # - ubuntu-22.04
           - macos-14
         compiler:
           - { CC: gcc, CXX: g++ }
           - { CC: clang, CXX: clang++ }
         layer:
           - { name: layer-00-default, nick: default }
-          - { name: layer-01-minimal, nick: minimal }
-          - { name: layer-02-maximus, nick: maximus }
+          # - { name: layer-01-minimal, nick: minimal }
+          # - { name: layer-02-maximus, nick: maximus }
         exclude:
           # Non-clang testing on MacOS is too much work for very little gain
           - { os: macos-14, compiler: { CC: gcc, CXX: g++ } }
@@ -166,34 +166,37 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-logs-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
-          path: btlayer-*.log
+          path: |
+            btlayer-*.log
+            /opt/homebrew/bin/glibtoolize
+            /opt/homebrew/Cellar/libtool/2.4.7
 
-  CodeQL-tests:
+  # CodeQL-tests:
 
-    runs-on: [ ubuntu-22.04 ]
+  #   runs-on: [ ubuntu-22.04 ]
 
-    permissions:
-      security-events: write
+  #   permissions:
+  #     security-events: write
 
-    steps:
+  #   steps:
 
-      - name: Install Squid prerequisite Linux packages
-        if: runner.os == 'Linux'
-        run: |
-          # required for "apt-get build-dep" to work
-          sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
-          sudo apt-get --quiet=2 update
-          sudo apt-get --quiet=2 build-dep squid
-          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin
+  #     - name: Install Squid prerequisite Linux packages
+  #       if: runner.os == 'Linux'
+  #       run: |
+  #         # required for "apt-get build-dep" to work
+  #         sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
+  #         sudo apt-get --quiet=2 update
+  #         sudo apt-get --quiet=2 build-dep squid
+  #         sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+  #     - name: Initialize CodeQL
+  #       uses: github/codeql-action/init@v3
 
-      - name: Build Squid
-        run: ./test-builds.sh ./test-suite/buildtests/layer-02-maximus.opts
+  #     - name: Build Squid
+  #       run: ./test-builds.sh ./test-suite/buildtests/layer-02-maximus.opts
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+  #     - name: Perform CodeQL Analysis
+  #       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -159,21 +159,6 @@ jobs:
           export CPPFLAGS="-I$HOMEBREW_PREFIX/include${CPPFLAGS:+ $CPPFLAGS}"
           export LDFLAGS="-L$HOMEBREW_PREFIX/lib${LDFLAGS:+ $LDFLAGS}"
           export CFLAGS="-Wno-compound-token-split-by-macro${CFLAGS:+ $CFLAGS}" # needed fir ltdl with Xcode
-
-          # libtool package referenced below fails to copy its configure*
-          # files, possibly due to a packaging/brewing bug. The following sed
-          # command restores installed libtoolize code to its earlier (and
-          # working) variation.
-          echo "brew libtool package details:"
-          brew info libtool --json | grep -E 'rebuild|tap_git_head'
-          # This hack was tested on libtoolize package with the following output:
-          # "rebuild": 2,
-          # "tap_git_head": "5cede8ea3b7b12c7f68215f75a951430b38d945f",
-          #
-          editable=/opt/homebrew/Cellar/libtool/2.4.7/bin/glibtoolize
-          sed -i.bak 's@ltdl_ac_aux_dir=""@ltdl_ac_aux_dir="../build-aux"@' $editable || true
-          diff -u $editable.bak $editable || true
-
           ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -159,6 +159,20 @@ jobs:
           export CPPFLAGS="-I$HOMEBREW_PREFIX/include${CPPFLAGS:+ $CPPFLAGS}"
           export LDFLAGS="-L$HOMEBREW_PREFIX/lib${LDFLAGS:+ $LDFLAGS}"
           export CFLAGS="-Wno-compound-token-split-by-macro${CFLAGS:+ $CFLAGS}" # needed fir ltdl with Xcode
+
+          # libtool package referenced below fails to copy its configure*
+          # files. We do not know whether that is a brewing bug, but the
+          # following sed command restores installed libtoolize code to its
+          # earlier(and working) variation.
+          brew info libtool --json | grep -E 'rebuild|tap_git_head'
+          # This hack was tested on libtoolize package with the following output:
+          # "rebuild": 2,
+          # "tap_git_head": "5cede8ea3b7b12c7f68215f75a951430b38d945f",
+          #
+          editable=/opt/homebrew/Cellar/libtool/2.4.7/bin/glibtoolize
+          sed -i.bak 's@ltdl_ac_aux_dir=""@ltdl_ac_aux_dir="../build-aux"@' $editable || true
+          diff -u $editable.bak $editable || true
+
           ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -116,38 +116,48 @@ echo "autoconf ($acversion) : autoconf$acver"
 echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
 echo "libtool path : $ltpath"
 
-for dir in \
-	""
-do
-    if [ -z "$dir" ] || [ -d $dir ]; then
-	if (
-	echo "Bootstrapping $dir"
-	cd ./$dir
-	if [ -n "$dir" ] && [ -f bootstrap.sh ]; then
-	    ./bootstrap.sh
-	elif [ ! -f $dir/configure ]; then
-	    mkdir -p cfgaux
-	    mkdir -p m4
+if test -n "$ltpath"; then
+    acincludeflag="-I $ltpath/../share/aclocal"
+else
+    acincludeflag=""
+fi
 
-            if test -n "$ltpath"; then
-              acincludeflag="-I $ltpath/../share/aclocal"
-            else
-              acincludeflag=""
-            fi
+# bootstrap primary or subproject sources
+bootstrap_dir() {
+    dir="$1"
+    cd $dir || exit $?
 
-	    # Bootstrap the autotool subsystems
-	    bootstrap aclocal$amver $acincludeflag
-	    bootstrap autoheader$acver
-	    bootstrap_libtoolize ${LIBTOOL_BIN}ize${ltver}
-	    bootstrap automake$amver --foreign --add-missing --copy -f
-	    bootstrap autoconf$acver --force
-	fi ); then
-	    : # OK
-	else
-	    exit 1
-	fi
+    bootstrap aclocal$amver $acincludeflag
+    bootstrap autoheader$acver
+
+    # Do not libtoolize ltdl
+    if grep -q '^LTDL_INIT' configure.ac
+    then
+        bootstrap_libtoolize ${LIBTOOL_BIN}ize${ltver}
     fi
-done
+
+    bootstrap automake$amver --foreign --add-missing --copy --force
+    bootstrap autoconf$acver --force
+
+    cd - > /dev/null
+}
+
+echo "Bootstrapping primary Squid sources"
+mkdir -p cfgaux || exit $?
+mkdir -p m4 || exit $?
+bootstrap_dir .
+
+# The above bootstrap_libtoolize step creates or updates libltdl. It copies
+# (with minor adjustments) configure.ac and configure, Makefile.am and
+# Makefile.in from libtool installation, but does not regenerate copied
+# configure from copied configure.ac and copied Makefile.in from Makefile.am.
+# We get libltdl/configure and libltdl/Makefile.in as they were bootstrapped
+# by libtool authors or package maintainers. Low-level idiosyncrasies in those
+# libtool files result in mismatches between copied code expectations and
+# Squid sub-project environment, leading to occasional build failures that
+# this bootstrapping addresses.
+echo "Bootstrapping libltdl sub-project"
+bootstrap_dir libltdl
 
 # Make a copy of SPONSORS we can package
 if test -f SPONSORS.list; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -128,8 +128,8 @@ do
 	if [ -n "$dir" ] && [ -f bootstrap.sh ]; then
 	    ./bootstrap.sh
 	elif [ ! -f $dir/configure ]; then
-	    # Make sure cfgaux exists
 	    mkdir -p cfgaux
+	    mkdir -p m4
 
             if test -n "$ltpath"; then
               acincludeflag="-I $ltpath/../share/aclocal"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -114,9 +114,7 @@ AUTOCONF="autoconf${acver}" ; export AUTOCONF
 echo "automake ($amversion) : automake$amver"
 echo "autoconf ($acversion) : autoconf$acver"
 echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
-echo "libtool path : $ltpath / ${LIBTOOL_BIN}${ltver}"
-
-brew info libtool
+echo "libtool path : $ltpath"
 
 for dir in \
 	""

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -84,7 +84,7 @@ bootstrap_libtoolize() {
 
     ltdl="--ltdl"
 
-    bootstrap $tool $ltdl --force --copy --automake  --debug
+    bootstrap $tool $ltdl --force --copy --automake
 }
 
 # On MAC OS X, GNU libtool is named 'glibtool':
@@ -116,12 +116,38 @@ echo "autoconf ($acversion) : autoconf$acver"
 echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
 echo "libtool path : $ltpath"
 
-mkdir -p cfgaux
+for dir in \
+	""
+do
+    if [ -z "$dir" ] || [ -d $dir ]; then
+	if (
+	echo "Bootstrapping $dir"
+	cd ./$dir
+	if [ -n "$dir" ] && [ -f bootstrap.sh ]; then
+	    ./bootstrap.sh
+	elif [ ! -f $dir/configure ]; then
+	    # Make sure cfgaux exists
+	    mkdir -p cfgaux
 
-autoreconf --force --install
-cd libltdl
-autoreconf --force --install
-cd ..
+            if test -n "$ltpath"; then
+              acincludeflag="-I $ltpath/../share/aclocal"
+            else
+              acincludeflag=""
+            fi
+
+	    # Bootstrap the autotool subsystems
+	    bootstrap aclocal$amver $acincludeflag
+	    bootstrap autoheader$acver
+	    bootstrap_libtoolize ${LIBTOOL_BIN}ize${ltver}
+	    bootstrap automake$amver --foreign --add-missing --copy -f
+	    bootstrap autoconf$acver --force
+	fi ); then
+	    : # OK
+	else
+	    exit 1
+	fi
+    fi
+done
 
 # Make a copy of SPONSORS we can package
 if test -f SPONSORS.list; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -126,8 +126,8 @@ do
 	if [ -n "$dir" ] && [ -f bootstrap.sh ]; then
 	    ./bootstrap.sh
 	elif [ ! -f $dir/configure ]; then
-	    # Make sure cfgaux exists
 	    mkdir -p cfgaux
+	    mkdir -p m4
 
             if test -n "$ltpath"; then
               acincludeflag="-I $ltpath/../share/aclocal"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -114,7 +114,9 @@ AUTOCONF="autoconf${acver}" ; export AUTOCONF
 echo "automake ($amversion) : automake$amver"
 echo "autoconf ($acversion) : autoconf$acver"
 echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
-echo "libtool path : $ltpath"
+echo "libtool path : $ltpath / ${LIBTOOL_BIN}${ltver}"
+
+brew info libtool
 
 for dir in \
 	""

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -84,7 +84,7 @@ bootstrap_libtoolize() {
 
     ltdl="--ltdl"
 
-    bootstrap $tool $ltdl --force --copy --automake
+    bootstrap $tool $ltdl --force --copy --automake  --debug
 }
 
 # On MAC OS X, GNU libtool is named 'glibtool':
@@ -116,38 +116,12 @@ echo "autoconf ($acversion) : autoconf$acver"
 echo "libtool  ($ltversion) : ${LIBTOOL_BIN}${ltver}"
 echo "libtool path : $ltpath"
 
-for dir in \
-	""
-do
-    if [ -z "$dir" ] || [ -d $dir ]; then
-	if (
-	echo "Bootstrapping $dir"
-	cd ./$dir
-	if [ -n "$dir" ] && [ -f bootstrap.sh ]; then
-	    ./bootstrap.sh
-	elif [ ! -f $dir/configure ]; then
-	    mkdir -p cfgaux
-	    mkdir -p m4
+mkdir -p cfgaux
 
-            if test -n "$ltpath"; then
-              acincludeflag="-I $ltpath/../share/aclocal"
-            else
-              acincludeflag=""
-            fi
-
-	    # Bootstrap the autotool subsystems
-	    bootstrap aclocal$amver $acincludeflag
-	    bootstrap autoheader$acver
-	    bootstrap_libtoolize ${LIBTOOL_BIN}ize${ltver}
-	    bootstrap automake$amver --foreign --add-missing --copy -f
-	    bootstrap autoconf$acver --force
-	fi ); then
-	    : # OK
-	else
-	    exit 1
-	fi
-    fi
-done
+autoreconf --force --install
+cd libltdl
+autoreconf --force --install
+cd ..
 
 # Make a copy of SPONSORS we can package
 if test -f SPONSORS.list; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -144,7 +144,6 @@ bootstrap_dir() {
 
 echo "Bootstrapping primary Squid sources"
 mkdir -p cfgaux || exit $?
-mkdir -p m4 || exit $?
 bootstrap_dir .
 
 # The above bootstrap_libtoolize step creates or updates libltdl. It copies

--- a/configure.ac
+++ b/configure.ac
@@ -9,10 +9,6 @@ AC_INIT([Squid Web Proxy],[7.0.0-VCS],[https://bugs.squid-cache.org/],[squid])
 AC_PREREQ(2.61)
 AC_CONFIG_HEADERS([include/autoconf.h])
 AC_CONFIG_AUX_DIR(cfgaux)
-
-# TODO: Require Autoconf v2.70 and upgrade to AC_CONFIG_MACRO_DIRS
-AC_CONFIG_MACRO_DIR([m4])
-
 AC_CONFIG_SRCDIR([src/main.cc])
 AM_INIT_AUTOMAKE([tar-ustar nostdinc subdir-objects dist-xz])
 AC_REVISION($Revision$)dnl

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_INIT([Squid Web Proxy],[7.0.0-VCS],[https://bugs.squid-cache.org/],[squid])
 AC_PREREQ(2.61)
 AC_CONFIG_HEADERS([include/autoconf.h])
 AC_CONFIG_AUX_DIR(cfgaux)
-AC_CONFIG_MACRO_DIRS([m4])
+LT_CONFIG_LTDL_DIR(libltdl)
 AC_CONFIG_SRCDIR([src/main.cc])
 AM_INIT_AUTOMAKE([tar-ustar nostdinc subdir-objects dist-xz])
 AC_REVISION($Revision$)dnl

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,6 @@ AC_INIT([Squid Web Proxy],[7.0.0-VCS],[https://bugs.squid-cache.org/],[squid])
 AC_PREREQ(2.61)
 AC_CONFIG_HEADERS([include/autoconf.h])
 AC_CONFIG_AUX_DIR(cfgaux)
-LT_CONFIG_LTDL_DIR(libltdl)
 AC_CONFIG_SRCDIR([src/main.cc])
 AM_INIT_AUTOMAKE([tar-ustar nostdinc subdir-objects dist-xz])
 AC_REVISION($Revision$)dnl

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_INIT([Squid Web Proxy],[7.0.0-VCS],[https://bugs.squid-cache.org/],[squid])
 AC_PREREQ(2.61)
 AC_CONFIG_HEADERS([include/autoconf.h])
 AC_CONFIG_AUX_DIR(cfgaux)
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_SRCDIR([src/main.cc])
 AM_INIT_AUTOMAKE([tar-ustar nostdinc subdir-objects dist-xz])
 AC_REVISION($Revision$)dnl

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,10 @@ AC_INIT([Squid Web Proxy],[7.0.0-VCS],[https://bugs.squid-cache.org/],[squid])
 AC_PREREQ(2.61)
 AC_CONFIG_HEADERS([include/autoconf.h])
 AC_CONFIG_AUX_DIR(cfgaux)
-AC_CONFIG_MACRO_DIRS([m4])
+
+# TODO: Require Autoconf v2.70 and upgrade to AC_CONFIG_MACRO_DIRS
+AC_CONFIG_MACRO_DIR([m4])
+
 AC_CONFIG_SRCDIR([src/main.cc])
 AM_INIT_AUTOMAKE([tar-ustar nostdinc subdir-objects dist-xz])
 AC_REVISION($Revision$)dnl


### PR DESCRIPTION
    gmake[3]: Entering directory .../libltdl
    .../cfgaux/missing: line 85: aclocal-1.16: command not found
    gmake[3]: *** [Makefile:561: .././../libltdl/aclocal.m4] Error 127

During bootstrap.sh run, libtoolize copies prepackaged configure and
Makefile.in files into our libltdl directory:

* libltdl/configure from libtool v2.4 has aclocal version set to 1.16;
* libltdl/Makefile.in from libtool v2.4 uses configure-set aclocal
  version to build aclocal.m4

Thus, libltdl/Makefile (generated from libltdl/Makefile.in above) runs
aclocal-1.16 if "make" needs to build libltdl/aclocal.m4.

Normally, "make" does not need to build libltdl/aclocal.m4 because that
file was created by libtoolize. However, libtool v2.4 is packaged with
(generated by packaging folks) libltdl/Makefile.in that makes
libltdl/aclocal.m4 target dependent on files in libltld/../m4 directory.
Squid does not have that ./m4 directory, so "make" attempts to
re-generate libltdl/aclocal.m4. When it does, it uses aclocal-1.16.

Our bootstrap.sh generated new ./configure but preserved copied
libltdl/configure with its aclocal version set to 1.16. In other words,
our bootstrap.sh did not bootstrap libltdl sub-project. In build
environments without aclocal-1.16, Squid build failed.

Several solutions or workarounds have been tried or considered:

* Adjust bootstrap.sh to bootstrap libltdl (this change). 2008 attempt
  to do that was reverted in commit bfd6b6a9 with "better to fix libtool
  installation" rationale. Another potential argument against this
  option is that packages should be bootstrapped by their distributors,
  not "users". We are not distributing libtool, but this is a gray area
  because we do distribute files that libtoolize creates. Finally,
  libtool itself does not provide a bootstrapping script and does not
  explicitly recommend bootstrapping in documentation.

* "Fix libtool installation". We failed to find a good way to do that on
  MacOS (without building and installing newer libtool from sources).

* Place m4 files where libtool v2.4 expects to find them. That change
  fixes MacOS builds that use automake v1.17, but breaks Gentoo builds
  because Gentoo libtool installs a buggy libltdl/Makefile.in that must
  be regenerated by automake before it can work. Fixing m4 files
  location prevents that regeneration.

We picked the first option despite its drawbacks because the third
option did not work on Gentoo, and asking Squid developers to install
libtool from sources (i.e. the second option) felt like a greater evil.

This old problem was exposed by recently introduced CI MacOS tests that
started to fail when MacOS brew updated automake package from v1.16
without the corresponding libtoolize package changes.


Also work around what seems to be a libtool packaging bug affecting
MacOS/brew environments, including GitHub Actions runners we use for CI:

    libtool  (2.4.7) : glibtool
    libtool path : /opt/homebrew/bin
    Bootstrapping
    glibtoolize:   error: creating 'libltdl/configure.ac' ... failed
    glibtoolize:   error: creating 'libltdl/configure' ... failed
    glibtoolize failed

That workaround will be removed after libtool package is fixed.


Also removed a single-iteration "for dir" loop with several stale hacks
from bootstrap.sh: With only two directories to bootstrap and with a
directory-specific mkdir command, source comments, and progress
messages, it is best to unroll that loop.
