### PR TITLE
Maintenance: Remove unused fde::flags.close_on_exec

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -555,9 +555,6 @@ comm_import_opened(const Comm::ConnectionPointer &conn,
 
     comm_init_opened(conn, note, AI);
 
-    if (!(conn->flags & COMM_NOCLOEXEC))
-        fd_table[conn->fd].flags.close_on_exec = true;
-
     if (conn->local.port() > (unsigned short) 0) {
 #if _SQUID_WINDOWS_
         if (AI->ai_socktype != SOCK_DGRAM)
@@ -1146,9 +1143,6 @@ commSetCloseOnExec(int fd)
         int xerrno = errno;
         debugs(50, DBG_CRITICAL, "ERROR: " << MYNAME << "FD " << fd << ": set close-on-exec failed: " << xstrerr(xerrno));
     }
-
-    fd_table[fd].flags.close_on_exec = true;
-
 #endif
 }
 

--- a/src/fde.h
+++ b/src/fde.h
@@ -124,7 +124,6 @@ public:
         bool ipc = false;
         bool called_connect = false;
         bool nodelay = false;
-        bool close_on_exec = false;
         /// buffering readMethod_ has data to give (regardless of socket state)
         bool read_pending = false;
         //bool write_pending; //XXX seems not to be used


### PR DESCRIPTION
This flag became effectively unused in 2010 commit cfd66529 when
copyFDFlags() -- the only function checking the flag -- became unused.
That unused function was removed a bit later in commit 5ae21d99.
