### PR TITLE
Fix systemd startup sequence to require active Local Filesystem

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -511,6 +511,7 @@ Thank you!
     Thomas Zajic <zlatko-github@zlatk0.net>
     Thomas-Martin Seck <tmseck@netcologne.de>
     Tianyin Xu <tixu@cs.ucsd.edu>
+    Tilman Heinrich <tilHeinrich@web.de>
     Tilmann Bubeck <t.bubeck@reinform.de>
     Tim Brown <squid-cache@machine.org.uk>
     Tim Starling <tstarling@wikimedia.org>

--- a/tools/systemd/squid.service
+++ b/tools/systemd/squid.service
@@ -8,7 +8,7 @@
 [Unit]
 Description=Squid Web Proxy Server
 Documentation=man:squid(8)
-After=network.target network-online.target nss-lookup.target
+After=local-fs.target network.target network-online.target nss-lookup.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
Squid requires Local Filesystem to be active. While uncommon, it
may in some cases be incomplete or delayed. Ensure that the
dependency is explicitly listed to prevent failure from Squid
early initialization.

This change resolves Debian Bug 956581:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956581