### PR TITLE
ext_time_quota_acl: remove -l option

### DIFF
--- a/doc/release-notes/release-6.sgml.in
+++ b/doc/release-notes/release-6.sgml.in
@@ -195,6 +195,7 @@ This section gives an account of those changes in three categories:
 	<item><ref id="newdirectives" name="New directives">
 	<item><ref id="modifieddirectives" name="Changes to existing directives">
 	<item><ref id="removeddirectives" name="Removed directives">
+	<item><ref id="otherchanges" name="Other changes">
 </itemize>
 <p>
 
@@ -278,6 +279,14 @@ This section gives an account of those changes in three categories:
 	   upgraded to an HTTP/1.1 message.
 </descrip>
 
+<sect1>Other changes<label id="otherchanges">
+<p>
+<descrip>
+	<tag>Adjusted configuration and format of ext_time_quota_acl helper debugging</tag>
+	<p>The <em>-l</em> option that enables <em>ext_time_quota_acl</em> to log debug messages
+		to a custom logfile has been removed, and their format has been
+		changed to be in line with Squid's cache.log format.
+</descrip>
 
 <sect>Changes to ./configure options since Squid-@SQUID_RELEASE_OLD@
 <p>

--- a/doc/release-notes/release-6.sgml.in
+++ b/doc/release-notes/release-6.sgml.in
@@ -282,10 +282,10 @@ This section gives an account of those changes in three categories:
 <sect1>Other changes<label id="otherchanges">
 <p>
 <descrip>
-	<tag>Adjusted configuration and format of ext_time_quota_acl helper debugging</tag>
+	<tag>Adjusted configuration and format of <em>ext_time_quota_acl</em> helper debugging</tag>
 	<p>The <em>-l</em> option that enables <em>ext_time_quota_acl</em> to log debug messages
 		to a custom logfile has been removed, and their format has been
-		changed to be in line with Squid's cache.log format.
+		changed to be in line with Squid <em>cache.log</em> format.
 </descrip>
 
 <sect>Changes to ./configure options since Squid-@SQUID_RELEASE_OLD@

--- a/src/acl/external/time_quota/ext_time_quota_acl.8
+++ b/src/acl/external/time_quota/ext_time_quota_acl.8
@@ -7,7 +7,7 @@ Version 1.0
 .
 .SH SYNOPSIS
 .if !'po4a'hide' .B ext_time_quota_acl
-.if !'po4a'hide' .B "[\-b database] [\-l logfile] [\-d] [\-p pauselen] [\-h] configfile
+.if !'po4a'hide' .B "[\-b database] [\-d] [\-p pauselen] [\-h] configfile
 .
 .SH DESCRIPTION
 .B ext_time_quota_acl
@@ -35,14 +35,8 @@ Pauses shorter than this value will be counted against the quota, longer ones ig
 Default is 300 seconds (5 minutes).
 .
 .if !'po4a'hide' .TP
-.if !'po4a'hide' .B "\-l logfile"
-.B Filename
-where all logging and debugging information will be written. If none is given,
-then stderr will be used and the logging will go to Squids main cache.log.
-.
-.if !'po4a'hide' .TP
 .if !'po4a'hide' .B "\-d"
-Enables debug logging in the logfile.
+Enables debug logging to stderr.
 .
 .if !'po4a'hide' .TP
 .if !'po4a'hide' .B "\-h"

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -76,15 +76,6 @@ static int pauseLength = 300;
 static FILE *logfile = stderr;
 static int tq_debug_enabled = false;
 
-static void open_log(const char *logfilename)
-{
-    logfile = fopen(logfilename, "a");
-    if ( logfile == NULL ) {
-        perror(logfilename);
-        logfile = stderr;
-    }
-}
-
 static void vlog(const char *level, const char *format, va_list args)
 {
     time_t now = time(NULL);
@@ -397,11 +388,8 @@ static void processActivity(const char *user_key)
 
 static void usage(void)
 {
-    log_error("Wrong usage. Please reconfigure in squid.conf.\n");
-
-    fprintf(stderr, "Usage: %s [-d] [-l logfile] [-b dbpath] [-p pauselen] [-h] configfile\n", program_name);
-    fprintf(stderr, "	-d            enable debugging output to logfile\n");
-    fprintf(stderr, "	-l logfile    log messages to logfile\n");
+    fprintf(stderr, "Usage: %s [-d] [-b dbpath] [-p pauselen] [-h] configfile\n", program_name);
+    fprintf(stderr, "	-d            enable debugging output\n");
     fprintf(stderr, "	-b dbpath     Path where persistent session database will be kept\n");
     fprintf(stderr, "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n");
     fprintf(stderr, "	-p pauselen   length in seconds to describe a pause between 2 requests.\n");
@@ -416,13 +404,10 @@ int main(int argc, char **argv)
 
     program_name = argv[0];
 
-    while ((opt = getopt(argc, argv, "dp:l:b:h")) != -1) {
+    while ((opt = getopt(argc, argv, "dp:b:h")) != -1) {
         switch (opt) {
         case 'd':
             tq_debug_enabled = true;
-            break;
-        case 'l':
-            open_log(optarg);
             break;
         case 'b':
             db_path = optarg;
@@ -433,6 +418,11 @@ int main(int argc, char **argv)
         case 'h':
             usage();
             exit(EXIT_SUCCESS);
+            break;
+        default:
+            // getopt() emits error message to stderr
+            usage();
+            exit(EXIT_FAILURE);
             break;
         }
     }


### PR DESCRIPTION
Supporting logging to a file complicates upgrading helper code to use
debugs() because DebugFile code calls commSetCloseOnExec(), and our
comm/libminimal does not currently provide a functioning implementation
for that API: The existing implementation is an unconditional assert.
To save development time while upgrading helpers, we are dropping this
feature. It can probably be emulated using shell redirection tricks.

----
Manual backport of master/v7 commit 2d93cfe7.