### PR TITLE
Bug 5489: Fix "make check" linking on Solaris

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1966,11 +1966,11 @@ tests_testHttpRange_LDADD = \
 	acl/libapi.la \
 	proxyp/libproxyp.la \
 	parser/libparser.la \
-	ip/libip.la \
 	fs/libfs.la \
 	anyp/libanyp.la \
 	icmp/libicmp.la \
 	comm/libcomm.la \
+	ip/libip.la \
 	log/liblog.la \
 	format/libformat.la \
 	$(REPL_OBJS) \
@@ -2351,7 +2351,6 @@ tests_testHttpRequest_LDADD = \
 	acl/libstate.la \
 	acl/libapi.la \
 	parser/libparser.la \
-	ip/libip.la \
 	fs/libfs.la \
 	$(SSL_LIBS) \
 	ipc/libipc.la \
@@ -2365,6 +2364,7 @@ tests_testHttpRequest_LDADD = \
 	$(SNMP_LIBS) \
 	icmp/libicmp.la \
 	comm/libcomm.la \
+	ip/libip.la \
 	log/liblog.la \
 	format/libformat.la \
 	store/libstore.la \
@@ -2649,9 +2649,9 @@ tests_testCacheManager_LDADD = \
 	acl/libapi.la \
 	dns/libdns.la \
 	base/libbase.la \
-	ip/libip.la \
 	fs/libfs.la \
 	comm/libcomm.la \
+	ip/libip.la \
 	eui/libeui.la \
 	icmp/libicmp.la \
 	log/liblog.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -510,10 +510,10 @@ squid_LDADD = \
 	dns/libdns.la \
 	base/libbase.la \
 	libsquid.la \
-	ip/libip.la \
 	fs/libfs.la \
 	DiskIO/libdiskio.la \
 	comm/libcomm.la \
+	ip/libip.la \
 	anyp/libanyp.la \
 	security/libsecurity.la \
 	$(SSL_LIBS) \


### PR DESCRIPTION
Change link order of libcomm and libip to fix missing symbols at link
time on Solaris:

    libtool: link: /usr/gcc/14/bin/g++ ... -o tests/testCacheManager
    _ZN2Ip11InterceptorE ... libcomm.a
    _ZN2Ip9Intercept9LookupNatERKN4Comm10ConnectionE ... libcomm.a
    ld: fatal: symbol referencing errors