### PR TITLE
CI: Upgrade Ubuntu runners from v22.04 to v24.04

### DIFF
--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -17,7 +17,7 @@ jobs:
     # only run the workflow on Squid's main repository
     if: github.repository == 'squid-cache/squid'
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # this job relies on GitHub repository secrets containing
     # username and password to access the Coverity Scan service

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       # XXX: A hack to fix Ubuntu runners that were created in April 2025.
       - name: Fix /etc/hosts
-      - run: |
+        run: |
           cat /etc/hosts
           cp -p /etc/hosts /tmp/etc-hosts.bak
           sudo sed --in-place -E 's/^(-e.*)/# \1/' /etc/hosts

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -53,10 +53,8 @@ jobs:
 
       - name: Install prerequisite Linux packages
         run: |
-          cp -p /etc/apt/sources.list.d/ubuntu.sources /tmp/ubuntu.sources.bak
           # required for "apt-get build-dep" to work
           sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-          diff -u /tmp/ubuntu.sources.bak /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
           sudo apt-get --quiet=2 install libtool-bin
@@ -145,10 +143,8 @@ jobs:
 
       - name: Install prerequisite Linux packages
         run: |
-          cp -p /etc/apt/sources.list.d/ubuntu.sources /tmp/ubuntu.sources.bak
           # required for "apt-get build-dep" to work
           sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-          diff -u /tmp/ubuntu.sources.bak /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
           sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin ${{ matrix.compiler.CC }} ccache valgrind
@@ -183,10 +179,8 @@ jobs:
 
       - name: Install prerequisite Linux packages
         run: |
-          cp -p /etc/apt/sources.list.d/ubuntu.sources /tmp/ubuntu.sources.bak
           # required for "apt-get build-dep" to work
           sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-          diff -u /tmp/ubuntu.sources.bak /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
           sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -43,7 +43,13 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - run: cat /etc/hosts
+      # XXX: A hack to fix Ubuntu runners that were created in April 2025.
+      - name: Fix /etc/hosts
+      - run: |
+          cat /etc/hosts
+          cp -p /etc/hosts /tmp/etc-hosts.bak
+          sudo sed --in-place -E 's/^-e.*/# \1/' /etc/hosts
+          diff -u /tmp/etc-hosts.bak /etc/hosts.bak
 
       - name: Install prerequisite packages
         run: |

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install prerequisite packages
         run: |
           sudo apt-get --quiet=2 update
-          sudo apt-get --quiet=2 install libtool-bin
+          sudo apt-get --quiet=2 install libtool-bin libltdl-dev
 
       - name: Setup a nodejs environment
         uses: actions/setup-node@v4

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -43,6 +43,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - run: cat /etc/hosts
+
       - name: Install prerequisite packages
         run: |
           sudo apt-get --quiet=2 update

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -49,7 +49,7 @@ jobs:
           cat /etc/hosts
           cp -p /etc/hosts /tmp/etc-hosts.bak
           sudo sed --in-place -E 's/^(-e.*)/# \1/' /etc/hosts
-          diff -u /tmp/etc-hosts.bak /etc/hosts.bak
+          diff -u /tmp/etc-hosts.bak /etc/hosts || true
 
       - name: Install prerequisite packages
         run: |
@@ -180,7 +180,7 @@ jobs:
           cp -pi /etc/apt/sources.list.d/ubuntu.sources /tmp/tus
           # required for "apt-get build-dep" to work
           sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-          diff -u /tmp/tus /etc/apt/sources.list.d/ubuntu.sources
+          diff -u /tmp/tus /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
           sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -40,7 +40,7 @@ jobs:
 
   functionality-tests:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Install prerequisite packages
@@ -83,7 +83,7 @@ jobs:
 
   source-maintenance-tests:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Install prerequisite packages
@@ -111,7 +111,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         compiler:
           - { CC: gcc, CXX: g++ }
           - { CC: clang, CXX: clang++ }
@@ -159,7 +159,7 @@ jobs:
 
   CodeQL-tests:
 
-    runs-on: [ ubuntu-22.04 ]
+    runs-on: [ ubuntu-24.04 ]
 
     permissions:
       security-events: write

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -51,10 +51,15 @@ jobs:
           sudo sed --in-place -E 's/^(-e.*)/# \1/' /etc/hosts
           diff -u /tmp/etc-hosts.bak /etc/hosts || true
 
-      - name: Install prerequisite packages
+      - name: Install prerequisite Linux packages
         run: |
+          cp -p /etc/apt/sources.list.d/ubuntu.sources /tmp/ubuntu.sources.bak
+          # required for "apt-get build-dep" to work
+          sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          diff -u /tmp/ubuntu.sources.bak /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt-get --quiet=2 update
-          sudo apt-get --quiet=2 install libtool-bin libltdl-dev
+          sudo apt-get --quiet=2 build-dep squid
+          sudo apt-get --quiet=2 install libtool-bin
 
       - name: Setup a nodejs environment
         uses: actions/setup-node@v4

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -168,8 +168,11 @@ jobs:
 
       - name: Install Squid prerequisite Linux packages
         run: |
+          cat /etc/apt/sources.list.d/ubuntu.sources
+          cp -pi /etc/apt/sources.list.d/ubuntu.sources /tmp/tus
           # required for "apt-get build-dep" to work
-          sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
+          sudo sed --in-place -E 's/^Types: deb$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          diff -u /tmp/tus /etc/apt/sources.list.d/ubuntu.sources
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
           sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -48,7 +48,7 @@ jobs:
       - run: |
           cat /etc/hosts
           cp -p /etc/hosts /tmp/etc-hosts.bak
-          sudo sed --in-place -E 's/^-e.*/# \1/' /etc/hosts
+          sudo sed --in-place -E 's/^(-e.*)/# \1/' /etc/hosts
           diff -u /tmp/etc-hosts.bak /etc/hosts.bak
 
       - name: Install prerequisite packages
@@ -179,7 +179,7 @@ jobs:
           cat /etc/apt/sources.list.d/ubuntu.sources
           cp -pi /etc/apt/sources.list.d/ubuntu.sources /tmp/tus
           # required for "apt-get build-dep" to work
-          sudo sed --in-place -E 's/^Types: deb$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
           diff -u /tmp/tus /etc/apt/sources.list.d/ubuntu.sources
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -140,8 +140,10 @@ jobs:
 
       - name: Install prerequisite Linux packages
         run: |
+          cp -p /etc/apt/sources.list.d/ubuntu.sources /tmp/ubuntu.sources.bak
           # required for "apt-get build-dep" to work
-          sudo sed --in-place -E 's/# (deb-src.*updates main)/  \1/g' /etc/apt/sources.list
+          sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          diff -u /tmp/ubuntu.sources.bak /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
           sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin ${{ matrix.compiler.CC }} ccache valgrind
@@ -174,13 +176,12 @@ jobs:
 
     steps:
 
-      - name: Install Squid prerequisite Linux packages
+      - name: Install prerequisite Linux packages
         run: |
-          cat /etc/apt/sources.list.d/ubuntu.sources
-          cp -pi /etc/apt/sources.list.d/ubuntu.sources /tmp/tus
+          cp -p /etc/apt/sources.list.d/ubuntu.sources /tmp/ubuntu.sources.bak
           # required for "apt-get build-dep" to work
           sudo sed --in-place -E 's/^(Types: deb)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-          diff -u /tmp/tus /etc/apt/sources.list.d/ubuntu.sources || true
+          diff -u /tmp/ubuntu.sources.bak /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt-get --quiet=2 update
           sudo apt-get --quiet=2 build-dep squid
           sudo apt-get --quiet=2 install linuxdoc-tools libtool-bin

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -50,7 +50,7 @@ jobs:
           - { name: layer-01-minimal, nick: minimal }
           - { name: layer-02-maximus, nick: maximus }
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: squidcache/buildfarm-${{ matrix.os }}:stable
       options: --user 1001 # uid used by worfklow runner
@@ -145,7 +145,7 @@ jobs:
           - 14.2
           - 13.4
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: freebsd(${{ matrix.osversion }})
 
     steps:
@@ -186,7 +186,7 @@ jobs:
           path: btlayer-*.log
 
   openbsd:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Sources


### PR DESCRIPTION
* Ubuntu 24.04 uses different apt sources file location and format.

* Some Ubuntu 24.04 GitHub Actions runners lack libltdl-dev as detailed
  at https://github.com/actions/runner-images/issues/11316.
  We could explicitly install libltdl-dev for functionality tests, but
  decided to go one step further and unify all prerequisites
  installation steps for tests that build Squid on Ubuntu.

Also added a hack to fix /etc/hosts broken on some Ubuntu runners and
resulting in Squid startup errors during functionality tests:

    kid1| ERROR: ipcacheAddEntryFromHosts: Bad IP address '-e'
