### PR TITLE
Fix FTP response parsing and error handling memory leaks

### DIFF
--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -166,6 +166,7 @@ Ftp::DataChannel::DataChannel():
 
 Ftp::DataChannel::~DataChannel()
 {
+    xfree(host);
     delete readBuf;
 }
 
@@ -1165,6 +1166,7 @@ Ftp::Client::parseControlReply(size_t &bytesUsed)
 
         if (complete) {
             // use list->key for last_reply because s contains the new line
+            safe_free(ctrl.last_reply);
             ctrl.last_reply = xstrdup(list->key + 4);
             ctrl.replycode = atoi(list->key);
         }

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -696,6 +696,7 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
             switch (*ct) {
 
             case '\t':
+                safe_free(p->name); // TODO: properly handle multiple p->name occurrences
                 p->name = xstrndup(ct + 1, l + 1);
                 break;
 
@@ -709,6 +710,7 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
                 if (tmp != ct + 1)
                     break;  /* not a valid integer */
 
+                safe_free(p->date); // TODO: properly handle multiple p->name occurrences
                 p->date = xstrdup(ctime(&tm));
 
                 *(strstr(p->date, "\n")) = '\0';

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -2223,6 +2223,7 @@ Ftp::Gateway::completedListing()
     entry->lock("Ftp::Gateway");
     ErrorState ferr(ERR_DIR_LISTING, Http::scOkay, request.getRaw(), fwd->al);
     ferr.ftp.listing = &listing;
+    safe_free(ferr.ftp.cwd_msg);
     ferr.ftp.cwd_msg = xstrdup(cwd_message.size()? cwd_message.termedBuf() : "");
     ferr.ftp.server_msg = ctrl.message;
     ctrl.message = nullptr;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -841,6 +841,7 @@ ErrorState::~ErrorState()
     wordlistDestroy(&ftp.server_msg);
     safe_free(ftp.request);
     safe_free(ftp.reply);
+    safe_free(ftp.cwd_msg);
     safe_free(err_msg);
 #if USE_ERR_LOCALES
     if (err_language != Config.errorDefaultLanguage)


### PR DESCRIPTION
FTP EPLF parsing leaks in ftpListParseParts() were detected by Coverity.
CID 1660782 and CID 1660785: Resource leaks (RESOURCE_LEAK).
    
Three other FTP client-related leaks were detected by Valgrind:
    
* Ftp::CtrlChannel::last_reply
* ErrorPage::ftp::cwd_msg
* Ftp::DataChannel::host
