### PR TITLE
Extend "make V=0" support to custom commands

### DIFF
--- a/doc/manuals/Substitute.am
+++ b/doc/manuals/Substitute.am
@@ -8,7 +8,7 @@
 ## DEFAULT_MIME_TABLE      = $(sysconfdir)/mime.conf
 ## DEFAULT_ERROR_DIR       = $(datadir)/errors
 
-SUBSTITUTE=sed "\
+SUBSTITUTE=$(SED) "\
 	s%@DEFAULT_ERROR_DIR@%$(DEFAULT_ERROR_DIR)%g;\
 	s%@DEFAULT_MIME_TABLE@%$(DEFAULT_MIME_TABLE)%g;\
 	s%@DEFAULT_SSL_CRTD@%$(DEFAULT_SSL_CRTD)%g;\

--- a/doc/manuals/Substitute.am
+++ b/doc/manuals/Substitute.am
@@ -8,7 +8,7 @@
 ## DEFAULT_MIME_TABLE      = $(sysconfdir)/mime.conf
 ## DEFAULT_ERROR_DIR       = $(datadir)/errors
 
-SUBSTITUTE=$(SED) "\
+SUBSTITUTE=sed "\
 	s%@DEFAULT_ERROR_DIR@%$(DEFAULT_ERROR_DIR)%g;\
 	s%@DEFAULT_MIME_TABLE@%$(DEFAULT_MIME_TABLE)%g;\
 	s%@DEFAULT_SSL_CRTD@%$(DEFAULT_SSL_CRTD)%g;\

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -59,13 +59,12 @@ NOTIDY=`$(PO2HTML) --help | grep -o "[-]-notidy"`
 	@if test "$(PO2HTML)" != "" && test "$(PO2HTML)" != "no" && test "$(PO2HTML)" != "off" && test -f $(top_srcdir)/errors/en.po; then \
 	    lang=$(@:.lang=); \
 	    mkdir -p $(top_builddir)/errors/$$lang; \
-	    echo "Translating $$lang ..."; \
+	    $(AM_V_GEN) "Translating $$lang"; \
 	    for f in $(ERROR_TEMPLATES); do \
 		page=`basename $$f`; \
 		$(PO2HTML) $(NOTIDY) --progress=none -i $(top_srcdir)/errors/$$lang.po -t $(top_srcdir)/errors/$$f >$(top_builddir)/errors/$$lang/$$page || exit 1; \
 	    done; \
 	    cp $(top_srcdir)/errors/templates/error-details.txt $(top_builddir)/errors/$$lang/error-details.txt || exit 1; \
-	    echo "Done translating $$lang"; \
 	else \
 	    lang=$(@:.lang=); \
 		echo "Translation of $$lang disabled"; \

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -41,7 +41,7 @@ all: all-am
 translate: translate-warn $(TRANSLATE_LANGUAGES)
 
 translate-warn:
-	case "$(PO2HTML)" in \
+	@case "$(PO2HTML)" in \
 	off) \
 	    echo "WARNING: Translation is disabled."; \
 	    ;; \

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -65,7 +65,7 @@ NOTIDY=`$(PO2HTML) --help | grep -o "[-]-notidy"`
 		$(PO2HTML) $(NOTIDY) --progress=none -i $(top_srcdir)/errors/$$lang.po -t $(top_srcdir)/errors/$$f >$(top_builddir)/errors/$$lang/$$page || exit 1; \
 	    done; \
 	    cp $(top_srcdir)/errors/templates/error-details.txt $(top_builddir)/errors/$$lang/error-details.txt || exit 1; \
-	else \
+	else \ 
 	    lang=$(@:.lang=); \
 		echo "Translation of $$lang disabled"; \
 	fi; \

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -59,7 +59,7 @@ NOTIDY=`$(PO2HTML) --help | grep -o "[-]-notidy"`
 	@if test "$(PO2HTML)" != "" && test "$(PO2HTML)" != "no" && test "$(PO2HTML)" != "off" && test -f $(top_srcdir)/errors/en.po; then \
 	    lang=$(@:.lang=); \
 	    mkdir -p $(top_builddir)/errors/$$lang; \
-	    $(AM_V_GEN) "Translating $$lang"; \
+	    $(AM_V_P) && echo "Translating $$lang"; \
 	    for f in $(ERROR_TEMPLATES); do \
 		page=`basename $$f`; \
 		$(PO2HTML) $(NOTIDY) --progress=none -i $(top_srcdir)/errors/$$lang.po -t $(top_srcdir)/errors/$$f >$(top_builddir)/errors/$$lang/$$page || exit 1; \

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -65,7 +65,7 @@ NOTIDY=`$(PO2HTML) --help | grep -o "[-]-notidy"`
 		$(PO2HTML) $(NOTIDY) --progress=none -i $(top_srcdir)/errors/$$lang.po -t $(top_srcdir)/errors/$$f >$(top_builddir)/errors/$$lang/$$page || exit 1; \
 	    done; \
 	    cp $(top_srcdir)/errors/templates/error-details.txt $(top_builddir)/errors/$$lang/error-details.txt || exit 1; \
-	else \ 
+	else \
 	    lang=$(@:.lang=); \
 		echo "Translation of $$lang disabled"; \
 	fi; \

--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -72,16 +72,16 @@ NOTIDY=`$(PO2HTML) --help | grep -o "[-]-notidy"`
 	touch $@
 
 install-exec-local: translate
-	if test -f $(DESTDIR)$(DEFAULT_STYLESHEET) ; then \
+	$(AM_V_at)if test -f $(DESTDIR)$(DEFAULT_STYLESHEET) ; then \
 		echo "$@ will not overwrite existing $(DESTDIR)$(DEFAULT_STYLESHEET)" ; \
 	else \
 		$(mkinstalldirs) $(DESTDIR)`dirname $(DEFAULT_STYLESHEET)` ; \
-		echo "$(INSTALL_DATA) $(srcdir)/errorpage.css $(DESTDIR)$(DEFAULT_STYLESHEET)"; \
+		$(AM_V_P) && echo "$(INSTALL_DATA) $(srcdir)/errorpage.css $(DESTDIR)$(DEFAULT_STYLESHEET)"; \
 		$(INSTALL_DATA) $(srcdir)/errorpage.css $(DESTDIR)$(DEFAULT_STYLESHEET); \
 	fi
 
 install-data-local: translate
-	$(mkinstalldirs) $(DESTDIR)$(DEFAULT_ERROR_DIR) ; \
+	$(AM_V_at)$(mkinstalldirs) $(DESTDIR)$(DEFAULT_ERROR_DIR) ; \
 	for l in $(TRANSLATE_LANGUAGES) templates; do \
 	    l=`basename $$l .lang`; \
 	    echo "Located $$l for install..."; \
@@ -91,11 +91,11 @@ install-data-local: translate
 	    for f in $(ERROR_TEMPLATES) templates/error-details.txt; do \
 		page=`basename $$f`; \
 		if test -f $(builddir)/$$l/$$page; then \
-		    echo "$(INSTALL_DATA) $(builddir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l"; \
-			    $(INSTALL_DATA) $(builddir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l; \
+		    $(AM_V_P) && echo "$(INSTALL_DATA) $(builddir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l"; \
+			$(INSTALL_DATA) $(builddir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l; \
 		elif test -f $(srcdir)/$$l/$$page; then \
-		    echo "$(INSTALL_DATA) $(srcdir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l"; \
-			    $(INSTALL_DATA) $(srcdir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l; \
+		    $(AM_V_P) && echo "$(INSTALL_DATA) $(srcdir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l"; \
+			$(INSTALL_DATA) $(srcdir)/$$l/$$page $(DESTDIR)$(DEFAULT_ERROR_DIR)/$$l; \
 		fi; \
 	    done; \
 	done; \
@@ -105,7 +105,7 @@ install-data-local: translate
 	$(ALIAS_LINKER) "$(srcdir)/aliases" || exit 1 ;
 
 uninstall-local:
-	for l in $(TRANSLATE_LANGUAGES) templates; do \
+	$(AM_V_at)for l in $(TRANSLATE_LANGUAGES) templates; do \
 	  l=`basename $$l .lang`; \
 	  echo "Located $$l for uninstall ..."; \
 	  if test -d $(srcdir)/$$l; then \

--- a/src/Common.am
+++ b/src/Common.am
@@ -67,6 +67,6 @@ $(OBJS): $(top_srcdir)/include/version.h $(top_builddir)/include/autoconf.h
 COMPAT_LIB = $(top_builddir)/compat/libcompatsquid.la $(LIBPROFILER)
 
 ## Some helpers are written in Perl and need the local shell defined properly
-subst_perlshell = $(SED) -e 's,[@]PERL[@],$(PERL),g' <$(srcdir)/$@.pl.in >$@ || ($(RM) -f $@ ; exit 1)
+subst_perlshell = sed -e 's,[@]PERL[@],$(PERL),g' <$(srcdir)/$@.pl.in >$@ || ($(RM) -f $@ ; exit 1)
 
 include $(top_srcdir)/src/TestHeaders.am

--- a/src/Common.am
+++ b/src/Common.am
@@ -67,6 +67,6 @@ $(OBJS): $(top_srcdir)/include/version.h $(top_builddir)/include/autoconf.h
 COMPAT_LIB = $(top_builddir)/compat/libcompatsquid.la $(LIBPROFILER)
 
 ## Some helpers are written in Perl and need the local shell defined properly
-subst_perlshell = sed -e 's,[@]PERL[@],$(PERL),g' <$(srcdir)/$@.pl.in >$@ || ($(RM) -f $@ ; exit 1)
+subst_perlshell = $(SED) -e 's,[@]PERL[@],$(PERL),g' <$(srcdir)/$@.pl.in >$@ || ($(RM) -f $@ ; exit 1)
 
 include $(top_srcdir)/src/TestHeaders.am

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -623,14 +623,9 @@ test_cache_digest: test_cache_digest.o CacheDigest.o debug.o globals.o store_key
 ## If autodependency works well this is not needed anymore
 cache_cf.o: cf_parser.cci
 
-AM_V_BUILDCXX = $(am__v_BUILDCXX_$(V))
-am__v_BUILDCXX_ = $(am__v_BUILDCXX_$(AM_DEFAULT_VERBOSITY))
-am__v_BUILDCXX_0 = @echo "  BUILDCXX" $@;
-am__v_BUILDCXX_1 =
-
 # cf_gen builds the configuration files.
 cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
-	$(AM_V_BUILDCXX) $(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
+	$(AM_V_GEN) $(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
 
 # squid.conf.default is built by cf_gen when making cf_parser.cci
 squid.conf.default squid.conf.documented: cf_parser.cci

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -674,7 +674,7 @@ repl_modules.cc: repl_modules.sh Makefile
 include $(top_srcdir)/doc/manuals/Substitute.am
 
 squid.8: $(srcdir)/squid.8.in Makefile
-	$(AC_V_GEN) $(SUBSTITUTE) < $(srcdir)/squid.8.in > $@
+	$(AM_V_GEN) $(SUBSTITUTE) < $(srcdir)/squid.8.in > $@
 
 man_MANS = squid.8
 EXTRA_DIST += squid.8.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -618,7 +618,7 @@ swap_log_op.cc: swap_log_op.h mk-string-arrays.awk
 ## other generated files...
 
 test_cache_digest: test_cache_digest.o CacheDigest.o debug.o globals.o store_key_md5.o
-	$(AM_V_C) $(CC) -o $@ $(LDFLAGS) $@.o CacheDigest.o debug.o globals.o store_key_md5.o $(STD_APP_LIBS)
+	$(AM_V_CC) $(CC) -o $@ $(LDFLAGS) $@.o CacheDigest.o debug.o globals.o store_key_md5.o $(STD_APP_LIBS)
 
 ## If autodependency works well this is not needed anymore
 cache_cf.o: cf_parser.cci

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -684,18 +684,18 @@ install-data-local: install-sysconfDATA install-dataDATA
 	@if test -f $(DESTDIR)$(DEFAULT_MIME_TABLE) ; then \
 	  echo "$@ will not overwrite existing $(DESTDIR)$(DEFAULT_MIME_TABLE)" ; \
 	else \
-	  echo "$(INSTALL_DATA) $(srcdir)/mime.conf.default $(DESTDIR)$(DEFAULT_MIME_TABLE)" ;\
+	  $(AM_V_P) && echo "$(INSTALL_DATA) $(srcdir)/mime.conf.default $(DESTDIR)$(DEFAULT_MIME_TABLE)" ;\
 	  $(INSTALL_DATA) $(srcdir)/mime.conf.default $(DESTDIR)$(DEFAULT_MIME_TABLE); \
 	fi
 	@if test -f $(DESTDIR)$(DEFAULT_CONFIG_FILE) ; then \
 	  echo "$@ will not overwrite existing $(DESTDIR)$(DEFAULT_CONFIG_FILE)" ; \
 	else \
-	  echo "$(INSTALL_DATA) squid.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
+	  $(AM_V_P) && echo "$(INSTALL_DATA) squid.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
 	  $(INSTALL_DATA) squid.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE); \
 	fi
-	echo "$(INSTALL_DATA) squid.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE).default"; \
+	$(AM_V_P) && echo "$(INSTALL_DATA) squid.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE).default"; \
 	$(INSTALL_DATA) squid.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE).default; \
-	echo "$(INSTALL_DATA) squid.conf.documented $(DESTDIR)$(DEFAULT_CONFIG_FILE).documented"; \
+	$(AM_V_P) && echo "$(INSTALL_DATA) squid.conf.documented $(DESTDIR)$(DEFAULT_CONFIG_FILE).documented"; \
 	$(INSTALL_DATA) squid.conf.documented $(DESTDIR)$(DEFAULT_CONFIG_FILE).documented; \
 	$(mkinstalldirs) $(DESTDIR)$(DEFAULT_LOG_PREFIX); \
 	$(mkinstalldirs) $(DESTDIR)$(DEFAULT_SWAP_DIR); \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -674,7 +674,7 @@ repl_modules.cc: repl_modules.sh Makefile
 include $(top_srcdir)/doc/manuals/Substitute.am
 
 squid.8: $(srcdir)/squid.8.in Makefile
-	$(SUBSTITUTE) < $(srcdir)/squid.8.in > $@
+	$(AC_V_at)$(SUBSTITUTE) < $(srcdir)/squid.8.in > $@
 
 man_MANS = squid.8
 EXTRA_DIST += squid.8.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -618,32 +618,32 @@ swap_log_op.cc: swap_log_op.h mk-string-arrays.awk
 ## other generated files...
 
 test_cache_digest: test_cache_digest.o CacheDigest.o debug.o globals.o store_key_md5.o
-	$(CC) -o $@ $(LDFLAGS) $@.o CacheDigest.o debug.o globals.o store_key_md5.o $(STD_APP_LIBS)
+	$(AM_V_C) $(CC) -o $@ $(LDFLAGS) $@.o CacheDigest.o debug.o globals.o store_key_md5.o $(STD_APP_LIBS)
 
 ## If autodependency works well this is not needed anymore
 cache_cf.o: cf_parser.cci
 
 # cf_gen builds the configuration files.
 cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
-	$(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
+	$(AM_V_CXX) $(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
 
 # squid.conf.default is built by cf_gen when making cf_parser.cci
 squid.conf.default squid.conf.documented: cf_parser.cci
 	true
 
 cf_parser.cci: cf.data cf_gen$(EXEEXT)
-	./cf_gen$(EXEEXT) cf.data $(srcdir)/cf.data.depend
+	$(AM_V_GEN) ./cf_gen$(EXEEXT) cf.data $(srcdir)/cf.data.depend
 
 # The cf_gen_defines.cci is auto-generated and does not exist when the
 # dependencies computed. We need to add its include files (autoconf.h) here
 cf_gen_defines.cci: $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre $(top_builddir)/include/autoconf.h
-	$(AM_V_GEN)$(AWK) -f $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre >$@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre >$@ || ($(RM) -f $@ && exit 1)
 
 
 ## TODO: generate a sed command file from configure. Then this doesn't
 ## depend on the Makefile.
 cf.data: cf.data.pre Makefile
-	sed \
+	$(AM_V_GEN) $(SED) \
 	-e "s%[@]DEFAULT_HTTP_PORT[@]%$(DEFAULT_HTTP_PORT)%g" \
 	-e "s%[@]DEFAULT_CACHE_EFFECTIVE_USER[@]%$(CACHE_EFFECTIVE_USER)%g" \
 	-e "s%[@]DEFAULT_MIME_TABLE[@]%$(DEFAULT_MIME_TABLE)%g" \
@@ -669,12 +669,12 @@ cf.data: cf.data.pre Makefile
 	< $(srcdir)/cf.data.pre >$@
 
 repl_modules.cc: repl_modules.sh Makefile
-	$(AM_V_GEN)$(SHELL) $(srcdir)/repl_modules.sh $(REPL_POLICIES) > repl_modules.cc
+	$(AM_V_GEN) $(SHELL) $(srcdir)/repl_modules.sh $(REPL_POLICIES) > repl_modules.cc
 
 include $(top_srcdir)/doc/manuals/Substitute.am
 
 squid.8: $(srcdir)/squid.8.in Makefile
-	$(AC_V_at)$(SUBSTITUTE) < $(srcdir)/squid.8.in > $@
+	$(AC_V_GEN) $(SUBSTITUTE) < $(srcdir)/squid.8.in > $@
 
 man_MANS = squid.8
 EXTRA_DIST += squid.8.in
@@ -712,7 +712,7 @@ CLEANFILES += cf.data squid.conf.default squid.conf.documented \
 	test_tools.cc *.a
 
 test_tools.cc: $(top_srcdir)/test-suite/test_tools.cc
-	cp $(top_srcdir)/test-suite/test_tools.cc .
+	$(AM_V_GEN) cp $(top_srcdir)/test-suite/test_tools.cc .
 
 # stock tools for unit tests - library independent versions of dlink_list
 # etc.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -599,20 +599,20 @@ EXTRA_DIST = \
 snmp_core.o snmp_agent.o: ../lib/snmplib/libsnmplib.la $(top_srcdir)/include/cache_snmp.h
 
 globals.cc: globals.h mk-globals-c.awk
-	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-globals-c.awk < $(srcdir)/globals.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(srcdir)/mk-globals-c.awk < $(srcdir)/globals.h > $@ || ($(RM) -f $@ && exit 1)
 
 ## Generate files containing string arrays for various enums....
 hier_code.cc: hier_code.h mk-string-arrays.awk
-	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/hier_code.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/hier_code.h > $@ || ($(RM) -f $@ && exit 1)
 
 lookup_t.cc: lookup_t.h mk-string-arrays.awk
-	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/lookup_t.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/lookup_t.h > $@ || ($(RM) -f $@ && exit 1)
 
 icp_opcode.cc: icp_opcode.h mk-string-arrays.awk
-	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/icp_opcode.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/icp_opcode.h > $@ || ($(RM) -f $@ && exit 1)
 
 swap_log_op.cc: swap_log_op.h mk-string-arrays.awk
-	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/swap_log_op.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/swap_log_op.h > $@ || ($(RM) -f $@ && exit 1)
 
 
 ## other generated files...

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -599,20 +599,20 @@ EXTRA_DIST = \
 snmp_core.o snmp_agent.o: ../lib/snmplib/libsnmplib.la $(top_srcdir)/include/cache_snmp.h
 
 globals.cc: globals.h mk-globals-c.awk
-	$(AWK) -f $(srcdir)/mk-globals-c.awk < $(srcdir)/globals.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-globals-c.awk < $(srcdir)/globals.h > $@ || ($(RM) -f $@ && exit 1)
 
 ## Generate files containing string arrays for various enums....
 hier_code.cc: hier_code.h mk-string-arrays.awk
-	$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/hier_code.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/hier_code.h > $@ || ($(RM) -f $@ && exit 1)
 
 lookup_t.cc: lookup_t.h mk-string-arrays.awk
-	$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/lookup_t.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/lookup_t.h > $@ || ($(RM) -f $@ && exit 1)
 
 icp_opcode.cc: icp_opcode.h mk-string-arrays.awk
-	$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/icp_opcode.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/icp_opcode.h > $@ || ($(RM) -f $@ && exit 1)
 
 swap_log_op.cc: swap_log_op.h mk-string-arrays.awk
-	$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/swap_log_op.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN)$(AWK) -f $(srcdir)/mk-string-arrays.awk < $(srcdir)/swap_log_op.h > $@ || ($(RM) -f $@ && exit 1)
 
 
 ## other generated files...
@@ -637,7 +637,7 @@ cf_parser.cci: cf.data cf_gen$(EXEEXT)
 # The cf_gen_defines.cci is auto-generated and does not exist when the
 # dependencies computed. We need to add its include files (autoconf.h) here
 cf_gen_defines.cci: $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre $(top_builddir)/include/autoconf.h
-	$(AWK) -f $(srcdir)/cf_gen_defines <$(srcdir)/cf.data.pre >$@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN)$(AWK) -f $(srcdir)/cf_gen_defines $(srcdir)/cf.data.pre >$@ || ($(RM) -f $@ && exit 1)
 
 
 ## TODO: generate a sed command file from configure. Then this doesn't
@@ -669,7 +669,7 @@ cf.data: cf.data.pre Makefile
 	< $(srcdir)/cf.data.pre >$@
 
 repl_modules.cc: repl_modules.sh Makefile
-	$(SHELL) $(srcdir)/repl_modules.sh $(REPL_POLICIES) > repl_modules.cc
+	$(AM_V_GEN)$(SHELL) $(srcdir)/repl_modules.sh $(REPL_POLICIES) > repl_modules.cc
 
 include $(top_srcdir)/doc/manuals/Substitute.am
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -623,9 +623,14 @@ test_cache_digest: test_cache_digest.o CacheDigest.o debug.o globals.o store_key
 ## If autodependency works well this is not needed anymore
 cache_cf.o: cf_parser.cci
 
+AM_V_BUILDCXX = $(am__v_BUILDCXX_$(V))
+am__v_BUILDCXX_ = $(am__v_BUILDCXX_$(AM_DEFAULT_VERBOSITY))
+am__v_BUILDCXX_0 = @echo "  BUILDCXX" $@;
+am__v_BUILDCXX_1 =
+
 # cf_gen builds the configuration files.
 cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
-	$(AM_V_CXX) $(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
+	$(AM_V_BUILDCXX) $(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
 
 # squid.conf.default is built by cf_gen when making cf_parser.cci
 squid.conf.default squid.conf.documented: cf_parser.cci

--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -15,7 +15,7 @@ EXCLUDE_FROM_HDR_TESTING =
 # headers to test
 
 testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite/testHeader.cc.in
-	$(MAKE) $(^:.h=.hdrtest) && touch $@ && $(CHMOD) +x $@
+	$(MAKE) $(filter %.hdrtest,$(^:.h=.hdrtest)) && touch $@ && $(CHMOD) +x $@
 
 .h.hdrtest:
 	@SrcFilePath=`echo $< | $(SED) 's%^$(top_srcdir)/%%'`; \
@@ -26,7 +26,7 @@ testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite
 		exit 0; \
 	fi; \
 	$(SED) "s%[@]HEADER[@]%${<}%" "$(top_srcdir)/test-suite/testHeader.cc.in" >"$$TargetFileName.cc" && \
-	echo "$(CXXCOMPILE) -c -o" "$$TargetFileName" "$$TargetFileName.cc" && \
+	if test "$(V)" != "0" ; then echo "$(CXXCOMPILE) -c -o" "$$TargetFileName" "$$TargetFileName.cc" ; fi && \
 	if $(CXXCOMPILE) -c -o "$$TargetFileName" "$$TargetFileName.cc" ; \
 		then echo "header-test: ok - $$SrcFilePath"; $(RM) "$$TargetFileName.cc" "$$TargetFileName"; \
 		else echo "header-test: not ok - $$SrcFilePath"; exit 1; fi

--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -15,7 +15,8 @@ EXCLUDE_FROM_HDR_TESTING =
 # headers to test
 
 testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite/testHeader.cc.in
-	$(MAKE) $(filter %.hdrtest,$(^:.h=.hdrtest)) && touch $@ && $(CHMOD) +x $@
+	$(AM_V_at)$(MAKE) `echo $(^:.h=.hdrtest) | $(AWK) '{for(i=1;i<=NF;i++) if($$i ~ /\.hdrtest/) printf "%s ", $$i}'` \
+		&& touch $@ && $(CHMOD) +x $@
 
 .h.hdrtest:
 	@SrcFilePath=`echo $< | $(SED) 's%^$(top_srcdir)/%%'`; \
@@ -26,7 +27,7 @@ testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite
 		exit 0; \
 	fi; \
 	$(SED) "s%[@]HEADER[@]%${<}%" "$(top_srcdir)/test-suite/testHeader.cc.in" >"$$TargetFileName.cc" && \
-	if test "$(V)" != "0" ; then echo "$(CXXCOMPILE) -c -o" "$$TargetFileName" "$$TargetFileName.cc" ; fi && \
+	if $(AM_V_P) ; then echo "$(CXXCOMPILE) -c -o" "$$TargetFileName" "$$TargetFileName.cc" ; fi && \
 	if $(CXXCOMPILE) -c -o "$$TargetFileName" "$$TargetFileName.cc" ; \
 		then echo "header-test: ok - $$SrcFilePath"; $(RM) "$$TargetFileName.cc" "$$TargetFileName"; \
 		else echo "header-test: not ok - $$SrcFilePath"; exit 1; fi

--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -15,7 +15,7 @@ EXCLUDE_FROM_HDR_TESTING =
 # headers to test
 
 testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite/testHeader.cc.in
-	$(AM_V_at)$(MAKE) `echo $(^:.h=.hdrtest) | $(AWK) '{for(i=1;i<=NF;i++) if($$i ~ /\.hdrtest/) printf "%s ", $$i}'` \
+	$(AM_V_at)$(MAKE) `echo $(^:.h=.hdrtest) | $(AWK) '{for(i=1;i<=NF;i++) if($$i ~ /\.hdrtest$$/) printf "%s ", $$i}'` \
 		&& touch $@ && $(CHMOD) +x $@
 
 .h.hdrtest:

--- a/src/acl/external/SQL_session/Makefile.am
+++ b/src/acl/external/SQL_session/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	required.m4
 
 ext_sql_session_acl: ext_sql_session_acl.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = ext_sql_session_acl.8
@@ -22,6 +22,6 @@ CLEANFILES += ext_sql_session_acl.8
 EXTRA_DIST += ext_sql_session_acl.8
 
 ext_sql_session_acl.8: ext_sql_session_acl
-	pod2man --section=8 ext_sql_session_acl ext_sql_session_acl.8
+	$(AM_V_GEN) pod2man --section=8 ext_sql_session_acl ext_sql_session_acl.8
 
 endif

--- a/src/acl/external/delayer/Makefile.am
+++ b/src/acl/external/delayer/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	ext_delayer_acl.pl.in
 
 ext_delayer_acl: ext_delayer_acl.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = ext_delayer_acl.8
@@ -22,6 +22,6 @@ CLEANFILES += ext_delayer_acl.8
 EXTRA_DIST += ext_delayer_acl.8
 
 ext_delayer_acl.8: ext_delayer_acl
-	pod2man --section=8 ext_delayer_acl ext_delayer_acl.8
+	$(AM_V_GEN) pod2man --section=8 ext_delayer_acl ext_delayer_acl.8
 
 endif

--- a/src/acl/external/kerberos_sid_group/Makefile.am
+++ b/src/acl/external/kerberos_sid_group/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	required.m4
 
 ext_kerberos_sid_group_acl: ext_kerberos_sid_group_acl.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = ext_kerberos_sid_group_acl.8
@@ -22,7 +22,7 @@ CLEANFILES += ext_kerberos_sid_group_acl.8
 EXTRA_DIST += ext_kerberos_sid_group_acl.8
 
 ext_kerberos_sid_group_acl.8: ext_kerberos_sid_group_acl
-	pod2man --section=8 ext_kerberos_sid_group_acl ext_kerberos_sid_group_acl.8
+	$(AM_V_GEN) pod2man --section=8 ext_kerberos_sid_group_acl ext_kerberos_sid_group_acl.8
 
 endif
 

--- a/src/acl/external/wbinfo_group/Makefile.am
+++ b/src/acl/external/wbinfo_group/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	required.m4
 
 ext_wbinfo_group_acl: ext_wbinfo_group_acl.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = ext_wbinfo_group_acl.8
@@ -22,6 +22,6 @@ CLEANFILES += ext_wbinfo_group_acl.8
 EXTRA_DIST += ext_wbinfo_group_acl.8
 
 ext_wbinfo_group_acl.8: ext_wbinfo_group_acl
-	pod2man --section=8 ext_wbinfo_group_acl ext_wbinfo_group_acl.8
+	$(AM_V_GEN) pod2man --section=8 ext_wbinfo_group_acl ext_wbinfo_group_acl.8
 
 endif

--- a/src/anyp/Makefile.am
+++ b/src/anyp/Makefile.am
@@ -25,7 +25,7 @@ libanyp_la_SOURCES = \
 	forward.h
 
 ProtocolType.cc: ProtocolType.h $(top_srcdir)/src/mk-string-arrays.awk
-	$(AM_V_GEN) ($(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk $(srcdir)/ProtocolType.h |\
+	$(AM_V_GEN) ($(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk $(srcdir)/ProtocolType.h | \
 		$(SED) -e 's%PROTO_%%' >$@) || \
 		($(RM) -f $@ && exit 1)
 

--- a/src/anyp/Makefile.am
+++ b/src/anyp/Makefile.am
@@ -25,6 +25,8 @@ libanyp_la_SOURCES = \
 	forward.h
 
 ProtocolType.cc: ProtocolType.h $(top_srcdir)/src/mk-string-arrays.awk
-	$(AM_V_GEN) $(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk $(srcdir)/ProtocolType.h | $(SED) -e 's%PROTO_%%' >$@
+	$(AM_V_GEN) ($(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk $(srcdir)/ProtocolType.h |\
+		$(SED) -e 's%PROTO_%%' >$@) || \
+		($(RM) -f $@ && exit 1)
 
 CLEANFILES += ProtocolType.cc

--- a/src/anyp/Makefile.am
+++ b/src/anyp/Makefile.am
@@ -25,6 +25,6 @@ libanyp_la_SOURCES = \
 	forward.h
 
 ProtocolType.cc: ProtocolType.h $(top_srcdir)/src/mk-string-arrays.awk
-	($(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk <$(srcdir)/ProtocolType.h | sed -e 's%PROTO_%%' >$@) || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk $(srcdir)/ProtocolType.h | $(SED) -e 's%PROTO_%%' >$@
 
 CLEANFILES += ProtocolType.cc

--- a/src/auth/Makefile.am
+++ b/src/auth/Makefile.am
@@ -61,9 +61,9 @@ libacls_la_SOURCES = \
 	AuthAclState.h
 
 CredentialState.cc: CredentialState.h $(top_srcdir)/src/mk-string-arrays.awk
-	$(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk < $(srcdir)/CredentialState.h > $@ || (rm -f $@ ; exit 1)
+	$(AM_V_GEN) $(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk $(srcdir)/CredentialState.h > $@ || (rm -f $@ ; exit 1)
 
 Type.cc: Type.h $(top_srcdir)/src/mk-string-arrays.awk
-	$(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk < $(srcdir)/Type.h > $@ || (rm -f $@ ; exit 1)
+	$(AM_V_GEN) $(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk $(srcdir)/Type.h > $@ || (rm -f $@ ; exit 1)
 
 CLEANFILES += CredentialState.cc Type.cc

--- a/src/auth/basic/DB/Makefile.am
+++ b/src/auth/basic/DB/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	required.m4
 
 basic_db_auth: basic_db_auth.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = basic_db_auth.8
@@ -22,6 +22,6 @@ CLEANFILES += basic_db_auth.8
 EXTRA_DIST += basic_db_auth.8
 
 basic_db_auth.8: basic_db_auth
-	pod2man --section=8 basic_db_auth basic_db_auth.8
+	$(AM_V_GEN) pod2man --section=8 basic_db_auth basic_db_auth.8
 
 endif

--- a/src/auth/basic/POP3/Makefile.am
+++ b/src/auth/basic/POP3/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	required.m4
 
 basic_pop3_auth: basic_pop3_auth.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = basic_pop3_auth.8
@@ -22,6 +22,6 @@ CLEANFILES += basic_pop3_auth.8
 EXTRA_DIST += basic_pop3_auth.8
 
 basic_pop3_auth.8: basic_pop3_auth
-	pod2man --section=8 basic_pop3_auth basic_pop3_auth.8
+	$(AM_V_GEN) pod2man --section=8 basic_pop3_auth basic_pop3_auth.8
 
 endif

--- a/src/auth/ntlm/fake/Makefile.am
+++ b/src/auth/ntlm/fake/Makefile.am
@@ -20,7 +20,7 @@ ntlm_fake_auth_LDADD= \
 
 ## Demo using perl.
 ## ntlm_fake_auth.pl: ntlm_fake_auth.pl.in
-##	$(subst_perlshell)
+##	$(AM_V_GEN) $(subst_perlshell)
 
 EXTRA_DIST= \
 	ntlm_fake_auth.pl.in \

--- a/src/error/Makefile.am
+++ b/src/error/Makefile.am
@@ -8,7 +8,7 @@
 include $(top_srcdir)/src/Common.am
 
 categories.cc: forward.h $(top_srcdir)/src/mk-string-arrays.awk
-	$(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk ifile=error/forward.h < $(srcdir)/forward.h > $@ || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) $(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk ifile=error/forward.h < $(srcdir)/forward.h > $@ || ($(RM) -f $@ && exit 1)
 
 BUILT_SOURCES = \
 	categories.cc

--- a/src/http/Makefile.am
+++ b/src/http/Makefile.am
@@ -38,8 +38,8 @@ libhttp_la_SOURCES = \
 libhttp_la_LIBADD= one/libhttp1.la
 
 MethodType.cc: MethodType.h $(top_srcdir)/src/mk-string-arrays.awk
-	($(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk sbuf=1 < $(srcdir)/MethodType.h | \
-		sed -e 's%METHOD_%%' -e 's%_C%-C%' >$@) || ($(RM) -f $@ && exit 1)
+	$(AM_V_GEN) ($(AWK) -f $(top_srcdir)/src/mk-string-arrays.awk sbuf=1 $(srcdir)/MethodType.h | \
+		$(SED) -e 's%METHOD_%%' -e 's%_C%-C%' >$@) || ($(RM) -f $@ && exit 1)
 
 CLEANFILES += MethodType.cc
 

--- a/src/http/url_rewriters/LFS/Makefile.am
+++ b/src/http/url_rewriters/LFS/Makefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST= \
 	url_lfs_rewrite.pl.in
 
 url_lfs_rewrite: url_lfs_rewrite.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = url_lfs_rewrite.8
@@ -28,6 +28,6 @@ CLEANFILES += url_lfs_rewrite.8
 EXTRA_DIST += url_lfs_rewrite.8
 
 url_lfs_rewrite.8: url_lfs_rewrite
-	pod2man --section=8 url_lfs_rewrite url_lfs_rewrite.8
+	$(AM_V_GEN) pod2man --section=8 url_lfs_rewrite url_lfs_rewrite.8
 
 endif

--- a/src/icmp/Makefile.am
+++ b/src/icmp/Makefile.am
@@ -84,16 +84,16 @@ CLEANFILES += $(COPIED_SOURCE)
 ## files we need to pull in from other locations
 ## copied like this to avoid subdir-objects collisions on 'make clean'
 globals.cc: $(top_srcdir)/src/globals.h
-	cp $(top_builddir)/src/globals.cc $@
+	$(AM_V_GEN) cp $(top_builddir)/src/globals.cc $@
 
 SquidConfig.cc: $(top_srcdir)/src/SquidConfig.cc
-	cp $(top_srcdir)/src/SquidConfig.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/SquidConfig.cc $@
 
 tests/stub_HelperChildConfig.cc: $(top_srcdir)/src/tests/stub_HelperChildConfig.cc | tests
-	cp $(top_srcdir)/src/tests/stub_HelperChildConfig.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_HelperChildConfig.cc $@
 
 tests/STUB.h: $(top_srcdir)/src/tests/STUB.h | tests
-	cp $(top_srcdir)/src/tests/STUB.h $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/STUB.h $@
 
 tests:
 	mkdir -p $@

--- a/src/log/DB/Makefile.am
+++ b/src/log/DB/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST= \
 	log_db_daemon.pl.in
 
 log_db_daemon: log_db_daemon.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = log_db_daemon.8
@@ -24,6 +24,6 @@ CLEANFILES += log_db_daemon.8
 EXTRA_DIST += log_db_daemon.8
 
 log_db_daemon.8: log_db_daemon
-	pod2man --section=8 log_db_daemon log_db_daemon.8
+	$(AM_V_GEN) pod2man --section=8 log_db_daemon log_db_daemon.8
 
 endif

--- a/src/security/cert_generators/file/Makefile.am
+++ b/src/security/cert_generators/file/Makefile.am
@@ -9,7 +9,7 @@ include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/doc/manuals/Substitute.am
 
 security_file_certgen.8: $(srcdir)/security_file_certgen.8.in Makefile
-	$(AC_V_at)$(SUBSTITUTE) < $(srcdir)/security_file_certgen.8.in > $@
+	$(AC_V_GEN) $(SUBSTITUTE) < $(srcdir)/security_file_certgen.8.in > $@
 
 man_MANS = security_file_certgen.8
 CLEANFILES += security_file_certgen.8

--- a/src/security/cert_generators/file/Makefile.am
+++ b/src/security/cert_generators/file/Makefile.am
@@ -9,7 +9,7 @@ include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/doc/manuals/Substitute.am
 
 security_file_certgen.8: $(srcdir)/security_file_certgen.8.in Makefile
-	$(AC_V_GEN) $(SUBSTITUTE) < $(srcdir)/security_file_certgen.8.in > $@
+	$(AM_V_GEN) $(SUBSTITUTE) < $(srcdir)/security_file_certgen.8.in > $@
 
 man_MANS = security_file_certgen.8
 CLEANFILES += security_file_certgen.8

--- a/src/security/cert_generators/file/Makefile.am
+++ b/src/security/cert_generators/file/Makefile.am
@@ -9,7 +9,7 @@ include $(top_srcdir)/src/Common.am
 include $(top_srcdir)/doc/manuals/Substitute.am
 
 security_file_certgen.8: $(srcdir)/security_file_certgen.8.in Makefile
-	$(SUBSTITUTE) < $(srcdir)/security_file_certgen.8.in > $@
+	$(AC_V_at)$(SUBSTITUTE) < $(srcdir)/security_file_certgen.8.in > $@
 
 man_MANS = security_file_certgen.8
 CLEANFILES += security_file_certgen.8

--- a/src/security/cert_validators/fake/Makefile.am
+++ b/src/security/cert_validators/fake/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	required.m4
 
 security_fake_certverify: security_fake_certverify.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = security_fake_certverify.8
@@ -22,6 +22,6 @@ CLEANFILES += security_fake_certverify.8
 EXTRA_DIST += security_fake_certverify.8
 
 security_fake_certverify.8: security_fake_certverify
-	pod2man --section=8 security_fake_certverify security_fake_certverify.8
+	$(AM_V_GEN) pod2man --section=8 security_fake_certverify security_fake_certverify.8
 
 endif

--- a/src/store/id_rewriters/file/Makefile.am
+++ b/src/store/id_rewriters/file/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST= \
 	required.m4
 
 storeid_file_rewrite: storeid_file_rewrite.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = storeid_file_rewrite.8
@@ -22,6 +22,6 @@ CLEANFILES += storeid_file_rewrite.8
 EXTRA_DIST += storeid_file_rewrite.8
 
 storeid_file_rewrite.8: storeid_file_rewrite
-	pod2man --section=8 storeid_file_rewrite storeid_file_rewrite.8
+	$(AM_V_GEN) pod2man --section=8 storeid_file_rewrite storeid_file_rewrite.8
 
 endif

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -47,28 +47,28 @@ DEBUG_SOURCE = test_tools.cc $(STUBS)
 CLEANFILES += $(STUBS) stub_libmem.cc
 
 stub_cbdata.cc: $(top_srcdir)/src/tests/stub_cbdata.cc
-	cp $(top_srcdir)/src/tests/stub_cbdata.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_cbdata.cc $@
 
 stub_MemBuf.cc: $(top_srcdir)/src/tests/stub_MemBuf.cc
-	cp $(top_srcdir)/src/tests/stub_MemBuf.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_MemBuf.cc $@
 
 stub_SBuf.cc: $(top_srcdir)/src/tests/stub_SBuf.cc
-	cp $(top_srcdir)/src/tests/stub_SBuf.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_SBuf.cc $@
 
 stub_tools.cc: $(top_srcdir)/src/tests/stub_tools.cc
-	cp $(top_srcdir)/src/tests/stub_tools.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_tools.cc $@
 
 stub_fatal.cc: $(top_srcdir)/src/tests/stub_fatal.cc
-	cp $(top_srcdir)/src/tests/stub_fatal.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_fatal.cc $@
 
 stub_libmem.cc: $(top_srcdir)/src/tests/stub_libmem.cc STUB.h
-	cp $(top_srcdir)/src/tests/stub_libmem.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_libmem.cc $@
 
 stub_libtime.cc: $(top_srcdir)/src/tests/stub_libtime.cc STUB.h
-	cp $(top_srcdir)/src/tests/stub_libtime.cc $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/stub_libtime.cc $@
 
 STUB.h: $(top_srcdir)/src/tests/STUB.h
-	cp $(top_srcdir)/src/tests/STUB.h $@
+	$(AM_V_GEN) cp $(top_srcdir)/src/tests/STUB.h $@
 
 mem_node_test_SOURCES = \
 	$(DEBUG_SOURCE) \

--- a/tools/helper-mux/Makefile.am
+++ b/tools/helper-mux/Makefile.am
@@ -11,7 +11,7 @@ CLEANFILES += helper-mux
 EXTRA_DIST= helper-mux.pl.in
 
 helper-mux: helper-mux.pl.in
-	$(subst_perlshell)
+	$(AM_V_GEN) $(subst_perlshell)
 
 if ENABLE_POD2MAN_DOC
 man_MANS = helper-mux.8
@@ -19,6 +19,6 @@ CLEANFILES += helper-mux.8
 EXTRA_DIST += helper-mux.8
 
 helper-mux.8: helper-mux
-	pod2man --section=8 helper-mux helper-mux.8
+	$(AM_V_GEN) pod2man --section=8 helper-mux helper-mux.8
 
 endif


### PR DESCRIPTION
Only print the compile command if the V variable
is non-zero, honoring the same convention used by autotools.
Error messages, warnings, and other output from the compiler
will still be printed to the console.

Also filter testHeaders targets early, avoiding needless late skips
for non-header files.

Also apply some opportunistic portability enhancements,
using detected tools such as $(SED) in place of sed