### PR TITLE
Bug 5502: Double free on reconfig with error_default_language

### DIFF
--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -169,7 +169,7 @@ private:
 public:
     err_type type = ERR_NONE;
     int page_id = ERR_NONE;
-    char *err_language = nullptr;
+    std::optional<SBuf> errLanguage; ///< Content-Language response header value
     Http::StatusCode httpStatus = Http::scNone;
 #if USE_AUTH
     Auth::UserRequest::Pointer auth_user_request;
@@ -309,8 +309,8 @@ public:
      */
     bool loadFromFile(const char *path);
 
-    /// The language used for the template
-    const char *language() {return errLanguage.termedBuf();}
+    /// The language of the first language-specific template read by loadFor().
+    const auto &errLanguage() const { return errLanguage_; }
 
     SBuf filename; ///< where the template was loaded from
 
@@ -332,7 +332,7 @@ protected:
 
     SBuf template_; ///< raw template contents
     bool wasLoaded; ///< True if the template data read from disk without any problem
-    String errLanguage; ///< The error language of the template.
+    std::optional<SBuf> errLanguage_; ///< \copydoc errLanguage()
     String templateName; ///< The name of the template
     err_type templateCode; ///< The internal code for this template.
 };

--- a/src/ssl/ErrorDetailManager.cc
+++ b/src/ssl/ErrorDetailManager.cc
@@ -134,9 +134,9 @@ Ssl::ErrorDetailsManager::findDetail(const Security::ErrorCode value, const Http
             errDetails = new ErrorDetailsList();
             ErrorDetailFile detailTmpl(errDetails);
             if (detailTmpl.loadFor(request.getRaw())) {
-                if (detailTmpl.language()) {
-                    debugs(83, 8, "Found details on disk for language " << detailTmpl.language());
-                    errDetails->errLanguage = detailTmpl.language();
+                if (detailTmpl.errLanguage()) {
+                    errDetails->errLanguage = *detailTmpl.errLanguage();
+                    debugs(83, 8, "Found details on disk for language " << errDetails->errLanguage);
                     cacheDetails(errDetails);
                 }
             }


### PR DESCRIPTION
If error_default_language was used, and Squid generated an error
response before reconfiguration but was done serving that response after
reconfiguration, then ErrorState destructor could free err_language
pointing to memory already freed via configFreeMemory(). This change
upgrades the corresponding code to use safer SBuf instead of c-strings.

The bug was introduced in 2008 commit 5bf33a09: A string copy avoidance
optimization apparently assumed that Config.errorDefaultLanguage pointer
value never changes. In reality, that value may change every time Squid
is reconfigured if error_default_language directive is set (before
and/or after reconfiguration), even if error_default_language value
itself does not change. Prior to that commit, Squid just leaked
ErrorState::err_language memory (if allocated) instead.

Besides unfortunate reconfiguration timing (relative to error response
handling stages), triggering this bug requires that Squid uses
configured error_default_language for the error response. With
`--enable-auto-locale` (enabled by default) and unset error_directory
directive (unset by default). That use happens when the request does not
have an Accept-Language header (which is typical for CONNECT requests),
but other conditions may trigger error_default_language use as well.

