### PR TITLE
Maintenance: Update OS version matrix for build tests

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -148,7 +148,6 @@ jobs:
         osversion:
           - "15.1"
           - "14.3"
-          - "13.5"
         platform:
           - amd64
           # We are ready to support multiple platforms, but

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -228,7 +228,7 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           usesh: true
-          release: "7.7"
+          release: "7.9"
           prepare: |
             pkg_add \
               autoconf%2.72 \

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       matrix:
         osversion:
-          # - "15.0" # build issues on 15.0 as of 2026-04. Let's wait for 15.1
+          - "15.1"
           - "14.3"
           - "13.5"
         platform:

--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -33,8 +33,8 @@ jobs:
           - debian-stable
           - debian-testing
           - debian-unstable
-          - fedora-42
           - fedora-43
+          - fedora-44
           - fedora-rawhide
           - gentoo
           - opensuse-leap
@@ -43,6 +43,7 @@ jobs:
           - ubuntu-jammy
           - ubuntu-noble
           - ubuntu-questing
+          - ubuntu-resolute
         compiler:
           - { CC: gcc, CXX: g++ }
           - { CC: clang, CXX: clang++ }


### PR DESCRIPTION
Update the oldest and/or the latest versions of Fedora, Ubuntu, FreeBSD,
and OpenBSD OS matrix used for "slow" build tests. No changes to OS
versions used for Coverity Scan "quick" PR tests.
