### PR TITLE
Display Linux variant at ./configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,18 @@ AS_IF([test -n "$squid_host_os_version"],[
 ])
 AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
+AS_IF([test -e /etc/os-release],[
+  . /etc/os-release
+  printed_os_name="no"
+  AS_IF([test "x$PRETTY_NAME" != "x"],[
+    AC_MSG_NOTICE([Building on $PRETTY_NAME])
+    printed_os_name="yes"
+  ])
+  AS_IF([test "x$printed_os_name" = "xno" -a "x$NAME" != "x"],[
+    AC_MSG_NOTICE([Building on $NAME])
+    printed_os_name="yes"
+  ])
+])
 
 AC_PROG_CC
 AM_PROG_CC_C_O

--- a/configure.ac
+++ b/configure.ac
@@ -49,9 +49,9 @@ AS_IF([test -n "$squid_host_os_version"],[
 AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
 
-printed_os_name="no"
 AS_IF([test -e /etc/os-release],[
   . /etc/os-release
+  printed_os_name="no"
   AS_IF([test "x$PRETTY_NAME" != "x"],[
     AC_MSG_NOTICE([Building on $PRETTY_NAME])
     printed_os_name="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -50,16 +50,14 @@ AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
 
 AS_IF([test -e /etc/os-release],[
-  squid_cv_linux_distro_name=`grep '^PRETTY_NAME=' /etc/os-release | sed 's/^[[^"]]*"//;s/".*$//'`
-  AS_IF([test "x$squid_cv_linux_distro_name" = "x"],[
-    squid_cv_linux_distro_name=`grep '^NAME=' /etc/os-release | sed 's/^[[^"]]*"//;s/".*$//'`
+  squid_build_os_release_name=`grep '^PRETTY_NAME=' /etc/os-release | sed 's/^[[^"]]*"//;s/".*$//'`
+  AS_IF([test "x$squid_build_os_release_name" = "x"],[
+    squid_build_os_release_name=`grep '^NAME=' /etc/os-release | sed 's/^[[^"]]*"//;s/".*$//'`
   ])
-  AS_IF([test "x$squid_cv_linux_distro_name" != "x"],[
-    AC_MSG_NOTICE([Building on $squid_cv_linux_distro_name])
+  AS_IF([test "x$squid_build_os_release_name" != "x"],[
+    AC_MSG_NOTICE([Building on $squid_build_os_release_name])
   ])
 ])
-
-
 
 AC_PROG_CC
 AM_PROG_CC_C_O

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,7 @@ AS_IF([test -n "$squid_host_os_version"],[
 ])
 AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
+
 AS_IF([test -e /etc/os-release],[
   . /etc/os-release
   printed_os_name="no"
@@ -58,6 +59,9 @@ AS_IF([test -e /etc/os-release],[
   AS_IF([test "x$printed_os_name" = "xno" -a "x$NAME" != "x"],[
     AC_MSG_NOTICE([Building on $NAME])
     printed_os_name="yes"
+  ])
+  AS_IF([test "x$printed_os_name" = "xno"],[
+    AC_MSG_NOTICE([Building on `uname -a`])
   ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,9 +49,9 @@ AS_IF([test -n "$squid_host_os_version"],[
 AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
 
+printed_os_name="no"
 AS_IF([test -e /etc/os-release],[
   . /etc/os-release
-  printed_os_name="no"
   AS_IF([test "x$PRETTY_NAME" != "x"],[
     AC_MSG_NOTICE([Building on $PRETTY_NAME])
     printed_os_name="yes"
@@ -59,9 +59,6 @@ AS_IF([test -e /etc/os-release],[
   AS_IF([test "x$printed_os_name" = "xno" -a "x$NAME" != "x"],[
     AC_MSG_NOTICE([Building on $NAME])
     printed_os_name="yes"
-  ])
-  AS_IF([test "x$printed_os_name" = "xno"],[
-    AC_MSG_NOTICE([Building on `uname -a`])
   ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,17 +50,16 @@ AC_MSG_RESULT($squid_host_os (version $squid_host_os_version))
 # on windows squid_host_os is either mingw or cygwin, version is 32
 
 AS_IF([test -e /etc/os-release],[
-  . /etc/os-release
-  printed_os_name="no"
-  AS_IF([test "x$PRETTY_NAME" != "x"],[
-    AC_MSG_NOTICE([Building on $PRETTY_NAME])
-    printed_os_name="yes"
+  squid_cv_linux_distro_name=`grep '^PRETTY_NAME=' /etc/os-release | sed 's/^[[^"]]*"//;s/".*$//'`
+  AS_IF([test "x$squid_cv_linux_distro_name" = "x"],[
+    squid_cv_linux_distro_name=`grep '^NAME=' /etc/os-release | sed 's/^[[^"]]*"//;s/".*$//'`
   ])
-  AS_IF([test "x$printed_os_name" = "xno" -a "x$NAME" != "x"],[
-    AC_MSG_NOTICE([Building on $NAME])
-    printed_os_name="yes"
+  AS_IF([test "x$squid_cv_linux_distro_name" != "x"],[
+    AC_MSG_NOTICE([Building on $squid_cv_linux_distro_name])
   ])
 ])
+
+
 
 AC_PROG_CC
 AM_PROG_CC_C_O


### PR DESCRIPTION
Linux standards offer an /etc/os-release file containing
information about the operating system.

Parse that file and print an identifier of the Linux version at
configure time.