### PR TITLE
HTCP: Check for too-small packed and too-large unpacked fields

### DIFF
--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -639,7 +639,7 @@ htcpUnpackSpecifier(char *buf, int sz)
     HttpRequestMethod method;
 
     /* Find length of METHOD */
-    uint16_t l;
+    uint16_t l = 0;
     if (!parseUint16(buf, sz, l, "METHOD length"))
         return nil;
 
@@ -753,7 +753,7 @@ htcpUnpackDetail(char *buf, int sz)
     auto d = std::make_unique<htcpDetail>();
 
     /* Find length of RESP-HDRS */
-    uint16_t l;
+    uint16_t l = 0;
     if (!parseUint16(buf, sz, l, "RESP-HDRS length"))
         return nullptr;
 


### PR DESCRIPTION
Harden HTCP parsing by checking HTCP fields

- Check packed field lengths and buffer space before reads.
- Guard CLR "reason" when sz < 2; log invalid messages.
- Support old minor==0 layout with safe prefix copy.
- Use early returns and unique_ptr for safer flows.