### PR TITLE
Fix ./configure gssapi and spnego checks under heimdal

### DIFF
--- a/acinclude/krb5.m4
+++ b/acinclude/krb5.m4
@@ -112,9 +112,6 @@ AC_DEFUN([SQUID_CHECK_WORKING_GSSAPI], [
 #elif HAVE_GSSAPI_H
 #include <gssapi.h>
 #endif
-#if HAVE_GSSAPI_GSSAPI_KRB5_H
-#include <gssapi/gssapi_krb5.h>
-#endif
 #if HAVE_GSSAPI_GSSAPI_GENERIC_H
 #include <gssapi/gssapi_generic.h>
 #endif
@@ -149,9 +146,6 @@ AC_DEFUN([SQUID_CHECK_SPNEGO_SUPPORT], [
 #include <gssapi/gssapi.h>
 #elif HAVE_GSSAPI_H
 #include <gssapi.h>
-#endif
-#if HAVE_GSSAPI_GSSAPI_KRB5_H
-#include <gssapi/gssapi_krb5.h>
 #endif
 #if HAVE_GSSAPI_GSSAPI_GENERIC_H
 #include <gssapi/gssapi_generic.h>


### PR DESCRIPTION
    configure:36759: checking for working gssapi
    .../gssapi/gssapi_krb5.h:130:70: error: unknown type name 'time_t'
    ...
    configure:36835: checking for spnego support
    .../gssapi/gssapi_krb5.h:130:70: error: unknown type name 'time_t'

Remove gssapi/gssapi_krb5.h header for gssapi and spnego checks.
Including that header makes checks fail under heimdal.

In Squid v6, this header inclusion was avoided for heimdal. It was
hidden under `if USE_HEIMDAL_KRB5` condition. In Squid v7, that
condition no longer exists.

Without the header, the checks work OK for heimdal. Even under MIT krb5,
the checks work fine without this header.

Discovered while porting Squid v7 to FreeBSD.
