### PR TITLE
Fix libnettle detection in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1043,7 +1043,7 @@ AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 
 # Cryptograhic libraries
 SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
-AS_IF(test "x$with_nettle" != "xno"],[
+AS_IF([test "x$with_nettle" != "xno"],[
   SQUID_STATE_SAVE(squid_nettle_state)
   PKG_CHECK_MODULES([LIBNETTLE],[nettle >= 3.4],[],[
     CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"


### PR DESCRIPTION
Commit a1c2236 introduced a syntax error in handling nettle
in configure.ac .

This was noticed by contributors to the FreeBSD project, 
see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=283669#c5

----

This syntax error was fixed in master/v7 commit a3bc98c, but that larger
change was not designated for backporting.