### PR TITLE
CI: drop FreeBSD 13 testing

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -145,7 +145,6 @@ jobs:
       matrix:
         osversion:
           - 14.2
-          - 13.4
 
     runs-on: ubuntu-24.04
     name: freebsd(${{ matrix.osversion }})


### PR DESCRIPTION
FreeBSD 13 packages are unreliably packaged, causing
version mismatches and CI pipeline stalls.

Only rely on FreeBSD 14 testing which is more reliable.
