### PR TITLE
ext_time_quota_acl: restore debug level feature and argument

### DIFF
--- a/src/acl/external/time_quota/ext_time_quota_acl.8
+++ b/src/acl/external/time_quota/ext_time_quota_acl.8
@@ -7,7 +7,7 @@ Version 1.0
 .
 .SH SYNOPSIS
 .if !'po4a'hide' .B ext_time_quota_acl
-.if !'po4a'hide' .B "[\-b database] [\-d] [\-p pauselen] [\-h] configfile
+.if !'po4a'hide' .B "[\-b database] [\-d level] [\-p pauselen] [\-h] configfile
 .
 .SH DESCRIPTION
 .B ext_time_quota_acl
@@ -36,7 +36,7 @@ Default is 300 seconds (5 minutes).
 .
 .if !'po4a'hide' .TP
 .if !'po4a'hide' .B "\-d"
-Enables debug logging to stderr.
+Enables debug logging to stderr, at growing levels of verbosity from 0 to 9.
 .
 .if !'po4a'hide' .TP
 .if !'po4a'hide' .B "\-h"

--- a/src/acl/external/time_quota/ext_time_quota_acl.8
+++ b/src/acl/external/time_quota/ext_time_quota_acl.8
@@ -36,7 +36,7 @@ Default is 300 seconds (5 minutes).
 .
 .if !'po4a'hide' .TP
 .if !'po4a'hide' .B "\-d"
-Enables debug logging to stderr, at growing levels of verbosity from 0 to 9.
+Sets verbosity level for debugging section 82 (0-9; defaults to 1; see debug_options).
 .
 .if !'po4a'hide' .TP
 .if !'po4a'hide' .B "\-h"

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
     while ((opt = getopt(argc, argv, "d:p:b:h")) != -1) {
         switch (opt) {
         case 'd':
-            Debug::parseOptions(ToSBuf("debug_options ", MY_DEBUG_SECTION, ",", optarg).c_str());
+            Debug::parseOptions(ToSBuf(MY_DEBUG_SECTION, ",", optarg).c_str());
             break;
         case 'b':
             db_path = optarg;

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -328,13 +328,12 @@ static void usage(void)
     debugs(MY_DEBUG_SECTION, DBG_CRITICAL, "Wrong usage. Please reconfigure in squid.conf.");
 
     std::cerr <<
-              "Usage: " << program_name << " [-d] [-b dbpath] [-p pauselen] [-h] configfile\n"
-              "	-d            enable debugging output\n"
-              "	-l logfile    log messages to logfile\n"
-              "	-b dbpath     Path where persistent session database will be kept\n"
-              "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n"
-              "	-p pauselen   length in seconds to describe a pause between 2 requests.\n"
-              "	-h            show show command line help.\n"
+              "Usage: " << program_name << " [-d] [-b dbpath] [-p pauselen] [-h] configfile\n" <<
+              "	-d level      enable debugging output at level\n" <<
+              "	-b dbpath     Path where persistent session database will be kept\n" <<
+              "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n" <<
+              "	-p pauselen   length in seconds to describe a pause between 2 requests.\n" <<
+              "	-h            show show command line help.\n" <<
               "configfile is a file containing time quota definitions.\n";
 }
 
@@ -346,10 +345,10 @@ int main(int argc, char **argv)
     program_name = argv[0];
     Debug::NameThisHelper("ext_time_quota_acl");
 
-    while ((opt = getopt(argc, argv, "dp:b:h")) != -1) {
+    while ((opt = getopt(argc, argv, "d:p:b:h")) != -1) {
         switch (opt) {
         case 'd':
-            Debug::Levels[MY_DEBUG_SECTION] = DBG_DATA;
+            Debug::Levels[DEBUG_SECTION] = atoi(optarg);
             break;
         case 'b':
             db_path = optarg;

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -330,7 +330,7 @@ static void usage(void)
     std::cerr <<
               "Usage: " << program_name << " [-d level] [-b dbpath] [-p pauselen] [-h] configfile\n" <<
               "	-d level      set section " << MY_DEBUG_SECTION << " debugging to the specified level,\n"
-              "               overwriting for this helper Squid's debug_options (default: 1)\n"
+              "               overwriting Squid's debug_options (default: 1)\n"
               "	-b dbpath     Path where persistent session database will be kept\n" <<
               "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n" <<
               "	-p pauselen   length in seconds to describe a pause between 2 requests.\n" <<

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -332,7 +332,7 @@ static void usage(void)
               "	-d level      set section " << MY_DEBUG_SECTION << " debugging to the specified level,\n"
               "               overwriting Squid's debug_options (default: 1)\n"
               "	-b dbpath     Path where persistent session database will be kept\n" <<
-              "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n" <<
+              "	              If option is not used, then " << DEFAULT_QUOTA_DB << " will be used.\n" <<
               "	-p pauselen   length in seconds to describe a pause between 2 requests.\n" <<
               "	-h            show show command line help.\n" <<
               "configfile is a file containing time quota definitions.\n";

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -329,7 +329,8 @@ static void usage(void)
 
     std::cerr <<
               "Usage: " << program_name << " [-d level] [-b dbpath] [-p pauselen] [-h] configfile\n" <<
-              "	-d level      enable debugging output at level\n" <<
+              "	-d level      set section " << MY_DEBUG_SECTION << " debugging to the specified level, "
+              "               overwriting for this helper Squid's debug_options (default: 1)\n"
               "	-b dbpath     Path where persistent session database will be kept\n" <<
               "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n" <<
               "	-p pauselen   length in seconds to describe a pause between 2 requests.\n" <<

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -348,7 +348,7 @@ int main(int argc, char **argv)
     while ((opt = getopt(argc, argv, "d:p:b:h")) != -1) {
         switch (opt) {
         case 'd':
-            Debug::Levels[MY_DEBUG_SECTION] = atoi(optarg);
+            Debug::parseOptions(ToSBuf("debug_options ", MY_DEBUG_SECTION, ",", optarg).c_str());
             break;
         case 'b':
             db_path = optarg;

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -328,7 +328,7 @@ static void usage(void)
     debugs(MY_DEBUG_SECTION, DBG_CRITICAL, "Wrong usage. Please reconfigure in squid.conf.");
 
     std::cerr <<
-              "Usage: " << program_name << " [-d] [-b dbpath] [-p pauselen] [-h] configfile\n" <<
+              "Usage: " << program_name << " [-d level] [-b dbpath] [-p pauselen] [-h] configfile\n" <<
               "	-d level      enable debugging output at level\n" <<
               "	-b dbpath     Path where persistent session database will be kept\n" <<
               "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n" <<

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -348,7 +348,7 @@ int main(int argc, char **argv)
     while ((opt = getopt(argc, argv, "d:p:b:h")) != -1) {
         switch (opt) {
         case 'd':
-            Debug::Levels[DEBUG_SECTION] = atoi(optarg);
+            Debug::Levels[MY_DEBUG_SECTION] = atoi(optarg);
             break;
         case 'b':
             db_path = optarg;

--- a/src/acl/external/time_quota/ext_time_quota_acl.cc
+++ b/src/acl/external/time_quota/ext_time_quota_acl.cc
@@ -329,7 +329,7 @@ static void usage(void)
 
     std::cerr <<
               "Usage: " << program_name << " [-d level] [-b dbpath] [-p pauselen] [-h] configfile\n" <<
-              "	-d level      set section " << MY_DEBUG_SECTION << " debugging to the specified level, "
+              "	-d level      set section " << MY_DEBUG_SECTION << " debugging to the specified level,\n"
               "               overwriting for this helper Squid's debug_options (default: 1)\n"
               "	-b dbpath     Path where persistent session database will be kept\n" <<
               "	              If option is not used, then " DEFAULT_QUOTA_DB " will be used.\n" <<


### PR DESCRIPTION
Commit 4878cfe567 modernized the time quota ACL helper,
but removed the '-d debuglevel' feature, reducing it to a binary
toggle.