### PR TITLE
Fix performance regressions with fastCheck() result copying

### DIFF
--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -76,7 +76,7 @@ Note::match(HttpRequest *request, HttpReply *reply, const AccessLogEntry::Pointe
 
     for (const auto &v: values) {
         assert(v->aclList);
-        const auto ret = ch.fastCheck(v->aclList);
+        const auto &ret = ch.fastCheck(v->aclList);
         debugs(93, 5, "Check for header name: " << theKey << ": " << v->value() <<
                ", HttpRequest: " << request << " HttpReply: " << reply << " matched: " << ret);
         if (ret.allowed()) {

--- a/src/auth/UserRequest.cc
+++ b/src/auth/UserRequest.cc
@@ -480,7 +480,7 @@ schemesConfig(HttpRequest *request, HttpReply *rep)
     if (!Auth::TheConfig.schemeLists.empty() && Auth::TheConfig.schemeAccess) {
         ACLFilledChecklist ch(nullptr, request);
         ch.updateReply(rep);
-        const auto answer = ch.fastCheck(Auth::TheConfig.schemeAccess);
+        const auto &answer = ch.fastCheck(Auth::TheConfig.schemeAccess);
         if (answer.allowed())
             return Auth::TheConfig.schemeLists.at(answer.kind).authConfigs;
     }

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1528,7 +1528,7 @@ ConnStateData::tunnelOnError(const err_type requestError)
     ACLFilledChecklist checklist(Config.accessList.on_unsupported_protocol, nullptr);
     checklist.requestErrorType = requestError;
     fillChecklist(checklist);
-    auto answer = checklist.fastCheck();
+    const auto &answer = checklist.fastCheck();
     if (answer.allowed() && answer.kind == 1) {
         debugs(33, 3, "Request will be tunneled to server");
         const auto context = pipeline.front();
@@ -2184,7 +2184,7 @@ ConnStateData::whenClientIpKnown()
             /* pools require explicit 'allow' to assign a client into them */
             if (pools[pool]->access) {
                 ch.changeAcl(pools[pool]->access);
-                auto answer = ch.fastCheck();
+                const auto &answer = ch.fastCheck();
                 if (answer.allowed()) {
 
                     /*  request client information from db after we did all checks

--- a/src/http.cc
+++ b/src/http.cc
@@ -2109,7 +2109,7 @@ HttpStateData::forwardUpgrade(HttpHeader &hdrOut)
         Config.http_upgrade_request_protocols->forApplicable(offeredProto, [&ch, offeredStr, offeredStrLen, &upgradeOut] (const SBuf &cfgProto, const acl_access *guard) {
             debugs(11, 5, "checks " << cfgProto << " rule(s)");
             ch.changeAcl(guard);
-            const auto answer = ch.fastCheck();
+            const auto &answer = ch.fastCheck();
             if (answer.implicit)
                 return false; // keep looking for an explicit rule match
             if (answer.allowed())

--- a/src/http/Stream.cc
+++ b/src/http/Stream.cc
@@ -293,7 +293,7 @@ Http::Stream::sendStartOfMessage(HttpReply *rep, StoreIOBuffer bodyData)
             ACLFilledChecklist chl(pool->access, nullptr);
             clientAclChecklistFill(chl, http);
             chl.updateReply(rep);
-            const auto answer = chl.fastCheck();
+            const auto &answer = chl.fastCheck();
             if (answer.allowed()) {
                 writeQuotaHandler = pool->createBucket();
                 fd_table[clientConnection->fd].writeQuotaHandler = writeQuotaHandler;


### PR DESCRIPTION
Detected by Coverity. CID 1616162: Performance inefficiencies
(AUTO_CAUSES_COPY). Using the 'auto' keyword without an '&' causes the
copy of an object of type Acl::Answer.
