### PR TITLE
HTTP: Improved field-line parser

### DIFF
--- a/src/http/FieldParser.cc
+++ b/src/http/FieldParser.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+/* DEBUG: section 55    HTTP Header Field Parser */
+
+#include "squid.h"
+#include "base/CharacterSet.h"
+#include "base/TextException.h"
+#include "debug/Stream.h"
+#include "http/FieldParser.h"
+#include "parser/Tokenizer.h"
+
+/**
+ * Governed by RFC 9110 section 5.1:
+ *
+ *  field-name     = token
+ *  token          = 1*TCHAR
+ */
+void
+Http::FieldParser::parseFieldName(::Parser::Tokenizer &tok)
+{
+    if (!tok.prefix(theName, CharacterSet::TCHAR))
+        throw TextException(SBuf("missing field name"), Here());
+
+    /* is it a "known" field? */
+    theId = Http::HeaderLookupTable.lookup(theName.rawContent(),theName.length()).id;
+    debugs(55, 9, "got hdr-id=" << id());
+    if (id() == Http::HdrType::BAD_HDR) {
+        theId = Http::HdrType::OTHER;
+    } else {
+        ++ FieldStats(id()).seenCount;
+        if (id() != Http::HdrType::OTHER)
+            theName = Http::HeaderLookupTable.lookup(id()).name;
+    }
+}
+
+/**
+ * Governed by RFC 9110 section 5.5:
+ *
+ *  field-value    = *field-content
+ *  field-content  = field-vchar
+ *                   [ 1*( SP / HTAB / field-vchar ) field-vchar ]
+ *  field-vchar    = VCHAR / obs-text
+ *  obs-text       = %x80-FF
+ */
+void
+Http::FieldParser::parseFieldValue(::Parser::Tokenizer &tok)
+{
+    static const CharacterSet fvCharacters =
+            (CharacterSet::VCHAR +
+            CharacterSet::WSP +
+            CharacterSet::OBSTEXT).rename("field-value");
+
+    // may be missing
+    (void)tok.prefix(theValue, fvCharacters);
+}
+
+HttpHeaderFieldStat &
+Http::FieldStats(const HdrType id)
+{
+    static HttpHeaderFieldStat bad;
+    if (id == HdrType::BAD_HDR) {
+        // 'bad header' stats are not to be kept in the table
+        return bad = HttpHeaderFieldStat();
+    }
+
+    static std::vector<HttpHeaderFieldStat> stats(Http::HdrType::enumEnd_);
+    return stats[id];
+}

--- a/src/http/FieldParser.h
+++ b/src/http/FieldParser.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_HTTP_FIELDPARSER_H
+#define SQUID_SRC_HTTP_FIELDPARSER_H
+
+#include "http/RegisteredHeaders.h"
+#include "HttpHeader.h" // for http_hdr_owner_type
+#include "HttpHeaderFieldStat.h"
+#include "parser/forward.h"
+#include "sbuf/SBuf.h"
+
+namespace Http
+{
+
+class FieldParser
+{
+    MEMPROXY_CLASS(Http::FieldParser);
+
+public:
+    /// parse a field-name from the given tokenizer
+    void parseFieldName(::Parser::Tokenizer &);
+
+    /// parse a field-value from the given tokenizer
+    void parseFieldValue(::Parser::Tokenizer &);
+
+    /// the Squid internal ID for known fields, or HdrType::OTHER
+    HdrType id() const { return theId; }
+
+    /// the HTTP field-name
+    SBuf name() const { return theName; }
+
+    /// the HTTP field-value
+    SBuf value() const { return theValue; }
+
+private:
+    HdrType theId;
+    SBuf theName;
+    SBuf theValue;
+};
+
+/// statistics counters for header fields.
+HttpHeaderFieldStat &FieldStats(const HdrType);
+
+} // namespace Http
+
+#endif /* SQUID_SRC_HTTP_FIELDPARSER_H */

--- a/src/http/Makefile.am
+++ b/src/http/Makefile.am
@@ -16,6 +16,8 @@ noinst_LTLIBRARIES = libhttp.la
 libhttp_la_SOURCES = \
 	ContentLengthInterpreter.cc \
 	ContentLengthInterpreter.h \
+	FieldParser.cc \
+	FieldParser.h \
 	Message.cc \
 	Message.h \
 	MethodType.cc \

--- a/src/http/one/FieldParser.cc
+++ b/src/http/one/FieldParser.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+/* DEBUG: section 55    HTTP Header Field Parser */
+
+#include "squid.h"
+#include "base/CharacterSet.h"
+#include "base/Raw.h"
+#include "base/TextException.h"
+#include "debug/Stream.h"
+#include "http/one/FieldParser.h"
+#include "parser/Tokenizer.h"
+#include "sbuf/Stream.h"
+#include "SquidConfig.h"
+
+/**
+ * Governed by RFC 9112 section 5:
+ *
+ *  field-line   = field-name ":" OWS field-value OWS
+ */
+void
+Http1::FieldParser::parseFieldLine(::Parser::Tokenizer &tok, const http_hdr_owner_type msgType)
+{
+    // Isolate the: field-name
+    parseFieldName(tok);
+
+    // TODO: remove when String is gone from Squid
+    if (name().length() > 65534) {
+        /* String must be LESS THAN 64K and it adds a terminating NULL */
+        debugs(55, 2, "ignoring huge header field (" <<
+               Raw("field_start", name().rawContent(), 100) <<
+               "...[skip " << name().length()-100 << " characters])");
+        throw TextException(SBuf("huge-header-name"), Here());
+    }
+
+    // handle delimiter ( BWS ":" ) or abort
+    skipColonDelimiter(tok, msgType);
+
+    // Isolate the: OWS field-value OWS
+    (void)tok.skipAll(CharacterSet::WSP); // at least an SP expected
+    parseFieldValue(tok);
+    (void)tok.skipAll(CharacterSet::WSP);
+
+    // TODO: remove when String is gone from Squid
+    if (value().length() > 65534) {
+        /* String must be LESS THAN 64K and it adds a terminating NULL */
+        throw TextException(ToSBuf("'", name(), "' header of ", value().length(), " bytes"), Here());
+    }
+
+    if (!tok.atEnd()) {
+        const auto garbage = tok.remaining();
+        const auto limit = min(garbage.length(), SBuf::size_type(100));
+        throw TextException(ToSBuf("invalid ", Raw("field-value", garbage.rawContent(), limit), "..."), Here());
+    }
+}
+
+/**
+ * Skip the field-line ":" delimiter.
+ * Maybe tolerate whitespace before it depending on message type and
+ * configured strict/relaxed parse setting.
+ *
+ * Governed by RFC 9112 section 5.1:
+ *
+ *  No whitespace is allowed between the header field-name and colon.
+ * ...
+ *  A server MUST reject any received request message that contains
+ *  whitespace between a header field-name and colon with a response code
+ *  of 400 (Bad Request).  A proxy MUST remove any such whitespace from a
+ *  response message before forwarding the message downstream.
+ */
+void
+Http1::FieldParser::skipColonDelimiter(::Parser::Tokenizer &tok, const http_hdr_owner_type msgType)
+{
+    if (tok.skip(':'))
+        return;
+
+    // Bad message syntax. Maybe tolerate whitespace.
+
+    if (msgType == hoRequest)
+        throw TextException(SBuf("invalid field-name"), Here());
+
+    // for now, also let relaxed parser remove this BWS from any non-HTTP messages
+    const bool stripWhitespace = (msgType == hoReply) ||
+                                 Config.onoff.relaxed_header_parser;
+    if (!stripWhitespace) // reject if we cannot strip
+        throw TextException(SBuf("invalid field-name"), Here());
+
+    if (const auto wspCount = tok.skipAll(CharacterSet::WSP)) {
+        const auto garbage = tok.remaining();
+        const auto limit = min(garbage.length(), SBuf::size_type(100));
+        debugs(55, Config.onoff.relaxed_header_parser <= 0 ? 1 : 2,
+               "WARNING: Whitespace after header name in '" <<
+               Raw("field-name", garbage.rawContent(), limit) << "...");
+    }
+
+    // now MUST be the colon
+    if (!tok.skip(':'))
+        throw TextException(SBuf("invalid field-name"), Here());
+}

--- a/src/http/one/FieldParser.h
+++ b/src/http/one/FieldParser.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_HTTP_ONE_FIELDPARSER_H
+#define SQUID_SRC_HTTP_ONE_FIELDPARSER_H
+
+#include "http/FieldParser.h"
+
+namespace Http
+{
+namespace One
+{
+class FieldParser : public Http::FieldParser
+{
+    MEMPROXY_CLASS(Http1::FieldParser);
+
+public:
+    /// parse an HTTP header field from the given tokenizer
+    void parseFieldLine(::Parser::Tokenizer &, const http_hdr_owner_type);
+
+private:
+    void skipColonDelimiter(::Parser::Tokenizer &, const http_hdr_owner_type);
+};
+
+} // namespace One
+} // namespace Http
+
+#endif /* SQUID_SRC_HTTP_ONE_FIELDPARSER_H */

--- a/src/http/one/Makefile.am
+++ b/src/http/one/Makefile.am
@@ -10,6 +10,8 @@ include $(top_srcdir)/src/Common.am
 noinst_LTLIBRARIES = libhttp1.la
 
 libhttp1_la_SOURCES = \
+	FieldParser.cc \
+	FieldParser.h \
 	Parser.cc \
 	Parser.h \
 	RequestParser.cc \


### PR DESCRIPTION
Replace with a Tokenizer based Parser and
updated for RFC 9110 and RFC 9112 compliance.