### PR TITLE
Fix OpenSSL build with GCC v15.1.1 [-Wformat-truncation=]

### DIFF
--- a/src/ssl/crtd_message.cc
+++ b/src/ssl/crtd_message.cc
@@ -128,9 +128,7 @@ void Ssl::CrtdMessage::setCode(std::string const & aCode) { code = aCode; }
 std::string Ssl::CrtdMessage::compose() const
 {
     if (code.empty()) return std::string();
-    char buffer[10];
-    snprintf(buffer, sizeof(buffer), "%zd", body.length());
-    return code + ' ' + buffer + ' ' + body;
+    return code + ' ' + std::to_string(body.length()) + ' ' + body;
 }
 
 void Ssl::CrtdMessage::clear()


### PR DESCRIPTION
On arm64 Fedora 42:

    src/ssl/crtd_message.cc:132:39: error: '%zd' directive output may be
        truncated writing between 1 and 19 bytes into a region
        of size 10 [-Werror=format-truncation=]
        snprintf(buffer, sizeof(buffer), "%zd", body.length());
