### PR TITLE
MingGW: do not build ext_edirectory_userip_acl

### DIFF
--- a/src/acl/external/eDirectory_userip/required.m4
+++ b/src/acl/external/eDirectory_userip/required.m4
@@ -5,4 +5,8 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AS_IF([test "x$LIBLDAP_LIBS" != "x"],[BUILD_HELPER="eDirectory_userip"])
+AS_IF([
+    test "x$LIBLDAP_LIBS" != "x" -a "x$squid_host_os" != "xmingw"
+],[
+    BUILD_HELPER="eDirectory_userip"
+])

--- a/src/acl/external/eDirectory_userip/required.m4
+++ b/src/acl/external/eDirectory_userip/required.m4
@@ -5,8 +5,6 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AS_IF([
-    test "x$LIBLDAP_LIBS" != "x" -a "x$squid_host_os" != "xmingw"
-],[
-    BUILD_HELPER="eDirectory_userip"
+AS_IF([test "x$LIBLDAP_LIBS" != "x" -a "x$squid_host_os" != "xmingw"],[
+  BUILD_HELPER="eDirectory_userip"
 ])


### PR DESCRIPTION
ext_edirectory_userip_acl uses API that are too
different from what is provided by windlap.h, do not build it