### PR TITLE
ext_ad_group_acl: Fix domain lookup error handling

### DIFF
--- a/src/acl/external/AD_group/ext_ad_group_acl.cc
+++ b/src/acl/external/AD_group/ext_ad_group_acl.cc
@@ -320,10 +320,10 @@ static char *
 GetDomainName(void)
 {
     static char *DomainName = nullptr;
-    PDSROLE_PRIMARY_DOMAIN_INFO_BASIC pDSRoleInfo;
+    PDSROLE_PRIMARY_DOMAIN_INFO_BASIC pDSRoleInfo = nullptr;
     DWORD netret;
 
-    if ((netret = DsRoleGetPrimaryDomainInformation(nullptr, DsRolePrimaryDomainInfoBasic, (PBYTE *) & pDSRoleInfo) == ERROR_SUCCESS)) {
+    if ((netret = DsRoleGetPrimaryDomainInformation(nullptr, DsRolePrimaryDomainInfoBasic, (PBYTE *) & pDSRoleInfo)) == ERROR_SUCCESS) {
         /*
          * Check the machine role.
          */


### PR DESCRIPTION
On errors, the helper was reporting DsRoleGetPrimaryDomainInformation()
error info using the wrong/bogus error code and probably freeing an
uninitialized pointer.
