### PR TITLE
negotiate_sspi_auth: Fix command debugging (-v)

### DIFF
--- a/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
+++ b/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
@@ -168,7 +168,7 @@ manage_request()
     if ((strlen(buf) > 3) && Negotiate_packet_debug_enabled) {
         if (!token_decode(&decodedLen, decoded, buf+3))
             return 1;
-        strncpy(helper_command, buf, 2);
+        xstrncpy(helper_command, buf, 2);
         debug("Got '%s' from Squid with data:\n", helper_command);
         hex_dump(reinterpret_cast<unsigned char*>(decoded), decodedLen);
     } else

--- a/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
+++ b/src/auth/negotiate/SSPI/negotiate_sspi_auth.cc
@@ -168,7 +168,7 @@ manage_request()
     if ((strlen(buf) > 3) && Negotiate_packet_debug_enabled) {
         if (!token_decode(&decodedLen, decoded, buf+3))
             return 1;
-        xstrncpy(helper_command, buf, 2);
+        xstrncpy(helper_command, buf, sizeof(helper_command));
         debug("Got '%s' from Squid with data:\n", helper_command);
         hex_dump(reinterpret_cast<unsigned char*>(decoded), decodedLen);
     } else


### PR DESCRIPTION
Terminate helper_command buffer before using it as a c-string. Supported
helper commands have two characters.

This change also reduces MinGW build errors.