### PR TITLE
FtpGateway: fix 'm' timestamp parsing; guard ctime(); trim safely

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -710,10 +710,14 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
                 if (tmp == ct + 1)
                     break;  /* not a valid integer */
 
-                safe_free(p->date); // TODO: properly handle multiple p->name occurrences
-                p->date = xstrdup(ctime(&tm));
+                const auto cts = ctime(&tm);
+                if (!cts)
+                    break;
 
-                *(strstr(p->date, "\n")) = '\0';
+                safe_free(p->date); // TODO: properly handle multiple p->name occurrences
+
+                auto n = strcspn(cts, "\n");
+                p->date = xstrndup(cts, n);
 
                 break;
 

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -707,7 +707,7 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
             case 'm':
                 tm = (time_t) strtol(ct + 1, &tmp, 0);
 
-                if (tmp != ct + 1)
+                if (tmp == ct + 1)
                     break;  /* not a valid integer */
 
                 safe_free(p->date); // TODO: properly handle multiple p->name occurrences


### PR DESCRIPTION
FtpGateway: fix 'm' timestamp parsing; guard ctime(); trim safely

The 'm' case in ftpListParseParts() reversed the strtol() validity
check. We broke out when any digits were consumed instead of only when
no conversion happened. As a result, valid epoch timestamps were treated
as invalid and p->date was often left unset.

Corrects the strtol() check (break only if tmp == ct + 1).
Guards against ctime() returning nullptr and bails out cleanly.
Stops modifying duplicated strings via strstr(); instead uses
strcspn() + xstrndup() to copy up to (but not including) the newline.

Correctly accepts valid 'm' (epoch) timestamps in FTP listings.
Avoids potential NULL dereference if no newline is present.
Avoids writing into copied buffers and keeps the code clearer.