### PR TITLE
Fix validation of Digest auth header parameters

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -967,7 +967,15 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
             return rv;
         }
     } else {
-        /* rfc7616 section 3.3 mandates qop to be present */
+        /* RFC7616 section 3.3, qop:
+         *  "MUST be used by all implementations"
+         *
+         * RFC7616 section 3.4, qop:
+         *  "value MUST be one of the alternatives the server
+         *   indicated it supports in the WWW-Authenticate header field"
+         *
+         * Squid sends qop=auth, reject buggy or outdated clients.
+        */
         debugs(29, 2, "missing qop!");
         rv = authDigestLogUsername(username, digest_request, aRequestRealm);
         safe_free(username);

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -967,13 +967,11 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
             return rv;
         }
     } else {
-        /* cnonce and nc both require qop */
-        if (digest_request->cnonce || digest_request->nc[0] != '\0') {
-            debugs(29, 2, "missing qop!");
-            rv = authDigestLogUsername(username, digest_request, aRequestRealm);
-            safe_free(username);
-            return rv;
-        }
+        /* rfc7616 mandates qop to be present */
+        debugs(29, 2, "missing qop!");
+        rv = authDigestLogUsername(username, digest_request, aRequestRealm);
+        safe_free(username);
+        return rv;
     }
 
     /** below nonce state dependent **/

--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -967,7 +967,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
             return rv;
         }
     } else {
-        /* rfc7616 mandates qop to be present */
+        /* rfc7616 section 3.3 mandates qop to be present */
         debugs(29, 2, "missing qop!");
         rv = authDigestLogUsername(username, digest_request, aRequestRealm);
         safe_free(username);


### PR DESCRIPTION
Insufficient validation of Digest authentication parameters resulted in
a DigestCalcHA1() call that dereferenced a nil pointer.

This bug was discovered and detailed by Joshua Rogers at
https://megamansec.github.io/Squid-Security-Audit/ where it was filed as
"strlen(NULL) Crash Using Digest Authentication".