### PR TITLE
Flip configure --enable-arch-native default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,8 @@ AC_ARG_ENABLE(arch-native,
 ])
 AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=no}])
 AS_IF([test "x${enable_arch_native}" = "xyes"],[
-  # XXX: make this a tristate yes/no/auto
+  # XXX: Fail if the explicitly requested native optimization is not available.
+  # TODO: Make this a tristate yes/no/auto.
   SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ AC_ARG_ENABLE(arch-native,
 ])
 AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=no}])
 AS_IF([test "x${enable_arch_native}" = "xyes"],[
+  # XXX: make this a tristate yes/no/auto
   SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ AC_ARG_ENABLE(arch-native,
                  provided that the compiler supports it. Enabling this
                  optimization may cause crashes due to illegal instruction errors
                  when Squid is run on a system different from the one it is built on,
-                 and in some containerised or virtualised environments]), [
+                 and in some containerized or virtualized environments]), [
   SQUID_YESNO([$enableval],[--enable-arch-native])
 ])
 AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=no}])

--- a/configure.ac
+++ b/configure.ac
@@ -68,8 +68,7 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_LANG([C++])
 
-# Clang 3.2 on some CPUs requires -march-native to detect correctly.
-# GCC 4.3+ can also produce faster executables when its used.
+# Some compilers can produce faster executables when its used.
 # But building inside a virtual machine environment has been found to
 # cause random Illegal Instruction errors due to mis-detection of CPU.
 AC_ARG_ENABLE(arch-native,

--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,10 @@ AC_ARG_ENABLE(arch-native,
   AS_HELP_STRING([--enable-arch-native],[Some compilers offer CPU-specific
                  optimizations with the -march=native parameter.
                  This flag enables the optimization, by default disabled,
-                 provided that the compiler supports it.]), [
+                 provided that the compiler supports it. Enabling this
+                 optimization may cause crashes due to illegal instruction errors
+                 when Squid is run on a system different from the one it is built on,
+                 and in some containerised or virtualised environments]), [
   SQUID_YESNO([$enableval],[--enable-arch-native])
 ])
 AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=no}])

--- a/configure.ac
+++ b/configure.ac
@@ -73,14 +73,14 @@ AC_LANG([C++])
 # But building inside a virtual machine environment has been found to
 # cause random Illegal Instruction errors due to mis-detection of CPU.
 AC_ARG_ENABLE(arch-native,
-  AS_HELP_STRING([--disable-arch-native],[Some compilers offer CPU-specific
+  AS_HELP_STRING([--enable-arch-native],[Some compilers offer CPU-specific
                  optimizations with the -march=native parameter.
-                 This flag disables the optimization. The default is to
-                 auto-detect compiler support and use where available.]), [
+                 This flag enables the optimization, by default disabled,
+                 provided that the compiler supports it.]), [
   SQUID_YESNO([$enableval],[--enable-arch-native])
 ])
-AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=auto}])
-AS_IF([test "x${enable_arch_native}" != "xno"],[
+AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=no}])
+AS_IF([test "x${enable_arch_native}" = "xyes"],[
   SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AC_ARG_ENABLE(arch-native,
                  This flag enables the optimization, by default disabled,
                  provided that the compiler supports it. Enabling this
                  optimization may cause crashes due to illegal instruction errors
-                 when Squid is run on a system different from the one it is built on,
+                 when Squid is run on a CPU different from the one it is built on,
                  and in some containerized or virtualized environments]), [
   SQUID_YESNO([$enableval],[--enable-arch-native])
 ])

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -286,7 +286,16 @@ This section gives an account of those changes in three categories:
 <sect1>Changes to existing options<label id="modifiedoptions">
 <p>
 <descrip>
-	<p>No build options have changed behaviour in this version.
+
+	<tag>--disable-arch-native</tag>
+	<p>The <em>-march=native</em> compiler option is no longer used by
+		default. It is possible to enable it by using the
+		<em>--enable-arch-native</em> option.
+		Using <em>-march=native</em> may cause problems when Squid is
+		run on a system with a different exact CPU model than the one
+		it is built on, or in some containerized environments.
+		The symptom is crashes with "illegal instruction" errors.
+		We do not recommend enabling this optimization in virtualized environments.
 
 </descrip>
 </p>

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -157,15 +157,6 @@ This section gives an account of those changes in three categories:
 	<p>Removed <em>LM_Group</em> helper. The LM protocol is
 	   insecure and no longer supported on the market since 2008.
 
-	<tag>--disable-arch-native</tag>
-	<p>The <em>-march=native</em> compiler option is no longer used by
-		default. It is possible to enable it by using the
-		<em>--enable-arch-native</em> option.
-		Using <em>-march=native</em> may cause problems when Squid is
-		run on a system with a different exact CPU model than the one
-		it is built on, or in some containerized environments.
-		The symptom is crashes with "illegal instruction" errors.
-		We do not recommend enabling this optimization in virtualized environments.
 </descrip>
 </p>
 

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -166,7 +166,7 @@ This section gives an account of those changes in three categories:
 		run on a system with a different exact CPU model than the one
 		it is built on, or in some containerized environments.
 		The symptom is crashes with "illegal instruction" errors.
-		Use with caution.
+		We do not recommend enabling this optimization in virtualized environments.
 </descrip>
 </p>
 

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -162,7 +162,7 @@ This section gives an account of those changes in three categories:
 		default. It is possible to enable it by using the
 		<em>--enable-arch-native</em> option.
 		<em>--enable-arch-native</em> option instead.
-		This optimization may cause problems when Squid is
+		Using <em>-march=native</em> may cause problems when Squid is
 		run on a system with a different exact CPU model than the one
 		it is built on, or in some containerized environments.
 		The symptom is crashes with "illegal instruction" errors.

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -158,7 +158,7 @@ This section gives an account of those changes in three categories:
 	   insecure and no longer supported on the market since 2008.
 
 	<tag>--disable-arch-native</tag>
-	<p>The <em>-march=native</em> compiler option is not used by
+	<p>The <em>-march=native</em> compiler option is no longer used by
 		default. It is possible to enable it by using the
 		<em>--enable-arch-native</em> option instead.
 		This optimization may cause problems when Squid is

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -161,7 +161,6 @@ This section gives an account of those changes in three categories:
 	<p>The <em>-march=native</em> compiler option is no longer used by
 		default. It is possible to enable it by using the
 		<em>--enable-arch-native</em> option.
-		<em>--enable-arch-native</em> option instead.
 		Using <em>-march=native</em> may cause problems when Squid is
 		run on a system with a different exact CPU model than the one
 		it is built on, or in some containerized environments.

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -157,6 +157,10 @@ This section gives an account of those changes in three categories:
 	<p>Removed <em>LM_Group</em> helper. The LM protocol is
 	   insecure and no longer supported on the market since 2008.
 
+	<tag>--disable-march-native</tag>
+	<p>The <em>-march=native</em> compiler option is not used by
+		default. It is possible to enable it by using the
+		<em>--enable-march-native</em> option instead
 </descrip>
 </p>
 

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -157,10 +157,15 @@ This section gives an account of those changes in three categories:
 	<p>Removed <em>LM_Group</em> helper. The LM protocol is
 	   insecure and no longer supported on the market since 2008.
 
-	<tag>--disable-march-native</tag>
+	<tag>--disable-arch-native</tag>
 	<p>The <em>-march=native</em> compiler option is not used by
 		default. It is possible to enable it by using the
-		<em>--enable-march-native</em> option instead
+		<em>--enable-arch-native</em> option instead.
+		This optimization may cause problems when Squid is
+		run on a system with a different exact CPU model than the one
+		it is built on, or in some containerized environments.
+		The symptom is crashes with "illegal instruction" errors.
+		Use with caution.
 </descrip>
 </p>
 

--- a/doc/release-notes/release-8.sgml.in
+++ b/doc/release-notes/release-8.sgml.in
@@ -160,6 +160,7 @@ This section gives an account of those changes in three categories:
 	<tag>--disable-arch-native</tag>
 	<p>The <em>-march=native</em> compiler option is no longer used by
 		default. It is possible to enable it by using the
+		<em>--enable-arch-native</em> option.
 		<em>--enable-arch-native</em> option instead.
 		This optimization may cause problems when Squid is
 		run on a system with a different exact CPU model than the one

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -86,6 +86,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--disable-auto-locale \
 	--disable-translation \
 	--disable-optimizations \
+	--disable-arch-native \
  \
 	--without-pthreads \
 	--without-aio \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -49,6 +49,7 @@ MAKETEST="distcheck"
 #   --with-ldap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
+#   --enable-arch-native \  can fail on virtualized environments
 #
 #
 # NP: DISTCHECK_CONFIGURE_FLAGS is a magic automake macro for the


### PR DESCRIPTION
Flip the default of configure's `--enable-arch-native` option from
enabled to disabled.

GCC's and clang's `-march=native` argument causes issues in some
environments, most notably containers where the compilers' heuristics
about CPU feature set may fail. These issues manifest as
hard-to-reproduce SIGILL errors in binaries such as `squid` or unit test
programs. The new default is safer. Performance-minded administrators
still have a convenient option to optimize via `--enable-arch-native`.
