### PR TITLE
CI: Cancel obsolete concurrent GitHub Actions workflow jobs

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -17,9 +17,10 @@ on:
     branches: [ "master" ]
 
 concurrency:
-  # cancel old runs in case of push to same pr or branch
+  # Cancel ongoing tests in case of push to the same PR or staging branch,
+  # but let previous master commit tests complete.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'master' }}
 
 env:
   # empty except for pull_request events

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -16,6 +16,11 @@ on:
     # test PRs targeting this branch code
     branches: [ "master" ]
 
+concurrency:
+  # cancel old runs in case of push to same pr or branch
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # empty except for pull_request events
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -139,7 +139,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run build on Linux
-        run: echo "ref: ${{ github.ref }}" ; ./test-builds.sh ${{ matrix.layer.name }}
+        run: |
+          echo "ref: ${{ github.ref }}"
+          ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -21,7 +21,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-
 env:
   # empty except for pull_request events
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -20,7 +20,7 @@ concurrency:
   # Cancel ongoing tests in case of push to the same PR or staging branch,
   # but let previous master commit tests complete.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   # empty except for pull_request events

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run build on Linux
-        run: ./test-builds.sh ${{ matrix.layer.name }}
+        run: echo "ref: ${{ github.ref }}" ; ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -21,6 +21,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+
 env:
   # empty except for pull_request events
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -139,9 +139,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run build on Linux
-        run: |
-          echo "ref: ${{ github.ref }}"
-          ./test-builds.sh ${{ matrix.layer.name }}
+        run: ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -14,6 +14,12 @@ on:
   push:
     branches: [ "auto" ]
 
+concurrency:
+  # Cancel ongoing tests in case of push to the same PR or staging branch,
+  # but let previous master commit tests complete.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   linux-distros:
 

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -15,10 +15,9 @@ on:
     branches: [ "auto" ]
 
 concurrency:
-  # Cancel ongoing tests in case of push to the same PR or staging branch,
-  # but let previous master commit tests complete.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  # Cancel ongoing tests in case of push to staging branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linux-distros:


### PR DESCRIPTION
If a new push happens to a staging branch or a PR branch, continuing to
run now-obsolete tests is pointless and wasteful. However, we do want to
finish any jobs running on previous master branch commits, so that every
master branch commit has full test results.
