### PR TITLE
Add SQUID_FEATURE macro

### DIFF
--- a/acinclude/squid-feature.m4
+++ b/acinclude/squid-feature.m4
@@ -1,0 +1,42 @@
+## Copyright (C) 1996-2025 The Squid Software Foundation and contributors
+##
+## Squid software is distributed under GPLv2+ license and includes
+## contributions from numerous individuals and organizations.
+## Please see the COPYING and CONTRIBUTORS files for details.
+##
+
+dnl check the build parameters for a Squid feature
+dnl Parameters for this macro are:
+dnl 1) feature name
+dnl 2) default: ON/OFF
+dnl 3) brief title/description for log entry
+dnl 4) long description for --help text
+dnl 5) conditions to be tested
+AC_DEFUN([SQUID_FEATURE],[
+
+  pushdef([FEATURE],$1)
+  pushdef([DEFAULT],m4_if([$2],[on],yes,no))
+  pushdef([INVERT],m4_if([$2],[on],disable,enable))
+  pushdef([ACVARIABLE],m4_translit(enable_[]FEATURE[],[-+.],[___]))
+  pushdef([AMVARIABLE],m4_toupper([]ACVARIABLE[]))
+  pushdef([PPVARIABLE],m4_toupper(m4_translit(USE_[]FEATURE[],[-+.],[___])))
+
+  AH_TEMPLATE([]PPVARIABLE[],[Define to have $3])
+  AC_ARG_ENABLE([]FEATURE[],
+    AS_HELP_STRING([--INVERT-FEATURE],[$3. $4]),
+    SQUID_YESNO([$enableval],[--INVERT-FEATURE])
+  )
+  AS_IF([test "x${ACVARIABLE:=DEFAULT}" != "xno"],[
+    $5
+  ])
+  SQUID_DEFINE_BOOL([]PPVARIABLE[],[${ACVARIABLE:=DEFAULT}])
+  AM_CONDITIONAL([]AMVARIABLE[],[test "x$ACVARIABLE" != "xno"])
+  AC_MSG_NOTICE([$3 enabled: ${ACVARIABLE:=DEFAULT (auto)}])
+
+  popdef([PPVARIABLE])
+  popdef([AMVARIABLE])
+  popdef([ACVARIABLE])
+  popdef([INVERT])
+  popdef([DEFAULT])
+  popdef([FEATURE])
+])

--- a/acinclude/squid-feature.m4
+++ b/acinclude/squid-feature.m4
@@ -5,13 +5,20 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-dnl check the build parameters for a Squid feature
+dnl Check the build parameters for a Squid feature.
+dnl
 dnl Parameters for this macro are:
 dnl 1) feature name
 dnl 2) default: ON/OFF
 dnl 3) brief title/description for log entry
 dnl 4) long description for --help text
 dnl 5) conditions to be tested
+dnl
+dnl Sets:
+dnl  $enable_feature_name variable for autoconf scripts,
+dnl  ENABLE_FEATURE_NAME conditional for automake scripts, and
+dnl  USE_FEATURE_NAME macro for C/C++ code.
+dnl
 AC_DEFUN([SQUID_FEATURE],[
 
   pushdef([FEATURE],$1)
@@ -24,14 +31,14 @@ AC_DEFUN([SQUID_FEATURE],[
   AH_TEMPLATE([]PPVARIABLE[],[Define to have $3])
   AC_ARG_ENABLE([]FEATURE[],
     AS_HELP_STRING([--INVERT-FEATURE],[$3. $4]),
-    SQUID_YESNO([$enableval],[--INVERT-FEATURE])
+    SQUID_YESNO([$enableval],[--enable-FEATURE])
   )
-  AS_IF([test "x${ACVARIABLE:=DEFAULT}" != "xno"],[
+  AS_IF([test "x${ACVARIABLE:-DEFAULT}" != "xno"],[
     $5
   ])
+  AC_MSG_NOTICE([$3 enabled: ${ACVARIABLE:-DEFAULT (auto)}])
   SQUID_DEFINE_BOOL([]PPVARIABLE[],[${ACVARIABLE:=DEFAULT}])
   AM_CONDITIONAL([]AMVARIABLE[],[test "x$ACVARIABLE" != "xno"])
-  AC_MSG_NOTICE([$3 enabled: ${ACVARIABLE:=DEFAULT (auto)}])
 
   popdef([PPVARIABLE])
   popdef([AMVARIABLE])

--- a/acinclude/squid-util.m4
+++ b/acinclude/squid-util.m4
@@ -211,7 +211,7 @@ unset squid_tmp_define
 dnl aborts with an error specified as the second argument if the first argument doesn't
 dnl contain either "yes" or "no"
 AC_DEFUN([SQUID_YESNO],[
-  AS_IF([test "$1" != "yes" -a "$1" != "no"],[AC_MSG_ERROR([Bad argument for $2: "$1". Expecting "yes", "no", or no argument.])])
+  AS_IF([test "$1" != "yes" -a "$1" != "no"],[AC_MSG_ERROR([[Bad argument for $2: '$1'. Expecting 'yes', 'no', or no argument.]])])
 ])
 
 dnl Check that a library is actually available, useable,

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ AM_MAINTAINER_MODE
 m4_include([acinclude/ax_with_prog.m4])
 m4_include([acinclude/init.m4])
 m4_include([acinclude/squid-util.m4])
+m4_include([acinclude/squid-feature.m4])
 m4_include([acinclude/compiler-flags.m4])
 m4_include([acinclude/os-deps.m4])
 m4_include([acinclude/krb5.m4])
@@ -68,22 +69,6 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_LANG([C++])
 
-# Clang 3.2 on some CPUs requires -march-native to detect correctly.
-# GCC 4.3+ can also produce faster executables when its used.
-# But building inside a virtual machine environment has been found to
-# cause random Illegal Instruction errors due to mis-detection of CPU.
-AC_ARG_ENABLE(arch-native,
-  AS_HELP_STRING([--disable-arch-native],[Some compilers offer CPU-specific
-                 optimizations with the -march=native parameter.
-                 This flag disables the optimization. The default is to
-                 auto-detect compiler support and use where available.]), [
-  SQUID_YESNO([$enableval],[--enable-arch-native])
-])
-AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=auto}])
-AS_IF([test "x${enable_arch_native}" != "xno"],[
-  SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
-])
-
 # If the user did not specify a C++ version.
 user_cxx=`echo "$PRESET_CXXFLAGS" | grep -o -E "(-)std="`
 AS_IF([test "x$user_cxx" = "x"],[
@@ -99,12 +84,7 @@ AS_IF([test "x$HOSTCXX" != "x" -a "x$BUILDCXX" = "x"],[
   AC_MSG_WARN([Cross-compiling with HOSTCXX is deprecated. Use BUILDCXX instead.])
   BUILDCXX="$HOSTCXX"
 ])
-AS_IF([test "x$BUILDCXX" = "x"],[
-  BUILDCXX="$CXX"
-  AS_IF([test "x$squid_cv_check_marchnative" = "xyes"],[
-    CXXFLAGS="$CXXFLAGS -march=native"
-  ])
-])
+AS_IF([test "x$BUILDCXX" = "x"],[BUILDCXX="$CXX"])
 AC_SUBST(BUILDCXX)
 
 # test for programs
@@ -377,6 +357,20 @@ AC_ARG_ENABLE(optimizations,
 dnl Nasty hack to get autoconf 2.64 on Linux to run.
 dnl all other uses of RUN_IFELSE are wrapped inside CACHE_CHECK which breaks on 2.64
 AC_RUN_IFELSE([AC_LANG_SOURCE([[ int main(int argc, char **argv) { return 0; } ]])],[],[],[:])
+
+SQUID_FEATURE(arch-native, on, [CPU arch native optimization],[
+  Some compilers offer CPU-specific optimizations with the -march=native parameter.
+  The default is to auto-detect compiler support and use where available.
+],[
+  # Clang 3.2 on some CPUs requires -march-native to detect correctly.
+  # GCC 4.3+ can also produce faster executables when its used.
+  # But building inside a virtual machine environment has been found to
+  # cause random Illegal Instruction errors due to mis-detection of CPU.
+  SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
+  AS_IF([test "x$BUILDCXX" = "x$CXX" -a "x$squid_cv_check_marchnative" = "xyes"],[
+    SQUID_CXXFLAGS="$SQUID_CXXFLAGS -march=native"
+  ])
+])
 
 AH_TEMPLATE(XMALLOC_STATISTICS,[Define to have malloc statistics])
 AC_ARG_ENABLE(xmalloc-statistics,

--- a/configure.ac
+++ b/configure.ac
@@ -367,8 +367,10 @@ SQUID_FEATURE(arch-native, on, [CPU arch native optimization],[
   # But building inside a virtual machine environment has been found to
   # cause random Illegal Instruction errors due to mis-detection of CPU.
   SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
-  AS_IF([test "x$BUILDCXX" = "x$CXX" -a "x$squid_cv_check_marchnative" = "xyes"],[
+  AS_IF([test "x$cross_compiling" = "xno" -a "x$squid_cv_check_marchnative" = "xyes"],[
     SQUID_CXXFLAGS="$SQUID_CXXFLAGS -march=native"
+  ],[
+    enable_arch_native=no
   ])
 ])
 

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -34,6 +34,7 @@ MAKETEST="distcheck"
 #     distcheck target recursive tests beteen scripted runs.
 #     we use it to perform the same duty between our nested scripts.
 DISTCHECK_CONFIGURE_FLAGS=" \
+	--disable-arch-native \
 	--disable-build-info \
 	--disable-shared \
 	--disable-xmalloc-statistics \


### PR DESCRIPTION
To perform the logic AC_ARG_ENABLE and following checks
for Squid features which have a simple enable/disable toggle
behaviour.

Refactor arch-native detection as demonstrator of usage.
Fixing pollution of CXXFLAGS by that logic.