### PR TITLE
Do not leak memory when reading FTP CWD responses

### DIFF
--- a/src/clients/FtpGateway.cc
+++ b/src/clients/FtpGateway.cc
@@ -1497,7 +1497,7 @@ ftpReadCwd(Ftp::Gateway * ftpState)
             ftpState->cwd_message.append('\n');
             ftpState->cwd_message.append(w->key);
         }
-        ftpState->ctrl.message = nullptr;
+        wordlistDestroy(&ftpState->ctrl.message);
 
         /* Continue to traverse the path */
         ftpTraverseDirectory(ftpState);


### PR DESCRIPTION
The bug affected a subset of HTTP transactions with `ftp://` URLs.
It was introduced in 2009 commit 0477a072.
