### PR TITLE
Nil request dereference in ACLExtUser and SourceDomainCheck ACLs

### DIFF
--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -27,6 +27,7 @@ public:
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;
+    bool requiresRequest() const override { return true; }
     SBufList dump() const override;
     bool empty () const override;
 

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -30,7 +30,11 @@ LookupDone(const char *, const Dns::LookupDetails &details, void *data)
 {
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->markSourceDomainChecked();
-    checklist->request->recordLookup(details);
+    if (checklist->request)
+        checklist->request->recordLookup(details);
+    else
+        debugs(28, 3, "no request to recordLookup()");
+
     checklist->resumeNonBlockingCheck();
 }
 

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -23,6 +23,7 @@ class SourceDomainCheck: public ParameterizedNode< ACLData<const char *> >
 public:
     /* Acl::Node API */
     int match(ACLChecklist *) override;
+    bool requiresRequest() const override { return true; }
 };
 
 } // namespace Acl

--- a/src/acl/SourceDomain.h
+++ b/src/acl/SourceDomain.h
@@ -23,7 +23,6 @@ class SourceDomainCheck: public ParameterizedNode< ACLData<const char *> >
 public:
     /* Acl::Node API */
     int match(ACLChecklist *) override;
-    bool requiresRequest() const override { return true; }
 };
 
 } // namespace Acl


### PR DESCRIPTION
ACLExtUser-based ACLs (i.e. ext_user and ext_user_regex) dereferenced a
nil request pointer when they were used in a context without a request
(e.g., when honoring on_unsupported_protocol).

SourceDomainCheck-based ACLs (i.e. srcdomain and srcdom_regex) have a
similar bug, although we do not know whether broken slow ACL code is
reachable without a request (e.g., on_unsupported_protocol tests cannot
reach that code until that directive starts supporting slow ACLs). This
change does not start to require request presence for these two ACLs to
avoid breaking any existing configurations that "work" without one.
