### PR TITLE
Do not reuse an idle connection to a removed cache_peer

### DIFF
--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -139,6 +139,12 @@ Comm::Connection::setPeer(CachePeer *p)
     }
 }
 
+bool
+Comm::Connection::toGoneCachePeer() const
+{
+    return peer_ && !cbdataReferenceValid(peer_);
+}
+
 time_t
 Comm::Connection::timeLeft(const time_t idleTimeout) const
 {

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -116,6 +116,9 @@ public:
      */
     void setPeer(CachePeer * p);
 
+    /// whether this is a connection to a cache_peer that was removed during reconfiguration
+    bool toGoneCachePeer() const;
+
     /** The time the connection started */
     time_t startTime() const {return startTime_;}
 

--- a/src/pconn.cc
+++ b/src/pconn.cc
@@ -227,6 +227,11 @@ IdleConnList::pop()
         if (fd_table[theList_[i]->fd].timeoutHandler == nullptr)
             continue;
 
+        // the cache_peer has been removed from the configuration
+        // TODO: remove all such connections at once during reconfiguration
+        if (theList_[i]->toGoneCachePeer())
+            continue;
+
         // finally, a match. pop and return it.
         Comm::ConnectionPointer result = theList_[i];
         clearHandlers(result);
@@ -272,6 +277,11 @@ IdleConnList::findUseable(const Comm::ConnectionPointer &aKey)
         // our connection timeout handler is scheduled to run already. unsafe for now.
         // TODO: cancel the pending timeout callback and allow re-use of the conn.
         if (fd_table[theList_[i]->fd].timeoutHandler == nullptr)
+            continue;
+
+        // the cache_peer has been removed from the configuration
+        // TODO: remove all such connections at once during reconfiguration
+        if (theList_[i]->toGoneCachePeer())
             continue;
 
         // finally, a match. pop and return it.


### PR DESCRIPTION
Sending new requests to a removed cache_peer contradicts current Squid
configuration and even exposes Squid code that forgets to check
CachePeer validity to dangling pointers. We will address the latter
concern separately.