### PR TITLE
HTTP/1.1: Transfer-Encoding:identity is prohibited

### DIFF
--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -642,8 +642,6 @@ HttpHeader::parse(const char *header_start, size_t hdrLen, Http::ContentLengthIn
 
         if (rawTe.caseCmp("chunked") == 0) {
             ; // leave header present for chunked() method
-        } else if (rawTe.caseCmp("identity") == 0) { // deprecated. no coding
-            delById(Http::HdrType::TRANSFER_ENCODING);
         } else {
             // This also rejects multiple encodings until we support them properly.
             debugs(55, warnOnError, "WARNING: unsupported Transfer-Encoding used by client: " << rawTe);


### PR DESCRIPTION
HTTP specification deprecated identity encoding but still allows
its use as an unknown encoding when the Transfer-Encoding
header is otherwise correctly used.

Squid compliance update at the time kept accepting identity
encoding as it was being used by agents. The form supported was
Transfer-Encoding:identity.

However, the HTTP specification explicitly requires that any
encoding MUST be wrapped within chunked encoding.

As such the bare Transfer-Encoding:identity form Squid accepted
is explicitly prohibited.

The correct Transfer-Encoding:identity,chunked syntax has been
rejected by Squid for nearly 5 years already without complaint.
So support is being dropped entirely here.