### PR TITLE
Prevent instances shared memory segments clashes

### DIFF
--- a/src/Instance.cc
+++ b/src/Instance.cc
@@ -265,7 +265,7 @@ Instance::WriteOurPid()
 }
 
 /// Returns murmur3 hash of the PID file name to make a uniq service name.
-/// It is called from the Ipc::Mem::Segment::GenerateName() function.
+/// It is called from Ipc::Mem::Segment::GenerateName() and Ipc::Port::MakeAddr() functions.
 SBuf
 Instance::GetPidFilenameHash()
 {

--- a/src/Instance.h
+++ b/src/Instance.h
@@ -30,6 +30,10 @@ void WriteOurPid();
 /// Throws if PID file maintenance is disabled.
 pid_t Other();
 
+/// Returns murmur3 hash of the PID file name to make a uniq service name
+/// to use it in the shared memory segments naming
+SBuf GetPidFilenameHash();
+
 } // namespace Instance
 
 #endif /* SQUID_SRC_INSTANCE_H */

--- a/src/ipc/Port.cc
+++ b/src/ipc/Port.cc
@@ -69,8 +69,10 @@ Ipc::Port::CoordinatorAddr()
 {
     static String coordinatorAddr;
     if (!coordinatorAddr.size()) {
-        coordinatorAddr= channelPathPfx;
+        coordinatorAddr = channelPathPfx;
         coordinatorAddr.append(service_name.c_str());
+        coordinatorAddr.append('.');
+        coordinatorAddr.append(Instance::GetPidFilenameHash().c_str());
         coordinatorAddr.append(coordinatorAddrLabel);
         coordinatorAddr.append(".ipc");
     }

--- a/src/ipc/Port.cc
+++ b/src/ipc/Port.cc
@@ -14,6 +14,7 @@
 #include "comm/Read.h"
 #include "CommCalls.h"
 #include "ipc/Port.h"
+#include "Instance.h"
 #include "sbuf/Stream.h"
 #include "tools.h"
 #include "util.h"
@@ -54,6 +55,8 @@ String Ipc::Port::MakeAddr(const char* processLabel, int id)
     assert(id >= 0);
     String addr = channelPathPfx;
     addr.append(service_name.c_str());
+    addr.append('.');
+    addr.append(Instance::GetPidFilenameHash().c_str());
     addr.append(processLabel);
     addr.append('-');
     addr.append(xitoa(id));

--- a/src/ipc/mem/Segment.cc
+++ b/src/ipc/mem/Segment.cc
@@ -14,6 +14,7 @@
 #include "debug/Stream.h"
 #include "fatal.h"
 #include "ipc/mem/Segment.h"
+#include "Instance.h"
 #include "sbuf/SBuf.h"
 #include "SquidConfig.h"
 #include "tools.h"
@@ -279,6 +280,8 @@ Ipc::Mem::Segment::GenerateName(const char *id)
     } else {
         name.append('/');
         name.append(service_name.c_str());
+        name.append('.');
+        name.append(Instance::GetPidFilenameHash().c_str());
         name.append('-');
     }
 


### PR DESCRIPTION
Add uniq instance hash-codes generated from the instacne PID file name to the names of the shared memory segments and ipc-files.
This prevents shared memory clashes when running multiple instances with the same service name.
It is an implementation of the A-example, which was described in the mailing list:
https://lists.squid-cache.org/pipermail/squid-users/2025-March/027500.html

It uses murmur3_32 hash algorithm to produce an 8-character code from the filename of the PID of the instance and add it to the corresponding filenames (in functions Ipc::Mem::Segment::GenerateName(), Ipc::Port::MakeAddr() and Ipc::Port::CoordinatorAddr()).

Some examples of names:
```/dev/squid.e7815e09-cf__metadata.shm
/dev/squid.e7815e09-cf__queues.shm
/dev/squid.e7815e09-cf__readers.shm
/dev/squid.e7815e09-tls_session_cache.shm

/var/run/squid/squid.e7815e09-coordinator.ipc
/var/run/squid/squid.e7815e09-kid-1.ipc
/var/run/squid/squid.e7815e09-kid-2.ipc
/var/run/squid/squid.e7815e09-kid-3.ipc
```
