### PR TITLE
MingGW: emulate pipe(2)

### DIFF
--- a/compat/os/mingw.h
+++ b/compat/os/mingw.h
@@ -46,7 +46,9 @@ fsync(int fd)
 }
 #endif
 
-#define mkdir(p,F) mkdir((p))
+/* importaed from mswindows.h */
+#define mkdir(p, F) ::mkdir((p))
+#define pipe(pipefd) ::_pipe((pipefd), 4096, _O_BINARY)
 
 #endif /* _SQUID_MINGW_*/
 #endif /* SQUID_COMPAT_OS_MINGW_H */


### PR DESCRIPTION
The pipe(2) function is not available on Windows,
in favour of a broader _pipe() call.

Wrap it in a macro to maintain the interface

Solves error:
```
DiskThreads/CommIO.cc:
   In static member function 'static void CommIO::Initialize()':
DiskThreads/CommIO.cc:26:9: error:
    'pipe' was not declared in this scope; did you mean '_pipe'?
```