### PR TITLE
Disable EUI when arpreq is missing and cannot be defined

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -223,13 +223,13 @@ jobs:
           run: |
             export MAKE=gmake
             export pjobs="-j`gnproc`"
-            export AUTOMAKE_VERSION=1.16
+            export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//' | tail -1`
             export amver=${AUTOMAKE_VERSION}
             export ACLOCAL_AUTOMAKE_DIR="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export ACLOCAL_PATH="/usr/local/share/aclocal:/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
-            export AUTOCONF_VERSION=2.72
+            export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//' | tail -1`
             export acver=${AUTOCONF_VERSION}
-            export ltver=2.4.2
+            export ltver=`libtool --version | head -1 | sed 's/.* //'`
             export CFLAGS='-Wno-compound-token-split-by-macro'
             export LDFLAGS="-L/usr/local/lib"
             # until we remove GNUisms from our grep commands,

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -223,10 +223,13 @@ jobs:
           run: |
             export MAKE=gmake
             export pjobs="-j`gnproc`"
-            export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//' | tail -1`
+            export AUTOMAKE_VERSION=1.16
+            export amver=${AUTOMAKE_VERSION}
             export ACLOCAL_AUTOMAKE_DIR="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export ACLOCAL_PATH="/usr/local/share/aclocal:/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
-            export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//' | tail -1`
+            export AUTOCONF_VERSION=2.72
+            export acver=${AUTOCONF_VERSION}
+            export ltver=2.4.2
             export CFLAGS='-Wno-compound-token-split-by-macro'
             export LDFLAGS="-L/usr/local/lib"
             # until we remove GNUisms from our grep commands,

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -224,12 +224,9 @@ jobs:
             export MAKE=gmake
             export pjobs="-j`gnproc`"
             export AUTOMAKE_VERSION=`ls /usr/local/bin/automake-* | sed 's/.*-//' | tail -1`
-            export amver=${AUTOMAKE_VERSION}
             export ACLOCAL_AUTOMAKE_DIR="/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export ACLOCAL_PATH="/usr/local/share/aclocal:/usr/local/share/aclocal-${AUTOMAKE_VERSION}"
             export AUTOCONF_VERSION=`ls /usr/local/bin/autoconf-* | sed 's/.*-//' | tail -1`
-            export acver=${AUTOCONF_VERSION}
-            export ltver=`libtool --version | head -1 | sed 's/.* //'`
             export CFLAGS='-Wno-compound-token-split-by-macro'
             export LDFLAGS="-L/usr/local/lib"
             # until we remove GNUisms from our grep commands,

--- a/configure.ac
+++ b/configure.ac
@@ -989,10 +989,10 @@ include <windows.h>
 #endif
   ]])
   AC_CHECK_MEMBER([struct arpreq.arp_pa],[],[
-  AS_IF([test "x$squid_host_os" != "xmingw" -a "x$squid_host_os" != "xcygwin"],[
-    AC_MSG_NOTICE([OS support for EUI seems incomplete, disabling it])
-    enable_eui=no
-  ],[
+    AS_IF([test "x$squid_host_os" != "xmingw" -a "x$squid_host_os" != "xcygwin"],[
+      AC_MSG_NOTICE([OS support for EUI seems incomplete, disabling it])
+      enable_eui=no
+    ])],[[
 #if HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1002,9 +1002,8 @@ include <windows.h>
 #if HAVE_NET_IF_ARP_H
 #include <net/if_arp.h>
 #endif
-  ])
+  ]])
   SQUID_STATE_ROLLBACK(LIBEUI)
-  ])
 ])
 AC_SUBST(EUILIB)
 AC_MSG_NOTICE([EUI (MAC address) controls enabled: $enable_eui])

--- a/configure.ac
+++ b/configure.ac
@@ -989,8 +989,12 @@ include <windows.h>
 #endif
   ]])
   AC_CHECK_MEMBER([struct arpreq.arp_pa],,,[
+#if HAVE_SYS_TYPES_H
 #include <sys/types.h>
+#endif
+#if HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
+#endif
 #if HAVE_NET_IF_ARP_H
 #include <net/if_arp.h>
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -1005,8 +1005,8 @@ include <windows.h>
   ])
   SQUID_STATE_ROLLBACK(LIBEUI)
   ])
-  AC_SUBST(EUILIB)
 ])
+AC_SUBST(EUILIB)
 AC_MSG_NOTICE([EUI (MAC address) controls enabled: $enable_eui])
 SQUID_DEFINE_BOOL(USE_SQUID_EUI,$enable_eui,
    [Define this to include code which lets you use ethernet addresses. This code uses API initially defined in 4.4-BSD.])

--- a/configure.ac
+++ b/configure.ac
@@ -988,7 +988,11 @@ include <windows.h>
 #include <sys/param.h>
 #endif
   ]])
-  AC_CHECK_MEMBER([struct arpreq.arp_pa],,,[
+  AC_CHECK_MEMBER([struct arpreq.arp_pa],[],[
+  AS_IF([test "x$squid_host_os" != "xwindows"],[
+    AC_MSG_NOTICE([OS support for EUI seems incomplete, disabling it])
+    enable_eui=no
+  ],[
 #if HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1000,11 +1004,8 @@ include <windows.h>
 #endif
   ])
   SQUID_STATE_ROLLBACK(LIBEUI)
-])
-AC_SUBST(EUILIB)
-AS_IF([ test "$enable_eui" = "yes" -a "$squid_host_os" != "windows" -a "x${ac_cv_member_struct_arpreq_arp_pa}" = "xno"],[
-    AC_MSG_NOTICE([OS support for EUI seems incomplete, disabling it])
-    enable_eui=no
+  ])
+  AC_SUBST(EUILIB)
 ])
 AC_MSG_NOTICE([EUI (MAC address) controls enabled: $enable_eui])
 SQUID_DEFINE_BOOL(USE_SQUID_EUI,$enable_eui,

--- a/configure.ac
+++ b/configure.ac
@@ -989,7 +989,7 @@ include <windows.h>
 #endif
   ]])
   AC_CHECK_MEMBER([struct arpreq.arp_pa],[],[
-  AS_IF([test "x$squid_host_os" != "xwindows"],[
+  AS_IF([test "x$squid_host_os" != "xmingw" -a "x$squid_host_os" != "xcygwin"],[
     AC_MSG_NOTICE([OS support for EUI seems incomplete, disabling it])
     enable_eui=no
   ],[

--- a/configure.ac
+++ b/configure.ac
@@ -988,9 +988,22 @@ include <windows.h>
 #include <sys/param.h>
 #endif
   ]])
+  AC_CHECK_MEMBER([struct arpreq.arp_pa],,,[
+#include <sys/types.h>
+#include <sys/socket.h>
+#if HAVE_NET_IF_ARP_H
+#include <net/if_arp.h>
+#endif
+  ])
+  SQUID_DEFINE_BOOL(HAVE_WORKABLE_STRUCT_ARPREQ,${ac_cv_member_struct_arpreq_arp_pa:=no},
+    [Does the system provide a struct arpreq we can use])
   SQUID_STATE_ROLLBACK(LIBEUI)
 ])
 AC_SUBST(EUILIB)
+AS_IF([ test "$enable_eui" = "yes" -a "$squid_host_os" != "windows" -a "x${ac_cv_member_struct_arpreq_arp_pa}" = "xno"],[
+    AC_MSG_NOTICE([OS support for EUI seems incomplete, disabling it])
+    enable_eui=no
+])
 AC_MSG_NOTICE([EUI (MAC address) controls enabled: $enable_eui])
 SQUID_DEFINE_BOOL(USE_SQUID_EUI,$enable_eui,
    [Define this to include code which lets you use ethernet addresses. This code uses API initially defined in 4.4-BSD.])

--- a/configure.ac
+++ b/configure.ac
@@ -999,8 +999,6 @@ include <windows.h>
 #include <net/if_arp.h>
 #endif
   ])
-  SQUID_DEFINE_BOOL(HAVE_WORKABLE_STRUCT_ARPREQ,${ac_cv_member_struct_arpreq_arp_pa:=no},
-    [Does the system provide a struct arpreq we can use])
   SQUID_STATE_ROLLBACK(LIBEUI)
 ])
 AC_SUBST(EUILIB)


### PR DESCRIPTION
OpenBSD 7.7 provides a net/if_arp.h header file,
but it doesn't provide a `struct arpreq`, which 
is necessary for our EUI implementation to work.

Disable EUI when arpreq definition is missing,
except on Windows where we provide our own.