### PR TITLE
Pinger: only send a 3 bytes response in Pinger

### DIFF
--- a/src/icmp/IcmpPinger.cc
+++ b/src/icmp/IcmpPinger.cc
@@ -122,7 +122,7 @@ IcmpPinger::Open(void)
         return -1;
     }
 
-    x = xsend(icmp_sock, buf, strlen(buf), 0);
+    x = xsend(icmp_sock, buf, 3, 0);
     xerrno = errno;
 
     if (x < 3 || strncmp("OK\n", buf, 3)) {


### PR DESCRIPTION
A prior memset(buf, 0, sizeof(buf)) protects this call against an
OOM read.