### PR TITLE
Fix translations build logging when translation is disabled (#2468)

### DIFF
--- a/errors/Makefile.am
+++ b/errors/Makefile.am
@@ -68,7 +68,7 @@ NOTIDY=`$(PO2HTML) --help | grep -o "[-]-notidy"`
 	    echo "Done translating $$lang"; \
 	else \
 	    lang=$(@:.lang=); \
-		echo "Translation of $$lang disabled\n"; \
+		echo "Translation of $$lang disabled"; \
 	fi; \
 	touch $@
 


### PR DESCRIPTION
Remove spurious \n character.