### PR TITLE
MinGW: add libnettle to negotiate_sspi_auth

### DIFF
--- a/src/auth/negotiate/SSPI/Makefile.am
+++ b/src/auth/negotiate/SSPI/Makefile.am
@@ -17,6 +17,7 @@ negotiate_sspi_auth_LDADD = \
 	$(top_builddir)/lib/sspi/libsspwin32.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	-ladvapi32 \
 	$(XTRA_LIBS)
 


### PR DESCRIPTION
libnettle is needed to build negotiate_sspi_auth.

This change fixes many errors similar to:

    negotiate_sspi_auth.cc:126: undefined reference to
        nettle_base64_decode_init
