### PR TITLE
CI: Use ccache-action repo maintained by its original author

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: squid-cache/ccache-action@v1.2.14
+        uses: hendrikmuhs/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: squid-cache/ccache-action@v1.2.14
+        uses: hendrikmuhs/ccache-action@v1.2.14
         with:
           verbose: 2 # default 0
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}


### PR DESCRIPTION
    squid-cache/ccache-action@v1.2.14 is not allowed to be used in ...

For recent commit 627cca6d, we cloned hendrikmuhs/ccache-action
repository because GitHub Actions prohibited usage of that repository in
Squid Project CI tests. Cloning worked around that restriction, but we
did not realize that there are other solutions, and that cloning forces
all other Squid repositories to either clone squid-cache/ccache-action
or permit squid-cache/ccache-action execution by other means.

To reduce the number of obscure repositories Squid Project and others
have to deal with, it is better to adjust repository configuration to
allow well-known hendrikmuhs/ccache-action in "Actions permissions" at
https://github.com/.../squid/settings/actions
