### PR TITLE
Replace MEM_DREAD_CTRL pool with MEMPROXY class pool

### DIFF
--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -364,7 +364,7 @@ diskHandleRead(int fd, void *data)
      */
 
     if (fd < 0) {
-        memFree(ctrl_dat, MEM_DREAD_CTRL);
+        delete ctrl_dat;
         return;
     }
 
@@ -414,7 +414,7 @@ diskHandleRead(int fd, void *data)
 
     cbdataReferenceDone(ctrl_dat->client_data);
 
-    memFree(ctrl_dat, MEM_DREAD_CTRL);
+    delete ctrl_dat;
 }
 
 /* start read operation */
@@ -424,14 +424,12 @@ diskHandleRead(int fd, void *data)
 void
 file_read(int fd, char *buf, int req_len, off_t offset, DRCB * handler, void *client_data)
 {
-    dread_ctrl *ctrl_dat;
     assert(fd >= 0);
-    ctrl_dat = (dread_ctrl *)memAllocate(MEM_DREAD_CTRL);
+    auto *ctrl_dat = new dread_ctrl;
     ctrl_dat->fd = fd;
     ctrl_dat->offset = offset;
     ctrl_dat->req_len = req_len;
     ctrl_dat->buf = buf;
-    ctrl_dat->end_of_file = 0;
     ctrl_dat->handler = handler;
     ctrl_dat->client_data = cbdataReference(client_data);
     diskHandleRead(fd, ctrl_dat);

--- a/src/fs_io.cc
+++ b/src/fs_io.cc
@@ -425,13 +425,7 @@ void
 file_read(int fd, char *buf, int req_len, off_t offset, DRCB * handler, void *client_data)
 {
     assert(fd >= 0);
-    auto *ctrl_dat = new dread_ctrl;
-    ctrl_dat->fd = fd;
-    ctrl_dat->offset = offset;
-    ctrl_dat->req_len = req_len;
-    ctrl_dat->buf = buf;
-    ctrl_dat->handler = handler;
-    ctrl_dat->client_data = cbdataReference(client_data);
+    const auto ctrl_dat = new dread_ctrl(fd, offset, buf, req_len, handler, cbdataReference(client_data));
     diskHandleRead(fd, ctrl_dat);
 }
 

--- a/src/fs_io.h
+++ b/src/fs_io.h
@@ -37,8 +37,8 @@ public:
     int req_len = 0;
     char *buf = nullptr;
     int end_of_file = 0;
-    DRCB *handler = {};
-    void *client_data = {};
+    DRCB *handler = nullptr;
+    void *client_data = nullptr;
 };
 
 class dwrite_q

--- a/src/fs_io.h
+++ b/src/fs_io.h
@@ -20,8 +20,18 @@ class MemBuf;
 class dread_ctrl
 {
     MEMPROXY_CLASS(dread_ctrl);
-
 public:
+    dread_ctrl(int aFd, off_t aOffset, char *aBuf, int aLen, DRCB *aHandler, void *aData) :
+        fd(aFd),
+        offset(aOffset),
+        req_len(aLen),
+        buf(aBuf),
+        handler(aHandler),
+        client_data(aData)
+    {}
+    dread_ctrl(dread_ctrl &&) = delete; // no copying or moving of any kind
+    ~dread_ctrl() = default;
+
     int fd = -1;
     off_t offset = 0;
     int req_len = 0;

--- a/src/fs_io.h
+++ b/src/fs_io.h
@@ -17,17 +17,18 @@
 
 class MemBuf;
 
-// POD
 class dread_ctrl
 {
+    MEMPROXY_CLASS(dread_ctrl);
+
 public:
-    int fd;
-    off_t offset;
-    int req_len;
-    char *buf;
-    int end_of_file;
-    DRCB *handler;
-    void *client_data;
+    int fd = -1;
+    off_t offset = 0;
+    int req_len = 0;
+    char *buf = nullptr;
+    int end_of_file = 0;
+    DRCB *handler = {};
+    void *client_data = {};
 };
 
 class dwrite_q

--- a/src/mem/forward.h
+++ b/src/mem/forward.h
@@ -51,7 +51,6 @@ typedef enum {
     MEM_16K_BUF,
     MEM_32K_BUF,
     MEM_64K_BUF,
-    MEM_DREAD_CTRL,
     MEM_MD5_DIGEST,
     MEM_MAX
 } mem_type;

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -308,7 +308,6 @@ Mem::Init(void)
     memDataInit(MEM_32K_BUF, "32K Buffer", 32768, 10, false);
     memDataInit(MEM_64K_BUF, "64K Buffer", 65536, 10, false);
     // TODO: Carefully stop zeroing these objects memory and drop the doZero parameter
-    memDataInit(MEM_DREAD_CTRL, "dread_ctrl", sizeof(dread_ctrl), 0, true);
     memDataInit(MEM_MD5_DIGEST, "MD5 digest", SQUID_MD5_DIGEST_LENGTH, 0, true);
     GetPool(MEM_MD5_DIGEST)->setChunkSize(512 * 1024);
 


### PR DESCRIPTION
Replacing memory allocate and destruct with C++ new/delete
and in-class initialization.