### PR TITLE
Remove NEWSOS detection and code

### DIFF
--- a/compat/osdetect.h
+++ b/compat/osdetect.h
@@ -73,9 +73,6 @@
 #elif defined(__APPLE__)
 #define _SQUID_APPLE_ 1
 
-#elif defined(sony_news) && defined(__svr4)
-#define _SQUID_NEWSOS6_ 1
-
 #elif defined(__QNX__)
 #define _SQUID_QNX_ 1
 

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -692,18 +692,6 @@ comm_connect_addr(int sock, const Ip::Address &address)
 
     } else {
         errno = 0;
-#if _SQUID_NEWSOS6_
-        /* Makoto MATSUSHITA <matusita@ics.es.osaka-u.ac.jp> */
-        if (connect(sock, AI->ai_addr, AI->ai_addrlen) < 0)
-            xerrno = errno;
-
-        if (xerrno == EINVAL) {
-            errlen = sizeof(err);
-            x = getsockopt(sock, SOL_SOCKET, SO_ERROR, &err, &errlen);
-            if (x >= 0)
-                xerrno = x;
-        }
-#else
         errlen = sizeof(err);
         x = getsockopt(sock, SOL_SOCKET, SO_ERROR, &err, &errlen);
         if (x == 0)
@@ -720,7 +708,6 @@ comm_connect_addr(int sock, const Ip::Address &address)
             xerrno = ENOTCONN;
         else
             xerrno = errno;
-#endif
 #endif
     }
 


### PR DESCRIPTION
Sony Network Engineering Workstation was discontinued in 1998.