### PR TITLE
Bug 5237: "make check" fails when ${TRUE} is a multicall binary

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -439,6 +439,7 @@ Thank you!
     Regents of the University of California (UCSD)
     Reinhard Posmyk <Reinhard.Posmyk@arxes.de>
     Reinhard Sojka <reinhard.sojka@parlament.gv.at>
+    Renan Rodrigo <rr@ubuntu.com>
     Rene Geile <rene.geile@t-online.de>
     Reuben Farrelly <reuben@reub.net>
     Ricardo Ferreira Ribeiro <garb12@pm.me>

--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -15,7 +15,7 @@ EXCLUDE_FROM_HDR_TESTING =
 # headers to test
 
 testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite/testHeader.cc.in
-	$(MAKE) $(^:.h=.hdrtest) && cp $(TRUE) $@
+	$(MAKE) $(^:.h=.hdrtest) && touch $@ && $(CHMOD) +x $@
 
 .h.hdrtest:
 	@SrcFilePath=`echo $< | $(SED) 's%^$(top_srcdir)/%%'`; \

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -150,7 +150,7 @@ squid-conf-tests: $(srcdir)/test-squid-conf.sh $(top_builddir)/src/squid.conf.de
 				sed s%$(srcdir)/squidconf/%% ; \
 		else break; fi; \
 	done; \
-	if test "$$failed" -eq 0; then cp $(TRUE) $@ ; else exit 1; fi
+	if test "$$failed" -eq 0; then touch $@ ; else exit 1; fi
 
 CLEANFILES += \
 	squid-conf-tests \


### PR DESCRIPTION
Authored-by: Renan Rodrigo <rr@ubuntu.com>

testHeaders copies the 'true' binary to a file named testHeaders relying
on the fact that GNU's true always exits 0. When 'true' implementation
is a multicall binary (e.g., in rust-coreutils and on Alpine Linux), it
cannot be called by other name. Create an empty executable file instead.

squid-conf-tests also copied the 'true' binary, but that Makefile target
is never executed and, hence, should not create an executable file.