### PR TITLE
MinGW: fix aio compatibility layer

### DIFF
--- a/src/DiskIO/AIO/aio_win32.h
+++ b/src/DiskIO/AIO/aio_win32.h
@@ -15,7 +15,7 @@
 typedef int64_t off64_t;
 #endif
 
-#if _SQUID_WINDOWS_
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
 
 union sigval {
     int sival_int; /* integer value */

--- a/src/DiskIO/AIO/async_io.h
+++ b/src/DiskIO/AIO/async_io.h
@@ -11,7 +11,7 @@
 
 #if HAVE_DISKIO_MODULE_AIO
 
-#if _SQUID_WINDOWS_
+#if _SQUID_WINDOWS_ || _SQUID_MINGW_
 #include "DiskIO/AIO/aio_win32.h"
 #else
 #if HAVE_AIO_H


### PR DESCRIPTION
The AIO Windows compatibilty layer is also
necessary on mingw

Problems fixed:

```
DiskIO/AIO/async_io.h:58:18:
    error: field 'aq_e_aiocb' has incomplete type 'aiocb'
DiskIO/AIO/async_io.h:58:12:
     note: forward declaration of 'struct aiocb'

DiskIO/AIO/AIODiskFile.cc:
    In member function
    'virtual void AIODiskFile::read(ReadRequest*)':
src/DiskIO/AIO/AIODiskFile.cc:134:9:
    error: 'aio_read' was not declared in this scope;
    did you mean 'file_read' ?
```