### PR TITLE
Optimization: Do not zero-terminate Server::inBuf

### DIFF
--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -1957,7 +1957,7 @@ ConnStateData::handleRequestBodyData()
         }
     } else { // identity encoding
         debugs(33,5, "handling plain request body for " << clientConnection);
-        const size_t putSize = bodyPipe->putMoreData(inBuf.c_str(), inBuf.length());
+        const auto putSize = bodyPipe->putMoreData(inBuf.rawContent(), inBuf.length());
         if (putSize > 0)
             consumeInput(putSize);
 


### PR DESCRIPTION
... when storing unencoded request body bytes in ConnStateData::bodyPipe

Calling SBuf::c_str() is unnecessary in this context because
BodyPipe::append() does not need/expect a zero-terminated buffer. The
call is relatively expensive when the previous Comm::ReadNow() was able
to fill the entire inBuf trailing space, which is a common occurrence
because Server::maybeMakeSpaceAvailable() uses CLIENT_REQ_BUF_SZ as
idealSpace size, and CLIENT_REQ_BUF_SZ is hard-coded to just 4096 bytes.

The call was added in 2014 commit e7287625 that converted inBuf to SBuf.
