### PR TITLE
Maintenance: Remove unused SNPRINTFSOURCE variable

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -54,7 +54,6 @@ libmisccontainers_la_SOURCES = \
 	hash.cc
 
 libmiscutil_la_SOURCES = \
-	$(SNPRINTFSOURCE) \
 	Splay.cc \
 	heap.c \
 	radix.c \


### PR DESCRIPTION
This Makefile.am variable became unused in 2007 commit d2eebe0f.
