### PR TITLE
do not allow more than Config.client_ip_max_connections connections

### DIFF
--- a/src/comm/TcpAcceptor.cc
+++ b/src/comm/TcpAcceptor.cc
@@ -414,7 +414,7 @@ Comm::TcpAcceptor::acceptInto(Comm::ConnectionPointer &details)
     details->nfConnmark = Ip::Qos::getNfConnmark(details, Ip::Qos::dirAccepted);
 
     if (Config.client_ip_max_connections >= 0) {
-        if (clientdbEstablished(details->remote, 0) > Config.client_ip_max_connections) {
+        if (clientdbEstablished(details->remote, 0) >= Config.client_ip_max_connections) {
             debugs(50, DBG_IMPORTANT, "WARNING: " << details->remote << " attempting more than " << Config.client_ip_max_connections << " connections.");
             return false;
         }


### PR DESCRIPTION
previously, this would allow one extra client connection, due
to an off-by-one error.