### PR TITLE
Honor reply_header_max_size for received FTP control responses

### DIFF
--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -142,7 +142,7 @@ Ftp::CtrlChannel::CtrlChannel():
     last_reply(nullptr),
     replycode(0)
 {
-    buf = static_cast<char*>(memAllocBuf(min(4096UL, Config.maxReplyHeaderSize), &size));
+    buf = static_cast<char*>(memAllocBuf(min(size_t{4096}, Config.maxReplyHeaderSize), &size));
 }
 
 Ftp::CtrlChannel::~CtrlChannel()

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -345,7 +345,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
-            debugs(9, DBG_IMPORTANT, "FTP control reply exceeding maxReplyHeaderSize=" << Config.maxReplyHeaderSize);
+            debugs(9, DBG_IMPORTANT, "FTP control reply exceeding reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);
             return;
         }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -345,8 +345,8 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
-            debugs(9, DBG_IMPORTANT, "FTP control reply too large: " << ctrl.offset << " bytes exceeds maxReplyHeaderSize=" << Config.maxReplyHeaderSize);
-            failed(ERR_TOO_BIG, 0);
+            debugs(9, DBG_IMPORTANT, "FTP control reply exceeding maxReplyHeaderSize=" << Config.maxReplyHeaderSize);
+            failed(ERR_FTP_FAILURE, 0);
             return;
         }
 

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -366,7 +366,6 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
-        
         comm_read(ctrl.conn, ctrl.buf + ctrl.offset, ctrl.size - ctrl.offset, reader);
     }
 }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -142,7 +142,7 @@ Ftp::CtrlChannel::CtrlChannel():
     last_reply(nullptr),
     replycode(0)
 {
-    buf = static_cast<char*>(memAllocBuf(4096, &size));
+    buf = static_cast<char*>(memAllocBuf(min(4096, Config.maxReplyHeaderSize), &size));
 }
 
 Ftp::CtrlChannel::~CtrlChannel()
@@ -344,6 +344,16 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
             commUnsetConnTimeout(data.conn);
         }
 
+        if (ctrl.offset >= Config.maxReplyHeaderSize) {
+            debugs(9, DBG_IMPORTANT, "FTP control reply too large: " << ctrl.offset << " bytes exceeds maxReplyHeaderSize=" << Config.maxReplyHeaderSize);
+            return;
+        }
+
+        if (ctrl.offset == ctrl.size) {
+            const auto newSize = min(ctrl.size << 1, Config.maxReplyHeaderSize);
+            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
+        }
+
         const time_t tout = shortenReadTimeout ?
                             min(Config.Timeout.connect, Config.Timeout.read):
                             Config.Timeout.read;
@@ -355,16 +365,6 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
-        
-        if (ctrl.offset >= Config.maxReplyHeaderSize) {
-            debugs(9, DBG_IMPORTANT, "FTP control reply too large: " << ctrl.offset << " bytes exceeds maxReplyHeaderSize=" << Config.maxReplyHeaderSize);
-            return;
-        }
-
-        if (ctrl.offset == ctrl.size) {
-            const auto newSize = min(ctrl.size << 1, Config.maxReplyHeaderSize);
-            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
-        }
         
         comm_read(ctrl.conn, ctrl.buf + ctrl.offset, ctrl.size - ctrl.offset, reader);
     }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -142,7 +142,7 @@ Ftp::CtrlChannel::CtrlChannel():
     last_reply(nullptr),
     replycode(0)
 {
-    buf = static_cast<char*>(memAllocBuf(min(4096, Config.maxReplyHeaderSize), &size));
+    buf = static_cast<char*>(memAllocBuf(min(4096UL, Config.maxReplyHeaderSize), &size));
 }
 
 Ftp::CtrlChannel::~CtrlChannel()
@@ -346,6 +346,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
             debugs(9, DBG_IMPORTANT, "FTP control reply too large: " << ctrl.offset << " bytes exceeds maxReplyHeaderSize=" << Config.maxReplyHeaderSize);
+            failed(ERR_TOO_BIG, 0);
             return;
         }
 

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -356,8 +356,14 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
         
+        if (ctrl.offset >= Config.maxReplyHeaderSize) {
+            debugs(9, DBG_IMPORTANT, "FTP control reply too large: " << ctrl.offset << " bytes exceeds maxReplyHeaderSize=" << Config.maxReplyHeaderSize);
+            return;
+        }
+
         if (ctrl.offset == ctrl.size) {
-            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, ctrl.size << 1, &ctrl.size));
+            const auto newSize = min(ctrl.size << 1, Config.maxReplyHeaderSize);
+            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
         }
         
         comm_read(ctrl.conn, ctrl.buf + ctrl.offset, ctrl.size - ctrl.offset, reader);

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -355,6 +355,11 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
+        
+        if (ctrl.offset == ctrl.size) {
+            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, ctrl.size << 1, &ctrl.size));
+        }
+        
         comm_read(ctrl.conn, ctrl.buf + ctrl.offset, ctrl.size - ctrl.offset, reader);
     }
 }
@@ -426,11 +431,6 @@ Ftp::Client::handleControlReply()
 
     if (!parseControlReply(bytes_used)) {
         /* didn't get complete reply yet */
-
-        if (ctrl.offset == ctrl.size) {
-            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, ctrl.size << 1, &ctrl.size));
-        }
-
         scheduleReadControlReply(0);
         return;
     }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -345,14 +345,16 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
             commUnsetConnTimeout(data.conn);
         }
 
-        if (ctrl.offset >= Config.maxReplyHeaderSize) {
+        const auto maxSize = min(Config.maxReplyHeaderSize, std::numeric_limits<decltype(ctrl.size)>::max());
+        if (ctrl.offset >= maxSize) {
             debugs(9, 2, "FTP control reply will exceed reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);
             return;
         }
 
         if (ctrl.offset == ctrl.size) {
-            const auto newSize = (ctrl.size > SIZE_MAX / 2) ? Config.maxReplyHeaderSize : min(ctrl.size*2, Config.maxReplyHeaderSize);
+            const auto maxSize = min(Config.maxReplyHeaderSize, std::numeric_limits<decltype(ctrl.size)>::max());
+            const auto newSize = (ctrl.size <= maxSize/2) ? (ctrl.size*2) : maxSize;
             Assure(newSize > ctrl.size);
             ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
             Assure(ctrl.offset < ctrl.size);

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -344,6 +344,8 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
             commUnsetConnTimeout(data.conn);
         }
 
+        asser(ctrl.offset <= ctrl.size);
+
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
             debugs(9, DBG_IMPORTANT, "FTP control reply exceeding reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -344,8 +344,6 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
             commUnsetConnTimeout(data.conn);
         }
 
-        asser(ctrl.offset <= ctrl.size);
-
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
             debugs(9, DBG_IMPORTANT, "FTP control reply exceeding reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);
@@ -353,7 +351,8 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset == ctrl.size) {
-            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, ctrl.size << 1, &ctrl.size));
+            const auto newSize = min(ctrl.size << 1, Config.maxReplyHeaderSize);
+            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
         }
 
         const time_t tout = shortenReadTimeout ?
@@ -367,7 +366,9 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
-        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, min(ctrl.size, Config.maxReplyHeaderSize) - ctrl.offset, reader);
+        auto const readLen = min(ctrl.size, Config.maxReplyHeaderSize) - ctrl.offset;
+        Assure(readLen > 0);
+        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, readLen, reader);
     }
 }
 

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -344,8 +344,6 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
             commUnsetConnTimeout(data.conn);
         }
 
-        assert(ctrl.offset <= ctrl.size);
-
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
             debugs(9, DBG_IMPORTANT, "FTP control reply exceeding reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);
@@ -353,8 +351,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset == ctrl.size) {
-            const auto newSize = min(ctrl.size << 1, Config.maxReplyHeaderSize);
-            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
+            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, ctrl.size << 1, &ctrl.size));
         }
 
         const time_t tout = shortenReadTimeout ?
@@ -368,7 +365,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
-        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, ctrl.size - ctrl.offset, reader);
+        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, min(ctrl.size, Config.maxReplyHeaderSize) - ctrl.offset, reader);
     }
 }
 

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -371,9 +371,9 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         // Do not accumulate more than Config.maxReplyHeaderSize bytes,
         // even if we happened to have enough buffer space to do so.
         const auto maxOffset = min(ctrl.size, Config.maxReplyHeaderSize);
-        Assure(endOffset > ctrl.offset); // we can make progress (and no underflows)
-        Assure(endOffset <= ctrl.size); // paranoid: we will not read beyond our buffer space
-        const auto maxReadSize = endOffset - ctrl.offset;
+        Assure(maxOffset > ctrl.offset); // we can make progress (and no underflows)
+        Assure(maxOffset <= ctrl.size); // paranoid: we will not read beyond our buffer space
+        const auto maxReadSize = maxOffset - ctrl.offset;
         comm_read(ctrl.conn, ctrl.buf + ctrl.offset, readLen, reader);
     }
 }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -353,7 +353,6 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset == ctrl.size) {
-            const auto maxSize = min(Config.maxReplyHeaderSize, std::numeric_limits<decltype(ctrl.size)>::max());
             const auto newSize = (ctrl.size <= maxSize/2) ? (ctrl.size*2) : maxSize;
             Assure(newSize > ctrl.size);
             ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -142,7 +142,8 @@ Ftp::CtrlChannel::CtrlChannel():
     last_reply(nullptr),
     replycode(0)
 {
-    buf = static_cast<char*>(memAllocBuf(min(size_t{4096}, Config.maxReplyHeaderSize), &size));
+    // min() limits the initial read size when Config.maxReplyHeaderSize is huge
+    buf = static_cast<char*>(memAllocBuf(min(size_t(4096), Config.maxReplyHeaderSize), &size));
 }
 
 Ftp::CtrlChannel::~CtrlChannel()
@@ -345,7 +346,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
-            debugs(9, DBG_IMPORTANT, "FTP control reply exceeding reply_header_max_size=" << Config.maxReplyHeaderSize);
+            debugs(9, 2, "FTP control reply will exceed reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);
             return;
         }
@@ -353,6 +354,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         if (ctrl.offset == ctrl.size) {
             const auto newSize = min(ctrl.size << 1, Config.maxReplyHeaderSize);
             ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
+            Assure(ctrl.offset < ctrl.size);
         }
 
         const time_t tout = shortenReadTimeout ?
@@ -366,8 +368,12 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
-        auto const readLen = min(ctrl.size, Config.maxReplyHeaderSize) - ctrl.offset;
-        Assure(readLen > 0);
+        // Do not accumulate more than Config.maxReplyHeaderSize bytes,
+        // even if we happened to have enough buffer space to do so.
+        const auto maxOffset = min(ctrl.size, Config.maxReplyHeaderSize);
+        Assure(endOffset > ctrl.offset); // we can make progress (and no underflows)
+        Assure(endOffset <= ctrl.size); // paranoid: we will not read beyond our buffer space
+        const auto maxReadSize = endOffset - ctrl.offset;
         comm_read(ctrl.conn, ctrl.buf + ctrl.offset, readLen, reader);
     }
 }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -344,6 +344,8 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
             commUnsetConnTimeout(data.conn);
         }
 
+        assert(ctrl.offset <= ctrl.size);
+
         if (ctrl.offset >= Config.maxReplyHeaderSize) {
             debugs(9, DBG_IMPORTANT, "FTP control reply exceeding reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -352,7 +352,8 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset == ctrl.size) {
-            const auto newSize = min(ctrl.size*2, Config.maxReplyHeaderSize);
+            const auto newSize = (ctrl.size > SIZE_MAX / 2) ? Config.maxReplyHeaderSize : min(ctrl.size*2, Config.maxReplyHeaderSize);
+            Assure(newSize > ctrl.size);
             ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
             Assure(ctrl.offset < ctrl.size);
         }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -347,7 +347,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         const auto maxSize = min(Config.maxReplyHeaderSize, std::numeric_limits<decltype(ctrl.size)>::max());
         if (ctrl.offset >= maxSize) {
-            debugs(9, 2, "FTP control reply will exceed reply_header_max_size=" << Config.maxReplyHeaderSize);
+            debugs(9, 2, "FTP control reply size will exceed " << maxSize << "; reply_header_max_size=" << Config.maxReplyHeaderSize);
             failed(ERR_FTP_FAILURE, 0);
             return;
         }

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -352,7 +352,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         }
 
         if (ctrl.offset == ctrl.size) {
-            const auto newSize = min(ctrl.size << 1, Config.maxReplyHeaderSize);
+            const auto newSize = min(ctrl.size*2, Config.maxReplyHeaderSize);
             ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
             Assure(ctrl.offset < ctrl.size);
         }
@@ -374,7 +374,7 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
         Assure(maxOffset > ctrl.offset); // we can make progress (and no underflows)
         Assure(maxOffset <= ctrl.size); // paranoid: we will not read beyond our buffer space
         const auto maxReadSize = maxOffset - ctrl.offset;
-        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, readLen, reader);
+        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, maxReadSize, reader);
     }
 }
 


### PR DESCRIPTION
2023 commit 801593a claimed that `reply_header_max_size` applied to "FTP
command responses". However, that misleading claim probably only covered
FTP command replies that were parsed while being loaded from cache[^1],
after being converted to HttpReply objects and written to Store. The
same claim now applies to all received/raw FTP command replies as well.

[^1]: Both store_client::parseHttpHeadersFromDisk() and
MemStore::copyFromShm() called HttpReply::parseTerminatedPrefix().

This is a Measurement Factory project.