### PR TITLE
Maintenance: remove auth initialization globals

### DIFF
--- a/src/auth/SchemeConfig.cc
+++ b/src/auth/SchemeConfig.cc
@@ -174,6 +174,8 @@ Auth::SchemeConfig::dump(StoreEntry *entry, const char *name, Auth::SchemeConfig
 void
 Auth::SchemeConfig::done()
 {
+    _active = false;
+
     delete keyExtras;
     keyExtras = nullptr;
     keyExtrasLine.clean();

--- a/src/auth/SchemeConfig.h
+++ b/src/auth/SchemeConfig.h
@@ -63,7 +63,8 @@ public:
      \retval true   Authentication Module loaded and running.
      \retval false  No Authentication Module loaded.
      */
-    virtual bool active() const = 0;
+    bool active() const { return _active; }
+    void activate() { _active = true; }
 
     /**
      * new decode API: virtual factory pattern
@@ -144,6 +145,9 @@ protected:
 
     /// RFC 7235 section 2.2 - Protection Space (Realm)
     SBuf realm;
+
+    /// whether this scheme has been configured and initialized
+    bool _active = false;
 };
 
 } // namespace Auth

--- a/src/auth/basic/Config.cc
+++ b/src/auth/basic/Config.cc
@@ -38,8 +38,6 @@ static AUTHSSTATS authenticateBasicStats;
 
 Helper::ClientPointer basicauthenticators;
 
-static int authbasic_initialised = 0;
-
 /*
  *
  * Public Functions
@@ -47,12 +45,6 @@ static int authbasic_initialised = 0;
  */
 
 /* internal functions */
-
-bool
-Auth::Basic::Config::active() const
-{
-    return authbasic_initialised == 1;
-}
 
 bool
 Auth::Basic::Config::configured() const
@@ -102,8 +94,6 @@ void
 Auth::Basic::Config::done()
 {
     Auth::SchemeConfig::done();
-
-    authbasic_initialised = 0;
 
     if (basicauthenticators) {
         helperShutdown(basicauthenticators);
@@ -301,7 +291,7 @@ void
 Auth::Basic::Config::init(Auth::SchemeConfig *)
 {
     if (authenticateProgram) {
-        authbasic_initialised = 1;
+        activate();
 
         if (basicauthenticators == nullptr)
             basicauthenticators = Helper::Client::Make("basicauthenticator");

--- a/src/auth/basic/Config.h
+++ b/src/auth/basic/Config.h
@@ -26,7 +26,6 @@ class Config : public Auth::SchemeConfig
 {
 public:
     Config();
-    bool active() const override;
     bool configured() const override;
     Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
     void done() override;

--- a/src/auth/digest/Config.h
+++ b/src/auth/digest/Config.h
@@ -73,7 +73,6 @@ class Config : public Auth::SchemeConfig
 {
 public:
     Config();
-    bool active() const override;
     bool configured() const override;
     Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
     void done() override;

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -34,8 +34,6 @@ static AUTHSSTATS authenticateNegotiateStats;
 
 Helper::StatefulClientPointer negotiateauthenticators;
 
-static int authnegotiate_initialised = 0;
-
 static hash_table *proxy_auth_cache = nullptr;
 
 void
@@ -53,8 +51,6 @@ void
 Auth::Negotiate::Config::done()
 {
     Auth::SchemeConfig::done();
-
-    authnegotiate_initialised = 0;
 
     if (negotiateauthenticators) {
         helperStatefulShutdown(negotiateauthenticators);
@@ -86,7 +82,7 @@ Auth::Negotiate::Config::init(Auth::SchemeConfig *)
 {
     if (authenticateProgram) {
 
-        authnegotiate_initialised = 1;
+        activate();
 
         if (negotiateauthenticators == nullptr)
             negotiateauthenticators = statefulhelper::Make("negotiateauthenticator");
@@ -112,12 +108,6 @@ Auth::Negotiate::Config::registerWithCacheManager(void)
     Mgr::RegisterAction("negotiateauthenticator",
                         "Negotiate User Authenticator Stats",
                         authenticateNegotiateStats, 0, 1);
-}
-
-bool
-Auth::Negotiate::Config::active() const
-{
-    return authnegotiate_initialised == 1;
 }
 
 bool

--- a/src/auth/negotiate/Config.h
+++ b/src/auth/negotiate/Config.h
@@ -25,7 +25,6 @@ namespace Negotiate
 class Config : public Auth::SchemeConfig
 {
 public:
-    bool active() const override;
     bool configured() const override;
     Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
     void done() override;

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -34,7 +34,6 @@
 static AUTHSSTATS authenticateNTLMStats;
 
 Helper::StatefulClientPointer ntlmauthenticators;
-static int authntlm_initialised = 0;
 
 static hash_table *proxy_auth_cache = nullptr;
 
@@ -54,8 +53,6 @@ void
 Auth::Ntlm::Config::done()
 {
     Auth::SchemeConfig::done();
-
-    authntlm_initialised = 0;
 
     if (ntlmauthenticators) {
         helperStatefulShutdown(ntlmauthenticators);
@@ -85,7 +82,7 @@ Auth::Ntlm::Config::init(Auth::SchemeConfig *)
 {
     if (authenticateProgram) {
 
-        authntlm_initialised = 1;
+        activate();
 
         if (ntlmauthenticators == nullptr)
             ntlmauthenticators = statefulhelper::Make("ntlmauthenticator");
@@ -111,12 +108,6 @@ Auth::Ntlm::Config::registerWithCacheManager(void)
     Mgr::RegisterAction("ntlmauthenticator",
                         "NTLM User Authenticator Stats",
                         authenticateNTLMStats, 0, 1);
-}
-
-bool
-Auth::Ntlm::Config::active() const
-{
-    return authntlm_initialised == 1;
 }
 
 bool

--- a/src/auth/ntlm/Config.h
+++ b/src/auth/ntlm/Config.h
@@ -28,7 +28,6 @@ namespace Ntlm
 class Config : public Auth::SchemeConfig
 {
 public:
-    bool active() const override;
     bool configured() const override;
     Auth::UserRequest::Pointer decode(char const *proxy_auth, const HttpRequest *request, const char *requestRealm) override;
     void done() override;


### PR DESCRIPTION
Replace with a scheme-specific flag.