### PR TITLE
rfc1738: fix OOB read on incomplete escapes and add tests

### DIFF
--- a/lib/rfc1738.c
+++ b/lib/rfc1738.c
@@ -150,9 +150,12 @@ rfc1738_unescape(char *s)
         s[i] = s[j];
         if (s[j] != '%') {
             /* normal case, nothing more to do */
+        } else if (!s[j + 1]) {         /* trailing '%' */
+            /* leave '%' as-is; next loop test on s[j+1] will end the loop */
+            continue;
         } else if (s[j + 1] == '%') {   /* %% case */
             j++;        /* Skip % */
-        } else {
+        } else if (s[j + 2]) {          /* need two hex digits */
             /* decode */
             int v1, v2, x;
             v1 = fromhex(s[j + 1]);
@@ -166,6 +169,9 @@ rfc1738_unescape(char *s)
                 s[i] = x;
                 j += 2;
             }
+        } else {
+            /* incomplete escape like "%A\0": leave as-is */
+            continue;
         }
     }
     s[i] = '\0';

--- a/lib/tests/testRFC1738.cc
+++ b/lib/tests/testRFC1738.cc
@@ -97,6 +97,42 @@ void TestRfc1738::testUrlDecode()
     rfc1738_unescape(unescaped_str);
     CPPUNIT_ASSERT(memcmp(unescaped_str, "Good String \032",14)==0);
     xfree(unescaped_str);
+
+    /* Trailing '%' should remain unchanged */
+    unescaped_str = xstrdup("abc%");
+    rfc1738_unescape(unescaped_str);
+    CPPUNIT_ASSERT(memcmp(unescaped_str, "abc%", 5) == 0);
+    xfree(unescaped_str);
+
+    /* Lone '%' should remain unchanged */
+    unescaped_str = xstrdup("%");
+    rfc1738_unescape(unescaped_str);
+    CPPUNIT_ASSERT(memcmp(unescaped_str, "%", 2) == 0);
+    xfree(unescaped_str);
+
+    /* Incomplete escape at end: "%A" should remain unchanged */
+    unescaped_str = xstrdup("abc%A");
+    rfc1738_unescape(unescaped_str);
+    CPPUNIT_ASSERT(memcmp(unescaped_str, "abc%A", 6) == 0);
+    xfree(unescaped_str);
+
+    /* Lone incomplete escape: "%A" should remain unchanged */
+    unescaped_str = xstrdup("%A");
+    rfc1738_unescape(unescaped_str);
+    CPPUNIT_ASSERT(memcmp(unescaped_str, "%A", 3) == 0);
+    xfree(unescaped_str);
+
+    /* Non-hex after '%' leaves sequence untouched */
+    unescaped_str = xstrdup("foo%G1bar");
+    rfc1738_unescape(unescaped_str);
+    CPPUNIT_ASSERT(memcmp(unescaped_str, "foo%G1bar", 10) == 0);
+    xfree(unescaped_str);
+
+    /* "%%" becomes "%" */
+    unescaped_str = xstrdup("%%");
+    rfc1738_unescape(unescaped_str);
+    CPPUNIT_ASSERT(memcmp(unescaped_str, "%", 2) == 0);
+    xfree(unescaped_str);
 }
 
 /**


### PR DESCRIPTION
Ensure we check for trailing '%' and incomplete hex sequences
before decoding to avoid out-of-bounds reads. Added unit tests
for trailing '%', lone '%', and incomplete escapes.