### PR TITLE
CI: Replace Fedora 39 with 41

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -24,8 +24,8 @@ jobs:
           - debian-stable
           - debian-testing
           - debian-unstable
-          - fedora-39
           - fedora-40
+          - fedora-41
           - fedora-rawhide
           - gentoo
           - opensuse-leap


### PR DESCRIPTION
Fedora 39 will become EOL on 2024-11-12. Fedora 41 has been released.