### PR TITLE
Remove always-zero CacheDigestGuessStats::closeHits

### DIFF
--- a/src/CacheDigest.cc
+++ b/src/CacheDigest.cc
@@ -237,8 +237,6 @@ cacheDigestGuessStatsReport(const CacheDigestGuessStats * stats, StoreEntry * se
                       hit_count, xpercent(hit_count, tot_count),
                       miss_count, xpercent(miss_count, tot_count),
                       tot_count, xpercent(tot_count, tot_count));
-    storeAppendPrintf(sentry, "\tclose_hits: %d ( %d%%) /* cd said hit, doc was in the peer cache, but we got a miss */\n",
-                      stats->closeHits, xpercentInt(stats->closeHits, stats->falseHits));
 }
 
 void

--- a/src/StatCounters.h
+++ b/src/StatCounters.h
@@ -22,7 +22,6 @@ public:
     int falseHits = 0;
     int trueMisses = 0;
     int falseMisses = 0;
-    int closeHits = 0;     // TODO: temporary. remove it later
 };
 #endif
 


### PR DESCRIPTION
The data member stopped being updated in 1998 commit 69c95dd3. It was
scheduled for removal since inception in 1998 commit 04f0c415.
