### PR TITLE
Refactor peerRefreshDNS() to clarify its (void*)1 logic

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1154,7 +1154,6 @@ peerDnsRefreshStart()
     for (const auto &p: CurrentCachePeers())
         ipcache_nbgethostbyname(p->host, peerDNSConfigure, p.get());
 
-    /* Reconfigure the peers every hour */
     peerScheduleDnsRefreshCheck(3600.0);
 }
 

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1159,9 +1159,9 @@ peerDnsRefreshStart()
 }
 
 static void
-peerDnsRefreshCheck(void *data)
+peerDnsRefreshCheck(void *)
 {
-    if (!data && 0 == stat5minClientRequests()) {
+    if (!stat5minClientRequests()) {
         /* no recent client traffic, wait a bit */
         peerScheduleDnsRefreshCheck(180.0);
         return;

--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -58,7 +58,7 @@ static void neighborAlive(CachePeer *, const MemObject *, const icp_common_t *);
 static void neighborAliveHtcp(CachePeer *, const MemObject *, const HtcpReplyData *);
 #endif
 static void neighborCountIgnored(CachePeer *);
-static void peerRefreshDNS(void *);
+static void peerRefreshDNSNow();
 static IPH peerDNSConfigure;
 static void peerProbeConnect(CachePeer *, const bool reprobeIfBusy = false);
 static CNCB peerProbeConnectDone;
@@ -533,7 +533,7 @@ neighbors_init(void)
         }
     }
 
-    peerRefreshDNS((void *) 1);
+    peerRefreshDNSNow();
 
     sep = getservbyname("echo", "udp");
     echo_port = sep ? ntohs((unsigned short) sep->s_port) : 7;
@@ -1159,6 +1159,12 @@ peerRefreshDNS(void *data)
         return;
     }
 
+    peerRefreshDNSNow();
+}
+
+static void
+peerRefreshDNSNow()
+{
     for (const auto &p: CurrentCachePeers())
         ipcache_nbgethostbyname(p->host, peerDNSConfigure, p.get());
 


### PR DESCRIPTION
Creating a raw pointer with 1 as an address/value raised red flags, and
it was difficult to interpret tricky peerRefreshDNS() logic correctly.