### PR TITLE
Simplify Ipc::Strand::handleRegistrationResponse()

### DIFF
--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -119,15 +119,8 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 void
 Ipc::Strand::handleRegistrationResponse(const StrandMessage &msg)
 {
-    // handle registration response from the coordinator; it could be stale
-    if (msg.strand.kidId == KidIdentifier && msg.strand.pid == getpid()) {
-        debugs(54, 6, "kid" << KidIdentifier << " registered");
-        clearTimeout(); // we are done
-    } else {
-        // could be an ACK to the registration message of our dead predecessor
-        debugs(54, 6, "kid" << KidIdentifier << " is not yet registered");
-        // keep listening, with a timeout
-    }
+    debugs(54, 6, "kid" << KidIdentifier << " registered");
+    clearTimeout(); // we are done
 }
 
 void Ipc::Strand::handleCacheMgrRequest(const Mgr::Request& request)

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -117,8 +117,9 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 }
 
 void
-Ipc::Strand::handleRegistrationResponse(const StrandMessage &)
+Ipc::Strand::handleRegistrationResponse(const StrandMessage &msg)
 {
+    Assure(KidIdentifier == msg.strand.kidId);
     debugs(54, 6, "kid" << KidIdentifier << " registered");
     clearTimeout(); // we are done
 }

--- a/src/ipc/Strand.cc
+++ b/src/ipc/Strand.cc
@@ -117,7 +117,7 @@ void Ipc::Strand::receive(const TypedMsgHdr &message)
 }
 
 void
-Ipc::Strand::handleRegistrationResponse(const StrandMessage &msg)
+Ipc::Strand::handleRegistrationResponse(const StrandMessage &)
 {
     debugs(54, 6, "kid" << KidIdentifier << " registered");
     clearTimeout(); // we are done


### PR DESCRIPTION
Checking PID to ignore stale responses became unnecessary after 2021
commit 4c21861 added Mine() calls that guarantee message freshness.

Also replaced the matching kidId check with an assertion because no IPC
messages, not even stale ones, may be sent to the kid with the wrong kid
identifier. This assertion cannot be easily generalized because most IPC
messages do not contain the kid identifier of the intended recipient.
