### PR TITLE
Handle even more Content-Range responses

### DIFF
--- a/src/HttpHdrContRange.cc
+++ b/src/HttpHdrContRange.cc
@@ -88,6 +88,11 @@ httpHdrRangeRespSpecParseInit(HttpHdrRangeSpec * spec, const char *field, int fl
         return 0;
     }
 
+    if (last_pos == std::numeric_limits<decltype(last_pos)>::max()) {
+        debugs(68, 2, "unsupported huge last-byte-pos resp-range-spec near:  '" << field << "'");
+        return 0;
+    }
+
     spec->length = size_diff(last_pos + 1, spec->offset);
 
     /* we managed to parse, check if the result makes sense */

--- a/src/HttpHdrContRange.cc
+++ b/src/HttpHdrContRange.cc
@@ -201,7 +201,7 @@ httpHdrContRangeParseInit(HttpHdrContRange * range, const char *str)
         return 0;
     }
 
-    if (range->elength < (range->spec.offset + range->spec.length)) {
+    if (known_spec(range->elength) && range->elength < (range->spec.offset + range->spec.length)) {
         debugs(68, 2, "invalid (range is outside entity-length) content-range-spec near: '" << str << "'");
         return 0;
     }

--- a/src/HttpHdrContRange.cc
+++ b/src/HttpHdrContRange.cc
@@ -16,6 +16,7 @@
 #include "HttpHeaderTools.h"
 
 #include <limits>
+
 /*
  *    Currently only byte ranges are supported
  *
@@ -185,11 +186,11 @@ httpHdrContRangeParseInit(HttpHdrContRange * range, const char *str)
         return 0;
     }
 
-    // We increase offset by the size of various objects/buffers (e.g., Store
-    // metadata, serialized HTTP headers, mem_node::data, and Store I/O buffer).
-    // Those increases do not check for overflows yet, so limit the offset here
-    // while assuming that none of those sizes would ever exceed maximumSize.
-    // We further assume that most offsets use int64_t or a larger type.
+    // Store I/O adds partial content offsets to the size of various objects and
+    // buffers (e.g., Store metadata, serialized HTTP headers, mem_node::data,
+    // and Store I/O buffer). Most such sums do not check for overflows, so we
+    // check here while assuming that those sizes cannot exceed maximumSize. We
+    // further assume that most offsets use int64_t or a larger integer type.
     static_assert(std::numeric_limits<decltype(range->spec.offset)>::max() >= std::numeric_limits<int64_t>::max());
     const auto maximumSize = int64_t(1024)*1024*1024*1024; // no in-memory Squid object/buffer size can exceed 1 TiB
     const auto maximumOffset = std::numeric_limits<int64_t>::max() - maximumSize;

--- a/src/HttpHdrContRange.cc
+++ b/src/HttpHdrContRange.cc
@@ -15,6 +15,7 @@
 #include "HttpHdrContRange.h"
 #include "HttpHeaderTools.h"
 
+#include <limits>
 /*
  *    Currently only byte ranges are supported
  *
@@ -181,6 +182,19 @@ httpHdrContRangeParseInit(HttpHdrContRange * range, const char *str)
     // reject unsatisfied-range and such; we only use well-defined ranges today
     if (!known_spec(range->spec.offset) || !known_spec(range->spec.length)) {
         debugs(68, 2, "unwanted content-range-spec near: '" << str << "'");
+        return 0;
+    }
+
+    // We increase offset by the size of various objects/buffers (e.g., Store
+    // metadata, serialized HTTP headers, mem_node::data, and Store I/O buffer).
+    // Those increases do not check for overflows yet, so limit the offset here
+    // while assuming that none of those sizes would ever exceed maximumSize.
+    // We further assume that most offsets use int64_t or a larger type.
+    static_assert(std::numeric_limits<decltype(range->spec.offset)>::max() >= std::numeric_limits<int64_t>::max());
+    const auto maximumSize = int64_t(1024)*1024*1024*1024; // no in-memory Squid object/buffer size can exceed 1 TiB
+    const auto maximumOffset = std::numeric_limits<int64_t>::max() - maximumSize;
+    if (range->spec.length > maximumOffset || range->spec.offset > maximumOffset - range->spec.length) {
+        debugs(68, 2, "huge content-range-spec near: '" << str << "'");
         return 0;
     }
 

--- a/src/HttpHdrContRange.cc
+++ b/src/HttpHdrContRange.cc
@@ -175,9 +175,6 @@ httpHdrContRangeParseInit(HttpHdrContRange * range, const char *str)
         /* Additional paranoidal check for BUG2155 - entity-length MUST be > 0 */
         debugs(68, 2, "invalid (entity-length is negative) content-range-spec near: '" << str << "'");
         return 0;
-    } else if (known_spec(range->spec.length) && range->elength < (range->spec.offset + range->spec.length)) {
-        debugs(68, 2, "invalid (range is outside entity-length) content-range-spec near: '" << str << "'");
-        return 0;
     }
 
     // reject unsatisfied-range and such; we only use well-defined ranges today
@@ -196,6 +193,11 @@ httpHdrContRangeParseInit(HttpHdrContRange * range, const char *str)
     const auto maximumOffset = std::numeric_limits<int64_t>::max() - maximumSize;
     if (range->spec.length > maximumOffset || range->spec.offset > maximumOffset - range->spec.length) {
         debugs(68, 2, "huge content-range-spec near: '" << str << "'");
+        return 0;
+    }
+
+    if (range->elength < (range->spec.offset + range->spec.length)) {
+        debugs(68, 2, "invalid (range is outside entity-length) content-range-spec near: '" << str << "'");
         return 0;
     }
 

--- a/src/HttpHdrRange.cc
+++ b/src/HttpHdrRange.cc
@@ -96,6 +96,11 @@ HttpHdrRangeSpec::parseInit(const char *field, int flen)
                     return false;
                 }
 
+                if (last_pos == std::numeric_limits<decltype(last_pos)>::max()) {
+                    debugs(64, 2, "unsupported huge last-byte-pos range-spec near: " << field);
+                    return false;
+                }
+
                 HttpHdrRangeSpec::HttpRange aSpec (offset, last_pos + 1);
 
                 length = aSpec.size();

--- a/src/stmem.cc
+++ b/src/stmem.cc
@@ -13,6 +13,7 @@
 #include "HttpReply.h"
 #include "mem_node.h"
 #include "MemObject.h"
+#include "SquidMath.h"
 #include "stmem.h"
 
 /*
@@ -311,7 +312,7 @@ mem_hdr::write (StoreIOBuffer const &writeBuffer)
         return false;
     }
 
-    assert (writeBuffer.offset >= 0);
+    Assure(IncreaseSum(writeBuffer.offset, writeBuffer.length));
 
     mem_node *target;
     int64_t currentOffset = writeBuffer.offset;
@@ -323,7 +324,6 @@ mem_hdr::write (StoreIOBuffer const &writeBuffer)
         assert (wrote);
         Assure(len >= wrote);
         len -= wrote;
-        Assure(currentOffset <= std::numeric_limits<decltype(currentOffset)>::max() - static_cast<decltype(currentOffset)>(wrote));
         currentOffset += wrote;
         currentSource += wrote;
     }

--- a/src/stmem.cc
+++ b/src/stmem.cc
@@ -321,7 +321,9 @@ mem_hdr::write (StoreIOBuffer const &writeBuffer)
     while (len && (target = nodeToRecieve(currentOffset))) {
         size_t wrote = writeAvailable(target, currentOffset, len, currentSource);
         assert (wrote);
+        Assure(len >= wrote);
         len -= wrote;
+        Assure(currentOffset <= std::numeric_limits<decltype(currentOffset)>::max() - static_cast<decltype(currentOffset)>(wrote));
         currentOffset += wrote;
         currentSource += wrote;
     }


### PR DESCRIPTION
This workaround continues the work started in 2021 commits 8af775ed and
7024fb73. A comprehensive long-term fix requires backlogged Client
Streams removal followed by noisy changes replacing raw integers with a
smart Offset class in StoreIOBuffer, HttpHdrRangeSpec, HttpHdrContRange,
ClientHttpRequest::Out, and similar offset-tracking APIs.

Also improved handling of Range and Request-Range request headers.

