### PR TITLE
Support Nettle 4.0 md5_digest API (#2424)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1017,7 +1017,7 @@ SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
 SQUID_CHECK_LIB_WORKS(nettle,[
   PKG_CHECK_MODULES([LIBNETTLE],[nettle >= 3.4],[
     CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
-    AC_CHECK_HEADERS(nettle/base64.h nettle/md5.h)
+    AC_CHECK_HEADERS(nettle/base64.h nettle/md5.h nettle/version.h)
   ],[:])
 ])
 

--- a/include/md5.h
+++ b/include/md5.h
@@ -12,11 +12,20 @@
 #if HAVE_NETTLE_MD5_H
 #include <nettle/md5.h>
 
+#if HAVE_NETTLE_VERSION_H
+#include <nettle/version.h>
+#endif
+
 typedef struct md5_ctx SquidMD5_CTX;
 
 #define SquidMD5Init(c)       md5_init((c))
 #define SquidMD5Update(c,b,l) md5_update((c), (l), (const uint8_t *)(b))
+
+#if NETTLE_VERSION_MAJOR >= 4
+#define SquidMD5Final(d,c)    md5_digest((c), (uint8_t *)(d))
+#else
 #define SquidMD5Final(d,c)    md5_digest((c), MD5_DIGEST_SIZE, (uint8_t *)(d))
+#endif
 
 #define SQUID_MD5_DIGEST_LENGTH MD5_DIGEST_SIZE
 


### PR DESCRIPTION
    error: no matching function for call to nettle_md5_digest

Nettle v4.x md5_digest() function does not have a length parameter
present in Nettle v3.