### PR TITLE
Fix missing condition for max_filedescriptors use

### DIFF
--- a/src/cache_cf.cc
+++ b/src/cache_cf.cc
@@ -753,16 +753,6 @@ configDoConfigure(void)
     if (Config.errHtmlText == nullptr)
         Config.errHtmlText = xstrdup(null_string);
 
-#if !HAVE_SETRLIMIT || !defined(RLIMIT_NOFILE)
-    if (Config.max_filedescriptors > 0) {
-        debugs(0, DBG_IMPORTANT, "WARNING: max_filedescriptors disabled. Operating System setrlimit(RLIMIT_NOFILE) is missing.");
-    }
-#elif USE_SELECT
-    if (Config.max_filedescriptors > FD_SETSIZE) {
-        debugs(0, DBG_IMPORTANT, "WARNING: max_filedescriptors limited to " << FD_SETSIZE << " by select() algorithm.");
-    }
-#endif
-
     storeConfigure();
 
     snprintf(ThisCache, sizeof(ThisCache), "%s (%s)",

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -10670,17 +10670,13 @@ DOC_END
 
 NAME: max_filedescriptors max_filedesc
 TYPE: int
+IFDEF: HAVE_SETRLIMIT&&(RLIMIT_NOFILE||RLIMIT_OFILE)
 DEFAULT: 0
 DEFAULT_DOC: Guess a reasonable value (e.g., use soft limit set by ulimit).
 LOC: Config.max_filedescriptors
 DOC_START
 	Sets the maximum number of file descriptors, up to the hard OS limit (where
 	supported).
-
-	Currently, the explicitly configured value is ignored when `setrlimit(2)` or
-	`RLIMIT_NOFILE` support was not detected at `./configure` time. A level-1
-	"WARNING" message is written to cache.log in such cases, but future Squid
-	versions will fail to start instead.
 
 	Currently, if `setrlimit(2)` fails to set the soft and hard limits to the
 	configured value, a level-0 "ERROR" message is written to cache.log, and

--- a/src/cf_gen_defines
+++ b/src/cf_gen_defines
@@ -29,6 +29,7 @@ BEGIN {
 	define["HAVE_LIBCAP&&SO_MARK"]="--with-cap and Packet MARK (Linux)"
 	define["HAVE_LIBGNUTLS||USE_OPENSSL"]="--with-gnutls or --with-openssl"
 	define["HAVE_MSTATS&&HAVE_GNUMALLOC_H"]="GNU Malloc with mstats()"
+	define["HAVE_SETRLIMIT&&(RLIMIT_NOFILE||RLIMIT_OFILE)"]="Operating System setrlimit(RLIMIT_NOFILE)"
 	define["ICAP_CLIENT"]="--enable-icap-client"
 	define["SQUID_SNMP"]="--enable-snmp"
 	define["USE_ADAPTATION"]="--enable-ecap or --enable-icap-client"

--- a/src/tools.cc
+++ b/src/tools.cc
@@ -775,7 +775,7 @@ setMaxFD(void)
         /* select() breaks if this gets set too big */
         if (Config.max_filedescriptors > FD_SETSIZE) {
             rl.rlim_cur = FD_SETSIZE;
-            debugs(50, DBG_CRITICAL, "WARNING: 'max_filedescriptors " << Config.max_filedescriptors << "' does not work with select()");
+            debugs(50, DBG_CRITICAL, "ERROR: max_filedescriptors limited to " << FD_SETSIZE << " by select() algorithm.");
         } else
 #endif
             rl.rlim_cur = Config.max_filedescriptors;


### PR DESCRIPTION
The max_filedescriptors directive is only useful when the OS
setrlimit() API is available. Add markup to the squid.conf
definition that enables appropriate errors and documentation
automatically.