### PR TITLE
Simplify DelayId composite position management

### DIFF
--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -31,7 +31,8 @@ DelayId::DelayId () : pool_ (0), compositeId(nullptr), markedAsNoDelay(false)
 DelayId::DelayId(unsigned short aPool, const DelayIdComposite::Pointer &aCompositeId):
     pool_(aPool), compositeId(aCompositeId), markedAsNoDelay(false)
 {
-    assert(bool(pool_) == bool(compositeId));
+    assert(pool_);
+    assert(compositeId);
     debugs(77, 3, "DelayId::DelayId: Pool " << aPool << "u");
 }
 

--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -28,7 +28,7 @@
 DelayId::DelayId () : pool_ (0), compositeId(nullptr), markedAsNoDelay(false)
 {}
 
-DelayId::DelayId(unsigned short aPool, const DelayIdComposite::Pointer &aCompositeId):
+DelayId::DelayId(const unsigned short aPool, const DelayIdComposite::Pointer &aCompositeId):
     pool_(aPool), compositeId(aCompositeId), markedAsNoDelay(false)
 {
     assert(pool_);
@@ -56,7 +56,7 @@ DelayId::operator == (DelayId const &rhs) const
 
 DelayId::operator bool() const
 {
-    return pool_ && !markedAsNoDelay;
+    return compositeId && !markedAsNoDelay;
 }
 
 /* create a delay Id for a given request */
@@ -130,8 +130,10 @@ DelayId::bytesWanted(int minimum, int maximum) const
 void
 DelayId::bytesIn(int qty)
 {
-    if (*this)
-        compositeId->bytesIn(qty);
+    if (! (*this))
+        return;
+
+    compositeId->bytesIn(qty);
 }
 
 void

--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -119,7 +119,11 @@ int
 DelayId::bytesWanted(int minimum, int maximum) const
 {
     const auto maxBytes = max(minimum, maximum);
-    return (*this) ? compositeId->bytesWanted(minimum, maxBytes) : maxBytes;
+
+    if (! (*this))
+        return maxBytes;
+
+    return compositeId->bytesWanted(minimum, maxBytes);
 }
 
 /*

--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -28,9 +28,10 @@
 DelayId::DelayId () : pool_ (0), compositeId(nullptr), markedAsNoDelay(false)
 {}
 
-DelayId::DelayId(unsigned short aPool, const DelayIdComposite::Pointer &composite) :
-    pool_(aPool), compositeId(composite), markedAsNoDelay(false)
+DelayId::DelayId(unsigned short aPool, const DelayIdComposite::Pointer &aCompositeId):
+    pool_(aPool), compositeId(aCompositeId), markedAsNoDelay(false)
 {
+    assert(bool(pool_) == bool(compositeId));
     debugs(77, 3, "DelayId::DelayId: Pool " << aPool << "u");
 }
 
@@ -54,7 +55,6 @@ DelayId::operator == (DelayId const &rhs) const
 
 DelayId::operator bool() const
 {
-    assert(bool(pool_) == bool(compositeId));
     return pool_;
 }
 
@@ -136,15 +136,13 @@ DelayId::bytesIn(int qty)
     if (markedAsNoDelay)
         return;
 
-    assert ((unsigned short)(pool() - 1) != 0xFFFF);
-
     compositeId->bytesIn(qty);
 }
 
 void
 DelayId::delayRead(const AsyncCall::Pointer &aRead)
 {
-    assert(*this);
+    assert (compositeId != nullptr);
     compositeId->delayRead(aRead);
 
 }

--- a/src/DelayId.cc
+++ b/src/DelayId.cc
@@ -119,7 +119,7 @@ DelayId::bytesWanted(int minimum, int maximum) const
 {
     const auto maxBytes = max(minimum, maximum);
     return (!(*this) || markedAsNoDelay) ?
-        maxBytes : compositeId->bytesWanted(minimum, maxBytes);
+           maxBytes : compositeId->bytesWanted(minimum, maxBytes);
 }
 
 /*

--- a/src/DelayId.h
+++ b/src/DelayId.h
@@ -24,12 +24,9 @@ class DelayId
 public:
     static DelayId DelayClient(ClientHttpRequest *, HttpReply *reply = nullptr);
     DelayId ();
-    DelayId (unsigned short);
+    DelayId(unsigned short, const DelayIdComposite::Pointer &);
     ~DelayId ();
     unsigned short pool() const;
-    DelayIdComposite::Pointer compositePosition();
-    DelayIdComposite::Pointer const compositePosition() const;
-    void compositePosition(const DelayIdComposite::Pointer &);
     bool operator == (DelayId const &rhs) const;
     operator bool() const;
     int bytesWanted(int min, int max) const;


### PR DESCRIPTION
Moved DelayId::compositeId initialization to the constructor and removed
its setter and getters as unused. Simplified DelayId methods by using
"pool and compositeId are either both set or both unset" invariant that
is now upheld by the two corresponding class constructors.