### PR TITLE
SNMP: Remove extraneous va_start() from snmpAddNode()

### DIFF
--- a/src/snmp_core.cc
+++ b/src/snmp_core.cc
@@ -993,7 +993,7 @@ snmpAddNode(oid * name, int len, oid_ParseFn * parsefunction, instance_Fn * inst
     MemBuf tmp;
     debugs(49, 6, "snmpAddNode: Children : " << children << ", Oid : " << snmpDebugOid(name, len, tmp));
 
-    const auto entry = (mib_tree_entry *)xmalloc(sizeof(mib_tree_entry));
+    const auto entry = static_cast<mib_tree_entry *>(xmalloc(sizeof(mib_tree_entry)));
     entry->name = name;
     entry->len = len;
     entry->parsefunction = parsefunction;


### PR DESCRIPTION
Also polished snmpAddNode() implementation, including adding
`mib_tree_head->parent` initialization.