### PR TITLE
asn1: bound check in asn_parse_objid loop

### DIFF
--- a/lib/snmplib/asn1.c
+++ b/lib/snmplib/asn1.c
@@ -676,10 +676,13 @@ asn_parse_objid(u_char * data, int *datalength,
         subidentifier = 0;
 
         do {            /* shift and add in low order 7 bits */
+            if (length-- <= 0) {
+                snmp_set_api_error(SNMPERR_ASN_DECODE);
+                return (NULL);
+            }
             subidentifier = (subidentifier << 7)
-                            + (*(u_char *) bufp & ~ASN_BIT8);
-            length--;
-        } while (*(u_char *) bufp++ & ASN_BIT8);
+                            | (*bufp & ~ASN_BIT8);
+        } while (*bufp++ & ASN_BIT8);
 
         /* while last byte has high bit clear */
         if (subidentifier > (u_int) MAX_SUBID) {


### PR DESCRIPTION
ASN.1 object identifiers are length-delimited, not null-terminated.
If the input encoding omits a terminating byte (MSB clear), the parser would walk past the buffer.
Add a length check inside the loop to avoid out-of-bounds reads on malformed ASN input.