### PR TITLE
ICP: Fix HttpRequest lifetime for ICP v3 queries

### DIFF
--- a/src/ICP.h
+++ b/src/ICP.h
@@ -94,10 +94,7 @@ extern Ip::Address theIcpPublicHostID;
 const char *icpGetUrl(const Ip::Address &from, const char *, const icp_common_t &);
 
 /// \ingroup ServerProtocolICPAPI
-HttpRequest *icpGetRequest(const char *url, int reqnum, int fd, const Ip::Address &from);
-
-/// \ingroup ServerProtocolICPAPI
-bool icpAccessAllowed(Ip::Address &from, HttpRequest * icp_request);
+HttpRequestPointer icpGetRequest(const char *url, int reqnum, int fd, const Ip::Address &from);
 
 /// \ingroup ServerProtocolICPAPI
 void icpCreateAndSend(icp_opcode, int flags, char const *url, int reqnum, int pad, int fd, const Ip::Address &from, AccessLogEntryPointer);

--- a/src/icp_v3.cc
+++ b/src/icp_v3.cc
@@ -40,19 +40,13 @@ doV3Query(int fd, Ip::Address &from, const char * const buf, icp_common_t header
         return;
     }
 
-    HttpRequest *icp_request = icpGetRequest(url, header.reqnum, fd, from);
+    const auto icp_request = icpGetRequest(url, header.reqnum, fd, from);
 
     if (!icp_request)
         return;
 
-    if (!icpAccessAllowed(from, icp_request)) {
-        icpDenyAccess (from, url, header.reqnum, fd);
-        delete icp_request;
-        return;
-    }
-
     /* The peer is allowed to use this cache */
-    ICP3State state(header, icp_request);
+    ICP3State state(header, icp_request.getRaw());
     state.fd = fd;
     state.from = from;
     state.url = xstrdup(url);

--- a/src/tests/stub_icp.cc
+++ b/src/tests/stub_icp.cc
@@ -9,6 +9,7 @@
 #include "squid.h"
 #include "AccessLogEntry.h"
 #include "comm/Connection.h"
+#include "HttpRequest.h"
 #include "ICP.h"
 
 #define STUB_API "icp_*.cc"
@@ -30,8 +31,7 @@ Comm::ConnectionPointer icpOutgoingConn;
 Ip::Address theIcpPublicHostID;
 
 const char *icpGetUrl(const Ip::Address &, const char *, const icp_common_t &) STUB_RETVAL(nullptr)
-HttpRequest* icpGetRequest(const char *, int, int, const Ip::Address &) STUB_RETVAL(nullptr)
-bool icpAccessAllowed(Ip::Address &, HttpRequest *) STUB_RETVAL(false)
+HttpRequest::Pointer icpGetRequest(const char *, int, int, const Ip::Address &) STUB_RETVAL(nullptr)
 void icpCreateAndSend(icp_opcode, int, char const *, int, int, int, const Ip::Address &, AccessLogEntryPointer) STUB
 icp_opcode icpGetCommonOpcode() STUB_RETVAL(ICP_INVALID)
 void icpDenyAccess(const Ip::Address &, const char *, int, int) STUB


### PR DESCRIPTION
ACLFilledChecklist correctly locks and unlocks HttpRequest. Thus, when
given an unlocked request object, an on-stack checklist destroys it.
Upon icpAccessAllowed() return, Squid uses the destroyed request object.

This bug was probably introduced in 2003 commit 8000a965 that started
automatically unlocking requests in ACLChecklist destructor. However,
the bug did not affect allowed ICP v3 queries until 2007 commit f72fb56b
started _using_ the request object for them. 2005 commit 319bf5a7 fixed
an equivalent ICP v2 bug for denied queries but missed the ICP v3 case.

The scope, age, and effect of this bug imply that Squid v3+ deployments
receive no ICP v3 queries since 2007 (or earlier). Squid itself does not
send ICP v3 messages, responding with ICP v2 replies to ICP v3 queries.
TODO: Consider dropping ICP v3 support.

Also moved icpAccessAllowed() inside icpGetRequest() to deduplicate code
and reduce the risk of allowing a request without consulting icp_access.
