### PR TITLE
Bug 5093: List http_port params that https_port/ftp_port lack

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2575,8 +2575,8 @@ DOC_START
 	The tls-cert= option is mandatory on HTTPS ports.
 
 	See http_port for a list of modes and options.
-	Not all http_port options are supported for https_port.
-	Among the unsupported options:
+	Not all http_port options are available for https_port.
+	Among the unavalable options:
 	- require-proxy-header
 DOC_END
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2575,6 +2575,9 @@ DOC_START
 	The tls-cert= option is mandatory on HTTPS ports.
 
 	See http_port for a list of modes and options.
+
+    http_port options not supported for https_port:
+    - require-proxy-header
 DOC_END
 
 NAME: ftp_port
@@ -2639,6 +2642,10 @@ DOC_START
 
 	Other http_port modes and options that are not specific to HTTP and
 	HTTPS may also work.
+
+    http_port options not supported for https_port:
+    - require-proxy-header
+    - ssl-bump
 DOC_END
 
 NAME: tcp_outgoing_tos tcp_outgoing_ds tcp_outgoing_dscp

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2575,9 +2575,9 @@ DOC_START
 	The tls-cert= option is mandatory on HTTPS ports.
 
 	See http_port for a list of modes and options.
-
-    http_port options not supported for https_port:
-    - require-proxy-header
+	Not all http_port options are supported for https_port.
+	Among the unsupported options:
+	- require-proxy-header
 DOC_END
 
 NAME: ftp_port
@@ -2642,10 +2642,9 @@ DOC_START
 
 	Other http_port modes and options that are not specific to HTTP and
 	HTTPS may also work.
-
-    http_port options not supported for https_port:
-    - require-proxy-header
-    - ssl-bump
+	Among the options that are not available for ftp_port:
+	- require-proxy-header
+	- ssl-bump
 DOC_END
 
 NAME: tcp_outgoing_tos tcp_outgoing_ds tcp_outgoing_dscp


### PR DESCRIPTION
To avoid documentation duplication, current https_port and ftp_port
directive descriptions reference http_port directive instead of
detailing their own supported parameters. For https_port, this solution
creates a false impression that the directive supports all http_port
options. Our ftp_port documentation is better but still leaves the
reader guessing which options are actually supported.

This change starts enumerating http_port configuration parameters that
ftp_port and https_port directives do _not_ support. Eventually, Squid
should reject configurations with unsupported listening port options.
