### PR TITLE
Improve parsing of certain FTP directory listing formats

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -624,7 +624,7 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
             // point after tokens[i+2] :
             copyFrom = buf + tokens[i + 2].pos + strlen(tokens[i + 2].token);
             if (flags.skip_whitespace) {
-                while (strchr(w_space, *copyFrom))
+                while (*copyFrom && strchr(w_space, *copyFrom))
                     ++copyFrom;
             } else {
                 /* Handle the following four formats:
@@ -635,7 +635,7 @@ ftpListParseParts(const char *buf, struct Ftp::GatewayFlags flags)
                  * Assuming a single space between date and filename
                  * suggested by:  Nathan.Bailey@cc.monash.edu.au and
                  * Mike Battersby <mike@starbug.bofh.asn.au> */
-                if (strchr(w_space, *copyFrom))
+                if (*copyFrom && strchr(w_space, *copyFrom))
                     ++copyFrom;
             }
 


### PR DESCRIPTION
This surgical fix restricts parsing to the input buffer when the listing
entry date in "TypeA" or "TypeB" formats is not followed by a filename.
It does not improve rendering of listings with missing filenames or the
overall quality of FTP listing parsing code.

C strchr() always returns a non-nil pointer when given a NUL character,
so its callers must be careful not to supply a NUL character if a
"natural" one-of-the-regular-c-string-characters membership test is
required.

The bug was probably introduced in 1997 commit 3fdadc70 and then
duplicated in 2017 commit 3d872090.
