### PR TITLE
Maintenance: update MemBlob

### DIFF
--- a/src/sbuf/MemBlob.cc
+++ b/src/sbuf/MemBlob.cc
@@ -57,8 +57,7 @@ MemBlob::GetStats()
 
 /* MemBlob */
 
-MemBlob::MemBlob(const MemBlob::size_type reserveSize) :
-    mem(nullptr), capacity(0), size(0) // will be set by memAlloc
+MemBlob::MemBlob(const size_type reserveSize)
 {
     debugs(MEMBLOB_DEBUGSECTION,9, "constructed, this="
            << static_cast<void*>(this) << " id=" << id
@@ -66,8 +65,7 @@ MemBlob::MemBlob(const MemBlob::size_type reserveSize) :
     memAlloc(reserveSize);
 }
 
-MemBlob::MemBlob(const char *buffer, const MemBlob::size_type bufSize) :
-    mem(nullptr), capacity(0), size(0) // will be set by memAlloc
+MemBlob::MemBlob(const_pointer buffer, const size_type bufSize)
 {
     debugs(MEMBLOB_DEBUGSECTION,9, "constructed, this="
            << static_cast<void*>(this) << " id=" << id
@@ -101,7 +99,7 @@ MemBlob::memAlloc(const size_type minSize)
     size_t actualAlloc = minSize;
 
     Must(!mem);
-    mem = static_cast<char*>(memAllocBuf(actualAlloc, &actualAlloc));
+    mem = static_cast<value_type *>(memAllocBuf(actualAlloc, &actualAlloc));
     Must(mem);
 
     capacity = actualAlloc;
@@ -124,7 +122,7 @@ MemBlob::appended(const size_type n)
 }
 
 void
-MemBlob::append(const char *source, const size_type n)
+MemBlob::append(const_pointer source, const size_type n)
 {
     if (n > 0) { // appending zero bytes is allowed but only affects the stats
         Must(willFit(n));

--- a/src/sbuf/MemBlob.h
+++ b/src/sbuf/MemBlob.h
@@ -46,7 +46,11 @@ class MemBlob: public RefCountable
 
 public:
     typedef RefCount<MemBlob> Pointer;
-    typedef uint32_t size_type;
+
+    /* emulate std::basic_string API */
+    using value_type = char;
+    using size_type = uint32_t;
+    using const_pointer = const value_type *;
 
     /// obtain a const view of class-wide statistics
     static const MemBlobStats& GetStats();
@@ -54,9 +58,8 @@ public:
     /// create a new MemBlob with at least reserveSize capacity
     explicit MemBlob(const size_type reserveSize);
 
-    /// create a MemBlob containing a copy of the buffer of a given size
-    MemBlob(const char *buffer, const size_type bufferSize);
-
+    /* emulate std::basic_string API */
+    MemBlob(const_pointer, const size_type);
     ~MemBlob() override;
 
     /// the number unused bytes at the end of the allocated blob
@@ -87,12 +90,9 @@ public:
      * \param source raw buffer to be copied
      * \param n the number of bytes to copy from the source buffer
      */
-    void append(const char *source, const size_type n);
+    void append(const_pointer source, const size_type n);
 
     /* non-const methods below require exclusive object ownership */
-
-    /// extends the available space to the entire allocated blob
-    void clear() { size = 0; }
 
     /// keep the first n bytes and forget the rest of data
     /// cannot be used to increase our size; use append*() methods for that
@@ -105,11 +105,14 @@ public:
     /// dump debugging information
     std::ostream & dump(std::ostream &os) const;
 
+    /* emulate std::basic_string API */
+    void clear() { size = 0; }
+
 public:
     /* MemBlob users should avoid these and must treat them as read-only */
-    char *mem;          ///< raw allocated memory block
-    size_type capacity; ///< size of the raw allocated memory block
-    size_type size;     ///< maximum allocated memory in use by callers
+    value_type *mem = nullptr; ///< raw allocated memory block
+    size_type capacity = 0; ///< size of the raw allocated memory block
+    size_type size = 0; ///< maximum allocated memory in use by callers
     const InstanceId<MemBlob> id; ///< blob identifier
 
 private:


### PR DESCRIPTION
Use C++11 initialization for constructors.

Update documentation for class details matching std::basic_string API.