### PR TITLE
Portability: add include guards to ldap_backend.cc

### DIFF
--- a/src/auth/digest/LDAP/ldap_backend.cc
+++ b/src/auth/digest/LDAP/ldap_backend.cc
@@ -46,8 +46,12 @@ PFldap_start_tls_s Win32_ldap_start_tls_s;
 
 #else
 
+#if HAVE_LBER_H
 #include <lber.h>
+#endif
+#if HAVE_LDAP_H
 #include <ldap.h>
+#endif
 
 #endif
 #define PROGRAM_NAME "digest_pw_auth(LDAP_backend)"


### PR DESCRIPTION
In the non-Windows case, we unconditinoally
include some system headers. Add conditions
for improved portability

Fixes error:
```
src/auth/digest/LDAP/ldap_backend.cc:49:10:
   fatal error: lber.h: No such file or directory
```