### PR TITLE
NoNewGlobals for Comm::AcceptLimiter::Instance_

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1155,7 +1155,7 @@ comm_init(void)
     assert(fd_table);
 
     /* make sure the accept() socket FIFO delay queue exists */
-    Comm::AcceptLimiter::Instance();
+    (void)Comm::AcceptLimiter::Instance();
 
     // make sure the IO pending callback table exists
     Comm::CallbackTableInit();

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -1154,9 +1154,6 @@ comm_init(void)
 {
     assert(fd_table);
 
-    /* make sure the accept() socket FIFO delay queue exists */
-    (void)Comm::AcceptLimiter::Instance();
-
     // make sure the IO pending callback table exists
     Comm::CallbackTableInit();
 

--- a/src/comm/AcceptLimiter.cc
+++ b/src/comm/AcceptLimiter.cc
@@ -13,12 +13,11 @@
 #include "fde.h"
 #include "globals.h"
 
-Comm::AcceptLimiter Comm::AcceptLimiter::Instance_;
-
 Comm::AcceptLimiter &
 Comm::AcceptLimiter::Instance()
 {
-    return Instance_;
+    static const auto Instance_ = new AcceptLimiter();
+    return *Instance_;
 }
 
 void

--- a/src/comm/AcceptLimiter.h
+++ b/src/comm/AcceptLimiter.h
@@ -43,8 +43,6 @@ public:
     void kick();
 
 private:
-    static AcceptLimiter Instance_;
-
     /** FIFO queue */
     std::deque<TcpAcceptor::Pointer> deferred_;
 };


### PR DESCRIPTION
Inspired by Coverity. CID 1441988: Useless call (USELESS_CALL).