### PR TITLE
WCCP: Fix offset calculation when parsing incoming packets

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -54,6 +54,7 @@ Thank you!
     Andrew Novikov <as.asaw@gmail.com>
     Andrew Tridgell
     Andrey <rybakovandrey85@gmail.com>
+    Andrey Kolesnik <akolesnik@astralinux.ru>
     Andrey Shorin <tolsty@tushino.com>
     Ankor <ankor2023@gmail.com>
     Anonymous <bigparrot@pirateperfection.com>

--- a/src/wccp2.cc
+++ b/src/wccp2.cc
@@ -1142,9 +1142,9 @@ static size_t
 CheckFieldDataLength(const FieldHeader *header, const size_t dataLength, const void *areaStart, const size_t areaSize, const char *error)
 {
     assert(header);
-    const auto dataStart = reinterpret_cast<const char*>(header) + sizeof(header);
+    const auto dataStart = reinterpret_cast<const char*>(header) + sizeof(*header);
     CheckSectionLength(dataStart, dataLength, areaStart, areaSize, error);
-    return sizeof(header) + dataLength; // no overflow after CheckSectionLength()
+    return sizeof(*header) + dataLength; // no overflow after CheckSectionLength()
 }
 
 /// Positions the given field at a given start within a given packet area.


### PR DESCRIPTION
Since 2021 commit 464223c1, WCCPv2 packet parsing code was using
wrong offsets due to a `CheckFieldDataLength()` bug:

* `wccp2_item_header_t` and `wccp2_capability_info_header_t`: The
  function returned a wrong offset on any 64-bit build, shifting
  dataStart and the returned field size by 4 bytes and desynchronizing
  the parse of subsequent WCCPv2 packet items;
* `wccp2_capability_element_t`: The function happened to return a
  correct offset only on platforms with 8-byte pointers.

This change is a reference point for automated CONTRIBUTORS updates.