### PR TITLE
HTTP: update 1xx status handling

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -630,18 +630,6 @@ HttpRequest::ignoreRange(const char *reason)
     // TODO: Some callers also delete HDR_RANGE, HDR_REQUEST_RANGE. Should we?
 }
 
-bool
-HttpRequest::canHandle1xx() const
-{
-    // old clients do not support 1xx unless they sent Expect: 100-continue
-    // (we reject all other Http::HdrType::EXPECT values so just check for Http::HdrType::EXPECT)
-    if (http_ver <= Http::ProtocolVersion(1,0) && !header.has(Http::HdrType::EXPECT))
-        return false;
-
-    // others must support 1xx control messages
-    return true;
-}
-
 Http::StatusCode
 HttpRequest::checkEntityFraming() const
 {

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -68,9 +68,6 @@ public:
 
     bool conditional() const; ///< has at least one recognized If-* header
 
-    /// whether the client is likely to be able to handle a 1xx reply
-    bool canHandle1xx() const;
-
     /// \returns a pointer to a local static buffer containing request URI
     /// that honors strip_query_terms and %-encodes unsafe URI characters
     char *canonicalCleanUrl() const;

--- a/src/http.cc
+++ b/src/http.cc
@@ -772,14 +772,14 @@ HttpStateData::handle1xx(const HttpReply::Pointer &reply)
         //  If the request did not contain an Expect header field containing
         //  the 100-continue expectation, the client can simply discard this
         //  interim response.
-        if (!request->header.has(Http::HdrType::EXPECT)) {
+        if (!request->header.has(Http::HdrType::EXPECT))
             return drop1xx("the client did not request 100-continue");
-    }
-    else if (port->actAsOrigin) {
+
+    } else if (fwd->al->cache.port->actAsOrigin) {
         // RFC 9110 section 15.2:
         //  a server MUST NOT send a 1xx response to an HTTP/1.0 client
-        static const h1 = Http::ProtocolVersion(1,0);
-        if (port->transport <= h1 || request->http_ver <= h1)
+        static const auto h1 = Http::ProtocolVersion(1,0);
+        if (fwd->al->cache.port->transport <= h1 || request->http_ver <= h1)
             return drop1xx("HTTP/1.0 protocol does not support 1xx status");
     }
     // else; RFC 9110 section 15.2: A proxy MUST forward 1xx responses

--- a/src/http.cc
+++ b/src/http.cc
@@ -761,7 +761,6 @@ HttpStateData::handle1xx(const HttpReply::Pointer &reply)
     Must(!flags.serverSwitchedProtocols);
     flags.serverSwitchedProtocols = (statusCode == Http::scSwitchingProtocols);
 
-    // old clients do not support 1xx unless they sent Expect: 100-continue
     if (statusCode == Http::scContinue) {
         // traffic optimization
         if (request->forcedBodyContinuation)
@@ -786,7 +785,7 @@ HttpStateData::handle1xx(const HttpReply::Pointer &reply)
     }
 
 #if USE_HTTP_VIOLATIONS
-    // check whether the 1xx response forwarding is denied by squid.conf
+    // check whether the 1xx response forwarding is allowed by squid.conf
     if (Config.accessList.reply) {
         ACLFilledChecklist ch(Config.accessList.reply, originalRequest().getRaw());
         ch.updateAle(fwd->al);

--- a/src/http.cc
+++ b/src/http.cc
@@ -766,7 +766,12 @@ HttpStateData::handle1xx(const HttpReply::Pointer &reply)
         if (request->forcedBodyContinuation)
             return drop1xx("we have sent 100-continue already");
         // tolerate HTTP/1.0 clients sending "Expect: 100-continue",
-        // and broken servers emitting 100 status without receiving Expect.
+        // but drop for servers emitting 100 status without receiving Expect.
+        //
+        // RFC 9110 section 15.2.1:
+        //  If the request did not contain an Expect header field containing
+        //  the 100-continue expectation, the client can simply discard this
+        //  interim response.
         if (!request->header.has(Http::HdrType::EXPECT)) {
             return drop1xx("the client did not request 100-continue");
     }

--- a/src/http.cc
+++ b/src/http.cc
@@ -845,7 +845,7 @@ HttpStateData::blockSwitchingProtocols(const HttpReply &reply) const
     //   A server that receives an Upgrade header field in an
     //   HTTP/1.0 request MUST ignore that Upgrade field.
     if (request->http_ver <= Http::ProtocolVersion(1,0))
-        return "HTTP/1.0 does not suport Upgrade header field";
+        return "HTTP/1.0 does not support Upgrade header field";
 
     // RFC 9110 section 7.8 paragraph 12:
     //  A sender of Upgrade MUST also send an "Upgrade" connection option

--- a/src/tests/stub_HttpRequest.cc
+++ b/src/tests/stub_HttpRequest.cc
@@ -23,7 +23,6 @@ void HttpRequest::initHTTP(const HttpRequestMethod &, AnyP::ProtocolType, const 
 HttpRequest * HttpRequest::clone() const STUB_RETVAL(nullptr)
 bool HttpRequest::maybeCacheable() STUB_RETVAL(false)
 bool HttpRequest::conditional() const STUB_RETVAL(false)
-bool HttpRequest::canHandle1xx() const STUB_RETVAL(false)
 char * HttpRequest::canonicalCleanUrl() const STUB_RETVAL(nullptr)
 #if USE_ADAPTATION
 Adaptation::History::Pointer HttpRequest::adaptLogHistory() const STUB_RETVAL(Adaptation::History::Pointer())


### PR DESCRIPTION
* Check Squid behaviour conforms to RFC 9110 and RFC 9112
  requirements.

* Update code documentation to reference latest RFCs.

* Move 'can handle' logic to the HTTP Server object. Most of the
  requirements are checking server state, not HTTP request
  message.

* Add performance optimization to 101 Switching Protocols logic.
  Avoids memory setup for handling the Upgrade list header
  unless the header actually exists and needs processing.

* Do not send 1xx status when the client connection transport is
  HTTP/1.0 or HTTP/0.9 unless client sent Expect:100-continue.