### PR TITLE
Reduce SO_LINGER code duplication

### DIFF
--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -48,6 +48,7 @@ libbase_la_SOURCES = \
 	JobWait.h \
 	Lock.h \
 	LookupTable.h \
+	OnOff.h \
 	Packable.h \
 	PackableStream.h \
 	Random.cc \

--- a/src/base/OnOff.h
+++ b/src/base/OnOff.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 1996-2024 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_BASE_ONOFF_H
+#define SQUID_SRC_BASE_ONOFF_H
+
+/// safer than bool in a list of integer-like function parameters
+enum class OnOff { off, on };
+
+#endif /* SQUID_SRC_BASE_ONOFF_H */
+

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -10,6 +10,7 @@
 
 #include "squid.h"
 #include "base/AsyncFunCalls.h"
+#include "base/OnOff.h"
 #include "ClientInfo.h"
 #include "comm/AcceptLimiter.h"
 #include "comm/comm_internal.h"
@@ -779,9 +780,6 @@ commCallCloseHandlers(int fd)
         }
     }
 }
-
-/// safer than bool in a list of integer-like function parameters
-enum class OnOff { off, on }; // TODO: Move somewhere to reuse.
 
 /// sets SO_LINGER socket(7) option
 /// \param enabled -- whether linger will be active (sets linger::l_onoff)

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -780,6 +780,25 @@ commCallCloseHandlers(int fd)
     }
 }
 
+/// safer than bool in a list of integer-like function parameters
+enum class OnOff { off, on }; // TODO: Move somewhere to reuse.
+
+/// sets SO_LINGER socket(7) option
+/// \param enabled -- whether linger will be active (sets linger::l_onoff)
+/// \param timeoutInSeconds -- how long to linger for (sets linger::l_linger)
+static void
+commConfigureLinger(const int fd, const OnOff enabled, const int timeoutInSeconds = 0)
+{
+    struct linger l;
+    l.l_onoff = (enabled == OnOff::on ? 1 : 0);
+    l.l_linger = timeoutInSeconds;
+
+    if (setsockopt(fd, SOL_SOCKET, SO_LINGER, reinterpret_cast<char*>(&l), sizeof(l)) < 0) {
+        const auto xerrno = errno;
+        debugs(50, DBG_CRITICAL, "ERROR: Failed to set closure behavior (SO_LINGER) for FD " << fd << ": " << xstrerr(xerrno));
+    }
+}
+
 /**
  * enable linger with time of 0 so that when the socket is
  * closed, TCP generates a RESET
@@ -787,29 +806,18 @@ commCallCloseHandlers(int fd)
 void
 comm_reset_close(const Comm::ConnectionPointer &conn)
 {
-    struct linger L;
-    L.l_onoff = 1;
-    L.l_linger = 0;
-
-    if (setsockopt(conn->fd, SOL_SOCKET, SO_LINGER, (char *) &L, sizeof(L)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_CRITICAL, "ERROR: Closing " << conn << " with TCP RST: " << xstrerr(xerrno));
+    if (Comm::IsConnOpen(conn)) {
+        commConfigureLinger(conn->fd, OnOff::on, 0);
+        debugs(5, 7, conn->id);
+        conn->close();
     }
-    conn->close();
 }
 
 // Legacy close function.
 void
 old_comm_reset_close(int fd)
 {
-    struct linger L;
-    L.l_onoff = 1;
-    L.l_linger = 0;
-
-    if (setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *) &L, sizeof(L)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_CRITICAL, "ERROR: Closing FD " << fd << " with TCP RST: " << xstrerr(xerrno));
-    }
+    commConfigureLinger(fd, OnOff::on, 0);
     comm_close(fd);
 }
 
@@ -1024,15 +1032,7 @@ comm_remove_close_handler(int fd, AsyncCall::Pointer &call)
 static void
 commSetNoLinger(int fd)
 {
-
-    struct linger L;
-    L.l_onoff = 0;      /* off */
-    L.l_linger = 0;
-
-    if (setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *) &L, sizeof(L)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_CRITICAL, MYNAME << "FD " << fd << ": " << xstrerr(xerrno));
-    }
+    commConfigureLinger(fd, OnOff::off);
     fd_table[fd].flags.nolinger = true;
 }
 

--- a/src/fde.h
+++ b/src/fde.h
@@ -119,7 +119,6 @@ public:
         bool close_request = false; ///< true if file_ or comm_close has been called
         bool write_daemon = false;
         bool socket_eof = false;
-        bool nolinger = false;
         bool nonblocking = false;
         bool ipc = false;
         bool called_connect = false;

--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -674,7 +674,7 @@ ipc_thread_1(void *in_params)
     }
 
     /* else {                       IPC_TCP_SOCKET */
-    /*     commSetNoLinger(fd); */
+    /*     commConfigureLinger(fd, OnOff::off); */
     /*  } */
     thread_params.prog = prog;
 


### PR DESCRIPTION
Also prevent nil connection pointer dereference and setsockopt() calls
with negative FD in comm_reset_close() and old_comm_reset_close().
It is unknown whether such bugs could be triggered before these changes.

Also removed fde::flags::nolinger as unused since 1999 commit 2391a162.