### PR TITLE
Use git to extract default build-info (when enabled)

### DIFF
--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -296,7 +296,7 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
             squid_git_revno="$squid_git_revno+changes"
           ])
         ])
-        squid_build_info="Built branch: ${squid_git_branch} revision ${squid_git_revno}"
+        squid_build_info="Git branch: ${squid_git_branch} revision ${squid_git_revno}"
       ],
       [squid_build_info=$enableval]
     )

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -288,16 +288,15 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
       [no],[:],
       [yes],[
         AC_PATH_PROG(GIT,git,$FALSE)
-        squid_git_branch=`cd ${srcdir} && ${GIT} branch --show-current 2>/dev/null`
-        AS_IF([test $? -eq 0 -a "x$squid_git_branch" != "x"],[
-          squid_git_revno=`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`
-          AS_IF([test $? -eq 0 -a "x$squid_git_revno" != "x"],[
-            AS_IF([cd ${srcdir} && ! ${GIT} diff --quiet HEAD],[ # there are uncommitted changes
-              squid_git_revno="$squid_git_revno+changes"
-            ])
+        squid_git_branch="`cd ${srcdir} && ${GIT} branch --show-current 2>/dev/null`"
+        squid_git_revno="`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`"
+        AS_IF([test "x$squid_git_branch" != "x"], [:], [squid_git_branch="unknown"])
+        AS_IF([test "x$squid_git_revno" != "x"],[
+          AS_IF([cd ${srcdir} && ! ${GIT} diff --quiet HEAD],[ # there are uncommitted changes
+            squid_git_revno="$squid_git_revno+changes"
           ])
-          squid_build_info="Built branch: ${squid_git_branch} revision ${squid_git_revno}"
         ])
+        squid_build_info="Built branch: ${squid_git_branch} revision ${squid_git_revno}"
       ],
       [squid_build_info=$enableval]
     )

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -293,7 +293,7 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
         AS_IF([test "x$squid_git_branch" != "x"], [:], [squid_git_branch="unknown"])
         AS_IF([test "x$squid_git_revno" != "x"],[
           AS_IF([cd ${srcdir} && ! ${GIT} diff --quiet HEAD],[ # there are uncommitted changes
-            squid_git_revno="$squid_git_revno+changes"
+            squid_git_revno="$squid_git_revno plus changes"
           ])
         ])
         squid_build_info="Git branch: ${squid_git_branch} revision ${squid_git_revno}"

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -288,15 +288,17 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
       [no],[:],
       [yes],[
         AC_PATH_PROG(GIT,git,$FALSE)
-        squid_git_branch="`cd ${srcdir} && ${GIT} branch --show-current 2>/dev/null`"
-        squid_git_revno="`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`"
-        AS_IF([test "x$squid_git_branch" != "x"], [:], [squid_git_branch="unknown"])
-        AS_IF([test "x$squid_git_revno" != "x"],[
-          AS_IF([cd ${srcdir} && ! ${GIT} diff --quiet HEAD],[ # there are uncommitted changes
-            squid_git_revno="$squid_git_revno plus changes"
+        AS_IF([test "x$GIT" != "x$FALSE"],[
+          squid_git_branch="`cd ${srcdir} && ${GIT} branch --show-current 2>/dev/null`"
+          squid_git_revno="`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`"
+          AS_IF([test "x$squid_git_branch" != "x"], [:], [squid_git_branch="unknown"])
+          AS_IF([test "x$squid_git_revno" != "x"],[
+            AS_IF([cd ${srcdir} && ! ${GIT} diff --quiet HEAD],[ # there are uncommitted changes
+              squid_git_revno="$squid_git_revno plus changes"
+            ])
           ])
         ])
-        squid_build_info="Git branch: ${squid_git_branch} revision ${squid_git_revno}"
+        squid_build_info="Git branch: ${squid_git_branch:-unavailable} revision ${squid_git_revno:-unavailable}"
       ],
       [squid_build_info=$enableval]
     )

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -292,7 +292,7 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
         AS_IF([test $? -eq 0 -a "x$squid_git_branch_nick" != "x"],[
           squid_git_branch_revno=`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`
           AS_IF([test $? -eq 0 -a "x$squid_git_branch_revno" != "x"],[
-            AS_IF([cd ${srcdir} && ${GIT} diff --name-only HEAD | grep -q '.*'],[ # there are uncommitted changes
+            AS_IF([cd ${srcdir} && ! ${GIT} diff --quiet HEAD],[ # there are uncommitted changes
               squid_git_branch_revno="$squid_git_branch_revno+changes"
             ])
           ])

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -288,15 +288,15 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
       [no],[:],
       [yes],[
         AC_PATH_PROG(GIT,git,$FALSE)
-        squid_git_branch_nick=`cd ${srcdir} && ${GIT} branch --show-current 2>/dev/null`
-        AS_IF([test $? -eq 0 -a "x$squid_git_branch_nick" != "x"],[
-          squid_git_branch_revno=`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`
-          AS_IF([test $? -eq 0 -a "x$squid_git_branch_revno" != "x"],[
+        squid_git_branch=`cd ${srcdir} && ${GIT} branch --show-current 2>/dev/null`
+        AS_IF([test $? -eq 0 -a "x$squid_git_branch" != "x"],[
+          squid_git_revno=`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`
+          AS_IF([test $? -eq 0 -a "x$squid_git_revno" != "x"],[
             AS_IF([cd ${srcdir} && ! ${GIT} diff --quiet HEAD],[ # there are uncommitted changes
-              squid_git_branch_revno="$squid_git_branch_revno+changes"
+              squid_git_revno="$squid_git_revno+changes"
             ])
           ])
-          squid_build_info="Built branch: ${squid_git_branch_nick} revision ${squid_git_branch_revno}"
+          squid_build_info="Built branch: ${squid_git_branch} revision ${squid_git_revno}"
         ])
       ],
       [squid_build_info=$enableval]

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -287,21 +287,16 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
     AS_CASE(["$enableval"],
       [no],[:],
       [yes],[
-        AS_IF([test -d "${srcdir}/.bzr"],[
-          AC_PATH_PROG(BZR,bzr,$FALSE)
-          squid_bzr_branch_nick=`cd ${srcdir} && ${BZR} nick 2>/dev/null`
-          AS_IF([test $? -eq 0 -a "x$squid_bzr_branch_nick" != "x"],[
-            squid_bzr_branch_revno=`cd ${srcdir} && ${BZR} revno 2>/dev/null | sed 's/\"//g'`
-          ])
-          AS_IF([test $? -eq 0 -a "x$squid_bzr_branch_revno" != "x"],[
-            sh -c "cd ${srcdir} && ${BZR} diff 2>&1 >/dev/null"
-            AS_IF([test $? -eq 1],[
-              squid_bzr_branch_revno="$squid_bzr_branch_revno+changes"
+        AC_PATH_PROG(GIT,git,$FALSE)
+        squid_git_branch_nick=`cd ${srcdir} && ${GIT} branch --show-current 2>/dev/null`
+        AS_IF([test $? -eq 0 -a "x$squid_git_branch_nick" != "x"],[
+          squid_git_branch_revno=`cd ${srcdir} && ${GIT} rev-parse --short HEAD 2>/dev/null`
+          AS_IF([test $? -eq 0 -a "x$squid_git_branch_revno" != "x"],[
+            AS_IF([cd ${srcdir} && ${GIT} diff --name-only HEAD | grep -q '.*'],[ # there are uncommitted changes
+              squid_git_branch_revno="$squid_git_branch_revno+changes"
             ])
           ])
-          AS_IF([test "x$squid_bzr_branch_revno" != "x"],[
-            squid_build_info="Built branch: ${squid_bzr_branch_nick}-r${squid_bzr_branch_revno}"
-          ])
+          squid_build_info="Built branch: ${squid_git_branch_nick} revision ${squid_git_branch_revno}"
         ])
       ],
       [squid_build_info=$enableval]

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -298,7 +298,7 @@ AC_DEFUN([SQUID_EMBED_BUILD_INFO],[
             ])
           ])
         ])
-        squid_build_info="Git branch: ${squid_git_branch:-unavailable} revision ${squid_git_revno:-unavailable}"
+        squid_build_info="Git: branch ${squid_git_branch:-unavailable} revision ${squid_git_revno:-unavailable}"
       ],
       [squid_build_info=$enableval]
     )


### PR DESCRIPTION
Have configure option --enable-build-info[=yes]
refer to git instead of bazaar to extract
information about what is being built to include
in the output of `squid -v`