### PR TITLE
Clarify --enable-ecap failure on missing shared library support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -840,7 +840,7 @@ AC_ARG_ENABLE(ecap,
 dnl Perform configuration consistency checks for eCAP
 AS_IF([test "x$enable_ecap" != "xno"],[
   AS_IF([test "x$enable_shared" != "xyes"],[
-    AC_MSG_ERROR([eCAP support requires loadable modules. Please do not use --disable-shared with --enable-ecap.])
+    AC_MSG_ERROR([eCAP support requires loadable modules (i.e. --enable-shared or equivalent).])
   ])
 
   AS_IF([test -n "$PKG_CONFIG"],[


### PR DESCRIPTION
    checking if libtool supports shared libraries... no
    checking whether to build shared libraries... no
    configure: error: eCAP support requires loadable modules.
        Please do not use --disable-shared with --enable-ecap.

After 2022 commit 5a2409b7, our advice for handling the above error
became misleading in environments that do not --disable-shared
explicitly but lack shared libraries support for other reasons
