### PR TITLE
CI: Fix gperf 3.2 output filter

### DIFF
--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -663,8 +663,8 @@ generateRawGperfFile ()
     echo
 
     if test `gperf --version | head -1 | cut -d ' ' -f 3 | cut -d. -f '-2' | sed -e 's/\.//'` -lt 32 ; then
-        # our C++17 compilers complain about missing '[[fallthrough]]' attribute
-        # when old gperf versions use a '/*FALLTHROUGH*/' code comment.
+        # We configure C++ compilers to complain about missing '[[fallthrough]]' attribute
+        # where old gperf versions use a '/*FALLTHROUGH*/' code comment.
         (cd `dirname $gperfFile` && gperf -m 100000 `basename $gperfFile`) | \
             sed -e 's@/[*]FALLTHROUGH[*]/@[[fallthrough]];@g'
     else

--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -662,8 +662,15 @@ generateRawGperfFile ()
     echo "/* $GeneratedByMe */"
     echo
 
-    (cd `dirname $gperfFile` && gperf -m 100000 `basename $gperfFile`) | \
-        sed 's@/[*]FALLTHROUGH[*]/@[[fallthrough]];@g'
+    if test `gperf --version | head -1 | cut -d ' ' -f 3 | cut -d. -f '-2' | sed -e 's/\.//'` -lt 32 ; then
+        # our C++17 compilers complain about missing '[[fallthrough]]' attribute
+        # when old gperf versions use a '/*FALLTHROUGH*/' code comment.
+        (cd `dirname $gperfFile` && gperf -m 100000 `basename $gperfFile`) | \
+            sed -e 's@/[*]FALLTHROUGH[*]/@[[fallthrough]];@g'
+    else
+        # gperf 3.2+ provide fallthrough attributes
+        (cd `dirname $gperfFile` && gperf -m 100000 `basename $gperfFile`)
+    fi
 }
 
 generateGperfFile ()


### PR DESCRIPTION
gperf 3.2 now provides properly compiler and C++ version scoped
fallthrough attributes. Our filter to convert the gperf 3.1 and
older output for C++17 attribute requirements is now broken and
produces compiler errors due to listing '[[fallback]];' on two
consecutive lines.