### PR TITLE
Portability: remove explicit check for libdl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,13 +403,6 @@ AS_IF([test "x$squid_opt_aufs_threads" != "x"],[
     [Defines how many threads aufs uses for I/O])
 ])
 
-## TODO check if this is necessary, LT_INIT does these checks
-SQUID_AUTO_LIB(dl,[dynamic linking],[LIBDL])
-SQUID_CHECK_LIB_WORKS(dl,[
-  LDFLAGS="$LIBDL_PATH $LDFLAGS"
-  AC_CHECK_LIB(dl, dlopen,[LIBDL_LIBS="-ldl"])
-])
-
 AC_DEFUN([LIBATOMIC_CHECKER],[
   AC_MSG_CHECKING(whether linking $1 -latomic works)
   AC_LINK_IFELSE([


### PR DESCRIPTION
OpenBSD does not have libdl, as it has dlopen() in libc.
It is not really needed, and force-requiring the presence of libdl
causes ./configure to fail on openbsd:

    checking for dlopen in -ldl... no
    configure: error: Required library 'dl' not found
