### PR TITLE
Do not forward HTCP CLR requests denied by htcp_clr_access

### DIFF
--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -103,6 +103,12 @@ This section gives an account of those changes in three categories:
 	connection should increase the configured limit by one to preserve
 	previous behavior.
 
+	<tag>htcp_clr_access</tag>
+
+	<p>HTCP CLR requests denied by this directive are no longer forwarded to
+	cache_peers that are configured to receive forwarded CLR requests. Only
+	HTCP CLR requests allowed by this directive are forwarded to those
+	cache_peers.
 
 </descrip>
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2037,13 +2037,12 @@ LOC: Config.accessList.htcp
 DEFAULT: none
 DEFAULT_DOC: Deny, unless rules exist in squid.conf.
 DOC_START
-	Allowing or Denying access to the HTCP port based on defined
-	access lists
+	Controls whether HTCP TST requests received on htcp_port are allowed.
 
 	htcp_access  allow|deny [!]aclname ...
 
-	See also htcp_clr_access for details on access control for
-	cache purge (CLR) HTCP messages.
+	This directive does not control whether HTCP CLR requests are allowed.
+	Use htcp_clr_access directive for that.
 
 	NOTE: The default if no htcp_access lines are present is to
 	deny all traffic. This default may cause problems with peers
@@ -2064,11 +2063,13 @@ LOC: Config.accessList.htcp_clr
 DEFAULT: none
 DEFAULT_DOC: Deny, unless rules exist in squid.conf.
 DOC_START
-	Allowing or Denying access to purge content using HTCP based
-	on defined access lists.
-	See htcp_access for details on general HTCP access control.
+	Controls whether HTCP CLR requests received on htcp_port are allowed.
+	See htcp_access for controlling other HTCP messages.
 
 	htcp_clr_access  allow|deny [!]aclname ...
+
+	HTCP CLR requests purge matching cached entries. They may be forwarded to
+	specially marked cache_peers (see cache_peer HTCP options for details).
 
 	This clause only supports fast acl types.
 	See https://wiki.squid-cache.org/SquidFaq/SquidAcl for details.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2044,6 +2044,9 @@ DOC_START
 	This directive does not control whether HTCP CLR requests are allowed.
 	Use htcp_clr_access directive for that.
 
+	This directive does not control whether HTCP requests with other opcodes
+	are allowed (e.g., NOP, MON, and SET). Squid ignores those HTCP requests.
+
 	NOTE: The default if no htcp_access lines are present is to
 	deny all traffic. This default may cause problems with peers
 	using the htcp option.

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2048,13 +2048,13 @@ DOC_START
 	are allowed (e.g., NOP, MON, and SET). Squid ignores those HTCP requests.
 
 	NOTE: The default if no htcp_access lines are present is to
-	deny all traffic. This default may cause problems with peers
+	deny all HTCP TST traffic. This default may cause problems with peers
 	using the htcp option.
 
 	This clause only supports fast acl types.
 	See https://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 
-# Allow HTCP queries from local networks only
+# Allow HTCP TST queries from local networks only
 #htcp_access allow localnet
 #htcp_access deny all
 DOC_END

--- a/src/htcp.cc
+++ b/src/htcp.cc
@@ -1235,8 +1235,6 @@ htcpSpecifier::checkedHit(StoreEntry *e)
     }
 }
 
-static void htcpForwardClr(char *buf, int sz);
-
 static void
 htcpHandleClr(htcpDataHeader * const hdr, char * const buf, const int sz, Ip::Address &from)
 {
@@ -1304,17 +1302,9 @@ htcpHandleClr(htcpDataHeader * const hdr, char * const buf, const int sz, Ip::Ad
         break;
     }
 
+    // Forward this CLR request to all peers who have requested that CLRs be
+    // forwarded to them.
     // TODO: Consider not forwarding requests with htcpClrStore() < 0.
-    htcpForwardClr(buf, sz);
-}
-
-/*
- * Forward a CLR request to all peers who have requested that CLRs be
- * forwarded to them.
- */
-static void
-htcpForwardClr(char *buf, int sz)
-{
     for (const auto &p: CurrentCachePeers()) {
         if (!p->options.htcp) {
             continue;


### PR DESCRIPTION
Before this change:

* htcp_access controls TST access
* htcp_clr_access controls CLR access to local cache purging
* nothing controls CLR forwarding -- it is always allowed

After this change:

* htcp_access controls TST access
* htcp_clr_access controls CLR access to local cache purging
* htcp_clr_access controls CLR forwarding

This bug was discovered and detailed by Joshua Rogers
https://joshua.hu/