### PR TITLE
smblib: Fix tree linking bug of first_tree and last_tree

### DIFF
--- a/lib/smblib/exper.c
+++ b/lib/smblib/exper.c
@@ -338,8 +338,8 @@ SMB_Tree_Handle SMB_Logon_And_TCon(SMB_Handle_Type Con_Handle,
 
     if (Con_Handle -> first_tree == NULL) {
 
-        Con_Handle -> first_tree == tree;
-        Con_Handle -> last_tree == tree;
+        Con_Handle -> first_tree = tree;
+        Con_Handle -> last_tree = tree;
 
     } else {
 
@@ -731,8 +731,8 @@ int SMB_Logon_TCon_Open(SMB_Handle_Type Con_Handle, char *UserName,
 
     if (Con_Handle -> first_tree == NULL) {
 
-        Con_Handle -> first_tree == tree;
-        Con_Handle -> last_tree == tree;
+        Con_Handle -> first_tree = tree;
+        Con_Handle -> last_tree = tree;
 
     } else {
 

--- a/lib/smblib/smblib-util.c
+++ b/lib/smblib/smblib-util.c
@@ -734,12 +734,12 @@ int SMB_TreeDisconnect(SMB_Tree_Handle Tree_Handle, BOOL discard)
     if (discard == TRUE) { /* Unlink it and free it ... */
 
         if (Tree_Handle -> next == NULL)
-            Tree_Handle -> con -> first_tree = Tree_Handle -> prev;
+            Tree_Handle -> con -> last_tree = Tree_Handle -> prev;
         else
             Tree_Handle -> next -> prev = Tree_Handle -> prev;
 
         if (Tree_Handle -> prev == NULL)
-            Tree_Handle -> con -> last_tree = Tree_Handle -> next;
+            Tree_Handle -> con -> first_tree = Tree_Handle -> next;
         else
             Tree_Handle -> prev -> next = Tree_Handle -> next;
 


### PR DESCRIPTION
Also fix the reversed SMB_TreeDisconnect unlinking, which hid this bug.

This bug has been here since inception.