### PR TITLE
Harden peerDigestSwapInMask against invalid cache digest reply

### DIFF
--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -558,10 +558,7 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
      * NOTENOTENOTENOTENOTE: buf doesn't point to pd->cd->mask anymore!
      * we need to do the copy ourselves!
      */
-    if (size < 0) {
-        finishAndDeleteFetch(fetch, "failure loading digest mask from Store", true);
-        return -1;
-    }
+    Assure(size >= 0);
     if (fetch->mask_offset + size > static_cast<ssize_t>(pd->cd->mask_size)) {
         finishAndDeleteFetch(fetch, "peer digest mask data too large", true);
         return -1;

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -558,6 +558,14 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
      * NOTENOTENOTENOTENOTE: buf doesn't point to pd->cd->mask anymore!
      * we need to do the copy ourselves!
      */
+    if (size < 0) {
+        finishAndDeleteFetch(fetch, "failure loading digest mask from Store", true);
+        return -1;
+    }
+    if (fetch->mask_offset + size > static_cast<ssize_t>(pd->cd->mask_size)) {
+        finishAndDeleteFetch(fetch, "peer digest mask data too large", true);
+        return -1;
+    }
     memcpy(pd->cd->mask + fetch->mask_offset, buf, size);
 
     /* NOTE! buf points to the middle of pd->cd->mask! */


### PR DESCRIPTION
A cache_digest on-the-wire size may be bigger than the
mask_size declared in the digest itself.

Ignore the digest in case this happens.