### PR TITLE
HttpStateData: fix recursion in handleMoreRequestBodyAvailable()

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -2650,7 +2650,7 @@ HttpStateData::handleMoreRequestBodyAvailable()
         }
     }
 
-    HttpStateData::handleMoreRequestBodyAvailable();
+    Client::handleMoreRequestBodyAvailable();
 }
 
 // premature end of the request body


### PR DESCRIPTION
We accidentally called the method itself, causing a stack overflow when
more request body arrives. Delegate to
Client::handleMoreRequestBodyAvailable() as intended to forward the
body.