### PR TITLE
Do not duplicate received Surrogate-Capability in sent requests

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -1957,6 +1957,7 @@ HttpStateData::httpBuildRequestHeader(HttpRequest * request,
         String strSurrogate(hdr_in->getList(Http::HdrType::SURROGATE_CAPABILITY));
         snprintf(bbuf, BBUF_SZ, "%s=\"Surrogate/1.0\"", Config.Accel.surrogate_id);
         strListAdd(&strSurrogate, bbuf, ',');
+        hdr_out->delById(Http::HdrType::SURROGATE_CAPABILITY);
         hdr_out->putStr(Http::HdrType::SURROGATE_CAPABILITY, strSurrogate.termedBuf());
     }
 


### PR DESCRIPTION
When computing Surrogate-Capability header while forwarding an
accelerated request, Squid duplicated old (i.e. received) header entries
(if any). For example, this outgoing request shows an extra hop1 entry:

    GET / HTTP/1.1
    ...
    Surrogate-Capability: hop1="Surrogate/1.0"
    Surrogate-Capability: hop1="Surrogate/1.0", hop2="Surrogate/1.0"