### PR TITLE
Maintenance: improved stat5minClientRequests() naming

### DIFF
--- a/src/neighbors.cc
+++ b/src/neighbors.cc
@@ -1153,7 +1153,7 @@ peerRefreshDNS(void *data)
     if (eventFind(peerRefreshDNS, nullptr))
         eventDelete(peerRefreshDNS, nullptr);
 
-    if (!data && 0 == stat5minClientRequests()) {
+    if (!data && !statSawRecentRequests()) {
         /* no recent client traffic, wait a bit */
         eventAddIsh("peerRefreshDNS", peerRefreshDNS, nullptr, 180.0, 1);
         return;

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1684,11 +1684,15 @@ snmpStatGet(int minutes)
     return &CountHist[minutes];
 }
 
-int
-stat5minClientRequests(void)
+bool
+statSawRecentRequests()
 {
-    assert(N_COUNT_HIST > 5);
-    return statCounter.client_http.requests - CountHist[5].client_http.requests;
+    static const int recentMinutes = 5;
+    assert(N_COUNT_HIST > recentMinutes);
+
+    if (NCountHist > recentMinutes)
+        return statCounter.client_http.requests - CountHist[recentMinutes].client_http.requests;
+    return 0;
 }
 
 static double

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1693,9 +1693,8 @@ statSawRecentRequests()
     // Math below computes the number of requests during the last 0-6 minutes.
     // CountHist is based on "minutes passed since Squid start" periods. It cannot
     // deliver precise info for "last N minutes", but we do not need to be precise.
-    if (NCountHist > recentMinutes)
-        return statCounter.client_http.requests - CountHist[recentMinutes].client_http.requests;
-    return 0;
+    const auto oldRequests = (NCountHist > recentMinutes) ? CountHist[recentMinutes].client_http.requests : 0;
+    return statCounter.client_http.requests - oldRequests;
 }
 
 static double

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -1687,9 +1687,12 @@ snmpStatGet(int minutes)
 bool
 statSawRecentRequests()
 {
-    static const int recentMinutes = 5;
+    static const auto recentMinutes = 5;
     assert(N_COUNT_HIST > recentMinutes);
 
+    // Math below computes the number of requests during the last 0-6 minutes.
+    // CountHist is based on "minutes passed since Squid start" periods. It cannot
+    // deliver precise info for "last N minutes", but we do not need to be precise.
     if (NCountHist > recentMinutes)
         return statCounter.client_http.requests - CountHist[recentMinutes].client_http.requests;
     return 0;

--- a/src/stat.h
+++ b/src/stat.h
@@ -14,8 +14,9 @@
 void statInit(void);
 double median_svc_get(int, int);
 void pconnHistCount(int, int);
-int stat5minClientRequests(void);
-double stat5minCPUUsage(void);
+/// whether we processed any incoming requests in the last few minutes
+/// \sa ClientHttpRequest::updateCounters()
+bool statSawRecentRequests();
 double statRequestHitRatio(int minutes);
 double statRequestHitMemoryRatio(int minutes);
 double statRequestHitDiskRatio(int minutes);


### PR DESCRIPTION
stat5minClientRequests() was to meant to return the number of recent
client requests. However, the function did not provide implied 5 minute
precision. It returned, roughly speaking, the number of requests during
the last 0-6 minutes. The new, less strict function name and boolean
type avoid this false precision implication.

Also removed unused stat5minCPUUsage().