### PR TITLE
Fix UDP log module opening and closing code

### DIFF
--- a/src/log/ModUdp.cc
+++ b/src/log/ModUdp.cc
@@ -145,6 +145,7 @@ logfile_mod_udp_open(Logfile * lf, const char *path, size_t bufsz, int fatal_fla
     lf->f_rotate = logfile_mod_udp_rotate;
 
     l_udp_t *ll = static_cast<l_udp_t*>(xcalloc(1, sizeof(*ll)));
+    ll->fd = -1;
     lf->data = ll;
 
     if (strncmp(path, "//", 2) == 0) {


### PR DESCRIPTION
logfile_mod_udp_open() mistreated successful comm_connect_addr() result
as an "Unable to connect" failure (and vice versa), rendering UDP-based
logging unusable. Broken since at least 2010 commit d938215.

Also fixed logfile_mod_udp_close() closing FD 0 after "Invalid UDP
logging address" ERRORs during logfile_mod_udp_open().