### PR TITLE
Bug 5417: An empty annotation value does not match

### DIFF
--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -339,11 +339,11 @@ static void
 AppendTokens(NotePairs::Entries &entries, const SBuf &key, const SBuf &val, const CharacterSet &delimiters)
 {
     Parser::Tokenizer tok(val);
-    static const auto tokenCharacters = delimiters.complement("non-delimiters");
+    const auto tokenCharacters = delimiters.complement("non-delimiters");
     do {
         SBuf token;
         (void)tok.prefix(token, tokenCharacters);
-        entries.push_back(new NotePairs::Entry(key, token)); // including empty tokens
+        entries.push_back(new NotePairs::Entry(key, token)); // token may be empty
     } while (tok.skipOne(delimiters));
 }
 

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -339,12 +339,12 @@ static void
 AppendTokens(NotePairs::Entries &entries, const SBuf &key, const SBuf &val, const CharacterSet &delimiters)
 {
     Parser::Tokenizer tok(val);
-    SBuf v;
-    while (tok.token(v, delimiters))
-        entries.push_back(new NotePairs::Entry(key, v));
-    v = tok.remaining();
-    if (!v.isEmpty() || entries.empty())
-        entries.push_back(new NotePairs::Entry(key, v));
+    static const auto tokenCharacters = delimiters.complement("non-delimiters");
+    do {
+        SBuf token;
+        (void)tok.prefix(token, tokenCharacters);
+        entries.push_back(new NotePairs::Entry(key, token)); // including empty tokens
+    } while (tok.skipOne(delimiters));
 }
 
 const NotePairs::Entries &

--- a/src/Notes.cc
+++ b/src/Notes.cc
@@ -343,7 +343,7 @@ AppendTokens(NotePairs::Entries &entries, const SBuf &key, const SBuf &val, cons
     while (tok.token(v, delimiters))
         entries.push_back(new NotePairs::Entry(key, v));
     v = tok.remaining();
-    if (!v.isEmpty())
+    if (!v.isEmpty() || entries.empty())
         entries.push_back(new NotePairs::Entry(key, v));
 }
 

--- a/src/acl/StringData.cc
+++ b/src/acl/StringData.cc
@@ -23,7 +23,7 @@ ACLStringData::insert(const char *value)
 bool
 ACLStringData::match(const SBuf &tf)
 {
-    if (stringValues.empty() || tf.isEmpty())
+    if (stringValues.empty())
         return 0;
 
     debugs(28, 3, "aclMatchStringList: checking '" << tf << "'");
@@ -38,6 +38,11 @@ ACLStringData::match(const SBuf &tf)
 bool
 ACLStringData::match(char const *toFind)
 {
+    if (!toFind) {
+        // TODO: Check whether we can Assure(toFind) instead.
+        debugs(28, 3, "not matching a nil c-string");
+        return false;
+    }
     return match(SBuf(toFind));
 }
 


### PR DESCRIPTION
Helpers may return annotations with empty values:

    OK team_=""

A note ACL may be configured to match an annotation with an empty value:

    configuration_includes_quoted_values on
    acl emptyTeam note team_ ""

However, that emptyTeam ACL did not match the above helper annotation:

* AppendTokens() split an empty annotation value into an empty vector
  instead of a vector with a single empty entry. That "never match an
  empty value received from the helper" bug was probably introduced in
  2017 commit 75d47340 when it replaced an "always try to match an empty
  value, even when it was not received from the helper" bug in
  ACLNoteStrategy::matchNotes().

* ACLStringData::match(SBuf v) never matched an empty value v. That bug
  was probably introduced in 2015 commit 76ee67ac that mistook a nil
  c-string pointer for an empty c-string.
