### PR TITLE
NoNewGlobals for OpenSSL-related structures

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -957,10 +957,10 @@ configDoConfigure(void)
         Ssl::loadSquidUntrusted(Config.ssl_client.foreignIntermediateCertsPath);
 #endif
 
-    if (Security::ProxyOutgoingConfig.encryptTransport) {
+    if (Security::ProxyOutgoingConfig().encryptTransport) {
         debugs(3, 2, "initializing https:// proxy context");
 
-        const auto rawSslContext = Security::ProxyOutgoingConfig.createClientContext(false);
+        const auto rawSslContext = Security::ProxyOutgoingConfig().createClientContext(false);
         Config.ssl_client.sslContext_ = rawSslContext ? new Security::ContextPointer(rawSslContext) : nullptr;
         if (!Config.ssl_client.sslContext_) {
 #if USE_OPENSSL
@@ -972,7 +972,7 @@ configDoConfigure(void)
 #if USE_OPENSSL
         Ssl::useSquidUntrusted(Config.ssl_client.sslContext_->get());
 #endif
-        Config.ssl_client.defaultPeerContext = new Security::FuturePeerContext(Security::ProxyOutgoingConfig, *Config.ssl_client.sslContext_);
+        Config.ssl_client.defaultPeerContext = new Security::FuturePeerContext(Security::ProxyOutgoingConfig(), *Config.ssl_client.sslContext_);
     }
 
     for (const auto &p: CurrentCachePeers()) {
@@ -1112,7 +1112,7 @@ parse_obsolete(const char *name)
             throw TextException(ToSBuf("missing required parameter for obsolete directive: ", name), Here());
 
         tmp.append(token, strlen(token));
-        Security::ProxyOutgoingConfig.parse(tmp.c_str());
+        Security::ProxyOutgoingConfig().parse(tmp.c_str());
     }
 }
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -3024,7 +3024,7 @@ NAME: tls_outgoing_options
 IFDEF: HAVE_LIBGNUTLS||USE_OPENSSL
 TYPE: securePeerOptions
 DEFAULT: min-version=1.0
-LOC: Security::ProxyOutgoingConfig
+LOC: Security::ProxyOutgoingConfig()
 DOC_START
 	disable		Do not support https:// URLs.
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2647,7 +2647,7 @@ Security::ContextPointer
 ConnStateData::getTlsContextFromCache(const SBuf &cacheKey, const Ssl::CertificateProperties &certProperties)
 {
     debugs(33, 5, "Finding SSL certificate for " << cacheKey << " in cache");
-    Ssl::LocalContextStorage * ssl_ctx_cache = Ssl::TheGlobalContextStorage.getLocalStorage(port->s);
+    Ssl::LocalContextStorage * ssl_ctx_cache = Ssl::TheGlobalContextStorage().getLocalStorage(port->s);
     if (const auto ctx = ssl_ctx_cache ? ssl_ctx_cache->get(cacheKey) : nullptr) {
         if (Ssl::verifySslCertificate(*ctx, certProperties)) {
             debugs(33, 5, "Cached SSL certificate for " << certProperties.commonName << " is valid");
@@ -2664,7 +2664,7 @@ ConnStateData::getTlsContextFromCache(const SBuf &cacheKey, const Ssl::Certifica
 void
 ConnStateData::storeTlsContextToCache(const SBuf &cacheKey, Security::ContextPointer &ctx)
 {
-    Ssl::LocalContextStorage *ssl_ctx_cache = Ssl::TheGlobalContextStorage.getLocalStorage(port->s);
+    Ssl::LocalContextStorage *ssl_ctx_cache = Ssl::TheGlobalContextStorage().getLocalStorage(port->s);
     if (!ssl_ctx_cache || !ssl_ctx_cache->add(cacheKey, ctx)) {
         // If it is not in storage delete after using. Else storage deleted it.
         fd_table[clientConnection->fd].dynamicTlsContext = ctx;
@@ -3268,7 +3268,7 @@ clientHttpConnectionsOpen(void)
             }
             if (s->flags.tunnelSslBumping) {
                 // Create ssl_ctx cache for this port.
-                Ssl::TheGlobalContextStorage.addLocalStorage(s->s, s->secure.dynamicCertMemCacheSize);
+                Ssl::TheGlobalContextStorage().addLocalStorage(s->s, s->secure.dynamicCertMemCacheSize);
             }
         }
 #endif

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2647,7 +2647,7 @@ Security::ContextPointer
 ConnStateData::getTlsContextFromCache(const SBuf &cacheKey, const Ssl::CertificateProperties &certProperties)
 {
     debugs(33, 5, "Finding SSL certificate for " << cacheKey << " in cache");
-    Ssl::LocalContextStorage * ssl_ctx_cache = Ssl::TheGlobalContextStorage().getLocalStorage(port->s);
+    const auto ssl_ctx_cache = Ssl::TheGlobalContextStorage().getLocalStorage(port->s);
     if (const auto ctx = ssl_ctx_cache ? ssl_ctx_cache->get(cacheKey) : nullptr) {
         if (Ssl::verifySslCertificate(*ctx, certProperties)) {
             debugs(33, 5, "Cached SSL certificate for " << certProperties.commonName << " is valid");
@@ -2664,7 +2664,7 @@ ConnStateData::getTlsContextFromCache(const SBuf &cacheKey, const Ssl::Certifica
 void
 ConnStateData::storeTlsContextToCache(const SBuf &cacheKey, Security::ContextPointer &ctx)
 {
-    Ssl::LocalContextStorage *ssl_ctx_cache = Ssl::TheGlobalContextStorage().getLocalStorage(port->s);
+    const auto ssl_ctx_cache = Ssl::TheGlobalContextStorage().getLocalStorage(port->s);
     if (!ssl_ctx_cache || !ssl_ctx_cache->add(cacheKey, ctx)) {
         // If it is not in storage delete after using. Else storage deleted it.
         fd_table[clientConnection->fd].dynamicTlsContext = ctx;

--- a/src/main.cc
+++ b/src/main.cc
@@ -857,7 +857,7 @@ mainReconfigureStart(void)
     htcpClosePorts();
 #endif
 #if USE_OPENSSL
-    Ssl::TheGlobalContextStorage.reconfigureStart();
+    Ssl::TheGlobalContextStorage().reconfigureStart();
 #endif
 #if USE_AUTH
     authenticateReset();

--- a/src/security/PeerOptions.cc
+++ b/src/security/PeerOptions.cc
@@ -21,7 +21,12 @@
 
 #include <bitset>
 
-Security::PeerOptions Security::ProxyOutgoingConfig;
+Security::PeerOptions &
+Security::ProxyOutgoingConfig()
+{
+    static const auto peerOptions = new PeerOptions();
+    return *peerOptions;
+}
 
 Security::PeerOptions::PeerOptions()
 {

--- a/src/security/PeerOptions.h
+++ b/src/security/PeerOptions.h
@@ -161,13 +161,13 @@ public:
 };
 
 /// configuration options for DIRECT server access
-extern PeerOptions ProxyOutgoingConfig;
+PeerOptions &ProxyOutgoingConfig();
 
 } // namespace Security
 
 // parse the tls_outgoing_options directive
 void parse_securePeerOptions(Security::PeerOptions *);
-#define free_securePeerOptions(x) Security::ProxyOutgoingConfig.clear()
+#define free_securePeerOptions(x) Security::ProxyOutgoingConfig().clear()
 #define dump_securePeerOptions(e,n,x) do { PackableStream os_(*(e)); os_ << n; (x).dumpCfg(os_,""); os_ << '\n'; } while (false)
 
 #endif /* SQUID_SRC_SECURITY_PEEROPTIONS_H */

--- a/src/ssl/context_storage.cc
+++ b/src/ssl/context_storage.cc
@@ -41,9 +41,9 @@ void Ssl::CertificateStorageAction::dump (StoreEntry *sentry)
     stream << "Port" << delimiter << "Max mem(KB)" << delimiter << "Cert number" << delimiter << "KB/cert" << delimiter << "Mem used(KB)" << delimiter << "Mem free(KB)" << endString;
 
     // Add info for each port.
-    for (std::map<Ip::Address, LocalContextStorage *>::iterator i = TheGlobalContextStorage().storage.begin(); i != TheGlobalContextStorage().storage.end(); ++i) {
-        stream << i->first << delimiter;
-        LocalContextStorage & ssl_store_policy(*(i->second));
+    for (const auto &i : TheGlobalContextStorage().storage) {
+        stream << i.first << delimiter;
+        LocalContextStorage & ssl_store_policy(*(i.second));
         const auto memoryPerEntry = ssl_store_policy.entries() ?
                                     ssl_store_policy.memoryUsed() / ssl_store_policy.entries() : 0;
         stream << ssl_store_policy.memLimit() / 1024 << delimiter;

--- a/src/ssl/context_storage.cc
+++ b/src/ssl/context_storage.cc
@@ -41,7 +41,7 @@ void Ssl::CertificateStorageAction::dump (StoreEntry *sentry)
     stream << "Port" << delimiter << "Max mem(KB)" << delimiter << "Cert number" << delimiter << "KB/cert" << delimiter << "Mem used(KB)" << delimiter << "Mem free(KB)" << endString;
 
     // Add info for each port.
-    for (std::map<Ip::Address, LocalContextStorage *>::iterator i = TheGlobalContextStorage.storage.begin(); i != TheGlobalContextStorage.storage.end(); ++i) {
+    for (std::map<Ip::Address, LocalContextStorage *>::iterator i = TheGlobalContextStorage().storage.begin(); i != TheGlobalContextStorage().storage.end(); ++i) {
         stream << i->first << delimiter;
         LocalContextStorage & ssl_store_policy(*(i->second));
         const auto memoryPerEntry = ssl_store_policy.entries() ?
@@ -120,5 +120,10 @@ void Ssl::GlobalContextStorage::reconfigureFinish()
     }
 }
 
-Ssl::GlobalContextStorage Ssl::TheGlobalContextStorage;
+Ssl::GlobalContextStorage &
+Ssl::TheGlobalContextStorage()
+{
+    static const auto storage = new GlobalContextStorage();
+    return *storage;
+}
 

--- a/src/ssl/context_storage.cc
+++ b/src/ssl/context_storage.cc
@@ -43,7 +43,7 @@ void Ssl::CertificateStorageAction::dump (StoreEntry *sentry)
     // Add info for each port.
     for (const auto &i: TheGlobalContextStorage().storage) {
         stream << i.first << delimiter;
-        LocalContextStorage & ssl_store_policy(*(i.second));
+        const auto &ssl_store_policy = *i.second;
         const auto memoryPerEntry = ssl_store_policy.entries() ?
                                     ssl_store_policy.memoryUsed() / ssl_store_policy.entries() : 0;
         stream << ssl_store_policy.memLimit() / 1024 << delimiter;

--- a/src/ssl/context_storage.cc
+++ b/src/ssl/context_storage.cc
@@ -41,7 +41,7 @@ void Ssl::CertificateStorageAction::dump (StoreEntry *sentry)
     stream << "Port" << delimiter << "Max mem(KB)" << delimiter << "Cert number" << delimiter << "KB/cert" << delimiter << "Mem used(KB)" << delimiter << "Mem free(KB)" << endString;
 
     // Add info for each port.
-    for (const auto &i : TheGlobalContextStorage().storage) {
+    for (const auto &i: TheGlobalContextStorage().storage) {
         stream << i.first << delimiter;
         LocalContextStorage & ssl_store_policy(*(i.second));
         const auto memoryPerEntry = ssl_store_policy.entries() ?

--- a/src/ssl/context_storage.h
+++ b/src/ssl/context_storage.h
@@ -74,7 +74,7 @@ private:
 };
 
 /// Global cache for store all SSL server certificates.
-extern GlobalContextStorage TheGlobalContextStorage;
+GlobalContextStorage &TheGlobalContextStorage();
 } //namespace Ssl
 #endif // USE_OPENSSL
 

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -1453,7 +1453,7 @@ void
 Ssl::unloadSquidUntrusted()
 {
     if (SquidUntrustedCerts().size()) {
-        for (const auto &i : SquidUntrustedCerts()) {
+        for (const auto &i: SquidUntrustedCerts()) {
             X509_free(i.second);
         }
         SquidUntrustedCerts().clear();

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -1453,8 +1453,8 @@ void
 Ssl::unloadSquidUntrusted()
 {
     if (SquidUntrustedCerts().size()) {
-        for (Ssl::CertsIndexedList::iterator it = SquidUntrustedCerts().begin(); it != SquidUntrustedCerts().end(); ++it) {
-            X509_free(it->second);
+        for (const auto &i : SquidUntrustedCerts()) {
+            X509_free(i.second);
         }
         SquidUntrustedCerts().clear();
     }

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -41,8 +41,6 @@
 // TODO: Move ssl_ex_index_* global variables from global.cc here.
 static int ssl_ex_index_verify_callback_parameters = -1;
 
-static Ssl::CertsIndexedList SquidUntrustedCerts;
-
 const EVP_MD *Ssl::DefaultSignHash = nullptr;
 
 std::vector<const char *> Ssl::BumpModeStr = {
@@ -72,6 +70,13 @@ protected:
 
     AnyP::Host needle_; ///< a name we are looking for
 };
+
+static CertsIndexedList &
+SquidUntrustedCerts()
+{
+    static auto untrustedCerts = new CertsIndexedList();
+    return *untrustedCerts;
+}
 
 } // namespace Ssl
 
@@ -1306,7 +1311,7 @@ Ssl::findIssuerCertificate(X509 *cert, const STACK_OF(X509) *serverCertificates,
     }
 
     // check untrusted certificates
-    if (const auto issuer = findCertIssuerFast(SquidUntrustedCerts, cert)) {
+    if (const auto issuer = findCertIssuerFast(SquidUntrustedCerts(), cert)) {
         X509_up_ref(issuer);
         return Security::CertPointer(issuer);
     }
@@ -1347,7 +1352,7 @@ static void
 completeIssuers(X509_STORE_CTX *ctx, STACK_OF(X509) &untrustedCerts)
 {
     debugs(83, 2,  "completing " << sk_X509_num(&untrustedCerts) <<
-           " OpenSSL untrusted certs using " << SquidUntrustedCerts.size() <<
+           " OpenSSL untrusted certs using " << Ssl::SquidUntrustedCerts().size() <<
            " configured untrusted certificates");
 
     const X509_VERIFY_PARAM *param = X509_STORE_CTX_get0_param(ctx);
@@ -1397,7 +1402,7 @@ VerifyCtxCertificates(X509_STORE_CTX *ctx, STACK_OF(X509) *extraCerts)
 
     // If the local untrusted certificates internal database is used
     // run completeIssuers to add missing certificates if possible.
-    if (SquidUntrustedCerts.size() > 0)
+    if (Ssl::SquidUntrustedCerts().size() > 0)
         completeIssuers(ctx, *untrustedCerts);
 
     X509_STORE_CTX_set0_untrusted(ctx, untrustedCerts.get()); // No locking/unlocking, just sets ctx->untrusted
@@ -1441,17 +1446,17 @@ Ssl::useSquidUntrusted(SSL_CTX *sslContext)
 bool
 Ssl::loadSquidUntrusted(const char *path)
 {
-    return Ssl::loadCerts(path, SquidUntrustedCerts);
+    return Ssl::loadCerts(path, SquidUntrustedCerts());
 }
 
 void
 Ssl::unloadSquidUntrusted()
 {
-    if (SquidUntrustedCerts.size()) {
-        for (Ssl::CertsIndexedList::iterator it = SquidUntrustedCerts.begin(); it != SquidUntrustedCerts.end(); ++it) {
+    if (SquidUntrustedCerts().size()) {
+        for (Ssl::CertsIndexedList::iterator it = SquidUntrustedCerts().begin(); it != SquidUntrustedCerts().end(); ++it) {
             X509_free(it->second);
         }
-        SquidUntrustedCerts.clear();
+        SquidUntrustedCerts().clear();
     }
 }
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -112,7 +112,7 @@ EncryptorAnswer &PeerConnector::answer() STUB_RETREF(EncryptorAnswer)
 }
 
 #include "security/PeerOptions.h"
-Security::PeerOptions Security::ProxyOutgoingConfig() STUB
+Security::PeerOptions &Security::ProxyOutgoingConfig() STUB_RETREF(Security::PeerOptions)
 
 Security::PeerOptions::PeerOptions() {
 #if USE_OPENSSL

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -112,7 +112,7 @@ EncryptorAnswer &PeerConnector::answer() STUB_RETREF(EncryptorAnswer)
 }
 
 #include "security/PeerOptions.h"
-Security::PeerOptions Security::ProxyOutgoingConfig;
+Security::PeerOptions Security::ProxyOutgoingConfig() STUB
 
 Security::PeerOptions::PeerOptions() {
 #if USE_OPENSSL

--- a/src/tests/stub_libsslsquid.cc
+++ b/src/tests/stub_libsslsquid.cc
@@ -40,7 +40,6 @@ void Ssl::GlobalContextStorage::addLocalStorage(Ip::Address const &, size_t ) ST
 Ssl::LocalContextStorage *Ssl::GlobalContextStorage::getLocalStorage(Ip::Address const &)
 { fatal(STUB_API " required"); static LocalContextStorage v(0); return &v; }
 void Ssl::GlobalContextStorage::reconfigureStart() STUB
-//Ssl::GlobalContextStorage Ssl::TheGlobalContextStorage;
 
 #include "ssl/ErrorDetail.h"
 #include "ssl/support.h"


### PR DESCRIPTION
These changes were anticipated in Bug 5390 fix (recent commit c565067):
https://bugs.squid-cache.org/show_bug.cgi?id=5390#c16

They eliminate all known OpenSSL-related globals:

* Security::ProxyOutgoingConfig
* Ssl::SquidUntrustedCerts
* Ssl::TheGeneratorRequests
* Ssl::TheGlobalContextStorage

Also applied AAA and range-based `for` loop upgrades to modified lines.
