### PR TITLE
digest_edirectory_auth: safely return password

### DIFF
--- a/src/auth/digest/eDirectory/edir_ldapext.cc
+++ b/src/auth/digest/eDirectory/edir_ldapext.cc
@@ -352,7 +352,6 @@ static int getLoginConfig(
 /**********************************************************************
  Attempts to get the Simple Password
 **********************************************************************/
-#define SMB_MALLOC_ARRAY(type, nelem)       calloc(nelem, sizeof(type))
 
 static int nmasldap_get_simple_pwd(
     LDAP     *ld,


### PR DESCRIPTION
Previously, nmasldap_get_simple_pwd() and nmasldap_get_password()
could overrun or return non-terminated strings at length
boundaries. This change adds strict bounds checks, copies at most
len - 1, and ensures explicit NUL termination, aligning both
helpers buffer/length semantics without altering call-site
behavior.