### PR TITLE
Turn STUB_* macros into something looking like functions

### DIFF
--- a/src/tests/STUB.h
+++ b/src/tests/STUB.h
@@ -31,11 +31,11 @@
 #define stub_fatal(m) { std::cerr<<"FATAL: "<<(m)<<" for use of "<<__func__<<"\n"; exit(EXIT_FAILURE); }
 
 /// macro to stub a void function.
-#define STUB { stub_fatal(STUB_API " required"); }
+#define STUB() { stub_fatal(STUB_API " required"); }
 
 /// macro to stub a void function without a fatal message
 /// Intended for registration pattern APIs where the function result does not matter to the test
-#define STUB_NOP { std::cerr<<"SKIP: "<<STUB_API<<" "<<__func__<<" (not implemented).\n"; }
+#define STUB_NOP() { std::cerr<<"SKIP: "<<STUB_API<<" "<<__func__<<" (not implemented).\n"; }
 
 /// macro to stub a function with return value.
 /// Aborts unit tests requiring its definition with a message about the missing linkage

--- a/src/tests/stub_CacheDigest.cc
+++ b/src/tests/stub_CacheDigest.cc
@@ -19,15 +19,15 @@ class StoreEntry;
 #include "CacheDigest.h"
 CacheDigest::CacheDigest(uint64_t, uint8_t) {STUB}
 CacheDigest::~CacheDigest() {STUB}
-CacheDigest *CacheDigest::clone() const STUB_RETVAL(nullptr)
-void CacheDigest::clear() STUB
-void CacheDigest::updateCapacity(uint64_t) STUB
-bool CacheDigest::contains(const cache_key *) const STUB_RETVAL(false)
-void CacheDigest::add(const cache_key *) STUB
-void CacheDigest::remove(const cache_key *) STUB
-double CacheDigest::usedMaskPercent() const STUB_RETVAL(0.0)
-void cacheDigestGuessStatsUpdate(CacheDigestGuessStats *, int, int) STUB
-void cacheDigestGuessStatsReport(const CacheDigestGuessStats *, StoreEntry *, const SBuf &) STUB
-void cacheDigestReport(CacheDigest *, const SBuf &, StoreEntry *) STUB
-uint32_t CacheDigest::CalcMaskSize(uint64_t, uint8_t) STUB_RETVAL(1)
+CacheDigest *CacheDigest::clone() const STUB_RETVAL(nullptr);
+void CacheDigest::clear() STUB();
+void CacheDigest::updateCapacity(uint64_t) STUB();
+bool CacheDigest::contains(const cache_key *) const STUB_RETVAL(false);
+void CacheDigest::add(const cache_key *) STUB();
+void CacheDigest::remove(const cache_key *) STUB();
+double CacheDigest::usedMaskPercent() const STUB_RETVAL(0.0);
+void cacheDigestGuessStatsUpdate(CacheDigestGuessStats *, int, int) STUB();
+void cacheDigestGuessStatsReport(const CacheDigestGuessStats *, StoreEntry *, const SBuf &) STUB();
+void cacheDigestReport(CacheDigest *, const SBuf &, StoreEntry *) STUB();
+uint32_t CacheDigest::CalcMaskSize(uint64_t, uint8_t) STUB_RETVAL(1);
 

--- a/src/tests/stub_CachePeer.cc
+++ b/src/tests/stub_CachePeer.cc
@@ -12,7 +12,7 @@
 #include "tests/STUB.h"
 
 #include "CachePeer.h"
-void CachePeer::rename(const char *) STUB
-time_t CachePeer::connectTimeout() const STUB_RETVAL(0)
-std::ostream &operator <<(std::ostream &os, const CachePeer &) STUB_RETVAL(os)
+void CachePeer::rename(const char *) STUB();
+time_t CachePeer::connectTimeout() const STUB_RETVAL(0);
+std::ostream &operator <<(std::ostream &os, const CachePeer &) STUB_RETVAL(os);
 

--- a/src/tests/stub_CollapsedForwarding.cc
+++ b/src/tests/stub_CollapsedForwarding.cc
@@ -12,7 +12,7 @@
 #define STUB_API "CollapsedForwarding.cc"
 #include "tests/STUB.h"
 
-void CollapsedForwarding::Broadcast(StoreEntry const&, const bool) STUB
-void CollapsedForwarding::Broadcast(const sfileno, const bool) STUB
-void CollapsedForwarding::StatQueue(std::ostream &) STUB
+void CollapsedForwarding::Broadcast(StoreEntry const&, const bool) STUB();
+void CollapsedForwarding::Broadcast(const sfileno, const bool) STUB();
+void CollapsedForwarding::StatQueue(std::ostream &) STUB();
 

--- a/src/tests/stub_CommIO.cc
+++ b/src/tests/stub_CommIO.cc
@@ -17,9 +17,9 @@ bool CommIO::DoneSignalled = false;
 int CommIO::DoneFD = -1;
 int CommIO::DoneReadFD = -1;
 
-void CommIO::ResetNotifications() STUB
-void CommIO::Initialise() STUB
-void CommIO::NotifyIOClose() STUB
-void CommIO::NULLFDHandler(int, void *) STUB
-void CommIO::FlushPipe() STUB
+void CommIO::ResetNotifications() STUB();
+void CommIO::Initialise() STUB();
+void CommIO::NotifyIOClose() STUB();
+void CommIO::NULLFDHandler(int, void *) STUB();
+void CommIO::FlushPipe() STUB();
 

--- a/src/tests/stub_DelayId.cc
+++ b/src/tests/stub_DelayId.cc
@@ -21,10 +21,10 @@ DelayId::DelayId(): pool_(0), compositeId(nullptr), markedAsNoDelay(false) {}
 DelayId::~DelayId() {}
 
 void DelayId::delayRead(const AsyncCallPointer &) STUB_NOP
-void BandwidthBucket::refillBucket() STUB
-bool BandwidthBucket::applyQuota(int &, Comm::IoCallback *) STUB_RETVAL(false)
-BandwidthBucket *BandwidthBucket::SelectBucket(fde *) STUB_RETVAL(nullptr)
-void BandwidthBucket::reduceBucket(const int) STUB
+void BandwidthBucket::refillBucket() STUB();
+bool BandwidthBucket::applyQuota(int &, Comm::IoCallback *) STUB_RETVAL(false);
+BandwidthBucket *BandwidthBucket::SelectBucket(fde *) STUB_RETVAL(nullptr);
+void BandwidthBucket::reduceBucket(const int) STUB();
 
 #endif /* USE_DELAY_POOLS */
 

--- a/src/tests/stub_ETag.cc
+++ b/src/tests/stub_ETag.cc
@@ -12,7 +12,7 @@
 #define STUB_API "ETag.cc"
 #include "tests/STUB.h"
 
-int etagParseInit(ETag *, const char *) STUB_RETVAL(0)
-bool etagIsStrongEqual(const ETag &, const ETag &) STUB_RETVAL(false)
-bool etagIsWeakEqual(const ETag &, const ETag &) STUB_RETVAL(false)
+int etagParseInit(ETag *, const char *) STUB_RETVAL(0);
+bool etagIsStrongEqual(const ETag &, const ETag &) STUB_RETVAL(false);
+bool etagIsWeakEqual(const ETag &, const ETag &) STUB_RETVAL(false);
 

--- a/src/tests/stub_EventLoop.cc
+++ b/src/tests/stub_EventLoop.cc
@@ -18,5 +18,5 @@ EventLoop::EventLoop(): errcount(0), last_loop(false), timeService(nullptr),
     primaryEngine(nullptr), loop_delay(0), error(false), runOnceResult(false)
     STUB_NOP
 
-    void EventLoop::registerEngine(AsyncEngine *) STUB
+    void EventLoop::registerEngine(AsyncEngine *) STUB();
 

--- a/src/tests/stub_HelperChildConfig.cc
+++ b/src/tests/stub_HelperChildConfig.cc
@@ -39,7 +39,7 @@ Helper::ChildConfig::ChildConfig(const unsigned int m):
     defaultQueueSize(true)
 {}
 
-int Helper::ChildConfig::needNew() const STUB_RETVAL(0)
-void Helper::ChildConfig::parseConfig() STUB
-Helper::ChildConfig & Helper::ChildConfig::updateLimits(const Helper::ChildConfig &) STUB_RETVAL(*this)
+int Helper::ChildConfig::needNew() const STUB_RETVAL(0);
+void Helper::ChildConfig::parseConfig() STUB();
+Helper::ChildConfig & Helper::ChildConfig::updateLimits(const Helper::ChildConfig &) STUB_RETVAL(*this);
 

--- a/src/tests/stub_HttpControlMsg.cc
+++ b/src/tests/stub_HttpControlMsg.cc
@@ -12,6 +12,6 @@
 #include "tests/STUB.h"
 
 #include "HttpControlMsg.h"
-void HttpControlMsgSink::wroteControlMsg(CommIoCbParams const&) STUB
-void HttpControlMsgSink::doneWithControlMsg() STUB
+void HttpControlMsgSink::wroteControlMsg(CommIoCbParams const&) STUB();
+void HttpControlMsgSink::doneWithControlMsg() STUB();
 

--- a/src/tests/stub_HttpHeader.cc
+++ b/src/tests/stub_HttpHeader.cc
@@ -16,75 +16,75 @@
 #include "HttpHeader.h"
 HttpHeaderEntry::HttpHeaderEntry(Http::HdrType, const SBuf &, const char *) {STUB}
 HttpHeaderEntry::~HttpHeaderEntry() {STUB}
-HttpHeaderEntry *HttpHeaderEntry::parse(const char *, const char *, const http_hdr_owner_type) STUB_RETVAL(nullptr)
-HttpHeaderEntry *HttpHeaderEntry::clone() const STUB_RETVAL(nullptr)
-void HttpHeaderEntry::packInto(Packable *) const STUB
-int HttpHeaderEntry::getInt() const STUB_RETVAL(0)
-int64_t HttpHeaderEntry::getInt64() const STUB_RETVAL(0)
+HttpHeaderEntry *HttpHeaderEntry::parse(const char *, const char *, const http_hdr_owner_type) STUB_RETVAL(nullptr);
+HttpHeaderEntry *HttpHeaderEntry::clone() const STUB_RETVAL(nullptr);
+void HttpHeaderEntry::packInto(Packable *) const STUB();
+int HttpHeaderEntry::getInt() const STUB_RETVAL(0);
+int64_t HttpHeaderEntry::getInt64() const STUB_RETVAL(0);
 HttpHeader::HttpHeader(const http_hdr_owner_type) {STUB}
 HttpHeader::HttpHeader(const HttpHeader &) {STUB}
 HttpHeader::~HttpHeader() {STUB}
-HttpHeader &HttpHeader::operator =(const HttpHeader &) STUB_RETVAL(*this)
-void HttpHeader::clean() STUB
-void HttpHeader::append(const HttpHeader *) STUB
-void HttpHeader::update(const HttpHeader *) STUB
-void HttpHeader::compact() STUB
-int HttpHeader::parse(const char *, size_t, Http::ContentLengthInterpreter &) STUB_RETVAL(-1)
-int HttpHeader::parse(const char *, size_t, bool, size_t &, Http::ContentLengthInterpreter &) STUB_RETVAL(-1)
-void HttpHeader::packInto(Packable *, bool) const STUB
-HttpHeaderEntry *HttpHeader::getEntry(HttpHeaderPos *) const STUB_RETVAL(nullptr)
-HttpHeaderEntry *HttpHeader::findEntry(Http::HdrType) const STUB_RETVAL(nullptr)
-int HttpHeader::delByName(const SBuf &) STUB_RETVAL(0)
-int HttpHeader::delById(Http::HdrType) STUB_RETVAL(0)
-void HttpHeader::delAt(HttpHeaderPos, int &) STUB
-void HttpHeader::refreshMask() STUB
-void HttpHeader::addEntry(HttpHeaderEntry *) STUB
-String HttpHeader::getList(Http::HdrType) const STUB_RETVAL(String())
-bool HttpHeader::getList(Http::HdrType, String *) const STUB_RETVAL(false)
-String HttpHeader::getStrOrList(Http::HdrType) const STUB_RETVAL(String())
-String HttpHeader::getByName(const SBuf &) const STUB_RETVAL(String())
-String HttpHeader::getByName(const char *) const STUB_RETVAL(String())
-String HttpHeader::getById(Http::HdrType) const STUB_RETVAL(String())
-bool HttpHeader::getByIdIfPresent(Http::HdrType, String *) const STUB_RETVAL(false)
-bool HttpHeader::hasNamed(const SBuf &, String *) const STUB_RETVAL(false)
-bool HttpHeader::hasNamed(const char *, unsigned int, String *) const STUB_RETVAL(false)
-SBuf HttpHeader::getByNameListMember(const char *, const char *, const char) const STUB_RETVAL(SBuf())
-SBuf HttpHeader::getListMember(Http::HdrType, const char *, const char) const STUB_RETVAL(SBuf())
-int HttpHeader::has(Http::HdrType) const STUB_RETVAL(0)
-void HttpHeader::addVia(const AnyP::ProtocolVersion &, const HttpHeader *) STUB
-void HttpHeader::putInt(Http::HdrType, int) STUB
-void HttpHeader::putInt64(Http::HdrType, int64_t ) STUB
-void HttpHeader::putTime(Http::HdrType, time_t) STUB
-void HttpHeader::putStr(Http::HdrType, const char *) STUB
-void HttpHeader::putAuth(const char *, const char *) STUB
-void HttpHeader::putCc(const HttpHdrCc &) STUB
-void HttpHeader::putContRange(const HttpHdrContRange *) STUB
-void HttpHeader::putRange(const HttpHdrRange *) STUB
-void HttpHeader::putSc(HttpHdrSc *) STUB
-void HttpHeader::putExt(const char *, const char *) STUB
-void HttpHeader::updateOrAddStr(Http::HdrType, const SBuf &) STUB
-int HttpHeader::getInt(Http::HdrType) const STUB_RETVAL(0)
-int64_t HttpHeader::getInt64(Http::HdrType) const STUB_RETVAL(0)
-time_t HttpHeader::getTime(Http::HdrType) const STUB_RETVAL(0)
-const char *HttpHeader::getStr(Http::HdrType) const STUB_RETVAL(nullptr)
-const char *HttpHeader::getLastStr(Http::HdrType) const STUB_RETVAL(nullptr)
-HttpHdrCc *HttpHeader::getCc() const STUB_RETVAL(nullptr)
-HttpHdrRange *HttpHeader::getRange() const STUB_RETVAL(nullptr)
-HttpHdrSc *HttpHeader::getSc() const STUB_RETVAL(nullptr)
-HttpHdrContRange *HttpHeader::getContRange() const STUB_RETVAL(nullptr)
-SBuf HttpHeader::getAuthToken(Http::HdrType, const char *) const STUB_RETVAL(SBuf())
-ETag HttpHeader::getETag(Http::HdrType) const STUB_RETVAL(ETag())
-TimeOrTag HttpHeader::getTimeOrTag(Http::HdrType) const STUB_RETVAL(TimeOrTag())
-int HttpHeader::hasListMember(Http::HdrType, const char *, const char) const STUB_RETVAL(0)
-int HttpHeader::hasByNameListMember(const char *, const char *, const char) const STUB_RETVAL(0)
-void HttpHeader::removeHopByHopEntries() STUB
-void HttpHeader::removeConnectionHeaderEntries() STUB
-bool HttpHeader::Isolate(const char **, size_t, const char **, const char **) STUB_RETVAL(false)
-bool HttpHeader::needUpdate(const HttpHeader *) const STUB_RETVAL(false)
-bool HttpHeader::skipUpdateHeader(const Http::HdrType) const STUB_RETVAL(false)
-int httpHeaderParseQuotedString(const char *, const int, String *) STUB_RETVAL(-1)
-SBuf Http::SlowlyParseQuotedString(const char *, const char *, size_t) STUB_RETVAL(SBuf())
-SBuf httpHeaderQuoteString(const char *) STUB_RETVAL(SBuf())
-void httpHeaderCalcMask(HttpHeaderMask *, Http::HdrType [], size_t) STUB
-void httpHeaderInitModule() STUB
+HttpHeader &HttpHeader::operator =(const HttpHeader &) STUB_RETVAL(*this);
+void HttpHeader::clean() STUB();
+void HttpHeader::append(const HttpHeader *) STUB();
+void HttpHeader::update(const HttpHeader *) STUB();
+void HttpHeader::compact() STUB();
+int HttpHeader::parse(const char *, size_t, Http::ContentLengthInterpreter &) STUB_RETVAL(-1);
+int HttpHeader::parse(const char *, size_t, bool, size_t &, Http::ContentLengthInterpreter &) STUB_RETVAL(-1);
+void HttpHeader::packInto(Packable *, bool) const STUB();
+HttpHeaderEntry *HttpHeader::getEntry(HttpHeaderPos *) const STUB_RETVAL(nullptr);
+HttpHeaderEntry *HttpHeader::findEntry(Http::HdrType) const STUB_RETVAL(nullptr);
+int HttpHeader::delByName(const SBuf &) STUB_RETVAL(0);
+int HttpHeader::delById(Http::HdrType) STUB_RETVAL(0);
+void HttpHeader::delAt(HttpHeaderPos, int &) STUB();
+void HttpHeader::refreshMask() STUB();
+void HttpHeader::addEntry(HttpHeaderEntry *) STUB();
+String HttpHeader::getList(Http::HdrType) const STUB_RETVAL(String());
+bool HttpHeader::getList(Http::HdrType, String *) const STUB_RETVAL(false);
+String HttpHeader::getStrOrList(Http::HdrType) const STUB_RETVAL(String());
+String HttpHeader::getByName(const SBuf &) const STUB_RETVAL(String());
+String HttpHeader::getByName(const char *) const STUB_RETVAL(String());
+String HttpHeader::getById(Http::HdrType) const STUB_RETVAL(String());
+bool HttpHeader::getByIdIfPresent(Http::HdrType, String *) const STUB_RETVAL(false);
+bool HttpHeader::hasNamed(const SBuf &, String *) const STUB_RETVAL(false);
+bool HttpHeader::hasNamed(const char *, unsigned int, String *) const STUB_RETVAL(false);
+SBuf HttpHeader::getByNameListMember(const char *, const char *, const char) const STUB_RETVAL(SBuf());
+SBuf HttpHeader::getListMember(Http::HdrType, const char *, const char) const STUB_RETVAL(SBuf());
+int HttpHeader::has(Http::HdrType) const STUB_RETVAL(0);
+void HttpHeader::addVia(const AnyP::ProtocolVersion &, const HttpHeader *) STUB();
+void HttpHeader::putInt(Http::HdrType, int) STUB();
+void HttpHeader::putInt64(Http::HdrType, int64_t ) STUB();
+void HttpHeader::putTime(Http::HdrType, time_t) STUB();
+void HttpHeader::putStr(Http::HdrType, const char *) STUB();
+void HttpHeader::putAuth(const char *, const char *) STUB();
+void HttpHeader::putCc(const HttpHdrCc &) STUB();
+void HttpHeader::putContRange(const HttpHdrContRange *) STUB();
+void HttpHeader::putRange(const HttpHdrRange *) STUB();
+void HttpHeader::putSc(HttpHdrSc *) STUB();
+void HttpHeader::putExt(const char *, const char *) STUB();
+void HttpHeader::updateOrAddStr(Http::HdrType, const SBuf &) STUB();
+int HttpHeader::getInt(Http::HdrType) const STUB_RETVAL(0);
+int64_t HttpHeader::getInt64(Http::HdrType) const STUB_RETVAL(0);
+time_t HttpHeader::getTime(Http::HdrType) const STUB_RETVAL(0);
+const char *HttpHeader::getStr(Http::HdrType) const STUB_RETVAL(nullptr);
+const char *HttpHeader::getLastStr(Http::HdrType) const STUB_RETVAL(nullptr);
+HttpHdrCc *HttpHeader::getCc() const STUB_RETVAL(nullptr);
+HttpHdrRange *HttpHeader::getRange() const STUB_RETVAL(nullptr);
+HttpHdrSc *HttpHeader::getSc() const STUB_RETVAL(nullptr);
+HttpHdrContRange *HttpHeader::getContRange() const STUB_RETVAL(nullptr);
+SBuf HttpHeader::getAuthToken(Http::HdrType, const char *) const STUB_RETVAL(SBuf());
+ETag HttpHeader::getETag(Http::HdrType) const STUB_RETVAL(ETag());
+TimeOrTag HttpHeader::getTimeOrTag(Http::HdrType) const STUB_RETVAL(TimeOrTag());
+int HttpHeader::hasListMember(Http::HdrType, const char *, const char) const STUB_RETVAL(0);
+int HttpHeader::hasByNameListMember(const char *, const char *, const char) const STUB_RETVAL(0);
+void HttpHeader::removeHopByHopEntries() STUB();
+void HttpHeader::removeConnectionHeaderEntries() STUB();
+bool HttpHeader::Isolate(const char **, size_t, const char **, const char **) STUB_RETVAL(false);
+bool HttpHeader::needUpdate(const HttpHeader *) const STUB_RETVAL(false);
+bool HttpHeader::skipUpdateHeader(const Http::HdrType) const STUB_RETVAL(false);
+int httpHeaderParseQuotedString(const char *, const int, String *) STUB_RETVAL(-1);
+SBuf Http::SlowlyParseQuotedString(const char *, const char *, size_t) STUB_RETVAL(SBuf());
+SBuf httpHeaderQuoteString(const char *) STUB_RETVAL(SBuf());
+void httpHeaderCalcMask(HttpHeaderMask *, Http::HdrType [], size_t) STUB();
+void httpHeaderInitModule() STUB();
 

--- a/src/tests/stub_HttpReply.cc
+++ b/src/tests/stub_HttpReply.cc
@@ -16,22 +16,22 @@ HttpReply::HttpReply() : Http::Message(hoReply), date (0), last_modified (0),
     expires(0), surrogate_control(nullptr), keep_alive(0),
     protoPrefix("HTTP/"), do_clean(false), bodySizeMax(-2), content_range(nullptr)
 {STUB_NOP}
-HttpReply::~HttpReply() STUB
-void HttpReply::setHeaders(Http::StatusCode, const char *, const char *, int64_t, time_t, time_t) STUB
-void HttpReply::packHeadersUsingFastPacker(Packable&) const STUB
-void HttpReply::packHeadersUsingSlowPacker(Packable&) const STUB
-void HttpReply::reset() STUB
-bool HttpReply::sanityCheckStartLine(const char *, const size_t, Http::StatusCode *) STUB_RETVAL(false)
-int HttpReply::httpMsgParseError() STUB_RETVAL(0)
-bool HttpReply::expectingBody(const HttpRequestMethod&, int64_t&) const STUB_RETVAL(false)
-size_t HttpReply::parseTerminatedPrefix(const char *, size_t) STUB_RETVAL(0)
-size_t HttpReply::prefixLen() const STUB_RETVAL(0)
-bool HttpReply::parseFirstLine(const char *, const char *) STUB_RETVAL(false)
-void HttpReply::hdrCacheInit() STUB
-HttpReply * HttpReply::clone() const STUB_RETVAL(nullptr)
-bool HttpReply::inheritProperties(const Http::Message *) STUB_RETVAL(false)
-HttpReply::Pointer HttpReply::recreateOnNotModified(const HttpReply &) const STUB_RETVAL(nullptr)
-int64_t HttpReply::bodySize(const HttpRequestMethod&) const STUB_RETVAL(0)
-const HttpHdrContRange *HttpReply::contentRange() const STUB_RETVAL(nullptr)
-void HttpReply::configureContentLengthInterpreter(Http::ContentLengthInterpreter &) STUB
+HttpReply::~HttpReply() STUB();
+void HttpReply::setHeaders(Http::StatusCode, const char *, const char *, int64_t, time_t, time_t) STUB();
+void HttpReply::packHeadersUsingFastPacker(Packable&) const STUB();
+void HttpReply::packHeadersUsingSlowPacker(Packable&) const STUB();
+void HttpReply::reset() STUB();
+bool HttpReply::sanityCheckStartLine(const char *, const size_t, Http::StatusCode *) STUB_RETVAL(false);
+int HttpReply::httpMsgParseError() STUB_RETVAL(0);
+bool HttpReply::expectingBody(const HttpRequestMethod&, int64_t&) const STUB_RETVAL(false);
+size_t HttpReply::parseTerminatedPrefix(const char *, size_t) STUB_RETVAL(0);
+size_t HttpReply::prefixLen() const STUB_RETVAL(0);
+bool HttpReply::parseFirstLine(const char *, const char *) STUB_RETVAL(false);
+void HttpReply::hdrCacheInit() STUB();
+HttpReply * HttpReply::clone() const STUB_RETVAL(nullptr);
+bool HttpReply::inheritProperties(const Http::Message *) STUB_RETVAL(false);
+HttpReply::Pointer HttpReply::recreateOnNotModified(const HttpReply &) const STUB_RETVAL(nullptr);
+int64_t HttpReply::bodySize(const HttpRequestMethod&) const STUB_RETVAL(0);
+const HttpHdrContRange *HttpReply::contentRange() const STUB_RETVAL(nullptr);
+void HttpReply::configureContentLengthInterpreter(Http::ContentLengthInterpreter &) STUB();
 

--- a/src/tests/stub_HttpRequest.cc
+++ b/src/tests/stub_HttpRequest.cc
@@ -17,45 +17,45 @@
 
 HttpRequest::HttpRequest(const MasterXaction::Pointer&) : Http::Message(hoRequest) {STUB}
 HttpRequest::HttpRequest(const HttpRequestMethod &, AnyP::ProtocolType, const char *, const char *, const MasterXaction::Pointer &) : Http::Message(hoRequest) {STUB}
-HttpRequest::~HttpRequest() STUB
-void HttpRequest::reset() STUB
-void HttpRequest::initHTTP(const HttpRequestMethod &, AnyP::ProtocolType, const char *, const char *) STUB
-HttpRequest * HttpRequest::clone() const STUB_RETVAL(nullptr)
-bool HttpRequest::maybeCacheable() STUB_RETVAL(false)
-bool HttpRequest::conditional() const STUB_RETVAL(false)
-bool HttpRequest::canHandle1xx() const STUB_RETVAL(false)
-char * HttpRequest::canonicalCleanUrl() const STUB_RETVAL(nullptr)
+HttpRequest::~HttpRequest() STUB();
+void HttpRequest::reset() STUB();
+void HttpRequest::initHTTP(const HttpRequestMethod &, AnyP::ProtocolType, const char *, const char *) STUB();
+HttpRequest * HttpRequest::clone() const STUB_RETVAL(nullptr);
+bool HttpRequest::maybeCacheable() STUB_RETVAL(false);
+bool HttpRequest::conditional() const STUB_RETVAL(false);
+bool HttpRequest::canHandle1xx() const STUB_RETVAL(false);
+char * HttpRequest::canonicalCleanUrl() const STUB_RETVAL(nullptr);
 #if USE_ADAPTATION
-Adaptation::History::Pointer HttpRequest::adaptLogHistory() const STUB_RETVAL(Adaptation::History::Pointer())
-Adaptation::History::Pointer HttpRequest::adaptHistory(bool) const STUB_RETVAL(Adaptation::History::Pointer())
-void HttpRequest::adaptHistoryImport(const HttpRequest &) STUB
+Adaptation::History::Pointer HttpRequest::adaptLogHistory() const STUB_RETVAL(Adaptation::History::Pointer());
+Adaptation::History::Pointer HttpRequest::adaptHistory(bool) const STUB_RETVAL(Adaptation::History::Pointer());
+void HttpRequest::adaptHistoryImport(const HttpRequest &) STUB();
 #endif
 #if ICAP_CLIENT
-Adaptation::Icap::History::Pointer HttpRequest::icapHistory() const STUB_RETVAL(Adaptation::Icap::History::Pointer())
+Adaptation::Icap::History::Pointer HttpRequest::icapHistory() const STUB_RETVAL(Adaptation::Icap::History::Pointer());
 #endif
-void HttpRequest::recordLookup(const Dns::LookupDetails &) STUB
-void HttpRequest::clearError() STUB
-void HttpRequest::clean() STUB
-void HttpRequest::init() STUB
+void HttpRequest::recordLookup(const Dns::LookupDetails &) STUB();
+void HttpRequest::clearError() STUB();
+void HttpRequest::clean() STUB();
+void HttpRequest::init() STUB();
 static const SBuf nilSBuf;
-const SBuf &HttpRequest::effectiveRequestUri() const STUB_RETVAL(nilSBuf)
-bool HttpRequest::multipartRangeRequest() const STUB_RETVAL(false)
-bool HttpRequest::parseFirstLine(const char *, const char *) STUB_RETVAL(false)
-bool HttpRequest::expectingBody(const HttpRequestMethod &, int64_t &) const STUB_RETVAL(false)
-bool HttpRequest::bodyNibbled() const STUB_RETVAL(false)
-int HttpRequest::prefixLen() const STUB_RETVAL(0)
-void HttpRequest::swapOut(StoreEntry *) STUB
-void HttpRequest::pack(Packable *) const STUB
-void HttpRequest::httpRequestPack(void *, Packable *) STUB
-HttpRequest * HttpRequest::FromUrl(const SBuf &, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr)
-HttpRequest * HttpRequest::FromUrlXXX(const char *, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr)
-ConnStateData *HttpRequest::pinnedConnection() STUB_RETVAL(nullptr)
-const SBuf HttpRequest::storeId() STUB_RETVAL(SBuf("."))
-void HttpRequest::ignoreRange(const char *) STUB
-int64_t HttpRequest::getRangeOffsetLimit() STUB_RETVAL(0)
-void HttpRequest::packFirstLineInto(Packable *, bool) const STUB
-bool HttpRequest::sanityCheckStartLine(const char *, const size_t, Http::StatusCode *) STUB_RETVAL(false)
-void HttpRequest::hdrCacheInit() STUB
-bool HttpRequest::inheritProperties(const Http::Message *) STUB_RETVAL(false)
-NotePairs::Pointer HttpRequest::notes() STUB_RETVAL(NotePairs::Pointer())
+const SBuf &HttpRequest::effectiveRequestUri() const STUB_RETVAL(nilSBuf);
+bool HttpRequest::multipartRangeRequest() const STUB_RETVAL(false);
+bool HttpRequest::parseFirstLine(const char *, const char *) STUB_RETVAL(false);
+bool HttpRequest::expectingBody(const HttpRequestMethod &, int64_t &) const STUB_RETVAL(false);
+bool HttpRequest::bodyNibbled() const STUB_RETVAL(false);
+int HttpRequest::prefixLen() const STUB_RETVAL(0);
+void HttpRequest::swapOut(StoreEntry *) STUB();
+void HttpRequest::pack(Packable *) const STUB();
+void HttpRequest::httpRequestPack(void *, Packable *) STUB();
+HttpRequest * HttpRequest::FromUrl(const SBuf &, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr);
+HttpRequest * HttpRequest::FromUrlXXX(const char *, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr);
+ConnStateData *HttpRequest::pinnedConnection() STUB_RETVAL(nullptr);
+const SBuf HttpRequest::storeId() STUB_RETVAL(SBuf("."));
+void HttpRequest::ignoreRange(const char *) STUB();
+int64_t HttpRequest::getRangeOffsetLimit() STUB_RETVAL(0);
+void HttpRequest::packFirstLineInto(Packable *, bool) const STUB();
+bool HttpRequest::sanityCheckStartLine(const char *, const size_t, Http::StatusCode *) STUB_RETVAL(false);
+void HttpRequest::hdrCacheInit() STUB();
+bool HttpRequest::inheritProperties(const Http::Message *) STUB_RETVAL(false);
+NotePairs::Pointer HttpRequest::notes() STUB_RETVAL(NotePairs::Pointer());
 

--- a/src/tests/stub_HttpUpgradeProtocolAccess.cc
+++ b/src/tests/stub_HttpUpgradeProtocolAccess.cc
@@ -13,12 +13,12 @@
 #include "tests/STUB.h"
 
 #include "HttpUpgradeProtocolAccess.h"
-ProtocolView::ProtocolView(const char * const, const size_t) STUB
-ProtocolView::ProtocolView(SBuf const &) STUB
-std::ostream &operator <<(std::ostream &os, const ProtocolView &) STUB_RETVAL(os)
-HttpUpgradeProtocolAccess::~HttpUpgradeProtocolAccess() STUB
-const acl_access *HttpUpgradeProtocolAccess::findGuard(const SBuf &) const STUB_RETVAL(nullptr)
-void HttpUpgradeProtocolAccess::configureGuard(ConfigParser &) STUB
+ProtocolView::ProtocolView(const char * const, const size_t) STUB();
+ProtocolView::ProtocolView(SBuf const &) STUB();
+std::ostream &operator <<(std::ostream &os, const ProtocolView &) STUB_RETVAL(os);
+HttpUpgradeProtocolAccess::~HttpUpgradeProtocolAccess() STUB();
+const acl_access *HttpUpgradeProtocolAccess::findGuard(const SBuf &) const STUB_RETVAL(nullptr);
+void HttpUpgradeProtocolAccess::configureGuard(ConfigParser &) STUB();
 HttpUpgradeProtocolAccess::NamedGuard::~NamedGuard() STUB_NOP
 HttpUpgradeProtocolAccess::NamedGuard::NamedGuard(const char *, acl_access *): protocol("STUB-UNDEF"), proto(protocol) STUB_NOP
 

--- a/src/tests/stub_IpcIoFile.cc
+++ b/src/tests/stub_IpcIoFile.cc
@@ -15,7 +15,7 @@
 
 #include "tests/STUB.h"
 
-void IpcIoFile::StatQueue(std::ostream &) STUB
+void IpcIoFile::StatQueue(std::ostream &) STUB();
 
 #endif /* HAVE_DISKIO_MODULE_IPCIO */
 

--- a/src/tests/stub_MemBuf.cc
+++ b/src/tests/stub_MemBuf.cc
@@ -12,20 +12,20 @@
 #define STUB_API "MemBuf.cc"
 #include "tests/STUB.h"
 
-mb_size_t MemBuf::spaceSize() const STUB_RETVAL(0)
-mb_size_t MemBuf::potentialSpaceSize() const STUB_RETVAL(0)
-void MemBuf::consume(mb_size_t) STUB
-void MemBuf::appended(mb_size_t) STUB
-void MemBuf::truncate(mb_size_t) STUB
-void MemBuf::terminate() STUB
-void MemBuf::init(mb_size_t, mb_size_t) STUB
-void MemBuf::init() STUB
-void MemBuf::clean() STUB
-void MemBuf::reset() STUB
-int MemBuf::isNull() const STUB_RETVAL(1)
-FREE *MemBuf::freeFunc() STUB_RETVAL(nullptr)
-void MemBuf::append(const char *, int) STUB
-void MemBuf::vappendf(const char *, va_list) STUB
+mb_size_t MemBuf::spaceSize() const STUB_RETVAL(0);
+mb_size_t MemBuf::potentialSpaceSize() const STUB_RETVAL(0);
+void MemBuf::consume(mb_size_t) STUB();
+void MemBuf::appended(mb_size_t) STUB();
+void MemBuf::truncate(mb_size_t) STUB();
+void MemBuf::terminate() STUB();
+void MemBuf::init(mb_size_t, mb_size_t) STUB();
+void MemBuf::init() STUB();
+void MemBuf::clean() STUB();
+void MemBuf::reset() STUB();
+int MemBuf::isNull() const STUB_RETVAL(1);
+FREE *MemBuf::freeFunc() STUB_RETVAL(nullptr);
+void MemBuf::append(const char *, int) STUB();
+void MemBuf::vappendf(const char *, va_list) STUB();
 
-void memBufReport(MemBuf *) STUB
+void memBufReport(MemBuf *) STUB();
 

--- a/src/tests/stub_MemObject.cc
+++ b/src/tests/stub_MemObject.cc
@@ -26,33 +26,33 @@ MemObject::endOffset() const
     return data_hdr.endOffset();
 }
 
-void MemObject::trimSwappable() STUB
-void MemObject::trimUnSwappable() STUB
-int64_t MemObject::policyLowestOffsetToKeep(bool) const STUB_RETVAL(-1)
+void MemObject::trimSwappable() STUB();
+void MemObject::trimUnSwappable() STUB();
+int64_t MemObject::policyLowestOffsetToKeep(bool) const STUB_RETVAL(-1);
 MemObject::MemObject() {
     ping_reply_callback = nullptr;
     memset(&start_ping, 0, sizeof(start_ping));
 } // NOP instead of elided due to Store
 
-const char *MemObject::storeId() const STUB_RETVAL(nullptr)
-const char *MemObject::logUri() const STUB_RETVAL(nullptr)
-void MemObject::setUris(char const *, char const *, const HttpRequestMethod &) STUB
-void MemObject::reset() STUB
-void MemObject::delayRead(const AsyncCallPointer &) STUB
-bool MemObject::readAheadPolicyCanRead() const STUB_RETVAL(false)
-void MemObject::setNoDelay(bool const) STUB
-MemObject::~MemObject() STUB
-int MemObject::mostBytesWanted(int, bool) const STUB_RETVAL(-1)
+const char *MemObject::storeId() const STUB_RETVAL(nullptr);
+const char *MemObject::logUri() const STUB_RETVAL(nullptr);
+void MemObject::setUris(char const *, char const *, const HttpRequestMethod &) STUB();
+void MemObject::reset() STUB();
+void MemObject::delayRead(const AsyncCallPointer &) STUB();
+bool MemObject::readAheadPolicyCanRead() const STUB_RETVAL(false);
+void MemObject::setNoDelay(bool const) STUB();
+MemObject::~MemObject() STUB();
+int MemObject::mostBytesWanted(int, bool) const STUB_RETVAL(-1);
 #if USE_DELAY_POOLS
-DelayId MemObject::mostBytesAllowed() const STUB_RETVAL(DelayId())
+DelayId MemObject::mostBytesAllowed() const STUB_RETVAL(DelayId());
 #endif
-void MemObject::write(const StoreIOBuffer &) STUB
-int64_t MemObject::lowestMemReaderOffset() const STUB_RETVAL(0)
-void MemObject::kickReads() STUB
-int64_t MemObject::objectBytesOnDisk() const STUB_RETVAL(0)
-bool MemObject::isContiguous() const STUB_RETVAL(false)
-int64_t MemObject::expectedReplySize() const STUB_RETVAL(0)
-void MemObject::markEndOfReplyHeaders() STUB
-size_t MemObject::inUseCount() STUB_RETVAL(0)
-int64_t MemObject::availableForSwapOut() const STUB_RETVAL(0)
+void MemObject::write(const StoreIOBuffer &) STUB();
+int64_t MemObject::lowestMemReaderOffset() const STUB_RETVAL(0);
+void MemObject::kickReads() STUB();
+int64_t MemObject::objectBytesOnDisk() const STUB_RETVAL(0);
+bool MemObject::isContiguous() const STUB_RETVAL(false);
+int64_t MemObject::expectedReplySize() const STUB_RETVAL(0);
+void MemObject::markEndOfReplyHeaders() STUB();
+size_t MemObject::inUseCount() STUB_RETVAL(0);
+int64_t MemObject::availableForSwapOut() const STUB_RETVAL(0);
 

--- a/src/tests/stub_MemStore.cc
+++ b/src/tests/stub_MemStore.cc
@@ -14,29 +14,29 @@
 #define STUB_API "MemStore.cc"
 #include "tests/STUB.h"
 
-MemStore::MemStore() STUB
-MemStore::~MemStore() STUB
-bool MemStore::keepInLocalMemory(const StoreEntry &) const STUB_RETVAL(false)
-void MemStore::write(StoreEntry &) STUB
-void MemStore::completeWriting(StoreEntry &) STUB
-void MemStore::disconnect(StoreEntry &) STUB
-void MemStore::reference(StoreEntry &) STUB
-void MemStore::updateHeaders(StoreEntry *) STUB
-void MemStore::maintain() STUB
-void MemStore::noteFreeMapSlice(const Ipc::StoreMapSliceId) STUB
-void MemStore::init() STUB
-void MemStore::getStats(StoreInfoStats&) const STUB
-void MemStore::stat(StoreEntry &) const STUB
-StoreEntry *MemStore::get(const cache_key *) STUB_RETVAL(nullptr)
-uint64_t MemStore::maxSize() const STUB_RETVAL(0)
-uint64_t MemStore::minSize() const STUB_RETVAL(0)
-uint64_t MemStore::currentSize() const STUB_RETVAL(0)
-uint64_t MemStore::currentCount() const STUB_RETVAL(0)
-int64_t MemStore::maxObjectSize() const STUB_RETVAL(0)
-bool MemStore::dereference(StoreEntry &) STUB_RETVAL(false)
-void MemStore::evictCached(StoreEntry&) STUB
-void MemStore::evictIfFound(const cache_key *) STUB
-bool MemStore::anchorToCache(StoreEntry&) STUB_RETVAL(false)
-bool MemStore::updateAnchored(StoreEntry&) STUB_RETVAL(false)
-int64_t MemStore::EntryLimit() STUB_RETVAL(0)
+MemStore::MemStore() STUB();
+MemStore::~MemStore() STUB();
+bool MemStore::keepInLocalMemory(const StoreEntry &) const STUB_RETVAL(false);
+void MemStore::write(StoreEntry &) STUB();
+void MemStore::completeWriting(StoreEntry &) STUB();
+void MemStore::disconnect(StoreEntry &) STUB();
+void MemStore::reference(StoreEntry &) STUB();
+void MemStore::updateHeaders(StoreEntry *) STUB();
+void MemStore::maintain() STUB();
+void MemStore::noteFreeMapSlice(const Ipc::StoreMapSliceId) STUB();
+void MemStore::init() STUB();
+void MemStore::getStats(StoreInfoStats&) const STUB();
+void MemStore::stat(StoreEntry &) const STUB();
+StoreEntry *MemStore::get(const cache_key *) STUB_RETVAL(nullptr);
+uint64_t MemStore::maxSize() const STUB_RETVAL(0);
+uint64_t MemStore::minSize() const STUB_RETVAL(0);
+uint64_t MemStore::currentSize() const STUB_RETVAL(0);
+uint64_t MemStore::currentCount() const STUB_RETVAL(0);
+int64_t MemStore::maxObjectSize() const STUB_RETVAL(0);
+bool MemStore::dereference(StoreEntry &) STUB_RETVAL(false);
+void MemStore::evictCached(StoreEntry&) STUB();
+void MemStore::evictIfFound(const cache_key *) STUB();
+bool MemStore::anchorToCache(StoreEntry&) STUB_RETVAL(false);
+bool MemStore::updateAnchored(StoreEntry&) STUB_RETVAL(false);
+int64_t MemStore::EntryLimit() STUB_RETVAL(0);
 

--- a/src/tests/stub_Port.cc
+++ b/src/tests/stub_Port.cc
@@ -14,6 +14,6 @@
 
 const char Ipc::strandAddrLabel[] = "-kid";
 
-String Ipc::Port::MakeAddr(char const*, int) STUB_RETVAL("")
-String Ipc::Port::CoordinatorAddr() STUB_RETVAL("")
+String Ipc::Port::MakeAddr(char const*, int) STUB_RETVAL("");
+String Ipc::Port::CoordinatorAddr() STUB_RETVAL("");
 

--- a/src/tests/stub_SBuf.cc
+++ b/src/tests/stub_SBuf.cc
@@ -21,8 +21,8 @@ const SBuf::size_type SBuf::maxSize;
 
 SBufStats::SizeRecorder SBufStats::SBufSizeAtDestructRecorder = nullptr;
 SBufStats::SizeRecorder SBufStats::MemBlobSizeAtDestructRecorder = nullptr;
-std::ostream& SBufStats::dump(std::ostream &os) const STUB_RETVAL(os)
-SBufStats& SBufStats::operator +=(const SBufStats&) STUB_RETVAL(*this)
+std::ostream& SBufStats::dump(std::ostream &os) const STUB_RETVAL(os);
+SBufStats& SBufStats::operator +=(const SBufStats&) STUB_RETVAL(*this);
 
 SBuf::SBuf() {}
 SBuf::SBuf(const SBuf &) {}
@@ -30,43 +30,43 @@ SBuf::SBuf(const char *, size_type) {}
 SBuf::SBuf(const char *) {}
 SBuf::SBuf(const std::string &) {}
 SBuf::~SBuf() {}
-SBuf& SBuf::assign(const SBuf &) STUB_RETVAL(*this)
-SBuf& SBuf::assign(const char *, size_type) STUB_RETVAL(*this)
-void SBuf::clear() STUB
-SBuf& SBuf::append(const SBuf &) STUB_RETVAL(*this)
-SBuf& SBuf::append(const char *, size_type) STUB_RETVAL(*this)
-void SBuf::push_back(char) STUB
-SBuf& SBuf::Printf(const char *, ...) STUB_RETVAL(*this)
-SBuf& SBuf::appendf(const char *, ...) STUB_RETVAL(*this)
-SBuf& SBuf::vappendf(const char *, va_list) STUB_RETVAL(*this)
-std::ostream& SBuf::print(std::ostream &os) const STUB_RETVAL(os)
-std::ostream& SBuf::dump(std::ostream &os) const STUB_RETVAL(os)
-void SBuf::setAt(size_type, char) STUB
-int SBuf::compare(const SBuf &, const SBufCaseSensitive, const size_type) const STUB_RETVAL(-1)
-int SBuf::compare(const char *, const SBufCaseSensitive, const size_type) const STUB_RETVAL(-1)
-bool SBuf::startsWith(const SBuf &, const SBufCaseSensitive) const STUB_RETVAL(false)
-bool SBuf::operator ==(const SBuf &) const STUB_RETVAL(false)
-bool SBuf::operator !=(const SBuf &) const STUB_RETVAL(false)
-SBuf SBuf::consume(size_type) STUB_RETVAL(*this)
-const SBufStats& SBuf::GetStats() STUB_RETVAL(SBuf::stats)
-SBuf::size_type SBuf::copy(char *, size_type) const STUB_RETVAL(0)
-const char* SBuf::rawContent() const STUB_RETVAL(nullptr)
-char *SBuf::rawAppendStart(size_type) STUB_RETVAL(nullptr)
-void SBuf::rawAppendFinish(const char *, size_type) STUB
-const char* SBuf::c_str() STUB_RETVAL("")
-void SBuf::reserveCapacity(size_type) STUB
-SBuf::size_type SBuf::reserve(const SBufReservationRequirements &) STUB_RETVAL(0)
-SBuf& SBuf::chop(size_type, size_type) STUB_RETVAL(*this)
-SBuf& SBuf::trim(const SBuf &, bool, bool) STUB_RETVAL(*this)
-SBuf SBuf::substr(size_type, size_type) const STUB_RETVAL(*this)
-SBuf::size_type SBuf::find(char, size_type) const STUB_RETVAL(SBuf::npos)
-SBuf::size_type SBuf::find(const SBuf &, size_type) const STUB_RETVAL(SBuf::npos)
-SBuf::size_type SBuf::rfind(char, size_type) const STUB_RETVAL(SBuf::npos)
-SBuf::size_type SBuf::rfind(const SBuf &, size_type) const STUB_RETVAL(SBuf::npos)
-SBuf::size_type SBuf::findFirstOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos)
-SBuf::size_type SBuf::findLastOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos)
-SBuf::size_type SBuf::findFirstNotOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos)
-SBuf::size_type SBuf::findLastNotOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos)
-void SBuf::toLower() STUB
-void SBuf::toUpper() STUB
+SBuf& SBuf::assign(const SBuf &) STUB_RETVAL(*this);
+SBuf& SBuf::assign(const char *, size_type) STUB_RETVAL(*this);
+void SBuf::clear() STUB();
+SBuf& SBuf::append(const SBuf &) STUB_RETVAL(*this);
+SBuf& SBuf::append(const char *, size_type) STUB_RETVAL(*this);
+void SBuf::push_back(char) STUB();
+SBuf& SBuf::Printf(const char *, ...) STUB_RETVAL(*this);
+SBuf& SBuf::appendf(const char *, ...) STUB_RETVAL(*this);
+SBuf& SBuf::vappendf(const char *, va_list) STUB_RETVAL(*this);
+std::ostream& SBuf::print(std::ostream &os) const STUB_RETVAL(os);
+std::ostream& SBuf::dump(std::ostream &os) const STUB_RETVAL(os);
+void SBuf::setAt(size_type, char) STUB();
+int SBuf::compare(const SBuf &, const SBufCaseSensitive, const size_type) const STUB_RETVAL(-1);
+int SBuf::compare(const char *, const SBufCaseSensitive, const size_type) const STUB_RETVAL(-1);
+bool SBuf::startsWith(const SBuf &, const SBufCaseSensitive) const STUB_RETVAL(false);
+bool SBuf::operator ==(const SBuf &) const STUB_RETVAL(false);
+bool SBuf::operator !=(const SBuf &) const STUB_RETVAL(false);
+SBuf SBuf::consume(size_type) STUB_RETVAL(*this);
+const SBufStats& SBuf::GetStats() STUB_RETVAL(SBuf::stats);
+SBuf::size_type SBuf::copy(char *, size_type) const STUB_RETVAL(0);
+const char* SBuf::rawContent() const STUB_RETVAL(nullptr);
+char *SBuf::rawAppendStart(size_type) STUB_RETVAL(nullptr);
+void SBuf::rawAppendFinish(const char *, size_type) STUB();
+const char* SBuf::c_str() STUB_RETVAL("");
+void SBuf::reserveCapacity(size_type) STUB();
+SBuf::size_type SBuf::reserve(const SBufReservationRequirements &) STUB_RETVAL(0);
+SBuf& SBuf::chop(size_type, size_type) STUB_RETVAL(*this);
+SBuf& SBuf::trim(const SBuf &, bool, bool) STUB_RETVAL(*this);
+SBuf SBuf::substr(size_type, size_type) const STUB_RETVAL(*this);
+SBuf::size_type SBuf::find(char, size_type) const STUB_RETVAL(SBuf::npos);
+SBuf::size_type SBuf::find(const SBuf &, size_type) const STUB_RETVAL(SBuf::npos);
+SBuf::size_type SBuf::rfind(char, size_type) const STUB_RETVAL(SBuf::npos);
+SBuf::size_type SBuf::rfind(const SBuf &, size_type) const STUB_RETVAL(SBuf::npos);
+SBuf::size_type SBuf::findFirstOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos);
+SBuf::size_type SBuf::findLastOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos);
+SBuf::size_type SBuf::findFirstNotOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos);
+SBuf::size_type SBuf::findLastNotOf(const CharacterSet &, size_type) const STUB_RETVAL(SBuf::npos);
+void SBuf::toLower() STUB();
+void SBuf::toUpper() STUB();
 

--- a/src/tests/stub_StatHist.cc
+++ b/src/tests/stub_StatHist.cc
@@ -14,11 +14,11 @@
 
 class StoreEntry;
 
-void StatHist::dump(StoreEntry *, StatHistBinDumper *) const STUB
+void StatHist::dump(StoreEntry *, StatHistBinDumper *) const STUB();
 void StatHist::enumInit(unsigned int) STUB_NOP
 void StatHist::count(double) {/* STUB_NOP */}
-double statHistDeltaMedian(const StatHist &, const StatHist &) STUB_RETVAL(0.0)
-double statHistDeltaPctile(const StatHist &, const StatHist &, double) STUB_RETVAL(0.0)
+double statHistDeltaMedian(const StatHist &, const StatHist &) STUB_RETVAL(0.0);
+double statHistDeltaPctile(const StatHist &, const StatHist &, double) STUB_RETVAL(0.0);
 void StatHist::logInit(unsigned int, double, double) STUB_NOP
-void statHistIntDumper(StoreEntry *, int, double, double, int) STUB
+void statHistIntDumper(StoreEntry *, int, double, double, int) STUB();
 

--- a/src/tests/stub_UdsOp.cc
+++ b/src/tests/stub_UdsOp.cc
@@ -12,5 +12,5 @@
 #define STUB_API "UdsOp.cc"
 #include "tests/STUB.h"
 
-void Ipc::SendMessage(const String&, const TypedMsgHdr&) STUB
+void Ipc::SendMessage(const String&, const TypedMsgHdr&) STUB();
 

--- a/src/tests/stub_access_log.cc
+++ b/src/tests/stub_access_log.cc
@@ -12,11 +12,11 @@
 #define STUB_API "access.log.cc"
 #include "tests/STUB.h"
 
-HierarchyLogEntry::HierarchyLogEntry() STUB
+HierarchyLogEntry::HierarchyLogEntry() STUB();
 
-void HierarchyLogEntry::notePeerRead() STUB
-void HierarchyLogEntry::notePeerWrite() STUB
-bool HierarchyLogEntry::peerResponseTime(struct timeval &) STUB_RETVAL(false)
+void HierarchyLogEntry::notePeerRead() STUB();
+void HierarchyLogEntry::notePeerWrite() STUB();
+bool HierarchyLogEntry::peerResponseTime(struct timeval &) STUB_RETVAL(false);
 
 ping_data::ping_data() :
     n_sent(0),

--- a/src/tests/stub_acl.cc
+++ b/src/tests/stub_acl.cc
@@ -16,5 +16,5 @@
 #include "acl/forward.h"
 
 #include "acl/Gadgets.h"
-size_t aclParseAclList(ConfigParser &, ACLList **, const char *) STUB_RETVAL(0)
+size_t aclParseAclList(ConfigParser &, ACLList **, const char *) STUB_RETVAL(0);
 

--- a/src/tests/stub_cache_cf.cc
+++ b/src/tests/stub_cache_cf.cc
@@ -22,16 +22,16 @@ const char *cfg_directive = nullptr;
 const char *cfg_filename = nullptr;
 int config_lineno = 0;
 char config_input_line[BUFSIZ] = {};
-void self_destruct(void) STUB
-void parse_int(int *) STUB
-void parse_onoff(int *) STUB
-void parse_eol(char *volatile *) STUB
-void parse_wordlist(wordlist **) STUB
+void self_destruct(void) STUB();
+void parse_int(int *) STUB();
+void parse_onoff(int *) STUB();
+void parse_eol(char *volatile *) STUB();
+void parse_wordlist(wordlist **) STUB();
 void requirePathnameExists(const char *, const char *) STUB_NOP
-void parse_time_t(time_t *) STUB
-void ConfigParser::ParseUShort(unsigned short *) STUB
-void ConfigParser::ParseWordList(wordlist **) STUB
-void parseBytesOptionValue(size_t *, const char *, char const *) STUB
-void dump_acl_access(StoreEntry *, const char *, acl_access *) STUB
-void dump_acl_list(StoreEntry*, ACLList*) STUB
+void parse_time_t(time_t *) STUB();
+void ConfigParser::ParseUShort(unsigned short *) STUB();
+void ConfigParser::ParseWordList(wordlist **) STUB();
+void parseBytesOptionValue(size_t *, const char *, char const *) STUB();
+void dump_acl_access(StoreEntry *, const char *, acl_access *) STUB();
+void dump_acl_list(StoreEntry*, ACLList*) STUB();
 

--- a/src/tests/stub_cache_manager.cc
+++ b/src/tests/stub_cache_manager.cc
@@ -14,13 +14,13 @@
 #define STUB_API "cache_manager.cc"
 #include "tests/STUB.h"
 
-Mgr::Action::Pointer CacheManager::createNamedAction(char const*) STUB_RETVAL(nullptr)
-void CacheManager::start(const Comm::ConnectionPointer &, HttpRequest *, StoreEntry *, const AccessLogEntryPointer &) STUB
+Mgr::Action::Pointer CacheManager::createNamedAction(char const*) STUB_RETVAL(nullptr);
+void CacheManager::start(const Comm::ConnectionPointer &, HttpRequest *, StoreEntry *, const AccessLogEntryPointer &) STUB();
 static CacheManager* instance = nullptr;
-CacheManager* CacheManager::GetInstance() STUB_RETVAL(instance)
+CacheManager* CacheManager::GetInstance() STUB_RETVAL(instance);
 void Mgr::RegisterAction(char const *, char const *, OBJH *, Protected, Atomic, Format) {}
 void Mgr::RegisterAction(char const *, char const *, ClassActionCreationHandler *, Protected, Atomic, Format) {}
 
-Mgr::Action::Pointer CacheManager::createRequestedAction(const Mgr::ActionParams &) STUB_RETVAL(nullptr)
-void CacheManager::PutCommonResponseHeaders(HttpReply &, const char *) STUB
+Mgr::Action::Pointer CacheManager::createRequestedAction(const Mgr::ActionParams &) STUB_RETVAL(nullptr);
+void CacheManager::PutCommonResponseHeaders(HttpReply &, const char *) STUB();
 

--- a/src/tests/stub_carp.cc
+++ b/src/tests/stub_carp.cc
@@ -13,5 +13,5 @@
 
 #include "carp.h"
 
-CachePeer *carpSelectParent(PeerSelector *) STUB_RETVAL(nullptr)
+CachePeer *carpSelectParent(PeerSelector *) STUB_RETVAL(nullptr);
 

--- a/src/tests/stub_cbdata.cc
+++ b/src/tests/stub_cbdata.cc
@@ -12,11 +12,11 @@
 #include "tests/STUB.h"
 
 #include "cbdata.h"
-void *cbdataInternalAlloc(cbdata_type) STUB_RETVAL(nullptr)
-void *cbdataInternalFree(void *) STUB_RETVAL(nullptr)
-void cbdataInternalLock(const void *) STUB
-void cbdataInternalUnlock(const void *) STUB
-int cbdataInternalReferenceDoneValid(void **, void **) STUB_RETVAL(0)
-int cbdataReferenceValid(const void *) STUB_RETVAL(0)
-cbdata_type cbdataInternalAddType(cbdata_type, const char *, int) STUB_RETVAL(CBDATA_UNKNOWN)
+void *cbdataInternalAlloc(cbdata_type) STUB_RETVAL(nullptr);
+void *cbdataInternalFree(void *) STUB_RETVAL(nullptr);
+void cbdataInternalLock(const void *) STUB();
+void cbdataInternalUnlock(const void *) STUB();
+int cbdataInternalReferenceDoneValid(void **, void **) STUB_RETVAL(0);
+int cbdataReferenceValid(const void *) STUB_RETVAL(0);
+cbdata_type cbdataInternalAddType(cbdata_type, const char *, int) STUB_RETVAL(CBDATA_UNKNOWN);
 

--- a/src/tests/stub_client_db.cc
+++ b/src/tests/stub_client_db.cc
@@ -12,16 +12,16 @@
 #include "tests/STUB.h"
 
 #include "client_db.h"
-void clientdbUpdate(const Ip::Address &, const LogTags &, AnyP::ProtocolType, size_t) STUB
-int clientdbCutoffDenied(const Ip::Address &) STUB_RETVAL(-1)
-void clientdbDump(StoreEntry *) STUB
-int clientdbEstablished(const Ip::Address &, int) STUB_RETVAL(-1)
+void clientdbUpdate(const Ip::Address &, const LogTags &, AnyP::ProtocolType, size_t) STUB();
+int clientdbCutoffDenied(const Ip::Address &) STUB_RETVAL(-1);
+void clientdbDump(StoreEntry *) STUB();
+int clientdbEstablished(const Ip::Address &, int) STUB_RETVAL(-1);
 #if USE_DELAY_POOLS
-void clientdbSetWriteLimiter(ClientInfo *, const int,const double,const double) STUB
-ClientInfo *clientdbGetInfo(const Ip::Address &) STUB_RETVAL(nullptr)
+void clientdbSetWriteLimiter(ClientInfo *, const int,const double,const double) STUB();
+ClientInfo *clientdbGetInfo(const Ip::Address &) STUB_RETVAL(nullptr);
 #endif
 #if SQUID_SNMP
-Ip::Address *client_entry(Ip::Address *) STUB_RETVAL(nullptr)
-variable_list *snmp_meshCtblFn(variable_list *, snint *) STUB_RETVAL(nullptr)
+Ip::Address *client_entry(Ip::Address *) STUB_RETVAL(nullptr);
+variable_list *snmp_meshCtblFn(variable_list *, snint *) STUB_RETVAL(nullptr);
 #endif
 

--- a/src/tests/stub_client_side.cc
+++ b/src/tests/stub_client_side.cc
@@ -14,50 +14,50 @@
 #include "tests/STUB.h"
 
 #include "client_side.h"
-void ConnStateData::parseRequests() STUB
-void ConnStateData::readNextRequest() STUB
-bool ConnStateData::isOpen() const STUB_RETVAL(false)
-void ConnStateData::kick() STUB
-void ConnStateData::sendControlMsg(HttpControlMsg) STUB
-int64_t ConnStateData::mayNeedToReadMoreBody() const STUB_RETVAL(0)
+void ConnStateData::parseRequests() STUB();
+void ConnStateData::readNextRequest() STUB();
+bool ConnStateData::isOpen() const STUB_RETVAL(false);
+void ConnStateData::kick() STUB();
+void ConnStateData::sendControlMsg(HttpControlMsg) STUB();
+int64_t ConnStateData::mayNeedToReadMoreBody() const STUB_RETVAL(0);
 #if USE_AUTH
-void ConnStateData::setAuth(const Auth::UserRequest::Pointer &, const char *) STUB
+void ConnStateData::setAuth(const Auth::UserRequest::Pointer &, const char *) STUB();
 #endif
-bool ConnStateData::transparent() const STUB_RETVAL(false)
-void ConnStateData::stopReceiving(const char *) STUB
-void ConnStateData::stopSending(const char *) STUB
-void ConnStateData::expectNoForwarding() STUB
-void ConnStateData::noteMoreBodySpaceAvailable(BodyPipe::Pointer) STUB
-void ConnStateData::noteBodyConsumerAborted(BodyPipe::Pointer) STUB
-bool ConnStateData::handleReadData() STUB_RETVAL(false)
-bool ConnStateData::handleRequestBodyData() STUB_RETVAL(false)
-void ConnStateData::pinBusyConnection(const Comm::ConnectionPointer &, const HttpRequest::Pointer &) STUB
-void ConnStateData::notePinnedConnectionBecameIdle(PinnedIdleContext) STUB
-void ConnStateData::unpinConnection(const bool) STUB
-Comm::ConnectionPointer ConnStateData::BorrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &) STUB_RETVAL(nullptr)
-void ConnStateData::clientPinnedConnectionClosed(const CommCloseCbParams &) STUB
-void ConnStateData::connStateClosed(const CommCloseCbParams &) STUB
-void ConnStateData::requestTimeout(const CommTimeoutCbParams &) STUB
-void ConnStateData::swanSong() STUB
-void ConnStateData::quitAfterError(HttpRequest *) STUB
-NotePairs::Pointer ConnStateData::notes() STUB_RETVAL(NotePairs::Pointer())
-void ConnStateData::fillConnectionLevelDetails(ACLFilledChecklist &) const STUB
+bool ConnStateData::transparent() const STUB_RETVAL(false);
+void ConnStateData::stopReceiving(const char *) STUB();
+void ConnStateData::stopSending(const char *) STUB();
+void ConnStateData::expectNoForwarding() STUB();
+void ConnStateData::noteMoreBodySpaceAvailable(BodyPipe::Pointer) STUB();
+void ConnStateData::noteBodyConsumerAborted(BodyPipe::Pointer) STUB();
+bool ConnStateData::handleReadData() STUB_RETVAL(false);
+bool ConnStateData::handleRequestBodyData() STUB_RETVAL(false);
+void ConnStateData::pinBusyConnection(const Comm::ConnectionPointer &, const HttpRequest::Pointer &) STUB();
+void ConnStateData::notePinnedConnectionBecameIdle(PinnedIdleContext) STUB();
+void ConnStateData::unpinConnection(const bool) STUB();
+Comm::ConnectionPointer ConnStateData::BorrowPinnedConnection(HttpRequest *, const AccessLogEntryPointer &) STUB_RETVAL(nullptr);
+void ConnStateData::clientPinnedConnectionClosed(const CommCloseCbParams &) STUB();
+void ConnStateData::connStateClosed(const CommCloseCbParams &) STUB();
+void ConnStateData::requestTimeout(const CommTimeoutCbParams &) STUB();
+void ConnStateData::swanSong() STUB();
+void ConnStateData::quitAfterError(HttpRequest *) STUB();
+NotePairs::Pointer ConnStateData::notes() STUB_RETVAL(NotePairs::Pointer());
+void ConnStateData::fillConnectionLevelDetails(ACLFilledChecklist &) const STUB();
 #if USE_OPENSSL
-void ConnStateData::httpsPeeked(PinnedIdleContext) STUB
-void ConnStateData::getSslContextStart() STUB
-void ConnStateData::getSslContextDone(Security::ContextPointer &) STUB
-void ConnStateData::sslCrtdHandleReplyWrapper(void *, const Helper::Reply &) STUB
-void ConnStateData::sslCrtdHandleReply(const Helper::Reply &) STUB
-void ConnStateData::switchToHttps(ClientHttpRequest *, Ssl::BumpMode) STUB
-void ConnStateData::buildSslCertGenerationParams(Ssl::CertificateProperties &) STUB
-bool ConnStateData::serveDelayedError(Http::Stream *) STUB_RETVAL(false)
+void ConnStateData::httpsPeeked(PinnedIdleContext) STUB();
+void ConnStateData::getSslContextStart() STUB();
+void ConnStateData::getSslContextDone(Security::ContextPointer &) STUB();
+void ConnStateData::sslCrtdHandleReplyWrapper(void *, const Helper::Reply &) STUB();
+void ConnStateData::sslCrtdHandleReply(const Helper::Reply &) STUB();
+void ConnStateData::switchToHttps(ClientHttpRequest *, Ssl::BumpMode) STUB();
+void ConnStateData::buildSslCertGenerationParams(Ssl::CertificateProperties &) STUB();
+bool ConnStateData::serveDelayedError(Http::Stream *) STUB_RETVAL(false);
 #endif
 
-const char *findTrailingHTTPVersion(const char *, const char *) STUB_RETVAL(nullptr)
-int varyEvaluateMatch(StoreEntry *, HttpRequest *) STUB_RETVAL(0)
-void clientOpenListenSockets(void) STUB
-void httpRequestFree(void *) STUB
-void clientPackRangeHdr(const HttpReplyPointer &, const HttpHdrRangeSpec *, String, MemBuf *) STUB
-void clientPackTermBound(String, MemBuf *) STUB
-void clientAclChecklistFill(ACLFilledChecklist &, ClientHttpRequest *) STUB
+const char *findTrailingHTTPVersion(const char *, const char *) STUB_RETVAL(nullptr);
+int varyEvaluateMatch(StoreEntry *, HttpRequest *) STUB_RETVAL(0);
+void clientOpenListenSockets(void) STUB();
+void httpRequestFree(void *) STUB();
+void clientPackRangeHdr(const HttpReplyPointer &, const HttpHdrRangeSpec *, String, MemBuf *) STUB();
+void clientPackTermBound(String, MemBuf *) STUB();
+void clientAclChecklistFill(ACLFilledChecklist &, ClientHttpRequest *) STUB();
 

--- a/src/tests/stub_comm.cc
+++ b/src/tests/stub_comm.cc
@@ -18,50 +18,50 @@
 
 #include <ostream>
 
-// void comm_read(const Comm::ConnectionPointer &, char *, int, IOCB *, void *) STUB
-// void comm_read(const Comm::ConnectionPointer &, char*, int, AsyncCall::Pointer &) STUB
+// void comm_read(const Comm::ConnectionPointer &, char *, int, IOCB *, void *) STUB();
+// void comm_read(const Comm::ConnectionPointer &, char*, int, AsyncCall::Pointer &) STUB();
 
 /* should be in stub_libbase */
 #include "base/DelayedAsyncCalls.h"
-void DelayedAsyncCalls::delay(const AsyncCall::Pointer &) STUB
-void DelayedAsyncCalls::schedule() STUB
+void DelayedAsyncCalls::delay(const AsyncCall::Pointer &) STUB();
+void DelayedAsyncCalls::schedule() STUB();
 
 #include "comm.h"
-bool comm_iocallbackpending(void) STUB_RETVAL(false)
-int commSetNonBlocking(int) STUB_RETVAL(Comm::COMM_ERROR)
-int commUnsetNonBlocking(int) STUB_RETVAL(-1)
+bool comm_iocallbackpending(void) STUB_RETVAL(false);
+int commSetNonBlocking(int) STUB_RETVAL(Comm::COMM_ERROR);
+int commUnsetNonBlocking(int) STUB_RETVAL(-1);
 void commSetCloseOnExec(int) STUB_NOP
-void _comm_close(int, char const *, int) STUB
-void old_comm_reset_close(int) STUB
-void comm_reset_close(const Comm::ConnectionPointer &) STUB
-int comm_connect_addr(int, const Ip::Address &) STUB_RETVAL(-1)
+void _comm_close(int, char const *, int) STUB();
+void old_comm_reset_close(int) STUB();
+void comm_reset_close(const Comm::ConnectionPointer &) STUB();
+int comm_connect_addr(int, const Ip::Address &) STUB_RETVAL(-1);
 
-void comm_init(void) STUB
-void comm_exit(void) STUB
-int comm_open(int, int, Ip::Address &, int, const char *) STUB_RETVAL(-1)
-int comm_open_uds(int, int, struct sockaddr_un*, int) STUB_RETVAL(-1)
-void comm_import_opened(const Comm::ConnectionPointer &, const char *, struct addrinfo *) STUB
-int comm_open_listener(int, int, Ip::Address &, int, const char *) STUB_RETVAL(-1)
-void comm_open_listener(int, int, Comm::ConnectionPointer &, const char *) STUB
-unsigned short comm_local_port(int) STUB_RETVAL(0)
-int comm_udp_sendto(int, const Ip::Address &, const void *, int) STUB_RETVAL(-1)
-void commCallCloseHandlers(int) STUB
-void commUnsetFdTimeout(int) STUB
-// int commSetTimeout(const Comm::ConnectionPointer &, int, AsyncCall::Pointer&) STUB_RETVAL(-1)
-void commSetConnTimeout(const Comm::ConnectionPointer &, time_t, AsyncCall::Pointer &) STUB
-void commUnsetConnTimeout(const Comm::ConnectionPointer &) STUB
-int ignoreErrno(int) STUB_RETVAL(-1)
-void commCloseAllSockets(void) STUB
-void checkTimeouts(void) STUB
-AsyncCall::Pointer comm_add_close_handler(int, CLCB *, void *) STUB
-void comm_add_close_handler(int, AsyncCall::Pointer &) STUB
-void comm_remove_close_handler(int, CLCB *, void *) STUB
-void comm_remove_close_handler(int, AsyncCall::Pointer &)STUB
-int comm_udp_recvfrom(int, void *, size_t, int, Ip::Address &) STUB_RETVAL(-1)
-int comm_udp_recv(int, void *, size_t, int) STUB_RETVAL(-1)
-ssize_t comm_udp_send(int, const void *, size_t, int) STUB_RETVAL(-1)
-bool comm_has_incomplete_write(int) STUB_RETVAL(false)
-void commStartHalfClosedMonitor(int) STUB
-bool commHasHalfClosedMonitor(int) STUB_RETVAL(false)
-int CommSelectEngine::checkEvents(int) STUB_RETVAL(0)
+void comm_init(void) STUB();
+void comm_exit(void) STUB();
+int comm_open(int, int, Ip::Address &, int, const char *) STUB_RETVAL(-1);
+int comm_open_uds(int, int, struct sockaddr_un*, int) STUB_RETVAL(-1);
+void comm_import_opened(const Comm::ConnectionPointer &, const char *, struct addrinfo *) STUB();
+int comm_open_listener(int, int, Ip::Address &, int, const char *) STUB_RETVAL(-1);
+void comm_open_listener(int, int, Comm::ConnectionPointer &, const char *) STUB();
+unsigned short comm_local_port(int) STUB_RETVAL(0);
+int comm_udp_sendto(int, const Ip::Address &, const void *, int) STUB_RETVAL(-1);
+void commCallCloseHandlers(int) STUB();
+void commUnsetFdTimeout(int) STUB();
+// int commSetTimeout(const Comm::ConnectionPointer &, int, AsyncCall::Pointer&) STUB_RETVAL(-1);
+void commSetConnTimeout(const Comm::ConnectionPointer &, time_t, AsyncCall::Pointer &) STUB();
+void commUnsetConnTimeout(const Comm::ConnectionPointer &) STUB();
+int ignoreErrno(int) STUB_RETVAL(-1);
+void commCloseAllSockets(void) STUB();
+void checkTimeouts(void) STUB();
+AsyncCall::Pointer comm_add_close_handler(int, CLCB *, void *) STUB();
+void comm_add_close_handler(int, AsyncCall::Pointer &) STUB();
+void comm_remove_close_handler(int, CLCB *, void *) STUB();
+void comm_remove_close_handler(int, AsyncCall::Pointer &)STUB();
+int comm_udp_recvfrom(int, void *, size_t, int, Ip::Address &) STUB_RETVAL(-1);
+int comm_udp_recv(int, void *, size_t, int) STUB_RETVAL(-1);
+ssize_t comm_udp_send(int, const void *, size_t, int) STUB_RETVAL(-1);
+bool comm_has_incomplete_write(int) STUB_RETVAL(false);
+void commStartHalfClosedMonitor(int) STUB();
+bool commHasHalfClosedMonitor(int) STUB_RETVAL(false);
+int CommSelectEngine::checkEvents(int) STUB_RETVAL(0);
 

--- a/src/tests/stub_debug.cc
+++ b/src/tests/stub_debug.cc
@@ -25,9 +25,9 @@ int Debug::rotateNumber = 0;
 int Debug::Levels[MAX_DEBUG_SECTIONS];
 int Debug::override_X = 0;
 bool Debug::log_syslog = false;
-void Debug::ForceAlert() STUB
+void Debug::ForceAlert() STUB();
 
-void ResyncDebugLog(FILE *) STUB
+void ResyncDebugLog(FILE *) STUB();
 
 FILE *
 DebugStream()
@@ -71,8 +71,8 @@ Debug::Extra(std::ostream &os)
     return os;
 }
 
-bool Debug::StderrEnabled() STUB_RETVAL(false)
-void Debug::PrepareToDie() STUB
+bool Debug::StderrEnabled() STUB_RETVAL(false);
+void Debug::PrepareToDie() STUB();
 
 void
 Debug::parseOptions(char const *)

--- a/src/tests/stub_errorpage.cc
+++ b/src/tests/stub_errorpage.cc
@@ -14,24 +14,24 @@
 #define STUB_API "errorpage.cc"
 #include "tests/STUB.h"
 
-err_type errorReservePageId(const char *, const SBuf &) STUB_RETVAL(err_type(0))
+err_type errorReservePageId(const char *, const SBuf &) STUB_RETVAL(err_type(0));
 CBDATA_CLASS_INIT(ErrorState);
-ErrorState::ErrorState(err_type, Http::StatusCode, HttpRequest *, const AccessLogEntryPointer &) STUB
-ErrorState::ErrorState(HttpRequest *, HttpReply *, const AccessLogEntryPointer &) STUB
-ErrorState::~ErrorState() STUB
-ErrorState *ErrorState::NewForwarding(err_type, HttpRequestPointer &, const AccessLogEntryPointer &) STUB_RETVAL(nullptr)
-HttpReply *ErrorState::BuildHttpReply(void) STUB_RETVAL(nullptr)
-void ErrorState::validate() STUB
-void errorInitialize(void) STUB
-void errorClean(void) STUB
-void errorSend(const Comm::ConnectionPointer &, ErrorState *) STUB
-void errorAppendEntry(StoreEntry *, ErrorState * ) STUB
-bool strHdrAcptLangGetItem(const String &, char *, int, size_t &) STUB_RETVAL(false)
-void TemplateFile::loadDefault() STUB
-const char *errorPageName(int) STUB_RETVAL(nullptr)
-TemplateFile::TemplateFile(char const*, err_type) STUB
-bool TemplateFile::loadFor(const HttpRequest *) STUB_RETVAL(false)
-bool TemplateFile::loadFromFile(const char *) STUB_RETVAL(false)
-bool TemplateFile::tryLoadTemplate(const char *) STUB_RETVAL(false)
-std::ostream &operator <<(std::ostream &os, const ErrorState *) STUB_RETVAL(os)
+ErrorState::ErrorState(err_type, Http::StatusCode, HttpRequest *, const AccessLogEntryPointer &) STUB();
+ErrorState::ErrorState(HttpRequest *, HttpReply *, const AccessLogEntryPointer &) STUB();
+ErrorState::~ErrorState() STUB();
+ErrorState *ErrorState::NewForwarding(err_type, HttpRequestPointer &, const AccessLogEntryPointer &) STUB_RETVAL(nullptr);
+HttpReply *ErrorState::BuildHttpReply(void) STUB_RETVAL(nullptr);
+void ErrorState::validate() STUB();
+void errorInitialize(void) STUB();
+void errorClean(void) STUB();
+void errorSend(const Comm::ConnectionPointer &, ErrorState *) STUB();
+void errorAppendEntry(StoreEntry *, ErrorState * ) STUB();
+bool strHdrAcptLangGetItem(const String &, char *, int, size_t &) STUB_RETVAL(false);
+void TemplateFile::loadDefault() STUB();
+const char *errorPageName(int) STUB_RETVAL(nullptr);
+TemplateFile::TemplateFile(char const*, err_type) STUB();
+bool TemplateFile::loadFor(const HttpRequest *) STUB_RETVAL(false);
+bool TemplateFile::loadFromFile(const char *) STUB_RETVAL(false);
+bool TemplateFile::tryLoadTemplate(const char *) STUB_RETVAL(false);
+std::ostream &operator <<(std::ostream &os, const ErrorState *) STUB_RETVAL(os);
 

--- a/src/tests/stub_event.cc
+++ b/src/tests/stub_event.cc
@@ -13,23 +13,23 @@
 #include "tests/STUB.h"
 
 void eventAdd(const char *, EVH *, void *, double, int, bool) STUB_NOP
-void eventAddIsh(const char *, EVH *, void *, double, int) STUB
-void eventDelete(EVH *, void *) STUB
-void eventInit(void) STUB
-int eventFind(EVH *, void *) STUB_RETVAL(-1)
+void eventAddIsh(const char *, EVH *, void *, double, int) STUB();
+void eventDelete(EVH *, void *) STUB();
+void eventInit(void) STUB();
+int eventFind(EVH *, void *) STUB_RETVAL(-1);
 
-// ev_entry::ev_entry(char const * name, EVH * func, void *arg, double when, int weight, bool cbdata) STUB
-// ev_entry::~ev_entry() STUB
+// ev_entry::ev_entry(char const * name, EVH * func, void *arg, double when, int weight, bool cbdata) STUB();
+// ev_entry::~ev_entry() STUB();
 //    EVH *func;
 
-EventScheduler::EventScheduler() STUB
-EventScheduler::~EventScheduler() STUB
-void EventScheduler::cancel(EVH *, void *) STUB
-int EventScheduler::timeRemaining() const STUB_RETVAL(1)
-void EventScheduler::clean() STUB
-void EventScheduler::dump(Packable *) STUB
-bool EventScheduler::find(EVH *, void *) STUB_RETVAL(false)
-void EventScheduler::schedule(const char *, EVH *, void *, double, int, bool) STUB
-int EventScheduler::checkEvents(int) STUB_RETVAL(-1)
-EventScheduler *EventScheduler::GetInstance() STUB_RETVAL(nullptr)
+EventScheduler::EventScheduler() STUB();
+EventScheduler::~EventScheduler() STUB();
+void EventScheduler::cancel(EVH *, void *) STUB();
+int EventScheduler::timeRemaining() const STUB_RETVAL(1);
+void EventScheduler::clean() STUB();
+void EventScheduler::dump(Packable *) STUB();
+bool EventScheduler::find(EVH *, void *) STUB_RETVAL(false);
+void EventScheduler::schedule(const char *, EVH *, void *, double, int, bool) STUB();
+int EventScheduler::checkEvents(int) STUB_RETVAL(-1);
+EventScheduler *EventScheduler::GetInstance() STUB_RETVAL(nullptr);
 

--- a/src/tests/stub_external_acl.cc
+++ b/src/tests/stub_external_acl.cc
@@ -14,14 +14,14 @@
 #include "ExternalACL.h"
 #include "ExternalACLEntry.h"
 
-void parse_externalAclHelper(external_acl ** ) STUB
-void dump_externalAclHelper(StoreEntry *, const char *, const external_acl *) STUB
-void free_externalAclHelper(external_acl **) STUB
-void ACLExternal::parse() STUB
-bool ACLExternal::valid () const STUB_RETVAL(false)
-bool ACLExternal::empty () const STUB_RETVAL(false)
-int ACLExternal::match(ACLChecklist *) STUB_RETVAL(0)
-SBufList ACLExternal::dump() const STUB_RETVAL(SBufList())
+void parse_externalAclHelper(external_acl ** ) STUB();
+void dump_externalAclHelper(StoreEntry *, const char *, const external_acl *) STUB();
+void free_externalAclHelper(external_acl **) STUB();
+void ACLExternal::parse() STUB();
+bool ACLExternal::valid () const STUB_RETVAL(false);
+bool ACLExternal::empty () const STUB_RETVAL(false);
+int ACLExternal::match(ACLChecklist *) STUB_RETVAL(0);
+SBufList ACLExternal::dump() const STUB_RETVAL(SBufList());
 void externalAclInit(void) STUB_NOP
 void externalAclShutdown(void) STUB_NOP
 

--- a/src/tests/stub_fatal.cc
+++ b/src/tests/stub_fatal.cc
@@ -12,7 +12,7 @@
 #define STUB_API "fatal.cc"
 #include "tests/STUB.h"
 
-void fatal(const char *) STUB
-void fatalf(const char *, ...) STUB
-void fatal_dump(const char *) STUB
+void fatal(const char *) STUB();
+void fatalf(const char *, ...) STUB();
+void fatal_dump(const char *) STUB();
 

--- a/src/tests/stub_fd.cc
+++ b/src/tests/stub_fd.cc
@@ -15,10 +15,10 @@
 
 fde *fde::Table = nullptr;
 
-int fdNFree(void) STUB_RETVAL(-1)
-void fd_open(int, unsigned int, const char *) STUB
-void fd_close(int) STUB
-void fd_bytes(int, int, IoDirection) STUB
-void fd_note(int, const char *) STUB
-void fdAdjustReserved() STUB
+int fdNFree(void) STUB_RETVAL(-1);
+void fd_open(int, unsigned int, const char *) STUB();
+void fd_close(int) STUB();
+void fd_bytes(int, int, IoDirection) STUB();
+void fd_note(int, const char *) STUB();
+void fdAdjustReserved() STUB();
 

--- a/src/tests/stub_fqdncache.cc
+++ b/src/tests/stub_fqdncache.cc
@@ -14,10 +14,10 @@
 
 bool Dns::ResolveClientAddressesAsap = false;
 
-void fqdncache_init(void) STUB
-void fqdnStats(StoreEntry *) STUB
-void fqdncache_restart(void) STUB
-void fqdncache_purgelru(void *) STUB
-void fqdncacheAddEntryFromHosts(char *, SBufList &) STUB
-const char *fqdncache_gethostbyaddr(const Ip::Address &, int) STUB_RETVAL(nullptr)
-void fqdncache_nbgethostbyaddr(const Ip::Address &, FQDNH *, void *) STUB
+void fqdncache_init(void) STUB();
+void fqdnStats(StoreEntry *) STUB();
+void fqdncache_restart(void) STUB();
+void fqdncache_purgelru(void *) STUB();
+void fqdncacheAddEntryFromHosts(char *, SBufList &) STUB();
+const char *fqdncache_gethostbyaddr(const Ip::Address &, int) STUB_RETVAL(nullptr);
+void fqdncache_nbgethostbyaddr(const Ip::Address &, FQDNH *, void *) STUB();

--- a/src/tests/stub_helper.cc
+++ b/src/tests/stub_helper.cc
@@ -12,13 +12,13 @@
 #define STUB_API "helper.cc"
 #include "tests/STUB.h"
 
-void helperSubmit(const Helper::Client::Pointer &, const char *, HLPCB *, void *) STUB
-void helperStatefulSubmit(const statefulhelper::Pointer &, const char *, HLPCB *, void *, const Helper::ReservationId &) STUB
-Helper::Client::~Client() STUB
-void Helper::Client::packStatsInto(Packable *, const char *) const STUB
-void Helper::Client::openSessions() STUB
+void helperSubmit(const Helper::Client::Pointer &, const char *, HLPCB *, void *) STUB();
+void helperStatefulSubmit(const statefulhelper::Pointer &, const char *, HLPCB *, void *, const Helper::ReservationId &) STUB();
+Helper::Client::~Client() STUB();
+void Helper::Client::packStatsInto(Packable *, const char *) const STUB();
+void Helper::Client::openSessions() STUB();
 
-void helperShutdown(const Helper::Client::Pointer &) STUB
-void helperStatefulShutdown(const statefulhelper::Pointer &) STUB
-void statefulhelper::openSessions() STUB
+void helperShutdown(const Helper::Client::Pointer &) STUB();
+void helperStatefulShutdown(const statefulhelper::Pointer &) STUB();
+void statefulhelper::openSessions() STUB();
 

--- a/src/tests/stub_http.cc
+++ b/src/tests/stub_http.cc
@@ -15,5 +15,5 @@
 
 class HttpRequest;
 class HttpReply;
-SBuf httpMakeVaryMark(HttpRequest *, HttpReply const *) STUB_RETVAL(SBuf())
+SBuf httpMakeVaryMark(HttpRequest *, HttpReply const *) STUB_RETVAL(SBuf());
 

--- a/src/tests/stub_icp.cc
+++ b/src/tests/stub_icp.cc
@@ -14,30 +14,30 @@
 #define STUB_API "icp_*.cc"
 #include "tests/STUB.h"
 
-icp_common_t::icp_common_t() STUB
-icp_common_t::icp_common_t(char *, unsigned int) STUB
-void icp_common_t::handleReply(char *, Ip::Address &) STUB
-icp_common_t *icp_common_t::CreateMessage(icp_opcode, int, const char *, int, int) STUB_RETVAL(nullptr)
-icp_opcode icp_common_t::getOpCode() const STUB_RETVAL(ICP_INVALID)
-ICPState::ICPState(icp_common_t &, HttpRequest *) STUB
-ICPState::~ICPState() STUB
-bool ICPState::confirmAndPrepHit(const StoreEntry &) const STUB_RETVAL(false)
-LogTags *ICPState::loggingTags() const STUB_RETVAL(nullptr)
-void ICPState::fillChecklist(ACLFilledChecklist&) const STUB
+icp_common_t::icp_common_t() STUB();
+icp_common_t::icp_common_t(char *, unsigned int) STUB();
+void icp_common_t::handleReply(char *, Ip::Address &) STUB();
+icp_common_t *icp_common_t::CreateMessage(icp_opcode, int, const char *, int, int) STUB_RETVAL(nullptr);
+icp_opcode icp_common_t::getOpCode() const STUB_RETVAL(ICP_INVALID);
+ICPState::ICPState(icp_common_t &, HttpRequest *) STUB();
+ICPState::~ICPState() STUB();
+bool ICPState::confirmAndPrepHit(const StoreEntry &) const STUB_RETVAL(false);
+LogTags *ICPState::loggingTags() const STUB_RETVAL(nullptr);
+void ICPState::fillChecklist(ACLFilledChecklist&) const STUB();
 
 Comm::ConnectionPointer icpIncomingConn;
 Comm::ConnectionPointer icpOutgoingConn;
 Ip::Address theIcpPublicHostID;
 
-HttpRequest* icpGetRequest(char *, int, int, Ip::Address &) STUB_RETVAL(nullptr)
-bool icpAccessAllowed(Ip::Address &, HttpRequest *) STUB_RETVAL(false)
-void icpCreateAndSend(icp_opcode, int, char const *, int, int, int, const Ip::Address &, AccessLogEntryPointer) STUB
-icp_opcode icpGetCommonOpcode() STUB_RETVAL(ICP_INVALID)
-void icpDenyAccess(Ip::Address &, char *, int, int) STUB
-void icpHandleIcpV3(int, Ip::Address &, char *, int) STUB
-void icpConnectionShutdown(void) STUB
-int icpSetCacheKey(const cache_key *) STUB_RETVAL(0)
-const cache_key *icpGetCacheKey(const char *, int) STUB_RETVAL(nullptr)
+HttpRequest* icpGetRequest(char *, int, int, Ip::Address &) STUB_RETVAL(nullptr);
+bool icpAccessAllowed(Ip::Address &, HttpRequest *) STUB_RETVAL(false);
+void icpCreateAndSend(icp_opcode, int, char const *, int, int, int, const Ip::Address &, AccessLogEntryPointer) STUB();
+icp_opcode icpGetCommonOpcode() STUB_RETVAL(ICP_INVALID);
+void icpDenyAccess(Ip::Address &, char *, int, int) STUB();
+void icpHandleIcpV3(int, Ip::Address &, char *, int) STUB();
+void icpConnectionShutdown(void) STUB();
+int icpSetCacheKey(const cache_key *) STUB_RETVAL(0);
+const cache_key *icpGetCacheKey(const char *, int) STUB_RETVAL(nullptr);
 
 #include "icp_opcode.h"
 // dynamically generated

--- a/src/tests/stub_internal.cc
+++ b/src/tests/stub_internal.cc
@@ -12,5 +12,5 @@
 #define STUB_API "internal.cc"
 #include "tests/STUB.h"
 
-char *internalLocalUri(const char *, const SBuf &) STUB_RETVAL(nullptr)
+char *internalLocalUri(const char *, const SBuf &) STUB_RETVAL(nullptr);
 

--- a/src/tests/stub_ipc.cc
+++ b/src/tests/stub_ipc.cc
@@ -12,5 +12,5 @@
 #define STUB_API "ipc.cc"
 #include "tests/STUB.h"
 
-pid_t ipcCreate(int, const char *, const char *const [], const char *, Ip::Address &, int *, int *, void **) STUB_RETVAL(-1)
+pid_t ipcCreate(int, const char *, const char *const [], const char *, Ip::Address &, int *, int *, void **) STUB_RETVAL(-1);
 

--- a/src/tests/stub_ipc_Forwarder.cc
+++ b/src/tests/stub_ipc_Forwarder.cc
@@ -13,12 +13,12 @@
 
 #include "ipc/Forwarder.h"
 Ipc::Forwarder::Forwarder(Request::Pointer, double): AsyncJob("Ipc::Forwarder"), timeout(0) {STUB}
-Ipc::Forwarder::~Forwarder() STUB
-void Ipc::Forwarder::start() STUB
-bool Ipc::Forwarder::doneAll() const STUB_RETVAL(false)
-void Ipc::Forwarder::swanSong() STUB
-void Ipc::Forwarder::callException(const std::exception &) STUB
-void Ipc::Forwarder::handleError() STUB
-void Ipc::Forwarder::handleTimeout() STUB
-void Ipc::Forwarder::handleException(const std::exception &) STUB
+Ipc::Forwarder::~Forwarder() STUB();
+void Ipc::Forwarder::start() STUB();
+bool Ipc::Forwarder::doneAll() const STUB_RETVAL(false);
+void Ipc::Forwarder::swanSong() STUB();
+void Ipc::Forwarder::callException(const std::exception &) STUB();
+void Ipc::Forwarder::handleError() STUB();
+void Ipc::Forwarder::handleTimeout() STUB();
+void Ipc::Forwarder::handleException(const std::exception &) STUB();
 

--- a/src/tests/stub_ipc_TypedMsgHdr.cc
+++ b/src/tests/stub_ipc_TypedMsgHdr.cc
@@ -13,11 +13,11 @@
 
 #include "ipc/TypedMsgHdr.h"
 
-Ipc::TypedMsgHdr::TypedMsgHdr() STUB
-void Ipc::TypedMsgHdr::checkType(int) const STUB
-void Ipc::TypedMsgHdr::setType(int) STUB
-void Ipc::TypedMsgHdr::getFixed(void*, size_t) const STUB
-void Ipc::TypedMsgHdr::putFixed(void const*, size_t) STUB
-void Ipc::TypedMsgHdr::getString(String&) const STUB
-void Ipc::TypedMsgHdr::putString(String const&) STUB
+Ipc::TypedMsgHdr::TypedMsgHdr() STUB();
+void Ipc::TypedMsgHdr::checkType(int) const STUB();
+void Ipc::TypedMsgHdr::setType(int) STUB();
+void Ipc::TypedMsgHdr::getFixed(void*, size_t) const STUB();
+void Ipc::TypedMsgHdr::putFixed(void const*, size_t) STUB();
+void Ipc::TypedMsgHdr::getString(String&) const STUB();
+void Ipc::TypedMsgHdr::putString(String const&) STUB();
 

--- a/src/tests/stub_ipcache.cc
+++ b/src/tests/stub_ipcache.cc
@@ -12,14 +12,14 @@
 #define STUB_API "ipcache.cc"
 #include "tests/STUB.h"
 
-void ipcache_purgelru(void *) STUB
-void ipcache_nbgethostbyname(const char *, IPH *, void *) STUB
-const ipcache_addrs *ipcache_gethostbyname(const char *, int) STUB_RETVAL(nullptr)
-void ipcacheInvalidate(const char *) STUB
-void ipcacheInvalidateNegative(const char *) STUB
-void ipcache_init(void) STUB
-void ipcacheMarkBadAddr(const char *, const Ip::Address &) STUB
-void ipcacheMarkGoodAddr(const char *, const Ip::Address &) STUB
-void ipcache_restart(void) STUB
-int ipcacheAddEntryFromHosts(const char *, const char *) STUB_RETVAL(-1)
+void ipcache_purgelru(void *) STUB();
+void ipcache_nbgethostbyname(const char *, IPH *, void *) STUB();
+const ipcache_addrs *ipcache_gethostbyname(const char *, int) STUB_RETVAL(nullptr);
+void ipcacheInvalidate(const char *) STUB();
+void ipcacheInvalidateNegative(const char *) STUB();
+void ipcache_init(void) STUB();
+void ipcacheMarkBadAddr(const char *, const Ip::Address &) STUB();
+void ipcacheMarkGoodAddr(const char *, const Ip::Address &) STUB();
+void ipcache_restart(void) STUB();
+int ipcacheAddEntryFromHosts(const char *, const char *) STUB_RETVAL(-1);
 

--- a/src/tests/stub_libanyp.cc
+++ b/src/tests/stub_libanyp.cc
@@ -13,12 +13,12 @@
 
 #include "anyp/Uri.h"
 AnyP::Uri::Uri(AnyP::UriScheme const &) {STUB}
-void AnyP::Uri::touch() STUB
-bool AnyP::Uri::parse(const HttpRequestMethod&, const SBuf &) STUB_RETVAL(true)
-void AnyP::Uri::host(const char *) STUB
+void AnyP::Uri::touch() STUB();
+bool AnyP::Uri::parse(const HttpRequestMethod&, const SBuf &) STUB_RETVAL(true);
+void AnyP::Uri::host(const char *) STUB();
 static SBuf nil;
-const SBuf &AnyP::Uri::path() const STUB_RETVAL(nil)
-void AnyP::Uri::addRelativePath(const char *) STUB
+const SBuf &AnyP::Uri::path() const STUB_RETVAL(nil);
+void AnyP::Uri::addRelativePath(const char *) STUB();
 const SBuf &AnyP::Uri::SlashPath()
 {
     static SBuf slash("/");
@@ -29,14 +29,14 @@ const SBuf &AnyP::Uri::Asterisk()
     static SBuf asterisk("*");
     return asterisk;
 }
-SBuf &AnyP::Uri::authority(bool) const STUB_RETVAL(nil)
-SBuf &AnyP::Uri::absolute() const STUB_RETVAL(nil)
-void urlInitialize() STUB
-const char *urlCanonicalFakeHttps(const HttpRequest *) STUB_RETVAL(nullptr)
-bool urlIsRelative(const char *) STUB_RETVAL(false)
-char *urlRInternal(const char *, unsigned short, const char *, const char *) STUB_RETVAL(nullptr)
-char *urlInternal(const char *, const char *) STUB_RETVAL(nullptr)
-int matchDomainName(const char *, const char *, enum MatchDomainNameFlags) STUB_RETVAL(0)
-bool urlCheckRequest(const HttpRequest *) STUB_RETVAL(false)
-void urlExtMethodConfigure() STUB
+SBuf &AnyP::Uri::authority(bool) const STUB_RETVAL(nil);
+SBuf &AnyP::Uri::absolute() const STUB_RETVAL(nil);
+void urlInitialize() STUB();
+const char *urlCanonicalFakeHttps(const HttpRequest *) STUB_RETVAL(nullptr);
+bool urlIsRelative(const char *) STUB_RETVAL(false);
+char *urlRInternal(const char *, unsigned short, const char *, const char *) STUB_RETVAL(nullptr);
+char *urlInternal(const char *, const char *) STUB_RETVAL(nullptr);
+int matchDomainName(const char *, const char *, enum MatchDomainNameFlags) STUB_RETVAL(0);
+bool urlCheckRequest(const HttpRequest *) STUB_RETVAL(false);
+void urlExtMethodConfigure() STUB();
 

--- a/src/tests/stub_libauth.cc
+++ b/src/tests/stub_libauth.cc
@@ -15,66 +15,66 @@
 #include "auth/SchemeConfig.h"
 namespace Auth
 {
-Auth::UserRequest::Pointer SchemeConfig::CreateAuthUser(const char *, AccessLogEntry::Pointer &) STUB_RETVAL(nullptr)
-Auth::SchemeConfig * SchemeConfig::Find(const char *) STUB_RETVAL(nullptr)
+Auth::UserRequest::Pointer SchemeConfig::CreateAuthUser(const char *, AccessLogEntry::Pointer &) STUB_RETVAL(nullptr);
+Auth::SchemeConfig * SchemeConfig::Find(const char *) STUB_RETVAL(nullptr);
 void SchemeConfig::registerWithCacheManager(void) STUB_NOP
 Auth::ConfigVector TheConfig;
 }
 
 #include "auth/Gadgets.h"
-int authenticateActiveSchemeCount(void) STUB_RETVAL(0)
-int authenticateSchemeCount(void) STUB_RETVAL(0)
-void authenticateInit(Auth::ConfigVector *) STUB
-void authenticateRotate(void) STUB
-void authenticateReset(void) STUB
+int authenticateActiveSchemeCount(void) STUB_RETVAL(0);
+int authenticateSchemeCount(void) STUB_RETVAL(0);
+void authenticateInit(Auth::ConfigVector *) STUB();
+void authenticateRotate(void) STUB();
+void authenticateReset(void) STUB();
 
 #include "auth/Scheme.h"
 #include <vector>
 std::vector<Auth::Scheme::Pointer> *Auth::Scheme::_Schemes = nullptr;
-void Auth::Scheme::AddScheme(Auth::Scheme::Pointer) STUB
-Auth::Scheme::Pointer Auth::Scheme::Find(const char *) STUB_RETVAL(nullptr)
+void Auth::Scheme::AddScheme(Auth::Scheme::Pointer) STUB();
+Auth::Scheme::Pointer Auth::Scheme::Find(const char *) STUB_RETVAL(nullptr);
 std::vector<Auth::Scheme::Pointer> & Auth::Scheme::GetSchemes() STUB_RETVAL(*_Schemes);
-void Auth::Scheme::FreeAll() STUB
+void Auth::Scheme::FreeAll() STUB();
 
 #include "auth/SchemesConfig.h"
-void Auth::SchemesConfig::expand() STUB
+void Auth::SchemesConfig::expand() STUB();
 
 #include "auth/User.h"
-Auth::User::User(Auth::SchemeConfig *, const char *) STUB
-Auth::CredentialState Auth::User::credentials() const STUB_RETVAL(credentials_state)
-void Auth::User::credentials(CredentialState) STUB
-void Auth::User::absorb(Auth::User::Pointer) STUB
+Auth::User::User(Auth::SchemeConfig *, const char *) STUB();
+Auth::CredentialState Auth::User::credentials() const STUB_RETVAL(credentials_state);
+void Auth::User::credentials(CredentialState) STUB();
+void Auth::User::absorb(Auth::User::Pointer) STUB();
 Auth::User::~User() STUB_NOP
-void Auth::User::clearIp() STUB
-void Auth::User::removeIp(Ip::Address) STUB
-void Auth::User::addIp(Ip::Address) STUB
-void Auth::User::CredentialsCacheStats(StoreEntry *) STUB
+void Auth::User::clearIp() STUB();
+void Auth::User::removeIp(Ip::Address) STUB();
+void Auth::User::addIp(Ip::Address) STUB();
+void Auth::User::CredentialsCacheStats(StoreEntry *) STUB();
 
 #include "auth/UserRequest.h"
-char const * Auth::UserRequest::username() const STUB_RETVAL("stub_username")
-void Auth::UserRequest::start(HttpRequest *, AccessLogEntry::Pointer &, AUTHCB *, void *) STUB
-bool Auth::UserRequest::valid() const STUB_RETVAL(false)
-void * Auth::UserRequest::operator new (size_t) STUB_RETVAL((void *)1)
-void Auth::UserRequest::operator delete (void *) STUB
-Auth::UserRequest::UserRequest() STUB
-Auth::UserRequest::~UserRequest() STUB
-void Auth::UserRequest::setDenyMessage(char const *) STUB
-bool Auth::UserRequest::authenticated() const STUB_RETVAL(false)
-char const * Auth::UserRequest::getDenyMessage() const STUB_RETVAL("stub")
-char const * Auth::UserRequest::denyMessage(char const * const) const STUB_RETVAL("stub")
-void authenticateAuthUserRequestRemoveIp(Auth::UserRequest::Pointer, Ip::Address const &) STUB
-void authenticateAuthUserRequestClearIp(Auth::UserRequest::Pointer) STUB
-int authenticateAuthUserRequestIPCount(Auth::UserRequest::Pointer) STUB_RETVAL(0)
-bool authenticateUserAuthenticated(const Auth::UserRequest::Pointer&) STUB_RETVAL(false)
-Auth::Direction Auth::UserRequest::direction() STUB_RETVAL(Auth::CRED_ERROR)
-void Auth::UserRequest::addAuthenticationInfoHeader(HttpReply *, int) STUB
-void Auth::UserRequest::addAuthenticationInfoTrailer(HttpReply *, int) STUB
-void Auth::UserRequest::releaseAuthServer() STUB
-const char * Auth::UserRequest::connLastHeader() STUB_RETVAL("stub")
-AuthAclState Auth::UserRequest::authenticate(Auth::UserRequest::Pointer *, Http::HdrType, HttpRequest *, ConnStateData *, Ip::Address &, AccessLogEntry::Pointer &) STUB_RETVAL(AUTH_AUTHENTICATED)
-AuthAclState Auth::UserRequest::tryToAuthenticateAndSetAuthUser(Auth::UserRequest::Pointer *, Http::HdrType, HttpRequest *, ConnStateData *, Ip::Address &, AccessLogEntry::Pointer &) STUB_RETVAL(AUTH_AUTHENTICATED)
-void Auth::UserRequest::AddReplyAuthHeader(HttpReply *, Auth::UserRequest::Pointer, HttpRequest *, int, int) STUB
-Auth::Scheme::Pointer Auth::UserRequest::scheme() const STUB_RETVAL(nullptr)
+char const * Auth::UserRequest::username() const STUB_RETVAL("stub_username");
+void Auth::UserRequest::start(HttpRequest *, AccessLogEntry::Pointer &, AUTHCB *, void *) STUB();
+bool Auth::UserRequest::valid() const STUB_RETVAL(false);
+void * Auth::UserRequest::operator new (size_t) STUB_RETVAL((void *)1);
+void Auth::UserRequest::operator delete (void *) STUB();
+Auth::UserRequest::UserRequest() STUB();
+Auth::UserRequest::~UserRequest() STUB();
+void Auth::UserRequest::setDenyMessage(char const *) STUB();
+bool Auth::UserRequest::authenticated() const STUB_RETVAL(false);
+char const * Auth::UserRequest::getDenyMessage() const STUB_RETVAL("stub");
+char const * Auth::UserRequest::denyMessage(char const * const) const STUB_RETVAL("stub");
+void authenticateAuthUserRequestRemoveIp(Auth::UserRequest::Pointer, Ip::Address const &) STUB();
+void authenticateAuthUserRequestClearIp(Auth::UserRequest::Pointer) STUB();
+int authenticateAuthUserRequestIPCount(Auth::UserRequest::Pointer) STUB_RETVAL(0);
+bool authenticateUserAuthenticated(const Auth::UserRequest::Pointer&) STUB_RETVAL(false);
+Auth::Direction Auth::UserRequest::direction() STUB_RETVAL(Auth::CRED_ERROR);
+void Auth::UserRequest::addAuthenticationInfoHeader(HttpReply *, int) STUB();
+void Auth::UserRequest::addAuthenticationInfoTrailer(HttpReply *, int) STUB();
+void Auth::UserRequest::releaseAuthServer() STUB();
+const char * Auth::UserRequest::connLastHeader() STUB_RETVAL("stub");
+AuthAclState Auth::UserRequest::authenticate(Auth::UserRequest::Pointer *, Http::HdrType, HttpRequest *, ConnStateData *, Ip::Address &, AccessLogEntry::Pointer &) STUB_RETVAL(AUTH_AUTHENTICATED);
+AuthAclState Auth::UserRequest::tryToAuthenticateAndSetAuthUser(Auth::UserRequest::Pointer *, Http::HdrType, HttpRequest *, ConnStateData *, Ip::Address &, AccessLogEntry::Pointer &) STUB_RETVAL(AUTH_AUTHENTICATED);
+void Auth::UserRequest::AddReplyAuthHeader(HttpReply *, Auth::UserRequest::Pointer, HttpRequest *, int, int) STUB();
+Auth::Scheme::Pointer Auth::UserRequest::scheme() const STUB_RETVAL(nullptr);
 
 #include "AuthReg.h"
 void Auth::Init() STUB_NOP

--- a/src/tests/stub_libauth_acls.cc
+++ b/src/tests/stub_libauth_acls.cc
@@ -15,31 +15,31 @@
 #include "acl/Acl.h" /* for Acl::Answer */
 
 #include "auth/Acl.h"
-Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::Node &) STUB_RETVAL(ACCESS_DENIED)
+Acl::Answer AuthenticateAcl(ACLChecklist *, const Acl::Node &) STUB_RETVAL(ACCESS_DENIED);
 
 #include "auth/AclMaxUserIp.h"
-ACLMaxUserIP::ACLMaxUserIP (char const *) STUB
-char const * ACLMaxUserIP::typeString() const STUB_RETVAL(nullptr)
-bool ACLMaxUserIP::empty () const STUB_RETVAL(false)
-bool ACLMaxUserIP::valid () const STUB_RETVAL(false)
-void ACLMaxUserIP::parse() STUB
-int ACLMaxUserIP::match(Auth::UserRequest::Pointer, Ip::Address const &) STUB_RETVAL(0)
-int ACLMaxUserIP::match(ACLChecklist *) STUB_RETVAL(0)
-SBufList ACLMaxUserIP::dump() const STUB_RETVAL(SBufList())
-const Acl::Options &ACLMaxUserIP::options() STUB_RETVAL(Acl::NoOptions())
+ACLMaxUserIP::ACLMaxUserIP (char const *) STUB();
+char const * ACLMaxUserIP::typeString() const STUB_RETVAL(nullptr);
+bool ACLMaxUserIP::empty () const STUB_RETVAL(false);
+bool ACLMaxUserIP::valid () const STUB_RETVAL(false);
+void ACLMaxUserIP::parse() STUB();
+int ACLMaxUserIP::match(Auth::UserRequest::Pointer, Ip::Address const &) STUB_RETVAL(0);
+int ACLMaxUserIP::match(ACLChecklist *) STUB_RETVAL(0);
+SBufList ACLMaxUserIP::dump() const STUB_RETVAL(SBufList());
+const Acl::Options &ACLMaxUserIP::options() STUB_RETVAL(Acl::NoOptions());
 
 #include "auth/AclProxyAuth.h"
-ACLProxyAuth::~ACLProxyAuth() STUB
-ACLProxyAuth::ACLProxyAuth(ACLData<char const *> *, char const *) STUB
-char const * ACLProxyAuth::typeString() const STUB_RETVAL(nullptr)
-void ACLProxyAuth::parse() STUB
-int ACLProxyAuth::match(ACLChecklist *) STUB_RETVAL(0)
-SBufList ACLProxyAuth::dump() const STUB_RETVAL(SBufList())
-bool ACLProxyAuth::empty () const STUB_RETVAL(false)
-bool ACLProxyAuth::valid () const STUB_RETVAL(false)
-int ACLProxyAuth::matchForCache(ACLChecklist *) STUB_RETVAL(0)
-int ACLProxyAuth::matchProxyAuth(ACLChecklist *) STUB_RETVAL(0)
-const Acl::Options &ACLProxyAuth::lineOptions() STUB_RETVAL(Acl::NoOptions())
+ACLProxyAuth::~ACLProxyAuth() STUB();
+ACLProxyAuth::ACLProxyAuth(ACLData<char const *> *, char const *) STUB();
+char const * ACLProxyAuth::typeString() const STUB_RETVAL(nullptr);
+void ACLProxyAuth::parse() STUB();
+int ACLProxyAuth::match(ACLChecklist *) STUB_RETVAL(0);
+SBufList ACLProxyAuth::dump() const STUB_RETVAL(SBufList());
+bool ACLProxyAuth::empty () const STUB_RETVAL(false);
+bool ACLProxyAuth::valid () const STUB_RETVAL(false);
+int ACLProxyAuth::matchForCache(ACLChecklist *) STUB_RETVAL(0);
+int ACLProxyAuth::matchProxyAuth(ACLChecklist *) STUB_RETVAL(0);
+const Acl::Options &ACLProxyAuth::lineOptions() STUB_RETVAL(Acl::NoOptions());
 
 #endif /* USE_AUTH */
 

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -14,76 +14,76 @@
 
 #include "comm/AcceptLimiter.h"
 Comm::AcceptLimiter dummy;
-Comm::AcceptLimiter & Comm::AcceptLimiter::Instance() STUB_RETVAL(dummy)
-void Comm::AcceptLimiter::defer(const Comm::TcpAcceptor::Pointer &) STUB
-void Comm::AcceptLimiter::removeDead(const Comm::TcpAcceptor::Pointer &) STUB
-void Comm::AcceptLimiter::kick() STUB
+Comm::AcceptLimiter & Comm::AcceptLimiter::Instance() STUB_RETVAL(dummy);
+void Comm::AcceptLimiter::defer(const Comm::TcpAcceptor::Pointer &) STUB();
+void Comm::AcceptLimiter::removeDead(const Comm::TcpAcceptor::Pointer &) STUB();
+void Comm::AcceptLimiter::kick() STUB();
 
 #include "comm/Connection.h"
-Comm::Connection::Connection() STUB
-Comm::Connection::~Connection() STUB
-Comm::ConnectionPointer Comm::Connection::cloneProfile() const STUB_RETVAL(nullptr)
-void Comm::Connection::close() STUB
-void Comm::Connection::noteClosure() STUB
-CachePeer * Comm::Connection::getPeer() const STUB_RETVAL(nullptr)
-void Comm::Connection::setPeer(CachePeer *) STUB
-ScopedId Comm::Connection::codeContextGist() const STUB_RETVAL(id.detach())
-std::ostream &Comm::Connection::detailCodeContext(std::ostream &os) const STUB_RETVAL(os)
+Comm::Connection::Connection() STUB();
+Comm::Connection::~Connection() STUB();
+Comm::ConnectionPointer Comm::Connection::cloneProfile() const STUB_RETVAL(nullptr);
+void Comm::Connection::close() STUB();
+void Comm::Connection::noteClosure() STUB();
+CachePeer * Comm::Connection::getPeer() const STUB_RETVAL(nullptr);
+void Comm::Connection::setPeer(CachePeer *) STUB();
+ScopedId Comm::Connection::codeContextGist() const STUB_RETVAL(id.detach());
+std::ostream &Comm::Connection::detailCodeContext(std::ostream &os) const STUB_RETVAL(os);
 InstanceIdDefinitions(Comm::Connection, "conn", uint64_t);
 
 #include "comm/ConnOpener.h"
 CBDATA_NAMESPACED_CLASS_INIT(Comm, ConnOpener);
-bool Comm::ConnOpener::doneAll() const STUB_RETVAL(false)
-void Comm::ConnOpener::start() STUB
-void Comm::ConnOpener::swanSong() STUB
-Comm::ConnOpener::ConnOpener(const Comm::ConnectionPointer &, const AsyncCall::Pointer &, time_t) : AsyncJob("STUB Comm::ConnOpener") STUB
-    Comm::ConnOpener::~ConnOpener() STUB
-    void Comm::ConnOpener::setHost(const char *) STUB
-    const char * Comm::ConnOpener::getHost() const STUB_RETVAL(nullptr)
+bool Comm::ConnOpener::doneAll() const STUB_RETVAL(false);
+void Comm::ConnOpener::start() STUB();
+void Comm::ConnOpener::swanSong() STUB();
+Comm::ConnOpener::ConnOpener(const Comm::ConnectionPointer &, const AsyncCall::Pointer &, time_t) : AsyncJob("STUB Comm::ConnOpener") STUB();
+Comm::ConnOpener::~ConnOpener() STUB();
+void Comm::ConnOpener::setHost(const char *) STUB();
+const char * Comm::ConnOpener::getHost() const STUB_RETVAL(nullptr);
 
 #include "comm/forward.h"
-    bool Comm::IsConnOpen(const Comm::ConnectionPointer &) STUB_RETVAL(false)
+bool Comm::IsConnOpen(const Comm::ConnectionPointer &) STUB_RETVAL(false);
 
 #include "comm/IoCallback.h"
-    void Comm::IoCallback::setCallback(iocb_type, AsyncCall::Pointer &, char *, FREE *, int) STUB
-    void Comm::IoCallback::selectOrQueueWrite() STUB
-    void Comm::IoCallback::cancel(const char *) STUB
-    void Comm::IoCallback::finish(Comm::Flag, int) STUB
-    Comm::CbEntry *Comm::iocb_table = nullptr;
-void Comm::CallbackTableInit() STUB
-void Comm::CallbackTableDestruct() STUB
+void Comm::IoCallback::setCallback(iocb_type, AsyncCall::Pointer &, char *, FREE *, int) STUB();
+void Comm::IoCallback::selectOrQueueWrite() STUB();
+void Comm::IoCallback::cancel(const char *) STUB();
+void Comm::IoCallback::finish(Comm::Flag, int) STUB();
+Comm::CbEntry *Comm::iocb_table = nullptr;
+void Comm::CallbackTableInit() STUB();
+void Comm::CallbackTableDestruct() STUB();
 
 #include "comm/Loops.h"
-void Comm::SelectLoopInit(void) STUB
-void Comm::SetSelect(int, unsigned int, PF *, void *, time_t) STUB
-Comm::Flag Comm::DoSelect(int) STUB_RETVAL(Comm::COMM_ERROR)
-void Comm::QuickPollRequired(void) STUB
+void Comm::SelectLoopInit(void) STUB();
+void Comm::SetSelect(int, unsigned int, PF *, void *, time_t) STUB();
+Comm::Flag Comm::DoSelect(int) STUB_RETVAL(Comm::COMM_ERROR);
+void Comm::QuickPollRequired(void) STUB();
 
 #include "comm/Read.h"
-void Comm::Read(const Comm::ConnectionPointer &, AsyncCall::Pointer &) STUB
-bool Comm::MonitorsRead(int) STUB_RETVAL(false)
-Comm::Flag Comm::ReadNow(CommIoCbParams &, SBuf &) STUB_RETVAL(Comm::COMM_ERROR)
-void Comm::ReadCancel(int, AsyncCall::Pointer &) STUB
-//void Comm::HandleRead(int, void*) STUB
+void Comm::Read(const Comm::ConnectionPointer &, AsyncCall::Pointer &) STUB();
+bool Comm::MonitorsRead(int) STUB_RETVAL(false);
+Comm::Flag Comm::ReadNow(CommIoCbParams &, SBuf &) STUB_RETVAL(Comm::COMM_ERROR);
+void Comm::ReadCancel(int, AsyncCall::Pointer &) STUB();
+//void Comm::HandleRead(int, void*) STUB();
 
-void comm_read_base(const Comm::ConnectionPointer &, char *, int, AsyncCall::Pointer &) STUB
-void comm_read_cancel(int, IOCB *, void *) STUB
+void comm_read_base(const Comm::ConnectionPointer &, char *, int, AsyncCall::Pointer &) STUB();
+void comm_read_cancel(int, IOCB *, void *) STUB();
 
 #include "comm/TcpAcceptor.h"
-//Comm::TcpAcceptor(const Comm::ConnectionPointer &, const char *, const Subscription::Pointer &) STUB
-void Comm::TcpAcceptor::subscribe(const Subscription::Pointer &) STUB
-void Comm::TcpAcceptor::unsubscribe(const char *) STUB
-void Comm::TcpAcceptor::acceptNext() STUB
-void Comm::TcpAcceptor::notify(const Comm::Flag, const Comm::ConnectionPointer &) const STUB
+//Comm::TcpAcceptor(const Comm::ConnectionPointer &, const char *, const Subscription::Pointer &) STUB();
+void Comm::TcpAcceptor::subscribe(const Subscription::Pointer &) STUB();
+void Comm::TcpAcceptor::unsubscribe(const char *) STUB();
+void Comm::TcpAcceptor::acceptNext() STUB();
+void Comm::TcpAcceptor::notify(const Comm::Flag, const Comm::ConnectionPointer &) const STUB();
 
 #include "comm/Tcp.h"
-void Comm::ApplyTcpKeepAlive(int, const TcpKeepAlive &) STUB
+void Comm::ApplyTcpKeepAlive(int, const TcpKeepAlive &) STUB();
 
 #include "comm/Write.h"
-void Comm::Write(const Comm::ConnectionPointer &, const char *, int, AsyncCall::Pointer &, FREE *) STUB
-void Comm::Write(const Comm::ConnectionPointer &, MemBuf *, AsyncCall::Pointer &) STUB
-void Comm::WriteCancel(const Comm::ConnectionPointer &, const char *) STUB
-/*PF*/ void Comm::HandleWrite(int, void*) STUB
+void Comm::Write(const Comm::ConnectionPointer &, const char *, int, AsyncCall::Pointer &, FREE *) STUB();
+void Comm::Write(const Comm::ConnectionPointer &, MemBuf *, AsyncCall::Pointer &) STUB();
+void Comm::WriteCancel(const Comm::ConnectionPointer &, const char *) STUB();
+/*PF*/ void Comm::HandleWrite(int, void*) STUB();
 
-std::ostream &Comm::operator <<(std::ostream &os, const Connection &) STUB_RETVAL(os << "[Connection object]")
+std::ostream &Comm::operator <<(std::ostream &os, const Connection &) STUB_RETVAL(os << "[Connection object]");
 

--- a/src/tests/stub_libdiskio.cc
+++ b/src/tests/stub_libdiskio.cc
@@ -15,16 +15,16 @@
 
 // #include "DiskIO/DiskFile.h"
 #include "DiskIO/DiskIOModule.h"
-void DiskIOModule::SetupAllModules() STUB
-void DiskIOModule::ModuleAdd(DiskIOModule &) STUB
-void DiskIOModule::FreeAllModules() STUB
-DiskIOModule *DiskIOModule::Find(char const *) STUB_RETVAL(nullptr)
-DiskIOModule *DiskIOModule::FindDefault() STUB_RETVAL(nullptr)
+void DiskIOModule::SetupAllModules() STUB();
+void DiskIOModule::ModuleAdd(DiskIOModule &) STUB();
+void DiskIOModule::FreeAllModules() STUB();
+DiskIOModule *DiskIOModule::Find(char const *) STUB_RETVAL(nullptr);
+DiskIOModule *DiskIOModule::FindDefault() STUB_RETVAL(nullptr);
 std::vector<DiskIOModule*> const &DiskIOModule::Modules() STUB_RETSTATREF(std::vector<DiskIOModule*>)
 DiskIOModule::DiskIOModule() {STUB}
 DiskIOModule::DiskIOModule(DiskIOModule const &) {STUB}
-DiskIOModule &DiskIOModule::operator=(DiskIOModule const&) STUB
-void DiskIOModule::RegisterAllModulesWithCacheManager() STUB
+DiskIOModule &DiskIOModule::operator=(DiskIOModule const&) STUB();
+void DiskIOModule::RegisterAllModulesWithCacheManager() STUB();
 
 // #include "DiskIO/DiskIOStrategy.h"
 // #include "DiskIO/DiskIORequestor.h"

--- a/src/tests/stub_liberror.cc
+++ b/src/tests/stub_liberror.cc
@@ -20,15 +20,15 @@ void Error::update(const ErrorDetailPointer &) STUB_NOP
 void Error::update(const Error &) STUB_NOP
 void Error::update(err_type, const ErrorDetailPointer &) STUB_NOP
 
-std::ostream &operator <<(std::ostream &os, const Error &) STUB_RETVAL(os)
-std::ostream &operator <<(std::ostream &os, const ErrorDetail::Pointer &) STUB_RETVAL(os)
-std::ostream &operator <<(std::ostream &os, const ErrorDetails &) STUB_RETVAL(os)
+std::ostream &operator <<(std::ostream &os, const Error &) STUB_RETVAL(os);
+std::ostream &operator <<(std::ostream &os, const ErrorDetail::Pointer &) STUB_RETVAL(os);
+std::ostream &operator <<(std::ostream &os, const ErrorDetails &) STUB_RETVAL(os);
 
-ErrorDetail::Pointer MakeNamedErrorDetail(const char *) STUB_RETVAL(ErrorDetail::Pointer())
+ErrorDetail::Pointer MakeNamedErrorDetail(const char *) STUB_RETVAL(ErrorDetail::Pointer());
 
 #include "error/SysErrorDetail.h"
-SBuf SysErrorDetail::Brief(int) STUB_RETVAL(SBuf())
-SBuf SysErrorDetail::brief() const STUB_RETVAL(SBuf())
-SBuf SysErrorDetail::verbose(const HttpRequestPointer &) const STUB_RETVAL(SBuf())
-std::ostream &operator <<(std::ostream &os, ReportSysError) STUB_RETVAL(os)
+SBuf SysErrorDetail::Brief(int) STUB_RETVAL(SBuf());
+SBuf SysErrorDetail::brief() const STUB_RETVAL(SBuf());
+SBuf SysErrorDetail::verbose(const HttpRequestPointer &) const STUB_RETVAL(SBuf());
+std::ostream &operator <<(std::ostream &os, ReportSysError) STUB_RETVAL(os);
 

--- a/src/tests/stub_libeui.cc
+++ b/src/tests/stub_libeui.cc
@@ -16,19 +16,19 @@ Eui::EuiConfig Eui::TheConfig;
 
 #include "eui/Eui48.h"
 #if USE_SQUID_EUI
-const unsigned char *Eui::Eui48::get(void) STUB_RETVAL(nullptr)
-bool Eui::Eui48::decode(const char *) STUB_RETVAL(false)
-bool Eui::Eui48::encode(char *, const int) const STUB_RETVAL(false)
-bool Eui::Eui48::lookup(const Ip::Address &) STUB_RETVAL(false)
+const unsigned char *Eui::Eui48::get(void) STUB_RETVAL(nullptr);
+bool Eui::Eui48::decode(const char *) STUB_RETVAL(false);
+bool Eui::Eui48::encode(char *, const int) const STUB_RETVAL(false);
+bool Eui::Eui48::lookup(const Ip::Address &) STUB_RETVAL(false);
 #endif
 
 #include "eui/Eui64.h"
 #if USE_SQUID_EUI
-const unsigned char *Eui::Eui64::get(void) STUB_RETVAL(nullptr)
-bool Eui::Eui64::decode(const char *) STUB_RETVAL(false)
-bool Eui::Eui64::encode(char *, const int) const STUB_RETVAL(false)
-bool Eui::Eui64::lookup(const Ip::Address &) STUB_RETVAL(false)
-bool Eui::Eui64::lookupNdp(const Ip::Address &) STUB_RETVAL(false)
-bool Eui::Eui64::lookupSlaac(const Ip::Address &) STUB_RETVAL(false)
+const unsigned char *Eui::Eui64::get(void) STUB_RETVAL(nullptr);
+bool Eui::Eui64::decode(const char *) STUB_RETVAL(false);
+bool Eui::Eui64::encode(char *, const int) const STUB_RETVAL(false);
+bool Eui::Eui64::lookup(const Ip::Address &) STUB_RETVAL(false);
+bool Eui::Eui64::lookupNdp(const Ip::Address &) STUB_RETVAL(false);
+bool Eui::Eui64::lookupSlaac(const Ip::Address &) STUB_RETVAL(false);
 #endif
 

--- a/src/tests/stub_libformat.cc
+++ b/src/tests/stub_libformat.cc
@@ -12,8 +12,8 @@
 #define STUB_API "stub_libformat.cc"
 #include "tests/STUB.h"
 
-void Format::Format::assemble(MemBuf &, const AccessLogEntryPointer &, int) const STUB
-bool Format::Format::parse(char const*) STUB_RETVAL(false)
-Format::Format::Format(char const*) STUB
-Format::Format::~Format() STUB
+void Format::Format::assemble(MemBuf &, const AccessLogEntryPointer &, int) const STUB();
+bool Format::Format::parse(char const*) STUB_RETVAL(false);
+Format::Format::Format(char const*) STUB();
+Format::Format::~Format() STUB();
 

--- a/src/tests/stub_libhttp.cc
+++ b/src/tests/stub_libhttp.cc
@@ -28,10 +28,10 @@ Http::ContentLengthInterpreter::ContentLengthInterpreter():
     prohibitedAndIgnored_(nullptr)
 {
 }
-bool ContentLengthInterpreter::checkField(const String &) STUB_RETVAL(false)
-bool ContentLengthInterpreter::goodSuffix(const char *, const char * const) const STUB_RETVAL(false)
-bool ContentLengthInterpreter::checkValue(const char *, const int) STUB_RETVAL(false)
-bool ContentLengthInterpreter::checkList(const String &) STUB_RETVAL(false)
+bool ContentLengthInterpreter::checkField(const String &) STUB_RETVAL(false);
+bool ContentLengthInterpreter::goodSuffix(const char *, const char * const) const STUB_RETVAL(false);
+bool ContentLengthInterpreter::checkValue(const char *, const int) STUB_RETVAL(false);
+bool ContentLengthInterpreter::checkList(const String &) STUB_RETVAL(false);
 }
 
 #include "http/Message.h"
@@ -39,17 +39,17 @@ namespace Http
 {
 Message::Message(const http_hdr_owner_type owner): header(owner) {STUB}
 Message::~Message() {STUB}
-void Message::packInto(Packable *, bool) const STUB
-void Message::setContentLength(int64_t) STUB
-bool Message::persistent() const STUB_RETVAL(false)
-void Message::putCc(const HttpHdrCc &) STUB
-bool Message::parse(const char *, const size_t, bool, Http::StatusCode *) STUB_RETVAL(false)
-bool Message::parseCharBuf(const char *, ssize_t) STUB_RETVAL(false)
-int Message::httpMsgParseStep(const char *, int, int) STUB_RETVAL(-1)
-int Message::httpMsgParseError() STUB_RETVAL(0)
-void Message::firstLineBuf(MemBuf&) STUB
-void Message::hdrCacheInit() STUB
-bool Message::parseHeader(Http1::Parser &, Http::ContentLengthInterpreter &) STUB_RETVAL(false)
+void Message::packInto(Packable *, bool) const STUB();
+void Message::setContentLength(int64_t) STUB();
+bool Message::persistent() const STUB_RETVAL(false);
+void Message::putCc(const HttpHdrCc &) STUB();
+bool Message::parse(const char *, const size_t, bool, Http::StatusCode *) STUB_RETVAL(false);
+bool Message::parseCharBuf(const char *, ssize_t) STUB_RETVAL(false);
+int Message::httpMsgParseStep(const char *, int, int) STUB_RETVAL(-1);
+int Message::httpMsgParseError() STUB_RETVAL(0);
+void Message::firstLineBuf(MemBuf&) STUB();
+void Message::hdrCacheInit() STUB();
+bool Message::parseHeader(Http1::Parser &, Http::ContentLengthInterpreter &) STUB_RETVAL(false);
 }
 
 #include "http/MethodType.h"
@@ -64,37 +64,37 @@ namespace Http
 HeaderTableRecord::HeaderTableRecord(const char *) {STUB_NOP}
 HeaderTableRecord::HeaderTableRecord(const char *, Http::HdrType, Http::HdrFieldType, int) {STUB}
 HeaderLookupTable_t::HeaderLookupTable_t() {STUB_NOP}
-const HeaderTableRecord& HeaderLookupTable_t::lookup(const char *, const std::size_t) const STUB_RETVAL(BadHdr)
+const HeaderTableRecord& HeaderLookupTable_t::lookup(const char *, const std::size_t) const STUB_RETVAL(BadHdr);
 const HeaderLookupTable_t HeaderLookupTable;
 }
-std::ostream &Http::operator <<(std::ostream &os, HdrType) STUB_RETVAL(os)
+std::ostream &Http::operator <<(std::ostream &os, HdrType) STUB_RETVAL(os);
 
 #include "http/RequestMethod.h"
 HttpRequestMethod::HttpRequestMethod(const SBuf &) {STUB}
-void HttpRequestMethod::HttpRequestMethodXXX(char const *) STUB
-const SBuf &HttpRequestMethod::image() const STUB_RETVAL(theImage)
-bool HttpRequestMethod::isHttpSafe() const STUB_RETVAL(false)
-bool HttpRequestMethod::isIdempotent() const STUB_RETVAL(false)
-bool HttpRequestMethod::respMaybeCacheable() const STUB_RETVAL(false)
-bool HttpRequestMethod::shouldInvalidate() const STUB_RETVAL(false)
-bool HttpRequestMethod::purgesOthers() const STUB_RETVAL(false)
+void HttpRequestMethod::HttpRequestMethodXXX(char const *) STUB();
+const SBuf &HttpRequestMethod::image() const STUB_RETVAL(theImage);
+bool HttpRequestMethod::isHttpSafe() const STUB_RETVAL(false);
+bool HttpRequestMethod::isIdempotent() const STUB_RETVAL(false);
+bool HttpRequestMethod::respMaybeCacheable() const STUB_RETVAL(false);
+bool HttpRequestMethod::shouldInvalidate() const STUB_RETVAL(false);
+bool HttpRequestMethod::purgesOthers() const STUB_RETVAL(false);
 
 #include "http/StatusCode.h"
 namespace Http
 {
-const char *StatusCodeString(const Http::StatusCode) STUB_RETVAL(nullptr)
+const char *StatusCodeString(const Http::StatusCode) STUB_RETVAL(nullptr);
 }
 
 #include "http/StatusLine.h"
 namespace Http
 {
-void StatusLine::init() STUB
-void StatusLine::clean() STUB
-void StatusLine::set(const AnyP::ProtocolVersion &, Http::StatusCode, const char *) STUB
-const char *StatusLine::reason() const STUB_RETVAL(nullptr)
-size_t StatusLine::packedLength() const STUB_RETVAL(0)
-void StatusLine::packInto(Packable *) const STUB
-bool StatusLine::parse(const String &, const char *, const char *) STUB_RETVAL(false)
+void StatusLine::init() STUB();
+void StatusLine::clean() STUB();
+void StatusLine::set(const AnyP::ProtocolVersion &, Http::StatusCode, const char *) STUB();
+const char *StatusLine::reason() const STUB_RETVAL(nullptr);
+size_t StatusLine::packedLength() const STUB_RETVAL(0);
+void StatusLine::packInto(Packable *) const STUB();
+bool StatusLine::parse(const String &, const char *, const char *) STUB_RETVAL(false);
 }
 
 #include "http/Stream.h"
@@ -102,25 +102,25 @@ namespace Http
 {
 Stream::Stream(const Comm::ConnectionPointer &, ClientHttpRequest *) {STUB}
 Stream::~Stream() {STUB}
-void Stream::registerWithConn() STUB
-bool Stream::startOfOutput() const STUB
-void Stream::writeComplete(size_t) STUB
-void Stream::pullData() STUB
-bool Stream::multipartRangeRequest() const STUB_RETVAL(false)
-int64_t Stream::getNextRangeOffset() const STUB_RETVAL(-1)
-bool Stream::canPackMoreRanges() const STUB_RETVAL(false)
-size_t Stream::lengthToSend(Range<int64_t> const &) const STUB_RETVAL(0)
-clientStream_status_t Stream::socketState() STUB_RETVAL(STREAM_NONE)
-void Stream::sendStartOfMessage(HttpReply *, StoreIOBuffer) STUB
-void Stream::sendBody(StoreIOBuffer) STUB
-void Stream::noteSentBodyBytes(size_t) STUB
-void Stream::buildRangeHeader(HttpReply *) STUB
-clientStreamNode *Stream::getTail() const STUB_RETVAL(nullptr)
-clientStreamNode *Stream::getClientReplyContext() const STUB_RETVAL(nullptr)
-ConnStateData *Stream::getConn() const STUB_RETVAL(nullptr)
-void Stream::noteIoError(const Error &, const LogTagsErrors &) STUB
-void Stream::finished() STUB
-void Stream::initiateClose(const char *) STUB
-void Stream::deferRecipientForLater(clientStreamNode *, HttpReply *, StoreIOBuffer) STUB
+void Stream::registerWithConn() STUB();
+bool Stream::startOfOutput() const STUB();
+void Stream::writeComplete(size_t) STUB();
+void Stream::pullData() STUB();
+bool Stream::multipartRangeRequest() const STUB_RETVAL(false);
+int64_t Stream::getNextRangeOffset() const STUB_RETVAL(-1);
+bool Stream::canPackMoreRanges() const STUB_RETVAL(false);
+size_t Stream::lengthToSend(Range<int64_t> const &) const STUB_RETVAL(0);
+clientStream_status_t Stream::socketState() STUB_RETVAL(STREAM_NONE);
+void Stream::sendStartOfMessage(HttpReply *, StoreIOBuffer) STUB();
+void Stream::sendBody(StoreIOBuffer) STUB();
+void Stream::noteSentBodyBytes(size_t) STUB();
+void Stream::buildRangeHeader(HttpReply *) STUB();
+clientStreamNode *Stream::getTail() const STUB_RETVAL(nullptr);
+clientStreamNode *Stream::getClientReplyContext() const STUB_RETVAL(nullptr);
+ConnStateData *Stream::getConn() const STUB_RETVAL(nullptr);
+void Stream::noteIoError(const Error &, const LogTagsErrors &) STUB();
+void Stream::finished() STUB();
+void Stream::initiateClose(const char *) STUB();
+void Stream::deferRecipientForLater(clientStreamNode *, HttpReply *, StoreIOBuffer) STUB();
 }
 

--- a/src/tests/stub_libicmp.cc
+++ b/src/tests/stub_libicmp.cc
@@ -11,29 +11,29 @@
 #include "tests/STUB.h"
 
 #include "icmp/IcmpSquid.h"
-//IcmpSquid::IcmpSquid() STUB
-//IcmpSquid::~IcmpSquid() STUB
-int IcmpSquid::Open() STUB_RETVAL(-1)
-void IcmpSquid::Close() STUB
-void IcmpSquid::DomainPing(Ip::Address &, const char *) STUB
+//IcmpSquid::IcmpSquid() STUB();
+//IcmpSquid::~IcmpSquid() STUB();
+int IcmpSquid::Open() STUB_RETVAL(-1);
+void IcmpSquid::Close() STUB();
+void IcmpSquid::DomainPing(Ip::Address &, const char *) STUB();
 #if USE_ICMP
-void IcmpSquid::SendEcho(Ip::Address &, int, const char*, int) STUB
-void IcmpSquid::Recv(void) STUB
+void IcmpSquid::SendEcho(Ip::Address &, int, const char*, int) STUB();
+void IcmpSquid::Recv(void) STUB();
 #endif
 //IcmpSquid icmpEngine;
 
 #include "icmp/net_db.h"
-void netdbInit(void) STUB
-void netdbHandlePingReply(const Ip::Address &, int, int) STUB
-void netdbPingSite(const char *) STUB
-void netdbDump(StoreEntry *) STUB
-int netdbHostHops(const char *) STUB_RETVAL(-1)
-int netdbHostRtt(const char *) STUB_RETVAL(-1)
-void netdbUpdatePeer(const AnyP::Uri &, CachePeer *, int, int) STUB
-void netdbDeleteAddrNetwork(Ip::Address &) STUB
-void netdbBinaryExchange(StoreEntry *) STUB
-void netdbExchangeStart(void *) STUB
-void netdbExchangeUpdatePeer(Ip::Address &, CachePeer *, double, double) STUB
-CachePeer *netdbClosestParent(PeerSelector *) STUB_RETVAL(nullptr)
-void netdbHostData(const char *, int *, int *, int *) STUB
+void netdbInit(void) STUB();
+void netdbHandlePingReply(const Ip::Address &, int, int) STUB();
+void netdbPingSite(const char *) STUB();
+void netdbDump(StoreEntry *) STUB();
+int netdbHostHops(const char *) STUB_RETVAL(-1);
+int netdbHostRtt(const char *) STUB_RETVAL(-1);
+void netdbUpdatePeer(const AnyP::Uri &, CachePeer *, int, int) STUB();
+void netdbDeleteAddrNetwork(Ip::Address &) STUB();
+void netdbBinaryExchange(StoreEntry *) STUB();
+void netdbExchangeStart(void *) STUB();
+void netdbExchangeUpdatePeer(Ip::Address &, CachePeer *, double, double) STUB();
+CachePeer *netdbClosestParent(PeerSelector *) STUB_RETVAL(nullptr);
+void netdbHostData(const char *, int *, int *, int *) STUB();
 

--- a/src/tests/stub_libip.cc
+++ b/src/tests/stub_libip.cc
@@ -13,104 +13,104 @@
 #include "tests/STUB.h"
 
 #include "ip/Address.h"
-std::optional<Ip::Address> Ip::Address::Parse(const char *) STUB_RETVAL(std::nullopt)
-Ip::Address::Address(const struct in_addr &) STUB
-Ip::Address::Address(const struct sockaddr_in &) STUB
-Ip::Address::Address(const struct in6_addr &) STUB
-Ip::Address::Address(const struct sockaddr_in6 &) STUB
-Ip::Address::Address(const struct hostent &) STUB
-Ip::Address::Address(const struct addrinfo &) STUB
-Ip::Address::Address(const char*) STUB
-Ip::Address& Ip::Address::operator =(struct sockaddr_in const &) STUB_RETVAL(*this)
-Ip::Address& Ip::Address::operator =(struct sockaddr_storage const &) STUB_RETVAL(*this)
-Ip::Address& Ip::Address::operator =(struct in_addr const &) STUB_RETVAL(*this)
-Ip::Address& Ip::Address::operator =(struct in6_addr const &) STUB_RETVAL(*this)
-Ip::Address& Ip::Address::operator =(struct sockaddr_in6 const &) STUB_RETVAL(*this)
-bool Ip::Address::operator =(const struct hostent &) STUB_RETVAL(false)
-bool Ip::Address::operator =(const struct addrinfo &) STUB_RETVAL(false)
-bool Ip::Address::operator =(const char *) STUB_RETVAL(false)
-bool Ip::Address::operator ==(Ip::Address const &) const STUB_RETVAL(false)
-bool Ip::Address::operator !=(Ip::Address const &) const STUB_RETVAL(false)
-bool Ip::Address::operator >=(Ip::Address const &) const STUB_RETVAL(false)
-bool Ip::Address::operator <=(Ip::Address const &) const STUB_RETVAL(false)
-bool Ip::Address::operator >(Ip::Address const &) const STUB_RETVAL(false)
-bool Ip::Address::operator <(Ip::Address const &) const STUB_RETVAL(false)
-bool Ip::Address::isIPv4() const STUB_RETVAL(false)
-bool Ip::Address::isIPv6() const STUB_RETVAL(false)
-bool Ip::Address::isSockAddr() const STUB_RETVAL(false)
-bool Ip::Address::isAnyAddr() const STUB_RETVAL(false)
-bool Ip::Address::isNoAddr() const STUB_RETVAL(false)
-bool Ip::Address::isLocalhost() const STUB_RETVAL(false)
-bool Ip::Address::isSiteLocal6() const STUB_RETVAL(false)
-bool Ip::Address::isSiteLocalAuto() const STUB_RETVAL(false)
-unsigned short Ip::Address::port() const STUB
-unsigned short Ip::Address::port(unsigned short) STUB
-void Ip::Address::setAnyAddr() STUB
-void Ip::Address::setNoAddr() STUB
-void Ip::Address::setLocalhost() STUB
+std::optional<Ip::Address> Ip::Address::Parse(const char *) STUB_RETVAL(std::nullopt);
+Ip::Address::Address(const struct in_addr &) STUB();
+Ip::Address::Address(const struct sockaddr_in &) STUB();
+Ip::Address::Address(const struct in6_addr &) STUB();
+Ip::Address::Address(const struct sockaddr_in6 &) STUB();
+Ip::Address::Address(const struct hostent &) STUB();
+Ip::Address::Address(const struct addrinfo &) STUB();
+Ip::Address::Address(const char*) STUB();
+Ip::Address& Ip::Address::operator =(struct sockaddr_in const &) STUB_RETVAL(*this);
+Ip::Address& Ip::Address::operator =(struct sockaddr_storage const &) STUB_RETVAL(*this);
+Ip::Address& Ip::Address::operator =(struct in_addr const &) STUB_RETVAL(*this);
+Ip::Address& Ip::Address::operator =(struct in6_addr const &) STUB_RETVAL(*this);
+Ip::Address& Ip::Address::operator =(struct sockaddr_in6 const &) STUB_RETVAL(*this);
+bool Ip::Address::operator =(const struct hostent &) STUB_RETVAL(false);
+bool Ip::Address::operator =(const struct addrinfo &) STUB_RETVAL(false);
+bool Ip::Address::operator =(const char *) STUB_RETVAL(false);
+bool Ip::Address::operator ==(Ip::Address const &) const STUB_RETVAL(false);
+bool Ip::Address::operator !=(Ip::Address const &) const STUB_RETVAL(false);
+bool Ip::Address::operator >=(Ip::Address const &) const STUB_RETVAL(false);
+bool Ip::Address::operator <=(Ip::Address const &) const STUB_RETVAL(false);
+bool Ip::Address::operator >(Ip::Address const &) const STUB_RETVAL(false);
+bool Ip::Address::operator <(Ip::Address const &) const STUB_RETVAL(false);
+bool Ip::Address::isIPv4() const STUB_RETVAL(false);
+bool Ip::Address::isIPv6() const STUB_RETVAL(false);
+bool Ip::Address::isSockAddr() const STUB_RETVAL(false);
+bool Ip::Address::isAnyAddr() const STUB_RETVAL(false);
+bool Ip::Address::isNoAddr() const STUB_RETVAL(false);
+bool Ip::Address::isLocalhost() const STUB_RETVAL(false);
+bool Ip::Address::isSiteLocal6() const STUB_RETVAL(false);
+bool Ip::Address::isSiteLocalAuto() const STUB_RETVAL(false);
+unsigned short Ip::Address::port() const STUB();
+unsigned short Ip::Address::port(unsigned short) STUB();
+void Ip::Address::setAnyAddr() STUB();
+void Ip::Address::setNoAddr() STUB();
+void Ip::Address::setLocalhost() STUB();
 void Ip::Address::setEmpty() STUB_NOP // NOP for default constructor
-bool Ip::Address::setIPv4() STUB_RETVAL(false)
-int Ip::Address::cidr() const STUB_RETVAL(0)
-int Ip::Address::applyMask(const Ip::Address &) STUB_RETVAL(0)
-bool Ip::Address::applyMask(const unsigned int, int) STUB_RETVAL(false)
-void Ip::Address::applyClientMask(const Ip::Address &) STUB
-char* Ip::Address::toStr(char *, const unsigned int, int) const STUB_RETVAL(nullptr)
-char* Ip::Address::toUrl(char *, unsigned int) const STUB_RETVAL(nullptr)
-unsigned int Ip::Address::toHostStr(char *, const unsigned int) const STUB_RETVAL(0)
-bool Ip::Address::fromHost(const char *) STUB_RETVAL(false)
-bool Ip::Address::getReverseString(char [MAX_IPSTRLEN], int) const STUB_RETVAL(false)
-int Ip::Address::matchIPAddr(const Ip::Address &) const STUB_RETVAL(0)
-int Ip::Address::compareWhole(const Ip::Address &) const STUB_RETVAL(0)
-void Ip::Address::getAddrInfo(struct addrinfo *&, int) const STUB
-void Ip::Address::FreeAddr(struct addrinfo *&) STUB
-void Ip::Address::InitAddr(struct addrinfo *&) STUB
-bool Ip::Address::GetHostByName(const char *) STUB_RETVAL(false)
-void Ip::Address::getSockAddr(struct sockaddr_storage &, const int) const STUB
-void Ip::Address::getSockAddr(struct sockaddr_in &) const STUB
-bool Ip::Address::getInAddr(struct in_addr &) const STUB_RETVAL(false)
-void Ip::Address::getSockAddr(struct sockaddr_in6 &) const STUB
-void Ip::Address::getInAddr(struct in6_addr &) const STUB
-void parse_IpAddress_list_token(Ip::Address_list **, char *) STUB
+bool Ip::Address::setIPv4() STUB_RETVAL(false);
+int Ip::Address::cidr() const STUB_RETVAL(0);
+int Ip::Address::applyMask(const Ip::Address &) STUB_RETVAL(0);
+bool Ip::Address::applyMask(const unsigned int, int) STUB_RETVAL(false);
+void Ip::Address::applyClientMask(const Ip::Address &) STUB();
+char* Ip::Address::toStr(char *, const unsigned int, int) const STUB_RETVAL(nullptr);
+char* Ip::Address::toUrl(char *, unsigned int) const STUB_RETVAL(nullptr);
+unsigned int Ip::Address::toHostStr(char *, const unsigned int) const STUB_RETVAL(0);
+bool Ip::Address::fromHost(const char *) STUB_RETVAL(false);
+bool Ip::Address::getReverseString(char [MAX_IPSTRLEN], int) const STUB_RETVAL(false);
+int Ip::Address::matchIPAddr(const Ip::Address &) const STUB_RETVAL(0);
+int Ip::Address::compareWhole(const Ip::Address &) const STUB_RETVAL(0);
+void Ip::Address::getAddrInfo(struct addrinfo *&, int) const STUB();
+void Ip::Address::FreeAddr(struct addrinfo *&) STUB();
+void Ip::Address::InitAddr(struct addrinfo *&) STUB();
+bool Ip::Address::GetHostByName(const char *) STUB_RETVAL(false);
+void Ip::Address::getSockAddr(struct sockaddr_storage &, const int) const STUB();
+void Ip::Address::getSockAddr(struct sockaddr_in &) const STUB();
+bool Ip::Address::getInAddr(struct in_addr &) const STUB_RETVAL(false);
+void Ip::Address::getSockAddr(struct sockaddr_in6 &) const STUB();
+void Ip::Address::getInAddr(struct in6_addr &) const STUB();
+void parse_IpAddress_list_token(Ip::Address_list **, char *) STUB();
 
 //#include "ip/forward.h"
 
 #include "ip/QosConfig.h"
 CBDATA_CLASS_INIT(acl_tos);
-acl_tos::~acl_tos() STUB
+acl_tos::~acl_tos() STUB();
 CBDATA_CLASS_INIT(acl_nfmark);
-acl_nfmark::~acl_nfmark() STUB
-void Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB
-nfmark_t Ip::Qos::getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1)
-bool Ip::Qos::setNfConnmark(Comm::ConnectionPointer &, const ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false)
-int Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
-int Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
-int Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
-int Ip::Qos::doNfmarkLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
-int Ip::Qos::setSockTos(const Comm::ConnectionPointer &, tos_t) STUB_RETVAL(-1)
-int Ip::Qos::setSockTos(const int, tos_t, int) STUB_RETVAL(-1)
-int Ip::Qos::setSockNfmark(const Comm::ConnectionPointer &, nfmark_t) STUB_RETVAL(-1)
-int Ip::Qos::setSockNfmark(const int, nfmark_t) STUB_RETVAL(-1)
+acl_nfmark::~acl_nfmark() STUB();
+void Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB();
+nfmark_t Ip::Qos::getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1);
+bool Ip::Qos::setNfConnmark(Comm::ConnectionPointer &, const ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false);
+int Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1);
+int Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1);
+int Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1);
+int Ip::Qos::doNfmarkLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1);
+int Ip::Qos::setSockTos(const Comm::ConnectionPointer &, tos_t) STUB_RETVAL(-1);
+int Ip::Qos::setSockTos(const int, tos_t, int) STUB_RETVAL(-1);
+int Ip::Qos::setSockNfmark(const Comm::ConnectionPointer &, nfmark_t) STUB_RETVAL(-1);
+int Ip::Qos::setSockNfmark(const int, nfmark_t) STUB_RETVAL(-1);
 Ip::Qos::Config::Config() STUB_NOP
-void Ip::Qos::Config::parseConfigLine() STUB
-void Ip::Qos::Config::dumpConfigLine(std::ostream &, const char *) const STUB
-bool Ip::Qos::Config::isAclNfmarkActive() const STUB_RETVAL(false)
-bool Ip::Qos::Config::isAclTosActive() const STUB_RETVAL(false)
+void Ip::Qos::Config::parseConfigLine() STUB();
+void Ip::Qos::Config::dumpConfigLine(std::ostream &, const char *) const STUB();
+bool Ip::Qos::Config::isAclNfmarkActive() const STUB_RETVAL(false);
+bool Ip::Qos::Config::isAclTosActive() const STUB_RETVAL(false);
 Ip::Qos::Config Ip::Qos::TheConfig;
 
 #include "ip/Intercept.h"
-bool Ip::Intercept::LookupNat(const Comm::Connection &) STUB_RETVAL(false)
-bool Ip::Intercept::ProbeForTproxy(Ip::Address &) STUB_RETVAL(false)
-void Ip::Intercept::StartTransparency() STUB
-void Ip::Intercept::StopTransparency(const char *) STUB
-void Ip::Intercept::StartInterception() STUB
+bool Ip::Intercept::LookupNat(const Comm::Connection &) STUB_RETVAL(false);
+bool Ip::Intercept::ProbeForTproxy(Ip::Address &) STUB_RETVAL(false);
+void Ip::Intercept::StartTransparency() STUB();
+void Ip::Intercept::StopTransparency(const char *) STUB();
+void Ip::Intercept::StartInterception() STUB();
 Ip::Intercept Ip::Interceptor;
 
 #include "ip/NfMarkConfig.h"
 Ip::NfMarkConfig Ip::NfMarkConfig::Parse(const SBuf &) STUB_RETSTATREF(Ip::NfMarkConfig)
-nfmark_t Ip::NfMarkConfig::applyToMark(nfmark_t) const STUB_RETVAL(0)
-std::ostream &Ip::operator <<(std::ostream &os, Ip::NfMarkConfig) STUB_RETVAL(os)
+nfmark_t Ip::NfMarkConfig::applyToMark(nfmark_t) const STUB_RETVAL(0);
+std::ostream &Ip::operator <<(std::ostream &os, Ip::NfMarkConfig) STUB_RETVAL(os);
 
 #include "ip/tools.h"
-void Ip::ProbeTransport() STUB
+void Ip::ProbeTransport() STUB();
 int Ip::EnableIpv6 = 0;
 

--- a/src/tests/stub_liblog.cc
+++ b/src/tests/stub_liblog.cc
@@ -17,82 +17,82 @@
 #include "AccessLogEntry.h"
 /*
 AccessLogEntry::~AccessLogEntry() {STUB}
-void AccessLogEntry::getLogClientIp(char *, size_t) const STUB
-SBuf AccessLogEntry::getLogMethod() const STUB_RETVAL(SBuf())
+void AccessLogEntry::getLogClientIp(char *, size_t) const STUB();
+SBuf AccessLogEntry::getLogMethod() const STUB_RETVAL(SBuf());
 #if USE_OPENSSL
 AccessLogEntry::SslDetails::SslDetails() {STUB}
 #endif
 */
-void accessLogLogTo(CustomLog *, const AccessLogEntry::Pointer &, ACLChecklist *) STUB
-void accessLogLog(const AccessLogEntry::Pointer &, ACLChecklist *) STUB
-void accessLogRotate(void) STUB
-void accessLogClose(void) STUB
-void accessLogInit(void) STUB
-const char *accessLogTime(time_t) STUB_RETVAL(nullptr)
+void accessLogLogTo(CustomLog *, const AccessLogEntry::Pointer &, ACLChecklist *) STUB();
+void accessLogLog(const AccessLogEntry::Pointer &, ACLChecklist *) STUB();
+void accessLogRotate(void) STUB();
+void accessLogClose(void) STUB();
+void accessLogInit(void) STUB();
+const char *accessLogTime(time_t) STUB_RETVAL(nullptr);
 
 #include "log/access_log.h"
-void fvdbCountVia(const SBuf &) STUB
+void fvdbCountVia(const SBuf &) STUB();
 
 #include "log/Config.h"
 namespace Log
 {
-void LogConfig::parseFormats() STUB
+void LogConfig::parseFormats() STUB();
 LogConfig TheConfig;
 }
 
 #include "log/FormattedLog.h"
-bool FormattedLog::usesDaemon() const STUB_RETVAL(false)
+bool FormattedLog::usesDaemon() const STUB_RETVAL(false);
 
 #include "log/File.h"
 CBDATA_CLASS_INIT(Logfile);
 Logfile::Logfile(const char *) {STUB}
-//void Logfile::f_linestart(Logfile *) STUB
-//void Logfile::f_linewrite(Logfile *, const char *, size_t) STUB
-//void Logfile::f_lineend(Logfile *) STUB
-//void Logfile::f_flush(Logfile *) STUB
-//void Logfile::f_rotate(Logfile *, const int16_t) STUB
-//void Logfile::f_close(Logfile *) STUB
-Logfile *logfileOpen(const char *, size_t, int) STUB_RETVAL(nullptr)
-void logfileClose(Logfile *) STUB
-void logfileRotate(Logfile *, int16_t) STUB
-void logfileWrite(Logfile *, const char *, size_t) STUB
-void logfileFlush(Logfile *) STUB
-void logfilePrintf(Logfile *, const char *, ...) STUB
-void logfileLineStart(Logfile *) STUB
-void logfileLineEnd(Logfile *) STUB
+//void Logfile::f_linestart(Logfile *) STUB();
+//void Logfile::f_linewrite(Logfile *, const char *, size_t) STUB();
+//void Logfile::f_lineend(Logfile *) STUB();
+//void Logfile::f_flush(Logfile *) STUB();
+//void Logfile::f_rotate(Logfile *, const int16_t) STUB();
+//void Logfile::f_close(Logfile *) STUB();
+Logfile *logfileOpen(const char *, size_t, int) STUB_RETVAL(nullptr);
+void logfileClose(Logfile *) STUB();
+void logfileRotate(Logfile *, int16_t) STUB();
+void logfileWrite(Logfile *, const char *, size_t) STUB();
+void logfileFlush(Logfile *) STUB();
+void logfilePrintf(Logfile *, const char *, ...) STUB();
+void logfileLineStart(Logfile *) STUB();
+void logfileLineEnd(Logfile *) STUB();
 
 #include "log/Formats.h"
 namespace Log
 {
 namespace Format
 {
-void SquidNative(const AccessLogEntryPointer &, Logfile *) STUB
-void SquidIcap(const AccessLogEntryPointer &, Logfile *) STUB
-void SquidUserAgent(const AccessLogEntryPointer &, Logfile *) STUB
-void SquidReferer(const AccessLogEntryPointer &, Logfile *) STUB
-void SquidCustom(const AccessLogEntryPointer &, CustomLog *) STUB
-void HttpdCommon(const AccessLogEntryPointer &, Logfile *) STUB
-void HttpdCombined(const AccessLogEntryPointer &, Logfile *) STUB
+void SquidNative(const AccessLogEntryPointer &, Logfile *) STUB();
+void SquidIcap(const AccessLogEntryPointer &, Logfile *) STUB();
+void SquidUserAgent(const AccessLogEntryPointer &, Logfile *) STUB();
+void SquidReferer(const AccessLogEntryPointer &, Logfile *) STUB();
+void SquidCustom(const AccessLogEntryPointer &, CustomLog *) STUB();
+void HttpdCommon(const AccessLogEntryPointer &, Logfile *) STUB();
+void HttpdCombined(const AccessLogEntryPointer &, Logfile *) STUB();
 }
 }
 
 #include "log/ModDaemon.h"
-int logfile_mod_daemon_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0)
+int logfile_mod_daemon_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0);
 
 #include "log/ModStdio.h"
-int logfile_mod_stdio_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0)
+int logfile_mod_stdio_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0);
 
 #include "log/ModSyslog.h"
-int logfile_mod_syslog_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0)
+int logfile_mod_syslog_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0);
 
 #include "log/ModUdp.h"
-int logfile_mod_udp_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0)
+int logfile_mod_udp_open(Logfile *, const char *, size_t, int) STUB_RETVAL(0);
 
 #include "log/TcpLogger.h"
 namespace Log
 {
 CBDATA_CLASS_INIT(TcpLogger);
-int TcpLogger::Open(Logfile *, const char *, size_t, int) STUB_RETVAL(0)
+int TcpLogger::Open(Logfile *, const char *, size_t, int) STUB_RETVAL(0);
 
 /*
 protected:
@@ -101,9 +101,9 @@ protected:
     void endGracefully();
     void logRecord(const char *buf, size_t len);
     void flush();
-    virtual void start() STUB
-    virtual bool doneAll() const STUB_RETVAL(true)
-    virtual void swanSong() STUB
+    virtual void start() STUB();
+    virtual bool doneAll() const STUB_RETVAL(true);
+    virtual void swanSong() STUB();
 */
 }
 

--- a/src/tests/stub_libmem.cc
+++ b/src/tests/stub_libmem.cc
@@ -19,7 +19,7 @@
 void *Mem::AllocatorProxy::alloc() {return xmalloc(64*1024);}
 void Mem::AllocatorProxy::freeOne(void *address) {xfree(address);}
 int Mem::AllocatorProxy::inUseCount() const {return 0;}
-size_t Mem::AllocatorProxy::getStats(PoolStats &) STUB_RETVAL(0)
+size_t Mem::AllocatorProxy::getStats(PoolStats &) STUB_RETVAL(0);
 
 #include "mem/forward.h"
 void Mem::Init() STUB_NOP
@@ -28,10 +28,10 @@ void Mem::CleanIdlePools(void *) STUB_NOP
 void Mem::Report(std::ostream &) STUB_NOP
 void Mem::PoolReport(const PoolStats *, const PoolMeter *, std::ostream &) STUB_NOP
 //const size_t squidSystemPageSize = 4096;
-void memClean(void) STUB
-void memInitModule(void) STUB
-void memCleanModule(void) STUB
-void memConfigure(void) STUB
+void memClean(void) STUB();
+void memInitModule(void) STUB();
+void memCleanModule(void) STUB();
+void memConfigure(void) STUB();
 
 void *memAllocate(mem_type)
 {
@@ -64,16 +64,16 @@ void memFree(void *p, int) {xfree(p);}
 void memFreeBuf(size_t, void *buf) {xfree(buf);}
 static void cxx_xfree(void * ptr) {xfree(ptr);}
 FREE *memFreeBufFunc(size_t) {return cxx_xfree;}
-int memInUse(mem_type) STUB_RETVAL(0)
+int memInUse(mem_type) STUB_RETVAL(0);
 
 #include "mem/Pool.h"
 static MemPools tmpMemPools;
 MemPools &MemPools::GetInstance() {return tmpMemPools;}
 MemPools::MemPools() STUB_NOP
-void MemPools::flushMeters() STUB
+void MemPools::flushMeters() STUB();
 Mem::Allocator * MemPools::create(const char *, size_t) STUB_RETVAL(nullptr);
-void MemPools::clean(time_t) STUB
-void MemPools::setDefaultPoolChunking(bool const &) STUB
+void MemPools::clean(time_t) STUB();
+void MemPools::setDefaultPoolChunking(bool const &) STUB();
 
 #include "mem/Stats.h"
-size_t Mem::GlobalStats(PoolStats &) STUB_RETVAL(0)
+size_t Mem::GlobalStats(PoolStats &) STUB_RETVAL(0);

--- a/src/tests/stub_libmgr.cc
+++ b/src/tests/stub_libmgr.cc
@@ -19,232 +19,232 @@
 
 // NP: used by Action.h instantiations
 #include "mgr/Command.h"
-std::ostream &Mgr::operator <<(std::ostream &os, const Command &) STUB_RETVAL(os)
+std::ostream &Mgr::operator <<(std::ostream &os, const Command &) STUB_RETVAL(os);
 
 #include "mgr/Action.h"
-Mgr::Action::Action(const CommandPointer &) STUB
-Mgr::Action::~Action() STUB
-void Mgr::Action::run(StoreEntry *, bool) STUB
-void Mgr::Action::fillEntry(StoreEntry *, bool) STUB
-void Mgr::Action::add(const Action &) STUB
-void Mgr::Action::respond(const Request &) STUB
-void Mgr::Action::sendResponse(const Ipc::RequestId) STUB
-Mgr::Format Mgr::Action::format() const STUB_RETVAL(Mgr::Format::informal)
-bool Mgr::Action::atomic() const STUB_RETVAL(false)
-const char * Mgr::Action::name() const STUB_RETVAL(nullptr)
+Mgr::Action::Action(const CommandPointer &) STUB();
+Mgr::Action::~Action() STUB();
+void Mgr::Action::run(StoreEntry *, bool) STUB();
+void Mgr::Action::fillEntry(StoreEntry *, bool) STUB();
+void Mgr::Action::add(const Action &) STUB();
+void Mgr::Action::respond(const Request &) STUB();
+void Mgr::Action::sendResponse(const Ipc::RequestId) STUB();
+Mgr::Format Mgr::Action::format() const STUB_RETVAL(Mgr::Format::informal);
+bool Mgr::Action::atomic() const STUB_RETVAL(false);
+const char * Mgr::Action::name() const STUB_RETVAL(nullptr);
 static Mgr::Command static_Command;
-const Mgr::Command & Mgr::Action::command() const STUB_RETVAL(static_Command)
-StoreEntry * Mgr::Action::createStoreEntry() const STUB_RETVAL(nullptr)
+const Mgr::Command & Mgr::Action::command() const STUB_RETVAL(static_Command);
+StoreEntry * Mgr::Action::createStoreEntry() const STUB_RETVAL(nullptr);
 static Mgr::Action::Pointer dummyAction;
 
 #include "mgr/ActionParams.h"
 Mgr::ActionParams::ActionParams() STUB_NOP
 Mgr::ActionParams::ActionParams(const Ipc::TypedMsgHdr &) STUB_NOP
-void Mgr::ActionParams::pack(Ipc::TypedMsgHdr &) const STUB
+void Mgr::ActionParams::pack(Ipc::TypedMsgHdr &) const STUB();
 
 #include "mgr/ActionWriter.h"
-//Mgr::ActionWriter::ActionWriter(const Action::Pointer &, int) STUB
+//Mgr::ActionWriter::ActionWriter(const Action::Pointer &, int) STUB();
 //protected:
-void Mgr::ActionWriter::start() STUB
+void Mgr::ActionWriter::start() STUB();
 
 #include "mgr/BasicActions.h"
-Mgr::Action::Pointer Mgr::MenuAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::MenuAction::dump(StoreEntry *) STUB
+Mgr::Action::Pointer Mgr::MenuAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::MenuAction::dump(StoreEntry *) STUB();
 //protected:
-//Mgr::MenuAction::MenuAction(const CommandPointer &cmd) STUB
+//Mgr::MenuAction::MenuAction(const CommandPointer &cmd) STUB();
 
-Mgr::Action::Pointer Mgr::ShutdownAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::ShutdownAction::dump(StoreEntry *) STUB
+Mgr::Action::Pointer Mgr::ShutdownAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::ShutdownAction::dump(StoreEntry *) STUB();
 // protected:
-//Mgr::ShutdownAction::ShutdownAction(const CommandPointer &) STUB
+//Mgr::ShutdownAction::ShutdownAction(const CommandPointer &) STUB();
 
-Mgr::Action::Pointer Mgr::ReconfigureAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::ReconfigureAction::dump(StoreEntry *) STUB
+Mgr::Action::Pointer Mgr::ReconfigureAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::ReconfigureAction::dump(StoreEntry *) STUB();
 //protected:
-//Mgr::ReconfigureAction::ReconfigureAction(const CommandPointer &) STUB
+//Mgr::ReconfigureAction::ReconfigureAction(const CommandPointer &) STUB();
 
-Mgr::Action::Pointer Mgr::RotateAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::RotateAction::dump(StoreEntry *) STUB
+Mgr::Action::Pointer Mgr::RotateAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::RotateAction::dump(StoreEntry *) STUB();
 //protected:
-//Mgr::RotateAction::RotateAction(const CommandPointer &) STUB
+//Mgr::RotateAction::RotateAction(const CommandPointer &) STUB();
 
-Mgr::Action::Pointer Mgr::OfflineToggleAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::OfflineToggleAction::dump(StoreEntry *) STUB
+Mgr::Action::Pointer Mgr::OfflineToggleAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::OfflineToggleAction::dump(StoreEntry *) STUB();
 //protected:
-//Mgr::OfflineToggleAction::OfflineToggleAction(const CommandPointer &) STUB
+//Mgr::OfflineToggleAction::OfflineToggleAction(const CommandPointer &) STUB();
 
-void Mgr::RegisterBasics() STUB
+void Mgr::RegisterBasics() STUB();
 
 #include "mgr/CountersAction.h"
-//Mgr::CountersActionData::CountersActionData() STUB
-Mgr::CountersActionData& Mgr::CountersActionData::operator +=(const Mgr::CountersActionData&) STUB_RETVAL(*this)
+//Mgr::CountersActionData::CountersActionData() STUB();
+Mgr::CountersActionData& Mgr::CountersActionData::operator +=(const Mgr::CountersActionData&) STUB_RETVAL(*this);
 
-Mgr::Action::Pointer Mgr::CountersAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::CountersAction::add(const Action &) STUB
-void Mgr::CountersAction::pack(Ipc::TypedMsgHdr &) const STUB
-void Mgr::CountersAction::unpack(const Ipc::TypedMsgHdr &) STUB
+Mgr::Action::Pointer Mgr::CountersAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::CountersAction::add(const Action &) STUB();
+void Mgr::CountersAction::pack(Ipc::TypedMsgHdr &) const STUB();
+void Mgr::CountersAction::unpack(const Ipc::TypedMsgHdr &) STUB();
 //protected:
-//Mgr::CountersAction::CountersAction(const CommandPointer &) STUB
-void Mgr::CountersAction::collect() STUB
-void Mgr::CountersAction::dump(StoreEntry *) STUB
+//Mgr::CountersAction::CountersAction(const CommandPointer &) STUB();
+void Mgr::CountersAction::collect() STUB();
+void Mgr::CountersAction::dump(StoreEntry *) STUB();
 
 #include "mgr/Filler.h"
-//Mgr::Filler::Filler(const Action::Pointer &, int, unsigned int) STUB
+//Mgr::Filler::Filler(const Action::Pointer &, int, unsigned int) STUB();
 //protected:
-//void Mgr::Filler::start() STUB
-//void Mgr::Filler::swanSong() STUB
+//void Mgr::Filler::start() STUB();
+//void Mgr::Filler::swanSong() STUB();
 
 #include "mgr/Forwarder.h"
-//Mgr::Forwarder::Forwarder(int, const ActionParams &, HttpRequest *, StoreEntry *) STUB
-//Mgr::Forwarder::~Forwarder() STUB
+//Mgr::Forwarder::Forwarder(int, const ActionParams &, HttpRequest *, StoreEntry *) STUB();
+//Mgr::Forwarder::~Forwarder() STUB();
 //protected:
-//void Mgr::Forwarder::swanSong() STUB
-void Mgr::Forwarder::handleError() STUB
-void Mgr::Forwarder::handleTimeout() STUB
-void Mgr::Forwarder::handleException(const std::exception &) STUB
+//void Mgr::Forwarder::swanSong() STUB();
+void Mgr::Forwarder::handleError() STUB();
+void Mgr::Forwarder::handleTimeout() STUB();
+void Mgr::Forwarder::handleException(const std::exception &) STUB();
 
 #include "mgr/FunAction.h"
-Mgr::Action::Pointer Mgr::FunAction::Create(const CommandPointer &, OBJH *) STUB_RETVAL(dummyAction)
-void Mgr::FunAction::respond(const Request &) STUB
+Mgr::Action::Pointer Mgr::FunAction::Create(const CommandPointer &, OBJH *) STUB_RETVAL(dummyAction);
+void Mgr::FunAction::respond(const Request &) STUB();
 //protected:
-//Mgr::FunAction::FunAction(const CommandPointer &, OBJH *) STUB
-void Mgr::FunAction::dump(StoreEntry *) STUB
+//Mgr::FunAction::FunAction(const CommandPointer &, OBJH *) STUB();
+void Mgr::FunAction::dump(StoreEntry *) STUB();
 
 #include "mgr/InfoAction.h"
-//Mgr::InfoActionData::InfoActionData() STUB
-Mgr::InfoActionData& Mgr::InfoActionData::operator += (const Mgr::InfoActionData &) STUB_RETVAL(*this)
+//Mgr::InfoActionData::InfoActionData() STUB();
+Mgr::InfoActionData& Mgr::InfoActionData::operator += (const Mgr::InfoActionData &) STUB_RETVAL(*this);
 
-Mgr::Action::Pointer Mgr::InfoAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::InfoAction::add(const Action &) STUB
-void Mgr::InfoAction::respond(const Request &) STUB
-void Mgr::InfoAction::pack(Ipc::TypedMsgHdr &) const STUB
-void Mgr::InfoAction::unpack(const Ipc::TypedMsgHdr &) STUB
+Mgr::Action::Pointer Mgr::InfoAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::InfoAction::add(const Action &) STUB();
+void Mgr::InfoAction::respond(const Request &) STUB();
+void Mgr::InfoAction::pack(Ipc::TypedMsgHdr &) const STUB();
+void Mgr::InfoAction::unpack(const Ipc::TypedMsgHdr &) STUB();
 //protected:
-//Mgr::InfoAction::InfoAction(const Mgr::CommandPointer &) STUB
-void Mgr::InfoAction::collect() STUB
-void Mgr::InfoAction::dump(StoreEntry *) STUB
+//Mgr::InfoAction::InfoAction(const Mgr::CommandPointer &) STUB();
+void Mgr::InfoAction::collect() STUB();
+void Mgr::InfoAction::dump(StoreEntry *) STUB();
 
 #include "mgr/Inquirer.h"
-//Mgr::Inquirer::Inquirer(Action::Pointer, const Request &, const Ipc::StrandCoords &) STUB
+//Mgr::Inquirer::Inquirer(Action::Pointer, const Request &, const Ipc::StrandCoords &) STUB();
 //protected:
-void Mgr::Inquirer::start() STUB
-bool Mgr::Inquirer::doneAll() const STUB_RETVAL(false)
-void Mgr::Inquirer::cleanup() STUB
-void Mgr::Inquirer::sendResponse() STUB
-bool Mgr::Inquirer::aggregate(Ipc::Response::Pointer) STUB_RETVAL(false)
+void Mgr::Inquirer::start() STUB();
+bool Mgr::Inquirer::doneAll() const STUB_RETVAL(false);
+void Mgr::Inquirer::cleanup() STUB();
+void Mgr::Inquirer::sendResponse() STUB();
+bool Mgr::Inquirer::aggregate(Ipc::Response::Pointer) STUB_RETVAL(false);
 
 #include "mgr/IntervalAction.h"
-//Mgr::IntervalActionData::IntervalActionData() STUB
-Mgr::IntervalActionData& Mgr::IntervalActionData::operator +=(const Mgr::IntervalActionData &) STUB_RETVAL(*this)
+//Mgr::IntervalActionData::IntervalActionData() STUB();
+Mgr::IntervalActionData& Mgr::IntervalActionData::operator +=(const Mgr::IntervalActionData &) STUB_RETVAL(*this);
 
-//Mgr::Action::Pointer Mgr::IntervalAction::Create5min(const CommandPointer &cmd) STUB_RETVAL(new Mgr::IntervalAction(*cmd))
-//Mgr::Action::Pointer Mgr::IntervalAction::Create60min(const CommandPointer &cmd) STUB_RETVAL(new Mgr::IntervalAction(*cmd))
-void Mgr::IntervalAction::add(const Action&) STUB
-void Mgr::IntervalAction::pack(Ipc::TypedMsgHdr&) const STUB
-void Mgr::IntervalAction::unpack(const Ipc::TypedMsgHdr&) STUB
+//Mgr::Action::Pointer Mgr::IntervalAction::Create5min(const CommandPointer &cmd) STUB_RETVAL(new Mgr::IntervalAction(*cmd));
+//Mgr::Action::Pointer Mgr::IntervalAction::Create60min(const CommandPointer &cmd) STUB_RETVAL(new Mgr::IntervalAction(*cmd));
+void Mgr::IntervalAction::add(const Action&) STUB();
+void Mgr::IntervalAction::pack(Ipc::TypedMsgHdr&) const STUB();
+void Mgr::IntervalAction::unpack(const Ipc::TypedMsgHdr&) STUB();
 //protected:
-//Mgr::IntervalAction::IntervalAction(const CommandPointer &, int, int) STUB
-void Mgr::IntervalAction::collect() STUB
-void Mgr::IntervalAction::dump(StoreEntry*) STUB
+//Mgr::IntervalAction::IntervalAction(const CommandPointer &, int, int) STUB();
+void Mgr::IntervalAction::collect() STUB();
+void Mgr::IntervalAction::dump(StoreEntry*) STUB();
 
 #include "mgr/IntParam.h"
-//Mgr::IntParam::IntParam() STUB
-//Mgr::IntParam::IntParam(const std::vector<int>&) STUB
-void Mgr::IntParam::pack(Ipc::TypedMsgHdr&) const STUB
-void Mgr::IntParam::unpackValue(const Ipc::TypedMsgHdr&) STUB
+//Mgr::IntParam::IntParam() STUB();
+//Mgr::IntParam::IntParam(const std::vector<int>&) STUB();
+void Mgr::IntParam::pack(Ipc::TypedMsgHdr&) const STUB();
+void Mgr::IntParam::unpackValue(const Ipc::TypedMsgHdr&) STUB();
 static std::vector<int> static_vector;
-const std::vector<int>& Mgr::IntParam::value() const STUB_RETVAL(static_vector)
+const std::vector<int>& Mgr::IntParam::value() const STUB_RETVAL(static_vector);
 
 #include "mgr/IoAction.h"
-//Mgr::IoActionData::IoActionData() STUB
-Mgr::IoActionData& Mgr::IoActionData::operator += (const IoActionData&) STUB_RETVAL(*this)
+//Mgr::IoActionData::IoActionData() STUB();
+Mgr::IoActionData& Mgr::IoActionData::operator += (const IoActionData&) STUB_RETVAL(*this);
 
-Mgr::Action::Pointer Mgr::IoAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction)
-void Mgr::IoAction::add(const Action&) STUB
-void Mgr::IoAction::pack(Ipc::TypedMsgHdr&) const STUB
-void Mgr::IoAction::unpack(const Ipc::TypedMsgHdr&) STUB
+Mgr::Action::Pointer Mgr::IoAction::Create(const CommandPointer &) STUB_RETVAL(dummyAction);
+void Mgr::IoAction::add(const Action&) STUB();
+void Mgr::IoAction::pack(Ipc::TypedMsgHdr&) const STUB();
+void Mgr::IoAction::unpack(const Ipc::TypedMsgHdr&) STUB();
 //protected:
-//Mgr::IoAction::IoAction(const CommandPointer &) STUB
-void Mgr::IoAction::collect() STUB
-void Mgr::IoAction::dump(StoreEntry*) STUB
+//Mgr::IoAction::IoAction(const CommandPointer &) STUB();
+void Mgr::IoAction::collect() STUB();
+void Mgr::IoAction::dump(StoreEntry*) STUB();
 
 //#include "mgr/QueryParam.h"
 //void Mgr::QueryParam::pack(Ipc::TypedMsgHdr&) const = 0;
 //void Mgr::QueryParam::unpackValue(const Ipc::TypedMsgHdr&) = 0;
 
 #include "mgr/QueryParams.h"
-Mgr::QueryParam::Pointer Mgr::QueryParams::get(const String&) const STUB_RETVAL(Mgr::QueryParam::Pointer(nullptr))
-void Mgr::QueryParams::pack(Ipc::TypedMsgHdr&) const STUB
-void Mgr::QueryParams::unpack(const Ipc::TypedMsgHdr&) STUB
-void Mgr::QueryParams::Parse(Parser::Tokenizer &, QueryParams &) STUB
+Mgr::QueryParam::Pointer Mgr::QueryParams::get(const String&) const STUB_RETVAL(Mgr::QueryParam::Pointer(nullptr));
+void Mgr::QueryParams::pack(Ipc::TypedMsgHdr&) const STUB();
+void Mgr::QueryParams::unpack(const Ipc::TypedMsgHdr&) STUB();
+void Mgr::QueryParams::Parse(Parser::Tokenizer &, QueryParams &) STUB();
 //private:
-//Params::const_iterator Mgr::QueryParams::find(const String&) const STUB_RETVAL(new Mgr::Params::const_iterator(*this))
-Mgr::QueryParam::Pointer Mgr::QueryParams::CreateParam(QueryParam::Type) STUB_RETVAL(Mgr::QueryParam::Pointer(nullptr))
+//Params::const_iterator Mgr::QueryParams::find(const String&) const STUB_RETVAL(new Mgr::Params::const_iterator(*this));
+Mgr::QueryParam::Pointer Mgr::QueryParams::CreateParam(QueryParam::Type) STUB_RETVAL(Mgr::QueryParam::Pointer(nullptr));
 
 #include "mgr/Registration.h"
 //void Mgr::RegisterAction(char const *, char const *, OBJH *, Protected, Atomic, Format);
 //void Mgr::RegisterAction(char const *, char const *, ClassActionCreationHandler *, Protected, Atomic, Format);
 
 #include "mgr/Request.h"
-//Mgr::Request::Request(int, unsigned int, int, const Mgr::ActionParams &) STUB
-//Mgr::Request::Request(const Ipc::TypedMsgHdr&) STUB
-void Mgr::Request::pack(Ipc::TypedMsgHdr&) const STUB
-Ipc::Request::Pointer Mgr::Request::clone() const STUB_RETVAL(const_cast<Mgr::Request*>(this))
+//Mgr::Request::Request(int, unsigned int, int, const Mgr::ActionParams &) STUB();
+//Mgr::Request::Request(const Ipc::TypedMsgHdr&) STUB();
+void Mgr::Request::pack(Ipc::TypedMsgHdr&) const STUB();
+Ipc::Request::Pointer Mgr::Request::clone() const STUB_RETVAL(const_cast<Mgr::Request*>(this));
 
 #include "mgr/Response.h"
-//Mgr::Response::Response(unsigned int, Action::Pointer) STUB
-//Mgr::Response::Response(const Ipc::TypedMsgHdr&) STUB
-void Mgr::Response::pack(Ipc::TypedMsgHdr&) const STUB
+//Mgr::Response::Response(unsigned int, Action::Pointer) STUB();
+//Mgr::Response::Response(const Ipc::TypedMsgHdr&) STUB();
+void Mgr::Response::pack(Ipc::TypedMsgHdr&) const STUB();
 static Ipc::Response::Pointer ipr_static;
-Ipc::Response::Pointer Mgr::Response::clone() const STUB_RETVAL(Ipc::Response::Pointer(nullptr))
-bool Mgr::Response::hasAction() const STUB_RETVAL(false)
+Ipc::Response::Pointer Mgr::Response::clone() const STUB_RETVAL(Ipc::Response::Pointer(nullptr));
+bool Mgr::Response::hasAction() const STUB_RETVAL(false);
 //static Mgr::Action mgraction_static;
-//const Mgr::Action& Mgr::Response::getAction() const STUB_RETVAL(mgraction_static)
+//const Mgr::Action& Mgr::Response::getAction() const STUB_RETVAL(mgraction_static);
 
 #include "mgr/ServiceTimesAction.h"
-//Mgr::ServiceTimesActionData::ServiceTimesActionData() STUB
-Mgr::ServiceTimesActionData& Mgr::ServiceTimesActionData::operator +=(const Mgr::ServiceTimesActionData&) STUB_RETVAL(*this)
+//Mgr::ServiceTimesActionData::ServiceTimesActionData() STUB();
+Mgr::ServiceTimesActionData& Mgr::ServiceTimesActionData::operator +=(const Mgr::ServiceTimesActionData&) STUB_RETVAL(*this);
 
-Mgr::Action::Pointer Mgr::ServiceTimesAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(Mgr::Action::Pointer(nullptr))
-void Mgr::ServiceTimesAction::add(const Action&) STUB
-void Mgr::ServiceTimesAction::pack(Ipc::TypedMsgHdr&) const STUB
-void Mgr::ServiceTimesAction::unpack(const Ipc::TypedMsgHdr&) STUB
+Mgr::Action::Pointer Mgr::ServiceTimesAction::Create(const Mgr::CommandPointer &) STUB_RETVAL(Mgr::Action::Pointer(nullptr));
+void Mgr::ServiceTimesAction::add(const Action&) STUB();
+void Mgr::ServiceTimesAction::pack(Ipc::TypedMsgHdr&) const STUB();
+void Mgr::ServiceTimesAction::unpack(const Ipc::TypedMsgHdr&) STUB();
 //protected:
-//Mgr::ServiceTimesAction::ServiceTimesAction(const CommandPointer &) STUB
-void Mgr::ServiceTimesAction::collect() STUB
-void Mgr::ServiceTimesAction::dump(StoreEntry*) STUB
+//Mgr::ServiceTimesAction::ServiceTimesAction(const CommandPointer &) STUB();
+void Mgr::ServiceTimesAction::collect() STUB();
+void Mgr::ServiceTimesAction::dump(StoreEntry*) STUB();
 
 #include "mgr/StoreIoAction.h"
-//Mgr::StoreIoActionData::StoreIoActionData() STUB
-Mgr::StoreIoActionData & Mgr::StoreIoActionData::operator +=(const StoreIoActionData&) STUB_RETVAL(*this)
-//Mgr::StoreIoAction::StoreIoAction(const CommandPointer &) STUB
-Mgr::Action::Pointer Mgr::StoreIoAction::Create(const CommandPointer &) STUB_RETVAL(Mgr::Action::Pointer(nullptr))
-void Mgr::StoreIoAction::add(const Action&) STUB
-void Mgr::StoreIoAction::pack(Ipc::TypedMsgHdr&) const STUB
-void Mgr::StoreIoAction::unpack(const Ipc::TypedMsgHdr&) STUB
-void Mgr::StoreIoAction::collect() STUB
-void Mgr::StoreIoAction::dump(StoreEntry*) STUB
+//Mgr::StoreIoActionData::StoreIoActionData() STUB();
+Mgr::StoreIoActionData & Mgr::StoreIoActionData::operator +=(const StoreIoActionData&) STUB_RETVAL(*this);
+//Mgr::StoreIoAction::StoreIoAction(const CommandPointer &) STUB();
+Mgr::Action::Pointer Mgr::StoreIoAction::Create(const CommandPointer &) STUB_RETVAL(Mgr::Action::Pointer(nullptr));
+void Mgr::StoreIoAction::add(const Action&) STUB();
+void Mgr::StoreIoAction::pack(Ipc::TypedMsgHdr&) const STUB();
+void Mgr::StoreIoAction::unpack(const Ipc::TypedMsgHdr&) STUB();
+void Mgr::StoreIoAction::collect() STUB();
+void Mgr::StoreIoAction::dump(StoreEntry*) STUB();
 
 #include "mgr/StoreToCommWriter.h"
-//Mgr::StoreToCommWriter::StoreToCommWriter(int, StoreEntry *) STUB
-Mgr::StoreToCommWriter::~StoreToCommWriter() STUB
-void Mgr::StoreToCommWriter::start() STUB
-void Mgr::StoreToCommWriter::swanSong() STUB
-bool Mgr::StoreToCommWriter::doneAll() const STUB_RETVAL(false)
-void Mgr::StoreToCommWriter::scheduleStoreCopy() STUB
-void Mgr::StoreToCommWriter::noteStoreCopied(StoreIOBuffer) STUB
-void Mgr::StoreToCommWriter::NoteStoreCopied(void*, StoreIOBuffer) STUB
-void Mgr::StoreToCommWriter::HandleStoreAbort(StoreToCommWriter *) STUB
-void Mgr::StoreToCommWriter::scheduleCommWrite(const StoreIOBuffer&) STUB
-void Mgr::StoreToCommWriter::noteCommWrote(const CommIoCbParams&) STUB
-void Mgr::StoreToCommWriter::noteCommClosed(const CommCloseCbParams&) STUB
-void Mgr::StoreToCommWriter::close() STUB
+//Mgr::StoreToCommWriter::StoreToCommWriter(int, StoreEntry *) STUB();
+Mgr::StoreToCommWriter::~StoreToCommWriter() STUB();
+void Mgr::StoreToCommWriter::start() STUB();
+void Mgr::StoreToCommWriter::swanSong() STUB();
+bool Mgr::StoreToCommWriter::doneAll() const STUB_RETVAL(false);
+void Mgr::StoreToCommWriter::scheduleStoreCopy() STUB();
+void Mgr::StoreToCommWriter::noteStoreCopied(StoreIOBuffer) STUB();
+void Mgr::StoreToCommWriter::NoteStoreCopied(void*, StoreIOBuffer) STUB();
+void Mgr::StoreToCommWriter::HandleStoreAbort(StoreToCommWriter *) STUB();
+void Mgr::StoreToCommWriter::scheduleCommWrite(const StoreIOBuffer&) STUB();
+void Mgr::StoreToCommWriter::noteCommWrote(const CommIoCbParams&) STUB();
+void Mgr::StoreToCommWriter::noteCommClosed(const CommCloseCbParams&) STUB();
+void Mgr::StoreToCommWriter::close() STUB();
 
 #include "mgr/StringParam.h"
-//Mgr::StringParam::StringParam() STUB
-//Mgr::StringParam::StringParam(const String&) STUB
-void Mgr::StringParam::pack(Ipc::TypedMsgHdr&) const STUB
-void Mgr::StringParam::unpackValue(const Ipc::TypedMsgHdr&) STUB
+//Mgr::StringParam::StringParam() STUB();
+//Mgr::StringParam::StringParam(const String&) STUB();
+void Mgr::StringParam::pack(Ipc::TypedMsgHdr&) const STUB();
+void Mgr::StringParam::unpackValue(const Ipc::TypedMsgHdr&) STUB();
 static String t;
-const String& Mgr::StringParam::value() const STUB_RETVAL(t)
+const String& Mgr::StringParam::value() const STUB_RETVAL(t);
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -26,60 +26,60 @@ BlindPeerConnector::BlindPeerConnector(HttpRequestPointer &, const Comm::Connect
     Security::PeerConnector(aServerConn, aCallback, alp, 0)
 {STUB_NOP}
 
-bool BlindPeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
-FuturePeerContext *BlindPeerConnector::peerContext() const STUB_RETVAL(nullptr)
-void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB
+bool BlindPeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false);
+FuturePeerContext *BlindPeerConnector::peerContext() const STUB_RETVAL(nullptr);
+void BlindPeerConnector::noteNegotiationDone(ErrorState *) STUB();
 }
 
 #include "security/EncryptorAnswer.h"
 Security::EncryptorAnswer::~EncryptorAnswer() {}
-std::ostream &Security::operator <<(std::ostream &os, const Security::EncryptorAnswer &) STUB_RETVAL(os)
+std::ostream &Security::operator <<(std::ostream &os, const Security::EncryptorAnswer &) STUB_RETVAL(os);
 
 #include "security/Certificate.h"
-SBuf Security::SubjectName(Certificate &) STUB_RETVAL(SBuf())
-SBuf Security::IssuerName(Certificate &) STUB_RETVAL(SBuf())
-bool Security::IssuedBy(Certificate &, Certificate &) STUB_RETVAL(false)
-std::ostream &operator <<(std::ostream &os, Security::Certificate &) STUB_RETVAL(os)
+SBuf Security::SubjectName(Certificate &) STUB_RETVAL(SBuf());
+SBuf Security::IssuerName(Certificate &) STUB_RETVAL(SBuf());
+bool Security::IssuedBy(Certificate &, Certificate &) STUB_RETVAL(false);
+std::ostream &operator <<(std::ostream &os, Security::Certificate &) STUB_RETVAL(os);
 
 #include "security/Handshake.h"
-Security::HandshakeParser::HandshakeParser(MessageSource) STUB
-bool Security::HandshakeParser::parseHello(const SBuf &) STUB_RETVAL(false)
+Security::HandshakeParser::HandshakeParser(MessageSource) STUB();
+bool Security::HandshakeParser::parseHello(const SBuf &) STUB_RETVAL(false);
 
 #include "security/Io.h"
-Security::IoResult Security::Accept(Comm::Connection &) STUB_RETVAL(IoResult(IoResult::ioError))
-Security::IoResult Security::Connect(Comm::Connection &) STUB_RETVAL(IoResult(IoResult::ioError))
-void Security::IoResult::printGist(std::ostream &) const STUB
-void Security::IoResult::printWithExtras(std::ostream &) const STUB
-void Security::ForgetErrors() STUB
+Security::IoResult Security::Accept(Comm::Connection &) STUB_RETVAL(IoResult(IoResult::ioError));
+Security::IoResult Security::Connect(Comm::Connection &) STUB_RETVAL(IoResult(IoResult::ioError));
+void Security::IoResult::printGist(std::ostream &) const STUB();
+void Security::IoResult::printWithExtras(std::ostream &) const STUB();
+void Security::ForgetErrors() STUB();
 
 #include "security/KeyData.h"
 namespace Security
 {
-void KeyData::loadFromFiles(const AnyP::PortCfg &, const char *) STUB
+void KeyData::loadFromFiles(const AnyP::PortCfg &, const char *) STUB();
 }
 
 #include "security/KeyLogger.h"
-void Security::KeyLogger::maybeLog(const Connection &, const Acl::ChecklistFiller &) STUB
+void Security::KeyLogger::maybeLog(const Connection &, const Acl::ChecklistFiller &) STUB();
 
 #include "security/ErrorDetail.h"
-Security::ErrorDetail::ErrorDetail(ErrorCode, const CertPointer &, const CertPointer &, const char *) STUB
+Security::ErrorDetail::ErrorDetail(ErrorCode, const CertPointer &, const CertPointer &, const char *) STUB();
 #if USE_OPENSSL
-Security::ErrorDetail::ErrorDetail(ErrorCode, int, int) STUB
+Security::ErrorDetail::ErrorDetail(ErrorCode, int, int) STUB();
 #elif HAVE_LIBGNUTLS
-Security::ErrorDetail::ErrorDetail(ErrorCode, LibErrorCode, int) STUB
+Security::ErrorDetail::ErrorDetail(ErrorCode, LibErrorCode, int) STUB();
 #endif
-void Security::ErrorDetail::setPeerCertificate(const CertPointer &) STUB
-SBuf Security::ErrorDetail::verbose(const HttpRequestPointer &) const STUB_RETVAL(SBuf())
-SBuf Security::ErrorDetail::brief() const STUB_RETVAL(SBuf())
-Security::ErrorCode Security::ErrorCodeFromName(const char *) STUB_RETVAL(0)
-const char *Security::ErrorNameFromCode(ErrorCode, bool) STUB_RETVAL("")
+void Security::ErrorDetail::setPeerCertificate(const CertPointer &) STUB();
+SBuf Security::ErrorDetail::verbose(const HttpRequestPointer &) const STUB_RETVAL(SBuf());
+SBuf Security::ErrorDetail::brief() const STUB_RETVAL(SBuf());
+Security::ErrorCode Security::ErrorCodeFromName(const char *) STUB_RETVAL(0);
+const char *Security::ErrorNameFromCode(ErrorCode, bool) STUB_RETVAL("");
 
 #include "security/NegotiationHistory.h"
-Security::NegotiationHistory::NegotiationHistory() STUB
-void Security::NegotiationHistory::retrieveNegotiatedInfo(const Security::SessionPointer &) STUB
-void Security::NegotiationHistory::retrieveParsedInfo(Security::TlsDetails::Pointer const &) STUB
-const char *Security::NegotiationHistory::cipherName() const STUB
-const char *Security::NegotiationHistory::printTlsVersion(AnyP::ProtocolVersion const &) const STUB
+Security::NegotiationHistory::NegotiationHistory() STUB();
+void Security::NegotiationHistory::retrieveNegotiatedInfo(const Security::SessionPointer &) STUB();
+void Security::NegotiationHistory::retrieveParsedInfo(Security::TlsDetails::Pointer const &) STUB();
+const char *Security::NegotiationHistory::cipherName() const STUB();
+const char *Security::NegotiationHistory::printTlsVersion(AnyP::ProtocolVersion const &) const STUB();
 
 #include "security/PeerConnector.h"
 class TlsNegotiationDetails: public RefCountable {};
@@ -87,27 +87,27 @@ namespace Security
 {
 PeerConnector::PeerConnector(const Comm::ConnectionPointer &, const AsyncCallback<EncryptorAnswer> &, const AccessLogEntryPointer &, const time_t):
     AsyncJob("Security::PeerConnector") {STUB}
-PeerConnector::~PeerConnector() STUB
-void PeerConnector::start() STUB
-bool PeerConnector::doneAll() const STUB_RETVAL(true)
-void PeerConnector::swanSong() STUB
-const char *PeerConnector::status() const STUB_RETVAL("")
-void PeerConnector::fillChecklist(ACLFilledChecklist &) const STUB
-void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB
-void PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &) STUB
-bool PeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false)
-void PeerConnector::negotiate() STUB
-bool PeerConnector::sslFinalized() STUB_RETVAL(false)
+PeerConnector::~PeerConnector() STUB();
+void PeerConnector::start() STUB();
+bool PeerConnector::doneAll() const STUB_RETVAL(true);
+void PeerConnector::swanSong() STUB();
+const char *PeerConnector::status() const STUB_RETVAL("");
+void PeerConnector::fillChecklist(ACLFilledChecklist &) const STUB();
+void PeerConnector::commCloseHandler(const CommCloseCbParams &) STUB();
+void PeerConnector::commTimeoutHandler(const CommTimeoutCbParams &) STUB();
+bool PeerConnector::initialize(Security::SessionPointer &) STUB_RETVAL(false);
+void PeerConnector::negotiate() STUB();
+bool PeerConnector::sslFinalized() STUB_RETVAL(false);
 void PeerConnector::handleNegotiationResult(const Security::IoResult &) STUB;
-void PeerConnector::noteWantRead() STUB
-void PeerConnector::noteWantWrite() STUB
-void PeerConnector::noteNegotiationError(const Security::ErrorDetailPointer &) STUB
-void PeerConnector::bail(ErrorState *) STUB
-void PeerConnector::sendSuccess() STUB
-void PeerConnector::callBack() STUB
-void PeerConnector::disconnect() STUB
-void PeerConnector::countFailingConnection() STUB
-void PeerConnector::recordNegotiationDetails() STUB
+void PeerConnector::noteWantRead() STUB();
+void PeerConnector::noteWantWrite() STUB();
+void PeerConnector::noteNegotiationError(const Security::ErrorDetailPointer &) STUB();
+void PeerConnector::bail(ErrorState *) STUB();
+void PeerConnector::sendSuccess() STUB();
+void PeerConnector::callBack() STUB();
+void PeerConnector::disconnect() STUB();
+void PeerConnector::countFailingConnection() STUB();
+void PeerConnector::recordNegotiationDetails() STUB();
 EncryptorAnswer &PeerConnector::answer() STUB_RETREF(EncryptorAnswer)
 }
 
@@ -120,44 +120,44 @@ Security::PeerOptions::PeerOptions() {
 #endif
     STUB_NOP
 }
-void Security::PeerOptions::parse(char const*) STUB
-Security::ContextPointer Security::PeerOptions::createClientContext(bool) STUB_RETVAL(Security::ContextPointer())
-void Security::PeerOptions::updateTlsVersionLimits() STUB
-Security::ContextPointer Security::PeerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer())
-void Security::PeerOptions::updateContextCa(Security::ContextPointer &) STUB
-void Security::PeerOptions::updateContextCrl(Security::ContextPointer &) STUB
-void Security::PeerOptions::updateContextTrust(Security::ContextPointer &) STUB
-void Security::PeerOptions::updateSessionOptions(Security::SessionPointer &) STUB
-void Security::PeerOptions::dumpCfg(std::ostream &, char const*) const STUB
-void Security::PeerOptions::parseOptions() STUB
-void parse_securePeerOptions(Security::PeerOptions *) STUB
+void Security::PeerOptions::parse(char const*) STUB();
+Security::ContextPointer Security::PeerOptions::createClientContext(bool) STUB_RETVAL(Security::ContextPointer());
+void Security::PeerOptions::updateTlsVersionLimits() STUB();
+Security::ContextPointer Security::PeerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer());
+void Security::PeerOptions::updateContextCa(Security::ContextPointer &) STUB();
+void Security::PeerOptions::updateContextCrl(Security::ContextPointer &) STUB();
+void Security::PeerOptions::updateContextTrust(Security::ContextPointer &) STUB();
+void Security::PeerOptions::updateSessionOptions(Security::SessionPointer &) STUB();
+void Security::PeerOptions::dumpCfg(std::ostream &, char const*) const STUB();
+void Security::PeerOptions::parseOptions() STUB();
+void parse_securePeerOptions(Security::PeerOptions *) STUB();
 
 #include "security/ServerOptions.h"
-//Security::ServerOptions::ServerOptions(const Security::ServerOptions &) STUB
+//Security::ServerOptions::ServerOptions(const Security::ServerOptions &) STUB();
 Security::ServerOptions &Security::ServerOptions::operator=(Security::ServerOptions const&) STUB_RETVAL(*this);
-void Security::ServerOptions::parse(const char *) STUB
-void Security::ServerOptions::dumpCfg(std::ostream &, const char *) const STUB
-Security::ContextPointer Security::ServerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer())
-void Security::ServerOptions::initServerContexts(AnyP::PortCfg&) STUB
-bool Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &) STUB_RETVAL(false)
-void Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &) STUB
-bool Security::ServerOptions::updateContextConfig(Security::ContextPointer &) STUB_RETVAL(false)
-void Security::ServerOptions::updateContextEecdh(Security::ContextPointer &) STUB
-void Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB
-void Security::ServerOptions::syncCaFiles() STUB
-void Security::ServerOptions::updateContextSessionId(Security::ContextPointer &) STUB
+void Security::ServerOptions::parse(const char *) STUB();
+void Security::ServerOptions::dumpCfg(std::ostream &, const char *) const STUB();
+Security::ContextPointer Security::ServerOptions::createBlankContext() const STUB_RETVAL(Security::ContextPointer());
+void Security::ServerOptions::initServerContexts(AnyP::PortCfg&) STUB();
+bool Security::ServerOptions::createStaticServerContext(AnyP::PortCfg &) STUB_RETVAL(false);
+void Security::ServerOptions::createSigningContexts(const AnyP::PortCfg &) STUB();
+bool Security::ServerOptions::updateContextConfig(Security::ContextPointer &) STUB_RETVAL(false);
+void Security::ServerOptions::updateContextEecdh(Security::ContextPointer &) STUB();
+void Security::ServerOptions::updateContextClientCa(Security::ContextPointer &) STUB();
+void Security::ServerOptions::syncCaFiles() STUB();
+void Security::ServerOptions::updateContextSessionId(Security::ContextPointer &) STUB();
 
 #include "security/Session.h"
 namespace Security {
-bool CreateClientSession(FuturePeerContext &, const Comm::ConnectionPointer &, const char *) STUB_RETVAL(false)
-bool CreateServerSession(const Security::ContextPointer &, const Comm::ConnectionPointer &, Security::PeerOptions &, const char *) STUB_RETVAL(false)
-void SessionSendGoodbye(const Security::SessionPointer &) STUB
-bool SessionIsResumed(const Security::SessionPointer &) STUB_RETVAL(false)
-void MaybeGetSessionResumeData(const Security::SessionPointer &, Security::SessionStatePointer &) STUB
-void SetSessionResumeData(const Security::SessionPointer &, const Security::SessionStatePointer &) STUB
+bool CreateClientSession(FuturePeerContext &, const Comm::ConnectionPointer &, const char *) STUB_RETVAL(false);
+bool CreateServerSession(const Security::ContextPointer &, const Comm::ConnectionPointer &, Security::PeerOptions &, const char *) STUB_RETVAL(false);
+void SessionSendGoodbye(const Security::SessionPointer &) STUB();
+bool SessionIsResumed(const Security::SessionPointer &) STUB_RETVAL(false);
+void MaybeGetSessionResumeData(const Security::SessionPointer &, Security::SessionStatePointer &) STUB();
+void SetSessionResumeData(const Security::SessionPointer &, const Security::SessionStatePointer &) STUB();
 #if USE_OPENSSL
-void SetSessionCacheCallbacks(Security::ContextPointer &) STUB
-Security::SessionPointer NewSessionObject(const Security::ContextPointer &) STUB_RETVAL(nullptr)
+void SetSessionCacheCallbacks(Security::ContextPointer &) STUB();
+Security::SessionPointer NewSessionObject(const Security::ContextPointer &) STUB_RETVAL(nullptr);
 #endif
 } // namespace Security
 

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -33,47 +33,47 @@ Ssl::Config::~Config() STUB_NOP
 Ssl::Config Ssl::TheConfig;
 
 #include "ssl/context_storage.h"
-//Ssl::CertificateStorageAction::CertificateStorageAction(const Mgr::Command::Pointer &) STUB
+//Ssl::CertificateStorageAction::CertificateStorageAction(const Mgr::Command::Pointer &) STUB();
 Ssl::CertificateStorageAction::Pointer Ssl::CertificateStorageAction::Create(const Mgr::Command::Pointer &) STUB_RETSTATREF(Ssl::CertificateStorageAction::Pointer)
-void Ssl::CertificateStorageAction::dump(StoreEntry *) STUB
-void Ssl::GlobalContextStorage::addLocalStorage(Ip::Address const &, size_t ) STUB
+void Ssl::CertificateStorageAction::dump(StoreEntry *) STUB();
+void Ssl::GlobalContextStorage::addLocalStorage(Ip::Address const &, size_t ) STUB();
 Ssl::LocalContextStorage *Ssl::GlobalContextStorage::getLocalStorage(Ip::Address const &)
 { fatal(STUB_API " required"); static LocalContextStorage v(0); return &v; }
-void Ssl::GlobalContextStorage::reconfigureStart() STUB
+void Ssl::GlobalContextStorage::reconfigureStart() STUB();
 //Ssl::GlobalContextStorage Ssl::TheGlobalContextStorage;
 
 #include "ssl/ErrorDetail.h"
 #include "ssl/support.h"
 namespace Ssl
 {
-bool ParseErrorString(const char *, Security::Errors &) STUB_RETVAL(false)
-int AskPasswordCb(char *, int, int, void *) STUB_RETVAL(0)
-bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &) STUB_RETVAL(false)
-bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, Security::ParsedPortFlags) STUB_RETVAL(false)
-void ConfigurePeerVerification(Security::ContextPointer &, const Security::ParsedPortFlags) STUB
-void DisablePeerVerification(Security::ContextPointer &) STUB
-void MaybeSetupRsaCallback(Security::ContextPointer &) STUB
+bool ParseErrorString(const char *, Security::Errors &) STUB_RETVAL(false);
+int AskPasswordCb(char *, int, int, void *) STUB_RETVAL(0);
+bool InitServerContext(Security::ContextPointer &, AnyP::PortCfg &) STUB_RETVAL(false);
+bool InitClientContext(Security::ContextPointer &, Security::PeerOptions &, Security::ParsedPortFlags) STUB_RETVAL(false);
+void ConfigurePeerVerification(Security::ContextPointer &, const Security::ParsedPortFlags) STUB();
+void DisablePeerVerification(Security::ContextPointer &) STUB();
+void MaybeSetupRsaCallback(Security::ContextPointer &) STUB();
 } // namespace Ssl
-const char *sslGetUserEmail(SSL *) STUB_RETVAL(nullptr)
-const char *sslGetUserAttribute(SSL *, const char *) STUB_RETVAL(nullptr)
-const char *sslGetCAAttribute(SSL *, const char *) STUB_RETVAL(nullptr)
-SBuf sslGetUserCertificatePEM(SSL *) STUB_RETVAL(SBuf())
-SBuf sslGetUserCertificateChainPEM(SSL *) STUB_RETVAL(SBuf())
+const char *sslGetUserEmail(SSL *) STUB_RETVAL(nullptr);
+const char *sslGetUserAttribute(SSL *, const char *) STUB_RETVAL(nullptr);
+const char *sslGetCAAttribute(SSL *, const char *) STUB_RETVAL(nullptr);
+SBuf sslGetUserCertificatePEM(SSL *) STUB_RETVAL(SBuf());
+SBuf sslGetUserCertificateChainPEM(SSL *) STUB_RETVAL(SBuf());
 namespace Ssl
 {
 //GETX509ATTRIBUTE GetX509UserAttribute;
 //GETX509ATTRIBUTE GetX509CAAttribute;
 //GETX509ATTRIBUTE GetX509Fingerprint;
 std::vector<const char *> BumpModeStr = {""};
-bool generateUntrustedCert(Security::CertPointer &, Security::PrivateKeyPointer &, Security::CertPointer const &, Security::PrivateKeyPointer const &) STUB_RETVAL(false)
-Security::ContextPointer GenerateSslContext(CertificateProperties const &, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer())
-bool verifySslCertificate(const Security::ContextPointer &, CertificateProperties const &) STUB_RETVAL(false)
-Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char *, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer())
-bool HasMatchingSubjectName(X509 &, const GeneralNameMatcher &) STUB_RETVAL(false)
-bool HasSubjectName(X509 &, const AnyP::Host &) STUB_RETVAL(false)
-int asn1timeToString(ASN1_TIME *, char *, int) STUB_RETVAL(0)
-void setClientSNI(SSL *, const char *) STUB
-SBuf GetX509PEM(X509 *) STUB_RETVAL(SBuf())
+bool generateUntrustedCert(Security::CertPointer &, Security::PrivateKeyPointer &, Security::CertPointer const &, Security::PrivateKeyPointer const &) STUB_RETVAL(false);
+Security::ContextPointer GenerateSslContext(CertificateProperties const &, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer());
+bool verifySslCertificate(const Security::ContextPointer &, CertificateProperties const &) STUB_RETVAL(false);
+Security::ContextPointer GenerateSslContextUsingPkeyAndCertFromMemory(const char *, Security::ServerOptions &, bool) STUB_RETVAL(Security::ContextPointer());
+bool HasMatchingSubjectName(X509 &, const GeneralNameMatcher &) STUB_RETVAL(false);
+bool HasSubjectName(X509 &, const AnyP::Host &) STUB_RETVAL(false);
+int asn1timeToString(ASN1_TIME *, char *, int) STUB_RETVAL(0);
+void setClientSNI(SSL *, const char *) STUB();
+SBuf GetX509PEM(X509 *) STUB_RETVAL(SBuf());
 } //namespace Ssl
 
 #endif

--- a/src/tests/stub_libstore.cc
+++ b/src/tests/stub_libstore.cc
@@ -15,45 +15,45 @@
 namespace Store
 {
 Controller::Controller() {STUB_NOP}
-Controller::~Controller() STUB
-void Controller::create() STUB
-void Controller::init() STUB
-uint64_t Controller::maxSize() const STUB_RETVAL(0)
-uint64_t Controller::minSize() const STUB_RETVAL(0)
-uint64_t Controller::currentSize() const STUB_RETVAL(0)
-uint64_t Controller::currentCount() const STUB_RETVAL(0)
-int64_t Controller::maxObjectSize() const STUB_RETVAL(0)
-void Controller::getStats(StoreInfoStats &) const STUB
-void Controller::stat(StoreEntry &) const STUB
-void Controller::sync() STUB
-void Controller::maintain() STUB
-void Controller::evictCached(StoreEntry &) STUB
-void Controller::evictIfFound(const cache_key *) STUB
-int Controller::callback() STUB
-StoreEntry *Controller::find(const cache_key *) STUB_RETVAL(nullptr)
-StoreEntry *Controller::peek(const cache_key *) STUB_RETVAL(nullptr)
-StoreEntry *Controller::findCallbackXXX(const cache_key *) STUB_RETVAL(nullptr)
-bool Controller::markedForDeletion(const cache_key *) const STUB_RETVAL(false)
-bool Controller::markedForDeletionAndAbandoned(const StoreEntry &) const STUB_RETVAL(false)
-bool Controller::hasReadableDiskEntry(const StoreEntry &) const STUB_RETVAL(false)
-int64_t Controller::accumulateMore(StoreEntry &) const STUB_RETVAL(0)
-void Controller::configure() STUB
-void Controller::handleIdleEntry(StoreEntry &) STUB
-void Controller::freeMemorySpace(const int) STUB
-void Controller::memoryOut(StoreEntry &, const bool) STUB
-bool Controller::updateOnNotModified(StoreEntry *, StoreEntry &) STUB
-bool Controller::allowCollapsing(StoreEntry *, const RequestFlags &, const HttpRequestMethod &) STUB_RETVAL(false)
-void Controller::addReading(StoreEntry *, const cache_key *) STUB
-void Controller::addWriting(StoreEntry *, const cache_key *) STUB
-bool Controller::transientsReader(const StoreEntry &) const STUB_RETVAL(false)
-bool Controller::transientsWriter(const StoreEntry &) const STUB_RETVAL(false)
-void Controller::syncCollapsed(const sfileno) STUB
-void Controller::noteStoppedSharedWriting(StoreEntry &) STUB
-int Controller::transientReaders(const StoreEntry &) const STUB_RETVAL(0)
-void Controller::transientsDisconnect(StoreEntry &) STUB
-void Controller::memoryDisconnect(StoreEntry &) STUB
-StoreSearch *Controller::search() STUB_RETVAL(nullptr)
-bool Controller::SmpAware() STUB_RETVAL(false)
+Controller::~Controller() STUB();
+void Controller::create() STUB();
+void Controller::init() STUB();
+uint64_t Controller::maxSize() const STUB_RETVAL(0);
+uint64_t Controller::minSize() const STUB_RETVAL(0);
+uint64_t Controller::currentSize() const STUB_RETVAL(0);
+uint64_t Controller::currentCount() const STUB_RETVAL(0);
+int64_t Controller::maxObjectSize() const STUB_RETVAL(0);
+void Controller::getStats(StoreInfoStats &) const STUB();
+void Controller::stat(StoreEntry &) const STUB();
+void Controller::sync() STUB();
+void Controller::maintain() STUB();
+void Controller::evictCached(StoreEntry &) STUB();
+void Controller::evictIfFound(const cache_key *) STUB();
+int Controller::callback() STUB();
+StoreEntry *Controller::find(const cache_key *) STUB_RETVAL(nullptr);
+StoreEntry *Controller::peek(const cache_key *) STUB_RETVAL(nullptr);
+StoreEntry *Controller::findCallbackXXX(const cache_key *) STUB_RETVAL(nullptr);
+bool Controller::markedForDeletion(const cache_key *) const STUB_RETVAL(false);
+bool Controller::markedForDeletionAndAbandoned(const StoreEntry &) const STUB_RETVAL(false);
+bool Controller::hasReadableDiskEntry(const StoreEntry &) const STUB_RETVAL(false);
+int64_t Controller::accumulateMore(StoreEntry &) const STUB_RETVAL(0);
+void Controller::configure() STUB();
+void Controller::handleIdleEntry(StoreEntry &) STUB();
+void Controller::freeMemorySpace(const int) STUB();
+void Controller::memoryOut(StoreEntry &, const bool) STUB();
+bool Controller::updateOnNotModified(StoreEntry *, StoreEntry &) STUB();
+bool Controller::allowCollapsing(StoreEntry *, const RequestFlags &, const HttpRequestMethod &) STUB_RETVAL(false);
+void Controller::addReading(StoreEntry *, const cache_key *) STUB();
+void Controller::addWriting(StoreEntry *, const cache_key *) STUB();
+bool Controller::transientsReader(const StoreEntry &) const STUB_RETVAL(false);
+bool Controller::transientsWriter(const StoreEntry &) const STUB_RETVAL(false);
+void Controller::syncCollapsed(const sfileno) STUB();
+void Controller::noteStoppedSharedWriting(StoreEntry &) STUB();
+int Controller::transientReaders(const StoreEntry &) const STUB_RETVAL(0);
+void Controller::transientsDisconnect(StoreEntry &) STUB();
+void Controller::memoryDisconnect(StoreEntry &) STUB();
+StoreSearch *Controller::search() STUB_RETVAL(nullptr);
+bool Controller::SmpAware() STUB_RETVAL(false);
 int Controller::store_dirs_rebuilding = 0;
 Controller &Root() STUB_RETREF(Controller)
 }
@@ -63,86 +63,86 @@ namespace Store
 {
 Disk::Disk(char const *) {STUB}
 Disk::~Disk() {STUB}
-char const *Disk::type() const STUB_RETVAL(nullptr)
-bool Disk::needsDiskStrand() const STUB_RETVAL(false)
-bool Disk::active() const STUB_RETVAL(false)
-void Disk::diskFull() STUB
-void Disk::create() STUB
-StoreEntry *Disk::get(const cache_key *) STUB_RETVAL(nullptr)
-uint64_t Disk::minSize() const STUB_RETVAL(0)
-int64_t Disk::maxObjectSize() const STUB_RETVAL(0)
-void Disk::getStats(StoreInfoStats &) const STUB
-void Disk::stat(StoreEntry &) const STUB
-void Disk::reference(StoreEntry &) STUB
-bool Disk::dereference(StoreEntry &) STUB_RETVAL(false)
-void Disk::maintain() STUB
-int64_t Disk::minObjectSize() const STUB_RETVAL(0)
-void Disk::maxObjectSize(int64_t) STUB
-bool Disk::objectSizeIsAcceptable(int64_t) const STUB_RETVAL(false)
-void Disk::parseOptions(int) STUB
-void Disk::dumpOptions(StoreEntry *) const STUB
-ConfigOption *Disk::getOptionTree() const STUB_RETVAL(nullptr)
-void Disk::dump(StoreEntry &) const STUB
-bool Disk::doubleCheck(StoreEntry &) STUB_RETVAL(false)
-void Disk::statfs(StoreEntry &) const STUB
-bool Disk::canLog(StoreEntry const &) const STUB_RETVAL(false)
-void Disk::openLog() STUB
-void Disk::closeLog() STUB
-void Disk::logEntry(const StoreEntry &, int) const STUB
-int Disk::writeCleanStart() STUB_RETVAL(0)
-void Disk::writeCleanDone() STUB
+char const *Disk::type() const STUB_RETVAL(nullptr);
+bool Disk::needsDiskStrand() const STUB_RETVAL(false);
+bool Disk::active() const STUB_RETVAL(false);
+void Disk::diskFull() STUB();
+void Disk::create() STUB();
+StoreEntry *Disk::get(const cache_key *) STUB_RETVAL(nullptr);
+uint64_t Disk::minSize() const STUB_RETVAL(0);
+int64_t Disk::maxObjectSize() const STUB_RETVAL(0);
+void Disk::getStats(StoreInfoStats &) const STUB();
+void Disk::stat(StoreEntry &) const STUB();
+void Disk::reference(StoreEntry &) STUB();
+bool Disk::dereference(StoreEntry &) STUB_RETVAL(false);
+void Disk::maintain() STUB();
+int64_t Disk::minObjectSize() const STUB_RETVAL(0);
+void Disk::maxObjectSize(int64_t) STUB();
+bool Disk::objectSizeIsAcceptable(int64_t) const STUB_RETVAL(false);
+void Disk::parseOptions(int) STUB();
+void Disk::dumpOptions(StoreEntry *) const STUB();
+ConfigOption *Disk::getOptionTree() const STUB_RETVAL(nullptr);
+void Disk::dump(StoreEntry &) const STUB();
+bool Disk::doubleCheck(StoreEntry &) STUB_RETVAL(false);
+void Disk::statfs(StoreEntry &) const STUB();
+bool Disk::canLog(StoreEntry const &) const STUB_RETVAL(false);
+void Disk::openLog() STUB();
+void Disk::closeLog() STUB();
+void Disk::logEntry(const StoreEntry &, int) const STUB();
+int Disk::writeCleanStart() STUB_RETVAL(0);
+void Disk::writeCleanDone() STUB();
 }
 
 #include "store/Disks.h"
 namespace Store
 {
 Disks::Disks() {STUB}
-void Disks::create() STUB
-void Disks::init() STUB
-StoreEntry *Disks::get(const cache_key *) STUB_RETVAL(nullptr)
-uint64_t Disks::maxSize() const STUB_RETVAL(0)
-uint64_t Disks::minSize() const STUB_RETVAL(0)
-uint64_t Disks::currentSize() const STUB_RETVAL(0)
-uint64_t Disks::currentCount() const STUB_RETVAL(0)
-int64_t Disks::maxObjectSize() const STUB_RETVAL(0)
-void Disks::getStats(StoreInfoStats &) const STUB
-void Disks::stat(StoreEntry &) const STUB
-void Disks::sync() STUB
-void Disks::reference(StoreEntry &) STUB
-bool Disks::dereference(StoreEntry &) STUB_RETVAL(false)
-void Disks::updateHeaders(StoreEntry *) STUB
-void Disks::maintain() STUB
-bool Disks::anchorToCache(StoreEntry &) STUB_RETVAL(false)
-bool Disks::updateAnchored(StoreEntry &) STUB_RETVAL(false)
-void Disks::evictCached(StoreEntry &) STUB
-void Disks::evictIfFound(const cache_key *) STUB
-int Disks::callback() STUB_RETVAL(0)
-void Disks::configure() STUB
-int64_t Disks::accumulateMore(const StoreEntry&) const STUB_RETVAL(0)
-bool Disks::SmpAware() STUB_RETVAL(false)
-bool Disks::hasReadableEntry(const StoreEntry &) const STUB_RETVAL(false)
-void Disks::Parse(DiskConfig &) STUB
-void Disks::Dump(const DiskConfig &, StoreEntry &, const char *) STUB
-SwapDir *Disks::SelectSwapDir(const StoreEntry *) STUB_RETVAL(nullptr)
+void Disks::create() STUB();
+void Disks::init() STUB();
+StoreEntry *Disks::get(const cache_key *) STUB_RETVAL(nullptr);
+uint64_t Disks::maxSize() const STUB_RETVAL(0);
+uint64_t Disks::minSize() const STUB_RETVAL(0);
+uint64_t Disks::currentSize() const STUB_RETVAL(0);
+uint64_t Disks::currentCount() const STUB_RETVAL(0);
+int64_t Disks::maxObjectSize() const STUB_RETVAL(0);
+void Disks::getStats(StoreInfoStats &) const STUB();
+void Disks::stat(StoreEntry &) const STUB();
+void Disks::sync() STUB();
+void Disks::reference(StoreEntry &) STUB();
+bool Disks::dereference(StoreEntry &) STUB_RETVAL(false);
+void Disks::updateHeaders(StoreEntry *) STUB();
+void Disks::maintain() STUB();
+bool Disks::anchorToCache(StoreEntry &) STUB_RETVAL(false);
+bool Disks::updateAnchored(StoreEntry &) STUB_RETVAL(false);
+void Disks::evictCached(StoreEntry &) STUB();
+void Disks::evictIfFound(const cache_key *) STUB();
+int Disks::callback() STUB_RETVAL(0);
+void Disks::configure() STUB();
+int64_t Disks::accumulateMore(const StoreEntry&) const STUB_RETVAL(0);
+bool Disks::SmpAware() STUB_RETVAL(false);
+bool Disks::hasReadableEntry(const StoreEntry &) const STUB_RETVAL(false);
+void Disks::Parse(DiskConfig &) STUB();
+void Disks::Dump(const DiskConfig &, StoreEntry &, const char *) STUB();
+SwapDir *Disks::SelectSwapDir(const StoreEntry *) STUB_RETVAL(nullptr);
 }
-void storeDirOpenSwapLogs(void) STUB
-int storeDirWriteCleanLogs(int) STUB_RETVAL(0)
-void storeDirCloseSwapLogs(void) STUB
-void allocate_new_swapdir(Store::DiskConfig &) STUB
+void storeDirOpenSwapLogs(void) STUB();
+int storeDirWriteCleanLogs(int) STUB_RETVAL(0);
+void storeDirCloseSwapLogs(void) STUB();
+void allocate_new_swapdir(Store::DiskConfig &) STUB();
 void free_cachedir(Store::DiskConfig *) STUB;
-void storeDirSwapLog(const StoreEntry *, int) STUB
+void storeDirSwapLog(const StoreEntry *, int) STUB();
 
 #include "store/LocalSearch.h"
 namespace Store
 {
-StoreSearch *NewLocalSearch() STUB_RETVAL(nullptr)
+StoreSearch *NewLocalSearch() STUB_RETVAL(nullptr);
 }
 
 #include "store/SwapMetaIn.h"
-size_t Store::UnpackSwapMetaSize(const SBuf &) STUB_RETVAL(0)
-size_t Store::UnpackIndexSwapMeta(const MemBuf &, StoreEntry &, cache_key *) STUB_RETVAL(0)
-void Store::UnpackHitSwapMeta(char const *, ssize_t, StoreEntry &) STUB
+size_t Store::UnpackSwapMetaSize(const SBuf &) STUB_RETVAL(0);
+size_t Store::UnpackIndexSwapMeta(const MemBuf &, StoreEntry &, cache_key *) STUB_RETVAL(0);
+void Store::UnpackHitSwapMeta(char const *, ssize_t, StoreEntry &) STUB();
 
 #include "store/SwapMetaOut.h"
-AllocedBuf Store::PackSwapMeta(const StoreEntry &, size_t &) STUB_RETVAL(nullptr)
+AllocedBuf Store::PackSwapMeta(const StoreEntry &, size_t &) STUB_RETVAL(nullptr);
 

--- a/src/tests/stub_libtime.cc
+++ b/src/tests/stub_libtime.cc
@@ -12,26 +12,26 @@
 #include "tests/STUB.h"
 
 #include "time/Engine.h"
-void Time::Engine::tick() STUB
+void Time::Engine::tick() STUB();
 
 #include "time/gadgets.h"
 struct timeval current_time = {};
 double current_dtime = 0.0;
 time_t squid_curtime = 0;
-time_t getCurrentTime() STUB_RETVAL(0)
-int tvSubUsec(struct timeval, struct timeval) STUB_RETVAL(0)
-double tvSubDsec(struct timeval, struct timeval) STUB_RETVAL(0.0)
-int tvSubMsec(struct timeval, struct timeval) STUB_RETVAL(0)
-void tvSub(struct timeval &, struct timeval const &, struct timeval const &) STUB
-void tvAdd(struct timeval &, struct timeval const &, struct timeval const &) STUB
-void tvAssignAdd(struct timeval &, struct timeval const &) STUB
-std::ostream &operator <<(std::ostream &os, const timeval &) STUB_RETVAL(os)
+time_t getCurrentTime() STUB_RETVAL(0);
+int tvSubUsec(struct timeval, struct timeval) STUB_RETVAL(0);
+double tvSubDsec(struct timeval, struct timeval) STUB_RETVAL(0.0);
+int tvSubMsec(struct timeval, struct timeval) STUB_RETVAL(0);
+void tvSub(struct timeval &, struct timeval const &, struct timeval const &) STUB();
+void tvAdd(struct timeval &, struct timeval const &, struct timeval const &) STUB();
+void tvAssignAdd(struct timeval &, struct timeval const &) STUB();
+std::ostream &operator <<(std::ostream &os, const timeval &) STUB_RETVAL(os);
 namespace Time
 {
-time_t ParseIso3307(const char *) STUB_RETVAL(0)
-const char *FormatRfc1123(time_t) STUB_RETVAL("")
-time_t ParseRfc1123(const char *) STUB_RETVAL(0)
-const char *FormatStrf(time_t) STUB_RETVAL("")
-const char *FormatHttpd(time_t) STUB_RETVAL("")
+time_t ParseIso3307(const char *) STUB_RETVAL(0);
+const char *FormatRfc1123(time_t) STUB_RETVAL("");
+time_t ParseRfc1123(const char *) STUB_RETVAL(0);
+const char *FormatStrf(time_t) STUB_RETVAL("");
+const char *FormatHttpd(time_t) STUB_RETVAL("");
 }
 

--- a/src/tests/stub_main_cc.cc
+++ b/src/tests/stub_main_cc.cc
@@ -12,7 +12,7 @@
 #define STUB_API "stub_main_cc.cc"
 #include "tests/STUB.h"
 
-void shut_down(int) STUB
-void reconfigure(int) STUB
-void rotate_logs(int) STUB
+void shut_down(int) STUB();
+void reconfigure(int) STUB();
+void rotate_logs(int) STUB();
 

--- a/src/tests/stub_mem_node.cc
+++ b/src/tests/stub_mem_node.cc
@@ -12,6 +12,6 @@
 #define STUB_API "mem_node.cc"
 #include "tests/STUB.h"
 
-mem_node::mem_node(int64_t offset) : nodeBuffer(0,offset,data) STUB
-    size_t mem_node::InUseCount() STUB_RETVAL(0)
+mem_node::mem_node(int64_t offset) : nodeBuffer(0,offset,data) STUB();
+size_t mem_node::InUseCount() STUB_RETVAL(0);
 

--- a/src/tests/stub_mime.cc
+++ b/src/tests/stub_mime.cc
@@ -13,6 +13,6 @@
 #define STUB_API "mime.cc"
 #include "tests/STUB.h"
 
-size_t headersEnd(const char *, size_t, bool &) STUB_RETVAL(0)
-size_t headersEnd(const SBuf &, bool &) STUB_RETVAL(0)
+size_t headersEnd(const char *, size_t, bool &) STUB_RETVAL(0);
+size_t headersEnd(const SBuf &, bool &) STUB_RETVAL(0);
 

--- a/src/tests/stub_neighbors.cc
+++ b/src/tests/stub_neighbors.cc
@@ -15,11 +15,11 @@
 #include "neighbors.h"
 
 void
-peerConnClosed(CachePeer *) STUB
-CachePeer *findCachePeerByName(const char *) STUB_RETVAL(nullptr)
+peerConnClosed(CachePeer *) STUB();
+CachePeer *findCachePeerByName(const char *) STUB_RETVAL(nullptr);
 
 time_t
-FwdState::ForwardTimeout(const time_t) STUB_RETVAL(0)
+FwdState::ForwardTimeout(const time_t) STUB_RETVAL(0);
 bool
-FwdState::EnoughTimeToReForward(const time_t) STUB_RETVAL(false)
+FwdState::EnoughTimeToReForward(const time_t) STUB_RETVAL(false);
 

--- a/src/tests/stub_pconn.cc
+++ b/src/tests/stub_pconn.cc
@@ -16,25 +16,25 @@
 #define STUB_API "pconn.cc"
 #include "tests/STUB.h"
 
-IdleConnList::IdleConnList(const char *, PconnPool *) STUB
-IdleConnList::~IdleConnList() STUB
-void IdleConnList::push(const Comm::ConnectionPointer &) STUB
-Comm::ConnectionPointer IdleConnList::findUseable(const Comm::ConnectionPointer &) STUB_RETVAL(Comm::ConnectionPointer())
-void IdleConnList::clearHandlers(const Comm::ConnectionPointer &) STUB
-void IdleConnList::endingShutdown() STUB
-PconnPool::PconnPool(const char *, const CbcPointer<PeerPoolMgr>&) STUB
-PconnPool::~PconnPool() STUB
-void PconnPool::moduleInit() STUB
-void PconnPool::push(const Comm::ConnectionPointer &, const char *) STUB
-Comm::ConnectionPointer PconnPool::pop(const Comm::ConnectionPointer &, const char *, bool) STUB_RETVAL(Comm::ConnectionPointer())
-void PconnPool::count(int) STUB
-void PconnPool::noteUses(int) STUB
-void PconnPool::dump(std::ostream&) const STUB
-void PconnPool::unlinkList(IdleConnList *) STUB
-PconnModule * PconnModule::GetInstance() STUB_RETVAL(nullptr)
-void PconnModule::DumpWrapper(StoreEntry *) STUB
-PconnModule::PconnModule() STUB
-void PconnModule::registerWithCacheManager(void) STUB
-void PconnModule::add(PconnPool *) STUB
-void PconnModule::dump(std::ostream &) STUB
+IdleConnList::IdleConnList(const char *, PconnPool *) STUB();
+IdleConnList::~IdleConnList() STUB();
+void IdleConnList::push(const Comm::ConnectionPointer &) STUB();
+Comm::ConnectionPointer IdleConnList::findUseable(const Comm::ConnectionPointer &) STUB_RETVAL(Comm::ConnectionPointer());
+void IdleConnList::clearHandlers(const Comm::ConnectionPointer &) STUB();
+void IdleConnList::endingShutdown() STUB();
+PconnPool::PconnPool(const char *, const CbcPointer<PeerPoolMgr>&) STUB();
+PconnPool::~PconnPool() STUB();
+void PconnPool::moduleInit() STUB();
+void PconnPool::push(const Comm::ConnectionPointer &, const char *) STUB();
+Comm::ConnectionPointer PconnPool::pop(const Comm::ConnectionPointer &, const char *, bool) STUB_RETVAL(Comm::ConnectionPointer());
+void PconnPool::count(int) STUB();
+void PconnPool::noteUses(int) STUB();
+void PconnPool::dump(std::ostream&) const STUB();
+void PconnPool::unlinkList(IdleConnList *) STUB();
+PconnModule * PconnModule::GetInstance() STUB_RETVAL(nullptr);
+void PconnModule::DumpWrapper(StoreEntry *) STUB();
+PconnModule::PconnModule() STUB();
+void PconnModule::registerWithCacheManager(void) STUB();
+void PconnModule::add(PconnPool *) STUB();
+void PconnModule::dump(std::ostream &) STUB();
 

--- a/src/tests/stub_redirect.cc
+++ b/src/tests/stub_redirect.cc
@@ -12,8 +12,8 @@
 #define STUB_API "redirect.cc"
 #include "tests/STUB.h"
 
-void redirectInit(void) STUB
-void redirectShutdown(void) STUB
-void redirectStart(ClientHttpRequest *, HLPCB *, void *) STUB
-void storeIdStart(ClientHttpRequest *, HLPCB *, void *) STUB
+void redirectInit(void) STUB();
+void redirectShutdown(void) STUB();
+void redirectStart(ClientHttpRequest *, HLPCB *, void *) STUB();
+void storeIdStart(ClientHttpRequest *, HLPCB *, void *) STUB();
 

--- a/src/tests/stub_stat.cc
+++ b/src/tests/stub_stat.cc
@@ -15,5 +15,5 @@
 #include "tests/STUB.h"
 
 class StoreEntry;
-const char *storeEntryFlags(const StoreEntry *) STUB_RETVAL(nullptr)
+const char *storeEntryFlags(const StoreEntry *) STUB_RETVAL(nullptr);
 

--- a/src/tests/stub_stmem.cc
+++ b/src/tests/stub_stmem.cc
@@ -12,9 +12,9 @@
 #define STUB_API "stmem.cc"
 #include "tests/STUB.h"
 
-mem_hdr::mem_hdr() STUB
-mem_hdr::~mem_hdr() STUB
-size_t mem_hdr::size() const STUB_RETVAL(0)
-int64_t mem_hdr::endOffset () const STUB_RETVAL(0)
-bool mem_hdr::write (StoreIOBuffer const &) STUB_RETVAL(false)
+mem_hdr::mem_hdr() STUB();
+mem_hdr::~mem_hdr() STUB();
+size_t mem_hdr::size() const STUB_RETVAL(0);
+int64_t mem_hdr::endOffset () const STUB_RETVAL(0);
+bool mem_hdr::write (StoreIOBuffer const &) STUB_RETVAL(false);
 

--- a/src/tests/stub_store.cc
+++ b/src/tests/stub_store.cc
@@ -18,99 +18,99 @@ const char *memStatusStr[] = { };
 const char *swapStatusStr[] = { };
 
 #include "RemovalPolicy.h"
-RemovalPolicy * createRemovalPolicy(RemovalPolicySettings *) STUB_RETVAL(nullptr)
+RemovalPolicy * createRemovalPolicy(RemovalPolicySettings *) STUB_RETVAL(nullptr);
 
 #include "Store.h"
 StoreIoStats store_io_stats;
-bool StoreEntry::checkDeferRead(int) const STUB_RETVAL(false)
-const char *StoreEntry::getMD5Text() const STUB_RETVAL(nullptr)
-StoreEntry::StoreEntry() STUB
-StoreEntry::~StoreEntry() STUB
-void StoreEntry::write(StoreIOBuffer) STUB
-bool StoreEntry::isAccepting() const STUB_RETVAL(false)
-size_t StoreEntry::bytesWanted(Range<size_t> const, bool) const STUB_RETVAL(0)
-void StoreEntry::complete() STUB
-store_client_t StoreEntry::storeClientType() const STUB_RETVAL(STORE_NON_CLIENT)
-char const *StoreEntry::getSerialisedMetaData(size_t &) const STUB_RETVAL(nullptr)
-void StoreEntry::replaceHttpReply(const HttpReplyPointer &, bool) STUB
-bool StoreEntry::mayStartSwapOut() STUB_RETVAL(false)
-void StoreEntry::trimMemory(const bool) STUB
-void StoreEntry::abort() STUB
-bool StoreEntry::makePublic(const KeyScope) STUB
-void StoreEntry::makePrivate(const bool) STUB
-bool StoreEntry::setPublicKey(const KeyScope) STUB
-void StoreEntry::setPrivateKey(const bool, const bool) STUB
-void StoreEntry::expireNow() STUB
-void StoreEntry::releaseRequest(const bool) STUB
-void StoreEntry::negativeCache() STUB
-bool StoreEntry::cacheNegatively() STUB
-void StoreEntry::swapOut() STUB
-void StoreEntry::swapOutFileClose(int) STUB
-const char *StoreEntry::url() const STUB_RETVAL(nullptr)
-bool StoreEntry::checkCachable() STUB_RETVAL(false)
-int StoreEntry::checkNegativeHit() const STUB_RETVAL(0)
-int StoreEntry::validToSend() const STUB_RETVAL(0)
-bool StoreEntry::memoryCachable() STUB_RETVAL(false)
-void StoreEntry::createMemObject() STUB
-void StoreEntry::createMemObject(const char *, const char *, const HttpRequestMethod &) STUB
-void StoreEntry::ensureMemObject(const char *, const char *, const HttpRequestMethod &) STUB
-void StoreEntry::dump(int) const STUB
-void StoreEntry::hashDelete() STUB
-void StoreEntry::hashInsert(const cache_key *) STUB
-void StoreEntry::registerAbortCallback(const AsyncCall::Pointer &) STUB
-void StoreEntry::reset() STUB
-void StoreEntry::setMemStatus(mem_status_t) STUB
-bool StoreEntry::timestampsSet() STUB_RETVAL(false)
-void StoreEntry::unregisterAbortCallback(const char *) STUB
-void StoreEntry::destroyMemObject() STUB
-int StoreEntry::checkTooSmall() STUB_RETVAL(0)
-void StoreEntry::setNoDelay (bool const) STUB
-bool StoreEntry::modifiedSince(const time_t, const int) const STUB_RETVAL(false)
-bool StoreEntry::hasIfMatchEtag(const HttpRequest &) const STUB_RETVAL(false)
-bool StoreEntry::hasIfNoneMatchEtag(const HttpRequest &) const STUB_RETVAL(false)
+bool StoreEntry::checkDeferRead(int) const STUB_RETVAL(false);
+const char *StoreEntry::getMD5Text() const STUB_RETVAL(nullptr);
+StoreEntry::StoreEntry() STUB();
+StoreEntry::~StoreEntry() STUB();
+void StoreEntry::write(StoreIOBuffer) STUB();
+bool StoreEntry::isAccepting() const STUB_RETVAL(false);
+size_t StoreEntry::bytesWanted(Range<size_t> const, bool) const STUB_RETVAL(0);
+void StoreEntry::complete() STUB();
+store_client_t StoreEntry::storeClientType() const STUB_RETVAL(STORE_NON_CLIENT);
+char const *StoreEntry::getSerialisedMetaData(size_t &) const STUB_RETVAL(nullptr);
+void StoreEntry::replaceHttpReply(const HttpReplyPointer &, bool) STUB();
+bool StoreEntry::mayStartSwapOut() STUB_RETVAL(false);
+void StoreEntry::trimMemory(const bool) STUB();
+void StoreEntry::abort() STUB();
+bool StoreEntry::makePublic(const KeyScope) STUB();
+void StoreEntry::makePrivate(const bool) STUB();
+bool StoreEntry::setPublicKey(const KeyScope) STUB();
+void StoreEntry::setPrivateKey(const bool, const bool) STUB();
+void StoreEntry::expireNow() STUB();
+void StoreEntry::releaseRequest(const bool) STUB();
+void StoreEntry::negativeCache() STUB();
+bool StoreEntry::cacheNegatively() STUB();
+void StoreEntry::swapOut() STUB();
+void StoreEntry::swapOutFileClose(int) STUB();
+const char *StoreEntry::url() const STUB_RETVAL(nullptr);
+bool StoreEntry::checkCachable() STUB_RETVAL(false);
+int StoreEntry::checkNegativeHit() const STUB_RETVAL(0);
+int StoreEntry::validToSend() const STUB_RETVAL(0);
+bool StoreEntry::memoryCachable() STUB_RETVAL(false);
+void StoreEntry::createMemObject() STUB();
+void StoreEntry::createMemObject(const char *, const char *, const HttpRequestMethod &) STUB();
+void StoreEntry::ensureMemObject(const char *, const char *, const HttpRequestMethod &) STUB();
+void StoreEntry::dump(int) const STUB();
+void StoreEntry::hashDelete() STUB();
+void StoreEntry::hashInsert(const cache_key *) STUB();
+void StoreEntry::registerAbortCallback(const AsyncCall::Pointer &) STUB();
+void StoreEntry::reset() STUB();
+void StoreEntry::setMemStatus(mem_status_t) STUB();
+bool StoreEntry::timestampsSet() STUB_RETVAL(false);
+void StoreEntry::unregisterAbortCallback(const char *) STUB();
+void StoreEntry::destroyMemObject() STUB();
+int StoreEntry::checkTooSmall() STUB_RETVAL(0);
+void StoreEntry::setNoDelay (bool const) STUB();
+bool StoreEntry::modifiedSince(const time_t, const int) const STUB_RETVAL(false);
+bool StoreEntry::hasIfMatchEtag(const HttpRequest &) const STUB_RETVAL(false);
+bool StoreEntry::hasIfNoneMatchEtag(const HttpRequest &) const STUB_RETVAL(false);
 Store::Disk &StoreEntry::disk() const STUB_RETREF(Store::Disk)
-size_t StoreEntry::inUseCount() STUB_RETVAL(0)
+size_t StoreEntry::inUseCount() STUB_RETVAL(0);
 void *StoreEntry::operator new(size_t)
 {
-    STUB
+    STUB();
     return new StoreEntry();
 }
-void StoreEntry::operator delete(void *) STUB
-void StoreEntry::buffer() STUB
-void StoreEntry::flush() STUB
-int StoreEntry::unlock(const char *) STUB_RETVAL(0)
-void StoreEntry::lock(const char *) STUB
-void StoreEntry::touch() STUB
-void StoreEntry::release(const bool) STUB
-void StoreEntry::append(char const *, int) STUB
-void StoreEntry::vappendf(const char *, va_list) STUB
-void StoreEntry::setCollapsingRequirement(const bool) STUB
+void StoreEntry::operator delete(void *) STUB();
+void StoreEntry::buffer() STUB();
+void StoreEntry::flush() STUB();
+int StoreEntry::unlock(const char *) STUB_RETVAL(0);
+void StoreEntry::lock(const char *) STUB();
+void StoreEntry::touch() STUB();
+void StoreEntry::release(const bool) STUB();
+void StoreEntry::append(char const *, int) STUB();
+void StoreEntry::vappendf(const char *, va_list) STUB();
+void StoreEntry::setCollapsingRequirement(const bool) STUB();
 
-void Store::Maintain(void *) STUB
+void Store::Maintain(void *) STUB();
 
 std::ostream &operator <<(std::ostream &os, const StoreEntry &)
 {
-    STUB
+    STUB();
     return os;
 }
 
-size_t storeEntryInUse() STUB_RETVAL(0)
-void storeEntryReplaceObject(StoreEntry *, HttpReply *) STUB
-StoreEntry *storeGetPublic(const char *, const HttpRequestMethod&) STUB_RETVAL(nullptr)
-StoreEntry *storeGetPublicByRequest(HttpRequest *, const KeyScope) STUB_RETVAL(nullptr)
-StoreEntry *storeGetPublicByRequestMethod(HttpRequest *, const HttpRequestMethod&, const KeyScope) STUB_RETVAL(nullptr)
-StoreEntry *storeCreateEntry(const char *, const char *, const RequestFlags &, const HttpRequestMethod&) STUB_RETVAL(nullptr)
-StoreEntry *storeCreatePureEntry(const char *, const char *, const HttpRequestMethod&) STUB_RETVAL(nullptr)
-void storeConfigure(void) STUB
-int expiresMoreThan(time_t, time_t) STUB_RETVAL(0)
-void storeAppendPrintf(StoreEntry *, const char *,...) STUB
-void storeAppendVPrintf(StoreEntry *, const char *, va_list) STUB
-int storeTooManyDiskFilesOpen(void) STUB_RETVAL(0)
-void storeHeapPositionUpdate(StoreEntry *, SwapDir *) STUB
-void storeSwapFileNumberSet(StoreEntry *, sfileno) STUB
-void storeFsInit(void) STUB
-void storeFsDone(void) STUB
-void storeReplAdd(const char *, REMOVALPOLICYCREATE *) STUB
-void destroyStoreEntry(void *) STUB
-void storeGetMemSpace(int) STUB
+size_t storeEntryInUse() STUB_RETVAL(0);
+void storeEntryReplaceObject(StoreEntry *, HttpReply *) STUB();
+StoreEntry *storeGetPublic(const char *, const HttpRequestMethod&) STUB_RETVAL(nullptr);
+StoreEntry *storeGetPublicByRequest(HttpRequest *, const KeyScope) STUB_RETVAL(nullptr);
+StoreEntry *storeGetPublicByRequestMethod(HttpRequest *, const HttpRequestMethod&, const KeyScope) STUB_RETVAL(nullptr);
+StoreEntry *storeCreateEntry(const char *, const char *, const RequestFlags &, const HttpRequestMethod&) STUB_RETVAL(nullptr);
+StoreEntry *storeCreatePureEntry(const char *, const char *, const HttpRequestMethod&) STUB_RETVAL(nullptr);
+void storeConfigure(void) STUB();
+int expiresMoreThan(time_t, time_t) STUB_RETVAL(0);
+void storeAppendPrintf(StoreEntry *, const char *,...) STUB();
+void storeAppendVPrintf(StoreEntry *, const char *, va_list) STUB();
+int storeTooManyDiskFilesOpen(void) STUB_RETVAL(0);
+void storeHeapPositionUpdate(StoreEntry *, SwapDir *) STUB();
+void storeSwapFileNumberSet(StoreEntry *, sfileno) STUB();
+void storeFsInit(void) STUB();
+void storeFsDone(void) STUB();
+void storeReplAdd(const char *, REMOVALPOLICYCREATE *) STUB();
+void destroyStoreEntry(void *) STUB();
+void storeGetMemSpace(int) STUB();
 

--- a/src/tests/stub_store_client.cc
+++ b/src/tests/stub_store_client.cc
@@ -20,14 +20,14 @@
 int storePendingNClients(const StoreEntry *) STUB_RETVAL_NOP(0)
 void StoreEntry::invokeHandlers() STUB_NOP
 void storeLog(int, const StoreEntry *) STUB_NOP
-void storeLogOpen(void) STUB
-void storeDigestInit(void) STUB
-void storeRebuildStart(void) STUB
-void storeReplSetup(void) STUB
-void store_client::noteSwapInDone(bool) STUB
+void storeLogOpen(void) STUB();
+void storeDigestInit(void) STUB();
+void storeRebuildStart(void) STUB();
+void storeReplSetup(void) STUB();
+void store_client::noteSwapInDone(bool) STUB();
 #if USE_DELAY_POOLS
-int store_client::bytesWanted() const STUB_RETVAL(0)
+int store_client::bytesWanted() const STUB_RETVAL(0);
 #endif
-void store_client::dumpStats(MemBuf *, int) const STUB
-int store_client::getType() const STUB_RETVAL(0)
+void store_client::dumpStats(MemBuf *, int) const STUB();
+int store_client::getType() const STUB_RETVAL(0);
 

--- a/src/tests/stub_store_digest.cc
+++ b/src/tests/stub_store_digest.cc
@@ -13,8 +13,8 @@
 #include "tests/STUB.h"
 
 class StoreEntry;
-void storeDigestInit(void) STUB
-void storeDigestNoteStoreReady(void) STUB
-void storeDigestDel(const StoreEntry *) STUB
-void storeDigestReport(StoreEntry *) STUB
+void storeDigestInit(void) STUB();
+void storeDigestNoteStoreReady(void) STUB();
+void storeDigestDel(const StoreEntry *) STUB();
+void storeDigestReport(StoreEntry *) STUB();
 

--- a/src/tests/stub_store_rebuild.cc
+++ b/src/tests/stub_store_rebuild.cc
@@ -19,8 +19,8 @@
 #define STUB_API "stub_store_rebuild.cc"
 #include "tests/STUB.h"
 
-void storeRebuildProgress(int, int, int) STUB
-bool storeRebuildParseEntry(MemBuf &, StoreEntry &, cache_key *, StoreRebuildData &, uint64_t) STUB_RETVAL(false)
+void storeRebuildProgress(int, int, int) STUB();
+bool storeRebuildParseEntry(MemBuf &, StoreEntry &, cache_key *, StoreRebuildData &, uint64_t) STUB_RETVAL(false);
 
 void StoreRebuildData::updateStartTime(const timeval &dirStartTime)
 {
@@ -47,5 +47,5 @@ storeRebuildLoadEntry(int fd, int, MemBuf &buf, StoreRebuildData &)
     return true;
 }
 
-void Progress::print(std::ostream &) const STUB
+void Progress::print(std::ostream &) const STUB();
 

--- a/src/tests/stub_store_stats.cc
+++ b/src/tests/stub_store_stats.cc
@@ -15,7 +15,7 @@
 #include <cstring>
 
 StoreInfoStats &
-StoreInfoStats::operator +=(const StoreInfoStats &) STUB_RETVAL(*this)
+StoreInfoStats::operator +=(const StoreInfoStats &) STUB_RETVAL(*this);
 
 StoreIoStats::StoreIoStats()
 {

--- a/src/tests/stub_tools.cc
+++ b/src/tests/stub_tools.cc
@@ -16,22 +16,22 @@
 int DebugSignal = -1;
 SBuf service_name(APP_SHORTNAME);
 void releaseServerSockets(void) STUB_NOP
-void dumpMallocStats(void) STUB
-void squid_getrusage(struct rusage *) STUB
-double rusage_cputime(struct rusage *) STUB_RETVAL(0)
-int rusage_maxrss(struct rusage *) STUB_RETVAL(0)
-int rusage_pagefaults(struct rusage *) STUB_RETVAL(0)
-void PrintRusage(void) STUB
-void death(int) STUB
-void BroadcastSignalIfAny(int &) STUB
-void sigusr2_handle(int) STUB
-void debug_trap(const char *) STUB
-void sig_child(int) STUB
-const char * getMyHostname(void) STUB_RETVAL(nullptr)
-const char * uniqueHostname(void) STUB_RETVAL(nullptr)
+void dumpMallocStats(void) STUB();
+void squid_getrusage(struct rusage *) STUB();
+double rusage_cputime(struct rusage *) STUB_RETVAL(0);
+int rusage_maxrss(struct rusage *) STUB_RETVAL(0);
+int rusage_pagefaults(struct rusage *) STUB_RETVAL(0);
+void PrintRusage(void) STUB();
+void death(int) STUB();
+void BroadcastSignalIfAny(int &) STUB();
+void sigusr2_handle(int) STUB();
+void debug_trap(const char *) STUB();
+void sig_child(int) STUB();
+const char * getMyHostname(void) STUB_RETVAL(nullptr);
+const char * uniqueHostname(void) STUB_RETVAL(nullptr);
 void leave_suid(void) STUB_NOP
-void enter_suid(void) STUB
-void no_suid(void) STUB
+void enter_suid(void) STUB();
+void no_suid(void) STUB();
 
 bool
 IamMasterProcess()
@@ -53,25 +53,25 @@ IamWorkerProcess()
 bool IamDiskProcess() STUB_RETVAL_NOP(false)
 bool InDaemonMode() STUB_RETVAL_NOP(false)
 bool UsingSmp() STUB_RETVAL_NOP(false)
-bool IamCoordinatorProcess() STUB_RETVAL(false)
-bool IamPrimaryProcess() STUB_RETVAL(false)
-int NumberOfKids() STUB_RETVAL(0)
+bool IamCoordinatorProcess() STUB_RETVAL(false);
+bool IamPrimaryProcess() STUB_RETVAL(false);
+int NumberOfKids() STUB_RETVAL(0);
 
 //not actually needed in the Stub, causes dependency on SBuf
-//SBuf ProcessRoles() STUB_RETVAL(SBuf())
-void setMaxFD(void) STUB
-void setSystemLimits(void) STUB
-void squid_signal(int, SIGHDLR *, int) STUB
-void logsFlush(void) STUB
-void debugObj(int, int, const char *, void *, ObjPackMethod) STUB
-void parseEtcHosts(void) STUB
-int getMyPort(void) STUB_RETVAL(0)
-void setUmask(mode_t) STUB
-void strwordquote(MemBuf *, const char *) STUB
-void keepCapabilities(void) STUB
-pid_t WaitForOnePid(pid_t, PidStatus &, int) STUB_RETVAL(0)
+//SBuf ProcessRoles() STUB_RETVAL(SBuf());
+void setMaxFD(void) STUB();
+void setSystemLimits(void) STUB();
+void squid_signal(int, SIGHDLR *, int) STUB();
+void logsFlush(void) STUB();
+void debugObj(int, int, const char *, void *, ObjPackMethod) STUB();
+void parseEtcHosts(void) STUB();
+int getMyPort(void) STUB_RETVAL(0);
+void setUmask(mode_t) STUB();
+void strwordquote(MemBuf *, const char *) STUB();
+void keepCapabilities(void) STUB();
+pid_t WaitForOnePid(pid_t, PidStatus &, int) STUB_RETVAL(0);
 
 #if _SQUID_WINDOWS_
-SBuf WindowsErrorMessage(DWORD) STUB_RETVAL(SBuf())
+SBuf WindowsErrorMessage(DWORD) STUB_RETVAL(SBuf());
 #endif // _SQUID_WINDOWS_
 

--- a/src/tests/stub_tunnel.cc
+++ b/src/tests/stub_tunnel.cc
@@ -16,7 +16,7 @@
 #include "tests/STUB.h"
 class ClientHttpRequest;
 
-void tunnelStart(ClientHttpRequest *) STUB
+void tunnelStart(ClientHttpRequest *) STUB();
 
-void switchToTunnel(HttpRequest *, const Comm::ConnectionPointer &, const Comm::ConnectionPointer &, const SBuf &) STUB
+void switchToTunnel(HttpRequest *, const Comm::ConnectionPointer &, const Comm::ConnectionPointer &, const SBuf &) STUB();
 

--- a/src/tests/stub_wccp2.cc
+++ b/src/tests/stub_wccp2.cc
@@ -16,22 +16,22 @@
 
 class StoreEntry;
 
-void wccp2Init(void) STUB
-void wccp2ConnectionOpen(void) STUB
-void wccp2ConnectionClose(void) STUB
-void dump_wccp2_method(StoreEntry *, const char *, int) STUB
-void free_wccp2_method(int *) STUB
-void parse_wccp2_amethod(int *) STUB
-void dump_wccp2_amethod(StoreEntry *, const char *, int) STUB
-void parse_wccp2_service(void *) STUB
-void dump_wccp2_service(StoreEntry *, const char *, void *) STUB
-void free_wccp2_service(void *) STUB
-int check_null_wccp2_service(void *) STUB_RETVAL(0)
-void parse_wccp2_service_info(void *) STUB
-void dump_wccp2_service_info(StoreEntry *, const char *, void *) STUB
-void free_wccp2_service_info(void *) STUB
-void free_wccp2_amethod(int *) STUB
-void parse_wccp2_method(int *) STUB
+void wccp2Init(void) STUB();
+void wccp2ConnectionOpen(void) STUB();
+void wccp2ConnectionClose(void) STUB();
+void dump_wccp2_method(StoreEntry *, const char *, int) STUB();
+void free_wccp2_method(int *) STUB();
+void parse_wccp2_amethod(int *) STUB();
+void dump_wccp2_amethod(StoreEntry *, const char *, int) STUB();
+void parse_wccp2_service(void *) STUB();
+void dump_wccp2_service(StoreEntry *, const char *, void *) STUB();
+void free_wccp2_service(void *) STUB();
+int check_null_wccp2_service(void *) STUB_RETVAL(0);
+void parse_wccp2_service_info(void *) STUB();
+void dump_wccp2_service_info(StoreEntry *, const char *, void *) STUB();
+void free_wccp2_service_info(void *) STUB();
+void free_wccp2_amethod(int *) STUB();
+void parse_wccp2_method(int *) STUB();
 
 #endif /* USE_WCCPv2 */
 

--- a/src/tests/stub_wordlist.cc
+++ b/src/tests/stub_wordlist.cc
@@ -12,6 +12,6 @@
 #define STUB_API "wordlist.cc"
 #include "tests/STUB.h"
 
-const char *wordlistAdd(wordlist **, const char *) STUB_RETVAL(nullptr)
-void wordlistDestroy(wordlist **) STUB
+const char *wordlistAdd(wordlist **, const char *) STUB_RETVAL(nullptr);
+void wordlistDestroy(wordlist **) STUB();
 


### PR DESCRIPTION
The undecorated STUB and STUB_RETVAL macros we use confuse
astyle, which as a consequence adds spruious indentation to several
stub declarations.

By turning STUB and STUB_RETVAL into something looking like
functions, astyle is less confused.
See for instance the stub for `Comm::ConnOpener::~ConnOpener()`