### PR TITLE
CI: autodetect autotools versions in openbsd

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -224,7 +224,7 @@ jobs:
             export pjobs="-j`gnproc`"
             export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//'`
             export ACLOCAL_AUTOMAKE_DIR="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
-            export ACLOCAL_PATH="/usr/local/share/aclocal:/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
+            export ACLOCAL_PATH="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//'`
             export CFLAGS='-Wno-compound-token-split-by-macro'
             export LDFLAGS="-L/usr/local/lib"

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -222,13 +222,13 @@ jobs:
           run: |
             export MAKE=gmake
             export pjobs="-j`gnproc`"
-            export AUTOMAKE_VERSION=1.16
+            export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//' | tail -1`
             export amver=${AUTOMAKE_VERSION}
             export ACLOCAL_AUTOMAKE_DIR="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export ACLOCAL_PATH="/usr/local/share/aclocal:/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
-            export AUTOCONF_VERSION=2.72
+            export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//' | tail -1`
             export acver=${AUTOCONF_VERSION}
-            export ltver=2.4.2
+            export ltver=`libtool --version | head -1 | sed 's/.* //'`
             export CFLAGS='-Wno-compound-token-split-by-macro'
             export LDFLAGS="-L/usr/local/lib"
             # until we remove GNUisms from our grep commands,

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -224,12 +224,9 @@ jobs:
             export MAKE=gmake
             export pjobs="-j`gnproc`"
             export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//' | tail -1`
-            export amver=${AUTOMAKE_VERSION}
             export ACLOCAL_AUTOMAKE_DIR="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export ACLOCAL_PATH="/usr/local/share/aclocal:/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//' | tail -1`
-            export acver=${AUTOCONF_VERSION}
-            export ltver=`libtool --version | head -1 | sed 's/.* //'`
             export CFLAGS='-Wno-compound-token-split-by-macro'
             export LDFLAGS="-L/usr/local/lib"
             # until we remove GNUisms from our grep commands,

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -200,7 +200,6 @@ jobs:
           release: "7.6"
           prepare: |
             pkg_add \
-              autoconf-2.72p0 \
               autoconf-archive \
               automake-1.16.5 \
               bash \
@@ -223,10 +222,10 @@ jobs:
           run: |
             export MAKE=gmake
             export pjobs="-j`gnproc`"
-            export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//' | tail -1`
+            export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//'`
             export ACLOCAL_AUTOMAKE_DIR="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export ACLOCAL_PATH="/usr/local/share/aclocal:/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
-            export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//' | tail -1`
+            export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//'`
             export CFLAGS='-Wno-compound-token-split-by-macro'
             export LDFLAGS="-L/usr/local/lib"
             # until we remove GNUisms from our grep commands,


### PR DESCRIPTION
Detect the installed version of autotools on an OpenBSD system, and use it.
Fail if it's missing or if more than one is installed