### PR TITLE
ext_file_userip_acl: harden lookups and memory handling

### DIFF
--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -61,6 +61,16 @@ int dict_lookup(struct ip_user_dict *, char *, char *);
 /** Size of lines read from the dictionary file */
 #define DICT_BUFFER_SIZE    8196
 
+static void
+free_dict(struct ip_user_dict *head){
+    while (head) {
+        struct ip_user_dict *next = head->next_entry;
+        free(head->username);
+        free(head);
+        head = next;
+    }
+}
+
 /** This function parses the dictionary file and loads it
  * in memory. All IP addresses are processed with a bitwise AND
  * with their netmasks before they are stored.
@@ -289,6 +299,7 @@ main (int argc, char *argv[])
     }
 
     fclose (FH);
+    free_dict(current_entry);
     return EXIT_SUCCESS;
 }
 

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -90,7 +90,7 @@ load_dict(FILE * FH) {
                    bitwise AND */
 
     /* the pointer to the first entry in the linked list */
-    first_entry = static_cast<struct ip_user_dict*>(calloc(1, sizeof(struct ip_user_dict)));
+    first_entry = static_cast<struct ip_user_dict*>(xcalloc(1, sizeof(struct ip_user_dict)));
     current_entry = first_entry;
 
     unsigned int lineCount = 0;

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -144,6 +144,10 @@ load_dict(FILE * FH) {
 
     }
 
+    if (current_entry) {
+        memset(current_entry, 0, sizeof *current_entry);
+    }
+
     /* Return a pointer to the first entry linked list */
     return first_entry;
 }
@@ -159,7 +163,7 @@ dict_lookup(struct ip_user_dict *first_entry, char *username,
     /* Move the pointer to the first entry of the linked list. */
     struct ip_user_dict *current_entry = first_entry;
 
-    while (current_entry->username != nullptr) {
+    while (current_entry && current_entry->username != nullptr) {
         debug("user: %s\naddr: %lu\nmask: %lu\n\n",
               current_entry->username, current_entry->address,
               current_entry->netmask);

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -159,7 +159,7 @@ dict_lookup(struct ip_user_dict *first_entry, char *username,
     /* Move the pointer to the first entry of the linked list. */
     struct ip_user_dict *current_entry = first_entry;
 
-    while (current_entry && current_entry->username != nullptr) {
+    while (current_entry && current_entry->username) {
         debug("user: %s\naddr: %lu\nmask: %lu\n\n",
               current_entry->username, current_entry->address,
               current_entry->netmask);

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -208,18 +208,17 @@ match_group(char *dict_group, char *username)
                    so we rip it off by incrementing
                    * the pointer by one */
 
-    if ((g = getgrnam(dict_group)) == nullptr) {
-        debug("Group does not exist '%s'\n", dict_group);
+    struct group *g = getgrnam(dict_group);
+    if (!g || !g->gr_mem) {
+        debug("Group does not exist or has no members '%s'\n", dict_group);
         return 0;
-    } else {
-        while (*(g->gr_mem) != nullptr) {
-            if (strcmp(*((g->gr_mem)++), username) == 0) {
-                return 1;
-            }
-        }
+    }
+
+    for (char **m = g->gr_mem; *m; ++m) {
+        if (strcmp(*m, username) == 0)
+            return 1;
     }
     return 0;
-
 }
 
 static void

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -65,8 +65,8 @@ static void
 free_dict(struct ip_user_dict *head) {
     while (head) {
         struct ip_user_dict *next = head->next_entry;
-        free(head->username);
-        free(head);
+        safe_free(head->username);
+        xfree(head);
         head = next;
     }
 }

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -208,7 +208,7 @@ match_group(char *dict_group, char *username)
                    so we rip it off by incrementing
                    * the pointer by one */
 
-    struct group *g = getgrnam(dict_group);
+    g = getgrnam(dict_group);
     if (!g || !g->gr_mem) {
         debug("Group does not exist or has no members '%s'\n", dict_group);
         return 0;

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -138,7 +138,7 @@ load_dict(FILE * FH) {
 
             /* get space and point current_entry to the new entry */
             current_entry->next_entry =
-                static_cast<struct ip_user_dict*>(calloc(1, sizeof(struct ip_user_dict)));
+                static_cast<struct ip_user_dict*>(xcalloc(1, sizeof(struct ip_user_dict)));
             current_entry = current_entry->next_entry;
         }
 

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -90,7 +90,7 @@ load_dict(FILE * FH) {
                    bitwise AND */
 
     /* the pointer to the first entry in the linked list */
-    first_entry = static_cast<struct ip_user_dict*>(xmalloc(sizeof(struct ip_user_dict)));
+    first_entry = static_cast<struct ip_user_dict*>(calloc(1, sizeof(struct ip_user_dict)));
     current_entry = first_entry;
 
     unsigned int lineCount = 0;
@@ -138,14 +138,10 @@ load_dict(FILE * FH) {
 
             /* get space and point current_entry to the new entry */
             current_entry->next_entry =
-                static_cast<struct ip_user_dict*>(xmalloc(sizeof(struct ip_user_dict)));
+                static_cast<struct ip_user_dict*>(calloc(1, sizeof(struct ip_user_dict)));
             current_entry = current_entry->next_entry;
         }
 
-    }
-
-    if (current_entry) {
-        memset(current_entry, 0, sizeof *current_entry);
     }
 
     /* Return a pointer to the first entry linked list */

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -210,7 +210,7 @@ match_group(char *dict_group, char *username)
         return 0;
     }
 
-    for (char **m = g->gr_mem; *m; ++m) {
+    for (char * const *m = g->gr_mem; *m; ++m) {
         if (strcmp(*m, username) == 0)
             return 1;
     }

--- a/src/acl/external/file_userip/ext_file_userip_acl.cc
+++ b/src/acl/external/file_userip/ext_file_userip_acl.cc
@@ -62,7 +62,7 @@ int dict_lookup(struct ip_user_dict *, char *, char *);
 #define DICT_BUFFER_SIZE    8196
 
 static void
-free_dict(struct ip_user_dict *head){
+free_dict(struct ip_user_dict *head) {
     while (head) {
         struct ip_user_dict *next = head->next_entry;
         free(head->username);


### PR DESCRIPTION
Stop mutating getgrnam(3) buffer; iterate gr_mem safely
Zero last node and NULL-check in dict_lookup() to prevent OOB read
Add free_dict() and free dictionary before exit