### PR TITLE
Remove HttpRequest::peer_host

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -93,7 +93,6 @@ HttpRequest::init()
     error.clear();
     peer_login = nullptr;      // not allocated/deallocated by this class
     peer_domain = nullptr;     // not allocated/deallocated by this class
-    peer_host = nullptr;
     vary_headers = SBuf();
     myportname = null_string;
     tag = null_string;

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -162,8 +162,6 @@ public:
 
     char *peer_login;       /* Configured peer login:password */
 
-    char *peer_host;           /* Selected peer host*/
-
     time_t lastmod;     /* Used on refreshes */
 
     /// The variant second-stage cache key. Generated from Vary header pattern for this request.

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -146,10 +146,12 @@ Http::Tunneler::writeRequest()
         mb.init();
         mb.appendf("CONNECT %s HTTP/1.1\r\n", url.c_str());
         HttpHeader hdr_out(hoRequest);
+        const auto peer = connection->getPeer();
         HttpStateData::httpBuildRequestHeader(request.getRaw(),
                                               nullptr, // StoreEntry
                                               al,
                                               &hdr_out,
+                                              (peer ? peer->host : nullptr),
                                               flags);
         hdr_out.packInto(&mb);
         hdr_out.clean();

--- a/src/clients/HttpTunneler.cc
+++ b/src/clients/HttpTunneler.cc
@@ -146,12 +146,11 @@ Http::Tunneler::writeRequest()
         mb.init();
         mb.appendf("CONNECT %s HTTP/1.1\r\n", url.c_str());
         HttpHeader hdr_out(hoRequest);
-        const auto peer = connection->getPeer();
         HttpStateData::httpBuildRequestHeader(request.getRaw(),
                                               nullptr, // StoreEntry
                                               al,
                                               &hdr_out,
-                                              (peer ? peer->host : nullptr),
+                                              connection->getPeer(),
                                               flags);
         hdr_out.packInto(&mb);
         hdr_out.clean();

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1533,7 +1533,7 @@ htcpQuery(StoreEntry * e, HttpRequest * req, CachePeer * p)
     stuff.S.method = sb.c_str();
     stuff.S.uri = (char *) e->url();
     stuff.S.version = vbuf;
-    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, flags);
+    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p->host, flags);
     MemBuf mb;
     mb.init();
     hdr.packInto(&mb);
@@ -1588,7 +1588,7 @@ htcpClear(StoreEntry * e, HttpRequest * req, const HttpRequestMethod &, CachePee
     stuff.S.uri = uri.c_str();
     stuff.S.version = vbuf;
     if (reason != HTCP_CLR_INVALIDATION) {
-        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, flags);
+        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p->host, flags);
         mb.init();
         hdr.packInto(&mb);
         hdr.clean();

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1533,7 +1533,7 @@ htcpQuery(StoreEntry * e, HttpRequest * req, CachePeer * p)
     stuff.S.method = sb.c_str();
     stuff.S.uri = (char *) e->url();
     stuff.S.version = vbuf;
-    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p->host, flags);
+    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p, flags);
     MemBuf mb;
     mb.init();
     hdr.packInto(&mb);
@@ -1588,7 +1588,7 @@ htcpClear(StoreEntry * e, HttpRequest * req, const HttpRequestMethod &, CachePee
     stuff.S.uri = uri.c_str();
     stuff.S.version = vbuf;
     if (reason != HTCP_CLR_INVALIDATION) {
-        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p->host, flags);
+        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p, flags);
         mb.init();
         hdr.packInto(&mb);
         hdr.clean();

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1533,7 +1533,8 @@ htcpQuery(StoreEntry * e, HttpRequest * req, CachePeer * p)
     stuff.S.method = sb.c_str();
     stuff.S.uri = (char *) e->url();
     stuff.S.version = vbuf;
-    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p, flags);
+    const auto peer = cbdataReferenceValid(p) ? p : nullptr;
+    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, peer, flags);
     MemBuf mb;
     mb.init();
     hdr.packInto(&mb);
@@ -1588,7 +1589,8 @@ htcpClear(StoreEntry * e, HttpRequest * req, const HttpRequestMethod &, CachePee
     stuff.S.uri = uri.c_str();
     stuff.S.version = vbuf;
     if (reason != HTCP_CLR_INVALIDATION) {
-        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p, flags);
+        const auto peer = cbdataReferenceValid(p) ? p : nullptr;
+        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, peer, flags);
         mb.init();
         hdr.packInto(&mb);
         hdr.clean();

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1533,8 +1533,7 @@ htcpQuery(StoreEntry * e, HttpRequest * req, CachePeer * p)
     stuff.S.method = sb.c_str();
     stuff.S.uri = (char *) e->url();
     stuff.S.version = vbuf;
-    const auto peer = cbdataReferenceValid(p) ? p : nullptr;
-    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, peer, flags);
+    HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p, flags);
     MemBuf mb;
     mb.init();
     hdr.packInto(&mb);
@@ -1589,8 +1588,7 @@ htcpClear(StoreEntry * e, HttpRequest * req, const HttpRequestMethod &, CachePee
     stuff.S.uri = uri.c_str();
     stuff.S.version = vbuf;
     if (reason != HTCP_CLR_INVALIDATION) {
-        const auto peer = cbdataReferenceValid(p) ? p : nullptr;
-        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, peer, flags);
+        HttpStateData::httpBuildRequestHeader(req, e, nullptr, &hdr, p, flags);
         mb.init();
         hdr.packInto(&mb);
         hdr.clean();

--- a/src/http.cc
+++ b/src/http.cc
@@ -1887,6 +1887,8 @@ httpFixupAuthentication(HttpRequest * request, const HttpHeader * hdr_in, HttpHe
         }
         return;
     }
+#else
+    (void)peer;
 #endif /* HAVE_KRB5 && HAVE_GSSAPI */
 
     blen = base64_encode_update(&ctx, loginbuf, strlen(request->peer_login), reinterpret_cast<const uint8_t*>(request->peer_login));

--- a/src/http.h
+++ b/src/http.h
@@ -50,7 +50,7 @@ public:
                                        StoreEntry * entry,
                                        const AccessLogEntryPointer &al,
                                        HttpHeader * hdr_out,
-                                       char *peerHost,
+                                       const CachePeer *peer,
                                        const Http::StateFlags &flags);
 
     const Comm::ConnectionPointer & dataConnection() const override;

--- a/src/http.h
+++ b/src/http.h
@@ -50,6 +50,7 @@ public:
                                        StoreEntry * entry,
                                        const AccessLogEntryPointer &al,
                                        HttpHeader * hdr_out,
+                                       char *peerHost,
                                        const Http::StateFlags &flags);
 
     const Comm::ConnectionPointer & dataConnection() const override;

--- a/src/peer_proxy_negotiate_auth.cc
+++ b/src/peer_proxy_negotiate_auth.cc
@@ -483,7 +483,7 @@ restart:
  * peer_proxy_negotiate_auth gets a GSSAPI token for principal_name
  * and base64 encodes it.
  */
-char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags) {
+char *peer_proxy_negotiate_auth(char *principal_name, const char * const proxy, int flags) {
     int rc = 0;
     OM_uint32 major_status, minor_status;
     gss_ctx_id_t gss_context = GSS_C_NO_CONTEXT;

--- a/src/peer_proxy_negotiate_auth.h
+++ b/src/peer_proxy_negotiate_auth.h
@@ -14,7 +14,7 @@
 #if HAVE_AUTH_MODULE_NEGOTIATE && HAVE_KRB5 && HAVE_GSSAPI
 
 /* upstream proxy authentication */
-char *peer_proxy_negotiate_auth(char *principal_name, char *proxy, int flags);
+char *peer_proxy_negotiate_auth(char *principal_name, const char *proxy, int flags);
 #endif
 
 #endif /* SQUID_SRC_PEER_PROXY_NEGOTIATE_AUTH_H */

--- a/src/tunnel.cc
+++ b/src/tunnel.cc
@@ -1155,8 +1155,6 @@ TunnelStateData::connectDone(const Comm::ConnectionPointer &conn, const char *or
 
     netdbPingSite(request->url.host());
 
-    request->peer_host = conn->getPeer() ? conn->getPeer()->host : nullptr;
-
     bool toOrigin = false; // same semantics as StateFlags::toOrigin
     if (const auto * const peer = conn->getPeer()) {
         request->prepForPeering(*peer);
@@ -1565,8 +1563,6 @@ switchToTunnel(HttpRequest *request, const Comm::ConnectionPointer &clientConn, 
     if (!srvConn->getPeer() || !srvConn->getPeer()->options.no_delay)
         tunnelState->server.setDelayId(DelayId::DelayClient(context->http));
 #endif
-
-    request->peer_host = srvConn->getPeer() ? srvConn->getPeer()->host : nullptr;
 
     debugs(26, 4, "determine post-connect handling pathway.");
     if (const auto peer = srvConn->getPeer())


### PR DESCRIPTION
HttpRequest::peer_host was added in 2009 commit 9ca29d23 so that
httpFixupAuthentication() could pass copied raw CachePeer::host pointer
value to peer_proxy_negotiate_auth(). Unfortunately, raw peer_host
pointer (to CachePeer::host memory) becomes dangling when CachePeer is
reconfigured away. Instead of maintaining this problematic field, we can
safely obtain the same CachePeer::host value from HttpStateData::_peer.