### PR TITLE
Store socket type in Comm::Connection

### DIFF
--- a/src/adaptation/ecap/MessageRep.cc
+++ b/src/adaptation/ecap/MessageRep.cc
@@ -165,6 +165,9 @@ Adaptation::Ecap::FirstLineRep::protocol() const
     case AnyP::PROTO_AUTHORITY_FORM:
     case AnyP::PROTO_SSL:
     case AnyP::PROTO_TLS:
+    case AnyP::PROTO_TCP:
+    case AnyP::PROTO_UDP:
+    case AnyP::PROTO_ICMP:
     case AnyP::PROTO_UNKNOWN:
         return protocolUnknown; // until we remember the protocol image
     case AnyP::PROTO_NONE:

--- a/src/anyp/ProtocolType.h
+++ b/src/anyp/ProtocolType.h
@@ -37,6 +37,9 @@ typedef enum {
     PROTO_ICY,
     PROTO_TLS,
     PROTO_SSL,
+    PROTO_TCP,
+    PROTO_UDP,
+    PROTO_ICMP,
     PROTO_AUTHORITY_FORM,
     PROTO_UNKNOWN,
     PROTO_MAX

--- a/src/client_side.cc
+++ b/src/client_side.cc
@@ -3294,6 +3294,7 @@ clientStartListeningOn(AnyP::PortCfgPointer &port, const RefCount< CommCbFunPtrC
 {
     // Fill out a Comm::Connection which IPC will open as a listener for us
     port->listenConn = new Comm::Connection;
+    port->listenConn->transport = AnyP::PROTO_TCP;
     port->listenConn->local = port->s;
     port->listenConn->flags =
         COMM_NONBLOCKING |
@@ -3309,7 +3310,7 @@ clientStartListeningOn(AnyP::PortCfgPointer &port, const RefCount< CommCbFunPtrC
                   ListeningStartedDialer(&clientListenerConnectionOpened,
                                          port, fdNote, sub));
     AsyncCallback<Ipc::StartListeningAnswer> callback(listenCall);
-    Ipc::StartListening(SOCK_STREAM, IPPROTO_TCP, port->listenConn, fdNote, callback);
+    Ipc::StartListening(port->listenConn, fdNote, callback);
 
     assert(NHttpSockets < MAXTCPLISTENPORTS);
     HttpSockets[NHttpSockets] = -1;

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -138,7 +138,7 @@ public:
     void completedListing(void);
 
     /// create a data channel acceptor and start listening.
-    void listenForDataChannel(const Comm::ConnectionPointer &conn);
+    void listenForDataChannel(Comm::ConnectionPointer &);
 
     int checkAuth(const HttpHeader * req_hdr);
     void checkUrlpath();
@@ -447,7 +447,7 @@ Ftp::Gateway::loginParser(const SBuf &login, bool escaped)
 }
 
 void
-Ftp::Gateway::listenForDataChannel(const Comm::ConnectionPointer &conn)
+Ftp::Gateway::listenForDataChannel(Comm::ConnectionPointer &conn)
 {
     if (!Comm::IsConnOpen(ctrl.conn)) {
         debugs(9, 5, "The control connection to the remote end is closed");
@@ -464,7 +464,7 @@ Ftp::Gateway::listenForDataChannel(const Comm::ConnectionPointer &conn)
 
     /* open the conn if its not already open */
     if (!Comm::IsConnOpen(conn)) {
-        conn->fd = comm_open_listener(SOCK_STREAM, IPPROTO_TCP, conn->local, conn->flags, note);
+        comm_open_listener(conn, note);
         if (!Comm::IsConnOpen(conn)) {
             debugs(5, DBG_CRITICAL, "ERROR: comm_open_listener failed:" << conn->local << " error: " << errno);
             return;
@@ -1774,6 +1774,7 @@ ftpOpenListenSocket(Ftp::Gateway * ftpState, int fallback)
      */
     Comm::ConnectionPointer temp = new Comm::Connection;
     temp->local = ftpState->ctrl.conn->local;
+    temp->transport = AnyP::PROTO_TCP;
 
     /*
      * REUSEADDR is needed in fallback mode, since the same port is

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -256,24 +256,17 @@ comm_open(int sock_type,
 }
 
 void
-comm_open_listener(int sock_type,
-                   int proto,
-                   Comm::ConnectionPointer &conn,
-                   const char *note)
+comm_open_listener(Comm::ConnectionPointer &conn, const char *note)
 {
     /* all listener sockets require bind() */
     conn->flags |= COMM_DOBIND;
 
     /* attempt native enabled port. */
-    conn->fd = comm_openex(sock_type, proto, conn->local, conn->flags, note);
+    conn->fd = comm_openex(conn->sockTransport(), conn->ipTransport(), conn->local, conn->flags, note);
 }
 
 int
-comm_open_listener(int sock_type,
-                   int proto,
-                   Ip::Address &addr,
-                   int flags,
-                   const char *note)
+comm_open_listener(int sock_type, int proto, Ip::Address &addr, int flags, const char *note)
 {
     int sock = -1;
 

--- a/src/comm.h
+++ b/src/comm.h
@@ -61,7 +61,7 @@ void comm_import_opened(const Comm::ConnectionPointer &, const char *note, struc
  * A reconfigure is needed to reset the stored IP in most cases and attempt a port re-open.
  */
 int comm_open_listener(int sock_type, int proto, Ip::Address &addr, int flags, const char *note);
-void comm_open_listener(int sock_type, int proto, Comm::ConnectionPointer &conn, const char *note);
+void comm_open_listener(Comm::ConnectionPointer &conn, const char *note);
 
 unsigned short comm_local_port(int fd);
 

--- a/src/comm/Connection.h
+++ b/src/comm/Connection.h
@@ -11,6 +11,7 @@
 #ifndef SQUID_SRC_COMM_CONNECTION_H
 #define SQUID_SRC_COMM_CONNECTION_H
 
+#include "anyp/ProtocolType.h"
 #include "base/CodeContext.h"
 #include "base/InstanceId.h"
 #include "comm/forward.h"
@@ -140,15 +141,21 @@ public:
     Security::NegotiationHistory *tlsNegotiations();
     const Security::NegotiationHistory *hasTlsNegotiations() const {return tlsHistory;}
 
+    /// The socket(2) SOCK_* type used by this connection FD
+    int sockTransport() const;
+
+    /// The socket(2) IPPROTO_* type used by this connection FD
+    int ipTransport() const;
+
     /* CodeContext API */
     ScopedId codeContextGist() const override;
     std::ostream &detailCodeContext(std::ostream &os) const override;
 
 public:
-    /** Address/Port for the Squid end of a TCP link. */
+    /** Address/Port for the Squid end of this connection */
     Ip::Address local;
 
-    /** Address for the Remote end of a TCP link. */
+    /** Address for the Remote end of this connection */
     Ip::Address remote;
 
     /** Hierarchy code for this connection link */
@@ -156,6 +163,10 @@ public:
 
     /** Socket used by this connection. Negative if not open. */
     int fd = -1;
+
+    /// Protocol used for lowest-level transport on this connection.
+    /// TCP, UDP, or ICMP currently supported by Squid.
+    AnyP::ProtocolType transport = AnyP::PROTO_UNKNOWN;
 
     /** Quality of Service TOS values currently sent on this connection */
     tos_t tos = 0;

--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -368,6 +368,7 @@ Comm::TcpAcceptor::acceptInto(Comm::ConnectionPointer &details)
     const auto sock = rawSock;
     fd_open(sock, FD_SOCKET, "HTTP Request");
     details->fd = sock;
+    details->transport = conn->transport;
     details->enterOrphanage();
 
     Assure(remoteAddressSize <= socklen_t(sizeof(remoteAddress)));

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1447,6 +1447,7 @@ htcpOpenPorts(void)
     }
 
     htcpIncomingConn = new Comm::Connection;
+    htcpIncomingConn->transport = AnyP::PROTO_UDP;
     htcpIncomingConn->local = Config.Addrs.udp_incoming;
     htcpIncomingConn->local.port(Config.Port.htcp);
 
@@ -1460,13 +1461,11 @@ htcpOpenPorts(void)
     }
 
     auto call = asyncCallbackFun(31, 2, htcpIncomingConnectionOpened);
-    Ipc::StartListening(SOCK_DGRAM,
-                        IPPROTO_UDP,
-                        htcpIncomingConn,
-                        Ipc::fdnInHtcpSocket, call);
+    Ipc::StartListening(htcpIncomingConn, Ipc::fdnInHtcpSocket, call);
 
     if (!Config.Addrs.udp_outgoing.isNoAddr()) {
         htcpOutgoingConn = new Comm::Connection;
+        htcpOutgoingConn->transport = AnyP::PROTO_UDP;
         htcpOutgoingConn->local = Config.Addrs.udp_outgoing;
         htcpOutgoingConn->local.port(Config.Port.htcp);
 
@@ -1480,7 +1479,7 @@ htcpOpenPorts(void)
         }
 
         enter_suid();
-        comm_open_listener(SOCK_DGRAM, IPPROTO_UDP, htcpOutgoingConn, "Outgoing HTCP Socket");
+        comm_open_listener(htcpOutgoingConn, "Outgoing HTCP Socket");
         leave_suid();
 
         if (!Comm::IsConnOpen(htcpOutgoingConn))

--- a/src/icp_v2.cc
+++ b/src/icp_v2.cc
@@ -683,6 +683,7 @@ icpOpenPorts(void)
         return;
 
     icpIncomingConn = new Comm::Connection;
+    icpIncomingConn->transport = AnyP::PROTO_UDP;
     icpIncomingConn->local = Config.Addrs.udp_incoming;
     icpIncomingConn->local.port(port);
 
@@ -696,13 +697,11 @@ icpOpenPorts(void)
     }
 
     auto call = asyncCallbackFun(12, 2, icpIncomingConnectionOpened);
-    Ipc::StartListening(SOCK_DGRAM,
-                        IPPROTO_UDP,
-                        icpIncomingConn,
-                        Ipc::fdnInIcpSocket, call);
+    Ipc::StartListening(icpIncomingConn, Ipc::fdnInIcpSocket, call);
 
     if ( !Config.Addrs.udp_outgoing.isNoAddr() ) {
         icpOutgoingConn = new Comm::Connection;
+        icpOutgoingConn->transport = AnyP::PROTO_UDP;
         icpOutgoingConn->local = Config.Addrs.udp_outgoing;
         icpOutgoingConn->local.port(port);
 
@@ -716,7 +715,7 @@ icpOpenPorts(void)
         }
 
         enter_suid();
-        comm_open_listener(SOCK_DGRAM, IPPROTO_UDP, icpOutgoingConn, "Outgoing ICP Port");
+        comm_open_listener(icpOutgoingConn, "Outgoing ICP Port");
         leave_suid();
 
         if (!Comm::IsConnOpen(icpOutgoingConn))

--- a/src/ipc/Coordinator.cc
+++ b/src/ipc/Coordinator.cc
@@ -265,11 +265,12 @@ Ipc::Coordinator::openListenSocket(const SharedListenRequest& request,
            request.requestorId);
 
     Comm::ConnectionPointer newConn = new Comm::Connection;
+    newConn->transport = AnyP::ProtocolType(p.sock_type);
     newConn->local = p.addr; // comm_open_listener may modify it
     newConn->flags = p.flags;
 
     enter_suid();
-    comm_open_listener(p.sock_type, p.proto, newConn, FdNote(p.fdNote));
+    comm_open_listener(newConn, FdNote(p.fdNote));
     errNo = Comm::IsConnOpen(newConn) ? 0 : errno;
     leave_suid();
 

--- a/src/ipc/StartListening.cc
+++ b/src/ipc/StartListening.cc
@@ -29,7 +29,7 @@ Ipc::operator <<(std::ostream &os, const StartListeningAnswer &answer)
 }
 
 void
-Ipc::StartListening(int sock_type, int proto, const Comm::ConnectionPointer &listenConn,
+Ipc::StartListening(const Comm::ConnectionPointer &listenConn,
                     const FdNoteId fdNote, StartListeningCallback &callback)
 {
     auto &answer = callback.answer();
@@ -40,8 +40,7 @@ Ipc::StartListening(int sock_type, int proto, const Comm::ConnectionPointer &lis
         // Ask Coordinator for a listening socket.
         // All askers share one listening queue.
         OpenListenerParams p;
-        p.sock_type = sock_type;
-        p.proto = proto;
+        p.sock_type = listenConn->transport;
         p.addr = listenConn->local;
         p.flags = listenConn->flags;
         p.fdNote = fdNote;
@@ -50,7 +49,7 @@ Ipc::StartListening(int sock_type, int proto, const Comm::ConnectionPointer &lis
     }
 
     enter_suid();
-    comm_open_listener(sock_type, proto, answer.conn, FdNote(fdNote));
+    comm_open_listener(answer.conn, FdNote(fdNote));
     const auto savedErrno = errno;
     leave_suid();
 

--- a/src/ipc/StartListening.h
+++ b/src/ipc/StartListening.h
@@ -35,8 +35,7 @@ using StartListeningCallback = AsyncCallback<StartListeningAnswer>;
 
 /// Depending on whether SMP is on, either ask Coordinator to send us
 /// the listening FD or open a listening socket directly.
-void StartListening(int sock_type, int proto, const Comm::ConnectionPointer &listenConn,
-                    FdNoteId, StartListeningCallback &);
+void StartListening(const Comm::ConnectionPointer &listenConn, FdNoteId, StartListeningCallback &);
 
 std::ostream &operator <<(std::ostream &, const StartListeningAnswer &);
 

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -372,11 +372,12 @@ Ftp::Server::listenForDataConnection()
     closeDataConnection();
 
     Comm::ConnectionPointer conn = new Comm::Connection;
+    conn->transport = AnyP::PROTO_TCP;
     conn->flags = COMM_NONBLOCKING;
     conn->local = transparent() ? port->s : clientConnection->local;
     conn->local.port(0);
     const char *const note = uri.c_str();
-    comm_open_listener(SOCK_STREAM, IPPROTO_TCP, conn, note);
+    comm_open_listener(conn, note);
     if (!Comm::IsConnOpen(conn)) {
         debugs(5, DBG_CRITICAL, "ERROR: comm_open_listener failed for FTP data: " <<
                conn->local << " error: " << errno);

--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -262,6 +262,7 @@ snmpOpenPorts()
         return;
 
     snmpIncomingConn = new Comm::Connection;
+    snmpIncomingConn->transport = AnyP::PROTO_UDP;
     snmpIncomingConn->local = Config.Addrs.snmp_incoming;
     snmpIncomingConn->local.port(Config.Port.snmp);
 
@@ -275,10 +276,11 @@ snmpOpenPorts()
     }
 
     auto call = asyncCallbackFun(49, 2, snmpPortOpened);
-    Ipc::StartListening(SOCK_DGRAM, IPPROTO_UDP, snmpIncomingConn, Ipc::fdnInSnmpSocket, call);
+    Ipc::StartListening(snmpIncomingConn, Ipc::fdnInSnmpSocket, call);
 
     if (!Config.Addrs.snmp_outgoing.isNoAddr()) {
         snmpOutgoingConn = new Comm::Connection;
+        snmpOutgoingConn->transport = AnyP::PROTO_UDP;
         snmpOutgoingConn->local = Config.Addrs.snmp_outgoing;
         snmpOutgoingConn->local.port(Config.Port.snmp);
 
@@ -292,7 +294,7 @@ snmpOpenPorts()
         }
         // TODO: Add/use snmpOutgoingPortOpened() instead of snmpPortOpened().
         auto c = asyncCallbackFun(49, 2, snmpPortOpened);
-        Ipc::StartListening(SOCK_DGRAM, IPPROTO_UDP, snmpOutgoingConn, Ipc::fdnOutSnmpSocket, c);
+        Ipc::StartListening(snmpOutgoingConn, Ipc::fdnOutSnmpSocket, c);
     } else {
         snmpOutgoingConn = snmpIncomingConn;
         debugs(1, DBG_IMPORTANT, "Sending SNMP messages from " << snmpOutgoingConn->local);

--- a/src/tests/stub_comm.cc
+++ b/src/tests/stub_comm.cc
@@ -42,7 +42,7 @@ int comm_open(int, int, Ip::Address &, int, const char *) STUB_RETVAL(-1)
 int comm_open_uds(int, int, struct sockaddr_un*, int) STUB_RETVAL(-1)
 void comm_import_opened(const Comm::ConnectionPointer &, const char *, struct addrinfo *) STUB
 int comm_open_listener(int, int, Ip::Address &, int, const char *) STUB_RETVAL(-1)
-void comm_open_listener(int, int, Comm::ConnectionPointer &, const char *) STUB
+void comm_open_listener(Comm::ConnectionPointer &, const char *) STUB
 unsigned short comm_local_port(int) STUB_RETVAL(0)
 int comm_udp_sendto(int, const Ip::Address &, const void *, int) STUB_RETVAL(-1)
 void commCallCloseHandlers(int) STUB


### PR DESCRIPTION
No behavioural changes. Just code refactoring to allow for
protocols to select either TCP or UDP transport layer in
their listening ports.