### PR TITLE
HTCP: Invalidate existing public entry in neighborsHtcpClear()

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -232,7 +232,7 @@ httpMaybeRemovePublic(StoreEntry * e, Http::StatusCode status)
     if (pe != nullptr) {
         assert(e != pe);
 #if USE_HTCP
-        neighborsHtcpClear(e, e->mem_obj->request.getRaw(), e->mem_obj->method, HTCP_CLR_INVALIDATION);
+        neighborsHtcpClear(pe, e->mem_obj->request.getRaw(), e->mem_obj->method, HTCP_CLR_INVALIDATION);
 #endif
         pe->release(true);
     }
@@ -249,7 +249,7 @@ httpMaybeRemovePublic(StoreEntry * e, Http::StatusCode status)
     if (pe != nullptr) {
         assert(e != pe);
 #if USE_HTCP
-        neighborsHtcpClear(e, e->mem_obj->request.getRaw(), HttpRequestMethod(Http::METHOD_HEAD), HTCP_CLR_INVALIDATION);
+        neighborsHtcpClear(pe, e->mem_obj->request.getRaw(), HttpRequestMethod(Http::METHOD_HEAD), HTCP_CLR_INVALIDATION);
 #endif
         pe->release(true);
     }


### PR DESCRIPTION
httpMaybeRemovePublic() passed the new private entry (e) to
neighborsHtcpClear() instead of the existing public one (pe). This
could misdirect HTCP invalidation metadata and peers.