### PR TITLE
CI: Do not classify "no failures" stats as test-build errors

### DIFF
--- a/test-builds.sh
+++ b/test-builds.sh
@@ -126,7 +126,8 @@ buildtest() {
     grep -E "BUILD" ${log}
 
     errors="^ERROR|[ ]error:|[ ]Error[ ]|No[ ]such|assertion[ ]failed|FAIL:|:[ ]undefined"
-    grep -E "${errors}" ${log}
+    noterrors=" X?FAIL:  ?0$"
+    grep -E "${errors}" ${log} | grep -v -E "${noterrors}"
 
     if test $result -eq 0; then
 	# successful execution


### PR DESCRIPTION
CppUnit tests emit a lot of "FAIL: 0" and "XFAIL: 0" lines, which are
incorrectly classified as errors by the test-builds.sh. Filter these
messages out as they are not indicative of problems.
