### PR TITLE
Bug 3390: Proxy auth data visible to scripts

### DIFF
--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -195,6 +195,9 @@ This section gives an account of those changes in three categories:
 	<tag>logformat</tag>
 	<p>Removed <em>%ui</em> format code with Ident protocol support.
 
+	<tag>email_err_data</tag>
+	<p>Since Squid-7.2 the default for this directive is <em>OFF</em>.
+
 	<tag>external_acl_type</tag>
 	<p>Removed <em>%IDENT</em> format code with Ident protocol support.
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -196,7 +196,7 @@ This section gives an account of those changes in three categories:
 	<p>Removed <em>%ui</em> format code with Ident protocol support.
 
 	<tag>email_err_data</tag>
-	<p>Since Squid-7.2 the default for this directive is <em>OFF</em>.
+	<p>Since Squid-7.2, the default for this directive is <em>off</em>.
 
 	<tag>external_acl_type</tag>
 	<p>Removed <em>%IDENT</em> format code with Ident protocol support.

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -340,14 +340,14 @@ HttpRequest::swapOut(StoreEntry * e)
 
 /* packs request-line and headers, appends <crlf> terminator */
 void
-HttpRequest::pack(Packable * p) const
+HttpRequest::pack(Packable * p, bool mask_sensitive_data) const
 {
     assert(p);
     /* pack request-line */
     packFirstLineInto(p, false /* origin-form */);
     /* headers */
-    header.packInto(p);
-    /* trailer */
+    header.packInto(p, mask_sensitive_data);
+    /* frame terminator */
     p->append("\r\n", 2);
 }
 
@@ -471,9 +471,10 @@ HttpRequest::packFirstLineInto(Packable * p, bool full_uri) const
     const SBuf tmp(full_uri ? effectiveRequestUri() : url.originForm());
 
     // form HTTP request-line
-    p->appendf(SQUIDSBUFPH " " SQUIDSBUFPH " HTTP/%d.%d\r\n",
+    p->appendf(SQUIDSBUFPH " " SQUIDSBUFPH " %s/%d.%d\r\n",
                SQUIDSBUFPRINT(method.image()),
                SQUIDSBUFPRINT(tmp),
+               AnyP::ProtocolType_str[http_ver.protocol],
                http_ver.major, http_ver.minor);
 }
 

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -347,7 +347,7 @@ HttpRequest::pack(Packable * p, bool mask_sensitive_data) const
     packFirstLineInto(p, false /* origin-form */);
     /* headers */
     header.packInto(p, mask_sensitive_data);
-    /* frame terminator */
+    /*  indicate the end of the header section */
     p->append("\r\n", 2);
 }
 

--- a/src/HttpRequest.h
+++ b/src/HttpRequest.h
@@ -204,7 +204,7 @@ public:
 
     void swapOut(StoreEntry * e);
 
-    void pack(Packable * p) const;
+    void pack(Packable * p, bool mask_sensitive_info = false) const;
 
     static void httpRequestPack(void *obj, Packable *p);
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -8905,6 +8905,12 @@ DOC_START
 	included in the mailto links of the ERR pages (if %W is set)
 	so that the email body contains the data.
 	Syntax is <A HREF="mailto:%w%W">%w</A>
+
+	SECURITY WARNING:
+		Request headers and other included facts may contain
+		sensitive information about transaction history, the
+		Squid instance, and its environment which would be
+		unavailable to error recipients otherwise).
 DOC_END
 
 NAME: deny_info

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -8910,7 +8910,7 @@ DOC_START
 		Request headers and other included facts may contain
 		sensitive information about transaction history, the
 		Squid instance, and its environment which would be
-		unavailable to error recipients otherwise).
+		unavailable to error recipients otherwise.
 DOC_END
 
 NAME: deny_info

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -8899,7 +8899,7 @@ NAME: email_err_data
 COMMENT: on|off
 TYPE: onoff
 LOC: Config.onoff.emailErrData
-DEFAULT: on
+DEFAULT: off
 DOC_START
 	If enabled, information about the occurred error will be
 	included in the mailto links of the ERR pages (if %W is set)

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -93,7 +93,7 @@ clientReplyContext::clientReplyContext(ClientHttpRequest *clientContext) :
 void
 clientReplyContext::setReplyToError(
     err_type err, Http::StatusCode status, char const *uri,
-    const ConnStateData *conn, HttpRequest *failedrequest, const char *unparsedrequest,
+    const ConnStateData *conn, HttpRequest *failedrequest, const char *,
 #if USE_AUTH
     Auth::UserRequest::Pointer auth_user_request
 #else
@@ -102,9 +102,6 @@ clientReplyContext::setReplyToError(
 )
 {
     auto errstate = clientBuildError(err, status, uri, conn, failedrequest, http->al);
-
-    if (unparsedrequest)
-        errstate->err_msg = xstrdup(unparsedrequest);
 
 #if USE_AUTH
     errstate->auth_user_request = auth_user_request;

--- a/src/client_side_reply.cc
+++ b/src/client_side_reply.cc
@@ -104,7 +104,7 @@ clientReplyContext::setReplyToError(
     auto errstate = clientBuildError(err, status, uri, conn, failedrequest, http->al);
 
     if (unparsedrequest)
-        errstate->request_hdrs = xstrdup(unparsedrequest);
+        errstate->err_msg = xstrdup(unparsedrequest);
 
 #if USE_AUTH
     errstate->auth_user_request = auth_user_request;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -837,7 +837,6 @@ ErrorState::~ErrorState()
 
     safe_free(redirect_url);
     safe_free(url);
-    safe_free(request_hdrs);
     wordlistDestroy(&ftp.server_msg);
     safe_free(ftp.request);
     safe_free(ftp.reply);
@@ -1151,8 +1150,6 @@ ErrorState::compileLegacyCode(Build &build)
         }
         else if (request)
             request->pack(&mb, true /* hide authorization data */);
-        else if (request_hdrs)
-            p = request_hdrs;
         else
             p = "[no request]";
         break;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -887,7 +887,7 @@ ErrorState::Dump(MemBuf * mb)
         body << "HTTP Request:\r\n";
         MemBuf r;
         r.init();
-        request->pack(&r);
+        request->pack(&r, true /* hide authorization data */);
         body << r.content();
     }
 
@@ -1149,18 +1149,12 @@ ErrorState::compileLegacyCode(Build &build)
                 p = "[no request]";
             break;
         }
-        if (request) {
-            mb.appendf(SQUIDSBUFPH " " SQUIDSBUFPH " %s/%d.%d\n",
-                       SQUIDSBUFPRINT(request->method.image()),
-                       SQUIDSBUFPRINT(request->url.originForm()),
-                       AnyP::ProtocolType_str[request->http_ver.protocol],
-                       request->http_ver.major, request->http_ver.minor);
-            request->header.packInto(&mb, true); //hide authorization data
-        } else if (request_hdrs) {
+        else if (request)
+            request->pack(&mb, true /* hide authorization data */);
+        else if (request_hdrs)
             p = request_hdrs;
-        } else {
+        else
             p = "[no request]";
-        }
         break;
 
     case 's':

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -193,7 +193,6 @@ public:
         MemBuf *listing = nullptr;
     } ftp;
 
-    char *request_hdrs = nullptr;
     char *err_msg = nullptr; /* Preformatted error message from the cache */
 
     AccessLogEntryPointer ale; ///< transaction details (or nil)

--- a/src/tests/stub_HttpRequest.cc
+++ b/src/tests/stub_HttpRequest.cc
@@ -45,7 +45,7 @@ bool HttpRequest::expectingBody(const HttpRequestMethod &, int64_t &) const STUB
 bool HttpRequest::bodyNibbled() const STUB_RETVAL(false)
 int HttpRequest::prefixLen() const STUB_RETVAL(0)
 void HttpRequest::swapOut(StoreEntry *) STUB
-void HttpRequest::pack(Packable *) const STUB
+void HttpRequest::pack(Packable *, bool) const STUB
 void HttpRequest::httpRequestPack(void *, Packable *) STUB
 HttpRequest * HttpRequest::FromUrl(const SBuf &, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr)
 HttpRequest * HttpRequest::FromUrlXXX(const char *, const MasterXaction::Pointer &, const HttpRequestMethod &) STUB_RETVAL(nullptr)


### PR DESCRIPTION
Original changes to redact credentials from error page %R code
expansion output was incomplete. It missed the parse failure
case where ErrorState::request_hdrs raw buffer contained
sensitive information.

Also missed was the %W case where full request message headers
were generated in a mailto link. This case is especially
problematic as it may be delivered over insecure SMTP even if
the error was secured with HTTPS.

After this change:
* the HttpRequest message packing code for error pages is
  de-duplicated and elides authentication headers for both %R
  and %W code outputs.
* The %W code displays the request message protocol label
   correctly.
* The %R code output includes the CRLF request message
   terminator.
* The email_err_data directive causing advanced details to be
   added to %W mailto links is disabled by default.