### PR TITLE
ntlm_fake_auth: Fix command debugging (-v)

### DIFF
--- a/src/auth/ntlm/fake/ntlm_fake_auth.cc
+++ b/src/auth/ntlm/fake/ntlm_fake_auth.cc
@@ -176,8 +176,7 @@ main(int argc, char *argv[])
         }
 
         if (buflen > 3 && NTLM_packet_debug_enabled) {
-            strncpy(helper_command, buf, 2);
-            helper_command[2] = '\0';
+            xstrncpy(helper_command, buf, sizeof(helper_command));
             debug("Got '%s' from Squid with data:\n", helper_command);
             hex_dump((unsigned char *)decodedBuf, decodedLen);
         } else


### PR DESCRIPTION
Terminate helper_command buffer before using it as a c-string. Supported
helper commands have two characters.