### PR TITLE
Bug 4940: Tolerate Host header forgery for fake CONNECTs

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2984,9 +2984,6 @@ DOC_START
 		   to the client original destination instead of DIRECT.
 		   This overrides 'client_dst_passthru off'.
 
-		For now suspicious intercepted CONNECT requests are always
-		responded to with an HTTP 409 (Conflict) error page.
-
 
 	SECURITY NOTE:
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -388,10 +388,12 @@ ClientRequestContext::hostHeaderIpVerify(const ipcache_addrs* ia, const Dns::Loo
 void
 ClientRequestContext::hostHeaderVerifyFailed(const char *A, const char *B)
 {
-    // IP address validation for Host: failed. Admin wants to ignore them.
-    // NP: we do not yet handle CONNECT tunnels well, so ignore for them
-    if ((!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) ||
-	(http->request->method == Http::METHOD_CONNECT && (http->request->flags.intercepted || http->request->flags.interceptTproxy))) {
+    // IP address validation for Host header failed, but we may ignore it in certain cases:
+    // 1. For non-CONNECT requests: ignore if hostStrictVerify is disabled (admin choice)
+    // 2. For CONNECT requests: ignore if intercepted (TPROXY or regular interception)
+    if ((!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) || 
+        (http->request->method == Http::METHOD_CONNECT && (http->request->flags.intercepted || http->request->flags.interceptTproxy))
+    ) {
         debugs(85, 3, "SECURITY ALERT: Host header forgery detected on " << http->getConn()->clientConnection <<
                " (" << A << " does not match " << B << ") on URL: " << http->request->effectiveRequestUri());
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -389,8 +389,7 @@ void
 ClientRequestContext::hostHeaderVerifyFailed(const char *A, const char *B)
 {
     // IP address validation for Host: failed. Admin wants to ignore them.
-    // NP: we do not yet handle CONNECT tunnels well, so ignore for them
-    if (!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) {
+    if (!Config.onoff.hostStrictVerify) {
         debugs(85, 3, "SECURITY ALERT: Host header forgery detected on " << http->getConn()->clientConnection <<
                " (" << A << " does not match " << B << ") on URL: " << http->request->effectiveRequestUri());
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -388,12 +388,10 @@ ClientRequestContext::hostHeaderIpVerify(const ipcache_addrs* ia, const Dns::Loo
 void
 ClientRequestContext::hostHeaderVerifyFailed(const char *A, const char *B)
 {
-    // IP address validation for Host header failed, but we may ignore it in certain cases:
-    // 1. For non-CONNECT requests: ignore if hostStrictVerify is disabled (admin choice)
-    // 2. For CONNECT requests: ignore if intercepted (TPROXY or regular interception)
-    if ((!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) || 
-        (http->request->method == Http::METHOD_CONNECT && (http->request->flags.intercepted || http->request->flags.interceptTproxy))
-    ) {
+    // IP address validation for Host: failed. Admin wants to ignore them.
+    // NP: we do not yet handle CONNECT tunnels well, so ignore for them
+    if ((!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) ||
+	(http->request->method == Http::METHOD_CONNECT && (http->request->flags.intercepted || http->request->flags.interceptTproxy))) {
         debugs(85, 3, "SECURITY ALERT: Host header forgery detected on " << http->getConn()->clientConnection <<
                " (" << A << " does not match " << B << ") on URL: " << http->request->effectiveRequestUri());
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -390,7 +390,8 @@ ClientRequestContext::hostHeaderVerifyFailed(const char *A, const char *B)
 {
     // IP address validation for Host: failed. Admin wants to ignore them.
     // NP: we do not yet handle CONNECT tunnels well, so ignore for them
-    if (!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) {
+    if ((!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) ||
+	(http->request->method == Http::METHOD_CONNECT && (http->request->flags.intercepted || http->request->flags.interceptTproxy))) {
         debugs(85, 3, "SECURITY ALERT: Host header forgery detected on " << http->getConn()->clientConnection <<
                " (" << A << " does not match " << B << ") on URL: " << http->request->effectiveRequestUri());
 

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -390,8 +390,7 @@ ClientRequestContext::hostHeaderVerifyFailed(const char *A, const char *B)
 {
     // IP address validation for Host: failed. Admin wants to ignore them.
     // NP: we do not yet handle CONNECT tunnels well, so ignore for them
-    if ((!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) ||
-	(http->request->method == Http::METHOD_CONNECT && (http->request->flags.intercepted || http->request->flags.interceptTproxy))) {
+    if (!Config.onoff.hostStrictVerify && http->request->method != Http::METHOD_CONNECT) {
         debugs(85, 3, "SECURITY ALERT: Host header forgery detected on " << http->getConn()->clientConnection <<
                " (" << A << " does not match " << B << ") on URL: " << http->request->effectiveRequestUri());
 


### PR DESCRIPTION
    SECURITY ALERT: Host header forgery detected on ... 
        (local IP does not match any domain IP)
        (intercepted port does not match 443)

N.B. This change does not affect (and the text below does not discuss)
`host_verify_strict on` configurations.

This change currently only affects (fake) CONNECT requests when Squid is
splicing an intercepted TLS connection at SslBump step 2. The sections
below establish basic terminology, summarize existing Host validation
protections, describe how existing protection bugs affect this change,
and detail problematic CONNECT handling, including existing bugs that
now affect more CONNECTs.

Since 2012 commit 2962f8b8, Squid usually forwards certain requests that
fail Host header validation: Intercepted plain text non-CONNECT requests
and non-CONNECT requests inside bumped intercepted TLS connections.
Here, we refer to these HTTP requests as problematic GET requests
although they may use other non-CONNECT methods (e.g., POST).

This change starts honoring certain problematic CONNECT requests as well
instead of rejecting them with "Host header forgery" SECURITY ALERTs and
TLS-violating plain HTTP 409 ERR_CONFLICT_HOST responses. Squid now
applies the same protections to those problematic CONNECTs as it applies
to problematic GETs.

Destination address pinning
---------------------------

While forwarding, Squid attempts to send problematic GET requests to the
destination address of the intercepted TCP connection, avoiding both
direct connection to the Host header address and cache_peer routes. This
destination address "pinning" should prevent the client from getting
responses from servers residing at other addresses, similar to what the
browser same-origin policy (SOP) does to scripts inside web pages.

This destination address pinning is currently implemented via a
combination of two mechanisms driven by `HttpRequest::flags`:

* Making `flags.hierarchical` false in hope to compel peer selection
  code to only find `HIER_DIRECT` and previously `PINNED` destinations.
* Keeping `flags.hostVerified` false and then overwriting `HIER_DIRECT`
  selection with `ORIGINAL_DST` when seeing that false flag.

To avoid cache poisoning, destination address pinning currently also
precludes response caching (because Squid cache key uses the Host header
value while ignoring the destination IP address that does not match the
Host header in these cases). This is done via `flags.cachable.veto()`.

N.B. All CONNECT requests already have false `flags.hierarchical`, and
their responses are never cachable, so exposing them to code that
(re)sets the corresponding flags does not really change how CONNECTs are
handled by code outside this change scope.

Avoiding cache_peers
--------------------

There are problems with how current Squid code implements destination
address pinning for problematic GETs. For example, a Squid instance
using `nonhierarchical_direct off` or `never_direct allow all` may
forward problematic GETs to cache_peers. This change does not fix those
bugs; a problematic CONNECT may now also be "forwarded" to a cache_peer.
Thus, this change increases the problem footprint -- client scripts may
be able to violate browser SOP using both GET and CONNECT requests. When
these bugs are fixed, both problematic GETs and problematic CONNECTs
will only be sent to their intended destination (or blocked).


Fake problematic CONNECTs
-------------------------

Both fake CONNECTs generated by Squid and real CONNECTs sent by clients
may, in principle, fail Host header validation. This section documents
what fake CONNECTs are affected by these changes. The next section deals
with real CONNECTs.

Fake CONNECTs always have a Host header. Fake CONNECTs created during
step 1 cannot fail validation -- their Host header always matches the
intended destination address of the intercepted client connection.

For a fake CONNECT to fail Host header validation, SslBump has to create
that CONNECT after extracting SNI from an intercepted TLS client
connection. That SNI value is used as a Host header that gets validated
for matching the intended destination address of the intercepted TLS
client connection. SNI extraction happens during SslBump step 2.

Moreover, due to unrelated Squid bugs, Squid only generates SNI-based
fake CONNECT requests when _splicing_ an intercepted connection during
SslBump step 2. Only those fake CONNECTs use SNI for the Host header
and, hence, only those fake CONNECT requests may fail Host validation.
When these bugs are fixed, Squid will also fake CONNECTs with SNI when
peeking, staring, or bumping during step 2, and those fake CONNECTs
would be validated, their validation could fail, but they would be
honored (i.e. Squid would attempt to connect to the intended destination
of the intercepted TLS connection) due to these changes.

Here is the summary for fake CONNECTs:

* Faked during SslBump step 1: Never fail validation.
* Faked when splicing at step 2: Now honored even if fail validation.
* Faked under other conditions: Never happen.


Real problematic CONNECTs
-------------------------

These changes do not affect handling of real problematic CONNECTs
without a Host header. This section is about problematic CONNECTs with a
Host header.

There are many different use cases involving real CONNECT requests!
Selecting specific value combinations from the following three primary
real CONNECT request handling aspects creates more than ten distinct
categories of possible problematic real CONNECT requests:

* sent to Squid vs. intercepted vs. nested inside a bumped TLS tunnel
* received on http_port vs. received on https_port
* SslBump processing (none vs. various SslBump actions/steps)

The exact handling details naturally differ among these categories, but
no real CONNECTs are actually affected by these changes:

* Real CONNECTs received on a non-intercepting port are unaffected
  because they are not validated (when `host_verify_strict` is off).

* Real CONNECTs received on an intercepting port are unaffected because
  they are rejected (before Host validation) since recent master/v8
  commit 12b87eed.

This is a Measurement Factory project.
