### PR TITLE
Bug 5538: Do not update Content-Length from 304 responses

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -73,6 +73,7 @@ Thank you!
     Assar Westerlund <assar@pdc.kth.se>
     Axel Westerhold <ml.awesterhold@dts.de>
     Aymeric Vincent <aymericvincent@free.fr>
+    Baolin Zhu <zhubaolin228@gmail.com>
     Barry Dobyns <barry@dobyns.com>
     Ben Kallus <benjamin.p.kallus.gr@dartmouth.edu>
     Benjamin Kerensa <bkerensa@ubuntu.com>

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -393,7 +393,11 @@ HttpHeader::skipUpdateHeader(const Http::HdrType id) const
     return
         // TODO: Consider updating Vary headers after comparing the magnitude of
         // the required changes (and/or cache losses) with compliance gains.
-        (id == Http::HdrType::VARY);
+        (id == Http::HdrType::VARY) ||
+        // RFC 9111 Section 3.2 explicitly excludes Content-Length
+        // from the "MUST add ..., replacing already present" list. Also,
+        // broken servers are known to send Content-Length:0 in their 304s.
+        (id == Http::HdrType::CONTENT_LENGTH);
 }
 
 void


### PR DESCRIPTION
This minimal fix addresses several known problems with broken servers
and improves Squid HTTP compliance. More work is needed to improve
handling of other 304-related cases, but that work requires a lot more
changes, and this fix does not stand in the way of that effort.
