### PR TITLE
basic_sspi_auth: stricter, bounded credential parsing

### DIFF
--- a/src/auth/basic/SSPI/basic_sspi_auth.cc
+++ b/src/auth/basic/SSPI/basic_sspi_auth.cc
@@ -154,7 +154,8 @@ main(int argc, char **argv)
         username[0] = '\0';
         password[0] = '\0';
 
-        char sep = '\0', junk = '\0';
+        char sep = '\0';
+        char junk = '\0';
         // XXX: sscanf silently skips series of isspace() characters in input
         // XXX: "Alice \v\t Bob" produces identical results to "Alice Bob"
         const auto parsed = sscanf(wstr, " %255s%1c%255s %c", username, &sep, password, &junk);

--- a/src/auth/basic/SSPI/basic_sspi_auth.cc
+++ b/src/auth/basic/SSPI/basic_sspi_auth.cc
@@ -112,8 +112,10 @@ main(int argc, char **argv)
     char wstr[HELPER_INPUT_BUFFER];
     char username[256];
     char password[256];
+    char sep = '\0', junk = '\0';
     char *p;
     int err = 0;
+    int parsed = 0;
 
     process_options(argc, argv);
 
@@ -149,7 +151,23 @@ main(int argc, char **argv)
         /* Clear any current settings */
         username[0] = '\0';
         password[0] = '\0';
-        sscanf(wstr, "%s %s", username, password);  /* Extract parameters */
+
+        parsed = sscanf(wstr, " %255s%1c%255s %c", username, &sep, password, &junk);
+
+        if (parsed < 2 || !isspace((unsigned char)sep)) {
+            username[0] = '\0';
+            password[0] = '\0';
+            puts("ERR");
+            continue;
+        }
+        if (parsed == 4) {
+            username[0] = '\0';
+            password[0] = '\0';
+            puts("ERR");
+            continue;
+        }
+        if (parsed == 2)
+            password[0] = '\0';
 
         debug("Got %s from Squid\n", wstr);
 

--- a/src/auth/basic/SSPI/basic_sspi_auth.cc
+++ b/src/auth/basic/SSPI/basic_sspi_auth.cc
@@ -113,7 +113,6 @@ main(int argc, char **argv)
     char wstr[HELPER_INPUT_BUFFER];
     char username[256];
     char password[256];
-    char sep = '\0', junk = '\0';
     char *p;
     int err = 0;
 
@@ -155,12 +154,16 @@ main(int argc, char **argv)
         username[0] = '\0';
         password[0] = '\0';
 
+        char sep = '\0', junk = '\0';
+        // XXX: sscanf silently skips series of isspace() characters in input
+        // XXX: "Alice \v\t Bob" produces identical results to "Alice Bob"
         const auto parsed = sscanf(wstr, " %255s%1c%255s %c", username, &sep, password, &junk);
 
         if (parsed != 3 || !xisspace(sep)) {
             username[0] = '\0';
             password[0] = '\0';
             SEND_ERR("Cannot parse request");
+            fflush(stdout);
             continue;
         }
 

--- a/src/auth/basic/SSPI/basic_sspi_auth.cc
+++ b/src/auth/basic/SSPI/basic_sspi_auth.cc
@@ -157,13 +157,13 @@ main(int argc, char **argv)
         if (parsed < 2 || !isspace((unsigned char)sep)) {
             username[0] = '\0';
             password[0] = '\0';
-            puts("ERR");
+            SEND_ERR("Cannot parse request");
             continue;
         }
         if (parsed == 4) {
             username[0] = '\0';
             password[0] = '\0';
-            puts("ERR");
+            SEND_ERR("Trailing garbage in request");
             continue;
         }
         if (parsed == 2)


### PR DESCRIPTION
Replace unbounded sscanf("%s %s") with a bounded parse (%255s...) that
requires a real whitespace separator and rejects trailing junk. This
prevents stack buffer overflow on overlong fields and fails closed
(ERR) on malformed input. Well-formed user pass lines remain unchanged.