### PR TITLE
check return values of comm_udp_recvfrom and log on error

### DIFF
--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -367,22 +367,26 @@ snmpHandleUdp(int sock, void *)
 
     len = comm_udp_recvfrom(sock, buf, sizeof(buf)-1, 0, from);
 
-    if (len > 0) {
-        debugs(49, 3, "snmpHandleUdp: FD " << sock << ": received " << len << " bytes from " << from << ".");
+    if (len == 0)
+        return;
 
-        snmp_rq = (SnmpRequest *)xcalloc(1, sizeof(SnmpRequest));
-        snmp_rq->buf = (u_char *) buf;
-        snmp_rq->len = len;
-        snmp_rq->sock = sock;
-        snmp_rq->outbuf = (unsigned char *)xmalloc(snmp_rq->outlen = SNMP_REQUEST_SIZE);
-        snmp_rq->from = from;
-        snmpDecodePacket(snmp_rq);
-        xfree(snmp_rq->outbuf);
-        xfree(snmp_rq);
-    } else {
+    if (len < 0) {
         int xerrno = errno;
         debugs(49, DBG_IMPORTANT, "snmpHandleUdp: FD " << sock << " recvfrom: " << xstrerr(xerrno));
+        return;
     }
+
+    debugs(49, 3, "snmpHandleUdp: FD " << sock << ": received " << len << " bytes from " << from << ".");
+
+    snmp_rq = (SnmpRequest *)xcalloc(1, sizeof(SnmpRequest));
+    snmp_rq->buf = (u_char *) buf;
+    snmp_rq->len = len;
+    snmp_rq->sock = sock;
+    snmp_rq->outbuf = (unsigned char *)xmalloc(snmp_rq->outlen = SNMP_REQUEST_SIZE);
+    snmp_rq->from = from;
+    snmpDecodePacket(snmp_rq);
+    xfree(snmp_rq->outbuf);
+    xfree(snmp_rq);
 }
 
 /*

--- a/src/wccp.cc
+++ b/src/wccp.cc
@@ -204,6 +204,12 @@ wccpHandleUdp(int sock, void *)
                             sizeof(wccp_i_see_you),
                             0,
                             from);
+    if (len < 0) {
+        int xerrno = errno;
+        debugs(80, DBG_IMPORTANT, "wccpHandleUdp: FD " << sock << " recvfrom: " << xstrerr(xerrno));
+        return;
+    }
+
     debugs(80, 3, "wccpHandleUdp: " << len << " bytes WCCP pkt from " << from <<
            ": type=" <<
            (unsigned) ntohl(wccp_i_see_you.type) << ", version=" <<
@@ -211,9 +217,6 @@ wccpHandleUdp(int sock, void *)
            (unsigned) ntohl(wccp_i_see_you.change) << ", id=" <<
            (unsigned) ntohl(wccp_i_see_you.id) << ", number=" <<
            (unsigned) ntohl(wccp_i_see_you.number));
-
-    if (len < 0)
-        return;
 
     if (from != Config.Wccp.router)
         return;

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -1230,8 +1230,15 @@ wccp2HandleUdp(int sock, void *)
 
     const auto lenOrError = comm_udp_recvfrom(sock, &wccp2_i_see_you, WCCP_RESPONSE_SIZE, 0, from_tmp);
 
-    if (lenOrError < 0)
+    if (lenOrError == 0)
         return;
+
+    if (lenOrError < 0) {
+        int xerrno = errno;
+        debugs(80, DBG_IMPORTANT, "wccp2HandleUdp: FD " << sock << " recvfrom: " << xstrerr(xerrno));
+        return;
+    }
+
     const auto len = static_cast<size_t>(lenOrError);
 
     try {


### PR DESCRIPTION
Note: there are some calls remaining that do not check the return value of `comm_udp_recvfrom` at all.