### PR TITLE
Fix scripts/update-contributors.pl CONTRIBUTORS screening

### DIFF
--- a/scripts/source-maintenance.sh
+++ b/scripts/source-maintenance.sh
@@ -763,15 +763,12 @@ collectAuthors ()
     # but do not add committers (--format='    %cn <%ce>').
 
     # add collected new (co-)authors, if any, to CONTRIBUTORS
-    if ./scripts/update-contributors.pl --quiet < authors.tmp > CONTRIBUTORS.new
-    then
-        updateIfChanged CONTRIBUTORS CONTRIBUTORS.new  \
-            "A human PR description should match: $vettedCommitPhraseRegex"
-    fi
-    result=$?
+    ./scripts/update-contributors.pl --quiet < authors.tmp > CONTRIBUTORS.new || return
+    updateIfChanged CONTRIBUTORS CONTRIBUTORS.new  \
+        "A human PR description should match: $vettedCommitPhraseRegex" || return
 
     rm -f authors.tmp
-    return $result
+    return 0
 }
 
 # Update CONTRIBUTORS content

--- a/scripts/update-contributors.pl
+++ b/scripts/update-contributors.pl
@@ -134,9 +134,10 @@ sub worseThan
 sub isManuallyExcluded
 {
     my ($c) = @_;
-    return true if lc(contributorToString($c)) =~ /squidadm/; # a known bot
-    return true if lc(contributorToString($c)) =~ /Copilot@users.noreply.github.com/; # a known bot
-    return false;
+    my $lowerCasedContributorGist = lc(contributorToString($c));
+    return 1 if $lowerCasedContributorGist =~ /squidadm/; # a known bot
+    return 1 if $lowerCasedContributorGist =~ /copilot[@]users[.]noreply[.]github[.]com/; # a known bot
+    return 0;
 }
 
 sub contributorToString


### PR DESCRIPTION
    Possible unintended interpolation of @users in string
    Bareword "true" not allowed
    Bareword "false" not allowed
    Execution of ... aborted due to compilation errors

Recent commit daa76f41 broke scripts/update-contributors.pl syntax (see
error messages quoted above) and its lower-case comparison logic,
effectively disabling CONTRIBUTORS checks.

Also do not hide update-contributors.pl execution failures. Buggy
failure detection contributed to the above problems ignored by CI tests.

