### PR TITLE
Fix -Wsign-compare on arm32

### DIFF
--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -559,7 +559,7 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
      * we need to do the copy ourselves!
      */
     Assure(size >= 0);
-    Assure(pd->cd->mask_size > fetch->mask_offset);
+    Assure(pd->cd->mask_size >= fetch->mask_offset);
     if (static_cast<size_t>(size) > pd->cd->mask_size - fetch->mask_offset) {
         finishAndDeleteFetch(fetch, "peer digest mask data too large", true);
         return -1;

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -559,6 +559,7 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
      * we need to do the copy ourselves!
      */
     Assure(size >= 0);
+    Assure(pd->cd->mask_size > fetch->mask_offset);
     if (static_cast<size_t>(size) > pd->cd->mask_size - fetch->mask_offset) {
         finishAndDeleteFetch(fetch, "peer digest mask data too large", true);
         return -1;

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -559,7 +559,7 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
      * we need to do the copy ourselves!
      */
     Assure(size >= 0);
-    if (fetch->mask_offset + size > static_cast<ssize_t>(pd->cd->mask_size)) {
+    if (static_cast<uint32_t>(size) > pd->cd->mask_size - fetch->mask_offset) {
         finishAndDeleteFetch(fetch, "peer digest mask data too large", true);
         return -1;
     }

--- a/src/peer_digest.cc
+++ b/src/peer_digest.cc
@@ -559,7 +559,7 @@ peerDigestSwapInMask(void *data, char *buf, ssize_t size)
      * we need to do the copy ourselves!
      */
     Assure(size >= 0);
-    if (static_cast<uint32_t>(size) > pd->cd->mask_size - fetch->mask_offset) {
+    if (static_cast<size_t>(size) > pd->cd->mask_size - fetch->mask_offset) {
         finishAndDeleteFetch(fetch, "peer digest mask data too large", true);
         return -1;
     }


### PR DESCRIPTION
Due to ssize_t differences on 32/64 bit platforms, changes
to peerDigestSwapInMask in commit 556b91a8a7 cause
signedness comparison errors.
Refactor to be safe both on 32- and 64-bit platforms