### PR TITLE
Add origin-form and absolute-path to URI API

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -344,9 +344,7 @@ HttpRequest::pack(Packable * p) const
 {
     assert(p);
     /* pack request-line */
-    p->appendf(SQUIDSBUFPH " " SQUIDSBUFPH " HTTP/%d.%d\r\n",
-               SQUIDSBUFPRINT(method.image()), SQUIDSBUFPRINT(url.path()),
-               http_ver.major, http_ver.minor);
+    packFirstLineInto(p, false /* origin-form */);
     /* headers */
     header.packInto(p);
     /* trailer */
@@ -368,7 +366,7 @@ int
 HttpRequest::prefixLen() const
 {
     return method.image().length() + 1 +
-           url.path().length() + 1 +
+           url.originForm().length() + 1 +
            4 + 1 + 3 + 2 +
            header.len + 2;
 }
@@ -470,7 +468,7 @@ HttpRequest::clearError()
 void
 HttpRequest::packFirstLineInto(Packable * p, bool full_uri) const
 {
-    const SBuf tmp(full_uri ? effectiveRequestUri() : url.path());
+    const SBuf tmp(full_uri ? effectiveRequestUri() : url.originForm());
 
     // form HTTP request-line
     p->appendf(SQUIDSBUFPH " " SQUIDSBUFPH " HTTP/%d.%d\r\n",

--- a/src/acl/UrlPath.cc
+++ b/src/acl/UrlPath.cc
@@ -12,20 +12,15 @@
 #include "acl/FilledChecklist.h"
 #include "acl/UrlPath.h"
 #include "HttpRequest.h"
-#include "rfc1738.h"
 
 int
 Acl::UrlPathCheck::match(ACLChecklist * const ch)
 {
     const auto checklist = Filled(ch);
+    auto urlPath = checklist->request->url.path();
 
-    if (checklist->request->url.path().isEmpty())
+    if (urlPath.isEmpty())
         return -1;
 
-    char *esc_buf = SBufToCstring(checklist->request->url.path());
-    rfc1738_unescape(esc_buf);
-    int result = data->match(esc_buf);
-    xfree(esc_buf);
-    return result;
+    return data->match(urlPath.c_str());
 }
-

--- a/src/adaptation/Service.cc
+++ b/src/adaptation/Service.cc
@@ -49,7 +49,7 @@ Adaptation::Service::wants(const ServiceFilter &filter) const
         // Sending a message to a service that does not want it is useless.
         // note that we cannot check wantsUrl for service that is not "up"
         // note that even essential services are skipped on unwanted URLs!
-        return wantsUrl(filter.request->url.path());
+        return wantsUrl(filter.request->url.absolutePath());
     }
 
     // The service is down and is either not bypassable or not probed due

--- a/src/adaptation/icap/ModXact.cc
+++ b/src/adaptation/icap/ModXact.cc
@@ -1634,10 +1634,9 @@ void Adaptation::Icap::ModXact::decideOnPreview()
         return;
     }
 
-    const SBuf urlPath(virginRequest().url.path());
     size_t wantedSize;
-    if (!service().wantsPreview(urlPath, wantedSize)) {
-        debugs(93, 5, "should not offer preview for " << urlPath);
+    if (!service().wantsPreview(virginRequest().url.absolutePath(), wantedSize)) {
+        debugs(93, 5, "should not offer preview for " << virginRequest().url.absolutePath());
         return;
     }
 

--- a/src/anyp/Uri.h
+++ b/src/anyp/Uri.h
@@ -102,9 +102,6 @@ public:
      * Implements RFC 3986 section 5.2.3
      *
      * The caller must ensure relUrl is a valid relative-path.
-     *
-     * NP: absolute-path are also accepted, but path() method
-     * should be used instead when possible.
      */
     void addRelativePath(const char *relUrl);
 
@@ -141,6 +138,12 @@ public:
      * when the protocol scheme is http: or https:.
      */
     SBuf &absolute() const;
+
+    /// RFC 3986 section 4.2 relative reference called 'absolute-path'.
+    SBuf &absolutePath() const;
+
+    /// The RFC 7230 origin-form URI for currently stored values.
+    SBuf &originForm() const { return absolutePath(); }
 
 private:
     void parseUrn(Parser::Tokenizer&);
@@ -187,6 +190,7 @@ private:
     mutable SBuf authorityHttp_;     ///< RFC 7230 section 5.3.3 authority, maybe without default-port
     mutable SBuf authorityWithPort_; ///< RFC 7230 section 5.3.3 authority with explicit port
     mutable SBuf absolute_;          ///< RFC 7230 section 5.3.2 absolute-URI
+    mutable SBuf absolutePath_; ///< RFC 3986 section 4.2 absolute-path
 };
 
 inline std::ostream &
@@ -202,7 +206,7 @@ operator <<(std::ostream &os, const Uri &url)
         os << "//" << url.authority();
 
     // path is what it is - including absent
-    os << url.path();
+    os << url.absolutePath();
     return os;
 }
 

--- a/src/carp.cc
+++ b/src/carp.cc
@@ -186,13 +186,13 @@ carpSelectParent(PeerSelector *ps)
             }
             if (tp->options.carp_key.path) {
                 // XXX: fix when path and query are separate
-                key.append(request->url.path().substr(0,request->url.path().find('?'))); // 0..N
+                key.append(request->url.absolutePath().substr(0,request->url.absolutePath().find('?'))); // 0..N
             }
             if (tp->options.carp_key.params) {
                 // XXX: fix when path and query are separate
                 SBuf::size_type pos;
-                if ((pos=request->url.path().find('?')) != SBuf::npos)
-                    key.append(request->url.path().substr(pos)); // N..npos
+                if ((pos=request->url.absolutePath().find('?')) != SBuf::npos)
+                    key.append(request->url.absolutePath().substr(pos)); // N..npos
             }
         }
         // if the url-based key is empty, e.g. because the user is

--- a/src/clients/WhoisGateway.cc
+++ b/src/clients/WhoisGateway.cc
@@ -64,10 +64,10 @@ whoisStart(FwdState * fwd)
     p->entry->lock("whoisStart");
     comm_add_close_handler(fwd->serverConnection()->fd, whoisClose, p);
 
-    size_t l = p->request->url.path().length() + 3;
+    size_t l = p->request->url.absolutePath().length() + 3;
     char *buf = (char *)xmalloc(l);
 
-    const SBuf str_print = p->request->url.path().substr(1);
+    const SBuf str_print = p->request->url.absolutePath().substr(1);
     snprintf(buf, l, SQUIDSBUFPH "\r\n", SQUIDSBUFPRINT(str_print));
 
     AsyncCall::Pointer writeCall = commCbCall(5,5, "whoisWriteComplete",

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1142,7 +1142,7 @@ ErrorState::compileLegacyCode(Build &build)
     case 'R':
         if (building_deny_info_url) {
             if (request != nullptr) {
-                const SBuf &tmp = request->url.path();
+                const SBuf &tmp = request->url.absolutePath();
                 mb.append(tmp.rawContent(), tmp.length());
                 no_urlescape = 1;
             } else
@@ -1152,7 +1152,7 @@ ErrorState::compileLegacyCode(Build &build)
         if (request) {
             mb.appendf(SQUIDSBUFPH " " SQUIDSBUFPH " %s/%d.%d\n",
                        SQUIDSBUFPRINT(request->method.image()),
-                       SQUIDSBUFPRINT(request->url.path()),
+                       SQUIDSBUFPRINT(request->url.originForm()),
                        AnyP::ProtocolType_str[request->http_ver.protocol],
                        request->http_ver.major, request->http_ver.minor);
             request->header.packInto(&mb, true); //hide authorization data

--- a/src/format/Format.cc
+++ b/src/format/Format.cc
@@ -1074,7 +1074,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
         case LFT_REQUEST_URLPATH_OLD_31:
         case LFT_CLIENT_REQ_URLPATH:
             if (al->request) {
-                sb = al->request->url.path();
+                sb = al->request->url.absolutePath();
                 out = sb.c_str();
                 quote = 1;
             }
@@ -1149,7 +1149,7 @@ Format::Format::assemble(MemBuf &mb, const AccessLogEntry::Pointer &al, int logS
 
         case LFT_SERVER_REQ_URLPATH:
             if (al->adapted_request) {
-                sb = al->adapted_request->url.path();
+                sb = al->adapted_request->url.absolutePath();
                 out = sb.c_str();
                 quote = 1;
             }

--- a/src/http.cc
+++ b/src/http.cc
@@ -2373,7 +2373,7 @@ HttpStateData::buildRequestPrefix(MemBuf * mb)
      * not the one we are sending. Needs checking.
      */
     const AnyP::ProtocolVersion httpver = Http::ProtocolVersion();
-    const SBuf url(flags.toOrigin ? request->url.path() : request->effectiveRequestUri());
+    const SBuf url(flags.toOrigin ? request->url.originForm() : request->effectiveRequestUri());
     mb->appendf(SQUIDSBUFPH " " SQUIDSBUFPH " %s/%d.%d\r\n",
                 SQUIDSBUFPRINT(request->method.image()),
                 SQUIDSBUFPRINT(url),

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -34,7 +34,7 @@ internalStart(const Comm::ConnectionPointer &clientConn, HttpRequest * request, 
     ErrorState *err;
 
     Assure(request);
-    const SBuf upath = request->url.path();
+    const SBuf upath = request->url.absolutePath();
     debugs(76, 3, clientConn << " requesting '" << upath << "'");
 
     Assure(request->flags.internal);

--- a/src/tests/stub_libanyp.cc
+++ b/src/tests/stub_libanyp.cc
@@ -31,6 +31,7 @@ const SBuf &AnyP::Uri::Asterisk()
 }
 SBuf &AnyP::Uri::authority(bool) const STUB_RETVAL(nil)
 SBuf &AnyP::Uri::absolute() const STUB_RETVAL(nil)
+SBuf &AnyP::Uri::absolutePath() const STUB_RETVAL(nil)
 void urlInitialize() STUB
 const char *urlCanonicalFakeHttps(const HttpRequest *) STUB_RETVAL(nullptr)
 bool urlIsRelative(const char *) STUB_RETVAL(false)


### PR DESCRIPTION
Convert callers of Uri::path() as appropriate to their needs.

These methods provide %-encoded URI components for use in
display or normalized processing. The path() method is now only
guaranteed to provide the URL-path component in un-escaped form
(though query has not yet been moved).