### PR TITLE
HTTP: Support templated TRACE responses

### DIFF
--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -82,6 +82,11 @@ typedef enum {
     ERR_REQUEST_PARSE_TIMEOUT, // Aborts the connection instead of error page
     ERR_RELAY_REMOTE, // Sends server reply instead of error page
 
+    // Reply message for TRACE requests is optional.
+    // HTTP specification default response (equivalent to '%R')
+    // will be generated if no template is found.
+    HTTP_TRACE_REPLY,
+
     /* Cache Manager GUI can install a manager index/home page */
     MGR_INDEX,
 


### PR DESCRIPTION
HTTP specification for the TRACE method states that agents
such as Squid should reflect the HTTP Request message headers.
With certain sensitive headers filtered out.

Allow admin to adjust the TRACE output by supplying a custom
template file called HTTP_TRACE_REPLY that will be used to
generate TRACE responses.

The template will be expanded the way Squid error pages are,
allowing any macro/code available on those templates to also
work for TRACE.

The default Squid generated response is equivalent to a template
containing only the %R code.