### PR TITLE
Bug 5407 Increase MAX_PAC_GROUP_SIZE

### DIFF
--- a/src/auth/negotiate/kerberos/negotiate_kerberos.h
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos.h
@@ -114,7 +114,7 @@ char *gethost_name(void);
 
 #if (HAVE_GSSKRB5_EXTRACT_AUTHZ_DATA_FROM_SEC_CONTEXT || HAVE_GSS_MAP_NAME_TO_ANY) && HAVE_KRB5_PAC
 #define HAVE_PAC_SUPPORT 1
-#define MAX_PAC_GROUP_SIZE 200*60
+#define MAX_PAC_GROUP_SIZE 1024*98
 typedef struct {
     uint16_t length;
     uint16_t maxlength;


### PR DESCRIPTION
Increase MAX_PAC_GROUP_SIZE to a more reasonable value, so negotiate_kerberos_auth can report more than approximately 200 groups back to squid an authenticated user is member of.