### PR TITLE
CI: Revert recent "show build commands on terminal" change

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -148,7 +148,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}
 
       - name: Run build on Linux
-        run: ./test-builds.sh --verbose ${{ matrix.layer.name }}
+        run: ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -181,7 +181,7 @@ jobs:
         uses: github/codeql-action/init@v3
 
       - name: Build Squid
-        run: ./test-builds.sh --verbose ./test-suite/buildtests/layer-02-maximus.opts
+        run: ./test-builds.sh ./test-suite/buildtests/layer-02-maximus.opts
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run test-builds
         id: test-builds
-        run: ./test-builds.sh --verbose ${{ matrix.layer.name }}
+        run: ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -130,7 +130,7 @@ jobs:
           diff -u $editable.bak $editable || true
           echo "::endgroup::"
 
-          ./test-builds.sh --verbose
+          ./test-builds.sh
 
       - name: Publish build logs
         if: success() || failure()
@@ -177,7 +177,7 @@ jobs:
 
           run: |
             export MAKE=gmake
-            ./test-builds.sh --verbose
+            ./test-builds.sh
 
       - name: Publish build logs
         if: success() || failure()
@@ -235,7 +235,7 @@ jobs:
             # until we remove GNUisms from our grep commands,
             # shadow system `grep` with `ggrep` installed/linked earlier
             export PATH="$HOME/bin:$PATH"
-            ./test-builds.sh --verbose
+            ./test-builds.sh
 
       - name: Publish build logs
         if: success() || failure()

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -72,7 +72,8 @@ jobs:
 
       - name: Run test-builds
         id: test-builds
-        run: ./test-builds.sh ${{ matrix.layer.name }}
+        run: |
+          ./test-builds.sh ${{ matrix.layer.name }}
 
       - name: Publish build logs
         if: success() || failure()
@@ -100,7 +101,6 @@ jobs:
       - name: Run test-builds
         id: test-builds
         run: |
-          echo "::group::setup output"
           eval `brew shellenv`
           PKG_CONFIG_PATH="$HOMEBREW_PREFIX/lib/pkgconfig"
           PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$HOMEBREW_PREFIX/opt/openldap/lib/pkgconfig"
@@ -128,7 +128,6 @@ jobs:
           editable=$HOMEBREW_CELLAR/libtool/2.4.7/bin/glibtoolize
           sed -i.bak 's@ltdl_ac_aux_dir=""@ltdl_ac_aux_dir="../build-aux"@' $editable || true
           diff -u $editable.bak $editable || true
-          echo "::endgroup::"
 
           ./test-builds.sh
 

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -235,7 +235,7 @@ jobs:
             # until we remove GNUisms from our grep commands,
             # shadow system `grep` with `ggrep` installed/linked earlier
             export PATH="$HOME/bin:$PATH"
-            ./test-builds.sh
+            ./test-builds.sh --verbose
 
       - name: Publish build logs
         if: success() || failure()

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -71,9 +71,7 @@ logtee() {
     local layer=$2
     case $verbose in
     yes)
-        echo "::group::$layer output" # github collapsible section
         tee $1
-        echo "::endgroup::"
         ;;
     progress)
         tee $1 | awk '{printf "."; n++; if (!(n % 80)) print "" } END {print ""}'

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -68,7 +68,6 @@ while [ $# -ge 1 ]; do
 done
 
 logtee() {
-    local layer=$2
     case $verbose in
     yes)
         tee $1
@@ -112,7 +111,7 @@ buildtest() {
 
 	# log the result for the outer script to notice
 	echo "buildtest.sh result is $result";
-    } 2>&1 | logtee ${log} ${layer}
+    } 2>&1 | logtee ${log}
 
     result=1 # failure by default
     if grep -q '^buildtest.sh result is 0$' ${log}; then


### PR DESCRIPTION
GitHub Actions UI does not handle large amounts of console output with
collapsable `::group::` sections well.
For example, UI may truncate console output if a collapsable `::group::`
section gets too many log lines. In some cases, GitHub does not report
truncation at all, resulting in misleading console output. In other, UI
warns: "This step has been truncated due to its large size. Download the
full logs from the menu once the workflow run has completed."

This change reverts recent commit e5a66fc26d.
