### PR TITLE
Make squid.conf LegacyParser available as non-global

### DIFF
--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -34,6 +34,13 @@ bool ConfigParser::PreviewMode_ = false;
 
 static const char *SQUID_ERROR_TOKEN = "[invalid token]";
 
+ConfigParser &
+Configuration::LegacyParser()
+{
+    static ConfigParser *instance = new ConfigParser();
+    return *instance;
+}
+
 void
 ConfigParser::destruct()
 {

--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -235,6 +235,16 @@ protected:
 namespace Configuration {
 /// interprets (and partially applies) squid.conf or equivalent configuration
 void Parse();
+
+/**
+ * A parser for legacy code that uses the global approach.
+ * Only valid when parsing squid.conf.
+ *
+ * Deprecated; code needing access to a ConfigParser should
+ * have it provided to them in their parseFoo() methods.
+ */
+ConfigParser &LegacyParser();
+
 }
 
 #endif /* SQUID_SRC_CONFIGPARSER_H */

--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -260,11 +260,11 @@ static void free_http_upgrade_request_protocols(HttpUpgradeProtocolAccess **prot
 
 /*
  * LegacyParser is a parser for legacy code that uses the global
- * approach.  This is static so that it is only exposed to cache_cf.
- * Other modules needing access to a ConfigParser should have it
- * provided to them in their parserFOO methods.
+ * approach.
+ * Deprecated; other modules needing access to a ConfigParser should
+ * have it provided to them in their parseFoo() methods.
  */
-static ConfigParser LegacyParser = ConfigParser();
+static auto LegacyParser = Configuration::LegacyParser();
 
 const char *cfg_directive = nullptr;
 const char *cfg_filename = nullptr;


### PR DESCRIPTION
... to assist transition to latest ConfigParser API for logic which
is buried too deep or called from too many legacy code places to
pass the parser in.