### PR TITLE
Re-fix parsing of legacy url_rewrite_program responses

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -439,6 +439,7 @@ Thank you!
     Regents of the University of California (UCSD)
     Reinhard Posmyk <Reinhard.Posmyk@arxes.de>
     Reinhard Sojka <reinhard.sojka@parlament.gv.at>
+    Renaud Metrich <renaud.metrich@gmail.com>
     Rene Geile <rene.geile@t-online.de>
     Reuben Farrelly <reuben@reub.net>
     Ricardo Ferreira Ribeiro <garb12@pm.me>

--- a/src/redirect.cc
+++ b/src/redirect.cc
@@ -110,8 +110,9 @@ redirectHandleReply(void *data, const Helper::Reply &reply)
             // parse it into status=, url= and rewrite-url= keys
             if (replySize) {
                 MemBuf replyBuffer;
-                replyBuffer.init(replySize, replySize);
-                replyBuffer.append(reply.other().content(), reply.other().contentSize());
+                replyBuffer.init(replySize + 1, replySize + 1); // with space for 0-terminator added by append()
+                Assure(replySize <= size_t(reply.other().contentSize()));
+                replyBuffer.append(reply.other().content(), replySize);
                 char * result = replyBuffer.content();
 
                 Helper::Reply newReply;


### PR DESCRIPTION
Legacy helper responses start with a URL instead of `OK rewrite_url=...`
and such. 2016 commit ddc77a2e introduced two bugs when handling legacy
responses:

* Response parsing code triggered MemBuf assertions when 0-terminating
  the parsing buffer for certain URLs. The bug affected legacy helper
  responses with and without space characters.

* Squid code attempted to accept/use helper-returned URLs with embedded
  space character(s), despite a WARNING implying that the post-space
  characters are not going to become a part of the new URL.

----

This change resurrects recent commit bb854bb9 that was accidentally
reverted by commit ec328cf16 during pull request merging by Anubis.

