### PR TITLE
Bug 5428: Warn if pkg-config is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,10 @@ dnl Libtool 2.2.6 requires: rm -f
 RM="$RM -f"
 
 PKG_PROG_PKG_CONFIG
+AS_IF([test "x$PKG_CONFIG" = "x"],[
+  AC_MSG_WARN([pkg-config not found. Squid might still build but miss some features, and 'make check' might fail])
+])
+
 
 AC_PATH_PROG(PERL, perl, none)
 AS_IF([test "x$ac_cv_path_PERL" = "xnone"],[

--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,7 @@ RM="$RM -f"
 
 PKG_PROG_PKG_CONFIG
 AS_IF([test "x$PKG_CONFIG" = "x"],[
-  AC_MSG_WARN([pkg-config not found. Squid might still build but miss some features, and 'make check' might fail])
+  AC_MSG_WARN([pkg-config not found. Many optional features with external dependencies will not be enabled by default, usually without further warnings.])
 ])
 
 


### PR DESCRIPTION
Squid builds without pkg-config, but results are likely to surprise
administrators because many optional features will not be
default-enabled despite properly installed libraries.
