### PR TITLE
Define MSG_DONTWAIT as MSG_NONBLOCK if needed and possible

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -443,6 +443,7 @@ Thank you!
     Renan Rodrigo <rr@ubuntu.com>
     Renaud Metrich <renaud.metrich@gmail.com>
     Rene Geile <rene.geile@t-online.de>
+    Reshma V Kumar <reskumar@in.ibm.com>
     Reuben Farrelly <reuben@reub.net>
     Ricardo Ferreira Ribeiro <garb12@pm.me>
     Richard Huveneers <Richard.Huveneers@hekkihek.hacom.nl>

--- a/compat/socket.h
+++ b/compat/socket.h
@@ -55,8 +55,6 @@ int xsocket(int domain, int type, int protocol);
 #endif
 
 // Solaris and possibly others lack MSG_NOSIGNAL optimization
-// TODO: move this into compat/? Use a dedicated compat file to avoid dragging
-// sys/socket.h into the rest of Squid??
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
 #endif

--- a/compat/socket.h
+++ b/compat/socket.h
@@ -49,6 +49,11 @@ int xsetsockopt(int socketFd, int level, int option, const void * value, socklen
 /// POSIX socket(2) equivalent
 int xsocket(int domain, int type, int protocol);
 
+// AIX and possibly others lack MSG_DONTWAIT but have a MSG_NONBLOCK equivalent
+#if !defined(MSG_DONTWAIT) && defined(MSG_NONBLOCK)
+#define MSG_DONTWAIT MSG_NONBLOCK
+#endif
+
 // Solaris and possibly others lack MSG_NOSIGNAL optimization
 // TODO: move this into compat/? Use a dedicated compat file to avoid dragging
 // sys/socket.h into the rest of Squid??

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -8,6 +8,10 @@
 
 /* DEBUG: section 51    Filedescriptor Functions */
 
+#ifdef _AIX
+#define MSG_DONTWAIT MSG_NONBLOCK
+#endif
+
 #include "squid.h"
 #include "comm/Loops.h"
 #include "compat/socket.h"

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -8,7 +8,8 @@
 
 /* DEBUG: section 51    Filedescriptor Functions */
 
-#ifdef _AIX
+// AIX and possibly others lack MSG_DONTWAIT but have a MSG_NONBLOCK equivalent
+#if !defined(MSG_DONTWAIT) && defined(MSG_NONBLOCK)
 #define MSG_DONTWAIT MSG_NONBLOCK
 #endif
 

--- a/src/fd.cc
+++ b/src/fd.cc
@@ -8,11 +8,6 @@
 
 /* DEBUG: section 51    Filedescriptor Functions */
 
-// AIX and possibly others lack MSG_DONTWAIT but have a MSG_NONBLOCK equivalent
-#if !defined(MSG_DONTWAIT) && defined(MSG_NONBLOCK)
-#define MSG_DONTWAIT MSG_NONBLOCK
-#endif
-
 #include "squid.h"
 #include "comm/Loops.h"
 #include "compat/socket.h"


### PR DESCRIPTION
    fd.cc:138:56: error: 'MSG_DONTWAIT' was not declared in this scope;
    did you mean 'MSG_DONTROUTE'?

AIX does not define `MSG_DONTWAIT`. The functional equivalent of this
flag on AIX is `MSG_NONBLOCK`.

This change fixes `src/fd.cc` compilation on AIX, but more changes are
required to fix AIX build.