### PR TITLE
Reject config with unknown directives before committing to it

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -625,21 +625,15 @@ Configuration::Parse()
 
     defaults_postscriptum();
 
+    if (unrecognizedDirectives)
+        throw TextException(ToSBuf("Found ", unrecognizedDirectives, " unrecognized directive(s)"), Here());
+
     /*
      * We must call configDoConfigure() before leave_suid() because
      * configDoConfigure() is where we turn username strings into
      * uid values.
      */
     configDoConfigure();
-
-    // TODO: Throw before configDoConfigure(). Doing that would reduce the set
-    // of configuration errors Squid can detect in one execution, but we should
-    // not apply a clearly broken configuration, especially when we are going to
-    // quit anyway. While some legacy parse_foo() functions apply significant
-    // changes before configDoConfigure(), we cannot easily stop them. We can
-    // easily stop configDoConfigure().
-    if (unrecognizedDirectives)
-        throw TextException(ToSBuf("Found ", unrecognizedDirectives, " unrecognized directive(s)"), Here());
 
     if (opt_send_signal == -1) {
         Mgr::RegisterAction("config",


### PR DESCRIPTION
Ideally, we want to reject configurations with unknown directives before
applying any configuration changes that correspond to known directives,
but current apply-as-you-parse architecture makes that impractical.
Pending smooth reconfiguration refactoring will make that possible, but
we can make a step towards that ideal future now.

Rejecting bad configurations before calling configDoConfigure() reduces
the set of configuration errors that Squid can detect in one execution
(because configDoConfigure() error-checking code is not reached), but
that small reduction is a lesser evil compared to running
configDoConfigure() with a clearly broken config, especially when we are
going to kill Squid anyway. While many legacy parse_foo() functions do
apply significant changes before configDoConfigure(), we cannot easily
prevent that (for now). We can easily prevent configDoConfigure().
