### PR TITLE
Fix support for squidconf directive parameter files (#2458)

### DIFF
--- a/test-suite/test-squid-conf.sh
+++ b/test-suite/test-squid-conf.sh
@@ -243,7 +243,11 @@ fi
 
 errorLog="squid-stderr.log"
 
-$sbindir/squid -k parse -f $configFile 2> $errorLog
+# Start `$sbindir/squid` from $configFile's directory, so that Squid can find files included by $configFile.
+# If we decide to support relative `$sbindir` paths, we will add a portable realpath replacement.
+configFileDirName=`dirname $configFile`
+configFileBaseName=`basename $configFile`
+(cd $configFileDirName && $sbindir/squid -k parse -f $configFileBaseName) 2> $errorLog
 result=$?
 
 # this is the value we return to our caller;


### PR DESCRIPTION
Those files were never found. 2022 commit d37a3744 probably missed this
bug because the corresponding `squid -k parse` failures (quoted below)
do not result in non-zero exit status code. That failure handling
problem deserves a dedicated fix.

    ERROR: Can not open file empty.conf for reading
        configuration context: ./squidconf/regressions-3.4.0.1.conf(27)