### PR TITLE
MinGW: Fix winldap.h detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1185,7 +1185,7 @@ SQUID_CHECK_LIB_WORKS(ldap,[
     dnl On MinGW OpenLDAP is not available, try Windows LDAP libraries
     dnl TODO: use AC_CHECK_LIB
     LIBLDAP_LIBS="-lwldap32"
-    AC_CHECK_HEADERS(winldap.h,,,[
+    AC_CHECK_HEADERS([windows.h winldap.h],,,[
       #if HAVE_WINDOWS_H
       #include <windows.h>
       #endif

--- a/configure.ac
+++ b/configure.ac
@@ -1185,7 +1185,11 @@ SQUID_CHECK_LIB_WORKS(ldap,[
     dnl On MinGW OpenLDAP is not available, try Windows LDAP libraries
     dnl TODO: use AC_CHECK_LIB
     LIBLDAP_LIBS="-lwldap32"
-    AC_CHECK_HEADERS(winldap.h)
+    AC_CHECK_HEADERS(winldap.h,,,[
+      #if HAVE_WINDOWS_H
+      #include <windows.h>
+      #endif
+    ])
   ])
   AC_CHECK_HEADERS(ldap.h lber.h)
   AC_CHECK_HEADERS(mozldap/ldap.h)


### PR DESCRIPTION
<winldap.h> requires <windows.h> to be previously
included in order to compile.

    configure:38466: checking for winldap.h
    wincrypt.h:5051:254: error: 'PSYSTEMTIME' has not been declared