### PR TITLE
Annotate PoolMalloc memory in valgrind builds

### DIFF
--- a/src/mem/PoolMalloc.cc
+++ b/src/mem/PoolMalloc.cc
@@ -31,7 +31,10 @@ MemPoolMalloc::allocate()
     if (obj) {
         --meter.idle;
         ++countSavedAllocs;
-        (void)VALGRIND_MAKE_MEM_UNDEFINED(obj, objectSize);
+        if (doZero)
+            (void)VALGRIND_MAKE_MEM_DEFINED(obj, objectSize);
+        else
+            (void)VALGRIND_MAKE_MEM_UNDEFINED(obj, objectSize);
     } else {
         if (doZero)
             obj = xcalloc(1, objectSize);

--- a/src/mem/PoolMalloc.cc
+++ b/src/mem/PoolMalloc.cc
@@ -31,6 +31,7 @@ MemPoolMalloc::allocate()
     if (obj) {
         --meter.idle;
         ++countSavedAllocs;
+        (void)VALGRIND_MAKE_MEM_UNDEFINED(obj, objectSize);
     } else {
         if (doZero)
             obj = xcalloc(1, objectSize);
@@ -52,6 +53,7 @@ MemPoolMalloc::deallocate(void *obj)
     } else {
         if (doZero)
             memset(obj, 0, objectSize);
+        (void)VALGRIND_MAKE_MEM_NOACCESS(obj, objectSize);
         ++meter.idle;
         freelist.push(obj);
     }


### PR DESCRIPTION
MemPoolMalloc code (i.e. memory_pools code used by default) was missing
VALGRIND_MAKE_MEM_*() calls. Similar calls do exist in MemPoolChunked
code (i.e. code enabled by setting MEMPOOLS environment variable to 1).

Even with these markings, "memory_pools on" configuration is still not
quite compatible with Valgrind leak reporting suppressions: In some
cases, Valgrind may still incorrectly suppress leak reporting (or report
leaks that should have been suppressed) because Valgrind associates leak
suppressions with memory _allocators_ while buggy code may leak memory
allocated by others. The long-term solution (if it exists) requires
upgrading these markings to VALGRIND_MEMPOOL_*() API targeting memory
pools, but that requires a serious effort, especially when dealing with
MemPoolChunked complexities. The added markings help detect non-leak
violations and improve PoolMalloc/MemPoolChunked code symmetry.
