### PR TITLE
ip: Harden against potentially short addresses

### DIFF
--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -889,7 +889,7 @@ Ip::Address::toUrl(char* buf, unsigned int blen) const
 
     // Ensure we have a buffer.
 
-    if (buf == nullptr) {
+    if (buf == nullptr || blen < 8) {
         return nullptr;
     }
 


### PR DESCRIPTION
1.1 is a valid representation of an ip address in some contexts(which
may or may not affect Squid).  This change does not currently affect
any callers, simply future-proofing.