### PR TITLE
Remove deprecated X509_NAME_get_text_by_NID()

### DIFF
--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -1060,14 +1060,18 @@ static const char *getSubjectEntry(X509 *x509, int nid)
         return nullptr;
 
     // TODO: What if the entry is a UTF8String? See X509_NAME_get_index_by_NID(3ssl).
-    const int nameLen = X509_NAME_get_text_by_NID(
-                            X509_get_subject_name(x509),
-                            nid,  name, sizeof(name));
 
-    if (nameLen > 0)
-        return name;
+    const auto nm = X509_get_subject_name(x509);
+    int pos = -1;
+    pos = X509_NAME_get_index_by_NID(nm, nid, pos);
+    if (pos < 0) {
+        debugs(83, 3, (pos == -2 ? "Invalid" : "Missing") << " SSL certificate subject name");
+        return nullptr;
+    }
 
-    return nullptr;
+    const auto str = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(nm, pos));
+    xstrncpy(name, reinterpret_cast<const char *>(ASN1_STRING_get0_data(str)), sizeof(name));
+    return (*name ? name : nullptr);
 }
 
 const char *Ssl::CommonHostName(X509 *x509)

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -874,7 +874,14 @@ ssl_get_attribute(X509_NAME * name, const char *attribute_name)
             debugs(83, DBG_IMPORTANT, "WARNING: Unknown SSL attribute name '" << attribute_name << "'");
             return nullptr;
         }
-        X509_NAME_get_text_by_NID(name, nid, buffer, sizeof(buffer));
+        int pos = -1;
+        pos = X509_NAME_get_index_by_NID(name, nid, pos);
+        if (pos < 0) {
+            debugs(83, 3, (pos == -2 ? "Invalid" : "Missing") << " SSL attribute name '" << attribute_name << "'");
+            return nullptr;
+        }
+        auto str = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, pos));
+        xstrncpy(buffer, reinterpret_cast<const char *>(ASN1_STRING_get0_data(str)), sizeof(buffer));
     }
 
     return *buffer ? buffer : nullptr;


### PR DESCRIPTION
OpenSSL v4 deprecates this function and produces build errors
when combined with the Squid default -Wall -Werror.

Replace with the recommended X509_NAME_get_index_by_NID()
function which is also supported by older OpenSSL.