### PR TITLE
Bug 5523: Do not percent-encode URI suffixes

### DIFF
--- a/src/acl/UrlPath.cc
+++ b/src/acl/UrlPath.cc
@@ -12,15 +12,19 @@
 #include "acl/FilledChecklist.h"
 #include "acl/UrlPath.h"
 #include "HttpRequest.h"
+#include "rfc1738.h"
 
 int
 Acl::UrlPathCheck::match(ACLChecklist * const ch)
 {
     const auto checklist = Filled(ch);
-    auto urlPath = checklist->request->url.path();
 
-    if (urlPath.isEmpty())
+    if (checklist->request->url.path().isEmpty())
         return -1;
 
-    return data->match(urlPath.c_str());
+    const auto esc_buf = SBufToCstring(checklist->request->url.path());
+    rfc1738_unescape(esc_buf);
+    const auto result = data->match(esc_buf);
+    xfree(esc_buf);
+    return result;
 }

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -776,7 +776,7 @@ AnyP::Uri::absolutePath() const
 {
     if (absolutePath_.isEmpty()) {
         // TODO: Encode each URI subcomponent in path_ as needed.
-        absolutePath_ = Encode(path(), PathChars());
+        absolutePath_ = path();
     }
 
     return absolutePath_;

--- a/src/anyp/Uri.cc
+++ b/src/anyp/Uri.cc
@@ -50,25 +50,6 @@ UserInfoChars()
     return userInfoValid;
 }
 
-/// Characters which are valid within a URI path section
-static const CharacterSet &
-PathChars()
-{
-    /*
-     * RFC 3986 section 3.3
-     *
-     *   path          = path-abempty    ; begins with "/" or is empty
-     * ...
-     *   path-abempty  = *( "/" segment )
-     *   segment       = *pchar
-     *   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-     */
-    static const auto pathValid = CharacterSet("path", "/:@-._~%!$&'()*+,;=") +
-                                  CharacterSet::ALPHA +
-                                  CharacterSet::DIGIT;
-    return pathValid;
-}
-
 /**
  * Governed by RFC 3986 section 2.1
  */

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -2316,7 +2316,6 @@ ftpTrySlashHack(Ftp::Gateway * ftpState)
         wordlistDestroy(&ftpState->pathcomps);
 
     /* Build the new path */
-    // XXX: Conversion to c-string effectively truncates where %00 was decoded
     safe_free(ftpState->filepath);
     const auto path = SBufToCstring(ftpState->request->url.absolutePath());
     rfc1738_unescape(path);

--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -2327,7 +2327,9 @@ ftpTrySlashHack(Ftp::Gateway * ftpState)
     /* Build the new path */
     // XXX: Conversion to c-string effectively truncates where %00 was decoded
     safe_free(ftpState->filepath);
-    ftpState->filepath = SBufToCstring(ftpState->decodedRequestUriPath().value());
+    const auto path = SBufToCstring(ftpState->request->url.absolutePath());
+    rfc1738_unescape(path);
+    ftpState->filepath = path;
 
     /* And off we go */
     ftpGetFile(ftpState);


### PR DESCRIPTION
In recent commit ff60b102, many `AnyP::Uri::path()` calls were replaced
with new `absolutePath()` and `originForm()` method calls, and those two
methods started to return percent-encoded URI suffixes[^1]. Encoding URI
suffixes broke forwarding of requests that use `?` characters (i.e.
requests that have a `query` part in their target). For example,
`http://example.com/c?p=v` request target was forwarded as
`http://example.com/c%3Fp=v`. Other cases were probably broken as well.

This change removes all encoding-related changes that were added in
commit ff60b102, effectively reducing that commit to differentiation of
many AnyP::Uri::path() use cases as originForm() or absolutePath()
cases. More percent-encoding work is needed, as hinted by an old TODO.

This change also removes Ftp::Gateway::decodedRequestUriPath() added in
recent commit ad365edb because the corresponding code was necessary to
decode the now-removed encoding added in problematic commit ff60b102.

This surgical fix does not solve all commit ff60b102 problems.

[^1]: Here, "URI suffix" is a `path [ "?" query ] [ "#" fragment ]`
portion of a URI in RFC 3986 terms. The RFC does not name that portion.
Many fixed cases involve `?` that separates `path` from `query`.

