### PR TITLE
CI: Add workflow_dispatch to workflows that still lack it

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -16,6 +16,8 @@ on:
     # test PRs targeting this branch code
     branches: [ "master" ]
 
+  workflow_dispatch:
+
 concurrency:
   # Cancel ongoing tests in case of push to the same PR or staging branch,
   # but let previous master commit tests complete.

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -16,6 +16,7 @@ on:
     # test PRs targeting this branch code
     branches: [ "master" ]
 
+  # allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -14,6 +14,8 @@ on:
   push:
     branches: [ "auto" ]
 
+  workflow_dispatch:
+
 concurrency:
   # Cancel ongoing tests in case of push to staging branch.
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -14,6 +14,7 @@ on:
   push:
     branches: [ "auto" ]
 
+  # allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Manually triggering a workflow rerun is handy when troubleshooting. Our
coverity-scan.yaml workflow already has a workflow_dispatch trigger.
