### PR TITLE
Maintenance: use void return for commSetTimeout functions

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -588,7 +588,7 @@ commUnsetFdTimeout(int fd)
     F->timeout = 0;
 }
 
-time_t
+void
 commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t timeout, AsyncCall::Pointer &callback)
 {
     debugs(5, 3, conn << " timeout " << timeout);
@@ -608,18 +608,16 @@ commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t timeout, AsyncCal
             F->timeoutHandler = callback;
         }
 
-        F->timeout = squid_curtime + (time_t) timeout;
+        F->timeout = squid_curtime + timeout;
     }
-
-    return F->timeout;
 }
 
-time_t
+void
 commUnsetConnTimeout(const Comm::ConnectionPointer &conn)
 {
     debugs(5, 3, "Remove timeout for " << conn);
     AsyncCall::Pointer nil;
-    return commSetConnTimeout(conn, -1, nil);
+    commSetConnTimeout(conn, -1, nil);
 }
 
 /**

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -588,7 +588,7 @@ commUnsetFdTimeout(int fd)
     F->timeout = 0;
 }
 
-int
+time_t
 commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t timeout, AsyncCall::Pointer &callback)
 {
     debugs(5, 3, conn << " timeout " << timeout);
@@ -614,7 +614,7 @@ commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t timeout, AsyncCal
     return F->timeout;
 }
 
-int
+time_t
 commUnsetConnTimeout(const Comm::ConnectionPointer &conn)
 {
     debugs(5, 3, "Remove timeout for " << conn);

--- a/src/comm.h
+++ b/src/comm.h
@@ -75,8 +75,8 @@ void commUnsetFdTimeout(int fd);
  * Set or clear the timeout for some action on an active connection.
  * API to replace commSetTimeout() when a Comm::ConnectionPointer is available.
  */
-time_t commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t seconds, AsyncCall::Pointer &callback);
-time_t commUnsetConnTimeout(const Comm::ConnectionPointer &conn);
+void commSetConnTimeout(const Comm::ConnectionPointer &, time_t seconds, AsyncCall::Pointer &);
+void commUnsetConnTimeout(const Comm::ConnectionPointer &);
 
 int ignoreErrno(int);
 void commCloseAllSockets(void);

--- a/src/comm.h
+++ b/src/comm.h
@@ -75,8 +75,8 @@ void commUnsetFdTimeout(int fd);
  * Set or clear the timeout for some action on an active connection.
  * API to replace commSetTimeout() when a Comm::ConnectionPointer is available.
  */
-int commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t seconds, AsyncCall::Pointer &callback);
-int commUnsetConnTimeout(const Comm::ConnectionPointer &conn);
+time_t commSetConnTimeout(const Comm::ConnectionPointer &conn, time_t seconds, AsyncCall::Pointer &callback);
+time_t commUnsetConnTimeout(const Comm::ConnectionPointer &conn);
 
 int ignoreErrno(int);
 void commCloseAllSockets(void);

--- a/src/tests/stub_comm.cc
+++ b/src/tests/stub_comm.cc
@@ -48,8 +48,8 @@ int comm_udp_sendto(int, const Ip::Address &, const void *, int) STUB_RETVAL(-1)
 void commCallCloseHandlers(int) STUB
 void commUnsetFdTimeout(int) STUB
 // int commSetTimeout(const Comm::ConnectionPointer &, int, AsyncCall::Pointer&) STUB_RETVAL(-1)
-int commSetConnTimeout(const Comm::ConnectionPointer &, time_t, AsyncCall::Pointer &) STUB_RETVAL(-1)
-int commUnsetConnTimeout(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
+time_t commSetConnTimeout(const Comm::ConnectionPointer &, time_t, AsyncCall::Pointer &) STUB_RETVAL(-1)
+time_t commUnsetConnTimeout(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
 int ignoreErrno(int) STUB_RETVAL(-1)
 void commCloseAllSockets(void) STUB
 void checkTimeouts(void) STUB

--- a/src/tests/stub_comm.cc
+++ b/src/tests/stub_comm.cc
@@ -48,8 +48,8 @@ int comm_udp_sendto(int, const Ip::Address &, const void *, int) STUB_RETVAL(-1)
 void commCallCloseHandlers(int) STUB
 void commUnsetFdTimeout(int) STUB
 // int commSetTimeout(const Comm::ConnectionPointer &, int, AsyncCall::Pointer&) STUB_RETVAL(-1)
-time_t commSetConnTimeout(const Comm::ConnectionPointer &, time_t, AsyncCall::Pointer &) STUB_RETVAL(-1)
-time_t commUnsetConnTimeout(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
+void commSetConnTimeout(const Comm::ConnectionPointer &, time_t, AsyncCall::Pointer &) STUB
+void commUnsetConnTimeout(const Comm::ConnectionPointer &) STUB
 int ignoreErrno(int) STUB_RETVAL(-1)
 void commCloseAllSockets(void) STUB
 void checkTimeouts(void) STUB


### PR DESCRIPTION
On some systems (e.g. Linux), time_t is a signed 64-bit integer. int may
be a signed 32-bit integer, resulting in possible truncation errors.

Detected by Coverity. CID 1547031: Use of 32-bit time_t (Y2K38_SAFETY).
