### PR TITLE
v7.6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+Changes in squid-7.6 (04 Jun 2026):
+
+	- HTTP/1.1: Transfer-Encoding:identity is prohibited
+	- Harden peerDigestSwapInMask against invalid cache digest reply
+	- Fix parsing of legacy url_rewrite_program responses
+	- Fix handling of truncated legacy errorpage %codes
+	- Do not treat tiny virgin response buffer space specially
+	- Honor reply_header_max_size for received FTP control responses
+	- Improve parsing of certain FTP directory listing formats
+	- Support Nettle 4.0 md5_digest API
+	- .. and some cleanups
+
 Changes in squid-7.5 (12 Mar 2026):
 
 	- Bug 5501: Squid may exit when ACLs decode an invalid URI

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 ## Please see the COPYING and CONTRIBUTORS files for details.
 ##
 
-AC_INIT([Squid Web Proxy],[7.5-VCS],[https://bugs.squid-cache.org/],[squid])
+AC_INIT([Squid Web Proxy],[7.6-VCS],[https://bugs.squid-cache.org/],[squid])
 AC_PREREQ(2.61)
 AC_CONFIG_HEADERS([include/autoconf.h])
 AC_CONFIG_AUX_DIR(cfgaux)


### PR DESCRIPTION
Changes in squid-7.6 (04 Jun 2026):

- HTTP/1.1: Transfer-Encoding:identity is prohibited
- Harden peerDigestSwapInMask against invalid cache digest reply
- Fix parsing of legacy url_rewrite_program responses
- Fix handling of truncated legacy errorpage %codes
- Do not treat tiny virgin response buffer space specially
- Honor reply_header_max_size for received FTP control responses
- Improve parsing of certain FTP directory listing formats
- Support Nettle 4.0 md5_digest API
- .. and some cleanups