### PR TITLE
SNMP: Match Var allocation/deallocation methods

### DIFF
--- a/src/snmp/Pdu.cc
+++ b/src/snmp/Pdu.cc
@@ -121,7 +121,7 @@ Snmp::Pdu::clearVars()
     while (var != nullptr) {
         variable_list* tmp = var;
         var = var->next_variable;
-        snmp_var_free(tmp);
+        delete static_cast<Var*>(tmp);
     }
     variables = nullptr;
 }


### PR DESCRIPTION
Pdu::setVars() and Pdu::unpack() allocate variables with `new Var(...)`,
but clearVars() freed them using snmp_var_free(). That skipped the `Var`
destructor and mismatched the allocator.

We hope that all Pdu::variables are allocated via Pdu class methods
despite the presence of snmp_var_new() and snmp_var_clone() calls in
low-level snmplib code.