### PR TITLE
source-maintenance.sh: Fix checkMakeNamedErrorDetails on MacOS

### DIFF
--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -291,7 +291,7 @@ checkMakeNamedErrorDetails ()
     problems=1 # assume there are problems until proven otherwise
 
     options='-h --only-matching --extended-regexp'
-    git grep $options 'MakeNamedErrorDetail[(]".*?"[)]' src |
+    git grep $options 'MakeNamedErrorDetail[(]"[^"]*"[)]' src |
         sort |
         uniq --count > \
         MakeNamedErrorDetail.tmp


### PR DESCRIPTION
    'MakeNamedErrorDetail....*?...': repetition-operator operand invalid

"git grep --extended-regexp" does not support non-greedy sequences on
MacOS. Use an equivalent greedy sequence instead.
