### PR TITLE
Maintenance: Avoid copy in ACLChecklist::calcImplicitAnswer()

### DIFF
--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -326,7 +326,7 @@ void
 ACLChecklist::calcImplicitAnswer()
 {
     const auto& lastAction = accessList ?
-                            accessList->lastAction() : Acl::Answer(ACCESS_DUNNO);
+                             accessList->lastAction() : Acl::Answer(ACCESS_DUNNO);
     auto implicitRuleAnswer = Acl::Answer(ACCESS_DUNNO);
     if (lastAction == ACCESS_DENIED) // reverse last seen "deny"
         implicitRuleAnswer = Acl::Answer(ACCESS_ALLOWED);

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -325,7 +325,7 @@ ACLChecklist::fastCheck()
 void
 ACLChecklist::calcImplicitAnswer()
 {
-    const auto& lastAction = accessList ?
+    const auto &lastAction = accessList ?
                              accessList->lastAction() : Acl::Answer(ACCESS_DUNNO);
     auto implicitRuleAnswer = Acl::Answer(ACCESS_DUNNO);
     if (lastAction == ACCESS_DENIED) // reverse last seen "deny"

--- a/src/acl/Checklist.cc
+++ b/src/acl/Checklist.cc
@@ -325,7 +325,7 @@ ACLChecklist::fastCheck()
 void
 ACLChecklist::calcImplicitAnswer()
 {
-    const auto lastAction = accessList ?
+    const auto& lastAction = accessList ?
                             accessList->lastAction() : Acl::Answer(ACCESS_DUNNO);
     auto implicitRuleAnswer = Acl::Answer(ACCESS_DUNNO);
     if (lastAction == ACCESS_DENIED) // reverse last seen "deny"


### PR DESCRIPTION
ACLChecklist::calcImplicitAnswer() stores a temporary copy of the last
action taken in an accessList. This copying is unnecessary.

Detected by Coverity. CID 1596327: Use of auto that causes a copy
(AUTO_CAUSES_COPY).
