### PR TITLE
CI: Retry mysterious HTTP 413 (Too Large) Coverity uploads

### DIFF
--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Prepare and upload sources to Coverity Scan
         run: |
           cov-build --dir cov-int ./test-builds.sh layer-02-maximus
-          tar -c -a -f cov-int.tar.xz cov-int
+          tar -c -I 'xz -9' -f cov-int.tar.xz cov-int
           curl \
             --fail-with-body \
             --retry 5 \

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -15,7 +15,7 @@ jobs:
   coverity-scan:
     name: Scan with Coverity
     # only run the workflow on Squid's main repository
-    if: github.repository == 'squid-cache/squid'
+    if: github.repository == 'measurement-factory/squid'
 
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           cov-build --dir cov-int ./test-builds.sh layer-02-maximus
           tar -c -a -f cov-int.tar.xz cov-int
+          echo "original/packed: $(du -sh ./cov-int|cut -f1)/$(du -m ./cov-int.tar.xz|cut -f1)M"
           curl \
             --fail-with-body \
             --retry 5 \

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -15,7 +15,7 @@ jobs:
   coverity-scan:
     name: Scan with Coverity
     # only run the workflow on Squid's main repository
-    if: github.repository == 'measurement-factory/squid'
+    if: github.repository == 'squid-cache/squid'
 
     runs-on: ubuntu-24.04
 
@@ -37,7 +37,8 @@ jobs:
         run: |
           cov-build --dir cov-int ./test-builds.sh layer-02-maximus
           tar -c -a -f cov-int.tar.xz cov-int
-          echo "original/packed: $(du -sh ./cov-int|cut -f1)/$(du -m ./cov-int.tar.xz|cut -f1)M"
+          echo "cov-int size: " `du -s ./cov-int`
+          ls -l ./cov-int.tar.xz
           curl \
             --fail-with-body \
             --retry 5 \

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -39,6 +39,9 @@ jobs:
           tar -c -a -f cov-int.tar.xz cov-int
           curl \
             --fail-with-body \
+            --retry 5 \
+            --retry-delay 15 \
+            --retry-all-errors \
             --form email=${coverity_user} \
             --form token=${coverity_token} \
             --form version=coverity_scan \

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Prepare and upload sources to Coverity Scan
         run: |
           cov-build --dir cov-int ./test-builds.sh layer-02-maximus
-          tar -c -I 'xz -9' -f cov-int.tar.xz cov-int
+          tar -c -a -f cov-int.tar.xz cov-int
           curl \
             --fail-with-body \
             --retry 5 \


### PR DESCRIPTION
When our coverity-scan GitHub Actions job uploads the results produced
by `cov-build` to the Coverity Scan service, the upload sometimes fails
with an HTTP 413 (Request Entity Too Large) error response. By default,
curl does not treat HTTP 413 responses as intermittent errors and,
hence, does not retry them. We speculate that those errors might be
caused by Coverity misconfiguration, _and_ that Coverity may use several
differently-configured servers behind some kind of load balancer, making
those errors worth retrying.

Besides enabling five retry attempts, this change also reports
upload-related sizes in hope to provide more information if those
retries fail to work around the problem: Curl already reports its notion
of the upload size, but that reporting is a bit odd/obscure, so we also
add a dedicated `ls` output. We also report raw/uncompressed upload size
now, in case Coverity is using that to limit uploads.
