### PR TITLE
Flip configure --enable-arch-native default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,19 +68,23 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_LANG([C++])
 
-# Clang 3.2 on some CPUs requires -march-native to detect correctly.
-# GCC 4.3+ can also produce faster executables when its used.
+# Some compilers can produce faster executables when its used.
 # But building inside a virtual machine environment has been found to
 # cause random Illegal Instruction errors due to mis-detection of CPU.
 AC_ARG_ENABLE(arch-native,
-  AS_HELP_STRING([--disable-arch-native],[Some compilers offer CPU-specific
+  AS_HELP_STRING([--enable-arch-native],[Some compilers offer CPU-specific
                  optimizations with the -march=native parameter.
-                 This flag disables the optimization. The default is to
-                 auto-detect compiler support and use where available.]), [
+                 This flag enables the optimization, by default disabled,
+                 provided that the compiler supports it. Enabling this
+                 optimization may cause crashes due to illegal instruction errors
+                 when Squid is run on a CPU different from the one it is built on,
+                 and in some containerized or virtualized environments]), [
   SQUID_YESNO([$enableval],[--enable-arch-native])
 ])
-AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=auto}])
-AS_IF([test "x${enable_arch_native}" != "xno"],[
+AC_MSG_NOTICE([CPU arch native optimization enabled: ${enable_arch_native:=no}])
+AS_IF([test "x${enable_arch_native}" = "xyes"],[
+  # XXX: Fail if the explicitly requested native optimization is not available.
+  # TODO: Make this a tristate yes/no/auto.
   SQUID_CC_CHECK_ARGUMENT([squid_cv_check_marchnative],[-march=native])
 ])
 

--- a/doc/release-notes/release-7.sgml.in
+++ b/doc/release-notes/release-7.sgml.in
@@ -311,6 +311,16 @@ This section gives an account of those changes in three categories:
 	<p>Removed <em>SMB_LM</em> helper, in favour of the <em>ntlm_auth</em>
 	   alternative offered by the Samba project.
 
+	<tag>--disable-arch-native</tag>
+	<p>The <em>-march=native</em> compiler option is no longer used by
+		default. It is possible to enable it by using the
+		<em>--enable-arch-native</em> option.
+		Using <em>-march=native</em> may cause problems when Squid is
+		run on a system with a different exact CPU model than the one
+		it is built on, or in some containerized environments.
+		The symptom is crashes with "illegal instruction" errors.
+		We do not recommend enabling this optimization in virtualized environments.
+
 </descrip>
 </p>
 

--- a/test-suite/buildtests/layer-01-minimal.opts
+++ b/test-suite/buildtests/layer-01-minimal.opts
@@ -86,6 +86,7 @@ DISTCHECK_CONFIGURE_FLAGS=" \
 	--disable-auto-locale \
 	--disable-translation \
 	--disable-optimizations \
+	--disable-arch-native \
  \
 	--without-pthreads \
 	--without-aio \

--- a/test-suite/buildtests/layer-02-maximus.opts
+++ b/test-suite/buildtests/layer-02-maximus.opts
@@ -51,6 +51,7 @@ MAKETEST="distcheck"
 #   --with-ldap \
 #
 #   --enable-cpu-profiling \  Requires CPU support.
+#   --enable-arch-native \  can fail on virtualized environments
 #
 #
 # NP: DISTCHECK_CONFIGURE_FLAGS is a magic automake macro for the


### PR DESCRIPTION
Flip the default of configure's `--enable-arch-native` option from
enabled to disabled.

GCC's and clang's `-march=native` argument causes issues in some
environments, most notably containers where the compilers' heuristics
about CPU feature set may fail. These issues manifest as
hard-to-reproduce SIGILL errors in binaries such as `squid` or unit test
programs. The new default is safer. Performance-minded administrators
still have a convenient option to optimize via `--enable-arch-native`.
