### PR TITLE
Fix bad uses of OpenSSL 0.9 API

### DIFF
--- a/src/security/cert_generators/file/certificate_db.cc
+++ b/src/security/cert_generators/file/certificate_db.cc
@@ -336,7 +336,7 @@ Ssl::CertificateDb::addCertAndPrivateKey(std::string const &useKey, const Securi
     }
 
     const auto tm = X509_getm_notAfter(cert.get());
-    row.setValue(cnlExp_date, std::string(reinterpret_cast<char *>(tm->data), tm->length).c_str());
+    row.setValue(cnlExp_date, std::string(reinterpret_cast<const char *>(ASN1_STRING_get0_data(tm)), ASN1_STRING_length(tm)).c_str());
     const auto subject = OneLineSummary(*X509_get_subject_name(cert.get()));
     row.setValue(cnlName, subject.get());
     row.setValue(cnlKey, useKey.c_str());

--- a/src/ssl/gadgets.cc
+++ b/src/ssl/gadgets.cc
@@ -300,13 +300,14 @@ Ssl::CertificateProperties::CertificateProperties():
 static void
 printX509Signature(const Security::CertPointer &cert, std::string &out)
 {
-    const ASN1_BIT_STRING *sig = Ssl::X509_get_signature(cert);
-    if (sig && sig->data) {
-        const unsigned char *s = sig->data;
-        for (int i = 0; i < sig->length; ++i) {
-            char hex[3];
-            snprintf(hex, sizeof(hex), "%02x", s[i]);
-            out.append(hex);
+    if (const auto sig = Ssl::X509_get_signature(cert)) {
+        if (const auto s = ASN1_STRING_get0_data(sig)) {
+            const auto len = ASN1_STRING_length(sig);
+            for (int i = 0; i < len; ++i) {
+                char hex[3];
+                snprintf(hex, sizeof(hex), "%02x", s[i]);
+                out.append(hex);
+            }
         }
     }
 }
@@ -418,8 +419,9 @@ mimicAuthorityKeyId(Security::CertPointer &cert, Security::CertPointer const &mi
     unsigned char *ext_der = nullptr;
     int ext_len = ASN1_item_i2d((ASN1_VALUE *)theAuthKeyId.get(), &ext_der, ASN1_ITEM_ptr(method->it));
     Ssl::ASN1_OCTET_STRING_Pointer extOct(ASN1_OCTET_STRING_new());
-    extOct.get()->data = ext_der;
-    extOct.get()->length = ext_len;
+    if (ASN1_STRING_set(extOct.get(), ext_der, ext_len) != 1)
+        return false;
+
     Ssl::X509_EXTENSION_Pointer extAuthKeyId(X509_EXTENSION_create_by_NID(nullptr, NID_authority_key_identifier, 0, extOct.get()));
     if (!extAuthKeyId.get())
         return false;
@@ -493,13 +495,9 @@ mimicExtensions(Security::CertPointer & cert, Security::CertPointer const &mimic
                     int ext_len = ASN1_item_i2d((ASN1_VALUE *)keyusage,
                                                 &ext_der,
                                                 (const ASN1_ITEM *)ASN1_ITEM_ptr(method->it));
-
-                    ASN1_OCTET_STRING *ext_oct = ASN1_OCTET_STRING_new();
-                    ext_oct->data = ext_der;
-                    ext_oct->length = ext_len;
-                    X509_EXTENSION_set_data(ext, ext_oct);
-
-                    ASN1_OCTET_STRING_free(ext_oct);
+                    Ssl::ASN1_OCTET_STRING_Pointer extOct(ASN1_OCTET_STRING_new());
+                    if (ASN1_STRING_set(extOct.get(), ext_der, ext_len) != 1)
+                        X509_EXTENSION_set_data(ext, extOct.get());
                     ASN1_BIT_STRING_free(keyusage);
                 }
             }
@@ -513,12 +511,6 @@ mimicExtensions(Security::CertPointer & cert, Security::CertPointer const &mimic
     // because Squid does not generate valid fake CA certificates.
 
     return added;
-}
-
-SBuf
-Ssl::AsnToSBuf(const ASN1_STRING &buffer)
-{
-    return SBuf(reinterpret_cast<const char *>(buffer.data), buffer.length);
 }
 
 /// OpenSSL ASN1_STRING_to_UTF8() wrapper

--- a/src/ssl/gadgets.h
+++ b/src/ssl/gadgets.h
@@ -281,9 +281,6 @@ bool certificateMatchesProperties(X509 *peer_cert, CertificateProperties const &
 */
 const char *CommonHostName(X509 *x509);
 
-/// converts ASN1_STRING to SBuf
-SBuf AsnToSBuf(const ASN1_STRING &);
-
 /// interprets X.509 Subject or Issuer name entry (at the given position) as CN
 std::optional<AnyP::Host> ParseCommonNameAt(X509_NAME &, int);
 

--- a/src/ssl/support.cc
+++ b/src/ssl/support.cc
@@ -267,7 +267,7 @@ ParseSubjectAltName(const GENERAL_NAME &san)
         Assure(san.d.dNSName);
         // GEN_DNS is an IA5STRING. IA5STRING is a subset of ASCII that does not
         // need to be converted to UTF-8 (or some such) before we parse it.
-        const auto buffer = Ssl::AsnToSBuf(*san.d.dNSName);
+        const SBuf buffer(reinterpret_cast<const char *>(ASN1_STRING_get0_data(san.d.dNSName)), ASN1_STRING_length(san.d.dNSName));
         return AnyP::Host::ParseWildDomainName(buffer);
     }
 
@@ -277,23 +277,23 @@ ParseSubjectAltName(const GENERAL_NAME &san)
 
         // RFC 5280 section 4.2.1.6 signals IPv4/IPv6 address family using data length
 
-        if (san.d.iPAddress->length == 4) {
+        if (ASN1_STRING_length(san.d.iPAddress) == 4) {
             struct in_addr addr;
             static_assert(sizeof(addr.s_addr) == 4);
-            memcpy(&addr.s_addr, san.d.iPAddress->data, sizeof(addr.s_addr));
+            memcpy(&addr.s_addr, ASN1_STRING_get0_data(san.d.iPAddress), sizeof(addr.s_addr));
             const Ip::Address ip(addr);
             return AnyP::Host::ParseIp(ip);
         }
 
-        if (san.d.iPAddress->length == 16) {
+        if (ASN1_STRING_length(san.d.iPAddress) == 16) {
             struct in6_addr addr;
             static_assert(sizeof(addr.s6_addr) == 16);
-            memcpy(&addr.s6_addr, san.d.iPAddress->data, sizeof(addr.s6_addr));
+            memcpy(&addr.s6_addr, ASN1_STRING_get0_data(san.d.iPAddress), sizeof(addr.s6_addr));
             const Ip::Address ip(addr);
             return AnyP::Host::ParseIp(ip);
         }
 
-        debugs(83, 3, "unexpected length of an IP address SAN: " << san.d.iPAddress->length);
+        debugs(83, 3, "unexpected length of an IP address SAN: " << ASN1_STRING_length(san.d.iPAddress));
         return std::nullopt;
     }
 
@@ -1489,7 +1489,7 @@ void Ssl::InRamCertificateDbKey(const Ssl::CertificateProperties &certProperties
     if (certProperties.mimicCert) {
         if (auto *sig = Ssl::X509_get_signature(certProperties.mimicCert)) {
             origSignatureAsKey = true;
-            key.append((const char *)sig->data, sig->length);
+            key.append(reinterpret_cast<const char *>(ASN1_STRING_get0_data(sig)), ASN1_STRING_length(sig));
         }
     }
 


### PR DESCRIPTION
Direct access to struct asn1_string_st internals has been
deprecated since OpenSSL v1.0.

OpenSSL v4 removes struct asn1_string_st from public
availability. Leading to compile problem:

  error: invalid use of incomplete type ASN1_OCTET_STRING
  
Squid should be using the API for OpenSSL v1.1 and later.