### PR TITLE
Disable -march=native in tests

### DIFF
--- a/test-suite/buildtests/layer-00-default.opts
+++ b/test-suite/buildtests/layer-00-default.opts
@@ -15,7 +15,7 @@ MAKETEST="distcheck"
 # NP: DISTCHECK_CONFIGURE_FLAGS is a magic automake macro for the
 #     distcheck target recursive tests beteen scripted runs.
 #     we use it to perform the same duty between our nested scripts.
-DISTCHECK_CONFIGURE_FLAGS=""
+DISTCHECK_CONFIGURE_FLAGS="--disable-arch-native"
 
 # Fix the distclean testing.
 export DISTCHECK_CONFIGURE_FLAGS

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -34,6 +34,7 @@ MAKETEST="distcheck"
 #     distcheck target recursive tests beteen scripted runs.
 #     we use it to perform the same duty between our nested scripts.
 DISTCHECK_CONFIGURE_FLAGS=" \
+	--disable-arch-native \
 	--disable-build-info \
 	--disable-shared \
 	--disable-xmalloc-statistics \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -55,6 +55,7 @@ MAKETEST="distcheck"
 #     distcheck target recursive tests beteen scripted runs.
 #     we use it to perform the same duty between our nested scripts.
 DISTCHECK_CONFIGURE_FLAGS=" \
+	--disable-arch-native \
 	--enable-shared \
 	--enable-optimizations \
 	--enable-xmalloc-statistics \


### PR DESCRIPTION
We had a string of failed build tests with
"illegal instruction" errors in github.
One of the possibilities is that some of
the VMs used in github's infrastructure
do not support arch-native building well.
Trying to disable it to see if that is indeed the case