### PR TITLE
Bug 5510: False Cache Digests misses

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -306,6 +306,7 @@ Thank you!
     Leonid Evdokimov <leon@darkk.net.ru>
     Liangliang Zhai <zhailiangliang@loongson.cn>
     libit <sambabug.lb@gmail.com>
+    Lior Brown <liorbrown@outlook.co.il>
     Lubos Uhliarik <luhliari@redhat.com>
     Luigi Gangitano <luigi@debian.org>
     Luis Daniel Lucio Quiroz <dlucio@okay.com.mx>

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -398,7 +398,7 @@ peerDigestHandleReply(void *data, StoreIOBuffer receivedData)
          */
         newsize = fetch->bufofs - retsize;
 
-        memmove(fetch->buf, fetch->buf + retsize, fetch->bufofs - newsize);
+        memmove(fetch->buf, fetch->buf + retsize, newsize);
 
         fetch->bufofs = newsize;
 


### PR DESCRIPTION
Authored-by: Lior Brown <liorbrown@outlook.co.il>

Since 2002 commit add2192d, code receiving fresh Cache Digests from
cache_peers corrupted peer digest bitmask, leading to misses for objects
that were supposed to be present in the digest[^1]. Memory overreads
were probably happening as well. The exact corruption conditions/effects
probably changed when 2023 commit 122a6e3c removed HTTP response headers
from storeClientCopy() API, but the underlying memmove() size
calculation bug predates that 2023 change.

[^1]: Bitmask corruption also ought to trigger some hits for objects
that were not present in peer's cache, although such hits were not
observed in triage, and some excessive hits are endemic to our Bloom
filters.

