### PR TITLE
v7 backport pr2423

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1017,7 +1017,7 @@ SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
 SQUID_CHECK_LIB_WORKS(nettle,[
   PKG_CHECK_MODULES([LIBNETTLE],[nettle >= 3.4],[
     CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"
-    AC_CHECK_HEADERS(nettle/base64.h nettle/md5.h)
+    AC_CHECK_HEADERS(nettle/base64.h nettle/md5.h nettle/version.h)
   ],[:])
 ])
 

--- a/include/md5.h
+++ b/include/md5.h
@@ -12,11 +12,20 @@
 #if HAVE_NETTLE_MD5_H
 #include <nettle/md5.h>
 
+#if HAVE_NETTLE_VERSION_H
+#include <nettle/version.h>
+#endif
+
 typedef struct md5_ctx SquidMD5_CTX;
 
 #define SquidMD5Init(c)       md5_init((c))
 #define SquidMD5Update(c,b,l) md5_update((c), (l), (const uint8_t *)(b))
+
+#if NETTLE_VERSION_MAJOR >= 4
+#define SquidMD5Final(d,c)    md5_digest((c), (uint8_t *)(d))
+#else
 #define SquidMD5Final(d,c)    md5_digest((c), MD5_DIGEST_SIZE, (uint8_t *)(d))
+#endif
 
 #define SQUID_MD5_DIGEST_LENGTH MD5_DIGEST_SIZE
 

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -558,6 +558,11 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
      * NOTENOTENOTENOTENOTE: buf doesn't point to pd->cd->mask anymore!
      * we need to do the copy ourselves!
      */
+    Assure(size >= 0);
+    if (fetch->mask_offset + size > static_cast<ssize_t>(pd->cd->mask_size)) {
+        finishAndDeleteFetch(fetch, "peer digest mask data too large", true);
+        return -1;
+    }
     memcpy(pd->cd->mask + fetch->mask_offset, buf, size);
 
     /* NOTE! buf points to the middle of pd->cd->mask! */


### PR DESCRIPTION
- **Support Nettle 4.0 md5_digest API (#2424)**
- **Harden peerDigestSwapInMask against invalid cache digest reply (#2423)**
