### PR TITLE
CI: enable slow build tests for github merge queue

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -14,6 +14,10 @@ on:
   push:
     branches: [ "auto" ]
 
+  # GitHub merge queue
+  merge_group:
+    branches: [ "master", "v7" ]
+
   # allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Add the workflow piece(s) to make github run our "slow" tests
only on merge queue entries.

Github merge queues are now able to perform all the required
checks and details Squid Project applies to code additions.

The manual "Add to merge queue" button on github UI is an
identical procedural step replacing the current manual
"M-cleared-for-merge" label.

The "Add to merge queue" is not available to PRs until they pass
review approval and the "quick" code tests. The same criteria
Anubis uses to determine whether to start these "slow" tests.

For now Anubis and 'auto' branch are left as-is. They can be
dropped later when the merge queue is formally accepted for
use by Squid Project.