### PR TITLE
Fix SQUID_YESNO 'syntax error near unexpected token'

### DIFF
--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -211,7 +211,7 @@ unset squid_tmp_define
 dnl aborts with an error specified as the second argument if the first argument doesn't
 dnl contain either "yes" or "no"
 AC_DEFUN([SQUID_YESNO],[
-  AS_IF([test "$1" != "yes" -a "$1" != "no"],[AC_MSG_ERROR([Bad argument for $2: "$1". Expecting "yes", "no", or no argument.])])
+  AS_IF([test "$1" != "yes" -a "$1" != "no"],[AC_MSG_ERROR([[Bad argument for $2: '$1'. Expecting 'yes', 'no', or no argument.]])])
 ])
 
 dnl Check that a library is actually available, useable,


### PR DESCRIPTION
autoconf can be confused by use of commas (,) in the error
message when the SQUID_YESNO macro is followed by AC_CASE.