### PR TITLE
CI: remove freebsd 15.0 from targets

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -145,7 +145,7 @@ jobs:
     strategy:
       matrix:
         osversion:
-          - "15.0"
+          # - "15.0" # build issues on 15.0 as of 2026-04. Let's wait for 15.1
           - "14.3"
           - "13.5"
         platform:


### PR DESCRIPTION
    pkg: Repository FreeBSD-ports cannot be opened. pkg update required
    pkg: No packages available to install matching autoconf have been
         found in the repositories

FreeBSD 15.0 has issues with packages.
Let's stop testing against it for now. We can track
FreeBSD-15 again when 15.1 is released.