### PR TITLE
SNMP: Do not send responses that we fail to encode

### DIFF
--- a/src/snmp/Forwarder.cc
+++ b/src/snmp/Forwarder.cc
@@ -87,8 +87,10 @@ Snmp::Forwarder::sendError(int error)
     req.pdu.errstat = error;
     u_char buffer[SNMP_REQUEST_SIZE];
     int len = sizeof(buffer);
-    snmp_build(&req.session, &req.pdu, buffer, &len);
-    comm_udp_sendto(fd, req.address, buffer, len);
+    if (snmp_build(&req.session, &req.pdu, buffer, &len) == 0)
+        comm_udp_sendto(fd, req.address, buffer, len);
+    else
+        debugs(49, DBG_IMPORTANT, "ERROR: Failed to encode an error response to SNMP agent query from " << req.address);
 }
 
 void

--- a/src/snmp/Inquirer.cc
+++ b/src/snmp/Inquirer.cc
@@ -115,7 +115,9 @@ Snmp::Inquirer::sendResponse()
     u_char buffer[SNMP_REQUEST_SIZE];
     int len = sizeof(buffer);
     Snmp::Request& req = static_cast<Snmp::Request&>(*request);
-    snmp_build(&req.session, &aggrPdu, buffer, &len);
-    comm_udp_sendto(conn->fd, req.address, buffer, len);
+    if (snmp_build(&req.session, &aggrPdu, buffer, &len) == 0)
+        comm_udp_sendto(conn->fd, req.address, buffer, len);
+    else
+        debugs(49, DBG_IMPORTANT, "ERROR: Failed to encode a response to SNMP agent query from " << req.address);
 }
 

--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -445,8 +445,10 @@ snmpConstructReponse(SnmpRequest * rq)
     snmp_free_pdu(rq->PDU);
 
     if (RespPDU != nullptr) {
-        snmp_build(&rq->session, RespPDU, rq->outbuf, &rq->outlen);
-        comm_udp_sendto(rq->sock, rq->from, rq->outbuf, rq->outlen);
+        if (snmp_build(&rq->session, RespPDU, rq->outbuf, &rq->outlen) == 0)
+            comm_udp_sendto(rq->sock, rq->from, rq->outbuf, rq->outlen);
+        else
+            debugs(49, DBG_IMPORTANT, "ERROR: Failed to encode a response to SNMP agent query from " << rq->from);
         snmp_free_pdu(RespPDU);
     }
 }


### PR DESCRIPTION
When snmp_build() fails, its output buffer must not be used:

    Syscall param sendto() points to uninitialised byte(s)
        by xsendto() (socket.h:118)
        by comm_udp_sendto() (comm.cc:923)
        by snmpConstructReponse() (snmp_core.cc:449)

Also inform the admin about SNMP encoding failures.
