### PR TITLE
CI: adopt ccache-action v1.2.17

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.14
+        uses: hendrikmuhs/ccache-action@v1.2.17
         with:
           verbose: 2 # default 0
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.14
+        uses: hendrikmuhs/ccache-action@v1.2.17
         with:
           verbose: 2 # default 0
           key: ${{ matrix.os }}-${{ matrix.compiler.CC }}-${{ matrix.layer.nick }}


### PR DESCRIPTION
GitHub deprecated v1 of its cache API. Adopt the latest version of
ccache-action, which uses action/cache v4.0.0, which uses cache API v2.
