### PR TITLE
ntlm_sspi_auth: Fix missing base64 symbol linkage

### DIFF
--- a/src/auth/ntlm/SSPI/Makefile.am
+++ b/src/auth/ntlm/SSPI/Makefile.am
@@ -16,6 +16,7 @@ ntlm_sspi_auth_LDADD= \
 	$(top_builddir)/lib/sspi/libsspwin32.la \
 	$(top_builddir)/lib/libmiscencoding.la \
 	$(COMPAT_LIB) \
+	$(LIBNETTLE_LIBS) \
 	-lnetapi32 \
 	-ladvapi32 \
 	$(XTRA_LIBS)


### PR DESCRIPTION
Solve build error:

```
ld: ntlm_sspi_auth.o: in function `token_decode':
    undefined reference to `nettle_base64_decode_init'
    undefined reference to `nettle_base64_decode_update'
    undefined reference to `nettle_base64_decode_final'
```