### PR TITLE
Do not expand errorpage %codes injected by X509 certificates

### DIFF
--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -78,7 +78,7 @@ Ftp::ErrorDetail::brief() const
 }
 
 SBuf
-Ftp::ErrorDetail::verbose(const HttpRequest::Pointer &) const
+Ftp::ErrorDetail::verbose(const ErrorTemplateCompiler &) const
 {
     return ToSBuf("FTP reply with completion code ", completionCode);
 }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -78,7 +78,7 @@ Ftp::ErrorDetail::brief() const
 }
 
 SBuf
-Ftp::ErrorDetail::verbose(const ErrorTemplateCompiler &) const
+Ftp::ErrorDetail::verbose(const TemplateCompiler &) const
 {
     return ToSBuf("FTP reply with completion code ", completionCode);
 }

--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -32,7 +32,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override;
-    SBuf verbose(const HttpRequestPointer &) const override;
+    SBuf verbose(const ErrorTemplateCompiler &) const override;
 
 private:
     int completionCode; ///< FTP reply completion code

--- a/src/clients/FtpClient.h
+++ b/src/clients/FtpClient.h
@@ -32,7 +32,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override;
-    SBuf verbose(const ErrorTemplateCompiler &) const override;
+    SBuf verbose(const TemplateCompiler &) const override;
 
 private:
     int completionCode; ///< FTP reply completion code

--- a/src/error/Detail.cc
+++ b/src/error/Detail.cc
@@ -22,7 +22,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override { return name; }
-    SBuf verbose(const HttpRequestPointer &) const override { return name; }
+    SBuf verbose(const ErrorTemplateCompiler &) const override { return name; }
 
 private:
     /// distinguishes us from all other NamedErrorDetail objects

--- a/src/error/Detail.cc
+++ b/src/error/Detail.cc
@@ -22,7 +22,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override { return name; }
-    SBuf verbose(const ErrorTemplateCompiler &) const override { return name; }
+    SBuf verbose(const TemplateCompiler &) const override { return name; }
 
 private:
     /// distinguishes us from all other NamedErrorDetail objects

--- a/src/error/Detail.h
+++ b/src/error/Detail.h
@@ -21,7 +21,7 @@ class ErrorDetail: public RefCountable
 {
 public:
     using Pointer = ErrorDetailPointer;
-    using Build = ErrorPage::Build;
+    using ErrorTemplateCompiler = ErrorState;
 
     ~ErrorDetail() override {}
 
@@ -29,9 +29,10 @@ public:
     /// suitable as an access.log field and similar output processed by programs
     virtual SBuf brief() const = 0;
 
-    /// \returns all available details; may be customized for the given request
+    /// \returns all available details
     /// suitable for error pages and other output meant for human consumption
-    virtual SBuf verbose2(const Build &) const = 0;
+    /// Supports configurable templates populated by the given compiler.
+    virtual SBuf verbose(const ErrorTemplateCompiler &) const = 0;
 
     // Duplicate details for the same error typically happen when we update some
     // error storage (e.g., ALE) twice from the same detail source (e.g., the

--- a/src/error/Detail.h
+++ b/src/error/Detail.h
@@ -21,6 +21,7 @@ class ErrorDetail: public RefCountable
 {
 public:
     using Pointer = ErrorDetailPointer;
+    using Build = ErrorPage::Build;
 
     ~ErrorDetail() override {}
 
@@ -30,7 +31,7 @@ public:
 
     /// \returns all available details; may be customized for the given request
     /// suitable for error pages and other output meant for human consumption
-    virtual SBuf verbose(const HttpRequestPointer &) const = 0;
+    virtual SBuf verbose2(const Build &) const = 0;
 
     // Duplicate details for the same error typically happen when we update some
     // error storage (e.g., ALE) twice from the same detail source (e.g., the

--- a/src/error/Detail.h
+++ b/src/error/Detail.h
@@ -21,7 +21,7 @@ class ErrorDetail: public RefCountable
 {
 public:
     using Pointer = ErrorDetailPointer;
-    using ErrorTemplateCompiler = ErrorState;
+    using TemplateCompiler = ErrorState;
 
     ~ErrorDetail() override {}
 
@@ -32,7 +32,7 @@ public:
     /// \returns all available details
     /// suitable for error pages and other output meant for human consumption
     /// Supports configurable templates populated by the given compiler.
-    virtual SBuf verbose(const ErrorTemplateCompiler &) const = 0;
+    virtual SBuf verbose(const TemplateCompiler &) const = 0;
 
     // Duplicate details for the same error typically happen when we update some
     // error storage (e.g., ALE) twice from the same detail source (e.g., the

--- a/src/error/ExceptionErrorDetail.h
+++ b/src/error/ExceptionErrorDetail.h
@@ -31,7 +31,7 @@ public:
         return ToSBuf("exception=", asHex(exceptionId));
     }
 
-    SBuf verbose(const HttpRequestPointer &) const override {
+    SBuf verbose(const ErrorTemplateCompiler &) const override {
         return ToSBuf("Exception (ID=", asHex(exceptionId), ')');
     }
 

--- a/src/error/ExceptionErrorDetail.h
+++ b/src/error/ExceptionErrorDetail.h
@@ -31,7 +31,7 @@ public:
         return ToSBuf("exception=", asHex(exceptionId));
     }
 
-    SBuf verbose(const ErrorTemplateCompiler &) const override {
+    SBuf verbose(const TemplateCompiler &) const override {
         return ToSBuf("Exception (ID=", asHex(exceptionId), ')');
     }
 

--- a/src/error/SysErrorDetail.cc
+++ b/src/error/SysErrorDetail.cc
@@ -24,7 +24,7 @@ SysErrorDetail::brief() const
 }
 
 SBuf
-SysErrorDetail::verbose(const HttpRequestPointer &) const
+SysErrorDetail::verbose(const ErrorTemplateCompiler &) const
 {
     return SBuf(xstrerr(errorNo));
 }

--- a/src/error/SysErrorDetail.cc
+++ b/src/error/SysErrorDetail.cc
@@ -24,7 +24,7 @@ SysErrorDetail::brief() const
 }
 
 SBuf
-SysErrorDetail::verbose(const ErrorTemplateCompiler &) const
+SysErrorDetail::verbose(const TemplateCompiler &) const
 {
     return SBuf(xstrerr(errorNo));
 }

--- a/src/error/SysErrorDetail.h
+++ b/src/error/SysErrorDetail.h
@@ -30,7 +30,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override;
-    SBuf verbose(const HttpRequestPointer &) const override;
+    SBuf verbose(const ErrorTemplateCompiler &) const override;
 
 private:
     // hidden by NewIfAny() to avoid creating SysErrorDetail from zero errno

--- a/src/error/SysErrorDetail.h
+++ b/src/error/SysErrorDetail.h
@@ -30,7 +30,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override;
-    SBuf verbose(const ErrorTemplateCompiler &) const override;
+    SBuf verbose(const TemplateCompiler &) const override;
 
 private:
     // hidden by NewIfAny() to avoid creating SysErrorDetail from zero errno

--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -92,6 +92,11 @@ class Error;
 class ErrorDetail;
 class ErrorState;
 
+namespace ErrorPage {
+    class PercentCodeCompiler;
+    class Build;
+} // namespace ErrorPage
+
 typedef RefCount<ErrorDetail> ErrorDetailPointer;
 
 #endif /* SQUID_SRC_ERROR_FORWARD_H */

--- a/src/error/forward.h
+++ b/src/error/forward.h
@@ -93,8 +93,8 @@ class ErrorDetail;
 class ErrorState;
 
 namespace ErrorPage {
-    class PercentCodeCompiler;
-    class Build;
+class PercentCodeCompiler;
+class Build;
 } // namespace ErrorPage
 
 typedef RefCount<ErrorDetail> ErrorDetailPointer;

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1471,7 +1471,7 @@ ErrorState::compileDetail(const char * const format, const ErrorPage::PercentCod
 void
 ErrorState::compile(Build &build) const
 {
-    assert(build.input);
+    Assure(build.input);
 
     // TODO: Instead of violating const-correctness with const_cast<ErrorState*>
     // below, adjust compile*() methods to avoid ErrorState modifications.

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -102,16 +102,6 @@ private:
 
 namespace ErrorPage {
 
-/// state and parameters shared by several ErrorState::compile*() methods
-class Build
-{
-public:
-    SBuf output; ///< compilation result
-    const char *input = nullptr; ///< template bytes that need to be compiled
-    bool building_deny_info_url = false; ///< whether we compile deny_info URI
-    bool allowRecursion = false; ///< whether top-level compile() calls are OK
-};
-
 /// pretty-prints error page/deny_info building error
 class BuildErrorPrinter
 {
@@ -1002,7 +992,7 @@ ErrorState::compileLegacyCode(Build &build)
         if (!build.allowRecursion)
             p = "%D";  // if recursion is not allowed, do not convert
         else if (detail) {
-            const auto compiledDetail = detail->verbose(request, this);
+            const auto compiledDetail = detail->verbose2(build);
             mb.append(compiledDetail.rawContent(), compiledDetail.length());
             do_quote = 0;
         }
@@ -1447,50 +1437,38 @@ ErrorState::compileBody(const char *input, bool allowRecursion)
 SBuf
 ErrorState::compile(const char *input, bool building_deny_info_url, bool allowRecursion)
 {
-    assert(input);
-
-    Build build;
+    Build build(*request, input, *this);
     build.building_deny_info_url = building_deny_info_url;
     build.allowRecursion = allowRecursion;
-    build.input = input;
-
-    auto blockStart = build.input;
-    while (*build.input) {
-        // here, "code" and %code are used in compileLeadingCode() sense
-        auto oneCode = build;
-        oneCode.output.clear(); // to capture just one compiled leading %code below
-        if (compileLeadingCode(oneCode)) {
-            // %code-less input block before the compiled %code
-            build.output.append(blockStart, build.input - blockStart);
-            // compiled %code itself
-            build.output.append(oneCode.output);
-            Assure(build.input < oneCode.input); // we are making progress
-            build.input = oneCode.input; // after the compiled %code
-            blockStart = build.input;
-        } else
-            ++build.input;
-    }
-    build.output.append(blockStart, build.input - blockStart);
+    build.compile();
     return build.output;
 }
 
-/// Here, "code" means legacy %code or modern @Squid{logformat %code) sequence
-SBuf
-ErrorState::compileLeadingCode(Build &build)
+void
+ErrorState::compile(Build &build) const
 {
-    const auto letter = *build.input; // may be the terminating NUL
+    assert(build.input);
 
-    if (letter == '%') {
-        compileLegacyCode(build);
-        return true;
+    // TODO: Instead of violating const-correctness with const_cast<ErrorState*>
+    // below, adjust compile*() methods to avoid ErrorState modifications.
+
+    auto blockStart = build.input;
+    while (const auto letter = *build.input) {
+        if (letter == '%') {
+            build.output.append(blockStart, build.input - blockStart);
+            if (build.secondaryCompiler && !build.secondaryCompiler->compilePercentCode(build))
+                const_cast<ErrorState*>(this)->compileLegacyCode(build);
+            blockStart = build.input;
+        }
+        else if (letter == '@' && LogformatMagic.cmp(build.input, LogformatMagic.length()) == 0) {
+            build.output.append(blockStart, build.input - blockStart);
+            const_cast<ErrorState*>(this)->compileLogformatCode(build);
+            blockStart = build.input;
+        } else {
+            ++build.input;
+        }
     }
-
-    if (letter == '@' && LogformatMagic.cmp(build.input, LogformatMagic.length()) == 0) {
-        compileLogformatCode(build);
-        return true;
-    }
-
-    return false;
+    build.output.append(blockStart, build.input - blockStart);
 }
 
 /// react to a compile() error
@@ -1526,6 +1504,25 @@ ErrorState::noteBuildError_(const char *const msg, const char * const errorLocat
     } else {
         throw TexcHere(ToSBuf(BuildErrorPrinter(inputLocation, page_id, msg, errorLocation)));
     }
+}
+
+/* ErrorPage::Build */
+
+ErrorPage::Build::Build(const HttpRequest &aRequest, const char * const templateFragment, const PrimaryCompiler &aPrimaryCompiler):
+    request(aRequest),
+    primaryCompiler(aPrimaryCompiler),
+    input(templateFragment)
+{
+}
+
+ErrorPage::Build
+ErrorPage::Build::subtask(const char * const templateFragment, const PercentCodeCompiler &aSecondaryCompiler) const
+{
+    Build subBuild(request, templateFragment, primaryCompiler);
+    subBuild.secondaryCompiler = &aSecondaryCompiler;
+    subBuild.building_deny_info_url = building_deny_info_url;
+    subBuild.allowRecursion = allowRecursion;
+    return subBuild;
 }
 
 /* ErrorPage::BuildErrorPrinter */

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1002,9 +1002,7 @@ ErrorState::compileLegacyCode(Build &build)
         if (!build.allowRecursion)
             p = "%D";  // if recursion is not allowed, do not convert
         else if (detail) {
-            auto rawDetail = detail->verbose(request);
-            // XXX: Performance regression. c_str() reallocates
-            const auto compiledDetail = compileBody(rawDetail.c_str(), false);
+            const auto compiledDetail = detail->verbose(request, this);
             mb.append(compiledDetail.rawContent(), compiledDetail.length());
             do_quote = 0;
         }
@@ -1457,22 +1455,42 @@ ErrorState::compile(const char *input, bool building_deny_info_url, bool allowRe
     build.input = input;
 
     auto blockStart = build.input;
-    while (const auto letter = *build.input) {
-        if (letter == '%') {
+    while (*build.input) {
+        // here, "code" and %code are used in compileLeadingCode() sense
+        auto oneCode = build;
+        oneCode.output.clear(); // to capture just one compiled leading %code below
+        if (compileLeadingCode(oneCode)) {
+            // %code-less input block before the compiled %code
             build.output.append(blockStart, build.input - blockStart);
-            compileLegacyCode(build);
+            // compiled %code itself
+            build.output.append(oneCode.output);
+            Assure(build.input < oneCode.input); // we are making progress
+            build.input = oneCode.input; // after the compiled %code
             blockStart = build.input;
-        }
-        else if (letter == '@' && LogformatMagic.cmp(build.input, LogformatMagic.length()) == 0) {
-            build.output.append(blockStart, build.input - blockStart);
-            compileLogformatCode(build);
-            blockStart = build.input;
-        } else {
+        } else
             ++build.input;
-        }
     }
     build.output.append(blockStart, build.input - blockStart);
     return build.output;
+}
+
+/// Here, "code" means legacy %code or modern @Squid{logformat %code) sequence
+SBuf
+ErrorState::compileLeadingCode(Build &build)
+{
+    const auto letter = *build.input; // may be the terminating NUL
+
+    if (letter == '%') {
+        compileLegacyCode(build);
+        return true;
+    }
+
+    if (letter == '@' && LogformatMagic.cmp(build.input, LogformatMagic.length()) == 0) {
+        compileLogformatCode(build);
+        return true;
+    }
+
+    return false;
 }
 
 /// react to a compile() error

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1480,7 +1480,7 @@ ErrorState::compile(Build &build) const
     while (const auto letter = *build.input) {
         if (letter == '%') {
             build.output.append(blockStart, build.input - blockStart);
-            if (build.secondaryCompiler && !build.secondaryCompiler->compilePercentCode(build))
+            if (!build.secondaryCompiler || !build.secondaryCompiler->compilePercentCode(build))
                 const_cast<ErrorState*>(this)->compileLegacyCode(build);
             blockStart = build.input;
         }

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -992,7 +992,7 @@ ErrorState::compileLegacyCode(Build &build)
         if (!build.allowRecursion)
             p = "%D";  // if recursion is not allowed, do not convert
         else if (detail) {
-            const auto compiledDetail = detail->verbose2(build);
+            const auto compiledDetail = detail->verbose(*this);
             mb.append(compiledDetail.rawContent(), compiledDetail.length());
             do_quote = 0;
         }
@@ -1437,13 +1437,37 @@ ErrorState::compileBody(const char *input, bool allowRecursion)
 SBuf
 ErrorState::compile(const char *input, bool building_deny_info_url, bool allowRecursion)
 {
-    Build build(*request, input, *this);
+    assert(input);
+
+    Build build;
     build.building_deny_info_url = building_deny_info_url;
     build.allowRecursion = allowRecursion;
-    build.compile();
+    build.input = input;
+
+    compile(build);
+    Assure(!*build.input); // compiled the whole template
+
     return build.output;
 }
 
+SBuf
+ErrorState::compileDetail(const char * const format, const ErrorPage::PercentCodeCompiler * const secondaryCompiler) const
+{
+    Assure(format);
+
+    Build build;
+    build.input = format;
+    build.secondaryCompiler = secondaryCompiler; // may be nil
+
+    compile(build);
+    Assure(!*build.input); // compiled the whole template
+
+    return build.output;
+}
+
+/// Replaces all %code sequences found in build.input.
+/// Appends processed input to build.output.
+/// Consumes processed build.input.
 void
 ErrorState::compile(Build &build) const
 {
@@ -1504,25 +1528,6 @@ ErrorState::noteBuildError_(const char *const msg, const char * const errorLocat
     } else {
         throw TexcHere(ToSBuf(BuildErrorPrinter(inputLocation, page_id, msg, errorLocation)));
     }
-}
-
-/* ErrorPage::Build */
-
-ErrorPage::Build::Build(const HttpRequest &aRequest, const char * const templateFragment, const PrimaryCompiler &aPrimaryCompiler):
-    request(aRequest),
-    primaryCompiler(aPrimaryCompiler),
-    input(templateFragment)
-{
-}
-
-ErrorPage::Build
-ErrorPage::Build::subtask(const char * const templateFragment, const PercentCodeCompiler &aSecondaryCompiler) const
-{
-    Build subBuild(request, templateFragment, primaryCompiler);
-    subBuild.secondaryCompiler = &aSecondaryCompiler;
-    subBuild.building_deny_info_url = building_deny_info_url;
-    subBuild.allowRecursion = allowRecursion;
-    return subBuild;
 }
 
 /* ErrorPage::BuildErrorPrinter */

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -1465,9 +1465,6 @@ ErrorState::compileDetail(const char * const format, const ErrorPage::PercentCod
     return build.output;
 }
 
-/// Replaces all %code sequences found in build.input.
-/// Appends processed input to build.output.
-/// Consumes processed build.input.
 void
 ErrorState::compile(Build &build) const
 {

--- a/src/errorpage.cc
+++ b/src/errorpage.cc
@@ -839,7 +839,7 @@ ErrorState::~ErrorState()
 }
 
 int
-ErrorState::Dump(MemBuf * mb)
+ErrorState::Dump(MemBuf * const mb) const
 {
     PackableStream out(*mb);
     const auto &encoding = CharacterSet::RFC3986_UNRESERVED();
@@ -900,7 +900,7 @@ ErrorState::Dump(MemBuf * mb)
 #define CVT_BUF_SZ 512
 
 void
-ErrorState::compileLogformatCode(Build &build)
+ErrorState::compileLogformatCode(Build &build) const
 {
     assert(LogformatMagic.cmp(build.input, LogformatMagic.length()) == 0);
 
@@ -936,7 +936,7 @@ ErrorState::compileLogformatCode(Build &build)
 }
 
 void
-ErrorState::compileLegacyCode(Build &build)
+ErrorState::compileLegacyCode(Build &build) const
 {
     static MemBuf mb;
     const char *p = nullptr;   /* takes priority over mb if set */
@@ -1231,7 +1231,7 @@ ErrorState::compileLegacyCode(Build &build)
     case 'z':
         if (building_deny_info_url) break;
         if (dnsError)
-            p = dnsError->c_str();
+            mb.append(dnsError->rawContent(), dnsError->length());
         else if (ftp.cwd_msg)
             p = ftp.cwd_msg;
         else
@@ -1393,7 +1393,7 @@ ErrorState::BuildHttpReply()
 }
 
 SBuf
-ErrorState::buildBody()
+ErrorState::buildBody() const
 {
     assert(page_id > ERR_NONE && page_id < error_page_count);
 
@@ -1429,13 +1429,13 @@ ErrorState::buildBody()
 }
 
 SBuf
-ErrorState::compileBody(const char *input, bool allowRecursion)
+ErrorState::compileBody(const char * const input, const bool allowRecursion) const
 {
     return compile(input, false, allowRecursion);
 }
 
 SBuf
-ErrorState::compile(const char *input, bool building_deny_info_url, bool allowRecursion)
+ErrorState::compile(const char * const input, const bool building_deny_info_url, const bool allowRecursion) const
 {
     assert(input);
 
@@ -1473,20 +1473,17 @@ ErrorState::compile(Build &build) const
 {
     Assure(build.input);
 
-    // TODO: Instead of violating const-correctness with const_cast<ErrorState*>
-    // below, adjust compile*() methods to avoid ErrorState modifications.
-
     auto blockStart = build.input;
     while (const auto letter = *build.input) {
         if (letter == '%') {
             build.output.append(blockStart, build.input - blockStart);
             if (!build.secondaryCompiler || !build.secondaryCompiler->compilePercentCode(build))
-                const_cast<ErrorState*>(this)->compileLegacyCode(build);
+                compileLegacyCode(build);
             blockStart = build.input;
         }
         else if (letter == '@' && LogformatMagic.cmp(build.input, LogformatMagic.length()) == 0) {
             build.output.append(blockStart, build.input - blockStart);
-            const_cast<ErrorState*>(this)->compileLogformatCode(build);
+            compileLogformatCode(build);
             blockStart = build.input;
         } else {
             ++build.input;
@@ -1503,7 +1500,7 @@ ErrorState::compile(Build &build) const
 /// successfully validated and deployed (i.e. the admin may not be
 /// able to fix this newly detected but old problem quickly)
 void
-ErrorState::noteBuildError_(const char *const msg, const char * const errorLocation, const bool forceBypass)
+ErrorState::noteBuildError_(const char * const msg, const char * const errorLocation, const bool forceBypass) const
 {
     using ErrorPage::BuildErrorPrinter;
     const auto runtime = !starting_up;

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -340,13 +340,13 @@ protected:
 
 namespace ErrorPage {
 
-/// An API for recognizing and replaces a %code sequence.
+/// An API for recognizing and replacing a single %code sequence.
 class PercentCodeCompiler: public Interface {
 public:
-    /// Either recognizes and replaces a single %code sequence at the beginning
-    /// of `build.input`, appending the replacement to `build.output`, OR does
-    /// not modify `build`.
-    /// \returns false when the leading %code was not recognized
+    /// Either recognizes a single %code sequence at the beginning of
+    /// `build.input` and appends its replacement to `build.output` OR does not
+    /// modify `build`.
+    /// \returns true when the leading %code was recognized
     /// \prec `build.input` starts with a `%` character.
     virtual bool compilePercentCode(Build &) const = 0;
 };
@@ -355,15 +355,16 @@ public:
 /// PercentCodeCompiler::compilePercentCode() and ErrorState::compile*() methods
 /// that convert an errorpage template fragment (or equivalent) into an error
 /// response body fragment. This conversion replaces legacy errorpage %code
-/// sequences, logformat %code sequences, and, in some cases, context-dependent
-/// %code sequences.
+/// sequences, logformat %code sequences, and, in some cases,
+/// ErrorDetail-dependent %code sequences.
 class Build
 {
 public:
     SBuf output; ///< compilation result
     const char *input; ///< template bytes that need to be compiled; never nil
 
-    /// handles context-dependent %code sequences unsupported by ErrorState
+    /// Handles context-dependent %code sequences unsupported by ErrorState.
+    /// Compiler object lifetime must exceed this Build object lifetime.
     const PercentCodeCompiler *secondaryCompiler = nullptr;
 
     bool building_deny_info_url = false; ///< whether we compile deny_info URI

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -109,8 +109,10 @@ public:
     /// ensures that a future BuildHttpReply() is likely to succeed
     void validate();
 
-    /// appends build.input to build.output after replacing all %codes
-    void compile(Build &) const;
+    /// Replaces all %codes in the given ErrorDetail `format` template.
+    /// \param compiler is an optional handler for caller-specific template %code sequences
+    /// \sa compile()
+    SBuf compileDetail(const char *format, const ErrorPage::PercentCodeCompiler *compiler) const;
 
     /// the source of the error template (for reporting purposes)
     SBuf inputLocation;
@@ -133,13 +135,15 @@ private:
     /// compile @Squid{%code} sequence containing a single logformat %code
     void compileLogformatCode(Build &build);
 
-    /// compile(Build&) convenience wrapper without a custom compiler support;
     /// replaces all legacy and logformat %codes in the given input
     /// \param input  the template text to be converted
     /// \param building_deny_info_url  whether input is a deny_info URL parameter
     /// \param allowRecursion  whether to compile %codes which produce %codes
     /// \returns the given input with all %codes substituted
+    /// \sa compileDetail()
     SBuf compile(const char *input, bool building_deny_info_url, bool allowRecursion);
+
+    void compile(Build &build) const;
 
     /// React to a compile() error, throwing if buildContext allows.
     /// \param msg description of what went wrong
@@ -347,40 +351,21 @@ public:
     virtual bool compilePercentCode(Build &) const = 0;
 };
 
-/// Manages conversion of an errorpage template fragment (or equivalent) into an
-/// error response body fragment. This conversion replaces legacy errorpage
-/// %code sequences, logformat %code sequences, and, in some cases,
-/// context-dependent %code sequences. Related ErrorState methods refer to this
-/// substitution process as errorpage "compilation".
+/// State and parameters shared by several
+/// PercentCodeCompiler::compilePercentCode() and ErrorState::compile*() methods
+/// that convert an errorpage template fragment (or equivalent) into an error
+/// response body fragment. This conversion replaces legacy errorpage %code
+/// sequences, logformat %code sequences, and, in some cases, context-dependent
+/// %code sequences.
 class Build
 {
 public:
-    using PrimaryCompiler = ErrorState;
-
-    /// Creates a build step that focuses on the given template fragment, using
-    /// the given primary compiler. The build object is expected to be allocated
-    /// on stack and have shorter lifetime than constructor parameters lifetime.
-    explicit Build(const HttpRequest &, const char *templateFragment, const PrimaryCompiler &);
-
-    /// Creates a build step that focuses on the given template fragment, using
-    /// the given "secondary" context-dependent compiler. The build object
-    /// lifetime is expected to be shorter than that of function parameters.
-    Build subtask(const char *templateFragment, const PercentCodeCompiler &secondary) const;
-
-    /// converts `input` into `output`, replacing all %codes as needed
-    void compile() { primaryCompiler.compile(*this); }
-
-    /// transaction that triggered this build
-    const HttpRequest &request;
-
-    /// handles legacy errorpage %code sequences and logformat %code sequences
-    const PrimaryCompiler &primaryCompiler;
-
-    /// handles context-dependent %code sequences
-    const PercentCodeCompiler *secondaryCompiler = nullptr;
-
     SBuf output; ///< compilation result
     const char *input; ///< template bytes that need to be compiled; never nil
+
+    /// handles context-dependent %code sequences unsupported by ErrorState
+    const PercentCodeCompiler *secondaryCompiler = nullptr;
+
     bool building_deny_info_url = false; ///< whether we compile deny_info URI
     bool allowRecursion = false; ///< whether top-level compile() calls are OK
 };

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -12,6 +12,7 @@
 #define SQUID_SRC_ERRORPAGE_H
 
 #include "cbdata.h"
+#include "base/TypeTraits.h"
 #include "comm/forward.h"
 #include "error/Detail.h"
 #include "error/forward.h"

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -78,18 +78,14 @@ class MemBuf;
 class StoreEntry;
 class wordlist;
 
-namespace ErrorPage {
-
-class Build;
-
-} // namespace ErrorPage
-
 /// \ingroup ErrorPageAPI
 class ErrorState
 {
     CBDATA_CLASS(ErrorState);
 
 public:
+    using Build = ErrorPage::Build;
+
     /// creates an error of type other than ERR_RELAY_REMOTE
     ErrorState(err_type type, Http::StatusCode, HttpRequest * request, const AccessLogEntryPointer &al);
     ErrorState() = delete; // not implemented.
@@ -113,12 +109,13 @@ public:
     /// ensures that a future BuildHttpReply() is likely to succeed
     void validate();
 
+    /// appends build.input to build.output after replacing all %codes
+    void compile(Build &) const;
+
     /// the source of the error template (for reporting purposes)
     SBuf inputLocation;
 
 private:
-    typedef ErrorPage::Build Build;
-
     /// initializations shared by public constructors
     ErrorState(err_type, const AccessLogEntryPointer &);
 
@@ -136,6 +133,7 @@ private:
     /// compile @Squid{%code} sequence containing a single logformat %code
     void compileLogformatCode(Build &build);
 
+    /// compile(Build&) convenience wrapper without a custom compiler support;
     /// replaces all legacy and logformat %codes in the given input
     /// \param input  the template text to be converted
     /// \param building_deny_info_url  whether input is a deny_info URL parameter
@@ -335,6 +333,59 @@ protected:
     String templateName; ///< The name of the template
     err_type templateCode; ///< The internal code for this template.
 };
+
+namespace ErrorPage {
+
+/// An API for recognizing and replaces a %code sequence.
+class PercentCodeCompiler: public Interface {
+public:
+    /// Either recognizes and replaces a single %code sequence at the beginning
+    /// of `build.input`, appending the replacement to `build.output`, OR does
+    /// not modify `build`.
+    /// \returns false when the leading %code was not recognized
+    /// \prec `build.input` starts with a `%` character.
+    virtual bool compilePercentCode(Build &) const = 0;
+};
+
+/// Manages conversion of an errorpage template fragment (or equivalent) into an
+/// error response body fragment. This conversion replaces legacy errorpage
+/// %code sequences, logformat %code sequences, and, in some cases,
+/// context-dependent %code sequences. Related ErrorState methods refer to this
+/// substitution process as errorpage "compilation".
+class Build
+{
+public:
+    using PrimaryCompiler = ErrorState;
+
+    /// Creates a build step that focuses on the given template fragment, using
+    /// the given primary compiler. The build object is expected to be allocated
+    /// on stack and have shorter lifetime than constructor parameters lifetime.
+    explicit Build(const HttpRequest &, const char *templateFragment, const PrimaryCompiler &);
+
+    /// Creates a build step that focuses on the given template fragment, using
+    /// the given "secondary" context-dependent compiler. The build object
+    /// lifetime is expected to be shorter than that of function parameters.
+    Build subtask(const char *templateFragment, const PercentCodeCompiler &secondary) const;
+
+    /// converts `input` into `output`, replacing all %codes as needed
+    void compile() { primaryCompiler.compile(*this); }
+
+    /// transaction that triggered this build
+    const HttpRequest &request;
+
+    /// handles legacy errorpage %code sequences and logformat %code sequences
+    const PrimaryCompiler &primaryCompiler;
+
+    /// handles context-dependent %code sequences
+    const PercentCodeCompiler *secondaryCompiler = nullptr;
+
+    SBuf output; ///< compilation result
+    const char *input; ///< template bytes that need to be compiled; never nil
+    bool building_deny_info_url = false; ///< whether we compile deny_info URI
+    bool allowRecursion = false; ///< whether top-level compile() calls are OK
+};
+
+} // namespace ErrorPage
 
 /**
  * Parses the Accept-Language header value and return one language item on

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -11,8 +11,8 @@
 #ifndef SQUID_SRC_ERRORPAGE_H
 #define SQUID_SRC_ERRORPAGE_H
 
-#include "cbdata.h"
 #include "base/TypeTraits.h"
+#include "cbdata.h"
 #include "comm/forward.h"
 #include "error/Detail.h"
 #include "error/forward.h"

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -144,6 +144,9 @@ private:
     /// \sa compileDetail()
     SBuf compile(const char *input, bool building_deny_info_url, bool allowRecursion) const;
 
+    /// Replaces all %code sequences found in build.input.
+    /// Appends processed input to build.output.
+    /// Consumes processed build.input.
     void compile(Build &build) const;
 
     /// React to a compile() error, throwing if buildContext allows.

--- a/src/errorpage.h
+++ b/src/errorpage.h
@@ -116,25 +116,25 @@ public:
     SBuf compileDetail(const char *format, const ErrorPage::PercentCodeCompiler *compiler) const;
 
     /// the source of the error template (for reporting purposes)
-    SBuf inputLocation;
+    mutable SBuf inputLocation;
 
 private:
     /// initializations shared by public constructors
     ErrorState(err_type, const AccessLogEntryPointer &);
 
     /// locates the right error page template for this error and compiles it
-    SBuf buildBody();
+    SBuf buildBody() const;
 
     /// compiles error page or error detail template (i.e. anything but deny_url)
     /// \param input  the template text to be compiled
     /// \param allowRecursion  whether to compile %codes which produce %codes
-    SBuf compileBody(const char *text, bool allowRecursion);
+    SBuf compileBody(const char *text, bool allowRecursion) const;
 
     /// compile a single-letter %code like %D
-    void compileLegacyCode(Build &build);
+    void compileLegacyCode(Build &) const;
 
     /// compile @Squid{%code} sequence containing a single logformat %code
-    void compileLogformatCode(Build &build);
+    void compileLogformatCode(Build &) const;
 
     /// replaces all legacy and logformat %codes in the given input
     /// \param input  the template text to be converted
@@ -142,14 +142,14 @@ private:
     /// \param allowRecursion  whether to compile %codes which produce %codes
     /// \returns the given input with all %codes substituted
     /// \sa compileDetail()
-    SBuf compile(const char *input, bool building_deny_info_url, bool allowRecursion);
+    SBuf compile(const char *input, bool building_deny_info_url, bool allowRecursion) const;
 
     void compile(Build &build) const;
 
     /// React to a compile() error, throwing if buildContext allows.
     /// \param msg description of what went wrong
     /// \param errorLocation approximate start of the problematic input
-    void noteBuildError(const char *const msg, const char * const errorLocation) {
+    void noteBuildError(const char *const msg, const char * const errorLocation) const {
         noteBuildError_(msg, errorLocation, false);
     }
 
@@ -158,7 +158,7 @@ private:
     /// Should eventually be replaced with noteBuildError().
     /// \param msg description of what went wrong
     /// \param errorLocation approximate start of the problematic input
-    void bypassBuildErrorXXX(const char *const msg, const char * const errorLocation) {
+    void bypassBuildErrorXXX(const char *const msg, const char * const errorLocation) const {
         noteBuildError_(msg, errorLocation, true);
     }
 
@@ -167,12 +167,17 @@ private:
      * Writes output into the given MemBuf.
      \retval 0 successful completion.
      */
-    int Dump(MemBuf * mb);
+    int Dump(MemBuf *) const;
 
 public:
     err_type type = ERR_NONE;
-    int page_id = ERR_NONE;
-    char *err_language = nullptr;
+
+    // TODO: Instead of hiding const-correctness violations behind "mutable"
+    // move mutable data members holding build information into Build and adjust
+    // compile*()-related methods to avoid ErrorState object modifications.
+    mutable int page_id = ERR_NONE;
+    mutable char *err_language = nullptr;
+
     Http::StatusCode httpStatus = Http::scNone;
 #if USE_AUTH
     Auth::UserRequest::Pointer auth_user_request;
@@ -209,7 +214,7 @@ public:
     HttpReplyPointer response_;
 
 private:
-    void noteBuildError_(const char *msg, const char *errorLocation, bool forceBypass);
+    void noteBuildError_(const char *msg, const char *errorLocation, bool forceBypass) const;
 
     static const SBuf LogformatMagic; ///< marks each embedded logformat entry
 };

--- a/src/mk-string-arrays.awk
+++ b/src/mk-string-arrays.awk
@@ -25,8 +25,11 @@ BEGIN {
         nspath = ""
 }
 
-# when namespace is encountered store it
+# Remember the name of the last namespace encountered before the enum.
+# XXX: We should remember the name(s) of the namespace(s) surrounding the enum
+# instead. TODO: Replace this C++ parsing hack with a command-line parameter.
 /^namespace *[a-zA-Z]+/	{
+	if (type) next
 	nspath = tolower($2) "/"		# nested folder
 	namespace = $2				# code namespace reconstruct
 	next

--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -787,7 +787,6 @@ Security::ErrorDetail::convertErrorCodeToDescription(const char * const code, st
         }
     }
 
-    // TODO: Support logformat %codes.
     return 0;
 }
 

--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -705,7 +705,7 @@ Security::ErrorDetail::printErrorDescription(std::ostream &os) const
 
 #if USE_OPENSSL
     if (detailEntry) {
-        os << detailEntry->descr; // quote for HTML?
+        os << detailEntry->descr;
         return;
     }
 #endif

--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -530,13 +530,12 @@ Security::ErrorDetail::brief() const
     return os.buf();
 }
 
-// XXX: API contradiction: Caller supplies build.output but we return new output instead of using that
 SBuf
-Security::ErrorDetail::verbose2(const ErrorPage::Build &build) const
+Security::ErrorDetail::verbose(const ErrorTemplateCompiler &compiler) const
 {
     std::optional<SBuf> customFormat;
 #if USE_OPENSSL
-    if (const auto errorDetail = Ssl::ErrorDetailsManager::GetInstance().findDetail(error_no, &build.request)) {
+    if (const auto errorDetail = Ssl::ErrorDetailsManager::GetInstance().findDetail(error_no, compiler.request)) {
         detailEntry = *errorDetail;
         customFormat = detailEntry->detail;
     } else {
@@ -544,10 +543,7 @@ Security::ErrorDetail::verbose2(const ErrorPage::Build &build) const
     }
 #endif
     auto format = customFormat ? customFormat->c_str() : "SSL handshake error (%err_name)";
-
-    auto myBuild = build.subtask(format, *this);
-    myBuild.compile(); // calls our compilePercentCode() as needed
-    return myBuild.output;
+    return compiler.compileDetail(format, this); // calls our compilePercentCode() as needed
 }
 
 /// textual representation of the subject of the broken certificate
@@ -709,7 +705,7 @@ Security::ErrorDetail::printErrorDescription(std::ostream &os) const
 
 #if USE_OPENSSL
     if (detailEntry) {
-        os << detailEntry->descr;
+        os << detailEntry->descr; // quote for HTML?
         return;
     }
 #endif

--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -530,8 +530,23 @@ Security::ErrorDetail::brief() const
     return os.buf();
 }
 
+// XXX: Duplicates errorpage.cc code.
+namespace ErrorPage {
+
+/// state and parameters shared by several ErrorState::compile*() methods
+class Build
+{
+public:
+    SBuf output; ///< compilation result
+    const char *input = nullptr; ///< template bytes that need to be compiled
+    bool building_deny_info_url = false; ///< whether we compile deny_info URI
+    bool allowRecursion = false; ///< whether top-level compile() calls are OK
+};
+
+} // namespace ErrorPage
+
 SBuf
-Security::ErrorDetail::verbose(const HttpRequestPointer &request) const
+Security::ErrorDetail::verbose(const HttpRequestPointer &request, ErrorDetailCompiler * const compiler) const
 {
     std::optional<SBuf> customFormat;
 #if USE_OPENSSL
@@ -549,12 +564,38 @@ Security::ErrorDetail::verbose(const HttpRequestPointer &request) const
     SBufStream os;
     assert(format);
     auto remainder = format;
-    while (auto p = strchr(remainder, '%')) {
+    // TODO: This loop condition mishandles modern @Squid{logformat %code}
+    // elements that compileLeadingCode() called below does support. We do not
+    // have to support them (in this branch), but we should not mishandle them!
+    while (const auto p = strchr(remainder, '%')) {
         os.write(remainder, p - remainder);
-        const auto formattingCodeLen = convertErrorCodeToDescription(++p, os);
-        if (!formattingCodeLen)
+        remainder = p;
+
+        // XXX: convertErrorCodeToDescription() does not need this.
+        Build build;
+        build.building_deny_info_url = false; // XXX: Assumes the caller does not support this. Correct for now.
+        build.allowRecursion = false;
+        build.input = remainder;
+
+        // When compiler is nil, we leave behind both legacy errorpage %codes and modern @Squid{} codes.
+        // The former is a regression because those codes used to be compiled by `%D` code in errorpage.cc.
+
+        // XXX: convertErrorCodeToDescription() does not want to see the leading
+        // '%' character, but compileLeadingCode() does need it, causing +1s.
+        if (const auto formattingCodeLen = convertErrorCodeToDescription(remainder+1, os)) {
+            remainder += formattingCodeLen + 1;
+        } else if (compiler && compiler->compileLeadingCode(oneCode)) {
+            os << oneCode.output;
+            Assure(remainder < oneCode.input); // we are making progress
+            remainder = oneCode.input;
+        } else {
+            // TODO: Perhaps compiler->compileLeadingCode() should always
+            // "succeed" if given a %code? We do not really support incremental
+            // parsing anyway: compileLogformatCode() rejects missing '}', and
+            // compileLegacyCode() in master/v8 now barf at "%\0", at least.
             os << '%';
-        remainder = p + formattingCodeLen;
+            ++remainder;
+        }
     }
     os << remainder;
     return os.buf();

--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -530,75 +530,24 @@ Security::ErrorDetail::brief() const
     return os.buf();
 }
 
-// XXX: Duplicates errorpage.cc code.
-namespace ErrorPage {
-
-/// state and parameters shared by several ErrorState::compile*() methods
-class Build
-{
-public:
-    SBuf output; ///< compilation result
-    const char *input = nullptr; ///< template bytes that need to be compiled
-    bool building_deny_info_url = false; ///< whether we compile deny_info URI
-    bool allowRecursion = false; ///< whether top-level compile() calls are OK
-};
-
-} // namespace ErrorPage
-
+// XXX: API contradiction: Caller supplies build.output but we return new output instead of using that
 SBuf
-Security::ErrorDetail::verbose(const HttpRequestPointer &request, ErrorDetailCompiler * const compiler) const
+Security::ErrorDetail::verbose2(const ErrorPage::Build &build) const
 {
     std::optional<SBuf> customFormat;
 #if USE_OPENSSL
-    if (const auto errorDetail = Ssl::ErrorDetailsManager::GetInstance().findDetail(error_no, request)) {
+    if (const auto errorDetail = Ssl::ErrorDetailsManager::GetInstance().findDetail(error_no, &build.request)) {
         detailEntry = *errorDetail;
         customFormat = detailEntry->detail;
     } else {
         detailEntry.reset();
     }
-#else
-    (void)request;
 #endif
     auto format = customFormat ? customFormat->c_str() : "SSL handshake error (%err_name)";
 
-    SBufStream os;
-    assert(format);
-    auto remainder = format;
-    // TODO: This loop condition mishandles modern @Squid{logformat %code}
-    // elements that compileLeadingCode() called below does support. We do not
-    // have to support them (in this branch), but we should not mishandle them!
-    while (const auto p = strchr(remainder, '%')) {
-        os.write(remainder, p - remainder);
-        remainder = p;
-
-        // XXX: convertErrorCodeToDescription() does not need this.
-        Build build;
-        build.building_deny_info_url = false; // XXX: Assumes the caller does not support this. Correct for now.
-        build.allowRecursion = false;
-        build.input = remainder;
-
-        // When compiler is nil, we leave behind both legacy errorpage %codes and modern @Squid{} codes.
-        // The former is a regression because those codes used to be compiled by `%D` code in errorpage.cc.
-
-        // XXX: convertErrorCodeToDescription() does not want to see the leading
-        // '%' character, but compileLeadingCode() does need it, causing +1s.
-        if (const auto formattingCodeLen = convertErrorCodeToDescription(remainder+1, os)) {
-            remainder += formattingCodeLen + 1;
-        } else if (compiler && compiler->compileLeadingCode(oneCode)) {
-            os << oneCode.output;
-            Assure(remainder < oneCode.input); // we are making progress
-            remainder = oneCode.input;
-        } else {
-            // TODO: Perhaps compiler->compileLeadingCode() should always
-            // "succeed" if given a %code? We do not really support incremental
-            // parsing anyway: compileLogformatCode() rejects missing '}', and
-            // compileLegacyCode() in master/v8 now barf at "%\0", at least.
-            os << '%';
-            ++remainder;
-        }
-    }
-    os << remainder;
-    return os.buf();
+    auto myBuild = build.subtask(format, *this);
+    myBuild.compile(); // calls our compilePercentCode() as needed
+    return myBuild.output;
 }
 
 /// textual representation of the subject of the broken certificate
@@ -778,6 +727,24 @@ Security::ErrorDetail::printErrorLibError(std::ostream &os) const
         os << ErrorString(lib_error_no);
     else
         os << "[No Error]";
+}
+
+bool
+Security::ErrorDetail::compilePercentCode(ErrorPage::Build &build) const
+{
+    Assure(build.input);
+    Assure(*build.input == '%');
+    const auto codeNameStart = build.input + 1;
+    SBufStream os;
+    if (const auto codeNameLength = convertErrorCodeToDescription(codeNameStart, os)) {
+        Assure(build.input < codeNameStart + codeNameLength); // making parsing progress
+        Assure(codeNameStart + codeNameLength <= build.input + strlen(build.input)); // still within bounds
+        build.input = codeNameStart + codeNameLength;
+        build.output.append(os.buf());
+        return true;
+    }
+
+    return false; // including bare/trailing '%' cases
 }
 
 /**

--- a/src/security/ErrorDetail.cc
+++ b/src/security/ErrorDetail.cc
@@ -531,7 +531,7 @@ Security::ErrorDetail::brief() const
 }
 
 SBuf
-Security::ErrorDetail::verbose(const ErrorTemplateCompiler &compiler) const
+Security::ErrorDetail::verbose(const TemplateCompiler &compiler) const
 {
     std::optional<SBuf> customFormat;
 #if USE_OPENSSL

--- a/src/security/ErrorDetail.h
+++ b/src/security/ErrorDetail.h
@@ -65,7 +65,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override;
-    SBuf verbose2(const Build &) const override;
+    SBuf verbose(const ErrorTemplateCompiler &) const override;
 
     /// \returns error category; \see ErrorCode
     ErrorCode errorNo() const { return error_no; }

--- a/src/security/ErrorDetail.h
+++ b/src/security/ErrorDetail.h
@@ -11,6 +11,7 @@
 
 #include "base/RefCount.h"
 #include "error/Detail.h"
+#include "errorpage.h"
 #include "http/forward.h"
 #include "security/forward.h"
 #include "SquidString.h"
@@ -36,7 +37,7 @@ namespace Security {
 /// * for certificate validation errors: validation failure reason
 /// * for non-validation errors: TLS library-reported error(s)
 /// * for non-validation errors: system call errno(3)
-class ErrorDetail: public ::ErrorDetail
+class ErrorDetail: public ::ErrorDetail, public ErrorPage::PercentCodeCompiler
 {
     MEMPROXY_CLASS(Security::ErrorDetail);
 
@@ -64,7 +65,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override;
-    SBuf verbose(const HttpRequestPointer &) const override;
+    SBuf verbose2(const Build &) const override;
 
     /// \returns error category; \see ErrorCode
     ErrorCode errorNo() const { return error_no; }
@@ -86,6 +87,9 @@ public:
 
 private:
     ErrorDetail(ErrorCode err, int aSysErrorNo);
+
+    /* ErrorPage::PercentCodeCompiler API */
+    bool compilePercentCode(ErrorPage::Build &) const override;
 
     /* methods for formatting error details using admin-configurable %codes */
     void printSubject(std::ostream &os) const;

--- a/src/security/ErrorDetail.h
+++ b/src/security/ErrorDetail.h
@@ -65,7 +65,7 @@ public:
 
     /* ErrorDetail API */
     SBuf brief() const override;
-    SBuf verbose(const ErrorTemplateCompiler &) const override;
+    SBuf verbose(const TemplateCompiler &) const override;
 
     /// \returns error category; \see ErrorCode
     ErrorCode errorNo() const { return error_no; }

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1105,17 +1105,15 @@ Ftp::Server::writeErrorReply(const HttpReply *reply, const int scode)
 
     if (!request->error.details.empty()) {
         // Addressing TODO at the end of this method should remove this temporary hack.
-        // XXX: ErrorState currently requires non-constant HttpRequest, HttpReply.
+        // XXX: ErrorState currently requires non-constant HttpRequest and HttpReply.
         const auto err = std::make_unique<ErrorState>(
             const_cast<HttpRequest*>(request),
             const_cast<HttpReply*>(reply),
             pipeline.front()->http->al);
 
         for (const auto &detail: request->error.details) {
-            ErrorPage::Build build(*request, "", *err);
-            detail->verbose(build);
             mb.appendf("%i-Error-Detail-Brief: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->brief()));
-            mb.appendf("%i-Error-Detail-Verbose: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(build.output));
+            mb.appendf("%i-Error-Detail-Verbose: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->verbose(*err)));
         }
     }
 

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1103,9 +1103,20 @@ Ftp::Server::writeErrorReply(const HttpReply *reply, const int scode)
     if (request->error)
         mb.appendf("%i-%s\r\n", scode, errorPageName(request->error.category));
 
-    for (const auto &detail: request->error.details) {
-        mb.appendf("%i-Error-Detail-Brief: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->brief()));
-        mb.appendf("%i-Error-Detail-Verbose: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->verbose(request, nullptr)));
+    if (!request->error.details.empty()) {
+        // Addressing TODO at the end of this method should remove this temporary hack.
+        // XXX: ErrorState currently requires non-constant HttpRequest, HttpReply.
+        const auto err = std::make_unique<ErrorState>(
+            const_cast<HttpRequest*>(request),
+            const_cast<HttpReply*>(reply),
+            pipeline.front()->http->al);
+
+        for (const auto &detail: request->error.details) {
+            ErrorPage::Build build(*request, "", *err);
+            detail->verbose(build);
+            mb.appendf("%i-Error-Detail-Brief: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->brief()));
+            mb.appendf("%i-Error-Detail-Verbose: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(build.output));
+        }
     }
 
 #if USE_ADAPTATION

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1107,9 +1107,9 @@ Ftp::Server::writeErrorReply(const HttpReply *reply, const int scode)
         // Addressing TODO at the end of this method should remove this temporary hack.
         // XXX: ErrorState currently requires non-constant HttpRequest and HttpReply.
         const auto err = std::make_unique<ErrorState>(
-            const_cast<HttpRequest*>(request),
-            const_cast<HttpReply*>(reply),
-            pipeline.front()->http->al);
+                             const_cast<HttpRequest*>(request),
+                             const_cast<HttpReply*>(reply),
+                             pipeline.front()->http->al);
 
         for (const auto &detail: request->error.details) {
             mb.appendf("%i-Error-Detail-Brief: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->brief()));

--- a/src/servers/FtpServer.cc
+++ b/src/servers/FtpServer.cc
@@ -1105,7 +1105,7 @@ Ftp::Server::writeErrorReply(const HttpReply *reply, const int scode)
 
     for (const auto &detail: request->error.details) {
         mb.appendf("%i-Error-Detail-Brief: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->brief()));
-        mb.appendf("%i-Error-Detail-Verbose: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->verbose(request)));
+        mb.appendf("%i-Error-Detail-Verbose: " SQUIDSBUFPH "\r\n", scode, SQUIDSBUFPRINT(detail->verbose(request, nullptr)));
     }
 
 #if USE_ADAPTATION

--- a/src/tests/stub_liberror.cc
+++ b/src/tests/stub_liberror.cc
@@ -29,6 +29,6 @@ ErrorDetail::Pointer MakeNamedErrorDetail(const char *) STUB_RETVAL(ErrorDetail:
 #include "error/SysErrorDetail.h"
 SBuf SysErrorDetail::Brief(int) STUB_RETVAL(SBuf())
 SBuf SysErrorDetail::brief() const STUB_RETVAL(SBuf())
-SBuf SysErrorDetail::verbose(const HttpRequestPointer &) const STUB_RETVAL(SBuf())
+SBuf SysErrorDetail::verbose(const ErrorTemplateCompiler &) const STUB_RETVAL(SBuf())
 std::ostream &operator <<(std::ostream &os, ReportSysError) STUB_RETVAL(os)
 

--- a/src/tests/stub_liberror.cc
+++ b/src/tests/stub_liberror.cc
@@ -29,6 +29,6 @@ ErrorDetail::Pointer MakeNamedErrorDetail(const char *) STUB_RETVAL(ErrorDetail:
 #include "error/SysErrorDetail.h"
 SBuf SysErrorDetail::Brief(int) STUB_RETVAL(SBuf())
 SBuf SysErrorDetail::brief() const STUB_RETVAL(SBuf())
-SBuf SysErrorDetail::verbose(const ErrorTemplateCompiler &) const STUB_RETVAL(SBuf())
+SBuf SysErrorDetail::verbose(const TemplateCompiler &) const STUB_RETVAL(SBuf())
 std::ostream &operator <<(std::ostream &os, ReportSysError) STUB_RETVAL(os)
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -72,6 +72,7 @@ Security::ErrorDetail::ErrorDetail(ErrorCode, LibErrorCode, int) STUB
 void Security::ErrorDetail::setPeerCertificate(const CertPointer &) STUB
 SBuf Security::ErrorDetail::verbose(const ErrorTemplateCompiler &) const STUB_RETVAL(SBuf())
 SBuf Security::ErrorDetail::brief() const STUB_RETVAL(SBuf())
+bool Security::ErrorDetail::compilePercentCode(ErrorPage::Build &) const STUB_RETVAL(false)
 Security::ErrorCode Security::ErrorCodeFromName(const char *) STUB_RETVAL(0)
 const char *Security::ErrorNameFromCode(ErrorCode, bool) STUB_RETVAL("")
 

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -70,7 +70,7 @@ Security::ErrorDetail::ErrorDetail(ErrorCode, int, int) STUB
 Security::ErrorDetail::ErrorDetail(ErrorCode, LibErrorCode, int) STUB
 #endif
 void Security::ErrorDetail::setPeerCertificate(const CertPointer &) STUB
-SBuf Security::ErrorDetail::verbose(const HttpRequestPointer &) const STUB_RETVAL(SBuf())
+SBuf Security::ErrorDetail::verbose(const ErrorTemplateCompiler &) const STUB_RETVAL(SBuf())
 SBuf Security::ErrorDetail::brief() const STUB_RETVAL(SBuf())
 Security::ErrorCode Security::ErrorCodeFromName(const char *) STUB_RETVAL(0)
 const char *Security::ErrorNameFromCode(ErrorCode, bool) STUB_RETVAL("")

--- a/src/tests/stub_libsecurity.cc
+++ b/src/tests/stub_libsecurity.cc
@@ -70,7 +70,7 @@ Security::ErrorDetail::ErrorDetail(ErrorCode, int, int) STUB
 Security::ErrorDetail::ErrorDetail(ErrorCode, LibErrorCode, int) STUB
 #endif
 void Security::ErrorDetail::setPeerCertificate(const CertPointer &) STUB
-SBuf Security::ErrorDetail::verbose(const ErrorTemplateCompiler &) const STUB_RETVAL(SBuf())
+SBuf Security::ErrorDetail::verbose(const TemplateCompiler &) const STUB_RETVAL(SBuf())
 SBuf Security::ErrorDetail::brief() const STUB_RETVAL(SBuf())
 bool Security::ErrorDetail::compilePercentCode(ErrorPage::Build &) const STUB_RETVAL(false)
 Security::ErrorCode Security::ErrorCodeFromName(const char *) STUB_RETVAL(0)


### PR DESCRIPTION
When available, Security::ErrorDetail is added to Squid-generated errors
that use customizable errorpage formats containing `%D` errorpage
`%code`. Security::ErrorDetail itself supports customizable verbose
reporting format (see `detail` in `errors/templates/error-details.txt`).
The latter format may contain both Security::ErrorDetail-specific %codes
and generic legacy errorpage %codes handled by ErrorState.

To support the above "nested" formats when processing `%D`,
ErrorState::compileLegacyCode() compiled ErrorDetail output,
substituting any legacy errorpage %codes outputted by ErrorDetail. That
re-compilation could not distinguish a `%code` sequence configured by
`error-details.txt` from a `%code` sequence that came from, say, a
received X509 certificate field. Both would be expanded!

This bug applies to both legacy errorpage `%code` sequences like `%R`
and modern `@Squid{logformat %code}` errorpage sequences (supported
since 2019 commit 7e6eabbc).

X509 certificate fields are the only known injection vector, but it is
conceivable that some other error details may contain character
sequences that match errorpage legacy %codes (e.g., SysErrorDetail
returns strerror(3) output that Squid does not control or escape).

This bug is similar to the bug fixed in 2018 commit 6feeb15f but deals
with injected errorpage %codes (that target Squid error response
assembling code) rather than injected HTML tags (that target browsers).

Two primary solution candidates were considered:

A) Escape-then-compile-to-unescape: Security::ErrorDetail could escape
   `%code` sequences received from "external" sources, so that
   ErrorState::compile() would see `%%X` and replace that with `%X`,
   correctly relaying received `%X`. This solution was rejected because
   we risk forgetting to escape some input, now or during code
   refactoring, especially since the risk applies to all ErrorDetail
   classes. Also, escaping what we know we will immediately un-escape is
   wasteful.

B) Never compile "external" input. This implemented solution required
   giving ErrorDetail::verbose() access to the `%code` compiling code in
   ErrorState, so that ErrorDetail can decide what to compile and what
   not to. Now, Security::ErrorDetail only compiles `%code` sequences
   found in `detail`; ErrorState does not compile ErrorDetail output.

Side effects
------------

The `details` field in `error-details.txt` now supports modern
`@Squid{logformat %code}` errorpage sequences by design rather than by
accident, addressing an old (and essentially misleading) TODO inside
Security::ErrorDetail::convertErrorCodeToDescription().

The `descr` field in `error-details.txt` no longer supports errorpage
`%code` sequences. It was never documented to support them, and it did
not support Security::ErrorDetail %codes like %ssl_ca_name. The field is
not meant to contain %code sequences -- they belong to the `details`
field that specifies detail reporting format. Hopefully, no deployed
configurations use `%code` sequences in the `descr` field.

Also improved `src/mk-string-arrays.awk` support for C++ forward
declarations inside a namespace. After we added forward declarations for
classes declared inside an `ErrorPage` namespace, the AWK script
incorrectly applied that namespace to the generated `err_type_str`
definition, breaking the build.
