### PR TITLE
CI: Add ccache to GitHub Actions build tests

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -136,7 +136,7 @@ jobs:
         uses: squid-cache/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
-          key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
+          key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux
         run: ./test-builds.sh ${{ matrix.layer.name }}

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: squid-cache/ccache-action@v1.2
+        uses: squid-cache/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
           append-timestamp: false

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: squid-cache/ccache-action@v1.2
         with:
           verbose: 2 # default 0
           append-timestamp: false

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -136,7 +136,7 @@ jobs:
         uses: squid-cache/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
-          append-timestamp: false
+          append-timestamp: true
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -116,8 +116,8 @@ jobs:
     name: build-tests(${{ matrix.os }},${{ matrix.compiler.CC }},${{ matrix.layer.nick }})
 
     env:
-      CC: ${{ matrix.compiler.CC }}
-      CXX: ${{ matrix.compiler.CXX }}
+      CC: /usr/bin/ccache ${{ matrix.compiler.CC }}
+      CXX: /usr/bin/ccache ${{ matrix.compiler.CXX }}
 
     steps:
 
@@ -127,10 +127,17 @@ jobs:
           sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
-          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin ${{ matrix.compiler.CC }}
+          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin ${{ matrix.compiler.CC }} ccache
 
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          verbose: 2 # default 0
+          append-timestamp: false
+          key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux
         run: ./test-builds.sh ${{ matrix.layer.name }}

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -136,7 +136,6 @@ jobs:
         uses: squid-cache/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
-          append-timestamp: true
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -60,7 +60,6 @@ jobs:
         uses: squid-cache/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
-          append-timestamp: false
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run test-builds

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: squid-cache/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
-          key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
+          key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run test-builds
         id: test-builds

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: squid-cache/ccache-action@v1.2
         with:
           verbose: 2 # default 0
           append-timestamp: false

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: squid-cache/ccache-action@v1.2
+        uses: squid-cache/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
           append-timestamp: false

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -49,12 +49,19 @@ jobs:
 
     name: linux-distros(${{ matrix.os }},${{ matrix.compiler.CC }},${{ matrix.layer.nick }})
     env:
-      CC: ${{ matrix.compiler.CC }}
-      CXX: ${{ matrix.compiler.CXX }}
+      CC: /usr/bin/ccache ${{ matrix.compiler.CC }}
+      CXX: /usr/bin/ccache ${{ matrix.compiler.CXX }}
 
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          verbose: 2 # default 0
+          append-timestamp: false
+          key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run test-builds
         id: test-builds


### PR DESCRIPTION
Depending on an individual build test, adding ccache currently reduces
build test time 35-60% (e.g., from 6m42s to 4m18s and from 17m to 7m).

Problematic ccache entries can be removed using GitHub API. For example:

    gh -R squid-cache/squid cache list
    gh -R squid-cache/squid cache delete <cache-key|"all">

Do not add ccache to MacOS build tests because I had mixed experience
with that optimization on that OS.