### PR TITLE
kerberos: properly align NDR data

### DIFF
--- a/src/auth/negotiate/kerberos/negotiate_kerberos_pac.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_pac.cc
@@ -53,13 +53,11 @@ extern int
 check_k5_err(krb5_context context, const char *function, krb5_error_code code);
 
 void
-align(int n)
+align(auto n)
 {
-    if ( bpos % n != 0 ) {
-        int al;
-        al = (bpos/n);
-        bpos = bpos+(bpos-n*al);
-    }
+    auto r = bpos % n;
+    if (r)
+        bpos += (n - r);
 }
 
 void


### PR DESCRIPTION
Previously, for n = 4:
bpos=5 (r=1): current: 6 (wrong), correct: 8
bpos=6 (r=2): current: 8 (accidentally right)
bpos=7 (r=3): current: 10 (wrong), correct: 8