### PR TITLE
Fix authentication module initialization state checks

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -486,7 +486,7 @@ Auth::Digest::Config::configured() const
 void
 Auth::Digest::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, HttpReply *rep, Http::HdrType hdrType, HttpRequest *)
 {
-    if (!authenticateProgram)
+    if (!active())
         return;
 
     bool stale = false;
@@ -522,21 +522,21 @@ Auth::Digest::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, Ht
 void
 Auth::Digest::Config::init(Auth::SchemeConfig *)
 {
-    if (authenticateProgram) {
-        authenticateDigestNonceSetup();
-        authdigest_initialised = 1;
+    if (!configured())
+        return;
 
-        if (digestauthenticators == nullptr)
-            digestauthenticators = Helper::Client::Make("digestauthenticator");
+    assert(!active());
 
-        digestauthenticators->cmdline = authenticateProgram;
+    authenticateDigestNonceSetup();
+    authdigest_initialised = 1;
 
-        digestauthenticators->childs.updateLimits(authenticateChildren);
+    if (!digestauthenticators)
+        digestauthenticators = Helper::Client::Make("digestauthenticator");
 
-        digestauthenticators->ipc_type = IPC_STREAM;
-
-        digestauthenticators->openSessions();
-    }
+    digestauthenticators->cmdline = authenticateProgram;
+    digestauthenticators->childs.updateLimits(authenticateChildren);
+    digestauthenticators->ipc_type = IPC_STREAM;
+    digestauthenticators->openSessions();
 }
 
 void

--- a/src/auth/negotiate/Config.cc
+++ b/src/auth/negotiate/Config.cc
@@ -84,26 +84,24 @@ Auth::Negotiate::Config::type() const
 void
 Auth::Negotiate::Config::init(Auth::SchemeConfig *)
 {
-    if (authenticateProgram) {
+    if (!configured())
+        return;
 
-        authnegotiate_initialised = 1;
+    assert(!active());
+    authnegotiate_initialised = 1;
 
-        if (negotiateauthenticators == nullptr)
-            negotiateauthenticators = statefulhelper::Make("negotiateauthenticator");
+    if (!negotiateauthenticators)
+        negotiateauthenticators = statefulhelper::Make("negotiateauthenticator");
 
-        if (!proxy_auth_cache)
-            proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
+    if (!proxy_auth_cache)
+        proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
 
-        assert(proxy_auth_cache);
+    assert(proxy_auth_cache);
 
-        negotiateauthenticators->cmdline = authenticateProgram;
-
-        negotiateauthenticators->childs.updateLimits(authenticateChildren);
-
-        negotiateauthenticators->ipc_type = IPC_STREAM;
-
-        negotiateauthenticators->openSessions();
-    }
+    negotiateauthenticators->cmdline = authenticateProgram;
+    negotiateauthenticators->childs.updateLimits(authenticateChildren);
+    negotiateauthenticators->ipc_type = IPC_STREAM;
+    negotiateauthenticators->openSessions();
 }
 
 void
@@ -135,7 +133,7 @@ Auth::Negotiate::Config::configured() const
 void
 Auth::Negotiate::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, HttpReply *rep, Http::HdrType reqType, HttpRequest * request)
 {
-    if (!authenticateProgram)
+    if (!active())
         return;
 
     /* Need keep-alive */

--- a/src/auth/ntlm/Config.cc
+++ b/src/auth/ntlm/Config.cc
@@ -83,26 +83,24 @@ Auth::Ntlm::Config::type() const
 void
 Auth::Ntlm::Config::init(Auth::SchemeConfig *)
 {
-    if (authenticateProgram) {
+    if (!configured())
+        return;
 
-        authntlm_initialised = 1;
+    assert(!active());
+    authntlm_initialised = 1;
 
-        if (ntlmauthenticators == nullptr)
-            ntlmauthenticators = statefulhelper::Make("ntlmauthenticator");
+    if (!ntlmauthenticators)
+        ntlmauthenticators = statefulhelper::Make("ntlmauthenticator");
 
-        if (!proxy_auth_cache)
-            proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
+    if (!proxy_auth_cache)
+        proxy_auth_cache = hash_create((HASHCMP *) strcmp, 7921, hash_string);
 
-        assert(proxy_auth_cache);
+    assert(proxy_auth_cache);
 
-        ntlmauthenticators->cmdline = authenticateProgram;
-
-        ntlmauthenticators->childs.updateLimits(authenticateChildren);
-
-        ntlmauthenticators->ipc_type = IPC_STREAM;
-
-        ntlmauthenticators->openSessions();
-    }
+    ntlmauthenticators->cmdline = authenticateProgram;
+    ntlmauthenticators->childs.updateLimits(authenticateChildren);
+    ntlmauthenticators->ipc_type = IPC_STREAM;
+    ntlmauthenticators->openSessions();
 }
 
 void
@@ -136,7 +134,7 @@ Auth::Ntlm::Config::configured() const
 void
 Auth::Ntlm::Config::fixHeader(Auth::UserRequest::Pointer auth_user_request, HttpReply *rep, Http::HdrType hdrType, HttpRequest * request)
 {
-    if (!authenticateProgram)
+    if (!active())
         return;
 
     /* Need keep-alive */


### PR DESCRIPTION
Squid was using the existence of an 'auth_param ... program'
setting to determine whether to initialize the scheme module for
use and advertise HTTP authentication headers for the scheme.

That parameter alone is not sufficient to determine that the
scheme is properly configured, and initialized. All schemes
require additional configuration and/or state.

Use the existing SchemeConfig::configured() method consistently
to determine whether the scheme has been fully configured.

Use the existing SchemeConfig::active() method consistently to
determine whether the scheme has been initialized and is ready
to handle traffic before allowing HTTP headers to be produced.