### PR TITLE
MinGW: use nameless unions in ext_ad_group_acl

### DIFF
--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -181,7 +181,8 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    hr = pUser->Get(SysAllocString(L"primaryGroupID"), &var);
+    static const auto primaryGroupIDStr = SysAllocString(L"primaryGroupID");
+    hr = pUser->Get(primaryGroupIDStr, &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
     } else {
@@ -192,7 +193,8 @@ Get_primaryGroup(IADs * pUser)
     VariantClear(&var);
 
     /*Get the objectSid property */
-    hr = pUser->Get(SysAllocString(L"objectSid"), &var);
+    static const auto objectSidStr = SysAllocString(L"objectSid");
+    hr = pUser->Get(objectSidStr, &var);
     if (SUCCEEDED(hr)) {
         PSID pObjectSID;
         LPBYTE pByte = nullptr;
@@ -266,7 +268,8 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         /* This is a fatal error */
         exit(EXIT_FAILURE);
     }
-    hr = pNto->Init(ADS_NAME_INITTYPE_GC, SysAllocString(L""));
+    static const auto emtpyStr = SysAllocString(L"");
+    hr = pNto->Init(ADS_NAME_INITTYPE_GC, emtpyStr);
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot initialise NameTranslate API, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
         pNto->Release();
@@ -424,7 +427,8 @@ Recursive_Memberof(IADs * pObj)
     HRESULT hr;
 
     VariantInit(&var);
-    hr = pObj->Get(SysAllocString(L"memberOf"), &var);
+    static const auto memberOfStr = SysAllocString(L"memberOf");
+    hr = pObj->Get(memberOfStr, &var);
     if (SUCCEEDED(hr)) {
         if (VT_BSTR == var.vt) {
             if (add_User_Group(var.bstrVal)) {

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -181,7 +181,7 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    hr = pUser->Get(BSTR(L"primaryGroupID"), &var);
+    hr = pUser->Get(SysAllocString(L"primaryGroupID"), &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
     } else {
@@ -192,7 +192,7 @@ Get_primaryGroup(IADs * pUser)
     VariantClear(&var);
 
     /*Get the objectSid property */
-    hr = pUser->Get(BSTR(L"objectSid"), &var);
+    hr = pUser->Get(SysAllocString(L"objectSid"), &var);
     if (SUCCEEDED(hr)) {
         PSID pObjectSID;
         LPBYTE pByte = nullptr;
@@ -245,7 +245,6 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
 {
     IADsNameTranslate *pNto;
     HRESULT hr;
-    BSTR bstr;
     wchar_t *wc;
 
     if (WIN32_COM_initialized == 0) {
@@ -267,7 +266,7 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         /* This is a fatal error */
         exit(EXIT_FAILURE);
     }
-    hr = pNto->Init(ADS_NAME_INITTYPE_GC, BSTR(L""));
+    hr = pNto->Init(ADS_NAME_INITTYPE_GC, SysAllocString(L""));
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot initialise NameTranslate API, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
         pNto->Release();
@@ -280,6 +279,7 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         pNto->Release();
         return nullptr;
     }
+    BSTR bstr;
     hr = pNto->Get(out_format, &bstr);
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot get translate of %S, ERROR: %s\n", name, Get_WIN32_ErrorMessage(hr));
@@ -424,7 +424,7 @@ Recursive_Memberof(IADs * pObj)
     HRESULT hr;
 
     VariantInit(&var);
-    hr = pObj->Get(BSTR(L"memberOf"), &var);
+    hr = pObj->Get(SysAllocString(L"memberOf"), &var);
     if (SUCCEEDED(hr)) {
         if (VT_BSTR == var.vt) {
             if (add_User_Group(var.bstrVal)) {

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -181,7 +181,7 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    hr = pUser->Get(SysAllocString(L"primaryGroupID"), &var);
+    hr = pUser->Get(BSTR(L"primaryGroupID"), &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
     } else {
@@ -192,7 +192,7 @@ Get_primaryGroup(IADs * pUser)
     VariantClear(&var);
 
     /*Get the objectSid property */
-    hr = pUser->Get(SysAllocString(L"objectSid"), &var);
+    hr = pUser->Get(BSTR(L"objectSid"), &var);
     if (SUCCEEDED(hr)) {
         PSID pObjectSID;
         LPBYTE pByte = nullptr;
@@ -267,7 +267,7 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         /* This is a fatal error */
         exit(EXIT_FAILURE);
     }
-    hr = pNto->Init(ADS_NAME_INITTYPE_GC, SysAllocString(L""));
+    hr = pNto->Init(ADS_NAME_INITTYPE_GC, BSTR(L""));
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot initialise NameTranslate API, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
         pNto->Release();
@@ -424,7 +424,7 @@ Recursive_Memberof(IADs * pObj)
     HRESULT hr;
 
     VariantInit(&var);
-    hr = pObj->Get(SysAllocString(L"memberOf"), &var);
+    hr = pObj->Get(BSTR(L"memberOf"), &var);
     if (SUCCEEDED(hr)) {
         if (VT_BSTR == var.vt) {
             if (add_User_Group(var.bstrVal)) {


### PR DESCRIPTION
ext_ad_group_acl was written in 2008 in C, and
it used the C variant of the Win32 API.
It was then ported to C++, but the API callers were
not updated to the C++ version of the API.
With more modern compilers, and
Squid enforcing more strict types and error handling,
it is no longer compiling.

This is part 1 of 2 of the fixes to make the helper build
again, the scope is to update Win32 API callers so they
use the C++ version of the API


Examples of fixed errors:

    error: 'IADs' {aka 'struct IADs'} has no member named 'lpVtbl'
    error: 'VARIANT' {aka 'struct tagVARIANT'} has no member named 'n1'
