### PR TITLE
Fix missing CONTRIBUTOR name

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -528,7 +528,7 @@ Thank you!
     trapexit <trapexit@spawn.link>
     Trever Adams <trever@middleearth.sapphiresunday.org>
     Tsantilas Christos <chtsanti@users.sourceforge.net>
-    <ture@turepalsson.se>
+    Ture Pålsson <ture@turepalsson.se>
     Unknown
     Unknown - Debian Project
     Unknown - NetBSD Project


### PR DESCRIPTION
Despite CONTRIBUTORS file being UTF-8 Ture's name
was dropped by our conversion script which does not
handle non-ASCII characters nicely. Re-add it manually.