### PR TITLE
Make hdrtest ccache-friendly (#2466)

### DIFF
--- a/src/TestHeaders.am
+++ b/src/TestHeaders.am
@@ -20,7 +20,7 @@ testHeaders: $(SOURCES) $(noinst_HEADERS) $(EXTRA_DIST) $(top_srcdir)/test-suite
 .h.hdrtest:
 	@SrcFilePath=`echo $< | $(SED) 's%^$(top_srcdir)/%%'`; \
 	SrcFileName=`basename $$SrcFilePath`; \
-	TargetFileName=tmp$$$$-`basename $@`; \
+	TargetFileName="`dirname $$SrcFilePath | $(SED) 's!/!-!g'`-`basename $@`"; \
 	if test "$(EXCLUDE_FROM_HDR_TESTING)" != "" && echo "$(EXCLUDE_FROM_HDR_TESTING)" | $(TR) ' ' '\n' | $(FGREP) -x -q "$$SrcFileName" ; then \
 		echo "header-test: skip - $$SrcFilePath"; \
 		exit 0; \


### PR DESCRIPTION
The solution implemented in commit ca4ed647e71
makes the testHeaders process unfriendly to ccache,
because the sources for testheaders are not hermetic.

Change how hdrtest filenames are derived so that they
are unique and reproducible across "make" runs.