### PR TITLE
CI: update FreeBSD target version to 14.4

### DIFF
--- a/.github/workflows/slow.yaml
+++ b/.github/workflows/slow.yaml
@@ -147,7 +147,7 @@ jobs:
       matrix:
         osversion:
           - "15.1"
-          - "14.3"
+          - "14.4"
         platform:
           - amd64
           # We are ready to support multiple platforms, but


### PR DESCRIPTION
Fix package version mismatch in build by
targeting the latest supported 14.X version