### PR TITLE
Bug 5481: Fix GCC v14 build [-Wmaybe-uninitialized]

### DIFF
--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -383,11 +383,12 @@ Ip::Qos::Config::parseConfigLine()
 
         } else if (strncmp(token, "miss=",5) == 0) {
 
-            char *end;
             if (mark) {
+                char *end = nullptr;
                 if (!xstrtoui(&token[5], &end, &markMiss, 0, std::numeric_limits<nfmark_t>::max())) {
                     throw TextException(ToSBuf("Bad mark miss value ", &token[5]), Here());
                 }
+                Assure(end);
                 if (*end == '/') {
                     if (!xstrtoui(end + 1, nullptr, &markMissMask, 0, std::numeric_limits<nfmark_t>::max())) {
                         debugs(3, DBG_CRITICAL, "ERROR: Bad mark miss mask value " << (end + 1) << ". Using 0xFFFFFFFF instead.");
@@ -397,11 +398,13 @@ Ip::Qos::Config::parseConfigLine()
                     markMissMask = 0xFFFFFFFF;
                 }
             } else {
+                char *end = nullptr;
                 unsigned int v = 0;
                 if (!xstrtoui(&token[5], &end, &v, 0, std::numeric_limits<tos_t>::max())) {
                     throw TextException(ToSBuf("Bad TOS miss value ", &token[5]), Here());
                 }
                 tosMiss = (tos_t)v;
+                Assure(end);
                 if (*end == '/') {
                     if (!xstrtoui(end + 1, nullptr, &v, 0, std::numeric_limits<tos_t>::max())) {
                         debugs(3, DBG_CRITICAL, "ERROR: Bad TOS miss mask value " << (end + 1) << ". Using 0xFF instead.");


### PR DESCRIPTION
Successful xstrtoui(start,end) calls do initialize `end`, but we can
polish this code and avoid triggering that GCC warning at the same time.
