### PR TITLE
Maintenance: use SetSocketOption() template

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -912,6 +912,7 @@ nodist_tests_testURL_SOURCES = \
 	tests/stub_HelperChildConfig.cc \
 	tests/stub_HttpHeader.cc \
 	tests/stub_HttpRequest.cc \
+	tests/stub_MemBuf.cc \
 	tests/stub_StatHist.cc \
 	String.cc \
 	tests/stub_access_log.cc \
@@ -922,8 +923,7 @@ nodist_tests_testURL_SOURCES = \
 	tests/stub_debug.cc \
 	tests/stub_libcomm.cc \
 	tests/stub_libhttp.cc \
-	tests/stub_libmem.cc \
-	tests/stub_MemBuf.cc
+	tests/stub_libmem.cc
 tests_testURL_LDADD = \
 	libsquid.la \
 	anyp/libanyp.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -917,10 +917,13 @@ nodist_tests_testURL_SOURCES = \
 	tests/stub_access_log.cc \
 	anyp/Uri.h \
 	anyp/UriScheme.h \
+	tests/stub_cache_manager.cc \
 	tests/stub_cbdata.cc \
 	tests/stub_debug.cc \
+	tests/stub_libcomm.cc \
 	tests/stub_libhttp.cc \
-	tests/stub_libmem.cc
+	tests/stub_libmem.cc \
+	tests/stub_MemBuf.cc
 tests_testURL_LDADD = \
 	libsquid.la \
 	anyp/libanyp.la \
@@ -2033,6 +2036,7 @@ tests_testHttp1Parser_SOURCES = \
 	wordlist.h
 nodist_tests_testHttp1Parser_SOURCES = \
 	$(TESTSOURCES) \
+	tests/stub_libcomm.cc \
 	tests/stub_libtime.cc
 tests_testHttp1Parser_LDADD= \
 	http/libhttp.la \
@@ -2363,8 +2367,8 @@ tests_testHttpRequest_LDADD = \
 	anyp/libanyp.la \
 	$(SNMP_LIBS) \
 	icmp/libicmp.la \
-	comm/libcomm.la \
 	ip/libip.la \
+	comm/libcomm.la \
 	log/liblog.la \
 	format/libformat.la \
 	store/libstore.la \
@@ -2397,8 +2401,12 @@ check_PROGRAMS += tests/testIpAddress
 tests_testIpAddress_SOURCES = \
 	tests/testIpAddress.cc
 nodist_tests_testIpAddress_SOURCES = \
+	tests/stub_MemBuf.cc \
 	tests/stub_SBuf.cc \
+	tests/stub_cache_manager.cc \
+	tests/stub_cbdata.cc \
 	tests/stub_debug.cc \
+	tests/stub_libcomm.cc \
 	tests/stub_libmem.cc \
 	tests/stub_tools.cc
 tests_testIpAddress_LDADD = \
@@ -2416,9 +2424,13 @@ check_PROGRAMS += tests/testIcmp
 tests_testIcmp_SOURCES = \
 	tests/testIcmp.cc
 nodist_tests_testIcmp_SOURCES = \
+	tests/stub_MemBuf.cc \
 	tests/stub_SBuf.cc \
+	tests/stub_cache_manager.cc \
+	tests/stub_cbdata.cc \
 	tests/stub_debug.cc \
 	icmp/Icmp.h \
+	tests/stub_libcomm.cc \
 	tests/stub_libmem.cc \
 	tests/stub_libtime.cc
 tests_testIcmp_LDADD=\

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2134,10 +2134,7 @@ ConnStateData::start()
             (transparent() || port->disable_pmtu_discovery == DISABLE_PMTU_ALWAYS)) {
 #if defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_DONT)
         int i = IP_PMTUDISC_DONT;
-        if (setsockopt(clientConnection->fd, SOL_IP, IP_MTU_DISCOVER, &i, sizeof(i)) < 0) {
-            int xerrno = errno;
-            debugs(33, 2, "WARNING: Path MTU discovery disabling failed on " << clientConnection << " : " << xstrerr(xerrno));
-        }
+        Comm::SetSocketOption(clientConnection->fd, SOL_IP, IP_MTU_DISCOVER, i, ToSBuf("IP_MTU_DISCOVER disabled for client ", clientConnection));
 #else
         static bool reported = false;
 

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -75,6 +75,7 @@
 #include "comm/Connection.h"
 #include "comm/Loops.h"
 #include "comm/Read.h"
+#include "comm/SocketOptions.h"
 #include "comm/TcpAcceptor.h"
 #include "comm/Write.h"
 #include "CommCalls.h"

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -2134,7 +2134,7 @@ ConnStateData::start()
             (transparent() || port->disable_pmtu_discovery == DISABLE_PMTU_ALWAYS)) {
 #if defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_DONT)
         int i = IP_PMTUDISC_DONT;
-        Comm::SetSocketOption(clientConnection->fd, SOL_IP, IP_MTU_DISCOVER, i, ToSBuf("IP_MTU_DISCOVER disabled for client ", clientConnection));
+        (void)Comm::SetSocketOption(clientConnection->fd, SOL_IP, IP_MTU_DISCOVER, i, ToSBuf("IP_MTU_DISCOVER disabled for client ", clientConnection));
 #else
         static bool reported = false;
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1709,15 +1709,15 @@ ClientHttpRequest::doCallouts()
         if (!calloutContext->toClientMarkingDone) {
             calloutContext->toClientMarkingDone = true;
             if (tos_t tos = aclMapTOS(Ip::Qos::TheConfig.tosToClient, &ch))
-                Ip::Qos::setSockTos(getConn()->clientConnection, tos);
+                (void)Ip::Qos::setSockTos(getConn()->clientConnection, tos);
 
             const auto packetMark = aclFindNfMarkConfig(Ip::Qos::TheConfig.nfmarkToClient, &ch);
             if (!packetMark.isEmpty())
-                Ip::Qos::setSockNfmark(getConn()->clientConnection, packetMark.mark);
+                (void)Ip::Qos::setSockNfmark(getConn()->clientConnection, packetMark.mark);
 
             const auto connmark = aclFindNfMarkConfig(Ip::Qos::TheConfig.nfConnmarkToClient, &ch);
             if (!connmark.isEmpty())
-                Ip::Qos::setNfConnmark(getConn()->clientConnection, Ip::Qos::dirAccepted, connmark);
+                (void)Ip::Qos::setNfConnmark(getConn()->clientConnection, Ip::Qos::dirAccepted, connmark);
         }
     }
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -1708,8 +1708,7 @@ ClientHttpRequest::doCallouts()
 
         if (!calloutContext->toClientMarkingDone) {
             calloutContext->toClientMarkingDone = true;
-            tos_t tos = aclMapTOS(Ip::Qos::TheConfig.tosToClient, &ch);
-            if (tos)
+            if (tos_t tos = aclMapTOS(Ip::Qos::TheConfig.tosToClient, &ch))
                 Ip::Qos::setSockTos(getConn()->clientConnection, tos);
 
             const auto packetMark = aclFindNfMarkConfig(Ip::Qos::TheConfig.nfmarkToClient, &ch);

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1774,15 +1774,7 @@ ftpOpenListenSocket(Ftp::Gateway * ftpState, int fallback)
      * REUSEADDR is needed in fallback mode, since the same port is
      * used for both control and data.
      */
-    if (fallback) {
-        int on = 1;
-        errno = 0;
-        if (setsockopt(ftpState->ctrl.conn->fd, SOL_SOCKET, SO_REUSEADDR,
-                       (char *) &on, sizeof(on)) == -1) {
-            int xerrno = errno;
-            // SO_REUSEADDR is only an optimization, no need to be verbose about error
-            debugs(9, 4, "setsockopt failed: " << xstrerr(xerrno));
-        }
+    if (fallback && Comm::SetBooleanSocketOption(ftpState->ctrl.conn->fd, SOL_SOCKET, SO_REUSEADDR, true, SBuf("SO_REUSEADDR"))) {
         ftpState->ctrl.conn->flags |= COMM_REUSEADDR;
         temp->flags |= COMM_REUSEADDR;
     } else {

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -16,6 +16,7 @@
 #include "comm.h"
 #include "comm/ConnOpener.h"
 #include "comm/Read.h"
+#include "comm/SocketOptions.h"
 #include "comm/TcpAcceptor.h"
 #include "CommCalls.h"
 #include "compat/strtoll.h"

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -18,6 +18,7 @@
 #include "comm/IoCallback.h"
 #include "comm/Loops.h"
 #include "comm/Read.h"
+#include "comm/SocketOptions.h"
 #include "comm/TcpAcceptor.h"
 #include "comm/Write.h"
 #include "compat/cmsg.h"

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -210,7 +210,7 @@ static void
 commSetBindAddressNoPort(const int fd)
 {
 #if defined(IP_BIND_ADDRESS_NO_PORT)
-    Comm::SetBooleanSocketOption(fd, IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, true, SBuf("IP_BIND_ADDRESS_NO_PORT"));
+    (void)Comm::SetBooleanSocketOption(fd, IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, true, SBuf("IP_BIND_ADDRESS_NO_PORT"));
 #else
     (void)fd;
 #endif
@@ -290,7 +290,7 @@ static void
 comm_set_v6only(int fd, bool enabled)
 {
 #if defined(IPV6_V6ONLY)
-    Comm::SetBooleanSocketOption(fd, IPPROTO_IPV6, IPV6_V6ONLY, enabled, SBuf("IPV6_V6ONLY"));
+    (void)Comm::SetBooleanSocketOption(fd, IPPROTO_IPV6, IPV6_V6ONLY, enabled, SBuf("IPV6_V6ONLY"));
 #else
     debugs(50, DBG_CRITICAL, "WARNING: setsockopt(IPV6_V6ONLY) not supported on this platform");
 #endif
@@ -761,7 +761,7 @@ commConfigureLinger(const int fd, const OnOff enabled)
 
     fd_table[fd].flags.harshClosureRequested = (l.l_onoff && !l.l_linger); // close(2) sends TCP RST if true
 
-    Comm::SetSocketOption(fd, SOL_SOCKET, SO_LINGER, l, ToSBuf("SO_LINGER (0 seconds) ", (l.l_onoff?"enabled":"disabled")));
+    (void)Comm::SetSocketOption(fd, SOL_SOCKET, SO_LINGER, l, ToSBuf("SO_LINGER (0 seconds) ", (l.l_onoff?"enabled":"disabled")));
 }
 
 /**
@@ -999,16 +999,16 @@ comm_remove_close_handler(int fd, AsyncCall::Pointer &call)
 static void
 commSetReuseAddr(int fd)
 {
-    Comm::SetBooleanSocketOption(fd, SOL_SOCKET, SO_REUSEADDR, true, SBuf("SO_REUSEADDR"));
+    (void)Comm::SetBooleanSocketOption(fd, SOL_SOCKET, SO_REUSEADDR, true, SBuf("SO_REUSEADDR"));
 }
 
 static void
 commSetTcpRcvbuf(int fd, int size)
 {
-    Comm::SetSocketOption(fd, SOL_SOCKET, SO_RCVBUF, size, ToSBuf("SO_RCVBUF to ", size, " bytes"));
-    Comm::SetSocketOption(fd, SOL_SOCKET, SO_SNDBUF, size, ToSBuf("SO_SNDBUF to ", size, " bytes"));
+    (void)Comm::SetSocketOption(fd, SOL_SOCKET, SO_RCVBUF, size, ToSBuf("SO_RCVBUF to ", size, " bytes"));
+    (void)Comm::SetSocketOption(fd, SOL_SOCKET, SO_SNDBUF, size, ToSBuf("SO_SNDBUF to ", size, " bytes"));
 #if defined(TCP_WINDOW_CLAMP)
-    Comm::SetSocketOption(fd, SOL_TCP, TCP_WINDOW_CLAMP, size, ToSBuf("TCP_WINDOW_CLAMP to ", size, " bytes"));
+    (void)Comm::SetSocketOption(fd, SOL_TCP, TCP_WINDOW_CLAMP, size, ToSBuf("TCP_WINDOW_CLAMP to ", size, " bytes"));
 #endif
 }
 
@@ -1097,7 +1097,7 @@ commSetCloseOnExec(int fd)
 static void
 commSetTcpNoDelay(int fd)
 {
-    Comm::SetBooleanSocketOption(fd, IPPROTO_TCP, TCP_NODELAY, true, SBuf("TCP_NODELAY"));
+    (void)Comm::SetBooleanSocketOption(fd, IPPROTO_TCP, TCP_NODELAY, true, SBuf("TCP_NODELAY"));
     fd_table[fd].flags.nodelay = true;
 }
 #endif

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -210,11 +210,7 @@ static void
 commSetBindAddressNoPort(const int fd)
 {
 #if defined(IP_BIND_ADDRESS_NO_PORT)
-    int flag = 1;
-    if (setsockopt(fd, IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, reinterpret_cast<char*>(&flag), sizeof(flag)) < 0) {
-        const auto savedErrno = errno;
-        debugs(50, DBG_IMPORTANT, "ERROR: setsockopt(IP_BIND_ADDRESS_NO_PORT) failure: " << xstrerr(savedErrno));
-    }
+    Comm::SetBooleanSocketOption(fd, IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, true, SBuf("IP_BIND_ADDRESS_NO_PORT"));
 #else
     (void)fd;
 #endif
@@ -291,16 +287,13 @@ limitError(int const anErrno)
 }
 
 static void
-comm_set_v6only(int fd, int tos)
+comm_set_v6only(int fd, bool enabled)
 {
-#ifdef IPV6_V6ONLY
-    if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &tos, sizeof(int)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "setsockopt(IPV6_V6ONLY) " << (tos?"ON":"OFF") << " for FD " << fd << ": " << xstrerr(xerrno));
-    }
+#if defined(IPV6_V6ONLY)
+    Comm::SetBooleanSocketOption(fd, IPPROTO_IPV6, IPV6_V6ONLY, enabled, SBuf("IPV6_V6ONLY"));
 #else
-    debugs(50, DBG_CRITICAL, MYNAME << "WARNING: setsockopt(IPV6_V6ONLY) not supported on this platform");
-#endif /* sockopt */
+    debugs(50, DBG_CRITICAL, "WARNING: setsockopt(IPV6_V6ONLY) not supported on this platform");
+#endif
 }
 
 /**
@@ -315,17 +308,20 @@ comm_set_transparent(int fd)
 #if _SQUID_LINUX_ && defined(IP_TRANSPARENT) // Linux
 # define soLevel SOL_IP
 # define soFlag  IP_TRANSPARENT
+    const SBuf name("IP_TRANSPARENT");
     bool doneSuid = false;
 
 #elif defined(SO_BINDANY) // OpenBSD 4.7+ and NetBSD with PF
 # define soLevel SOL_SOCKET
 # define soFlag  SO_BINDANY
+    const SBuf name("SO_BINDANY");
     enter_suid();
     bool doneSuid = true;
 
 #elif defined(IP_BINDANY) // FreeBSD with IPFW
 # define soLevel IPPROTO_IP
 # define soFlag  IP_BINDANY
+    const SBuf name("IP_BINDANY");
     enter_suid();
     bool doneSuid = true;
 
@@ -335,11 +331,7 @@ comm_set_transparent(int fd)
 #endif /* sockopt */
 
 #if defined(soLevel) && defined(soFlag)
-    int tos = 1;
-    if (setsockopt(fd, soLevel, soFlag, (char *) &tos, sizeof(int)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "setsockopt(TPROXY) on FD " << fd << ": " << xstrerr(xerrno));
-    } else {
+    if (Comm::SetBooleanSocketOption(fd, soLevel, soFlag, true, name)) {
         /* mark the socket as having transparent options */
         fd_table[fd].flags.transparent = true;
     }
@@ -423,12 +415,12 @@ comm_openex(int sock_type,
     debugs(50, 3, "comm_openex: Opened socket " << conn << " : family=" << AI->ai_family << ", type=" << AI->ai_socktype << ", protocol=" << AI->ai_protocol );
 
     if ( Ip::EnableIpv6&IPV6_SPECIAL_SPLITSTACK && addr.isIPv6() )
-        comm_set_v6only(conn->fd, 1);
+        comm_set_v6only(conn->fd, true);
 
     /* Windows Vista supports Dual-Sockets. BUT defaults them to V6ONLY. Turn it OFF. */
     /* Other OS may have this administratively disabled for general use. Same deal. */
     if ( Ip::EnableIpv6&IPV6_SPECIAL_V4MAPPING && addr.isIPv6() )
-        comm_set_v6only(conn->fd, 0);
+        comm_set_v6only(conn->fd, false);
 
     comm_init_opened(conn, note, AI);
     new_socket = comm_apply_flags(conn->fd, addr, flags, AI);
@@ -505,8 +497,7 @@ comm_apply_flags(int new_socket,
 
 #if defined(SO_REUSEPORT)
         if (flags & COMM_REUSEPORT) {
-            int on = 1;
-            if (setsockopt(new_socket, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<char*>(&on), sizeof(on)) < 0) {
+            if (!Comm::SetBooleanSocketOption(new_socket, SOL_SOCKET, SO_REUSEPORT, true, ToSBuf("SO_REUSEPORT on ", addr))) {
                 const auto savedErrno = errno;
                 const auto errorMessage = ToSBuf("cannot enable SO_REUSEPORT socket option when binding to ",
                                                  addr, ": ", xstrerr(savedErrno));
@@ -770,10 +761,7 @@ commConfigureLinger(const int fd, const OnOff enabled)
 
     fd_table[fd].flags.harshClosureRequested = (l.l_onoff && !l.l_linger); // close(2) sends TCP RST if true
 
-    if (setsockopt(fd, SOL_SOCKET, SO_LINGER, reinterpret_cast<char*>(&l), sizeof(l)) < 0) {
-        const auto xerrno = errno;
-        debugs(50, DBG_CRITICAL, "ERROR: Failed to set closure behavior (SO_LINGER) for FD " << fd << ": " << xstrerr(xerrno));
-    }
+    Comm::SetSocketOption(fd, SOL_SOCKET, SO_LINGER, l, ToSBuf("SO_LINGER (0 seconds) ", (l.l_onoff?"enabled":"disabled")));
 }
 
 /**
@@ -1011,29 +999,16 @@ comm_remove_close_handler(int fd, AsyncCall::Pointer &call)
 static void
 commSetReuseAddr(int fd)
 {
-    int on = 1;
-    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *) &on, sizeof(on)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "FD " << fd << ": " << xstrerr(xerrno));
-    }
+    Comm::SetBooleanSocketOption(fd, SOL_SOCKET, SO_REUSEADDR, true, SBuf("SO_REUSEADDR"));
 }
 
 static void
 commSetTcpRcvbuf(int fd, int size)
 {
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (char *) &size, sizeof(size)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "FD " << fd << ", SIZE " << size << ": " << xstrerr(xerrno));
-    }
-    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *) &size, sizeof(size)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "FD " << fd << ", SIZE " << size << ": " << xstrerr(xerrno));
-    }
-#ifdef TCP_WINDOW_CLAMP
-    if (setsockopt(fd, SOL_TCP, TCP_WINDOW_CLAMP, (char *) &size, sizeof(size)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "FD " << fd << ", SIZE " << size << ": " << xstrerr(xerrno));
-    }
+    Comm::SetSocketOption(fd, SOL_SOCKET, SO_RCVBUF, size, ToSBuf("SO_RCVBUF to ", size, " bytes"));
+    Comm::SetSocketOption(fd, SOL_SOCKET, SO_SNDBUF, size, ToSBuf("SO_SNDBUF to ", size, " bytes"));
+#if defined(TCP_WINDOW_CLAMP)
+    Comm::SetSocketOption(fd, SOL_TCP, TCP_WINDOW_CLAMP, size, ToSBuf("TCP_WINDOW_CLAMP to ", size, " bytes"));
 #endif
 }
 
@@ -1118,20 +1093,13 @@ commSetCloseOnExec(int fd)
 #endif
 }
 
-#ifdef TCP_NODELAY
+#if defined(TCP_NODELAY)
 static void
 commSetTcpNoDelay(int fd)
 {
-    int on = 1;
-
-    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *) &on, sizeof(on)) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, MYNAME << "FD " << fd << ": " << xstrerr(xerrno));
-    }
-
+    Comm::SetBooleanSocketOption(fd, IPPROTO_TCP, TCP_NODELAY, true, SBuf("TCP_NODELAY"));
     fd_table[fd].flags.nodelay = true;
 }
-
 #endif
 
 void

--- a/src/comm/ConnOpener.cc
+++ b/src/comm/ConnOpener.cc
@@ -291,12 +291,10 @@ Comm::ConnOpener::createFd()
     }
 
     // Set TOS if needed.
-    if (conn_->tos &&
-            Ip::Qos::setSockTos(temporaryFd_, conn_->tos, conn_->remote.isIPv4() ? AF_INET : AF_INET6) < 0)
+    if (conn_->tos && !Ip::Qos::setSockTos(temporaryFd_, conn_->tos, conn_->remote.isIPv4() ? AF_INET : AF_INET6))
         conn_->tos = 0;
 #if SO_MARK
-    if (conn_->nfmark &&
-            Ip::Qos::setSockNfmark(temporaryFd_, conn_->nfmark) < 0)
+    if (conn_->nfmark && !Ip::Qos::setSockNfmark(temporaryFd_, conn_->nfmark))
         conn_->nfmark = 0;
 #endif
 

--- a/src/comm/Makefile.am
+++ b/src/comm/Makefile.am
@@ -43,4 +43,6 @@ libcomm_la_SOURCES = \
 
 # a bare-bones implementation of few Comm APIs sufficient for helpers use
 libminimal_la_SOURCES = \
+	Tcp.cc \
+	Tcp.h \
 	minimal.cc

--- a/src/comm/Makefile.am
+++ b/src/comm/Makefile.am
@@ -32,6 +32,8 @@ libcomm_la_SOURCES = \
 	ModSelect.cc \
 	Read.cc \
 	Read.h \
+	SocketOptions.cc \
+	SocketOptions.h \
 	Tcp.cc \
 	Tcp.h \
 	TcpAcceptor.cc \
@@ -43,6 +45,6 @@ libcomm_la_SOURCES = \
 
 # a bare-bones implementation of few Comm APIs sufficient for helpers use
 libminimal_la_SOURCES = \
-	Tcp.cc \
-	Tcp.h \
+	SocketOptions.cc \
+	SocketOptions.h \
 	minimal.cc

--- a/src/comm/SocketOptions.h
+++ b/src/comm/SocketOptions.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_COMM_SOCKETOPTIONS_H
+#define SQUID_SRC_COMM_SOCKETOPTIONS_H
+
+#include "debug/Stream.h"
+#include "sbuf/SBuf.h"
+
+#if HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+
+namespace Comm
+{
+
+/// setsockopt(2) wrapper
+template <typename Option>
+bool
+SetSocketOption(const int fd, const int level, const int optName, const Option &optValue, const SBuf &description)
+{
+    static_assert(std::is_trivially_copyable<Option>::value, "setsockopt() expects POD-like options");
+    static_assert(!std::is_same<Option, bool>::value, "setsockopt() uses int to represent boolean options");
+    if (setsockopt(fd, level, optName, reinterpret_cast<const char *>(&optValue), sizeof(optValue)) < 0) {
+        const auto xerrno = errno;
+        debugs(5, DBG_IMPORTANT, "ERROR: setsockopt(2) failure on FD " << fd << " : " << xstrerr(xerrno)
+               << Debug::Extra << "setting " << description);
+        // TODO: Generalize to throw on errors when some callers need that.
+        return false;
+    }
+    return true;
+}
+
+/// setsockopt(2) wrapper for setting typical on/off options
+bool SetBooleanSocketOption(const int fd, const int level, const int optName, const bool enable, const SBuf &description);
+
+} // namespace Comm
+
+#endif /* SQUID_SRC_COMM_SOCKETOPTIONS_H */

--- a/src/comm/Tcp.cc
+++ b/src/comm/Tcp.cc
@@ -9,8 +9,8 @@
 /* DEBUG: section 05    TCP Socket Functions */
 
 #include "squid.h"
+#include "comm/SocketOptions.h"
 #include "comm/Tcp.h"
-#include "debug/Stream.h"
 #include "sbuf/Stream.h"
 
 #if HAVE_NETINET_TCP_H
@@ -19,17 +19,6 @@
 #if HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-#if HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
-#include <type_traits>
-
-bool
-Comm::SetBooleanSocketOption(const int fd, const int level, const int optName, const bool enable, const SBuf &description)
-{
-    const int optValue = enable ? 1 :0;
-    return SetSocketOption(fd, level, optName, optValue, ToSBuf((enable ? "enable ":"disable "), description));
-}
 
 void
 Comm::ApplyTcpKeepAlive(int fd, const TcpKeepAlive &cfg)
@@ -40,20 +29,20 @@ Comm::ApplyTcpKeepAlive(int fd, const TcpKeepAlive &cfg)
 #if defined(TCP_KEEPCNT)
     if (cfg.timeout && cfg.interval) {
         const int count = (cfg.timeout + cfg.interval - 1) / cfg.interval; // XXX: unsigned-to-signed conversion
-        SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPCNT, count, ToSBuf("TCP_KEEPCNT to ", count));
+        (void)SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPCNT, count, ToSBuf("TCP_KEEPCNT to ", count));
     }
 #endif
 #if defined(TCP_KEEPIDLE)
     if (cfg.idle) {
         // XXX: TCP_KEEPIDLE expects an int; cfg.idle is unsigned
-        SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPIDLE, cfg.idle, ToSBuf("TCP_KEEPIDLE to ", cfg.idle));
+        (void)SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPIDLE, cfg.idle, ToSBuf("TCP_KEEPIDLE to ", cfg.idle));
     }
 #endif
 #if defined(TCP_KEEPINTVL)
     if (cfg.interval) {
         // XXX: TCP_KEEPINTVL expects an int; cfg.interval is unsigned
-        SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPINTVL, cfg.interval, ToSBuf("TCP_KEEPINTVL to ", cfg.interval));
+        (void)SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPINTVL, cfg.interval, ToSBuf("TCP_KEEPINTVL to ", cfg.interval));
     }
 #endif
-    SetBooleanSocketOption(fd, SOL_SOCKET, SO_KEEPALIVE, true, SBuf("SO_KEEPALIVE"));
+    (void)SetBooleanSocketOption(fd, SOL_SOCKET, SO_KEEPALIVE, true, SBuf("SO_KEEPALIVE"));
 }

--- a/src/comm/Tcp.cc
+++ b/src/comm/Tcp.cc
@@ -11,6 +11,7 @@
 #include "squid.h"
 #include "comm/Tcp.h"
 #include "debug/Stream.h"
+#include "sbuf/Stream.h"
 
 #if HAVE_NETINET_TCP_H
 #include <netinet/tcp.h>
@@ -23,28 +24,11 @@
 #endif
 #include <type_traits>
 
-/// setsockopt(2) wrapper
-template <typename Option>
-static bool
-SetSocketOption(const int fd, const int level, const int optName, const Option &optValue)
-{
-    static_assert(std::is_trivially_copyable<Option>::value, "setsockopt() expects POD-like options");
-    static_assert(!std::is_same<Option, bool>::value, "setsockopt() uses int to represent boolean options");
-    if (setsockopt(fd, level, optName, reinterpret_cast<const char *>(&optValue), sizeof(optValue)) < 0) {
-        const auto xerrno = errno;
-        debugs(5, DBG_IMPORTANT, "ERROR: setsockopt(2) failure: " << xstrerr(xerrno));
-        // TODO: Generalize to throw on errors when some callers need that.
-        return false;
-    }
-    return true;
-}
-
-/// setsockopt(2) wrapper for setting typical on/off options
-static bool
-SetBooleanSocketOption(const int fd, const int level, const int optName, const bool enable)
+bool
+Comm::SetBooleanSocketOption(const int fd, const int level, const int optName, const bool enable, const SBuf &description)
 {
     const int optValue = enable ? 1 :0;
-    return SetSocketOption(fd, level, optName, optValue);
+    return SetSocketOption(fd, level, optName, optValue, ToSBuf((enable ? "enable ":"disable "), description));
 }
 
 void
@@ -56,20 +40,20 @@ Comm::ApplyTcpKeepAlive(int fd, const TcpKeepAlive &cfg)
 #if defined(TCP_KEEPCNT)
     if (cfg.timeout && cfg.interval) {
         const int count = (cfg.timeout + cfg.interval - 1) / cfg.interval; // XXX: unsigned-to-signed conversion
-        (void)SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPCNT, count);
+        SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPCNT, count, ToSBuf("TCP_KEEPCNT to ", count));
     }
 #endif
 #if defined(TCP_KEEPIDLE)
     if (cfg.idle) {
         // XXX: TCP_KEEPIDLE expects an int; cfg.idle is unsigned
-        (void)SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPIDLE, cfg.idle);
+        SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPIDLE, cfg.idle, ToSBuf("TCP_KEEPIDLE to ", cfg.idle));
     }
 #endif
 #if defined(TCP_KEEPINTVL)
     if (cfg.interval) {
         // XXX: TCP_KEEPINTVL expects an int; cfg.interval is unsigned
-        (void)SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPINTVL, cfg.interval);
+        SetSocketOption(fd, IPPROTO_TCP, TCP_KEEPINTVL, cfg.interval, ToSBuf("TCP_KEEPINTVL to ", cfg.interval));
     }
 #endif
-    (void)SetBooleanSocketOption(fd, SOL_SOCKET, SO_KEEPALIVE, true);
+    SetBooleanSocketOption(fd, SOL_SOCKET, SO_KEEPALIVE, true, SBuf("SO_KEEPALIVE"));
 }

--- a/src/comm/Tcp.h
+++ b/src/comm/Tcp.h
@@ -9,6 +9,9 @@
 #ifndef SQUID_SRC_COMM_TCP_H
 #define SQUID_SRC_COMM_TCP_H
 
+#include "debug/Stream.h"
+#include "sbuf/SBuf.h"
+
 namespace Comm
 {
 
@@ -24,6 +27,26 @@ public:
 
 /// apply configured TCP keep-alive settings to the given FD socket
 void ApplyTcpKeepAlive(int fd, const TcpKeepAlive &);
+
+/// setsockopt(2) wrapper
+template <typename Option>
+bool
+SetSocketOption(const int fd, const int level, const int optName, const Option &optValue, const SBuf &description)
+{
+    static_assert(std::is_trivially_copyable<Option>::value, "setsockopt() expects POD-like options");
+    static_assert(!std::is_same<Option, bool>::value, "setsockopt() uses int to represent boolean options");
+    if (setsockopt(fd, level, optName, reinterpret_cast<const char *>(&optValue), sizeof(optValue)) < 0) {
+        const auto xerrno = errno;
+        debugs(5, DBG_IMPORTANT, "ERROR: setsockopt(2) failure on FD " << fd << " : " << xstrerr(xerrno)
+               << Debug::Extra << "setting " << description);
+        // TODO: Generalize to throw on errors when some callers need that.
+        return false;
+    }
+    return true;
+}
+
+/// setsockopt(2) wrapper for setting typical on/off options
+bool SetBooleanSocketOption(const int fd, const int level, const int optName, const bool enable, const SBuf &description);
 
 } // namespace Comm
 

--- a/src/comm/Tcp.h
+++ b/src/comm/Tcp.h
@@ -9,9 +9,6 @@
 #ifndef SQUID_SRC_COMM_TCP_H
 #define SQUID_SRC_COMM_TCP_H
 
-#include "debug/Stream.h"
-#include "sbuf/SBuf.h"
-
 namespace Comm
 {
 
@@ -27,26 +24,6 @@ public:
 
 /// apply configured TCP keep-alive settings to the given FD socket
 void ApplyTcpKeepAlive(int fd, const TcpKeepAlive &);
-
-/// setsockopt(2) wrapper
-template <typename Option>
-bool
-SetSocketOption(const int fd, const int level, const int optName, const Option &optValue, const SBuf &description)
-{
-    static_assert(std::is_trivially_copyable<Option>::value, "setsockopt() expects POD-like options");
-    static_assert(!std::is_same<Option, bool>::value, "setsockopt() uses int to represent boolean options");
-    if (setsockopt(fd, level, optName, reinterpret_cast<const char *>(&optValue), sizeof(optValue)) < 0) {
-        const auto xerrno = errno;
-        debugs(5, DBG_IMPORTANT, "ERROR: setsockopt(2) failure on FD " << fd << " : " << xstrerr(xerrno)
-               << Debug::Extra << "setting " << description);
-        // TODO: Generalize to throw on errors when some callers need that.
-        return false;
-    }
-    return true;
-}
-
-/// setsockopt(2) wrapper for setting typical on/off options
-bool SetBooleanSocketOption(const int fd, const int level, const int optName, const bool enable, const SBuf &description);
 
 } // namespace Comm
 

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -163,12 +163,12 @@ Comm::TcpAcceptor::setListen()
         bzero(&afa, sizeof(afa));
         debugs(5, DBG_IMPORTANT, "Installing accept filter '" << Config.accept_filter << "' on " << conn);
         xstrncpy(afa.af_name, Config.accept_filter, sizeof(afa.af_name));
-        Comm::SetSocketOption(conn->fd, SOL_SOCKET, SO_ACCEPTFILTER, afa, ToSBuf("SO_ACCEPTFILTER to '", Config.accept_filter, "'"));
+        (void)Comm::SetSocketOption(conn->fd, SOL_SOCKET, SO_ACCEPTFILTER, afa, ToSBuf("SO_ACCEPTFILTER to '", Config.accept_filter, "'"));
 #elif defined(TCP_DEFER_ACCEPT)
         int seconds = 30;
         if (strncmp(Config.accept_filter, "data=", 5) == 0)
             seconds = atoi(Config.accept_filter + 5);
-        Comm::SetSocketOption(conn->fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, seconds, ToSBuf("TCP_DEFER_ACCEPT to '", Config.accept_filter, "'"));
+        (void)Comm::SetSocketOption(conn->fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, seconds, ToSBuf("TCP_DEFER_ACCEPT to '", Config.accept_filter, "'"));
 #else
         debugs(5, DBG_CRITICAL, "WARNING: accept_filter not supported on your OS");
 #endif

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -18,7 +18,7 @@
 #include "comm/comm_internal.h"
 #include "comm/Connection.h"
 #include "comm/Loops.h"
-#include "comm/Tcp.h"
+#include "comm/SocketOptions.h"
 #include "comm/TcpAcceptor.h"
 #include "CommCalls.h"
 #include "eui/Config.h"

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -13,7 +13,7 @@
 
 #include "squid.h"
 #include "comm/Connection.h"
-#include "comm/Tcp.h"
+#include "comm/SocketOptions.h"
 #include "fde.h"
 #include "ip/Intercept.h"
 #include "ip/tools.h"

--- a/src/ip/Intercept.cc
+++ b/src/ip/Intercept.cc
@@ -13,6 +13,7 @@
 
 #include "squid.h"
 #include "comm/Connection.h"
+#include "comm/Tcp.h"
 #include "fde.h"
 #include "ip/Intercept.h"
 #include "ip/tools.h"
@@ -444,7 +445,7 @@ Ip::Intercept::ProbeForTproxy(Ip::Address &test)
         tmp.getSockAddr(tmp_ip6);
 
         if ( (tmp_sock = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP)) >= 0 &&
-                setsockopt(tmp_sock, soLevel, soFlag, (char *)&tos, sizeof(int)) == 0 &&
+                Comm::SetSocketOption(tmp_sock, soLevel, soFlag, tos, SBuf("IPv6 TPROXY check")) &&
                 bind(tmp_sock, (struct sockaddr*)&tmp_ip6, sizeof(struct sockaddr_in6)) == 0 ) {
 
             debugs(3, 3, "IPv6 TPROXY support detected. Using.");
@@ -476,7 +477,7 @@ Ip::Intercept::ProbeForTproxy(Ip::Address &test)
         tmp.getSockAddr(tmp_ip4);
 
         if ( (tmp_sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) >= 0 &&
-                setsockopt(tmp_sock, soLevel, soFlag, (char *)&tos, sizeof(int)) == 0 &&
+                Comm::SetSocketOption(tmp_sock, soLevel, soFlag, tos, SBuf("IPv4 TPROXY check")) &&
                 bind(tmp_sock, (struct sockaddr*)&tmp_ip4, sizeof(struct sockaddr_in)) == 0 ) {
 
             debugs(3, 3, "IPv4 TPROXY support detected. Using.");

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -13,6 +13,7 @@
 #include "base/TextException.h"
 #include "cache_cf.h"
 #include "comm/Connection.h"
+#include "comm/Tcp.h"
 #include "compat/cmsg.h"
 #include "ConfigParser.h"
 #include "fde.h"
@@ -49,36 +50,33 @@ Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &server, fde *clientFde)
 #if USE_QOS_TOS && _SQUID_LINUX_
     /* Bug 2537: This part of ZPH only applies to patched Linux kernels. */
     tos_t tos = 1;
-    int tos_len = sizeof(tos);
     clientFde->tosFromServer = 0;
-    if (setsockopt(server->fd,SOL_IP,IP_RECVTOS,&tos,tos_len)==0) {
-        unsigned char buf[512];
-        int len = 512;
-        if (getsockopt(server->fd,SOL_IP,IP_PKTOPTIONS,buf,(socklen_t*)&len) == 0) {
-            /* Parse the PKTOPTIONS structure to locate the TOS data message
-             * prepared in the kernel by the ZPH incoming TCP TOS preserving
-             * patch.
-             */
-            unsigned char * pbuf = buf;
-            while (pbuf-buf < len) {
-                struct cmsghdr *o = (struct cmsghdr*)pbuf;
-                if (o->cmsg_len<=0)
-                    break;
+    if (!Comm::SetSocketOption(server->fd, SOL_IP, IP_RECVTOS, tos, ToSBuf("IP_RECVTOS to 0x1 for server ", server)))
+        return;
 
-                if (o->cmsg_level == SOL_IP && o->cmsg_type == IP_TOS) {
-                    int *tmp = (int*)SQUID_CMSG_DATA(o);
-                    clientFde->tosFromServer = (tos_t)*tmp;
-                    break;
-                }
-                pbuf += CMSG_LEN(o->cmsg_len);
+    unsigned char buf[512];
+    int len = 512;
+    if (getsockopt(server->fd,SOL_IP,IP_PKTOPTIONS,buf,(socklen_t*)&len) == 0) {
+        /* Parse the PKTOPTIONS structure to locate the TOS data message
+         * prepared in the kernel by the ZPH incoming TCP TOS preserving
+         * patch.
+         */
+        unsigned char * pbuf = buf;
+        while (pbuf-buf < len) {
+            struct cmsghdr *o = (struct cmsghdr*)pbuf;
+            if (o->cmsg_len<=0)
+                break;
+
+            if (o->cmsg_level == SOL_IP && o->cmsg_type == IP_TOS) {
+                int *tmp = (int*)SQUID_CMSG_DATA(o);
+                clientFde->tosFromServer = (tos_t)*tmp;
+                break;
             }
-        } else {
-            int xerrno = errno;
-            debugs(33, DBG_IMPORTANT, "ERROR: QOS: getsockopt(IP_PKTOPTIONS) failure on " << server << " " << xstrerr(xerrno));
+            pbuf += CMSG_LEN(o->cmsg_len);
         }
     } else {
         int xerrno = errno;
-        debugs(33, DBG_IMPORTANT, "ERROR: QOS: setsockopt(IP_RECVTOS) failure on " << server << " " << xstrerr(xerrno));
+        debugs(33, DBG_IMPORTANT, "ERROR: QOS: getsockopt(IP_PKTOPTIONS) failure on " << server << " " << xstrerr(xerrno));
     }
 #else
     (void)server;
@@ -226,7 +224,7 @@ Ip::Qos::setNfConnmark(Comm::ConnectionPointer &conn, const Ip::Qos::ConnectionD
     return ret;
 }
 
-int
+bool
 Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &conn, const hier_code hierCode)
 {
     tos_t tos = 0;
@@ -247,7 +245,7 @@ Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &conn, const hier_code hie
     return setSockTos(conn, tos);
 }
 
-int
+bool
 Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &conn, const hier_code hierCode)
 {
     nfmark_t mark = 0;
@@ -268,14 +266,14 @@ Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &conn, const hier_code 
     return setSockNfmark(conn, mark);
 }
 
-int
+bool
 Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &conn)
 {
     debugs(33, 2, "QOS: Setting TOS for local hit, TOS=" << int(Ip::Qos::TheConfig.tosLocalHit));
     return setSockTos(conn, Ip::Qos::TheConfig.tosLocalHit);
 }
 
-int
+bool
 Ip::Qos::doNfmarkLocalHit(const Comm::ConnectionPointer &conn)
 {
     debugs(33, 2, "QOS: Setting netfilter mark for local hit, mark=" << Ip::Qos::TheConfig.markLocalHit);
@@ -513,7 +511,7 @@ Ip::Qos::Config::dumpConfigLine(std::ostream &os, const char *directiveName) con
     }
 }
 
-int
+bool
 Ip::Qos::setSockTos(const int fd, tos_t tos, int type)
 {
     // Bug 3731: FreeBSD produces 'invalid option'
@@ -526,70 +524,52 @@ Ip::Qos::setSockTos(const int fd, tos_t tos, int type)
 
     if (type == AF_INET) {
 #if defined(IP_TOS)
-        const int x = setsockopt(fd, IPPROTO_IP, IP_TOS, &bTos, sizeof(bTos));
-        if (x < 0) {
-            int xerrno = errno;
-            debugs(50, 2, "setsockopt(IP_TOS) on " << fd << ": " << xstrerr(xerrno));
-        }
-        return x;
+        return Comm::SetSocketOption(fd, IPPROTO_IP, IP_TOS, &bTos, ToSBuf("IP_TOS to ", AsHex(tos)));
 #else
         debugs(50, DBG_IMPORTANT, "WARNING: setsockopt(IP_TOS) not supported on this platform");
-        return -1;
 #endif
     } else { // type == AF_INET6
 #if defined(IPV6_TCLASS)
-        const int x = setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, &bTos, sizeof(bTos));
-        if (x < 0) {
-            int xerrno = errno;
-            debugs(50, 2, "setsockopt(IPV6_TCLASS) on " << fd << ": " << xstrerr(xerrno));
-        }
-        return x;
+        return Comm::SetSocketOption(fd, IPPROTO_IPV6, IPV6_TCLASS, bTos, ToSBuf("IPV6_TCLASS to ", AsHex(tos)));
 #else
         debugs(50, DBG_IMPORTANT, "WARNING: setsockopt(IPV6_TCLASS) not supported on this platform");
-        return -1;
 #endif
     }
-
-    /* CANNOT REACH HERE */
+    return false;
 }
 
-int
+bool
 Ip::Qos::setSockTos(const Comm::ConnectionPointer &conn, tos_t tos)
 {
-    const int x = Ip::Qos::setSockTos(conn->fd, tos, conn->remote.isIPv4() ? AF_INET : AF_INET6);
-    conn->tos = (x >= 0) ? tos : 0;
+    const auto x = Ip::Qos::setSockTos(conn->fd, tos, conn->remote.isIPv4() ? AF_INET : AF_INET6);
+    conn->tos = (x ? tos : 0);
     return x;
 }
 
-int
+bool
 Ip::Qos::setSockNfmark(const int fd, nfmark_t mark)
 {
 #if HAVE_LIBCAP && SO_MARK
     debugs(50, 3, "for FD " << fd << " to " << mark);
-    const int x = setsockopt(fd, SOL_SOCKET, SO_MARK, &mark, sizeof(nfmark_t));
-    if (x < 0) {
-        int xerrno = errno;
-        debugs(50, 2, "setsockopt(SO_MARK) on " << fd << ": " << xstrerr(xerrno));
-    }
-    return x;
+    return Comm::SetSocketOption(fd, SOL_SOCKET, SO_MARK, mark, ToSBuf("SO_MARK to ", AsHex(mark)));
 #elif HAVE_LIBCAP
     (void)mark;
     (void)fd;
     debugs(50, DBG_IMPORTANT, "WARNING: setsockopt(SO_MARK) not supported on this platform");
-    return -1;
+    return false;
 #else
     (void)mark;
     (void)fd;
     debugs(50, DBG_IMPORTANT, "WARNING: Netfilter marking disabled (requires build --with-cap)");
-    return -1;
+    return false;
 #endif
 }
 
-int
+bool
 Ip::Qos::setSockNfmark(const Comm::ConnectionPointer &conn, nfmark_t mark)
 {
-    const int x = Ip::Qos::setSockNfmark(conn->fd, mark);
-    conn->nfmark = (x >= 0) ? mark : 0;
+    const auto x = Ip::Qos::setSockNfmark(conn->fd, mark);
+    conn->nfmark = (x ? mark : 0);
     return x;
 }
 

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -13,7 +13,7 @@
 #include "base/TextException.h"
 #include "cache_cf.h"
 #include "comm/Connection.h"
-#include "comm/Tcp.h"
+#include "comm/SocketOptions.h"
 #include "compat/cmsg.h"
 #include "ConfigParser.h"
 #include "fde.h"

--- a/src/ip/QosConfig.h
+++ b/src/ip/QosConfig.h
@@ -106,45 +106,38 @@ bool setNfConnmark(Comm::ConnectionPointer &conn, const ConnectionDirection conn
 * TOS value to set on packets when items have not been retrieved from
 * local cache. Called by clientReplyContext::sendMoreData if QOS is
 * enabled for TOS.
-* @param conn     Descriptor of socket to set the TOS for
-* @param hierCode Hier code of request
 */
-int doTosLocalMiss(const Comm::ConnectionPointer &conn, const hier_code hierCode);
+bool doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code);
 
 /**
 * Function to work out and then apply to the socket the appropriate
 * netfilter mark value to set on packets when items have not been
 * retrieved from local cache. Called by clientReplyContext::sendMoreData
 * if QOS is enabled for TOS.
-* @param conn     Descriptor of socket to set the mark for
-* @param hierCode Hier code of request
 */
-int doNfmarkLocalMiss(const Comm::ConnectionPointer &conn, const hier_code hierCode);
+bool doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code);
 
 /**
 * Function to work out and then apply to the socket the appropriate
 * TOS value to set on packets when items *have* been retrieved from
 * local cache. Called by clientReplyContext::doGetMoreData if QOS is
 * enabled for TOS.
-* @param conn Descriptor of socket to set the TOS for
 */
-int doTosLocalHit(const Comm::ConnectionPointer &conn);
+bool doTosLocalHit(const Comm::ConnectionPointer &);
 
 /**
 * Function to work out and then apply to the socket the appropriate
 * netfilter mark value to set on packets when items *have* been
 * retrieved from local cache. Called by clientReplyContext::doGetMoreData
 * if QOS is enabled for TOS.
-* @param conn Descriptor of socket to set the mark for
 */
-int doNfmarkLocalHit(const Comm::ConnectionPointer &conn);
+bool doNfmarkLocalHit(const Comm::ConnectionPointer &);
 
 /**
 * Function to set the TOS value of packets. Sets the value on the socket
 * which then gets copied to the packets.
-* @param conn Descriptor of socket to set the TOS for
 */
-int setSockTos(const Comm::ConnectionPointer &conn, tos_t tos);
+bool setSockTos(const Comm::ConnectionPointer &, tos_t);
 
 /**
 * The low level variant of setSockTos function to set TOS value of packets.
@@ -152,22 +145,20 @@ int setSockTos(const Comm::ConnectionPointer &conn, tos_t tos);
 * @param fd Descriptor of socket to set the TOS for
 * @param type The socket family, AF_INET or AF_INET6
 */
-int setSockTos(const int fd, tos_t tos, int type);
+bool setSockTos(const int fd, tos_t, int type);
 
 /**
 * Function to set the netfilter mark value of packets. Sets the value on the
 * socket which then gets copied to the packets. Called from Ip::Qos::doNfmarkLocalMiss
-* @param conn Descriptor of socket to set the mark for
 */
-int setSockNfmark(const Comm::ConnectionPointer &conn, nfmark_t mark);
+bool setSockNfmark(const Comm::ConnectionPointer &, nfmark_t);
 
 /**
 * The low level variant of setSockNfmark function to set the netfilter mark
 * value of packets.
 * Avoid if you can use the Connection-based setSockNfmark().
-* @param fd Descriptor of socket to set the mark for
 */
-int setSockNfmark(const int fd, nfmark_t mark);
+bool setSockNfmark(const int fd, nfmark_t);
 
 /**
  * QOS configuration class. Contains all the parameters for QOS functions as well

--- a/src/ip/tools.cc
+++ b/src/ip/tools.cc
@@ -9,7 +9,7 @@
 /* DEBUG: section 21    Misc Functions */
 
 #include "squid.h"
-#include "comm/Tcp.h"
+#include "comm/SocketOptions.h"
 #include "debug/Messages.h"
 #include "ip/Address.h"
 #include "ip/tools.h"

--- a/src/ip/tools.cc
+++ b/src/ip/tools.cc
@@ -9,6 +9,7 @@
 /* DEBUG: section 21    Misc Functions */
 
 #include "squid.h"
+#include "comm/Tcp.h"
 #include "debug/Messages.h"
 #include "ip/Address.h"
 #include "ip/tools.h"
@@ -42,8 +43,7 @@ Ip::ProbeTransport()
     // Test for v4-mapping capability
     // (AKA. the operating system supports RFC 3493 section 5.3)
 #if defined(IPV6_V6ONLY)
-    int tos = 0;
-    if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &tos, sizeof(int)) == 0) {
+    if (Comm::SetBooleanSocketOption(s, IPPROTO_IPV6, IPV6_V6ONLY, false, SBuf("IPV6_V6ONLY"))) {
         debugs(3, 2, "Detected IPv6 hybrid or v4-mapping stack...");
         EnableIpv6 |= IPV6_SPECIAL_V4MAPPING;
     } else {

--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -126,7 +126,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     if (WIN32_OS_version != _WIN_OS_WINNT) {
         getsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE, (char *) &opt, &optlen);
         opt = opt & ~(SO_SYNCHRONOUS_NONALERT | SO_SYNCHRONOUS_ALERT);
-        setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE, (char *) &opt, sizeof(opt));
+        Comm::SetSocketOption(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE, opt, SBuf("SO_OPENTYPE"));
     }
 
     if (type == IPC_TCP_SOCKET) {

--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -126,7 +126,7 @@ ipcCreate(int type, const char *prog, const char *const args[], const char *name
     if (WIN32_OS_version != _WIN_OS_WINNT) {
         getsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE, (char *) &opt, &optlen);
         opt = opt & ~(SO_SYNCHRONOUS_NONALERT | SO_SYNCHRONOUS_ALERT);
-        Comm::SetSocketOption(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE, opt, SBuf("SO_OPENTYPE"));
+        (void)Comm::SetSocketOption(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE, opt, SBuf("SO_OPENTYPE"));
     }
 
     if (type == IPC_TCP_SOCKET) {

--- a/src/multicast.cc
+++ b/src/multicast.cc
@@ -10,24 +10,21 @@
 
 #include "squid.h"
 #include "comm/Connection.h"
+#include "comm/Tcp.h"
 #include "debug/Stream.h"
 // XXX: for icpIncomingConn - need to pass it as a generic parameter.
 #include "ICP.h"
 #include "ipcache.h"
 #include "multicast.h"
+#include "sbuf/Stream.h"
 
 int
 mcastSetTtl(int fd, int mcast_ttl)
 {
-#ifdef IP_MULTICAST_TTL
-    char ttl = (char) mcast_ttl;
-
-    if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, 1) < 0) {
-        int xerrno = errno;
-        debugs(50, DBG_IMPORTANT, "mcastSetTtl: FD " << fd << ", TTL: " << mcast_ttl << ": " << xstrerr(xerrno));
-    }
+#if defined(IP_MULTICAST_TTL)
+    auto ttl = char(mcast_ttl);
+    Comm::SetSocketOption(fd, IPPROTO_IP, IP_MULTICAST_TTL, ttl, ToSBuf("IP_MULTICAST_TTL to ", mcast_ttl, " hops"));
 #endif
-
     return 0;
 }
 
@@ -54,14 +51,11 @@ mcastJoinGroups(const ipcache_addrs *ia, const Dns::LookupDetails &, void *)
 
         mr.imr_interface.s_addr = INADDR_ANY;
 
-        if (setsockopt(icpIncomingConn->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *) &mr, sizeof(struct ip_mreq)) < 0)
-            debugs(7, DBG_IMPORTANT, "ERROR: Join failed for " << icpIncomingConn << ", Multicast IP=" << ip);
+        Comm::SetSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, mr,
+                              ToSBuf("IP_ADD_MEMBERSHIP for multicast-IP=", ip, " on ICP listener ", icpIncomingConn));
 
-        char c = 0;
-        if (setsockopt(icpIncomingConn->fd, IPPROTO_IP, IP_MULTICAST_LOOP, &c, 1) < 0) {
-            int xerrno = errno;
-            debugs(7, DBG_IMPORTANT, "ERROR: " << icpIncomingConn << " can't disable multicast loopback: " << xstrerr(xerrno));
-        }
+        Comm::SetBooleanSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_MULTICAST_LOOP, false,
+                                     ToSBuf("IP_MULTICAST_LOOP on ICP listener ", icpIncomingConn));
     }
 
 #endif

--- a/src/multicast.cc
+++ b/src/multicast.cc
@@ -23,7 +23,7 @@ mcastSetTtl(int fd, int mcast_ttl)
 {
 #if defined(IP_MULTICAST_TTL)
     auto ttl = char(mcast_ttl);
-    Comm::SetSocketOption(fd, IPPROTO_IP, IP_MULTICAST_TTL, ttl, ToSBuf("IP_MULTICAST_TTL to ", mcast_ttl, " hops"));
+    (void)Comm::SetSocketOption(fd, IPPROTO_IP, IP_MULTICAST_TTL, ttl, ToSBuf("IP_MULTICAST_TTL to ", mcast_ttl, " hops"));
 #endif
     return 0;
 }
@@ -51,10 +51,10 @@ mcastJoinGroups(const ipcache_addrs *ia, const Dns::LookupDetails &, void *)
 
         mr.imr_interface.s_addr = INADDR_ANY;
 
-        Comm::SetSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, mr,
+        (void)Comm::SetSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, mr,
                               ToSBuf("IP_ADD_MEMBERSHIP for multicast-IP=", ip, " on ICP listener ", icpIncomingConn));
 
-        Comm::SetBooleanSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_MULTICAST_LOOP, false,
+        (void)Comm::SetBooleanSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_MULTICAST_LOOP, false,
                                      ToSBuf("IP_MULTICAST_LOOP on ICP listener ", icpIncomingConn));
     }
 

--- a/src/multicast.cc
+++ b/src/multicast.cc
@@ -10,8 +10,7 @@
 
 #include "squid.h"
 #include "comm/Connection.h"
-#include "comm/Tcp.h"
-#include "debug/Stream.h"
+#include "comm/SocketOptions.h"
 // XXX: for icpIncomingConn - need to pass it as a generic parameter.
 #include "ICP.h"
 #include "ipcache.h"
@@ -52,10 +51,10 @@ mcastJoinGroups(const ipcache_addrs *ia, const Dns::LookupDetails &, void *)
         mr.imr_interface.s_addr = INADDR_ANY;
 
         (void)Comm::SetSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, mr,
-                              ToSBuf("IP_ADD_MEMBERSHIP for multicast-IP=", ip, " on ICP listener ", icpIncomingConn));
+                                    ToSBuf("IP_ADD_MEMBERSHIP for multicast-IP=", ip, " on ICP listener ", icpIncomingConn));
 
         (void)Comm::SetBooleanSocketOption(icpIncomingConn->fd, IPPROTO_IP, IP_MULTICAST_LOOP, false,
-                                     ToSBuf("IP_MULTICAST_LOOP on ICP listener ", icpIncomingConn));
+                                           ToSBuf("IP_MULTICAST_LOOP on ICP listener ", icpIncomingConn));
     }
 
 #endif

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -75,6 +75,7 @@ void Comm::TcpAcceptor::notify(const Comm::Flag, const Comm::ConnectionPointer &
 
 #include "comm/Tcp.h"
 void Comm::ApplyTcpKeepAlive(int, const TcpKeepAlive &) STUB
+bool Comm::SetBooleanSocketOption(int, int, int, bool, SBuf const &) STUB_RETVAL(false)
 
 #include "comm/Write.h"
 void Comm::Write(const Comm::ConnectionPointer &, const char *, int, AsyncCall::Pointer &, FREE *) STUB

--- a/src/tests/stub_libcomm.cc
+++ b/src/tests/stub_libcomm.cc
@@ -66,6 +66,9 @@ void Comm::ReadCancel(int, AsyncCall::Pointer &) STUB
 void comm_read_base(const Comm::ConnectionPointer &, char *, int, AsyncCall::Pointer &) STUB
 void comm_read_cancel(int, IOCB *, void *) STUB
 
+#include "comm/SocketOptions.h"
+bool Comm::SetBooleanSocketOption(int, int, int, bool, SBuf const &) STUB_RETVAL(false)
+
 #include "comm/TcpAcceptor.h"
 //Comm::TcpAcceptor(const Comm::ConnectionPointer &, const char *, const Subscription::Pointer &) STUB
 void Comm::TcpAcceptor::subscribe(const Subscription::Pointer &) STUB
@@ -75,7 +78,6 @@ void Comm::TcpAcceptor::notify(const Comm::Flag, const Comm::ConnectionPointer &
 
 #include "comm/Tcp.h"
 void Comm::ApplyTcpKeepAlive(int, const TcpKeepAlive &) STUB
-bool Comm::SetBooleanSocketOption(int, int, int, bool, SBuf const &) STUB_RETVAL(false)
 
 #include "comm/Write.h"
 void Comm::Write(const Comm::ConnectionPointer &, const char *, int, AsyncCall::Pointer &, FREE *) STUB

--- a/src/tests/stub_libip.cc
+++ b/src/tests/stub_libip.cc
@@ -82,14 +82,14 @@ acl_nfmark::~acl_nfmark() STUB
 void Ip::Qos::getTosFromServer(const Comm::ConnectionPointer &, fde *) STUB
 nfmark_t Ip::Qos::getNfConnmark(const Comm::ConnectionPointer &, const ConnectionDirection) STUB_RETVAL(-1)
 bool Ip::Qos::setNfConnmark(Comm::ConnectionPointer &, const ConnectionDirection, const Ip::NfMarkConfig &) STUB_RETVAL(false)
-int Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
-int Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(-1)
-int Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
-int Ip::Qos::doNfmarkLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(-1)
-int Ip::Qos::setSockTos(const Comm::ConnectionPointer &, tos_t) STUB_RETVAL(-1)
-int Ip::Qos::setSockTos(const int, tos_t, int) STUB_RETVAL(-1)
-int Ip::Qos::setSockNfmark(const Comm::ConnectionPointer &, nfmark_t) STUB_RETVAL(-1)
-int Ip::Qos::setSockNfmark(const int, nfmark_t) STUB_RETVAL(-1)
+bool Ip::Qos::doTosLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(false)
+bool Ip::Qos::doNfmarkLocalMiss(const Comm::ConnectionPointer &, const hier_code) STUB_RETVAL(false)
+bool Ip::Qos::doTosLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(false)
+bool Ip::Qos::doNfmarkLocalHit(const Comm::ConnectionPointer &) STUB_RETVAL(false)
+bool Ip::Qos::setSockTos(const Comm::ConnectionPointer &, tos_t) STUB_RETVAL(false)
+bool Ip::Qos::setSockTos(const int, tos_t, int) STUB_RETVAL(false)
+bool Ip::Qos::setSockNfmark(const Comm::ConnectionPointer &, nfmark_t) STUB_RETVAL(false)
+bool Ip::Qos::setSockNfmark(const int, nfmark_t) STUB_RETVAL(false)
 Ip::Qos::Config::Config() STUB_NOP
 void Ip::Qos::Config::parseConfigLine() STUB
 void Ip::Qos::Config::dumpConfigLine(std::ostream &, const char *) const STUB

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -983,7 +983,7 @@ wccp2ConnectionOpen(void)
 
 #if defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_DONT)
     static_assert(IP_PMTUDISC_DONT == 0);
-    Comm::SetBooleanSocketOption(theWccp2Connection, SOL_IP, IP_MTU_DISCOVER, false, SBuf("IP_MTU_DISCOVER for WCCPv2 receiver"));
+    (void)Comm::SetBooleanSocketOption(theWccp2Connection, SOL_IP, IP_MTU_DISCOVER, false, SBuf("IP_MTU_DISCOVER for WCCPv2 receiver"));
 #endif
 
     Comm::SetSelect(theWccp2Connection, COMM_SELECT_READ, wccp2HandleUdp, nullptr, 0);

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -16,7 +16,7 @@
 #include "comm.h"
 #include "comm/Connection.h"
 #include "comm/Loops.h"
-#include "comm/Tcp.h"
+#include "comm/SocketOptions.h"
 #include "ConfigParser.h"
 #include "event.h"
 #include "ip/Address.h"


### PR DESCRIPTION
Commit db60fdb26c0b92988f7a059655beb051c5b8e545 added
SetSocketOption() and SetBooleanSocketOption() to remove code
duplication around calls to setsockopt(2) but did not convert
most of the relevant syscalls.

Implement the waiting "TODO: Move SetSocketOption() and friends
for wider reuse.") and cleanup code around all relevant
setsockopt(2) calls. That cleanup has implicated addition of a
description parameter to the template to ease debugs() output,
some API and documentation changes to QoS setting functions, and
some polish of #ifdef precompiler directives.