### PR TITLE
Fix Mem::Segment::open() stub to fix build without shm_open()

### DIFF
--- a/src/ipc/mem/Segment.cc
+++ b/src/ipc/mem/Segment.cc
@@ -343,7 +343,7 @@ Ipc::Mem::Segment::create(const off_t aSize)
 }
 
 void
-Ipc::Mem::Segment::open(const bool)
+Ipc::Mem::Segment::open(bool)
 {
     assert(!theMem);
     checkSupport("Fake segment open");

--- a/src/ipc/mem/Segment.cc
+++ b/src/ipc/mem/Segment.cc
@@ -343,7 +343,7 @@ Ipc::Mem::Segment::create(const off_t aSize)
 }
 
 void
-Ipc::Mem::Segment::open()
+Ipc::Mem::Segment::open(const bool)
 {
     assert(!theMem);
     checkSupport("Fake segment open");


### PR DESCRIPTION
When the environment does not HAVE_SHM, Ipc::Mem::Segment::open() method
definition does not match its declaration. Make it match.

    src/ipc/mem/Segment.cc:346:1: error: no declaration matches
    void Ipc::Mem::Segment::open()
    src/ipc/mem/Segment.h:37:10: note: candidate is:
    void Ipc::Mem::Segment::open(bool)