### PR TITLE
Bug 5497: Fix detection of duped IPs returned by getaddrinfo()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ Thank you!
     Alan Mizrahi <alan@mizrahi.com.ve>
     Alan Nastac <mrness@gentoo.org>
     Aleksa <susulic@gmail.com>
+    Andre Albsmeier <45147422+aafbsd@users.noreply.github.com>
     Alex Bason <nonsleepr@gmail.com>
     Alex Dowad <alexinbeijing@gmail.com>
     Alex Rousskov <rousskov@measurement-factory.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,7 +11,6 @@ Thank you!
     Alan Mizrahi <alan@mizrahi.com.ve>
     Alan Nastac <mrness@gentoo.org>
     Aleksa <susulic@gmail.com>
-    Andre Albsmeier <45147422+aafbsd@users.noreply.github.com>
     Alex Bason <nonsleepr@gmail.com>
     Alex Dowad <alexinbeijing@gmail.com>
     Alex Rousskov <rousskov@measurement-factory.com>
@@ -38,6 +37,7 @@ Thank you!
     Amos Jeffries <squid3@treenet.co.nz>
     Amos Jeffries <yadij@users.noreply.github.com>
     Anatoli <me@anatoli.ws>
+    Andre Albsmeier <45147422+aafbsd@users.noreply.github.com>
     Andre Albsmeier <Andre.Albsmeier@siemens.com>
     Andrea Gagliardi <andrea@netlite.it>
     Andreas Hasenack <panlinux@gmail.com>

--- a/src/acl/Ip.cc
+++ b/src/acl/Ip.cc
@@ -290,7 +290,7 @@ acl_ip_data::FactoryParse(const char *t)
         debugs(28, 5, "aclIpParseIpData: Lookup Host/IP " << addr1);
         struct addrinfo *hp = nullptr, *x = nullptr;
         struct addrinfo hints;
-      
+
         memset(&hints, 0, sizeof(struct addrinfo));
 
         int errcode = getaddrinfo(addr1,nullptr,&hints,&hp);
@@ -336,7 +336,8 @@ acl_ip_data::FactoryParse(const char *t)
             Q = &r->next;
 
             debugs(28, 3, "" << addr1 << " --> " << r->addr1 );
-skip:;
+skip:
+            ;
         }
 
         freeaddrinfo(hp);

--- a/src/acl/Ip.cc
+++ b/src/acl/Ip.cc
@@ -320,8 +320,8 @@ acl_ip_data::FactoryParse(const char *t)
             r->addr1 = *x;
             x = x->ai_next;
             acl_ip_data* cmp = q;
-            for( cmp = q; cmp != nullptr; cmp = cmp->next )
-                if( cmp->next != nullptr && cmp->addr1 == r->addr1 ) {
+            for (cmp = q; cmp != nullptr; cmp = cmp->next)
+                if (cmp->next != nullptr && cmp->addr1 == r->addr1) {
                     debugs(28, 3, "aclIpParseIpData: Duplicate host/IP: '" << r->addr1 << "' dropped.");
                     delete r;
                     *Q = nullptr;

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -45,7 +45,7 @@ private:
 
     static bool DecodeMask(const char *asc, Ip::Address &mask, int string_format_type);
 
-     bool containsVetted(const Ip::Address &needle) const;
+    bool containsVetted(const Ip::Address &needle) const;
 };
 
 class ACLIP : public Acl::Node

--- a/src/acl/Ip.h
+++ b/src/acl/Ip.h
@@ -44,6 +44,8 @@ public:
 private:
 
     static bool DecodeMask(const char *asc, Ip::Address &mask, int string_format_type);
+
+     bool containsVetted(const Ip::Address &needle) const;
 };
 
 class ACLIP : public Acl::Node


### PR DESCRIPTION
    WARNING: Ignoring <IP X> because it is already covered by <IP X>

Affects `src`, `dst`, and `localip` ACLs, especially those that use
domain names with multiple DNS A or AAAA records.

IP addresses returned by getaddrinfo(3) may not be sorted (e.g., when a
host has multiple DNS A RRs on FreeBSD). Instead of comparing the
current address with just the previous one, we now check all previously
added addresses (while processing a single getaddrinfo() call output).

This surgical fix minimizes changes without improving surrounding code.
