### PR TITLE
Remove useless free in edirectory digest

### DIFF
--- a/src/auth/digest/eDirectory/edir_ldapext.cc
+++ b/src/auth/digest/eDirectory/edir_ldapext.cc
@@ -110,7 +110,6 @@ static int berEncodePasswordData(
     /* Allocate a BerElement for the request parameters. */
     if ((requestBer = ber_alloc()) == nullptr) {
         err = LDAP_ENCODING_ERROR;
-        ber_free(requestBer, 1);
         return err;
     }
 


### PR DESCRIPTION
In this codepath, `requestBer` is nullptr.