### PR TITLE
Maintenance: split SUBDIRS in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,13 +7,23 @@
 
 AUTOMAKE_OPTIONS = dist-bzip2 1.5 foreign
 
-SUBDIRS = compat contrib doc errors icons
+SUBDIRS = \
+	compat \
+	contrib \
+	doc \
+	errors \
+	icons
 
 if ENABLE_LOADABLE_MODULES
 SUBDIRS += libltdl
 endif
 
-SUBDIRS += lib scripts src tools test-suite
+SUBDIRS += \
+	lib \
+	scripts \
+	src \
+	tools \
+	test-suite
 
 DISTCLEANFILES = include/stamp-h include/stamp-h[0-9]*
 DEFAULT_PINGER = $(libexecdir)/`echo pinger | sed '$(transform);s/$$/$(EXEEXT)/'`

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,30 @@ LOADABLE_MODULES_SOURCES = \
 	LoadableModules.h
 
 # subdir Y that requires a file built in subdir X must appear after X
-SUBDIRS = mem time debug base anyp helper dns html ftp parser comm error eui sbuf acl format clients servers fs repl store DiskIO proxyp
+SUBDIRS = \
+	mem \
+	time \
+	debug \
+	base \
+	anyp \
+	helper \
+	dns \
+	html \
+	ftp \
+	parser \
+	comm \
+	error \
+	eui \
+	sbuf \
+	acl \
+	format \
+	clients \
+	servers \
+	fs \
+	repl \
+	store \
+	DiskIO \
+	proxyp
 
 if ENABLE_AUTH
 SUBDIRS += auth
@@ -25,7 +48,13 @@ AUTH_LIBS= auth/libauth.la
 AUTH_ACL_LIBS= auth/libacls.la
 endif
 
-SUBDIRS	+= http ip icmp log ipc mgr
+SUBDIRS	+= \
+	http \
+	ip \
+	icmp \
+	log \
+	ipc \
+	mgr
 
 SSL_LIBS=
 if ENABLE_SSL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,7 +48,7 @@ AUTH_LIBS= auth/libauth.la
 AUTH_ACL_LIBS= auth/libacls.la
 endif
 
-SUBDIRS	+= \
+SUBDIRS += \
 	http \
 	ip \
 	icmp \

--- a/src/auth/Makefile.am
+++ b/src/auth/Makefile.am
@@ -8,7 +8,11 @@
 include $(top_srcdir)/src/Common.am
 
 SUBDIRS = $(AUTH_MODULES)
-DIST_SUBDIRS = basic digest negotiate ntlm
+DIST_SUBDIRS = \
+	basic \
+	digest \
+	negotiate \
+	ntlm
 
 noinst_LTLIBRARIES = libauth.la libacls.la
 ## not needed? $(AUTH_LIBS_TO_BUILD)

--- a/src/auth/digest/Makefile.am
+++ b/src/auth/digest/Makefile.am
@@ -7,7 +7,11 @@
 
 include $(top_srcdir)/src/Common.am
 
-DIST_SUBDIRS= eDirectory file LDAP
+DIST_SUBDIRS = \
+	eDirectory \
+	file \
+	LDAP
+
 SUBDIRS= $(DIGEST_AUTH_HELPERS)
 EXTRA_DIST= helpers.m4
 

--- a/src/auth/negotiate/Makefile.am
+++ b/src/auth/negotiate/Makefile.am
@@ -7,7 +7,10 @@
 
 include $(top_srcdir)/src/Common.am
 
-DIST_SUBDIRS= kerberos SSPI wrapper
+DIST_SUBDIRS = \
+	kerberos \
+	SSPI \
+	wrapper
 SUBDIRS= $(NEGOTIATE_AUTH_HELPERS)
 EXTRA_DIST= helpers.m4
 

--- a/src/auth/ntlm/Makefile.am
+++ b/src/auth/ntlm/Makefile.am
@@ -7,7 +7,10 @@
 
 include $(top_srcdir)/src/Common.am
 
-DIST_SUBDIRS= fake SMB_LM SSPI
+DIST_SUBDIRS = \
+	fake \
+	SMB_LM \
+	SSPI
 SUBDIRS= $(NTLM_AUTH_HELPERS)
 EXTRA_DIST= helpers.m4
 

--- a/src/http/Makefile.am
+++ b/src/http/Makefile.am
@@ -7,7 +7,9 @@
 
 include $(top_srcdir)/src/Common.am
 
-SUBDIRS = one url_rewriters
+SUBDIRS = \
+	one \
+	url_rewriters
 
 noinst_LTLIBRARIES = libhttp.la
 

--- a/src/http/url_rewriters/Makefile.am
+++ b/src/http/url_rewriters/Makefile.am
@@ -5,5 +5,7 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-DIST_SUBDIRS= fake LFS
+DIST_SUBDIRS = \
+    fake \
+    LFS
 SUBDIRS= $(URL_REWRITE_HELPERS)

--- a/src/log/Makefile.am
+++ b/src/log/Makefile.am
@@ -7,7 +7,9 @@
 
 include $(top_srcdir)/src/Common.am
 
-DIST_SUBDIRS= DB file
+DIST_SUBDIRS = \
+	DB \
+	file
 SUBDIRS= $(LOG_DAEMON_HELPERS)
 EXTRA_DIST= helpers.m4
 

--- a/src/security/Makefile.am
+++ b/src/security/Makefile.am
@@ -7,7 +7,9 @@
 
 include $(top_srcdir)/src/Common.am
 
-SUBDIRS= cert_generators cert_validators
+SUBDIRS = \
+	cert_generators \
+	cert_validators
 
 noinst_LTLIBRARIES = libsecurity.la
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -5,5 +5,9 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-SUBDIRS = apparmor helper-mux systemd sysvinit
+SUBDIRS = \
+    apparmor \
+    helper-mux \
+    systemd \
+    sysvinit
 EXTRA_DIST = helper-ok-dying.pl helper-ok.pl


### PR DESCRIPTION
Single-line multi-entry SUBDIRS often increase management noise.