### PR TITLE
Do not assert when debugging SNMP requests with long OIDs

### DIFF
--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -1057,8 +1057,7 @@ snmpDebugOid(oid * Name, snint Len, MemBuf &outbuf)
 {
     char mbuf[16];
     int x;
-    if (outbuf.isNull())
-        outbuf.init(16, MAX_IPSTRLEN);
+    outbuf.reset();
 
     for (x = 0; x < Len; ++x) {
         size_t bytes = snprintf(mbuf, sizeof(mbuf), ".%u", (unsigned int) Name[x]);


### PR DESCRIPTION
    FATAL: assertion failed: MemBuf.cc: "new_cap > (size_t) capacity"

Also fixes repeated same-buffer snmpDebugOid() calls that used to
accumulate stale content in snmpTreeNext():

    snmpTreeNext: Current : .1.3.6.1.4.1.3495
    snmpTreeNext: Next : .1.3.6.1.4.1.3495.1.3.6.1.4.1.3495.1.1.1.0

Current snmpDebugOid() callers have been checked for compatibility with
this fix. Fixing snmpDebugOid() API is out of this surgical fix scope.
