### PR TITLE
CI: update FreeBSD version

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -142,8 +142,8 @@ jobs:
     strategy:
       matrix:
         osversion:
-          - 14.1
-          - 13.3
+          - 14.2
+          - 13.4
 
     runs-on: ubuntu-22.04
     name: freebsd(${{ matrix.osversion }})


### PR DESCRIPTION
The FreeBSD project has promoted version 14.2 to stable.
Some packages we use are not compatible with version 14.1.
Upgrade the reference version we use, the action supports it