### PR TITLE
v7 backport pr2417,2420

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -438,6 +438,7 @@ Thank you!
     Regents of the University of California (UCSD)
     Reinhard Posmyk <Reinhard.Posmyk@arxes.de>
     Reinhard Sojka <reinhard.sojka@parlament.gv.at>
+    Renaud Metrich <renaud.metrich@gmail.com>
     Rene Geile <rene.geile@t-online.de>
     Reuben Farrelly <reuben@reub.net>
     Ricardo Ferreira Ribeiro <garb12@pm.me>

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -142,7 +142,8 @@ Ftp::CtrlChannel::CtrlChannel():
     last_reply(nullptr),
     replycode(0)
 {
-    buf = static_cast<char*>(memAllocBuf(4096, &size));
+    // min() limits the initial read size when Config.maxReplyHeaderSize is huge
+    buf = static_cast<char*>(memAllocBuf(min(size_t(4096), Config.maxReplyHeaderSize), &size));
 }
 
 Ftp::CtrlChannel::~CtrlChannel()
@@ -344,6 +345,20 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
             commUnsetConnTimeout(data.conn);
         }
 
+        const auto maxSize = min(Config.maxReplyHeaderSize, std::numeric_limits<decltype(ctrl.size)>::max());
+        if (ctrl.offset >= maxSize) {
+            debugs(9, 2, "FTP control reply size will exceed " << maxSize << "; reply_header_max_size=" << Config.maxReplyHeaderSize);
+            failed(ERR_FTP_FAILURE, 0);
+            return;
+        }
+
+        if (ctrl.offset == ctrl.size) {
+            const auto newSize = (ctrl.size <= maxSize/2) ? (ctrl.size*2) : maxSize;
+            Assure(newSize > ctrl.size);
+            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, newSize, &ctrl.size));
+            Assure(ctrl.offset < ctrl.size);
+        }
+
         const time_t tout = shortenReadTimeout ?
                             min(Config.Timeout.connect, Config.Timeout.read):
                             Config.Timeout.read;
@@ -355,7 +370,13 @@ Ftp::Client::scheduleReadControlReply(int buffered_ok)
 
         typedef CommCbMemFunT<Client, CommIoCbParams> Dialer;
         AsyncCall::Pointer reader = JobCallback(9, 5, Dialer, this, Ftp::Client::readControlReply);
-        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, ctrl.size - ctrl.offset, reader);
+        // Do not accumulate more than Config.maxReplyHeaderSize bytes,
+        // even if we happened to have enough buffer space to do so.
+        const auto maxOffset = min(ctrl.size, Config.maxReplyHeaderSize);
+        Assure(maxOffset > ctrl.offset); // we can make progress (and no underflows)
+        Assure(maxOffset <= ctrl.size); // paranoid: we will not read beyond our buffer space
+        const auto maxReadSize = maxOffset - ctrl.offset;
+        comm_read(ctrl.conn, ctrl.buf + ctrl.offset, maxReadSize, reader);
     }
 }
 
@@ -426,11 +447,6 @@ Ftp::Client::handleControlReply()
 
     if (!parseControlReply(bytes_used)) {
         /* didn't get complete reply yet */
-
-        if (ctrl.offset == ctrl.size) {
-            ctrl.buf = static_cast<char*>(memReallocBuf(ctrl.buf, ctrl.size << 1, &ctrl.size));
-        }
-
         scheduleReadControlReply(0);
         return;
     }

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -110,8 +110,9 @@ redirectHandleReply(void *data, const Helper::Reply &reply)
             // parse it into status=, url= and rewrite-url= keys
             if (replySize) {
                 MemBuf replyBuffer;
-                replyBuffer.init(replySize, replySize);
-                replyBuffer.append(reply.other().content(), reply.other().contentSize());
+                replyBuffer.init(replySize + 1, replySize + 1); // with space for 0-terminator added by append()
+                Assure(replySize <= size_t(reply.other().contentSize()));
+                replyBuffer.append(reply.other().content(), replySize);
                 char * result = replyBuffer.content();
 
                 Helper::Reply newReply;


### PR DESCRIPTION
- Fix parsing of legacy url_rewrite_program responses (#2420)
- Honor reply_header_max_size for received FTP control responses (#2417)
