### PR TITLE
Do not clobber the Total line in mgr:mem report

### DIFF
--- a/src/mem/PoolChunked.cc
+++ b/src/mem/PoolChunked.cc
@@ -437,7 +437,6 @@ MemPoolChunked::getStats(Mem::PoolStats &stats)
 
     clean((time_t) 555555); /* don't want to get chunks released before reporting */
 
-    stats.pool = this;
     stats.label = label;
     stats.meter = &meter;
     stats.obj_size = objectSize;

--- a/src/mem/PoolMalloc.cc
+++ b/src/mem/PoolMalloc.cc
@@ -61,7 +61,6 @@ MemPoolMalloc::deallocate(void *obj)
 size_t
 MemPoolMalloc::getStats(Mem::PoolStats &stats)
 {
-    stats.pool = this;
     stats.label = label;
     stats.meter = &meter;
     stats.obj_size = objectSize;

--- a/src/mem/Stats.cc
+++ b/src/mem/Stats.cc
@@ -25,10 +25,11 @@ Mem::GlobalStats(PoolStats &stats)
     }
 
     // Reset PoolStats::meter, label, and obj_size data members after getStats()
-    // calls in the above loop set them. TODO: Refactor to remove these members.
+    // calls in the above loop set them. TODO: Refactor to remove these data members.
     stats.meter = &TheMeter;
     stats.label = "Total";
     stats.obj_size = 1;
+
     stats.overhead += sizeof(MemPools);
 
     return pools_inuse;

--- a/src/mem/Stats.cc
+++ b/src/mem/Stats.cc
@@ -25,7 +25,7 @@ Mem::GlobalStats(PoolStats &stats)
     }
 
     // Reset PoolStats::meter, label, and obj_size data members after getStats()
-    // calls in the above loop set them. TODO: Refactor to remove these data members.
+    // calls in the above loop set them.
     stats.meter = &TheMeter;
     stats.label = "Total";
     stats.obj_size = 1;

--- a/src/mem/Stats.cc
+++ b/src/mem/Stats.cc
@@ -16,11 +16,6 @@ Mem::GlobalStats(PoolStats &stats)
 {
     MemPools::GetInstance().flushMeters();
 
-    stats.meter = &TheMeter;
-    stats.label = "Total";
-    stats.obj_size = 1;
-    stats.overhead += sizeof(MemPools);
-
     /* gather all stats for Totals */
     size_t pools_inuse = 0;
     for (const auto pool: MemPools::GetInstance().pools) {
@@ -28,6 +23,13 @@ Mem::GlobalStats(PoolStats &stats)
             ++pools_inuse;
         stats.overhead += sizeof(Allocator *);
     }
+
+    // Reset PoolStats::meter, label, and obj_size data members after getStats()
+    // calls in the above loop set them. TODO: Refactor to remove these members.
+    stats.meter = &TheMeter;
+    stats.label = "Total";
+    stats.obj_size = 1;
+    stats.overhead += sizeof(MemPools);
 
     return pools_inuse;
 }

--- a/src/mem/Stats.h
+++ b/src/mem/Stats.h
@@ -17,7 +17,6 @@ namespace Mem
 class PoolStats
 {
 public:
-    Allocator *pool = nullptr;
     const char *label = nullptr;
     PoolMeter *meter = nullptr;
     int obj_size = 0;

--- a/src/mem/old_api.cc
+++ b/src/mem/old_api.cc
@@ -586,7 +586,7 @@ Mem::Report(std::ostream &stream)
         PoolStats mp_stats;
         pool->getStats(mp_stats);
 
-        if (mp_stats.pool->meter.gb_allocated.count > 0)
+        if (pool->meter.gb_allocated.count > 0)
             usedPools.emplace_back(mp_stats);
         else
             ++not_used;


### PR DESCRIPTION
Since 2022 commit a7508376, Squid reported incorrect aggregate "Total"
line stats. The line itself was mislabeled by repeating the name of the
last MemPools::pools pool (which may vary with traffic patterns!),
confusing admins and wreaking havoc on mgr:mem analysis scripts.
