### PR TITLE
Fix parsing of malformed quoted squid.conf strings

### DIFF
--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -146,8 +146,13 @@ ConfigParser::UnQuote(const char *token, const char **next)
     const char  *s = token + 1;
     char *d = UnQuoted;
     /* scan until the end of the quoted string, handling escape sequences*/
-    while (*s && *s != quoteChar && !errorStr && (size_t)(d - UnQuoted) < sizeof(UnQuoted)) {
+    while (*s && *s != quoteChar && !errorStr && (size_t)(d - UnQuoted) < sizeof(UnQuoted) - 1) {
         if (*s == '\\') {
+            if (s[1] == '\0') {
+                errorStr = "Unterminated escape sequence";
+                errorPos = s;
+                break;
+            }
             s++;
             switch (*s) {
             case 'r':


### PR DESCRIPTION
Iteration of a quoted token that ends with a backslash (escape with no
next char) kept going past the end of the token. That bug as well as
hypothetical 2KB-byte tokens (exceeding CONFIG_LINE_LIMIT) could also
result in a 1-byte NUL overrun.
