### PR TITLE
CI: show build commands on terminal

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -145,10 +145,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux
-        run: |
-          echo "::group::output"
-          ./test-builds.sh --verbose ${{ matrix.layer.name }}
-          echo "::endgroup::"
+        run: ./test-builds.sh --verbose ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -181,10 +178,7 @@ jobs:
         uses: github/codeql-action/init@v3
 
       - name: Build Squid
-        run: |
-          echo "::group::output"
-          ./test-builds.sh --verbose ./test-suite/buildtests/layer-02-maximus.opts
-          echo "::endgroup::"
+        run: ./test-builds.sh --verbose ./test-suite/buildtests/layer-02-maximus.opts
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -145,7 +145,10 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux
-        run: ./test-builds.sh --verbose ${{ matrix.layer.name }}
+        run: |
+          echo "::group:: output from ./test-builds.sh"
+          ./test-builds.sh --verbose ${{ matrix.layer.name }}
+          echo "::endgroup::"
 
       - name: Publish build logs
         if: success() || failure()
@@ -178,7 +181,10 @@ jobs:
         uses: github/codeql-action/init@v3
 
       - name: Build Squid
-        run: ./test-builds.sh --verbose layer-02-maximus
+        run: |
+          echo "::group:: output from ./test-builds.sh"
+          ./test-builds.sh --verbose ./test-suite/buildtests/layer-02-maximus.opts
+          echo "::endgroup::"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -145,7 +145,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux
-        run: ./test-builds.sh ${{ matrix.layer.name }}
+        run: ./test-builds.sh --verbose ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -178,7 +178,7 @@ jobs:
         uses: github/codeql-action/init@v3
 
       - name: Build Squid
-        run: ./test-builds.sh ./test-suite/buildtests/layer-02-maximus.opts
+        run: ./test-builds.sh --verbose ./test-suite/buildtests/layer-02-maximus.opts
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -178,7 +178,7 @@ jobs:
         uses: github/codeql-action/init@v3
 
       - name: Build Squid
-        run: ./test-builds.sh --verbose ./test-suite/buildtests/layer-02-maximus.opts
+        run: ./test-builds.sh --verbose layer-02-maximus
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Run build on Linux
         run: |
-          echo "::group:: output from ./test-builds.sh"
+          echo "::group::output"
           ./test-builds.sh --verbose ${{ matrix.layer.name }}
           echo "::endgroup::"
 
@@ -182,7 +182,7 @@ jobs:
 
       - name: Build Squid
         run: |
-          echo "::group:: output from ./test-builds.sh"
+          echo "::group::output"
           ./test-builds.sh --verbose ./test-suite/buildtests/layer-02-maximus.opts
           echo "::endgroup::"
 

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Run test-builds
         id: test-builds
         run: |
-          echo "::group:: output from ./test-builds.sh ${{ matrix.layer.name }}"
+          echo "::group::output"
           ./test-builds.sh --verbose ${{ matrix.layer.name }}
           echo "::endgroup::"
 
@@ -100,7 +100,7 @@ jobs:
       - name: Run test-builds
         id: test-builds
         run: |
-          echo "::group:: Output from setup phase"
+          echo "::group::setup output"
           eval `brew shellenv`
           PKG_CONFIG_PATH="$HOMEBREW_PREFIX/lib/pkgconfig"
           PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$HOMEBREW_PREFIX/opt/openldap/lib/pkgconfig"
@@ -130,7 +130,7 @@ jobs:
           diff -u $editable.bak $editable || true
           echo "::endgroup::"
 
-          echo "::group:: Output from ./test-builds.sh"
+          echo "::group::build output"
           ./test-builds.sh --verbose
           echo "::endgroup::"
 
@@ -179,7 +179,7 @@ jobs:
 
           run: |
             export MAKE=gmake
-            echo "::group:: Output from ./test-builds.sh"
+            echo "::group::output"
             ./test-builds.sh --verbose
             echo "::endgroup::"
 

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Run test-builds
         id: test-builds
         run: |
-          ./test-builds.sh ${{ matrix.layer.name }}
+          ./test-builds.sh --verbose ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -126,7 +126,7 @@ jobs:
           sed -i.bak 's@ltdl_ac_aux_dir=""@ltdl_ac_aux_dir="../build-aux"@' $editable || true
           diff -u $editable.bak $editable || true
 
-          ./test-builds.sh
+          ./test-builds.sh --verbose
 
       - name: Publish build logs
         if: success() || failure()
@@ -173,7 +173,7 @@ jobs:
 
           run: |
             export MAKE=gmake
-            ./test-builds.sh
+            ./test-builds.sh --verbose
 
       - name: Publish build logs
         if: success() || failure()

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -70,7 +70,9 @@ jobs:
       - name: Run test-builds
         id: test-builds
         run: |
+          echo "::group:: output from ./test-builds.sh ${{ matrix.layer.name }}"
           ./test-builds.sh --verbose ${{ matrix.layer.name }}
+          echo "::endgroup::"
 
       - name: Publish build logs
         if: success() || failure()
@@ -98,6 +100,7 @@ jobs:
       - name: Run test-builds
         id: test-builds
         run: |
+          echo "::group:: Output from setup phase"
           eval `brew shellenv`
           PKG_CONFIG_PATH="$HOMEBREW_PREFIX/lib/pkgconfig"
           PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$HOMEBREW_PREFIX/opt/openldap/lib/pkgconfig"
@@ -125,8 +128,11 @@ jobs:
           editable=$HOMEBREW_CELLAR/libtool/2.4.7/bin/glibtoolize
           sed -i.bak 's@ltdl_ac_aux_dir=""@ltdl_ac_aux_dir="../build-aux"@' $editable || true
           diff -u $editable.bak $editable || true
+          echo "::endgroup::"
 
+          echo "::group:: Output from ./test-builds.sh"
           ./test-builds.sh --verbose
+          echo "::endgroup::"
 
       - name: Publish build logs
         if: success() || failure()
@@ -173,7 +179,9 @@ jobs:
 
           run: |
             export MAKE=gmake
+            echo "::group:: Output from ./test-builds.sh"
             ./test-builds.sh --verbose
+            echo "::endgroup::"
 
       - name: Publish build logs
         if: success() || failure()

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -69,10 +69,7 @@ jobs:
 
       - name: Run test-builds
         id: test-builds
-        run: |
-          echo "::group::output"
-          ./test-builds.sh --verbose ${{ matrix.layer.name }}
-          echo "::endgroup::"
+        run: ./test-builds.sh --verbose ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -130,9 +127,7 @@ jobs:
           diff -u $editable.bak $editable || true
           echo "::endgroup::"
 
-          echo "::group::build output"
           ./test-builds.sh --verbose
-          echo "::endgroup::"
 
       - name: Publish build logs
         if: success() || failure()
@@ -179,9 +174,7 @@ jobs:
 
           run: |
             export MAKE=gmake
-            echo "::group::output"
             ./test-builds.sh --verbose
-            echo "::endgroup::"
 
       - name: Publish build logs
         if: success() || failure()

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -71,7 +71,7 @@ logtee() {
     local layer=$2
     case $verbose in
     yes)
-        echo "::group::$layer output" # github collapsable section
+        echo "::group::$layer output" # github collapsible section
         tee $1
         echo "::endgroup::"
         ;;

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -68,9 +68,12 @@ while [ $# -ge 1 ]; do
 done
 
 logtee() {
+    local layer=$2
     case $verbose in
     yes)
+        echo "::group::$layer output" # github collapsable section
         tee $1
+        echo "::endgroup::"
         ;;
     progress)
         tee $1 | awk '{printf "."; n++; if (!(n % 80)) print "" } END {print ""}'
@@ -111,7 +114,7 @@ buildtest() {
 
 	# log the result for the outer script to notice
 	echo "buildtest.sh result is $result";
-    } 2>&1 | logtee ${log}
+    } 2>&1 | logtee ${log} ${layer}
 
     result=1 # failure by default
     if grep -q '^buildtest.sh result is 0$' ${log}; then


### PR DESCRIPTION
test-builds.sh records build output in per-layer logs, and we are
already collecting those logs. Send build output to standard output as
well, to expose it in GitHub Actions user interface. This new detailed
output is enclosed in a "layer ... output" group to keep emphasizing
problematic output lines extracted by test-builds.sh.

Also enclose MacOS build setup output in a group, for similar reasons.
