### PR TITLE
MinGW: Fix ext_ad_group_acl build errors

### DIFF
--- a/compat/debug.h
+++ b/compat/debug.h
@@ -25,11 +25,13 @@ extern int debug_enabled;
 /* the macro overload style is really a gcc-ism */
 #if defined(__GNUC__) || defined(__SUNPRO_CC)
 
-#define debug(X...) \
-                     if (debug_enabled) { \
-                         fprintf(stderr, "%s(%d): pid=%ld :", __FILE__, __LINE__, static_cast<long>(getpid())); \
-                         fprintf(stderr,X); \
-                     } else (void)0
+#define debug(X...)                                                                                \
+    do {                                                                                           \
+        if (debug_enabled) {                                                                       \
+            fprintf(stderr, "%s(%d): pid=%ld :", __FILE__, __LINE__, static_cast<long>(getpid())); \
+            fprintf(stderr, X);                                                                    \
+        }                                                                                          \
+    } while (/*CONSTCOND*/  0)
 
 #define ndebug(content) ndebug_(__FILE__, __LINE__, content)
 #define ndebug_(file, line, content) if (debug_enabled) { \

--- a/compat/debug.h
+++ b/compat/debug.h
@@ -25,13 +25,13 @@ extern int debug_enabled;
 /* the macro overload style is really a gcc-ism */
 #if defined(__GNUC__) || defined(__SUNPRO_CC)
 
-#define debug(X...)                                                                                \
-    do {                                                                                           \
-        if (debug_enabled) {                                                                       \
+#define debug(X...) \
+    do { \
+        if (debug_enabled) { \
             fprintf(stderr, "%s(%d): pid=%ld :", __FILE__, __LINE__, static_cast<long>(getpid())); \
-            fprintf(stderr, X);                                                                    \
-        }                                                                                          \
-    } while (/*CONSTCOND*/  0)
+            fprintf(stderr, X); \
+        } \
+    } while (/*CONSTCOND*/ 0)
 
 #define ndebug(content) ndebug_(__FILE__, __LINE__, content)
 #define ndebug_(file, line, content) if (debug_enabled) { \

--- a/src/acl/external/AD_group/Makefile.am
+++ b/src/acl/external/AD_group/Makefile.am
@@ -12,12 +12,7 @@ man_MANS = ext_ad_group_acl.8
 
 ext_ad_group_acl_SOURCES = ext_ad_group_acl.cc
 
-#
-# Currently activeds and adsiid libraries are not available on MinGW or Cygwin,
-# so the following library list is just a placeholder for future MinGW/Cygwin releases.
-# This helper can be compiled only using Microsoft Visual Studio.
 # TODO: test for these libraries in required.m4
-#
 ext_ad_group_acl_LDADD = \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \

--- a/src/acl/external/AD_group/Makefile.am
+++ b/src/acl/external/AD_group/Makefile.am
@@ -19,6 +19,7 @@ ext_ad_group_acl_SOURCES = ext_ad_group_acl.cc
 # TODO: test for these libraries in required.m4
 #
 ext_ad_group_acl_LDADD = \
+	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
 	-lnetapi32 \
 	-ladvapi32 \

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -182,7 +182,7 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    stsatic const auto primaryGroupIdString = SysAllocString(L"primaryGroupID");
+    static const auto primaryGroupIdString = SysAllocString(L"primaryGroupID");
     hr = pUser->Get(primaryGroupIdString, &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
@@ -283,6 +283,7 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         pNto->Release();
         return nullptr;
     }
+    BSTR bstr;
     hr = pNto->Get(out_format, &bstr);
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot get translate of %S, ERROR: %s\n", name, Get_WIN32_ErrorMessage(hr));
@@ -489,8 +490,9 @@ Recursive_Memberof(IADs * pObj)
                     }
                     ++lBound;
                 }
-            } else
+            } else {
                 debug("Recursive_Memberof: ERROR SafeArrayGetxBound failed: %s\n", Get_WIN32_ErrorMessage(hr));
+            }
         }
         VariantClear(&var);
     } else {
@@ -637,7 +639,7 @@ Valid_Global_Groups(char *UserName, const char **Groups)
     IADs *pUser;
     HRESULT hr;
 
-    strncpy(NTDomain, UserName, sizeof(NTDomain));
+    strncpy(NTDomain, UserName, sizeof(NTDomain)-1);
 
     for (j = 0; j < strlen(NTV_VALID_DOMAIN_SEPARATOR); ++j) {
         if ((domain_qualify = strchr(NTDomain, NTV_VALID_DOMAIN_SEPARATOR[j])) != NULL)

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -182,8 +182,8 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    static const auto primaryGroupIdString = SysAllocString(L"primaryGroupID");
-    hr = pUser->Get(primaryGroupIdString, &var);
+    static const auto primaryGroupIdStr = SysAllocString(L"primaryGroupID");
+    hr = pUser->Get(primaryGroupIdStr, &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
     } else {
@@ -194,8 +194,8 @@ Get_primaryGroup(IADs * pUser)
     VariantClear(&var);
 
     /*Get the objectSid property */
-    static const auto objectSidString = SysAllocString(L"objectSid");
-    hr = pUser->Get(objectSidString, &var);
+    static const auto objectSidStr = SysAllocString(L"objectSid");
+    hr = pUser->Get(objectSidStr, &var);
     if (SUCCEEDED(hr)) {
         PSID pObjectSID;
         LPBYTE pByte = nullptr;
@@ -270,8 +270,8 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         /* This is a fatal error */
         exit(EXIT_FAILURE);
     }
-    static const auto emptyString = SysAllocString(L"");
-    hr = pNto->Init(ADS_NAME_INITTYPE_GC, emptyString);
+    static const auto emptyStr = SysAllocString(L"");
+    hr = pNto->Init(ADS_NAME_INITTYPE_GC, emptyStr);
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot initialise NameTranslate API, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
         pNto->Release();
@@ -433,8 +433,8 @@ Recursive_Memberof(IADs * pObj)
     HRESULT hr;
 
     VariantInit(&var);
-    static const auto memberOfString = SysAllocString(L"memberOf");
-    hr = pObj->Get(memberOfString, &var);
+    static const auto memberOfStr = SysAllocString(L"memberOf");
+    hr = pObj->Get(memberOfStr, &var);
     if (SUCCEEDED(hr)) {
         if (VT_BSTR == var.vt) {
             if (add_User_Group(var.bstrVal)) {

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -182,7 +182,8 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    hr = pUser->Get(BSTR(L"primaryGroupID"), &var);
+    stsatic const auto primaryGroupIdString = SysAllocString(L"primaryGroupID");
+    hr = pUser->Get(primaryGroupIdString, &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
     } else {
@@ -193,7 +194,8 @@ Get_primaryGroup(IADs * pUser)
     VariantClear(&var);
 
     /*Get the objectSid property */
-    hr = pUser->Get(BSTR(L"objectSid"), &var);
+    static const auto objectSidString = SysAllocString(L"objectSid");
+    hr = pUser->Get(objectSidString, &var);
     if (SUCCEEDED(hr)) {
         PSID pObjectSID;
         LPBYTE pByte = nullptr;
@@ -267,7 +269,8 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         /* This is a fatal error */
         exit(EXIT_FAILURE);
     }
-    hr = pNto->Init(ADS_NAME_INITTYPE_GC, BSTR(L""));
+    static const auto emptyString = SysAllocString(L"");
+    hr = pNto->Init(ADS_NAME_INITTYPE_GC, emptyString);
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot initialise NameTranslate API, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
         pNto->Release();
@@ -425,7 +428,8 @@ Recursive_Memberof(IADs * pObj)
     HRESULT hr;
 
     VariantInit(&var);
-    hr = pObj->Get(BSTR(L"memberOf"), &var);
+    static const auto memberOfString = SysAllocString(L"memberOf");
+    hr = pObj->Get(memberOfString, &var);
     if (SUCCEEDED(hr)) {
         if (VT_BSTR == var.vt) {
             if (add_User_Group(var.bstrVal)) {

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -516,7 +516,7 @@ build_groups_DN_array(const char **array, char *userdomain)
 
     while (*array) {
         if (strchr(*array, '/') != NULL) {
-            strncpy(Group, *array, GNLEN);
+            xstrncpy(Group, *array, GNLEN);
             source_group_format = ADS_NAME_TYPE_CANONICAL;
         } else {
             source_group_format = ADS_NAME_TYPE_NT4;
@@ -525,7 +525,7 @@ build_groups_DN_array(const char **array, char *userdomain)
                 strcat(Group, "\\");
                 strncat(Group, *array, GNLEN - sizeof(userdomain) - 1);
             } else
-                strncpy(Group, *array, GNLEN);
+                xstrncpy(Group, *array, GNLEN);
         }
 
         wcsize = MultiByteToWideChar(CP_ACP, 0, Group, -1, wc, 0);
@@ -639,20 +639,20 @@ Valid_Global_Groups(char *UserName, const char **Groups)
     IADs *pUser;
     HRESULT hr;
 
-    strncpy(NTDomain, UserName, sizeof(NTDomain)-1);
+    xstrncpy(NTDomain, UserName, sizeof(NTDomain));
 
     for (j = 0; j < strlen(NTV_VALID_DOMAIN_SEPARATOR); ++j) {
         if ((domain_qualify = strchr(NTDomain, NTV_VALID_DOMAIN_SEPARATOR[j])) != NULL)
             break;
     }
     if (domain_qualify == NULL) {
-        strncpy(User, DefaultDomain, DNLEN);
+        xstrncpy(User, DefaultDomain, DNLEN);
         strcat(User, "\\");
         strncat(User, UserName, UNLEN);
-        strncpy(NTDomain, DefaultDomain, DNLEN);
+        xstrncpy(NTDomain, DefaultDomain, DNLEN);
     } else {
         domain_qualify[0] = '\\';
-        strncpy(User, NTDomain, DNLEN + UNLEN + 2);
+        xstrncpy(User, NTDomain, DNLEN + UNLEN + 2);
         domain_qualify[0] = '\0';
     }
 

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -849,7 +849,7 @@ main(int argc, char *argv[])
         if ((p = strchr(buf, '\r')) != NULL)
             *p = '\0';      /* strip \r */
 
-        debug("Got '%s' from Squid (length: %d).\n", buf, static_cast<int>(strlen(buf)));
+        debug("Got '%s' from Squid (length: %zu).\n", buf, strlen(buf));
 
         if (buf[0] == '\0') {
             SEND_BH(HLP_MSG("Invalid Request. No Input."));

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -223,8 +223,9 @@ Get_primaryGroup(IADs * pUser)
             debug("Get_primaryGroup: cannot get DN for %s.\n", tmpSID);
         else
             debug("Get_primaryGroup: Primary group DN: %S.\n", result);
-    } else
+    } else {
         debug("Get_primaryGroup: cannot get objectSid, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
+    }
     VariantClear(&var);
     return result;
 }
@@ -353,8 +354,9 @@ GetDomainName(void)
         } else {
             debug("Not a Domain member\n");
         }
-    } else
+    } else {
         debug("GetDomainName: ERROR DsRoleGetPrimaryDomainInformation returned: %s\n", Get_WIN32_ErrorMessage(netret));
+    }
 
     /*
      * Free the allocated memory.
@@ -450,10 +452,12 @@ Recursive_Memberof(IADs * pObj)
                     if (SUCCEEDED(hr)) {
                         hr = Recursive_Memberof(pGrp);
                         pGrp->Release();
-                    } else
+                    } else {
                         debug("Recursive_Memberof: ERROR ADsGetObject for %S failed: %s\n", Group_Path, Get_WIN32_ErrorMessage(hr));
-                } else
+                    }
+                } else {
                     debug("Recursive_Memberof: ERROR ADsGetObject for %S failed: %s\n", Group_Path, Get_WIN32_ErrorMessage(hr));
+                }
                 safe_free(Group_Path);
             }
         } else {
@@ -479,10 +483,12 @@ Recursive_Memberof(IADs * pObj)
                                     hr = Recursive_Memberof(pGrp);
                                     pGrp->Release();
                                     safe_free(Group_Path);
-                                } else
+                                } else {
                                     debug("Recursive_Memberof: ERROR ADsGetObject for %S failed: %s\n", Group_Path, Get_WIN32_ErrorMessage(hr));
-                            } else
+                                }
+                            } else {
                                 debug("Recursive_Memberof: ERROR ADsGetObject for %S failed: %s\n", Group_Path, Get_WIN32_ErrorMessage(hr));
+                            }
                             safe_free(Group_Path);
                         }
                         VariantClear(&elem);
@@ -680,9 +686,9 @@ Valid_Global_Groups(char *UserName, const char **Groups)
         IADs *pGrp;
 
         User_PrimaryGroup = Get_primaryGroup(pUser);
-        if (!User_PrimaryGroup)
+        if (!User_PrimaryGroup) {
             debug("Valid_Global_Groups: cannot get Primary Group for '%s'.\n", User);
-        else {
+        } else {
             add_User_Group(User_PrimaryGroup);
             User_PrimaryGroup_Path = GetLDAPPath(User_PrimaryGroup, GC_MODE);
             hr = ADsGetObject(User_PrimaryGroup_Path, IID_IADs, (void **) &pGrp);
@@ -695,10 +701,12 @@ Valid_Global_Groups(char *UserName, const char **Groups)
                 if (SUCCEEDED(hr)) {
                     hr = Recursive_Memberof(pGrp);
                     pGrp->Release();
-                } else
+                } else {
                     debug("Valid_Global_Groups: ADsGetObject for %S failed, ERROR: %s\n", User_PrimaryGroup_Path, Get_WIN32_ErrorMessage(hr));
-            } else
+                }
+            } else {
                 debug("Valid_Global_Groups: ADsGetObject for %S failed, ERROR: %s\n", User_PrimaryGroup_Path, Get_WIN32_ErrorMessage(hr));
+            }
             safe_free(User_PrimaryGroup_Path);
         }
         hr = Recursive_Memberof(pUser);
@@ -709,8 +717,9 @@ Valid_Global_Groups(char *UserName, const char **Groups)
         if (SUCCEEDED(hr)) {
             hr = Recursive_Memberof(pUser);
             pUser->Release();
-        } else
+        } else {
             debug("Valid_Global_Groups: ADsGetObject for %S failed, ERROR: %s\n", User_LDAP_path, Get_WIN32_ErrorMessage(hr));
+        }
 
         auto tmp = User_Groups;
         while (*tmp) {
@@ -825,12 +834,10 @@ main(int argc, char *argv[])
             DefaultDomain = xstrdup(machinedomain);
     }
     debug("%s " VERSION " " SQUID_BUILD_INFO " starting up...\n", argv[0]);
-    if (use_global) {
+    if (use_global)
         debug("Domain Global group mode enabled using '%s' as default domain.\n", DefaultDomain);
-    }
-    if (use_case_insensitive_compare) {
+    if (use_case_insensitive_compare)
         debug("Warning: running in case insensitive mode !!!\n");
-    }
 
     atexit(CloseCOM);
 

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -496,9 +496,8 @@ Recursive_Memberof(IADs * pObj)
         }
         VariantClear(&var);
     } else {
-        if (hr != E_ADS_PROPERTY_NOT_FOUND) {
+        if (hr != E_ADS_PROPERTY_NOT_FOUND)
             debug("Recursive_Memberof: ERROR getting memberof attribute: %s\n", Get_WIN32_ErrorMessage(hr));
-        }
     }
     return hr;
 }

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -393,8 +393,10 @@ add_User_Group(wchar_t * Group)
 /* returns true on match, false if no match */
 /* TODO: convert to std::containers */
 static bool
-wccmparray(const wchar_t * str, wchar_t ** array)
+wStrIsInArray(const wchar_t * str, wchar_t ** array)
 {
+    if (!array)
+        return false;
     while (*array) {
         debug("Windows group: %S, Squid group: %S\n", str, *array);
         if (wcscmp(str, *array) == 0)
@@ -713,7 +715,7 @@ Valid_Global_Groups(char *UserName, const char **Groups)
 
         auto tmp = User_Groups;
         while (*tmp) {
-            if (wccmparray(*tmp, wszGroups)) {
+            if (wStrIsInArray(*tmp, wszGroups)) {
                 result = 1;
                 break;
             }

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -181,8 +181,7 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    static const auto primaryGroupIDStr = SysAllocString(L"primaryGroupID");
-    hr = pUser->Get(primaryGroupIDStr, &var);
+    hr = pUser->Get(SysAllocString(L"primaryGroupID"), &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
     } else {
@@ -193,8 +192,7 @@ Get_primaryGroup(IADs * pUser)
     VariantClear(&var);
 
     /*Get the objectSid property */
-    static const auto objectSidStr = SysAllocString(L"objectSid");
-    hr = pUser->Get(objectSidStr, &var);
+    hr = pUser->Get(SysAllocString(L"objectSid"), &var);
     if (SUCCEEDED(hr)) {
         PSID pObjectSID;
         LPBYTE pByte = nullptr;
@@ -268,8 +266,7 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         /* This is a fatal error */
         exit(EXIT_FAILURE);
     }
-    static const auto emtpyStr = SysAllocString(L"");
-    hr = pNto->Init(ADS_NAME_INITTYPE_GC, emtpyStr);
+    hr = pNto->Init(ADS_NAME_INITTYPE_GC, SysAllocString(L""));
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot initialise NameTranslate API, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
         pNto->Release();
@@ -282,7 +279,6 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         pNto->Release();
         return nullptr;
     }
-    BSTR bstr;
     hr = pNto->Get(out_format, &bstr);
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot get translate of %S, ERROR: %s\n", name, Get_WIN32_ErrorMessage(hr));
@@ -427,8 +423,7 @@ Recursive_Memberof(IADs * pObj)
     HRESULT hr;
 
     VariantInit(&var);
-    static const auto memberOfStr = SysAllocString(L"memberOf");
-    hr = pObj->Get(memberOfStr, &var);
+    hr = pObj->Get(SysAllocString(L"memberOf"), &var);
     if (SUCCEEDED(hr)) {
         if (VT_BSTR == var.vt) {
             if (add_User_Group(var.bstrVal)) {

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -635,7 +635,8 @@ Valid_Global_Groups(char *UserName, const char **Groups)
     char User[DNLEN + UNLEN + 2];
     size_t j;
 
-    wchar_t *User_DN, *User_LDAP_path, *User_PrimaryGroup;
+    wchar_t *User_DN = nullptr, *User_LDAP_path = nullptr;
+    wchar_t *User_PrimaryGroup = nullptr;
     IADs *pUser;
     HRESULT hr;
 

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -542,7 +542,7 @@ build_groups_DN_array(const char **array, char *userdomain)
         *entry = My_NameTranslate(wc, source_group_format, ADS_NAME_TYPE_1779);
         safe_free(wc);
         ++array;
-        if (!(*entry)) {
+        if (!*entry) {
             debug("build_groups_DN_array: cannot get DN for '%s'.\n", Group);
             continue;
         }

--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -181,7 +181,7 @@ Get_primaryGroup(IADs * pUser)
     VariantInit(&var);
 
     /* Get the primaryGroupID property */
-    hr = pUser->Get(SysAllocString(L"primaryGroupID"), &var);
+    hr = pUser->Get(BSTR(L"primaryGroupID"), &var);
     if (SUCCEEDED(hr)) {
         User_primaryGroupID = var.uintVal;
     } else {
@@ -192,7 +192,7 @@ Get_primaryGroup(IADs * pUser)
     VariantClear(&var);
 
     /*Get the objectSid property */
-    hr = pUser->Get(SysAllocString(L"objectSid"), &var);
+    hr = pUser->Get(BSTR(L"objectSid"), &var);
     if (SUCCEEDED(hr)) {
         PSID pObjectSID;
         LPBYTE pByte = nullptr;
@@ -266,7 +266,7 @@ My_NameTranslate(wchar_t * name, int in_format, int out_format)
         /* This is a fatal error */
         exit(EXIT_FAILURE);
     }
-    hr = pNto->Init(ADS_NAME_INITTYPE_GC, SysAllocString(L""));
+    hr = pNto->Init(ADS_NAME_INITTYPE_GC, BSTR(L""));
     if (FAILED(hr)) {
         debug("My_NameTranslate: cannot initialise NameTranslate API, ERROR: %s\n", Get_WIN32_ErrorMessage(hr));
         pNto->Release();
@@ -423,7 +423,7 @@ Recursive_Memberof(IADs * pObj)
     HRESULT hr;
 
     VariantInit(&var);
-    hr = pObj->Get(SysAllocString(L"memberOf"), &var);
+    hr = pObj->Get(BSTR(L"memberOf"), &var);
     if (SUCCEEDED(hr)) {
         if (VT_BSTR == var.vt) {
             if (add_User_Group(var.bstrVal)) {


### PR DESCRIPTION
- In C++, win32 APIs want references, not pointers
- Fix const mismatch
- Other minor polishing touches
