### PR TITLE
Fix Comm::TcpAcceptor::status() reporting of listening address

### DIFF
--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -126,9 +126,8 @@ Comm::TcpAcceptor::status() const
     if (conn == nullptr)
         return "[nil connection]";
 
-    static char ipbuf[MAX_IPSTRLEN] = {'\0'};
-    if (ipbuf[0] == '\0')
-        conn->local.toHostStr(ipbuf, MAX_IPSTRLEN);
+    char ipbuf[MAX_IPSTRLEN];
+    conn->local.toHostStr(ipbuf, MAX_IPSTRLEN); // XXX: report port using toUrl()
 
     static MemBuf buf;
     buf.reset();


### PR DESCRIPTION
Buggy "static" caching optimization led to TcpAcceptor X reporting
listening address of TcpAcceptor Y or an incorrect 0.0.0.0 address.
TcpAcceptor status is visible in mgr:jobs and level-5+ debugs() output.

Side effect: For a listening port configured without an explicit IP
address, the listening address part of status() is now reported using
"[::]" rather than "0.0.0.0" string.

Broken since 2011 commit cbff89ba.
