### PR TITLE
DelayId boolean conversion should account for cache_peer no-delay

### DIFF
--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -60,7 +60,7 @@ DelayId::operator == (DelayId const &rhs) const
 
 DelayId::operator bool() const
 {
-    return pool_ || compositeId.getRaw();
+    return (pool_ || compositeId.getRaw()) && !markedAsNoDelay;
 }
 
 /* create a delay Id for a given request */
@@ -127,7 +127,7 @@ DelayId::bytesWanted(int minimum, int maximum) const
 {
     /* unlimited */
 
-    if (! (*this) || markedAsNoDelay)
+    if (!(*this))
         return max(minimum, maximum);
 
     /* limited */
@@ -148,9 +148,6 @@ void
 DelayId::bytesIn(int qty)
 {
     if (! (*this))
-        return;
-
-    if (markedAsNoDelay)
         return;
 
     assert ((unsigned short)(pool() - 1) != 0xFFFF);

--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -127,7 +127,7 @@ DelayId::bytesWanted(int minimum, int maximum) const
 {
     /* unlimited */
 
-    if (!(*this))
+    if (!*this)
         return max(minimum, maximum);
 
     /* limited */

--- a/src/DelayId.h
+++ b/src/DelayId.h
@@ -31,6 +31,9 @@ public:
     DelayIdComposite::Pointer const compositePosition() const;
     void compositePosition(const DelayIdComposite::Pointer &);
     bool operator == (DelayId const &rhs) const;
+
+    /// whether we may limit reading (i.e. return zero from bytesWanted()
+    /// with a positive maximum limit)
     operator bool() const;
     int bytesWanted(int min, int max) const;
     void bytesIn (int qty);

--- a/src/DelayId.h
+++ b/src/DelayId.h
@@ -32,8 +32,10 @@ public:
     void compositePosition(const DelayIdComposite::Pointer &);
     bool operator == (DelayId const &rhs) const;
 
-    /// whether we may delay reading (i.e. return zero from bytesWanted() called
-    /// with a positive maximum limit parameter)
+    /// Whether we may delay reading. This operator is meant to be used as an
+    /// optimization that helps avoid more expensive bytesWanted() computations.
+    /// \returns false if bytesWanted() called with a positive maximum limit
+    /// parameter will never return zero
     operator bool() const;
 
     int bytesWanted(int min, int max) const;

--- a/src/DelayId.h
+++ b/src/DelayId.h
@@ -32,9 +32,10 @@ public:
     void compositePosition(const DelayIdComposite::Pointer &);
     bool operator == (DelayId const &rhs) const;
 
-    /// whether we may limit reading (i.e. return zero from bytesWanted()
-    /// with a positive maximum limit)
+    /// whether we may delay reading (i.e. return zero from bytesWanted() called
+    /// with a positive maximum limit parameter)
     operator bool() const;
+
     int bytesWanted(int min, int max) const;
     void bytesIn (int qty);
     void setNoDelay(bool const);


### PR DESCRIPTION
Without this check, a DelayId::operator bool() caller could incorrectly
limit reading from a cache_peer that has been configured to ignore delay
pools. Luckily, all existing code paths that use this operator checked
the markedAsNoDelay flag, avoiding this problem:
    
* DelayId::bytesWanted() and DelayId::bytesIn() checked markedAsNoDelay.
    
* While MemObject::delayRead() itself did not check markedAsNoDelay, the
  method is not called when markedAsNoDelay is true. The analysis of the
  corresponding code paths is complex, especially for HttpStateData! We
  also call expensive mostBytesAllowed() several times on these paths.
  Refactoring this code is outside this API safety improvement scope.

This change helps avoid accidental/unwanted read delays during future
code changes.