### PR TITLE
Reject eui64 ACL addresses with trailing garbage

### DIFF
--- a/src/acl/Eui64.cc
+++ b/src/acl/Eui64.cc
@@ -42,7 +42,8 @@ aclParseEuiData(const char *t)
     Eui::Eui64 *q = new Eui::Eui64;
     debugs(28, 5, "aclParseEuiData: " << t);
 
-    if (sscanf(t, "%[0-9a-fA-F:]", buf) != 1) {
+    int n = 0;
+    if (sscanf(t, "%255[0-9a-fA-F:]%n", buf, &n) != 1 || t[n] != '\0') {
         debugs(28, DBG_CRITICAL, "ERROR: aclParseEuiData: Bad EUI-64 address: '" << t << "'");
         delete q;
         return nullptr;


### PR DESCRIPTION
Also limit eui64 ACL addresses to 255 characters.