### PR TITLE
MinGW: do not build negotiate_wrapper

### DIFF
--- a/src/auth/negotiate/wrapper/required.m4
+++ b/src/auth/negotiate/wrapper/required.m4
@@ -5,4 +5,6 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-BUILD_HELPER="wrapper"
+AS_IF([test "x$squid_host_os" != "xmingw"], [
+    BUILD_HELPER="wrapper"
+])


### PR DESCRIPTION
MinGW is missing fork(2). Deeper changes will be
needed to build this helper