### PR TITLE
Fix support for test-suite/squidconf directive parameter files

### DIFF
--- a/test-suite/test-squid-conf.sh
+++ b/test-suite/test-squid-conf.sh
@@ -243,7 +243,11 @@ fi
 
 errorLog="squid-stderr.log"
 
-$sbindir/squid -k parse -f $configFile 2> $errorLog
+# Run in $configFile directory so that Squid can find files included by $configFile
+configFileDirName=`dirname $configFile`
+configFileBaseName=`basename $configFile`
+squidExeFile=`realpath $sbindir/squid`
+(cd $configFileDirName && $squidExeFile -k parse -f $configFileBaseName) 2> $errorLog
 result=$?
 
 # this is the value we return to our caller;

--- a/test-suite/test-squid-conf.sh
+++ b/test-suite/test-squid-conf.sh
@@ -243,11 +243,11 @@ fi
 
 errorLog="squid-stderr.log"
 
-# Run $squidExeFile from $configFile's directory, so that Squid can find files included by $configFile
+# Start `$sbindir/squid` from $configFile's directory, so that Squid can find files included by $configFile.
+# If we decide to support relative `$sbindir` paths, we will add a portable realpath replacement.
 configFileDirName=`dirname $configFile`
 configFileBaseName=`basename $configFile`
-squidExeFile=`realpath $sbindir/squid`
-(cd $configFileDirName && $squidExeFile -k parse -f $configFileBaseName) 2> $errorLog
+(cd $configFileDirName && $sbindir/squid -k parse -f $configFileBaseName) 2> $errorLog
 result=$?
 
 # this is the value we return to our caller;

--- a/test-suite/test-squid-conf.sh
+++ b/test-suite/test-squid-conf.sh
@@ -243,7 +243,7 @@ fi
 
 errorLog="squid-stderr.log"
 
-# Run in $configFile directory so that Squid can find files included by $configFile
+# Run $squidExeFile from $configFile's directory, so that Squid can find files included by $configFile
 configFileDirName=`dirname $configFile`
 configFileBaseName=`basename $configFile`
 squidExeFile=`realpath $sbindir/squid`


### PR DESCRIPTION
Those files were never found. 2022 commit d37a3744 probably missed this
bug because the corresponding `squid -k parse` failures (quoted below)
do not result in non-zero exit status code. That failure handling
problem deserves a dedicated fix.

    ERROR: Can not open file empty.conf for reading
        configuration context: ./squidconf/regressions-3.4.0.1.conf(27)

