### PR TITLE
Fix debugging of Eui48::lookup() problems

### DIFF
--- a/src/eui/Eui48.cc
+++ b/src/eui/Eui48.cc
@@ -209,7 +209,7 @@ Eui::Eui48::lookup(const Ip::Address &c)
         xclose(tmpSocket);
 
         if (arpReq.arp_ha.sa_family != ARPHRD_ETHER) {
-            debugs(28, 4, "id=" << (void*)this << " ... not an Ethernet interface: " << arpReq.arp_ha.sa_data);
+            debugs(28, 4, "id=" << (void*)this << " ... not an Ethernet interface, sa_family=" << arpReq.arp_ha.sa_family);
             clear();
             return false;
         }


### PR DESCRIPTION
arpReq.arp_ha.sa_data is not a null-terminated buffer.
Log meaningful data: the sa_family which caused the log.