### PR TITLE
Fix cross-compilation on Gentoo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ AS_IF([test "x$ac_cv_path_PERL" = "xnone"],[
 AC_PATH_PROG(POD2MAN, pod2man, $FALSE)
 AM_CONDITIONAL(ENABLE_POD2MAN_DOC, test "x${ac_cv_path_POD2MAN}" != "x$FALSE")
 
-AC_PATH_PROG(AR, ar, $FALSE)
+AC_CHECK_TOOL(AR, ar, :)
 AR_R="$AR r"
 AC_SUBST(AR_R)
 


### PR DESCRIPTION
    AR="x86_64-pc-linux-gnu-ar"
    checking for ar... /bin/false
    checking for x86_64-pc-linux-gnu-ar... /bin/false
    ...
    libtool: link: /bin/false cr .libs/libcompatsquid.a...
    make[1]: *** [Makefile:899: libcompatsquid.la] Error 1

Use AC_CHECK_TOOL that checks the environment variable `$AR` as well,
which is useful when cross-compiling (e.g., on Gentoo).

Autoconf v2.72 introduces AC_PROG_AR which does the same thing, but we
do not want to require that 2023 Autoconf version at this time.

TODO: We should be using Automake's AM_PROG_AR (available since 2011
Automake v1.11.0a) instead of manually creating AR_R. AM_PROG_AR also
uses AC_CHECK_TOOLS internally but checks for more `ar` tool variations.

Gentoo bug report: https://bugs.gentoo.org/911945