### PR TITLE
Bug 5428: Missing pkg-config not treated as an error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,7 +117,7 @@ dnl Libtool 2.2.6 requires: rm -f
 RM="$RM -f"
 
 PKG_PROG_PKG_CONFIG
-AS_IF([test -z "$PKG_CONFIG"],[
+AS_IF([test "x$PKG_CONFIG" = "x"],[
   AC_MSG_ERROR([pkg-config is required to compile Squid. Please install and then re-run configure ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,9 @@ dnl Libtool 2.2.6 requires: rm -f
 RM="$RM -f"
 
 PKG_PROG_PKG_CONFIG
+AS_IF([test -z "$PKG_CONFIG"],[
+  AC_MSG_ERROR([pkg-config is required to compile Squid. Please install and then re-run configure ])
+])
 
 AC_PATH_PROG(PERL, perl, none)
 AS_IF([test "x$ac_cv_path_PERL" = "xnone"],[


### PR DESCRIPTION
pkg-config is required for building many parts of Squid.
But the PKG_PROG_PKG_CONFIG macro silently ignores
a missing binary. Causing errors far later at build time
which are often mistaken for issues with the library it was
used to detect.

Make pkg-config a mandatory build dependency now
that we rely on PKG_CHECK_MODULES to auto-detect
supported libraries.