### PR TITLE
Only rely on our own assert()

### DIFF
--- a/compat/assert.h
+++ b/compat/assert.h
@@ -15,7 +15,11 @@
 
 #define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 
+#ifdef __cplusplus
+extern "C" void
+#else
 extern void
+#endif
 xassert(const char *, const char *, int);
 
 #endif /* SQUID_COMPAT_ASSERT_H */

--- a/compat/assert.h
+++ b/compat/assert.h
@@ -9,13 +9,11 @@
 #ifndef SQUID_COMPAT_ASSERT_H
 #define SQUID_COMPAT_ASSERT_H
 
-#if PURIFY
-#define assert(EX) ((void)0)
-#elif defined(NODEBUG)
-#define assert(EX) ((void)0)
-#else
-#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
+#if defined(assert)
+#undef assert
 #endif
+
+#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 
 #ifdef __cplusplus
 extern "C" void

--- a/compat/assert.h
+++ b/compat/assert.h
@@ -15,12 +15,7 @@
 
 #define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
 
-#ifdef __cplusplus
-extern "C" void
-#else
 extern void
-#endif
 xassert(const char *, const char *, int);
 
 #endif /* SQUID_COMPAT_ASSERT_H */
-

--- a/compat/mswindows.cc
+++ b/compat/mswindows.cc
@@ -20,8 +20,6 @@
 
 #define sys_nerr _sys_nerr
 
-#undef assert
-#include <cassert>
 #include <cstring>
 #include <fcntl.h>
 #include <memory>

--- a/lib/hash.cc
+++ b/lib/hash.cc
@@ -11,7 +11,6 @@
 #include "squid.h"
 #include "hash.h"
 
-#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>

--- a/lib/heap.c
+++ b/lib/heap.c
@@ -21,9 +21,6 @@
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#if HAVE_ASSERT_H
-#include <assert.h>
-#endif
 #if HAVE_STRING_H
 #include <string.h>
 #endif

--- a/lib/snmplib/parse.c
+++ b/lib/snmplib/parse.c
@@ -81,9 +81,6 @@ SOFTWARE.
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_ASSERT_H
-#include <assert.h>
-#endif
 #if HAVE_ERRNO_H
 #include <errno.h>
 #endif

--- a/lib/snmplib/snmp_msg.c
+++ b/lib/snmplib/snmp_msg.c
@@ -87,9 +87,6 @@
 #if HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#if HAVE_ASSERT_H
-#include <assert.h>
-#endif
 
 #include "asn1.h"
 #include "snmp.h"

--- a/lib/tests/testRFC1738.cc
+++ b/lib/tests/testRFC1738.cc
@@ -9,7 +9,6 @@
 #include "squid.h"
 #include "unitTestMain.h"
 
-#include <cassert>
 #include <cppunit/extensions/HelperMacros.h>
 
 /* Being a C library code it is best bodily included and tested with C++ type-safe techniques. */

--- a/src/base/Assure.h
+++ b/src/base/Assure.h
@@ -24,8 +24,6 @@
     while (!(condition)) \
         ReportAndThrow_((debugLevel), (description), (location))
 
-#if !defined(NDEBUG)
-
 /// Like assert() but throws an exception instead of aborting the process. Use
 /// this macro to detect code logic mistakes (i.e. bugs) where aborting the
 /// current AsyncJob or a similar task is unlikely to jeopardize Squid service
@@ -39,14 +37,6 @@
 /// \param description string literal describing the condition (i.e. what MUST happen)
 #define Assure2(condition, description) \
         Assure_(0, (condition), ("assurance failed: " description), Here())
-
-#else
-
-/* do-nothing implementations for NDEBUG builds */
-#define Assure(condition) ((void)0)
-#define Assure2(condition, description) ((void)0)
-
-#endif /* NDEBUG */
 
 #endif /* SQUID_SRC_BASE_ASSURE_H */
 

--- a/src/base/JobWait.cc
+++ b/src/base/JobWait.cc
@@ -10,7 +10,6 @@
 #include "base/AsyncJobCalls.h"
 #include "base/JobWait.h"
 
-#include <cassert>
 #include <iostream>
 
 JobWaitBase::JobWaitBase() = default;

--- a/src/base/TextException.h
+++ b/src/base/TextException.h
@@ -70,8 +70,8 @@ std::ostream &operator <<(std::ostream &, const TextException &);
     Assure_(3, (condition), ("check failed: " description), (location))
 
 /// Like Assure() but only logs the exception if level-3 debugging is enabled
-/// and runs even when NDEBUG macro is defined. Deprecated: Use Assure() for
-/// code logic checks and throw explicitly when input validation fails.
+/// Deprecated: Use Assure() for code logic checks and throw
+/// explicitly when input validation fails.
 #define Must(condition) Must3((condition), #condition, Here())
 
 /// Reports and swallows all exceptions to prevent compiler warnings and runtime

--- a/src/debug/Stream.h
+++ b/src/debug/Stream.h
@@ -12,7 +12,6 @@
 #define SQUID_SRC_DEBUG_STREAM_H
 
 #include "base/Here.h"
-#include "compat/assert.h"
 // XXX should be mem/forward.h once it removes dependencies on typedefs.h
 #include "mem/AllocatorProxy.h"
 

--- a/src/debug/Stream.h
+++ b/src/debug/Stream.h
@@ -12,23 +12,13 @@
 #define SQUID_SRC_DEBUG_STREAM_H
 
 #include "base/Here.h"
+#include "compat/assert.h"
 // XXX should be mem/forward.h once it removes dependencies on typedefs.h
 #include "mem/AllocatorProxy.h"
 
 #include <iostream>
-#undef assert
 #include <sstream>
 #include <iomanip>
-#if defined(assert)
-#undef assert
-#endif
-#if PURIFY
-#define assert(EX) ((void)0)
-#elif defined(NODEBUG)
-#define assert(EX) ((void)0)
-#else
-#define assert(EX)  ((EX)?((void)0):xassert( # EX , __FILE__, __LINE__))
-#endif
 
 /* defined debug section limits */
 #define MAX_DEBUG_SECTIONS 100

--- a/src/dns/rfc1035.cc
+++ b/src/dns/rfc1035.cc
@@ -19,7 +19,6 @@
 #include "dns/rfc2671.h"
 #include "util.h"
 
-#include <cassert>
 #include <cstring>
 #if HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/dns/rfc3596.cc
+++ b/src/dns/rfc3596.cc
@@ -18,7 +18,6 @@
 #if HAVE_MEMORY_H
 #include <memory.h>
 #endif
-#include <cassert>
 #if HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif

--- a/src/ip/Address.cc
+++ b/src/ip/Address.cc
@@ -14,7 +14,6 @@
 #include "ip/tools.h"
 #include "util.h"
 
-#include <cassert>
 #include <cstring>
 #if HAVE_ARPA_INET_H
 /* for inet_ntoa() */

--- a/src/log/file/log_file_daemon.cc
+++ b/src/log/file/log_file_daemon.cc
@@ -10,7 +10,6 @@
 
 #include "compat/unistd.h"
 
-#include <cassert>
 #include <cerrno>
 #include <csignal>
 #include <cstring>

--- a/src/mem/Pool.cc
+++ b/src/mem/Pool.cc
@@ -16,7 +16,6 @@
 #include "mem/PoolMalloc.h"
 #include "mem/Stats.h"
 
-#include <cassert>
 #include <cstring>
 
 extern time_t squid_curtime;

--- a/src/mem/PoolChunked.cc
+++ b/src/mem/PoolChunked.cc
@@ -14,7 +14,6 @@
 #include "mem/PoolChunked.h"
 #include "mem/Stats.h"
 
-#include <cassert>
 #include <cstring>
 
 #define MEM_MAX_MMAP_CHUNKS 2048

--- a/src/mem/PoolMalloc.cc
+++ b/src/mem/PoolMalloc.cc
@@ -15,7 +15,6 @@
 #include "mem/PoolMalloc.h"
 #include "mem/Stats.h"
 
-#include <cassert>
 #include <cstring>
 
 extern time_t squid_curtime;

--- a/src/tests/testRFC1035.cc
+++ b/src/tests/testRFC1035.cc
@@ -11,8 +11,6 @@
 #include "dns/rfc1035.h"
 #include "unitTestMain.h"
 
-// #include <cassert>
-
 /*
  * test the DNS resolver RFC 1035 Engine
  */

--- a/test-suite/waiter.c
+++ b/test-suite/waiter.c
@@ -8,10 +8,6 @@
 
 #include "squid.h"
 
-#if HAVE_ASSERT_H
-#include <assert.h>
-#endif
-
 int
 main(int argc, char *argv[])
 {


### PR DESCRIPTION
The interactions between our own assert() implementation
(in compat/assert.h) and the system-level assert()
are unclear and implementation-dependent.
Also, due to historic reasons, sometimes assert()
is used to validate user input, making building with debug
disabled a risky endeavour.

Remove references to system assert, and make assert()
unconditional