### PR TITLE
Use ERR_ACCESS_DENIED for HTTP 403 (Forbidden) errors

### DIFF
--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -758,7 +758,7 @@ ClientRequestContext::clientAccessCheckDone(const Acl::Answer &answer)
             status = Http::scForbidden;
 #endif
             if (page_id == ERR_NONE)
-                page_id = ERR_CACHE_ACCESS_DENIED;
+                page_id = (status == Http::scForbidden) ? ERR_ACCESS_DENIED : ERR_CACHE_ACCESS_DENIED;
         } else {
             status = Http::scForbidden;
 


### PR DESCRIPTION
... when request authentication fails. Do not use
ERR_CACHE_ACCESS_DENIED for those "permanent" errors.

Default ERR_CACHE_ACCESS_DENIED is meant for cases where the user is
likely to eventually gain access (e.g., by supplying credentials). Its
default text says "not currently allowed... until you have authenticated
yourself". When the error page was added in 1998 commit cb69b4c7 it was
only used for HTTP 407 errors. The same logic was preserved when that
code was refactored in 1999 commit 1cfdbcf0, but exceptions started to
creep in, perhaps accidentally, since 2011 when HTTP 403 case was added
in commit 2f1431ea that introduced USE_AUTH macro. 2011 commit 21512911
added a similar "not possible to authenticate" SslBump case.

Other HTTP 403 (Forbidden) cases already use ERR_ACCESS_DENIED or a
similar "permanent" error (e.g., ERR_FORWARDING_DENIED or ERR_TOO_BIG).

It is still possible to customize the returned error page via deny_info.
