### PR TITLE
Fix missing LDFLAGS when linking squid binary

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -560,7 +560,7 @@ squid_LDADD = \
 if ENABLE_LOADABLE_MODULES
 squid_SOURCES += $(LOADABLE_MODULES_SOURCES)
 squid_LDADD += -L$(top_builddir) $(LIBLTDL)
-squid_LDFLAGS = -export-dynamic -dlopen force
+squid_LDFLAGS = $(AM_LDFLAGS) -export-dynamic -dlopen force
 ## when static module linking is supported and enabled:
 ## squid_LDFLAGS = -all-static -dlopen self
 ##


### PR DESCRIPTION
The auto-tools build system defines AM_LDFLAGS as the place for
tools to add linker flags automatically determined to be needed,
so as not to clobber user provide flags in LDFLAGS variable.

This AM_* variable can be replaced in the linker command line
for binary 'foo' by defining a replacement foo_LDFLAGS variable
in Makefile.am.

When third-party build and test tools use AM_LDFLAGS to pass additional
flags to our build process, the current squid_LDFLAGS ignores them.
