### PR TITLE
win32: close pi.hThread as required by Windows API

### DIFF
--- a/src/ipc_win32.cc
+++ b/src/ipc_win32.cc
@@ -573,6 +573,7 @@ ipc_thread_1(void *in_params)
                       nullptr, nullptr, &si, &pi)) {
         pid = pi.dwProcessId;
         hProcess = pi.hProcess;
+        CloseHandle(pi.hThread);
     } else {
         pid = -1;
         x = GetLastError();


### PR DESCRIPTION
Previously, a leak would occur due to an unclosed pi.hThread.