### PR TITLE
Remove DEFAULT_ICP_PORT build variable

### DIFF
--- a/src/Common.am
+++ b/src/Common.am
@@ -12,7 +12,6 @@
 
 ## Default variables
 DEFAULT_HTTP_PORT	= 3128
-DEFAULT_ICP_PORT	= 3130
 DEFAULT_PREFIX		= $(prefix)
 DEFAULT_CONFIG_DIR	= $(sysconfdir)
 DEFAULT_CONFIG_FILE	= $(DEFAULT_CONFIG_DIR)/squid.conf

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -643,7 +643,6 @@ cf_gen_defines.cci: $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre $(top_builddi
 cf.data: cf.data.pre Makefile
 	sed \
 	-e "s%[@]DEFAULT_HTTP_PORT[@]%$(DEFAULT_HTTP_PORT)%g" \
-	-e "s%[@]DEFAULT_ICP_PORT[@]%$(DEFAULT_ICP_PORT)%g" \
 	-e "s%[@]DEFAULT_CACHE_EFFECTIVE_USER[@]%$(CACHE_EFFECTIVE_USER)%g" \
 	-e "s%[@]DEFAULT_MIME_TABLE[@]%$(DEFAULT_MIME_TABLE)%g" \
 	-e "s%[@]DEFAULT_SSL_CRTD[@]%$(DEFAULT_SSL_CRTD)%g" \

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -8479,7 +8479,7 @@ DOC_START
 	and from neighbor caches.  The standard UDP port for ICP is 3130.
 
 	Example:
-		icp_port @DEFAULT_ICP_PORT@
+		icp_port 3130
 DOC_END
 
 NAME: htcp_port


### PR DESCRIPTION
For some time this variable has only been used for documentation
which is better served by just stating the IANA registered port.