### PR TITLE
Bug 5390: Non-POD SquidConfig::ssl_client::sslContext exit crash

### DIFF
--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -505,7 +505,7 @@ public:
     struct {
         Security::FuturePeerContext *defaultPeerContext;
         // TODO: Remove when FuturePeerContext above becomes PeerContext
-        Security::ContextPointer sslContext;
+        Security::ContextPointer *sslContext;
 #if USE_OPENSSL
         char *foreignIntermediateCertsPath;
         acl_access *cert_error;

--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -505,7 +505,8 @@ public:
     struct {
         Security::FuturePeerContext *defaultPeerContext;
         // TODO: Remove when FuturePeerContext above becomes PeerContext
-        Security::ContextPointer *sslContext;
+        /// \deprecated Legacy storage. Use defaultPeerContext instead.
+        Security::ContextPointer *sslContext_;
 #if USE_OPENSSL
         char *foreignIntermediateCertsPath;
         acl_access *cert_error;

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -3914,8 +3914,8 @@ configFreeMemory(void)
     free_all();
     Dns::ResolveClientAddressesAsap = false;
     delete Config.ssl_client.defaultPeerContext;
-    delete Config.ssl_client.sslContext;
     Config.ssl_client.defaultPeerContext = nullptr;
+    delete Config.ssl_client.sslContext;
     Config.ssl_client.sslContext = nullptr;
 #if USE_OPENSSL
     Ssl::unloadSquidUntrusted();

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -961,8 +961,8 @@ configDoConfigure(void)
         debugs(3, 2, "initializing https:// proxy context");
 
         const auto rawSslContext = Security::ProxyOutgoingConfig.createClientContext(false);
-        Config.ssl_client.sslContext = rawSslContext ? new Security::ContextPointer(rawSslContext) : nullptr;
-        if (!Config.ssl_client.sslContext) {
+        Config.ssl_client.sslContext_ = rawSslContext ? new Security::ContextPointer(rawSslContext) : nullptr;
+        if (!Config.ssl_client.sslContext_) {
 #if USE_OPENSSL
             fatal("ERROR: Could not initialize https:// proxy context");
 #else
@@ -970,9 +970,9 @@ configDoConfigure(void)
 #endif
         }
 #if USE_OPENSSL
-        Ssl::useSquidUntrusted(Config.ssl_client.sslContext->get());
+        Ssl::useSquidUntrusted(Config.ssl_client.sslContext_->get());
 #endif
-        Config.ssl_client.defaultPeerContext = new Security::FuturePeerContext(Security::ProxyOutgoingConfig, *Config.ssl_client.sslContext);
+        Config.ssl_client.defaultPeerContext = new Security::FuturePeerContext(Security::ProxyOutgoingConfig, *Config.ssl_client.sslContext_);
     }
 
     for (const auto &p: CurrentCachePeers()) {
@@ -3915,8 +3915,8 @@ configFreeMemory(void)
     Dns::ResolveClientAddressesAsap = false;
     delete Config.ssl_client.defaultPeerContext;
     Config.ssl_client.defaultPeerContext = nullptr;
-    delete Config.ssl_client.sslContext;
-    Config.ssl_client.sslContext = nullptr;
+    delete Config.ssl_client.sslContext_;
+    Config.ssl_client.sslContext_ = nullptr;
 #if USE_OPENSSL
     Ssl::unloadSquidUntrusted();
 #endif


### PR DESCRIPTION
Squid may crash when the SquidConfig global is auto-destructed after
main() ends. Since SquidConfig global is used by cleanup code, we should
keep its fields alive, essentially emulating "No New Globals" policy
effects. This surgical fix will be followed up with more changes to
address general OpenSSL cleanup problems exposed by this bug.

This bug fix facilitates backporting by using FuturePeerContext shim.