### PR TITLE
Flip configure --enable-arch-native default setting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,14 +73,14 @@ AC_LANG([C++])
 # But building inside a virtual machine environment has been found to
 # cause random Illegal Instruction errors due to mis-detection of CPU.
 AC_ARG_ENABLE(arch-native,
-  AS_HELP_STRING([--disable-arch-native],[Some compilers offer CPU-specific
+  AS_HELP_STRING([--enable-arch-native],[Some compilers offer CPU-specific
                  optimizations with the -march=native parameter.
-                 This flag disables the optimization. The default is to
-                 auto-detect compiler support and use where available.]), [
+                 This flag enables the optimization, by default disabled,
+                 provided that the compiler supports it.]), [
   SQUID_YESNO([$enableval],[--enable-arch-native])
 ])
-AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=auto}])
-AS_IF([test "x${enable_arch_native}" != "xno"],[
+AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=no}])
+AS_IF([test "x${enable_arch_native}" = "xyes"],[
   SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
 ])
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -310,6 +310,11 @@ This section gives an account of those changes in three categories:
 	<tag>--enable-auth-ntlm=</tag>
 	<p>Removed <em>SMB_LM</em> helper, in favour of the <em>ntlm_auth</em>
 	   alternative offered by the Samba project.
+	
+	<tag>--disable-march-native</tag>
+	<p>The <em>-march=native</em> compiler option is not used by
+		default. It is possible to enable it by using the
+		<em>--enable-march-native</em> option instead
 
 </descrip>
 </p>


### PR DESCRIPTION
Flip the default of configure's --enable-arch-native
option from enabled to disabled

gcc's and clang's -march=native argument is known
to cause issues in some environemnts, most notably
containers where the compilers' heuristics about
CPU feature set may be misled.
This surfaces as hard-to-reproduce SIGILL errors
in random binaries such as squid or unit tests.
The changed default is safer, while leaving
performance-minded administrators the option
to optimize

