### PR TITLE
MinGW: add mkdir adapter

### DIFF
--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -46,5 +46,8 @@ fsync(int fd)
 }
 #endif
 
+/* importaed from mswindows.h */
+#define mkdir(p, F) ::mkdir((p))
+
 #endif /* _SQUID_MINGW_*/
 #endif /* SQUID_COMPAT_OS_MINGW_H */

--- a/src/acl/external/eDirectory_userip/required.m4
+++ b/src/acl/external/eDirectory_userip/required.m4
@@ -5,4 +5,8 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AS_IF([test "x$LIBLDAP_LIBS" != "x"],[BUILD_HELPER="eDirectory_userip"])
+AS_IF([
+    test "x$LIBLDAP_LIBS" != "x" -a "x$squid_host_os" != "xmingw"
+],[
+    BUILD_HELPER="eDirectory_userip"
+])

--- a/src/acl/external/eDirectory_userip/required.m4
+++ b/src/acl/external/eDirectory_userip/required.m4
@@ -5,8 +5,4 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AS_IF([
-    test "x$LIBLDAP_LIBS" != "x" -a "x$squid_host_os" != "xmingw"
-],[
-    BUILD_HELPER="eDirectory_userip"
-])
+AS_IF([test "x$LIBLDAP_LIBS" != "x"],[BUILD_HELPER="eDirectory_userip"])


### PR DESCRIPTION
On Windows, mkdir only takes one argument.
compat/mswindows.h has an adapter, add it to
compat/mingw.h as well.

Solves error:

```
UFSSwapDir.cc:617:26: error: too many arguments to function 'int mkdir(const char*)'
/usr/x86_64-w64-mingw32/sys-root/mingw/include/io.h:282:15: note: declared here
  282 |   int __cdecl mkdir (const char *) __MINGW_ATTRIB_DEPRECATED_MSVC2005;
```