### PR TITLE
Limit Server::inBuf growth

### DIFF
--- a/src/adaptation/icap/Xaction.cc
+++ b/src/adaptation/icap/Xaction.cc
@@ -442,6 +442,7 @@ void Adaptation::Icap::Xaction::noteCommRead(const CommIoCbParams &io)
 
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
+    rd.size = SQUID_TCP_SO_RCVBUF - readBuf.length();
 
     switch (Comm::ReadNow(rd, readBuf)) {
     case Comm::INPROGRESS:

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -146,6 +146,8 @@ Server::doClientRead(const CommIoCbParams &io)
 
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
+    rd.size = Config.maxRequestBufferSize - inBuf.length();
+
     switch (Comm::ReadNow(rd, inBuf)) {
     case Comm::INPROGRESS:
 

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -146,6 +146,7 @@ Server::doClientRead(const CommIoCbParams &io)
 
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
+    Assure(Config.maxRequestBufferSize > inBuf.length());
     rd.size = Config.maxRequestBufferSize - inBuf.length();
 
     switch (Comm::ReadNow(rd, inBuf)) {


### PR DESCRIPTION
After a ReadNow() call, the buffer length must not exceed accumulation
limits (e.g., client_request_buffer_max_size). SBuf::reserve() alone
cannot reliably enforce those limits because it does not decrease SBuf
space; various SBuf manipulations may lead to excessive SBuf space. When
filled by ReadNow(), that space exceeds the limit.

This change uses documented CommIoCbParams::size trick to limit how much
Comm::ReadNow() may read, obeying SQUID_TCP_SO_RCVBUF (server-to-Squid)
and client_request_buffer_max_size (client-to-Squid) accumulation limit.