### PR TITLE
Explicitly deny to_localnet requests in squid.conf.default

### DIFF
--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1720,7 +1720,7 @@ CONFIG_START
 # Adapt to list your (internal) IP networks.
 # It is common to allow access from these addresses, but your needs may vary.
 # Be careful with negating this ACL: This ACL does not match Squid-generated
-# requests, so "!localnet" does _not_ mean an "external" request received
+# requests, so `!localnet` does _not_ mean an "external" request received
 # from a non-local address. It means "external or internally-generated"!
 acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
 acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -1716,9 +1716,12 @@ CONFIG_START
 # Recommended minimum configuration:
 #
 
-# Example rule allowing access from your local networks.
-# Adapt to list your (internal) IP networks from where browsing
-# should be allowed
+# Define what "from your local network" means.
+# Adapt to list your (internal) IP networks.
+# It is common to allow access from these addresses, but your needs may vary.
+# Be careful with negating this ACL: This ACL does not match Squid-generated
+# requests, so "!localnet" does _not_ mean an "external" request received
+# from a non-local address. It means "external or internally-generated"!
 acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
 acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
 acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
@@ -1727,6 +1730,18 @@ acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
 acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
 acl localnet src fc00::/7       	# RFC 4193 local private network range
 acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+# Define what "to your local network" means.
+# Adapt to list your (internal) IP networks.
+# It is common to deny access to these addresses, but your needs may vary.
+acl to_localnet dst 0.0.0.1-0.255.255.255 # RFC 1122 "this" network (LAN)
+acl to_localnet dst 10.0.0.0/8     # RFC 1918 local private network (LAN)
+acl to_localnet dst 100.64.0.0/10  # RFC 6598 shared address space (CGN)
+acl to_localnet dst 169.254.0.0/16 # RFC 3927 link-local (directly plugged) machines
+acl to_localnet dst 172.16.0.0/12  # RFC 1918 local private network (LAN)
+acl to_localnet dst 192.168.0.0/16 # RFC 1918 local private network (LAN)
+acl to_localnet dst fc00::/7       # RFC 4193 local private network range
+acl to_localnet dst fe80::/10      # RFC 4291 link-local (directly plugged) machines
 
 acl SSL_ports port 443
 acl Safe_ports port 80		# http
@@ -1967,7 +1982,7 @@ http_access deny manager
 # network by proxying external TCP connections to unprotected services.
 http_access allow localhost
 
-# The two deny rules below are unnecessary in this default configuration
+# The three deny rules below are unnecessary in this default configuration
 # because they are followed by a "deny all" rule. However, they may become
 # critically important when you start allowing external requests below them.
 
@@ -1979,15 +1994,29 @@ http_access deny to_localhost
 # their server via certain well-known link-local (a.k.a. APIPA) addresses.
 http_access deny to_linklocal
 
+# Protect services running inside your "local" networks. These services often
+# assume that only "local" users can access them. This rule also denies
+# internally-generated AIA requests for missing intermediate X.509
+# certificates when those requests target "local" services.
+http_access deny !localnet to_localnet
+
 #
-# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW PERMITTED TRANSACTIONS.
+# The two examples below cover one common use case, but your needs may vary.
 #
 
-# For example, to allow access from your local networks, you may uncomment the
-# following rule (and/or add rules that match your definition of "local"):
+# Uncomment to allow access from "local" networks to any destination that was
+# not banned earlier (e.g., all `to_linklocal` destinations were banned).
 # http_access allow localnet
 
-# And finally deny all other access to this proxy
+# Uncomment to allow all internally-generated requests (e.g., AIA requests for
+# missing intermediate X.509 certificates) to any destination that was not
+# banned earlier (e.g., all `to_localnet` destinations were banned for such
+# requests).
+# acl internallyGenerated transaction_initiator internal
+# http_access allow internallyGenerated
+
+# And finally deny all other requests
 http_access deny all
 CONFIG_END
 DOC_END


### PR DESCRIPTION
This ban is not appropriate for some use cases, but our default
configuration template should prioritize safety over coverage breadth.
This work can be seen as a followup to 2022 commit 6d2f8ed0.

The new `to_localnet` ban appears to use a more complex http_access rule
than existing to `to_localhost` and `to_linklocal bans`, but that
additional complexity is misleading: In fact, existing bans should be
interpreted in their `http_access allow localhost` context. In other
words, existing bans can be viewed as if they were written like this:

    http_access deny !localhost to_localhost
    http_access deny !localhost to_linklocal

Existing bans exclude localhost requests because a client running on
localhost can send banned requests directly to those protected services,
bypassing Squid. We use the same "do not ban access to what the clients
may be able to access without going through Squid" logic for the new
`to_localnet` rule, resulting in the `localnet` clients exclusion:

    http_access deny !localnet to_localnet

Unlike the `localhost` case, we do not want to allow all `localnet`
clients by default. That caveat necessitates a different rule shape.

XXX: This duplicates "local" address range definitions.
TODO: Add "local", similar to existing "all", "ipv4" and "ipv6" aliases?

Also show how to allow internally-generated requests. Without that or
some other "allow" rule that matches internally-generated requests, our
configuration template bans all AIA requests, effectively disabling
fetching of missing intermediate X.509 certificates. AIA requests are
currently the only known use case of an internally-generated request not
associated with a client-to-Squid connection. Typical src-based
`http_access allow` rules cannot cover such requests.
