### PR TITLE
SNMP: clear community aliases after free to avoid dangling pointer

### DIFF
--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -424,7 +424,9 @@ snmpDecodePacket(SnmpRequest * rq)
             snmp_free_pdu(PDU);
         }
         xfree(Community);
-
+        rq->community = nullptr;
+        rq->session.community = nullptr;
+        rq->session.community_len = 0;
     } else {
         debugs(49, DBG_IMPORTANT, "WARNING: Failed SNMP agent query from : " << rq->from);
         snmp_free_pdu(PDU);


### PR DESCRIPTION
Currently not a issue, but reduces dangling pointers in the future