### PR TITLE
Replace header field-line parser

### DIFF
--- a/src/http/one/FieldParser.cc
+++ b/src/http/one/FieldParser.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+#include "base/Raw.h"
+#include "http/one/FieldParser.h"
+#include "sbuf/Stream.h"
+#include "SquidConfig.h"
+#include "debug/Stream.h"
+
+Http::One::FieldParser::FieldParser(const SBuf &aBuf, const http_hdr_owner_type &aType) :
+    Http::One::Parser(),
+    msgType(aType),
+    tok(aBuf)
+{}
+
+/**
+ * RFC 9112 section 5:
+ *
+ *  field-line   = field-name ":" OWS field-value OWS
+ */
+void
+Http::One::FieldParser::parseFieldLine(SBuf &name, SBuf &value)
+{
+    name = parseFieldName(); // consumes ':' delimiter
+    value = parseFieldValue();
+
+    if (!tok.atEnd())
+        skipLineTerminator(tok);
+}
+
+/**
+ * RFC 9110 section 5.1:
+ *
+ *  field-name   = token
+ *  token        = 1*TCHAR
+ */
+SBuf
+Http::One::FieldParser::parseFieldName()
+{
+    // TODO: handle pseudo-header which begin with ':'
+
+    auto name = tok.prefix("field-name", CharacterSet::TCHAR);
+
+    /*
+     * RFC 9112 section 5.1:
+     * "No whitespace is allowed between the field name and colon.
+     * ...
+     *  A server MUST reject, with a response status code of 400 (Bad Request),
+     *  any received request message that contains whitespace between a header
+     *  field name and colon.  A proxy MUST remove any such whitespace from a
+     *  response message before forwarding the message downstream."
+     */
+    const bool stripWhitespace = (msgType == hoReply) || Config.onoff.relaxed_header_parser;
+    if (stripWhitespace && tok.skipAll(Http1::Parser::WhitespaceCharacters())) {
+        // TODO: reduce log spam from 'tok.buf()' below
+        debugs(11, Config.onoff.relaxed_header_parser <= 0 ? 2 : 3,
+               "WARNING: Whitespace after field-name '" << name << tok.buf() << "'");
+    }
+
+    if(!tok.skip(':'))
+        throw TextException("invalid field-name", Here());
+
+    if (name.length() == 0)
+        throw TextException("missing field-name", Here());
+
+    if (name.length() > 65534) {
+        /* String must be LESS THAN 64K and it adds a terminating NULL */
+        // TODO: update this to show proper name.length()  in Raw markup, but not print all that
+        throw TextException(ToSBuf("huge field-line (", Raw("field-name", name.c_str(), 100), "...)"), Here());
+    }
+
+    return name;
+}
+
+/**
+ * RFC 9110 section 5.1:
+ *
+ *  field-value    = *field-content
+ *  field-content  = field-vchar
+ *                   [ 1*( SP / HTAB / field-vchar ) field-vchar ]
+ *  field-vchar    = VCHAR / obs-text
+ *  obs-text       = %x80-FF
+ */
+SBuf
+Http::One::FieldParser::parseFieldValue()
+{
+    static const CharacterSet fvChars = (CharacterSet::VCHAR + CharacterSet::OBSTEXT).rename("field-value");
+    auto value = tok.prefix("field-value", fvChars);
+
+    /**
+     * RFC 9110 section 5.5:
+     *   field value does not include leading or trailing whitespace.
+     *   ... parsing implementation MUST exclude such whitespace prior
+     *    to evaluating the field value
+     */
+    const auto start = value.findFirstNotOf(Http1::Parser::WhitespaceCharacters());
+    const auto end = value.findLastNotOf(Http1::Parser::WhitespaceCharacters());
+    value.chop(start, (end-start));
+
+    if (value.length() > 65534) {
+        /* String must be LESS THAN 64K and it adds a terminating NULL */
+        // TODO: update this to show proper length() in Raw markup, but not print all that
+        throw TextException(ToSBuf("huge field-line (", Raw("field-value", value.c_str(), 100), "...)"), Here());
+    }
+
+    return value;
+}

--- a/src/http/one/FieldParser.h
+++ b/src/http/one/FieldParser.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_HTTP_ONE_FIELDPARSER_H
+#define SQUID_SRC_HTTP_ONE_FIELDPARSER_H
+
+#include "http/one/Parser.h"
+#include "HttpHeader.h"
+#include "parser/Tokenizer.h"
+
+namespace Http {
+namespace One {
+
+/** HTTP/1.x header field parser
+ *
+ * Works on a raw character I/O buffer and tokenizes the content into
+ * the field-lines of an HTTP/1 message:
+ *
+ * RFC 9112 section 5:
+ *  field-line   = field-name ":" OWS field-value OWS
+ */
+class FieldParser : public Http1::Parser
+{
+public:
+    FieldParser(const SBuf &, const http_hdr_owner_type &);
+
+    /// extract a field name and value from the buffer being parsed.
+    void parseFieldLine(SBuf &name, SBuf &value);
+
+    /* Http1::Parser API */
+    void clear() { tok.reset(SBuf()); }
+    bool parse(const SBuf &newBuf) override { const bool e = tok.atEnd(); tok.reset(newBuf); return e; }
+
+private:
+    SBuf parseFieldName();
+    SBuf parseFieldValue();
+
+    /* Http1::Parser API */
+    size_type firstLineSize() const override { return 0; }
+
+    // Whether a request or response message is being parsed.
+    // Some parser validation and tolerance depends on type.
+    const http_hdr_owner_type msgType;
+
+    // low-level tokenizer to use for parsing.
+    // owns and manages the buffer being parsed.
+    Http1::Parser::Tokenizer tok;
+};
+
+} // namespace One
+} // namespace Http
+
+#endif /* SQUID_SRC_HTTP_ONE_FIELDPARSER_H */

--- a/src/http/one/Makefile.am
+++ b/src/http/one/Makefile.am
@@ -10,6 +10,8 @@ include $(top_srcdir)/src/Common.am
 noinst_LTLIBRARIES = libhttp1.la
 
 libhttp1_la_SOURCES = \
+	FieldParser.cc \
+	FieldParser.h \
 	Parser.cc \
 	Parser.h \
 	RequestParser.cc \


### PR DESCRIPTION
.. with Tokenizer based parser.

Update specification references to latest RFCs. There are no
behavioural differences from this.

Also, remove one more SquidString allocate+copy. Although this
is replaced with an SBuf allocate+copy so only bug fixes, no
performance gain expected.