### PR TITLE
CI: Enable eCAP and Valgrind in layer build tests if possible

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -136,7 +136,7 @@ jobs:
           sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
-          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin ${{ matrix.compiler.CC }} ccache
+          sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin ${{ matrix.compiler.CC }} ccache valgrind
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/test-suite/buildtest.sh
+++ b/test-suite/buildtest.sh
@@ -22,10 +22,14 @@ config="${2}"
 if ${PKG_CONFIG:-pkg-config} --exists 'libecap >= 1.0 libecap < 1.1' 2>/dev/null
 then
     CONFIGURE_FLAGS_MAYBE_ENABLE_ECAP="--enable-ecap"
+else
+    echo "WARNING: eCAP testing disabled" >&2
 fi
 if ${PKG_CONFIG:-pkg-config} --exists valgrind 2>/dev/null
 then
     CONFIGURE_FLAGS_MAYBE_ENABLE_VALGRIND="--with-valgrind-debug"
+else
+    echo "WARNING: Valgrind testing disabled" >&2
 fi
 
 # cache_file may be set by environment variable

--- a/test-suite/buildtest.sh
+++ b/test-suite/buildtest.sh
@@ -16,6 +16,16 @@
 action="${1}"
 config="${2}"
 
+# Allow a layer to enable optional features supported in current build environment
+if ${PKG_CONFIG:-pkg-config} --exists --exact-version=1.0.0 libecap 2>/dev/null
+then
+    CONFIGURE_FLAGS_MAYBE_ENABLE_ECAP="--enable-ecap"
+fi
+if ${PKG_CONFIG:-pkg-config} --exists  valgrind 2>/dev/null
+then
+    CONFIGURE_FLAGS_MAYBE_ENABLE_VALGRIND="--with-valgrind-debug"
+fi
+
 # cache_file may be set by environment variable
 configcache=""
 if [ -n "$cache_file" ]; then

--- a/test-suite/buildtest.sh
+++ b/test-suite/buildtest.sh
@@ -19,7 +19,7 @@ config="${2}"
 # Allow a layer to enable optional default-disabled features when
 # those features are supported in the current build environment
 # (and we can easily detect such support).
-if ${PKG_CONFIG:-pkg-config} --exists --atleast-version=1.0.0 libecap 2>/dev/null
+if ${PKG_CONFIG:-pkg-config} --exists 'libecap >= 1.0 libecap < 1.1' 2>/dev/null
 then
     CONFIGURE_FLAGS_MAYBE_ENABLE_ECAP="--enable-ecap"
 fi

--- a/test-suite/buildtest.sh
+++ b/test-suite/buildtest.sh
@@ -16,12 +16,14 @@
 action="${1}"
 config="${2}"
 
-# Allow a layer to enable optional features supported in current build environment
+# Allow a layer to enable optional default-disabled features when
+# those features are supported in the current build environment
+# (and we can easily detect such support).
 if ${PKG_CONFIG:-pkg-config} --exists --exact-version=1.0.0 libecap 2>/dev/null
 then
     CONFIGURE_FLAGS_MAYBE_ENABLE_ECAP="--enable-ecap"
 fi
-if ${PKG_CONFIG:-pkg-config} --exists  valgrind 2>/dev/null
+if ${PKG_CONFIG:-pkg-config} --exists valgrind 2>/dev/null
 then
     CONFIGURE_FLAGS_MAYBE_ENABLE_VALGRIND="--with-valgrind-debug"
 fi

--- a/test-suite/buildtest.sh
+++ b/test-suite/buildtest.sh
@@ -19,7 +19,7 @@ config="${2}"
 # Allow a layer to enable optional default-disabled features when
 # those features are supported in the current build environment
 # (and we can easily detect such support).
-if ${PKG_CONFIG:-pkg-config} --exists --exact-version=1.0.0 libecap 2>/dev/null
+if ${PKG_CONFIG:-pkg-config} --exists --atleast-version=1.0.0 libecap 2>/dev/null
 then
     CONFIGURE_FLAGS_MAYBE_ENABLE_ECAP="--enable-ecap"
 fi

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -37,11 +37,9 @@ MAKETEST="distcheck"
 #	We can't test them automatically everywhere without detecting those
 #	optional packages first.
 #
-#   --enable-ecap \
 #   --enable-epoll \
 #   --enable-kqueue \
 #   --enable-win32-service \
-#   --with-valgrind-debug \
 #   --with-gnutls \
 #   --with-tdb \
 #   --with-cap \
@@ -110,6 +108,8 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--enable-build-info=squid\ test\ build \
 	--enable-ssl-crtd \
 	--with-openssl \
+	$CONFIGURE_FLAGS_MAYBE_ENABLE_ECAP \
+	$CONFIGURE_FLAGS_MAYBE_ENABLE_VALGRIND \
 	"
 
 # Fix the distclean testing.

--- a/test-suite/buildtests/layer-04-noauth-everything.opts
+++ b/test-suite/buildtests/layer-04-noauth-everything.opts
@@ -42,11 +42,9 @@ MAKETEST="distcheck"
 #	We can't test them automatically everywhere without detecting those
 #	optional packages first.
 #
-#   --enable-ecap \
 #   --enable-epoll \
 #   --enable-kqueue \
 #   --enable-win32-service \
-#   --with-valgrind-debug \
 #   --with-ldap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
@@ -110,6 +108,8 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--with-pic \
 	--with-pthreads \
 	--enable-build-info=squid\ test\ build \
+	$CONFIGURE_FLAGS_MAYBE_ENABLE_ECAP \
+	$CONFIGURE_FLAGS_MAYBE_ENABLE_VALGRIND \
 	"
 
 # Fix the distclean testing.


### PR DESCRIPTION
Now these optional features are enabled during applicable layer tests if
their packages appear to be available on the build system. This should
help prevent regressions like the one fixed in recent commit 53ed1a9.